### PR TITLE
Speedup Metropolis and NUTS

### DIFF
--- a/pymc3/blocking.py
+++ b/pymc3/blocking.py
@@ -8,7 +8,7 @@ import collections
 
 __all__ = ['ArrayOrdering', 'DictToArrayBijection', 'DictToVarBijection']
 
-VarMap = collections.namedtuple('VarMap', 'var, slc, shp')
+VarMap = collections.namedtuple('VarMap', 'var, slc, shp, dtyp')
 
 # TODO Classes and methods need to be fully documented.
 
@@ -23,7 +23,7 @@ class ArrayOrdering(object):
 
         for var in vars:
             slc = slice(dim, dim + var.dsize)
-            self.vmap.append(VarMap(str(var), slc, var.dshape))
+            self.vmap.append(VarMap(str(var), slc, var.dshape, var.dtype))
             dim += var.dsize
 
         self.dimensions = dim
@@ -46,7 +46,7 @@ class DictToArrayBijection(object):
         dpt : dict
         """
         apt = np.empty(self.ordering.dimensions)
-        for var, slc, _ in self.ordering.vmap:
+        for var, slc, _, _ in self.ordering.vmap:
                 apt[slc] = dpt[var].ravel()
         return apt
 
@@ -60,8 +60,8 @@ class DictToArrayBijection(object):
         """
         dpt = self.dpt.copy()
 
-        for var, slc, shp in self.ordering.vmap:
-            dpt[var] = apt[slc].reshape(shp)
+        for var, slc, shp, dtyp in self.ordering.vmap:
+            dpt[var] = apt[slc].reshape(shp).astype(dtyp)
 
         return dpt
 

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -222,7 +222,7 @@ class LKJCorr(Continuous):
     def __init__(self, n, p, *args, **kwargs):
         self.n = n
         self.p = p
-        n_elem = p * (p - 1) / 2
+        n_elem = int(p * (p - 1) / 2)
         self.mean = np.zeros(n_elem)
         super(LKJCorr, self).__init__(shape=n_elem, *args, **kwargs)
 

--- a/pymc3/examples/LKJ_correlation.py
+++ b/pymc3/examples/LKJ_correlation.py
@@ -27,7 +27,7 @@ dataset = multivariate_normal(mu, cov_matrix, size=n_obs)
 
 # In order to convert the upper triangular correlation values to a complete
 # correlation matrix, we need to construct an index matrix:
-n_elem = n_var * (n_var - 1) / 2
+n_elem = int(n_var * (n_var - 1) / 2)
 tri_index = np.zeros([n_var, n_var], dtype=int)
 tri_index[np.triu_indices(n_var, k=1)] = np.arange(n_elem)
 tri_index[np.triu_indices(n_var, k=1)[::-1]] = np.arange(n_elem)

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -154,12 +154,15 @@ class Model(Context, Factor):
             if var.missing_values:
                 self.free_RVs += var.missing_values
                 self.missing_values += var.missing_values
+                for v in var.missing_values:
+                    self.named_vars[v.name] = v
         else: 
             var = ObservedRV(name=name, data=data, distribution=dist, model=self)
             self.observed_RVs.append(var)
             if var.missing_values:
                 self.free_RVs.append(var.missing_values)
                 self.missing_values.append(var.missing_values)
+                self.named_vars[var.missing_values.name] = var.missing_values
 
         self.add_random_variable(var)
         return var
@@ -219,7 +222,9 @@ class Model(Context, Factor):
         Returns
         -------
         Compiled Theano function as point function."""
-        return FastPointFunc(self.makefn(outs, mode, *args, **kwargs))
+        f = self.makefn(outs, mode, *args, **kwargs)
+        f.trust_input = True
+        return FastPointFunc(f)
 
     def profile(self, outs, n=1000, point=None, profile=True, *args, **kwargs):
         """Compiles and profiles a Theano function which returns `outs` and takes values of model
@@ -311,7 +316,8 @@ class FastPointFunc(object):
         self.f = f
 
     def __call__(self, state):
-        return self.f(**state)
+        inputs = [state[ind[0].name] for ind in self.f.indices]
+        return self.f(*inputs)
 
 class LoosePointFunc(object):
     """Wraps so a function so it takes a dict of arguments instead of arguments

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -223,7 +223,6 @@ class Model(Context, Factor):
         -------
         Compiled Theano function as point function."""
         f = self.makefn(outs, mode, *args, **kwargs)
