### PR TITLE
Tweak trace __getitem__

### DIFF
--- a/pymc3/backends/__init__.py
+++ b/pymc3/backends/__init__.py
@@ -36,14 +36,14 @@ The call will return the sampling values of `x`, with the values for
 all chains concatenated. (For a single call to `sample`, the number of
 chains will correspond to the `njobs` argument.)
 
-For more control of which values are returned, the `get_values` method
-can be used. The call below will return values from all chains, burning
-the first 1000 iterations from each chain.
+To discard the first N values of each chain, slicing syntax can be
+used.
 
-    >>> trace.get_values('x', burn=1000)
+    >>> trace['x', 1000:]
 
-Setting the `combine` flag to False will return a list of arrays,
-keeping the results from all the chains separate.
+The `get_values` method offers more control over which values are
+returned. The call below will discard the first 1000 iterations
+from each chain and keep the values for each chain as separate arrays.
 
     >>> trace.get_values('x', burn=1000, combine=False)
 

--- a/pymc3/backends/__init__.py
+++ b/pymc3/backends/__init__.py
@@ -32,9 +32,9 @@ backend object with a variable or variable name.
 
     >>> trace['x']  # or trace.x or trace[x]
 
-The call will return a list containing the sampling values of `x` for
-all chains. (For a single call to `sample`, the number of chains will
-correspond to the `njobs` argument.)
+The call will return the sampling values of `x`, with the values for
+all chains concatenated. (For a single call to `sample`, the number of
+chains will correspond to the `njobs` argument.)
 
 For more control of which values are returned, the `get_values` method
 can be used. The call below will return values from all chains, burning
@@ -42,15 +42,15 @@ the first 1000 iterations from each chain.
 
     >>> trace.get_values('x', burn=1000)
 
-Setting the `combine` flag will concatenate the results from all the
-chains.
+Setting the `combine` flag to False will return a list of arrays,
+keeping the results from all the chains separate.
 
-    >>> trace.get_values('x', burn=1000, combine=True)
+    >>> trace.get_values('x', burn=1000, combine=False)
 
 The `chains` parameter of `get_values` can be used to limit the chains
 that are retrieved.
 
-    >>> trace.get_values('x', burn=1000, combine=True, chains=[0, 2])
+    >>> trace.get_values('x', burn=1000, chains=[0, 2])
 
 Some backends also suppport slicing the MultiTrace object. For example,
 the following call would return a new trace object without the first

--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -199,7 +199,7 @@ class MultiTrace(object):
         chain = self.chains[-1]
         return self._traces[chain].varnames
 
