### PR TITLE
test_sqlite_backend.py: Don't hardcode /tmp

### DIFF
--- a/pymc3/tests/test_sqlite_backend.py
+++ b/pymc3/tests/test_sqlite_backend.py
@@ -1,48 +1,52 @@
 import numpy.testing as npt
+import os
 from pymc3.tests import backend_fixtures as bf
 from pymc3.backends import ndarray, sqlite
+import tempfile
+
+DBNAME = os.path.join(tempfile.gettempdir(), 'test.db')
 
 
 class TestSQlite0dSampling(bf.SamplingTestCase):
     backend = sqlite.SQLite
-    name = '/tmp/test.db'
+    name = DBNAME
     shape = ()
 
 
 class TestSQlite1dSampling(bf.SamplingTestCase):
     backend = sqlite.SQLite
-    name = '/tmp/test.db'
+    name = DBNAME
     shape = 2
 
 
 class TestSQlite2dSampling(bf.SamplingTestCase):
     backend = sqlite.SQLite
-    name = '/tmp/test.db'
+    name = DBNAME
     shape = (2, 3)
 
 
 class TestSQLite0dSelection(bf.SelectionNoSliceTestCase):
     backend = sqlite.SQLite
-    name = '/tmp/test.db'
+    name = DBNAME
     shape = ()
 
 
 class TestSQLite1dSelection(bf.SelectionNoSliceTestCase):
     backend = sqlite.SQLite
-    name = '/tmp/test.db'
+    name = DBNAME
     shape = 2
 
 
 class TestSQLite2dSelection(bf.SelectionNoSliceTestCase):
     backend = sqlite.SQLite
-    name = '/tmp/test.db'
+    name = DBNAME
     shape = (2, 3)
 
 
 class TestSQLiteDumpLoad(bf.DumpLoadTestCase):
     backend = sqlite.SQLite
     load_func = staticmethod(sqlite.load)
-    name = '/tmp/test.db'
+    name = DBNAME
     shape = (2, 3)
 
 
@@ -50,7 +54,7 @@ class TestNDArraySqliteEquality(bf.BackendEqualityTestCase):
     backend0 = ndarray.NDArray
     name0 = None
     backend1 = sqlite.SQLite
-    name1 = '/tmp/test.db'
+    name1 = DBNAME
     shape = (2, 3)
 
 


### PR DESCRIPTION
Commit 85b53d4c08 changed the location of the test sqlite file from
the PWD to /tmp.  (I believe this was because, due to permission
issues, the file was not being removed, and subsequent tests were
failing as a result).

Use tempfile.gettempdir to be more portable.