-        f.trust_input = True
         return FastPointFunc(f)
 
     def profile(self, outs, n=1000, point=None, profile=True, *args, **kwargs):
@@ -316,8 +315,7 @@ class FastPointFunc(object):
         self.f = f
 
     def __call__(self, state):
-        inputs = [state[ind[0].name] for ind in self.f.indices]
-        return self.f(*inputs)
+        return self.f(**state)
 
 class LoosePointFunc(object):
     """Wraps so a function so it takes a dict of arguments instead of arguments

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.random import uniform
 from numpy import log, isfinite
 
-__all__ = ['ArrayStep', 'metrop_select', 'SamplerHist']
+__all__ = ['ArrayStep', 'ArrayStepSpecial', 'metrop_select', 'SamplerHist']
 
 # TODO Add docstrings to ArrayStep
 
@@ -63,6 +63,56 @@ class ArrayStep(object):
         apoint = self.astep(bij.map(point), *inputs)
         return bij.rmap(apoint)
 
+class ArrayStepSpecial(object):
+    def __new__(cls, *args, **kwargs):
+        blocked = kwargs.get('blocked')
+        if blocked is None:
+            # Try to look up default value from class
+            blocked = getattr(cls, 'default_blocked', True)
+            kwargs['blocked'] = blocked
+
+        model = modelcontext(kwargs.get('model'))
+
+        # vars can either be first arg or a kwarg
+        if 'vars' not in kwargs and len(args) >= 1:
+            vars = args[0]
+            args = args[1:]
+        elif 'vars' in kwargs:
+            vars = kwargs.pop('vars')
+        else: # Assume all model variables
+            vars = model.vars
+
+        #get the actual inputs from the vars
+        vars = inputvars(vars) 
+
+        if not blocked and len(vars) > 1:
+            # In this case we create a separate sampler for each var
+            # and append them to a CompoundStep
+            steps = []
+            for var in vars:
+                step = super(ArrayStep, cls).__new__(cls)
+                # If we don't return the instance we have to manually
+                # call __init__
+                step.__init__([var], *args, **kwargs)
+                steps.append(step)
+
+            return CompoundStep(steps)
+        else:
+            return super(ArrayStepSpecial, cls).__new__(cls)
+
+    def __init__(self, vars, shared, blocked=True):
+        self.ordering = ArrayOrdering(vars)
+        self.shared = shared
+        self.blocked = blocked
+
+    def step(self, point):
+        for var, share in self.shared.items():
+            share.set_value(point[var])
+
+        bij = DictToArrayBijection(self.ordering, point)
+
+        apoint = self.astep(bij.map(point))
+        return bij.rmap(apoint)
 
 def metrop_select(mr, q, q0):
     # Perform rejection/acceptance step for Metropolis class samplers

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -107,7 +107,7 @@ class ArrayStepSpecial(object):
 
     def step(self, point):
         for var, share in self.shared.items():
-            share.set_value(point[var])
+            share.set_value(point[var], borrow=True)
 
         bij = DictToArrayBijection(self.ordering, point)
 

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -5,12 +5,12 @@ import numpy as np
 from numpy.random import uniform
 from numpy import log, isfinite
 
-__all__ = ['ArrayStep', 'ArrayStepSpecial', 'metrop_select', 'SamplerHist']
+__all__ = ['ArrayStep', 'FastArrayStep', 'metrop_select', 'SamplerHist']
 
 # TODO Add docstrings to ArrayStep
 
 
-class ArrayStep(object):
+class BlockedStep(object):
     def __new__(cls, *args, **kwargs):
         blocked = kwargs.get('blocked')
         if blocked is None:
@@ -37,7 +37,7 @@ class ArrayStep(object):
             # and append them to a CompoundStep
             steps = []
             for var in vars:
-                step = super(ArrayStep, cls).__new__(cls)
+                step = super(BlockedStep, cls).__new__(cls)
                 # If we don't return the instance we have to manually
                 # call __init__
                 step.__init__([var], *args, **kwargs)
@@ -45,8 +45,9 @@ class ArrayStep(object):
 
             return CompoundStep(steps)
         else:
-            return super(ArrayStep, cls).__new__(cls)
+            return super(BlockedStep, cls).__new__(cls)
 
+class ArrayStep(BlockedStep):
     def __init__(self, vars, fs, allvars=False, blocked=True):
         self.ordering = ArrayOrdering(vars)
         self.fs = fs
@@ -63,51 +64,24 @@ class ArrayStep(object):
         apoint = self.astep(bij.map(point), *inputs)
         return bij.rmap(apoint)
 
-class ArrayStepSpecial(object):
-    def __new__(cls, *args, **kwargs):
-        blocked = kwargs.get('blocked')
-        if blocked is None:
-            # Try to look up default value from class
-            blocked = getattr(cls, 'default_blocked', True)
-            kwargs['blocked'] = blocked
-
-        model = modelcontext(kwargs.get('model'))
-
-        # vars can either be first arg or a kwarg
-        if 'vars' not in kwargs and len(args) >= 1:
-            vars = args[0]
-            args = args[1:]
-        elif 'vars' in kwargs:
-            vars = kwargs.pop('vars')
-        else: # Assume all model variables
-            vars = model.vars
-
-        #get the actual inputs from the vars
-        vars = inputvars(vars) 
-
-        if not blocked and len(vars) > 1:
-            # In this case we create a separate sampler for each var
-            # and append them to a CompoundStep
-            steps = []
-            for var in vars:
-                step = super(ArrayStep, cls).__new__(cls)
-                # If we don't return the instance we have to manually
-                # call __init__
-                step.__init__([var], *args, **kwargs)
-                steps.append(step)
-
-            return CompoundStep(steps)
-        else:
-            return super(ArrayStepSpecial, cls).__new__(cls)
-
+class FastArrayStep(BlockedStep):
+    """Faster version of ArrayStep that requires the substep method that does not wrap the functions the step method uses.
+    """
     def __init__(self, vars, shared, blocked=True):
+        """
+        Parameters
+        ----------
+        vars : list of sampling variables
+        shared : dict of theano variable -> shared variable
+        blocked : Boolean (default True)
+        """
         self.ordering = ArrayOrdering(vars)
-        self.shared = shared
+        self.shared = { str(var) : shared for var, shared in shared.items() }
         self.blocked = blocked
 
     def step(self, point):
         for var, share in self.shared.items():
-            share.set_value(point[var], borrow=True)
+            share.container.storage[0] = point[var]
 
         bij = DictToArrayBijection(self.ordering, point)
 

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.random import uniform
 from numpy import log, isfinite
 
-__all__ = ['ArrayStep', 'FastArrayStep', 'metrop_select', 'SamplerHist']
+__all__ = ['ArrayStep', 'ArrayStepShared', 'metrop_select', 'SamplerHist']
 
 # TODO Add docstrings to ArrayStep
 
@@ -64,8 +64,11 @@ class ArrayStep(BlockedStep):
         apoint = self.astep(bij.map(point), *inputs)
         return bij.rmap(apoint)
 
-class FastArrayStep(BlockedStep):
+class ArrayStepShared(BlockedStep):
     """Faster version of ArrayStep that requires the substep method that does not wrap the functions the step method uses.
