### PR TITLE
Test whether we are running in IPython before importing widgets

### DIFF
--- a/pymc3/interactive_sampling.py
+++ b/pymc3/interactive_sampling.py
@@ -1,4 +1,5 @@
 try:
+    __IPYTHON__
     import IPython
     from IPython.html import widgets
     from IPython.core import display
@@ -8,6 +9,8 @@ try:
     import time
     from .backends.base import MultiTrace
     from .sampling import _iter_sample
+except NameError:
+    IPython = False
 except ImportError:
     IPython = False
 

--- a/pymc3/interactive_sampling.py
+++ b/pymc3/interactive_sampling.py
@@ -9,9 +9,7 @@ try:
     import time
     from .backends.base import MultiTrace
     from .sampling import _iter_sample
-except NameError:
-    IPython = False
-except ImportError:
+except (NameError, ImportError):
     IPython = False
 
 _no_notebook_error_message = "nbsample can only be run inside IPython Notebook."

--- a/pymc3/progressbar.py
+++ b/pymc3/progressbar.py
@@ -9,7 +9,10 @@ import sys
 import time
 import uuid
 try:
+    __IPYTHON__
     from IPython.core.display import HTML, Javascript, display
+except NameError:
+    pass
 except ImportError:
     pass
 

--- a/pymc3/progressbar.py
+++ b/pymc3/progressbar.py
@@ -11,9 +11,7 @@ import uuid
 try:
     __IPYTHON__
     from IPython.core.display import HTML, Javascript, display
-except NameError:
-    pass
-except ImportError:
+except (NameError, ImportError):
     pass
 
 __all__ = ['progress_bar']


### PR DESCRIPTION
Re:  Finish IPython notebook progress bar #429 

Avoiding IPython imports when we are not running inside IPython has a couple of advantages:
1. should lower resource usage by not importing unused packages.
1. no surprise IPython warnings when you are just running python shell.

I have kept the import logic here to the minimum.  3 test cases I have tried:
1. python command line:  IPython warnings and unnecessary IPython imports avoided.
2. IPython terminal: same (widget warning)
3. IPython notebook: same (widget warning)

The test currently checks `__IPYTHON__`.  It could be made to differentiate between case 2 and 3 if the test checked the value of `get_ipython()` however it would rely on assumptions about the object name returned.

If this request is accepted, I can fine tune the progressbar logic (ref #707) and maybe even fix #429.
