### PR TITLE
Add --process-dependency-links to install command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,8 +35,10 @@ Check out the [Tutorial](http://nbviewer.ipython.org/urls/raw.github.com/pymc-de
 The latest version of PyMC 3 can be installed from the master branch using pip:
 
 ```
-pip install git+https://github.com/pymc-devs/pymc
+pip install --process-dependency-links git+https://github.com/pymc-devs/pymc
 ```
+
+The `--process-dependency-links` flag ensures that the developmental branch of Theano, which PyMC requires, is installed. If a recent developmental version of Theano has been installed with another method, this flag can be dropped.
 
 Another option is to clone the repository and install PyMC using `python setup.py install` or `python setup.py develop`.
 


### PR DESCRIPTION
As of v1.5, pip will ignore dependency links in setup.py unless the
--process-dependency-links flag is passed.  As a result, the PyPI
version of Theano will be installed instead of the developmental
version.

See #669.