+
+    Works by setting shared variables before using the step. This eliminates the mapping and unmapping overhead as well 
+    as moving fewer variables around.
     """
     def __init__(self, vars, shared, blocked=True):
         """

--- a/pymc3/step_methods/hmc.py
+++ b/pymc3/step_methods/hmc.py
@@ -92,6 +92,8 @@ class HamiltonianMC(ArrayStep):
         return metrop_select(mr, q, q0)
 
 
+    
+
 
 def bern(p):
     return np.random.uniform() < p

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -106,10 +106,12 @@ class Metropolis(ArrayStep):
         if self.any_discrete:
             if self.all_discrete:
                 delta = round(delta, 0).astype(int)
+                q0 = q0.astype(int)
+                q = (q0 + delta).astype(int)
             else:
                 delta[self.discrete] = round(delta[self.discrete], 0).astype(int)
+                q = q0 + delta
 
-        q = q0 + delta
 
         q_new = metrop_select(logp(q) - logp(q0), q, q0)
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -6,8 +6,9 @@ from .quadpotential import quad_potential
 from .arraystep import *
 from numpy.random import normal, standard_cauchy, standard_exponential, poisson, random
 from numpy import round, exp, copy, where
-from .nuts import special_logp, get_shared
 import theano
+
+from ..theanof import make_shared_replacements, join_nonshared_inputs, CallableTensor
 
 
 __all__ = ['Metropolis', 'BinaryMetropolis', 'NormalProposal', 'CauchyProposal', 'LaplaceProposal', 'PoissonProposal', 'MultivariateNormalProposal']
