### PR TITLE
(not ready) Speed up Metropolis and NUTS

### DIFF
--- a/pymc3/blocking.py
+++ b/pymc3/blocking.py
@@ -8,7 +8,7 @@ import collections
 
 __all__ = ['ArrayOrdering', 'DictToArrayBijection', 'DictToVarBijection']
 
-VarMap = collections.namedtuple('VarMap', 'var, slc, shp')
+VarMap = collections.namedtuple('VarMap', 'var, slc, shp, dtyp')
 
 # TODO Classes and methods need to be fully documented.
 
@@ -23,7 +23,7 @@ class ArrayOrdering(object):
 
         for var in vars:
             slc = slice(dim, dim + var.dsize)
-            self.vmap.append(VarMap(str(var), slc, var.dshape))
+            self.vmap.append(VarMap(str(var), slc, var.dshape, var.dtype))
             dim += var.dsize
 
         self.dimensions = dim
@@ -46,7 +46,7 @@ class DictToArrayBijection(object):
         dpt : dict
         """
         apt = np.empty(self.ordering.dimensions)
-        for var, slc, _ in self.ordering.vmap:
+        for var, slc, _, _ in self.ordering.vmap:
                 apt[slc] = dpt[var].ravel()
         return apt
 
@@ -60,8 +60,8 @@ class DictToArrayBijection(object):
         """
         dpt = self.dpt.copy()
 
-        for var, slc, shp in self.ordering.vmap:
-            dpt[var] = apt[slc].reshape(shp)
+        for var, slc, shp, dtyp in self.ordering.vmap:
+            dpt[var] = apt[slc].reshape(shp).astype(dtyp)
 
         return dpt
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -219,7 +219,9 @@ class Model(Context, Factor):
         Returns
         -------
         Compiled Theano function as point function."""
-        return FastPointFunc(self.makefn(outs, mode, *args, **kwargs))
+        f = self.makefn(outs, mode, *args, **kwargs)
+        f.trust_input = True
+        return FastPointFunc(f)
 
     def profile(self, outs, n=1000, point=None, profile=True, *args, **kwargs):
         """Compiles and profiles a Theano function which returns `outs` and takes values of model
@@ -311,7 +313,8 @@ class FastPointFunc(object):
         self.f = f
 
     def __call__(self, state):
