### PR TITLE
Fix: MvNormal.logp now works with multiple observations.

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -32,7 +32,9 @@ class MvNormal(Continuous):
         delta = value - mu
         k = tau.shape[0]
 
-        return 1/2. * (-k * log(2*pi) + log(det(tau)) - dot(delta.T, dot(tau, delta)))
+        result = k * log(2*pi) + log(1./det(tau))
+        result += (delta.dot(tau) * delta).sum(axis=delta.ndim - 1)
+        return -1/2. * result
 
 
 class Dirichlet(Continuous):


### PR DESCRIPTION
The function `logp` was working only when `value` was a single observation.
With this fix the function returns the correct element wise log probability for all observations.

Additional fix:
Since `tau` is a precision matrix, we need to take the inverse of `det(tau)`.