@@ -46,7 +47,7 @@ class MultivariateNormalProposal(Proposal):
         return np.random.multivariate_normal(mean=np.zeros(self.s.shape[0]), cov=self.s)
 
 
-class Metropolis(ArrayStepSpecial):
+class Metropolis(FastArrayStep):
     """
     Metropolis-Hastings sampling step
 
@@ -92,14 +93,8 @@ class Metropolis(ArrayStepSpecial):
         self.any_discrete = self.discrete.any()
         self.all_discrete = self.discrete.all()
 
-        shared = get_shared(vars, model)
-        if self.all_discrete:
-            tensor_type = theano.tensor.lvector
-            print(tensor_type)
-        else:
-            tensor_type = theano.tensor.dvector
-
-        self.delta_logp = special_logp(model.logpt, vars, shared, model, tensor_type)
+        shared = make_shared_replacements(vars, model)
+        self.delta_logp = delta_logp(model.logpt, vars, shared)
         super(Metropolis, self).__init__(vars, shared)
 
     def astep(self, q0):
@@ -121,6 +116,8 @@ class Metropolis(ArrayStepSpecial):
             else:
                 delta[self.discrete] = round(delta[self.discrete], 0).astype(int)
                 q = q0 + delta
+        else:
+            q = q0 + delta
 
 
         q_new = metrop_select(self.delta_logp(q,q0), q, q0)
@@ -172,7 +169,7 @@ def tune(scale, acc_rate):
     return scale
 
 
-class BinaryMetropolis(ArrayStepSpecial):
+class BinaryMetropolis(ArrayStep):
     """Metropolis-Hastings optimized for binary variables"""
     def __init__(self, vars, scaling=1., tune=True, tune_interval=100, model=None):
 
@@ -190,7 +187,7 @@ class BinaryMetropolis(ArrayStepSpecial):
 
         super(BinaryMetropolis, self).__init__(vars, [model.fastlogp])
 
-    def astep(self, q0):
+    def astep(self, q0, logp):
 
         # Convert adaptive_scale_factor to a jump probability
         p_jump = 1. - .5 ** self.scaling
@@ -201,7 +198,18 @@ class BinaryMetropolis(ArrayStepSpecial):
         switch_locs = where(rand_array < p_jump)
         q[switch_locs] = True - q[switch_locs]
 
-
-        q_new = metrop_select(self.delta_logp(q,q0), q, q0)
+        q_new = metrop_select(logp(q) - logp(q0), q, q0)
 
         return q_new
+
+def delta_logp(logp, vars, shared):
+    [logp0], inarray0 = join_nonshared_inputs([logp], vars, shared)
+
+    tensor_type = inarray0.type
+    inarray1 = tensor_type('inarray1')
+
+    logp1 = CallableTensor(logp0)(inarray1)
+
+    f = theano.function([inarray1, inarray0], logp1 - logp0)
+    f.trust_input = True
+    return f

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -47,7 +47,7 @@ class MultivariateNormalProposal(Proposal):
         return np.random.multivariate_normal(mean=np.zeros(self.s.shape[0]), cov=self.s)
 
 
-class Metropolis(FastArrayStep):
+class Metropolis(ArrayStepShared):
     """
     Metropolis-Hastings sampling step
 

--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -6,12 +6,12 @@ from numpy.random import uniform
 from .hmc import leapfrog, Hamiltonian, bern, energy
 from ..tuning import guess_scaling
 import theano
-from  .. import theanof 
+from ..theanof import make_shared_replacements, join_nonshared_inputs, CallableTensor
 import theano.tensor
 
 __all__ = ['NUTS']
 