-        return self.f(**state)
+        inputs = [state[ind[0].name] for ind in self.f.indices]
+        return self.f(*inputs)
 
 class LoosePointFunc(object):
     """Wraps so a function so it takes a dict of arguments instead of arguments

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -154,12 +154,15 @@ class Model(Context, Factor):
             if var.missing_values:
                 self.free_RVs += var.missing_values
                 self.missing_values += var.missing_values
+                for v in var.missing_values:
+                    self.named_vars[v.name] = v
         else: 
             var = ObservedRV(name=name, data=data, distribution=dist, model=self)
             self.observed_RVs.append(var)
             if var.missing_values:
                 self.free_RVs.append(var.missing_values)
                 self.missing_values.append(var.missing_values)
+                self.named_vars[var.missing_values.name] = var.missing_values
 
         self.add_random_variable(var)
         return var

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.random import uniform
 from numpy import log, isfinite
 
-__all__ = ['ArrayStep', 'metrop_select', 'SamplerHist']
+__all__ = ['ArrayStep', 'ArrayStepSpecial', 'metrop_select', 'SamplerHist']
 
 # TODO Add docstrings to ArrayStep
 
@@ -63,6 +63,56 @@ class ArrayStep(object):
         apoint = self.astep(bij.map(point), *inputs)
         return bij.rmap(apoint)
 
+class ArrayStepSpecial(object):
+    def __new__(cls, *args, **kwargs):
+        blocked = kwargs.get('blocked')
+        if blocked is None:
+            # Try to look up default value from class
+            blocked = getattr(cls, 'default_blocked', True)
+            kwargs['blocked'] = blocked
+
+        model = modelcontext(kwargs.get('model'))
+
+        # vars can either be first arg or a kwarg
+        if 'vars' not in kwargs and len(args) >= 1:
+            vars = args[0]
+            args = args[1:]
+        elif 'vars' in kwargs:
+            vars = kwargs.pop('vars')
+        else: # Assume all model variables
+            vars = model.vars
+
+        #get the actual inputs from the vars
+        vars = inputvars(vars) 
+
+        if not blocked and len(vars) > 1:
+            # In this case we create a separate sampler for each var
+            # and append them to a CompoundStep
+            steps = []
+            for var in vars:
+                step = super(ArrayStep, cls).__new__(cls)
+                # If we don't return the instance we have to manually
+                # call __init__
+                step.__init__([var], *args, **kwargs)
+                steps.append(step)
+
+            return CompoundStep(steps)
+        else:
+            return super(ArrayStepSpecial, cls).__new__(cls)
+
+    def __init__(self, vars, shared, blocked=True):
+        self.ordering = ArrayOrdering(vars)
+        self.shared = shared
+        self.blocked = blocked
+
+    def step(self, point):
+        for var, share in self.shared.items():
+            share.set_value(point[var])
+
+        bij = DictToArrayBijection(self.ordering, point)
+
+        apoint = self.astep(bij.map(point))
+        return bij.rmap(apoint)
 
 def metrop_select(mr, q, q0):
     # Perform rejection/acceptance step for Metropolis class samplers

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -107,7 +107,7 @@ class ArrayStepSpecial(object):
 
     def step(self, point):
         for var, share in self.shared.items():
-            share.set_value(point[var])
+            share.set_value(point[var], borrow=True)
 
         bij = DictToArrayBijection(self.ordering, point)
 

--- a/pymc3/step_methods/hmc.py
+++ b/pymc3/step_methods/hmc.py
@@ -92,6 +92,8 @@ class HamiltonianMC(ArrayStep):
         return metrop_select(mr, q, q0)
 
 
+    
+
 
 def bern(p):
     return np.random.uniform() < p

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -106,10 +106,12 @@ class Metropolis(ArrayStep):
         if self.any_discrete:
             if self.all_discrete:
                 delta = round(delta, 0).astype(int)
+                q0 = q0.astype(int)
+                q = (q0 + delta).astype(int)
             else:
                 delta[self.discrete] = round(delta[self.discrete], 0).astype(int)
+                q = q0 + delta
 
-        q = q0 + delta
 
         q_new = metrop_select(logp(q) - logp(q0), q, q0)
 

--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -5,10 +5,13 @@ from numpy import exp, log
 from numpy.random import uniform
 from .hmc import leapfrog, Hamiltonian, bern, energy
 from ..tuning import guess_scaling
+import theano
+from  .. import theanof 
+import theano.tensor
 
 __all__ = ['NUTS']
 
-class NUTS(ArrayStep):
+class NUTS(ArrayStepSpecial):
     """
     Automatically tunes step size and adjust number of steps for good performance.
 
@@ -85,10 +88,13 @@ class NUTS(ArrayStep):
 
 
 
-        super(NUTS, self).__init__(vars, [model.fastlogp, model.fastdlogp(vars)], **kwargs)
+        shared = get_shared(vars, model)
+        self.logp = special_logp(model.logpt, vars, shared, model)
+        self.dlogp = special_dlogp(theanof.gradient(model.logpt, vars), vars, shared, model)
+        super(NUTS, self).__init__(vars, shared, **kwargs)
 
-    def astep(self, q0, logp, dlogp):
-        H = Hamiltonian(logp, dlogp, self.potential)
+    def astep(self, q0):
+        H = Hamiltonian(self.logp, self.dlogp, self.potential)
         Emax = self.Emax
         e = self.step_size
 
@@ -130,10 +136,11 @@ class NUTS(ArrayStep):
 def buildtree(H, q, p, u, v, j, e, Emax, q0, p0):
     if j == 0:
         q1, p1 = leapfrog(H, q, p, 1, v*e)
-        E = energy(H, q1, p1)
-        E0 = energy(H, q0, p0)
+        #E = energy(H, q1, p1)
+        #E0 = energy(H, q0, p0)
 
-        dE = E - E0
+
+        dE = denergy(H, q1, p1, q0, p0) #E - E0
 
         n1 = int(log(u) + dE <= 0)
         s1 = int(log(u) + dE < Emax)
@@ -157,3 +164,77 @@ def buildtree(H, q, p, u, v, j, e, Emax, q0, p0):
             n1 = n1 + n11
         return qn, pn, qp, pp, q1, n1, s1, a1, na1
     return
