### PR TITLE
Fix shared variables

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -342,10 +342,10 @@ class ObservedRV(Factor):
 
         if len(args) > 1:
             params = getargspec(distribution.logp).args
-            args = [t.constant(d, name=name + "_" + param)
+            args = [t.as_tensor_variable(d, name=name + "_" + param)
                     for d,param in zip(args,params) ]
         else:
-            args = [t.constant(args[0], name=name)]
+            args = [t.as_tensor_variable(args[0], name=name)]
 
         self.logp_elemwiset = distribution.logp(*args)
         self.model = model

--- a/pymc3/tests/test_shared.py
+++ b/pymc3/tests/test_shared.py
@@ -1,0 +1,17 @@
+import pymc3 as pm
+import numpy as np 
+import theano
+
+def test_deterministic():
+    with pm.Model() as model:
+
+        data_values = np.array([.5,.4,5,2])
+
+        X = theano.shared(np.asarray(data_values,
+            dtype=theano.config.floatX),
+            borrow=True)
+
+        y = pm.Normal('y', 0, 1, observed=X)
+
+        model.logp(model.test_point)
+


### PR DESCRIPTION
Shared variables were failing because they can't be turned into constants (see http://stackoverflow.com/questions/30426216/using-theano-shared-variables-with-pymc3). This fixes that and adds a test.