-class NUTS(ArrayStepSpecial):
+class NUTS(FastArrayStep):
     """
     Automatically tunes step size and adjust number of steps for good performance.
 
@@ -89,11 +89,8 @@ class NUTS(ArrayStepSpecial):
 
 
 
-        shared = get_shared(vars, model)
-        #self.logp = special_logp(model.logpt, vars, shared, model)
-        #self.dlogp = special_dlogp(theanof.gradient(model.logpt, vars), vars, shared, model)
-
-        self.leapfrog1_dE = special_leapfrog1_dE(model.logpt, theanof.gradient(model.logpt, vars), vars, shared, model, self.potential, profile=profile)
+        shared = make_shared_replacements(vars, model)
+        self.leapfrog1_dE = leapfrog1_dE(model.logpt, vars, shared, self.potential, profile=profile)
         
 
         super(NUTS, self).__init__(vars, shared, **kwargs)
@@ -143,15 +140,6 @@ def buildtree(H, q, p, u, v, j, e, Emax, q0, p0):
         leapfrog1_dE = H
         q1, p1, dE = leapfrog1_dE(q, p, np.array(v*e))
 
-        """
-        q1, p1 = leapfrog(H, q, p, 1, v*e)
-        #E = energy(H, q1, p1)
-        #E0 = energy(H, q0, p0)
-
-
-        dE = denergy(H, q1, p1, q0, p0) #E - E0
-        """
-
         n1 = int(log(u) + dE <= 0)
         s1 = int(log(u) + dE < Emax)
         return q1, p1, q1, p1, q1, n1, s1, min(1, exp(-dE)), 1
@@ -175,80 +163,39 @@ def buildtree(H, q, p, u, v, j, e, Emax, q0, p0):
         return qn, pn, qp, pp, q1, n1, s1, a1, na1
     return
 
+def leapfrog1_dE(logp, vars, shared, pot, profile):
+    """Computes a theano function that computes one leapfrog step and the energy difference between the beginning and end of the trajectory.
+    Parameters
+    ----------
+    logp : TensorVariable 
+    vars : list of tensor variables
+    shared : list of shared variables not to compute leapfrog over
+    pot : quadpotential
+    porifle : Boolean
 
-def get_shared(vars, model):
-    othervars = set(model.vars) - set(vars)
-    return {var.name : theano.shared(var.tag.test_value, var.name + '_shared') for var in othervars }
-
-def specialize(xs, vars, shared, model, tensor_type=theano.tensor.dvector):
-    inarray = tensor_type('inarray')
-    ordering = ArrayOrdering(vars)
-    inarray.tag.test_value = np.concatenate([var.tag.test_value.ravel() for var in vars])
-    
-    replace = {
-        model[var] : reshape_t(inarray[slc], shp).astype(dtyp)
-        for var, slc, shp, dtyp in ordering.vmap }
-
-    shared = { model[var] : value for var, value in shared.items() }
-    replace.update(shared)
-
-    
-    xs_special = [theano.clone(x, replace, strict=False) for x in xs]
-    return xs_special, inarray
-
-def reshape_t(x, shape):
-    if shape:   return x.reshape(shape)
-    else:       return x[0]
-        
-
-def special_logp(logp, vars, shared, model, tensor_type=theano.tensor.dvector):
-    
-    [logp0], inarray0 = specialize([logp], vars, shared, model, tensor_type)
-
-    inarray1 = tensor_type('inarray1')
-    inarray1.tag.test_value = inarray0.tag.test_value
-    logp1 = theano.clone(logp0, { inarray0 : inarray1}, strict=False)
-
-    f = theano.function([inarray1, inarray0], logp1 - logp0)
-
-    f.trust_input = True
-    return f
-
-def special_dlogp(dlogp, vars, shared, model):
-    [dlogp], inarray = specialize([dlogp], vars, shared, model)
-    f =  theano.function([inarray], dlogp)
-    f.trust_input = True
-    return f
-
-def denergy(H, q1, p1, q0, p0):
-    return -H.logp(q1, q0) + H.pot.energy(p1) - H.pot.energy(p0)
-
-def special_leapfrog1_dE(logp, dlogp, vars, shared, model, pot, profile):
-
-    (logp, dlogp), inarray = specialize([logp, dlogp], vars, shared, model)
-    logp = CallableTensor(logp, inarray)
-    dlogp = CallableTensor(dlogp, inarray)
+    Returns
+    -------
+    theano function which returns
+    q_new, p_new, delta_E
+    """
+    dlogp = gradient(logp, vars)
+    (logp, dlogp), q0 = join_nonshared_inputs([logp, dlogp], vars, shared)
+    logp = CallableTensor(logp)
+    dlogp = CallableTensor(dlogp)
 
     H = Hamiltonian(logp, dlogp, pot)
 
-    p = theano.tensor.dvectors('p')
-    p.tag.test_value = inarray.tag.test_value
+    p0 = theano.tensor.dvector('p0')
+    p0.tag.test_value = q0.tag.test_value
     e = theano.tensor.dscalar('e')
     e.tag.test_value = 1
 
-    q1, p1 = leapfrog(H, inarray, p, 1, e)
+    q1, p1 = leapfrog(H, q0, p0, 1, e)
     E = energy(H, q1, p1)
-    E0 = energy(H, inarray, p)
+    E0 = energy(H, q0, p0)
     dE = E - E0
 
-    f = theano.function([inarray, p, e], [q1, p1, dE], profile=profile)
+    f = theano.function([q0, p0, e], [q1, p1, dE], profile=profile)
     f.trust_input = True
     return f
 
-class CallableTensor(object):
-    def __init__(self, tensor, inarray): 
-        self.tensor = tensor
-        self.inarray = inarray
-
-    def __call__(self, input):
-        return theano.clone(self.tensor, { self.inarray : input }, strict=False)

--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -5,10 +5,13 @@ from numpy import exp, log
 from numpy.random import uniform
 from .hmc import leapfrog, Hamiltonian, bern, energy
 from ..tuning import guess_scaling
+import theano
+from  .. import theanof 
+import theano.tensor
 
 __all__ = ['NUTS']
 
-class NUTS(ArrayStep):
+class NUTS(ArrayStepSpecial):
     """
     Automatically tunes step size and adjust number of steps for good performance.
 
