### PR TITLE
ignore non finite default values unless manually specified

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -451,6 +451,7 @@ class Pareto(PositiveContinuous):
         self.alpha = alpha
         self.m = m
         self.mean = switch(gt(alpha,1), alpha * m / (alpha - 1.), inf)
+        self.median = m * 2.**(1./alpha)
         self.variance = switch(gt(alpha,2), (alpha * m**2) / ((alpha - 2.) * (alpha - 1.)**2), inf)
 
     def logp(self, value):

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -42,17 +42,21 @@ class Distribution(object):
     def default(self):
         return self.get_test_val(self.testval, self.defaults)
 
+
     def get_test_val(self, val, defaults):
         if val is None:
             for v in defaults:
-                if hasattr(self, v):
-                    val = getattr(self, v)
-                    break
-
+                if hasattr(self, v) and np.all(np.isfinite(self.getattr_value(v))):
+                    return self.getattr_value(v)
+        else:
+            return self.getattr_value(val)
+                        
         if val is None:
             raise AttributeError(str(self) + " has no default value to use, checked for: " +
                          str(defaults) + " pass testval argument or provide one of these.")
 
+
+    def getattr_value(self, val):
         if isinstance(val, str):
             val = getattr(self, val)
 
@@ -67,13 +71,13 @@ def TensorType(dtype, shape):
 
 class Discrete(Distribution):
     """Base class for discrete distributions"""
-    def __init__(self, shape=(), dtype='int64', *args, **kwargs):
-        super(Discrete, self).__init__(shape, dtype, defaults=['mode'], *args, **kwargs)
+    def __init__(self, shape=(), dtype='int64', defaults=['mode'], *args, **kwargs):
+        super(Discrete, self).__init__(shape, dtype, defaults=defaults, *args, **kwargs)
 
 class Continuous(Distribution):
     """Base class for continuous distributions"""
-    def __init__(self, shape=(), dtype='float64', *args, **kwargs):
-        super(Continuous, self).__init__(shape, dtype, defaults=['median', 'mean', 'mode'], *args, **kwargs)
+    def __init__(self, shape=(), dtype='float64', defaults=['median', 'mean', 'mode'], *args, **kwargs):
+        super(Continuous, self).__init__(shape, dtype, defaults=defaults, *args, **kwargs)
 
 class DensityDist(Distribution):
     """Distribution based on a given log density function."""

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -52,8 +52,8 @@ class Distribution(object):
             return self.getattr_value(val)
                         
         if val is None:
-            raise AttributeError(str(self) + " has no default value to use, checked for: " +
-                         str(defaults) + " pass testval argument or provide one of these.")
+            raise AttributeError(str(self) + " has no finite default value to use, checked: " +
+                         str(defaults) + " pass testval argument or adjust so value is finite.")
 
 
     def getattr_value(self, val):

--- a/pymc3/tests/test_distribution_defaults.py
+++ b/pymc3/tests/test_distribution_defaults.py
@@ -1,0 +1,53 @@
+from __future__ import division
+
+from .checks import *
+from pymc3 import *
+from numpy import array, inf
+from nose.tools import raises
+
+class DistTest(Continuous):
+    def __init__(self, a, b, *args, **kwargs):
+        super(DistTest, self).__init__(*args, **kwargs)
+        self.a = a
+        self.b = b 
+
+    def logp(self, v):
+        return 0
+
+
+@raises(AttributeError)
+def test_default_nan_fail():
+    with Model() as model:
+        x = DistTest('x', np.nan, 2, defaults=['a'])
+
+
+@raises(AttributeError)
+def test_default_empty_fail():
+    with Model() as model:
+        x = DistTest('x', 1, 2, defaults=[])
+
+def test_default_testval():
+    with Model() as model:
+        x = DistTest('x', 1, 2, testval=5, defaults=[])
+        assert x.tag.test_value == 5
+
+def test_default_testval_nan():
+    with Model() as model:
+        x = DistTest('x', 1,2, testval=np.nan, defaults=['a'])
+        np.testing.assert_almost_equal(x.tag.test_value, np.nan)
+
+def test_default_a():
+    with Model() as model:
+        x = DistTest('x', 1, 2, defaults=['a'])
+        assert x.tag.test_value == 1
+
+def test_default_b():
+    with Model() as model:
+        x = DistTest('x', np.nan, 2, defaults=['a', 'b'])
+        assert x.tag.test_value == 2
+
+def test_default_b():
+    with Model() as model:
+        y = DistTest('y', 7, 8, testval=94)
+        x = DistTest('x', y, 2, defaults=['a', 'b'])
+        assert x.tag.test_value == 94


### PR DESCRIPTION
We've had some problems with nans propagating through.
