### PR TITLE
Update for Theano v0.7.0 release

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,10 +35,8 @@ Check out the [Tutorial](http://nbviewer.ipython.org/github/pymc-devs/pymc3/blob
 The latest version of PyMC 3 can be installed from the master branch using pip:
 
 ```
-pip install --process-dependency-links git+https://github.com/pymc-devs/pymc3
+pip install git+https://github.com/pymc-devs/pymc3
 ```
-
-The `--process-dependency-links` flag ensures that the developmental branch of Theano, which PyMC requires, is installed. If a recent developmental version of Theano has been installed with another method, this flag can be dropped.
 
 Another option is to clone the repository and install PyMC using `python setup.py install` or `python setup.py develop`.
 

--- a/setup.py
+++ b/setup.py
@@ -27,15 +27,11 @@ classifiers = ['Development Status :: 3 - Alpha',
                'Operating System :: OS Independent']
 
 install_reqs = ['numpy>=1.7.1', 'scipy>=0.12.0', 'matplotlib>=1.2.1',
-                'Theano<=0.7dev']
+                'Theano>=0.7.0']
 
 test_reqs = ['nose']
 if sys.version_info[0] == 2:  # py3 has mock in stdlib
     test_reqs.append('mock')
-
-## The current release of Theano does not support `as_op` decorator, so
-## we're using the developmental version from github.
-dep_links = ['https://github.com/Theano/Theano/tarball/master#egg=Theano-0.7dev']
 
 if __name__ == "__main__":
     setup(name=DISTNAME,
@@ -53,6 +49,5 @@ if __name__ == "__main__":
           package_data = {'pymc3.examples': ['data/*']},
           classifiers=classifiers,
           install_requires=install_reqs,
-          dependency_links=dep_links,
           tests_require=test_reqs,
           test_suite='nose.collector')


### PR DESCRIPTION
We were using the development version for `as_op` (177c4061903ba72b65e39cbac78b1c69ea12a7c0), but now the current PyPI version for Theano (v0.7.0) includes this.  It also contains the fix for issue #660.