-    def get_values(self, varname, burn=0, thin=1, combine=False, chains=None,
+    def get_values(self, varname, burn=0, thin=1, combine=True, chains=None,
                    squeeze=True):
         """Get values from traces.
 

--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -83,12 +83,9 @@ class BaseTrace(object):
             return self._slice(idx)
 
         try:
-            return self.point(idx)
-        except ValueError:
-            pass
-        except TypeError:
-            pass
-        return self.get_values(idx)
+            return self.point(int(idx))
+        except (ValueError, TypeError):  # Passed variable or variable name.
+            raise ValueError('Can only index with slice or integer')
 
     def __len__(self):
         raise NotImplementedError

--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -167,12 +167,21 @@ class MultiTrace(object):
             return self._slice(idx)
 
         try:
-            return self.point(idx)
-        except ValueError:
+            return self.point(int(idx))
+        except (ValueError, TypeError):  # Passed variable or variable name.
             pass
-        except TypeError:
-            pass
-        return self.get_values(idx)
+
+        if isinstance(idx, tuple):
+            var, vslice = idx
+            burn, thin = vslice.start, vslice.step
+            if burn is None:
+                burn = 0
+            if thin is None:
+                thin = 1
+        else:
+            var = idx
+            burn, thin = 0, 1
+        return self.get_values(var, burn=burn, thin=thin)
 
     _attrs = set(['_traces', 'varnames', 'chains'])
 

--- a/pymc3/backends/text.py
+++ b/pymc3/backends/text.py
@@ -239,7 +239,7 @@ def _trace_to_df(trace, flat_names=None):
 
     var_dfs = []
     for varname, shape in trace.var_shapes.items():
-        vals = trace[varname]
+        vals = trace.get_values(varname)
         if len(shape) == 1:
             flat_vals = vals
         else:

--- a/pymc3/diagnostics.py
+++ b/pymc3/diagnostics.py
@@ -159,7 +159,7 @@ def gelman_rubin(mtrace):
     for var in mtrace.varnames:
 
         # Get all traces for var
-        x = np.array(mtrace.get_values(var))
+        x = np.array(mtrace.get_values(var, combine=False))
 
         try:
             Rhat[var] = calc_rhat(x)
@@ -256,7 +256,7 @@ def effective_n(mtrace):
     for var in mtrace.varnames:
 
         # Get all traces for var
-        x = np.array(mtrace.get_values(var))
+        x = np.array(mtrace.get_values(var, combine=False))
 
         try:
             n_eff[var] = calc_n_eff(x)

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -187,7 +187,8 @@ def autocorrplot(trace, vars=None, max_lag=100, burn=0, ax=None):
 
     for i, v in enumerate(vars):
         for j in range(chains):
-            d = np.squeeze(trace.get_values(v, chains=[j], burn=burn))
+            d = np.squeeze(trace.get_values(v, chains=[j], burn=burn,
+                                            combine=False))
 
             ax[i, j].acorr(d, detrend=plt.mlab.detrend_mean, maxlags=max_lag)
 

--- a/pymc3/tests/backend_fixtures.py
+++ b/pymc3/tests/backend_fixtures.py
@@ -115,17 +115,17 @@ class SamplingTestCase(ModelBackendSetupTestCase):
         self.trace.close()
 
         for varname in self.test_point.keys():
-            npt.assert_equal(self.trace[varname][0, ...],
+            npt.assert_equal(self.trace.get_values(varname)[0, ...],
                              np.zeros(self.trace.var_shapes[varname]))
             last_idx = self.draws - 1
-            npt.assert_equal(self.trace[varname][last_idx, ...],
+            npt.assert_equal(self.trace.get_values(varname)[last_idx, ...],
                              np.tile(last_idx, self.trace.var_shapes[varname]))
 
     def test_clean_interrupt(self):
         self.trace.record(point=self.test_point)
         self.trace.close()
         for varname in self.test_point.keys():
-            self.assertEqual(self.trace[varname].shape[0], 1)
+            self.assertEqual(self.trace.get_values(varname).shape[0], 1)
 
 
 class SelectionTestCase(ModelBackendSampledTestCase):

--- a/pymc3/tests/backend_fixtures.py
+++ b/pymc3/tests/backend_fixtures.py
@@ -138,16 +138,17 @@ class SelectionTestCase(ModelBackendSampledTestCase):
     """
     def test_get_values_default(self):
         for varname in self.test_point.keys():
-            expected = [self.expected[0][varname], self.expected[1][varname]]
+            expected = np.concatenate([self.expected[chain][varname]
+                                       for chain in [0, 1]])
             result = self.mtrace.get_values(varname)
             npt.assert_equal(result, expected)
 
-    def test_get_values_burn_keyword(self):
+    def test_get_values_nocombine_burn_keyword(self):
         burn = 2
         for varname in self.test_point.keys():
             expected = [self.expected[0][varname][burn:],
                         self.expected[1][varname][burn:]]
-            result = self.mtrace.get_values(varname, burn=burn)
+            result = self.mtrace.get_values(varname, burn=burn, combine=False)
             npt.assert_equal(result, expected)
 
     def test_len(self):
@@ -158,12 +159,12 @@ class SelectionTestCase(ModelBackendSampledTestCase):
             self.assertEqual(self.expected[0][varname].dtype,
                              self.mtrace.get_values(varname, chains=0).dtype)
 
-    def test_get_values_thin_keyword(self):
+    def test_get_values_nocombine_thin_keyword(self):
         thin = 2
         for varname in self.test_point.keys():
             expected = [self.expected[0][varname][::thin],
                         self.expected[1][varname][::thin]]
-            result = self.mtrace.get_values(varname, thin=thin)
+            result = self.mtrace.get_values(varname, thin=thin, combine=False)
             npt.assert_equal(result, expected)
 
     def test_get_point(self):
@@ -190,10 +191,11 @@ class SelectionTestCase(ModelBackendSampledTestCase):
             result = self.mtrace.get_values(varname, chains=[0])
             npt.assert_equal(result, expected)
 
-    def test_get_values_chains_reversed(self):
+    def test_get_values_nocombine_chains_reversed(self):
         for varname in self.test_point.keys():
             expected = [self.expected[1][varname], self.expected[0][varname]]
-            result = self.mtrace.get_values(varname, chains=[1, 0])
+            result = self.mtrace.get_values(varname, chains=[1, 0],
+                                            combine=False)
             npt.assert_equal(result, expected)
 
     def test_nchains(self):
@@ -322,8 +324,10 @@ class BackendEqualityTestCase(ModelBackendSampledTestCase):
 
     def test_number_of_draws(self):
         for varname in self.test_point.keys():
-            values0 = self.mtrace0.get_values(varname, squeeze=False)
-            values1 = self.mtrace1.get_values(varname, squeeze=False)
+            values0 = self.mtrace0.get_values(varname, combine=False,
+                                              squeeze=False)
+            values1 = self.mtrace1.get_values(varname, combine=False,
+                                              squeeze=False)
             assert values0[0].shape[0] == self.draws
             assert values1[0].shape[0] == self.draws
 

--- a/pymc3/tests/backend_fixtures.py
+++ b/pymc3/tests/backend_fixtures.py
@@ -229,6 +229,18 @@ class SelectionTestCase(ModelBackendSampledTestCase):
             result = self.mtrace.get_values(varname, combine=True, thin=thin)
             npt.assert_equal(result, expected)
 
+    def test_getitem_equivalence(self):
+        mtrace = self.mtrace
+        for varname in self.test_point.keys():
+            npt.assert_equal(mtrace[varname],
+                             mtrace.get_values(varname, combine=True))
+            npt.assert_equal(mtrace[varname, 2:],
+                             mtrace.get_values(varname, burn=2,
+                                               combine=True))
+            npt.assert_equal(mtrace[varname, 2::2],
+                             mtrace.get_values(varname, burn=2, thin=2,
+                                               combine=True))
+
     def test_selection_method_equivalence(self):
         varname = self.mtrace.varnames[0]
         mtrace = self.mtrace


### PR DESCRIPTION
The first commit makes the change proposed in #759.  

The last commit adds support for slicing when indexing with a variable.

```
trace[x, start::step]
```

Since chain values will now be combined by default, this provides an easy way to  burn and thin the values for the chains (versus the combined array).