@@ -24,7 +27,8 @@ class NUTS(ArrayStep):
                  gamma=0.05,
                  k=0.75,
                  t0=10,
-                 model=None, **kwargs):
+                 model=None,
+                 profile=False,**kwargs):
         """
         Parameters
         ----------
@@ -85,14 +89,21 @@ class NUTS(ArrayStep):
 
 
 
-        super(NUTS, self).__init__(vars, [model.fastlogp, model.fastdlogp(vars)], **kwargs)
+        shared = get_shared(vars, model)
+        #self.logp = special_logp(model.logpt, vars, shared, model)
+        #self.dlogp = special_dlogp(theanof.gradient(model.logpt, vars), vars, shared, model)
 
-    def astep(self, q0, logp, dlogp):
-        H = Hamiltonian(logp, dlogp, self.potential)
+        self.leapfrog1_dE = special_leapfrog1_dE(model.logpt, theanof.gradient(model.logpt, vars), vars, shared, model, self.potential, profile=profile)
+        
+
+        super(NUTS, self).__init__(vars, shared, **kwargs)
+
+    def astep(self, q0):
+        H = self.leapfrog1_dE #Hamiltonian(self.logp, self.dlogp, self.potential)
         Emax = self.Emax
         e = self.step_size
 
-        p0 = H.pot.random()
+        p0 = self.potential.random()
         u = uniform()
         q = qn = qp = q0
         p = pn = pp = p0
@@ -129,11 +140,17 @@ class NUTS(ArrayStep):
 
 def buildtree(H, q, p, u, v, j, e, Emax, q0, p0):
     if j == 0:
-        q1, p1 = leapfrog(H, q, p, 1, v*e)
-        E = energy(H, q1, p1)
-        E0 = energy(H, q0, p0)
+        leapfrog1_dE = H
+        q1, p1, dE = leapfrog1_dE(q, p, np.array(v*e))
 
-        dE = E - E0
+        """
+        q1, p1 = leapfrog(H, q, p, 1, v*e)
+        #E = energy(H, q1, p1)
+        #E0 = energy(H, q0, p0)
+
+
+        dE = denergy(H, q1, p1, q0, p0) #E - E0
+        """
 
         n1 = int(log(u) + dE <= 0)
         s1 = int(log(u) + dE < Emax)
@@ -157,3 +174,81 @@ def buildtree(H, q, p, u, v, j, e, Emax, q0, p0):
             n1 = n1 + n11
         return qn, pn, qp, pp, q1, n1, s1, a1, na1
     return
+
+
+def get_shared(vars, model):
+    othervars = set(model.vars) - set(vars)
+    return {var.name : theano.shared(var.tag.test_value, var.name + '_shared') for var in othervars }
+
+def specialize(xs, vars, shared, model, tensor_type=theano.tensor.dvector):
+    inarray = tensor_type('inarray')
+    ordering = ArrayOrdering(vars)
+    inarray.tag.test_value = np.concatenate([var.tag.test_value.ravel() for var in vars])
+    
+    replace = {
+        model[var] : reshape_t(inarray[slc], shp).astype(dtyp)
+        for var, slc, shp, dtyp in ordering.vmap }
+
+    shared = { model[var] : value for var, value in shared.items() }
+    replace.update(shared)
+
+    
+    xs_special = [theano.clone(x, replace, strict=False) for x in xs]
+    return xs_special, inarray
+
+def reshape_t(x, shape):
+    if shape:   return x.reshape(shape)
+    else:       return x[0]
+        
+
+def special_logp(logp, vars, shared, model, tensor_type=theano.tensor.dvector):
+    
+    [logp0], inarray0 = specialize([logp], vars, shared, model, tensor_type)
+
+    inarray1 = tensor_type('inarray1')
+    inarray1.tag.test_value = inarray0.tag.test_value
+    logp1 = theano.clone(logp0, { inarray0 : inarray1}, strict=False)
+
+    f = theano.function([inarray1, inarray0], logp1 - logp0)
+
+    f.trust_input = True
+    return f
+
+def special_dlogp(dlogp, vars, shared, model):
+    [dlogp], inarray = specialize([dlogp], vars, shared, model)
+    f =  theano.function([inarray], dlogp)
+    f.trust_input = True
+    return f
+
+def denergy(H, q1, p1, q0, p0):
+    return -H.logp(q1, q0) + H.pot.energy(p1) - H.pot.energy(p0)
+
+def special_leapfrog1_dE(logp, dlogp, vars, shared, model, pot, profile):
+
+    (logp, dlogp), inarray = specialize([logp, dlogp], vars, shared, model)
+    logp = CallableTensor(logp, inarray)
+    dlogp = CallableTensor(dlogp, inarray)
+
+    H = Hamiltonian(logp, dlogp, pot)
+
+    p = theano.tensor.dvectors('p')
+    p.tag.test_value = inarray.tag.test_value
+    e = theano.tensor.dscalar('e')
+    e.tag.test_value = 1
+
+    q1, p1 = leapfrog(H, inarray, p, 1, e)
+    E = energy(H, q1, p1)
+    E0 = energy(H, inarray, p)
+    dE = E - E0
+
+    f = theano.function([inarray, p, e], [q1, p1, dE], profile=profile)
+    f.trust_input = True
+    return f
+
+class CallableTensor(object):
+    def __init__(self, tensor, inarray): 
+        self.tensor = tensor
+        self.inarray = inarray
+
+    def __call__(self, input):
+        return theano.clone(self.tensor, { self.inarray : input }, strict=False)

--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -11,7 +11,7 @@ import theano.tensor
 
 __all__ = ['NUTS']
 
-class NUTS(FastArrayStep):
+class NUTS(ArrayStepShared):
     """
     Automatically tunes step size and adjust number of steps for good performance.
 
