### PR TITLE
mc_error: Update for trimmed shape

### DIFF
--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -192,7 +192,8 @@ def mc_error(x, batches=5):
         except ValueError:
             # If batches do not divide evenly, trim excess samples
             resid = len(x) % batches
-            batched_traces = np.resize(x[:-resid], (batches, len(x)/batches))
+            new_shape = (batches, (len(x) - resid) / batches)
+            batched_traces = np.resize(x[:-resid], new_shape)
 
         means = np.mean(batched_traces, 1)
 


### PR DESCRIPTION
Pass numpy.resize the trimmed shape instead of the old shape.  This
avoids the error below.

```
Traceback (most recent call last):
[...]
  File "[...]/pymc3/stats.py", line 195, in mc_error
    batched_traces = np.resize(x[:-resid], (batches, len(x)/batches))
  File "[...]/numpy/core/fromnumeric.py", line 1128, in resize
    return reshape(a, new_shape)
  File "[...]/numpy/core/fromnumeric.py", line 225, in reshape
    return reshape(newshape, order=order)
ValueError: total size of new array must be unchanged
```

This was showing up as an error in the "short" Travis run of
examples/best.py under python 3 (but not python 2, for some reason).
