### PR TITLE
Fix: Change determinant in Wishart log probability.

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -170,10 +170,9 @@ class Wishart(Continuous):
         V = self.V
 
         IVI = det(V)
+        IXI = det(X)
 
         return bound(
-            ((n - p - 1) * log(IVI) - trace(matrix_inverse(V).dot(X)) -
-             n * p * log(
-             2) - n * log(IVI) - 2 * multigammaln(p, n / 2)) / 2,
-
+            ((n - p - 1) * log(IXI) - trace(matrix_inverse(V).dot(X)) -
+                n * p * log(2) - n * log(IVI) - 2 * multigammaln(p, n / 2)) / 2,
              n > (p - 1))

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -174,5 +174,5 @@ class Wishart(Continuous):
 
         return bound(
             ((n - p - 1) * log(IXI) - trace(matrix_inverse(V).dot(X)) -
-                n * p * log(2) - n * log(IVI) - 2 * multigammaln(p, n / 2)) / 2,
+                n * p * log(2) - n * log(IVI) - 2 * multigammaln(n / 2., p)) / 2,
              n > (p - 1))

--- a/pymc/distributions/special.py
+++ b/pymc/distributions/special.py
@@ -53,10 +53,9 @@ def multigammaln(a, p):
         p : int degrees of freedom
             p > 0
     """
-    a = t.shape_padright(a)
-    i = arange(p)
+    i = arange(1, p + 1)
 
-    return p * (p - 1) * log(pi) / 4. + t.sum(gammaln(a + i / 2.), axis=a.ndim - 1)
+    return p * (p - 1) * log(pi) / 4. + t.sum(gammaln(a + (1. - i) / 2.), axis=0)
 
 
 cpsifunc = """


### PR DESCRIPTION
The PDF of the Wishart distribution is given by:
![255ae736aa2bdc387ed3134453a4cb9d](https://cloud.githubusercontent.com/assets/564473/6042279/b3038e04-ac83-11e4-9a00-a7b676d07963.png)

In the current code both determinants are calculated for the matrix V, but the one in the numerator should be the determinant of matrix X.