@@ -51,6 +51,8 @@ class NUTS(FastArrayStep):
             t0 : int, default 10
                 slows inital adapatation
             model : Model
+            profile : bool or ProfileStats
+                sets the functions to be profiled
         """
         model = modelcontext(model)
 

--- a/pymc3/step_methods/quadpotential.py
+++ b/pymc3/step_methods/quadpotential.py
@@ -86,7 +86,7 @@ class ElemWiseQuadPotential(object):
         return normal(size=self.s.shape) * self.inv_s
 
     def energy(self, x):
-        return .5 * dot(x, self.v * x)
+        return .5 * x.dot(self.v * x)
 
 
 class QuadPotential_Inv(object):

--- a/pymc3/step_methods/quadpotential.py
+++ b/pymc3/step_methods/quadpotential.py
@@ -111,14 +111,14 @@ class QuadPotential(object):
         self.L = cholesky(A, lower=True)
 
     def velocity(self, x):
-        return dot(self.A, x)
+        return x.T.dot(self.A.T)
 
     def random(self):
         n = normal(size=self.L.shape[0])
         return solve(self.L.T, n)
 
     def energy(self, x):
-        return .5 * dot(x, dot(self.A, x))
+        return .5 * x.dot(self.A).dot(x)
 
     __call__ = random
 

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -2,8 +2,9 @@ from .vartypes import typefilter, continuous_types
 from theano import theano, scalar,  tensor as t
 from theano.gof.graph import inputs
 from .memoize import memoize
+from .blocking import ArrayOrdering
 
-__all__ = ['gradient', 'hessian', 'hessian_diag', 'inputvars', 'cont_inputs', 'jacobian']
+__all__ = ['gradient', 'hessian', 'hessian_diag', 'inputvars', 'cont_inputs', 'jacobian', 'CallableTensor', 'join_nonshared_inputs', 'make_shared_replacements']
 
 def inputvars(a):
     """
