### PR TITLE
Fix: Check the support for the Dirichlet distribution.

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -79,11 +79,11 @@ class Dirichlet(Continuous):
 
         # only defined for sum(value) == 1
         return bound(
-            sum(logpow(
-                value, a - 1) - gammaln(a), axis=0) + gammaln(sum(a)),
-
+            sum(logpow(value, a - 1) - gammaln(a), axis=0) + gammaln(sum(a)),
             k > 1,
-            all(a > 0))
+            all(a > 0),
+            all(value >= 0),
+            all(value <= 1))
 
 
 class Multinomial(Discrete):


### PR DESCRIPTION
When debugging #692, I noticed that the sampler returned values outside of the support `[0,1]`.
I added the constraint to the `logp` function of the Dirichlet distribution.
