### PR TITLE
Make multinomial with two possibilities and n=0 act the same as binomial...

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -129,7 +129,7 @@ class Multinomial(Discrete):
         # only defined for sum(p) == 1
         return bound(
             factln(n) + sum(x * log(p) - factln(x)),
-            n > 0,
+            n >= 0,
             eq(sum(x), n),
             all(0 <= x), all(x <= n))
 


### PR DESCRIPTION
Make multinomial with two possibilities and n=0 act the same as binomial with n=0.
Addressing #657.

> > > pm.Binomial.dist(p=.5, n=0).logp(0).eval()
> > > array(-0.0, dtype=float32)

Before change:

> > > pm.Multinomial.dist(p=np.array([.5,.5]), n=0).logp(np.array([0,0])).eval()
> > > array(-inf)
> > > After change:
> > > pm.Multinomial.dist(p=np.array([.5,.5]), n=0).logp(np.array([0,0])).eval()
> > > array(0.0)

I have only done one pull request before, so apologies if this is way off.