@@ -134,6 +135,76 @@ class IdentityOp(scalar.UnaryScalarOp):
 
     def __hash__(self):
         return hash(type(self))
+
+def make_shared_replacements(vars, model):
+    """
+    Makes shared replacements for all *other* variables than the ones passed.
+
+    Parameters
+    ----------
+    vars : list of variables not to make shared
+    model : model 
+
+    Returns
+    -------
+    Dict of variable -> new shared variable
+    """
+    othervars = set(model.vars) - set(vars)
+    return {var : theano.shared(var.tag.test_value, var.name + '_shared') for var in othervars }
+
+def join_nonshared_inputs(xs, vars, shared):
+    """
+    Takes a list of theano Variables and joins their non shared inputs into a single input.
+    
+    Parameters
+    ----------
+    xs : list of theano tensors
+    vars : list of variables to join
+
+    Returns
+    -------
+    tensors, inarray
+    tensors : list of same tensors but with inarray as input
+    inarray : vector of inputs
+    """
+    joined = theano.tensor.concatenate([var.ravel() for var in vars])
+
+    tensor_type = joined.type
+    inarray = tensor_type('inarray')
+    ordering = ArrayOrdering(vars)
+    inarray.tag.test_value = joined.tag.test_value
+    
+    get_var = { var.name : var for var in vars} 
+    replace = {
+        get_var[var] : reshape_t(inarray[slc], shp).astype(dtyp)
+        for var, slc, shp, dtyp in ordering.vmap }
+
+    replace.update(shared)
+
+    xs_special = [theano.clone(x, replace, strict=False) for x in xs]
+    return xs_special, inarray
+
+def reshape_t(x, shape):
+    """Work around fact that x.reshape(()) doesn't work"""
+    if shape:   return x.reshape(shape)
+    else:       return x[0]
+
+class CallableTensor(object):
+    """Turns a symbolic variable with one input into a function that returns symbolic arguments with the one variable replaced with the input.
+    
+    """
+    def __init__(self, tensor): 
+        self.tensor = tensor
+
+    def __call__(self, input):
+        """ Replaces the single input of symbolic variable to be the passed argument.
+
+        Parameters
+        ----------
+        input : TensorVariable  
+        """
+        oldinput, = inputvars(self.tensor)
+        return theano.clone(self.tensor, { oldinput : input }, strict=False)
 
 scalar_identity = IdentityOp(scalar.upgrade_to_float, name='scalar_identity')
 identity = t.Elemwise(scalar_identity, name='identity')

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -140,6 +140,9 @@ def make_shared_replacements(vars, model):
     """
     Makes shared replacements for all *other* variables than the ones passed.
 
+    This way functions can be called many times without setting unchanging variables. Allows us 
+    to use func.trust_input by removing the need for DictToArrayBijection and kwargs.
+
     Parameters
     ----------
     vars : list of variables not to make shared
@@ -186,8 +189,8 @@ def join_nonshared_inputs(xs, vars, shared):
 
 def reshape_t(x, shape):
     """Work around fact that x.reshape(()) doesn't work"""
-    if shape:   return x.reshape(shape)
-    else:       return x[0]
+    if shape != ():   return x.reshape(shape)
+    else:             return x[0]
 
 class CallableTensor(object):
     """Turns a symbolic variable with one input into a function that returns symbolic arguments with the one variable replaced with the input.

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -125,8 +125,8 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
                          "density. 2) your distribution logp's are " +
                          "properly specified. Specific issues: \n" + 
                          specific_errors)
-    mx = {v.name: np.floor(mx[v.name]) if v.dtype in discrete_types else
-          mx[v.name] for v in model.vars}
+    mx = {v.name: mx[v.name].astype(v.dtype) for v in model.vars}
+
     if return_raw:
         return mx, r
     else:


### PR DESCRIPTION
Introduces FastArrayStep which does not wrap functions for you and instead sets shared variables of the variables you are not sampling for you. This allows us to use function.trust_input which provides a significant speedup.

NUTS now has a theano function that does a single leapfrog iteration and computes the energy difference in one step.

Metropolis now directly computes the logp difference rather than just two logps.

Both of these allow theano to optimize more and provide some speedup and also avoid theano overhead of multiple theano calls.