+
+
+def get_shared(vars, model):
+    othervars = set(model.vars) - set(vars)
+    return {var.name : theano.shared(var.tag.test_value, var.name + '_shared') for var in othervars }
+
+def specialize(xs, vars, shared, model):
+    inarray = theano.tensor.dvector('inarray')
+    ordering = ArrayOrdering(vars)
+    inarray.tag.test_value = np.concatenate([var.tag.test_value.ravel() for var in vars])
+    
+    replace = {
+        model[var] : reshape_t(inarray[slc], shp).astype(dtyp)
+        for var, slc, shp, dtyp in ordering.vmap }
+
+    shared = { model[var] : value for var, value in shared.items() }
+    replace.update(shared)
+
+    
+    xs_special = [theano.clone(x, replace, strict=False) for x in xs]
+    return xs_special, inarray
+
+def reshape_t(x, shape):
+    if shape:   return x.reshape(shape)
+    else:       return x[0]
+        
+
+def special_logp(logp, vars, shared, model):
+    
+    logp0, inarray0 = specialize(logp, vars, shared, model)
+
+    inarray1 = theano.tensor.dvector('inarray1')
+    inarray1.tag.test_value = inarray0.tag.test_value
+    logp1 = theano.clone(logp0, { inarray0 : inarray1}, strict=False)
+
+    f = theano.function([inarray1, inarray0], logp1 - logp0)
+
+    f.trust_input = True
+    return f
+
+def special_dlogp(dlogp, vars, shared, model):
+    dlogp, inarray = specialize(dlogp, vars, shared, model)
+    f =  theano.function([inarray], dlogp)
+    f.trust_input = True
+    return f
+
+def denergy(H, q1, p1, q0, p0):
+    return -H.logp(q1, q0) + H.pot.energy(p1) - H.pot.energy(p0)
+
+def special_leapfrog1_dE(logp, dlogp, vars, shared, model, pot, q, p, n, e):
+
+    logp = CallableTensor(logp)
+    dlogp = CallableTensor(dlogp)
+    
+    (logp, dlogp), inarray = specialize([logp, dlogp], vars, shared, model)
+    H = Hamiltonian(logp, dlogp, pot)
+
+    q, p = dvectors('q', 'p')
+    e = dscalar('e')
+
+    q1, p1 = leapfrog(H, q, p, 1, e):
+    E = energy(H, q1, p1)
+    E0 = energy(H, q0, p0)
+    dE = E - E0
+
+    f = theano.function([inarray], [q1, p1, dE])
+    f.trust_input = True
+    return f
+
+class CallableTensor(object):
+    def __init__(self, tensor): 
+        self.tensor = tensor
+    def __call__(self, input):
+        return theano.clone(tensor, { inarray : input }, strict=False)

--- a/pymc3/step_methods/quadpotential.py
+++ b/pymc3/step_methods/quadpotential.py
@@ -86,7 +86,7 @@ class ElemWiseQuadPotential(object):
         return normal(size=self.s.shape) * self.inv_s
 
     def energy(self, x):
-        return .5 * dot(x, self.v * x)
+        return .5 * x.dot(self.v * x)
 
 
 class QuadPotential_Inv(object):

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -125,8 +125,8 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
                          "density. 2) your distribution logp's are " +
                          "properly specified. Specific issues: \n" + 
                          specific_errors)
-    mx = {v.name: np.floor(mx[v.name]) if v.dtype in discrete_types else
-          mx[v.name] for v in model.vars}
+    mx = {v.name: mx[v.name].astype(v.dtype) for v in model.vars}
+
     if return_raw:
         return mx, r
     else:


### PR DESCRIPTION
Addressing https://github.com/pymc-devs/pymc3/issues/739

Using func.trust_inputs=True and using _args instead of *_kwargs is about 100% faster for smallish Metropolis problems and about 15% faster for NUTS (not sure why is not most of a speedup for NUTS).

In NUTS I combined the leapfrog step and the energy computation which lead to a %100 speedup.

I also combined the logp difference in metropolis and got another nice speedup.

I have the theano functions now taking a single array argument of all the combined parameters instead of the wrapping them. This seems to be a bit faster, though currently internally in Theano this uses theano.Split.perform which is in python, and so kind of slow. But hopefully I can get theano to make this into C for a nice speedup.

Also now I'm using shared variables for values not being updated.

I'd like to find a way to theanoize the whole NUTS buildtree function or at least larger chunks of it. I think that will lead to a huge speedup. I'll have to go back and look at the NUTS paper to see how it can be sped up.
