### PR TITLE
Differentiate names for single-chain traces

### DIFF
--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -149,12 +149,12 @@ class MultiTrace(object):
     of the MultiTrace instance, which returns the number of draws), the
     trace with the highest chain number is always used.
     """
-    def __init__(self, traces):
-        self._traces = {}
-        for trace in traces:
-            if trace.chain in self._traces:
+    def __init__(self, straces):
+        self._straces = {}
+        for strace in straces:
+            if strace.chain in self._straces:
                 raise ValueError("Chains are not unique.")
-            self._traces[trace.chain] = trace
+            self._straces[strace.chain] = strace
 
     def __repr__(self):
         template = '<{}: {} chains, {} iterations, {} variables>'
@@ -163,11 +163,11 @@ class MultiTrace(object):
 
     @property
     def nchains(self):
-        return len(self._traces)
+        return len(self._straces)
 
     @property
     def chains(self):
-        return list(sorted(self._traces.keys()))
+        return list(sorted(self._straces.keys()))
 
     def __getitem__(self, idx):
         if isinstance(idx, slice):
@@ -190,7 +190,7 @@ class MultiTrace(object):
             burn, thin = 0, 1
         return self.get_values(var, burn=burn, thin=thin)
 
-    _attrs = set(['_traces', 'varnames', 'chains'])
+    _attrs = set(['_straces', 'varnames', 'chains'])
 
     def __getattr__(self, name):
         # Avoid infinite recursion when called before __init__
@@ -205,12 +205,12 @@ class MultiTrace(object):
 
     def __len__(self):
         chain = self.chains[-1]
-        return len(self._traces[chain])
+        return len(self._straces[chain])
 
     @property
     def varnames(self):
         chain = self.chains[-1]
-        return self._traces[chain].varnames
+        return self._straces[chain].varnames
 
     def get_values(self, varname, burn=0, thin=1, combine=True, chains=None,
                    squeeze=True):
@@ -240,15 +240,15 @@ class MultiTrace(object):
             chains = self.chains
         varname = str(varname)
         try:
-            results = [self._traces[chain].get_values(varname, burn, thin)
+            results = [self._straces[chain].get_values(varname, burn, thin)
                        for chain in chains]
         except TypeError:  # Single chain passed.
-            results = [self._traces[chains].get_values(varname, burn, thin)]
+            results = [self._straces[chains].get_values(varname, burn, thin)]
         return _squeeze_cat(results, combine, squeeze)
 
     def _slice(self, idx):
         """Return a new MultiTrace object sliced according to `idx`."""
-        new_traces = [trace._slice(idx) for trace in self._traces.values()]
+        new_traces = [trace._slice(idx) for trace in self._straces.values()]
         return MultiTrace(new_traces)
 
     def point(self, idx, chain=None):
@@ -262,7 +262,7 @@ class MultiTrace(object):
         """
         if chain is None:
             chain = self.chains[-1]
-        return self._traces[chain].point(idx)
+        return self._straces[chain].point(idx)
 
 
 def merge_traces(mtraces):
@@ -283,10 +283,10 @@ def merge_traces(mtraces):
     """
     base_mtrace = mtraces[0]
     for new_mtrace in mtraces[1:]:
-        for new_chain, trace in new_mtrace._traces.items():
-            if new_chain in base_mtrace._traces:
+        for new_chain, strace in new_mtrace._straces.items():
+            if new_chain in base_mtrace._straces:
                 raise ValueError("Chains are not unique.")
-            base_mtrace._traces[new_chain] = trace
+            base_mtrace._straces[new_chain] = strace
     return base_mtrace
 
 

--- a/pymc3/backends/ndarray.py
+++ b/pymc3/backends/ndarray.py
@@ -43,9 +43,9 @@ class NDArray(base.BaseTrace):
             self.draws = old_draws + draws
             self.draws_idx = old_draws
             for varname, shape in self.var_shapes.items():
-                old_trace = self.samples[varname]
-                new_trace = np.zeros((draws, ) + shape, self.var_dtypes[varname])
-                self.samples[varname] = np.concatenate((old_trace, new_trace),
+                old_vtrace = self.samples[varname]
+                new_vtrace = np.zeros((draws, ) + shape, self.var_dtypes[varname])
+                self.samples[varname] = np.concatenate((old_vtrace, new_vtrace),
                                                        axis=0)
         else:  # Otherwise, make array of zeros for each variable.
             self.draws = draws
@@ -70,8 +70,8 @@ class NDArray(base.BaseTrace):
             return
         ## Remove trailing zeros if interrupted before completed all
         ## draws.
-        self.samples = {var: trace[:self.draw_idx]
-                        for var, trace in self.samples.items()}
+        self.samples = {var: vtrace[:self.draw_idx]
+                        for var, vtrace in self.samples.items()}
 
     ## Selection methods
 

--- a/pymc3/backends/sqlite.py
+++ b/pymc3/backends/sqlite.py
@@ -322,15 +322,15 @@ def load(name, model=None):
     varnames = _get_table_list(db.cursor)
     chains = _get_chain_list(db.cursor, varnames[0])
 
-    traces = []
+    straces = []
     for chain in chains:
-        trace = SQLite(name, model=model)
-        trace.varnames = varnames
-        trace.chain = chain
-        trace._is_setup = True
-        trace.db = db  # Share the db with all traces.
-        traces.append(trace)
-    return base.MultiTrace(traces)
+        strace = SQLite(name, model=model)
+        strace.varnames = varnames
+        strace.chain = chain
+        strace._is_setup = True
+        strace.db = db  # Share the db with all traces.
+        straces.append(strace)
+    return base.MultiTrace(straces)
 
 
 def _get_table_list(cursor):

--- a/pymc3/backends/text.py
+++ b/pymc3/backends/text.py
@@ -186,14 +186,14 @@ def load(name, model=None):
     """
     files = glob(os.path.join(name, 'chain-*.csv'))
 
-    traces = []
+    straces = []
     for f in files:
         chain = int(os.path.splitext(f)[0].rsplit('-', 1)[1])
-        trace = Text(name, model=model)
-        trace.chain = chain
-        trace.filename = f
-        traces.append(trace)
-    return base.MultiTrace(traces)
+        strace = Text(name, model=model)
+        strace.chain = chain
+        strace.filename = f
+        straces.append(strace)
+    return base.MultiTrace(straces)
 
 
 def dump(name, trace, chains=None):
@@ -213,36 +213,36 @@ def dump(name, trace, chains=None):
     if chains is None:
         chains = trace.chains
 
-    var_shapes = trace._traces[chains[0]].var_shapes
+    var_shapes = trace._straces[chains[0]].var_shapes
     flat_names = {v: _create_flat_names(v, shape)
                   for v, shape in var_shapes.items()}
 
     for chain in chains:
         filename = os.path.join(name, 'chain-{}.csv'.format(chain))
-        df = _trace_to_df(trace._traces[chain], flat_names)
+        df = _strace_to_df(trace._straces[chain], flat_names)
         df.to_csv(filename, index=False)
 
 
-def _trace_to_df(trace, flat_names=None):
+def _strace_to_df(strace, flat_names=None):
     """Convert single-chain trace to Pandas DataFrame.
 
     Parameters
     ----------
-    trace : NDarray trace
+    strace : NDarray trace
     flat_names : dict or None
-        A dictionary that maps each variable name in `trace` to a list
+        A dictionary that maps each variable name in `strace` to a list
         of flat variable names (e.g., ['x__0', 'x__1', ...])
     """
     if flat_names is None:
         flat_names = {v: _create_flat_names(v, shape)
-                      for v, shape in trace.var_shapes.items()}
+                      for v, shape in strace.var_shapes.items()}
 
     var_dfs = []
-    for varname, shape in trace.var_shapes.items():
-        vals = trace.get_values(varname)
+    for varname, shape in strace.var_shapes.items():
+        vals = strace.get_values(varname)
         if len(shape) == 1:
             flat_vals = vals
         else:
-            flat_vals = vals.reshape(len(trace), np.prod(shape))
+            flat_vals = vals.reshape(len(strace), np.prod(shape))
         var_dfs.append(pd.DataFrame(flat_vals, columns=flat_names[varname]))
     return pd.concat(var_dfs, axis=1)

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -94,12 +94,12 @@ def _sample(draws, step, start=None, trace=None, chain=0, tune=None,
                             tune, model, random_seed)
     progress = progress_bar(draws)
     try:
-        for i, trace in enumerate(sampling):
+        for i, strace in enumerate(sampling):
             if progressbar:
                 progress.update(i)
     except KeyboardInterrupt:
-        trace.close()
-    return MultiTrace([trace])
+        strace.close()
+    return MultiTrace([strace])
 
 
 def iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
@@ -143,8 +143,8 @@ def iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
     """
     sampling = _iter_sample(draws, step, start, trace, chain, tune,
                             model, random_seed)
-    for i, trace in enumerate(sampling):
-        yield MultiTrace([trace[:i + 1]])
+    for i, strace in enumerate(sampling):
+        yield MultiTrace([strace[:i + 1]])
 
 
 def _iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
@@ -158,10 +158,10 @@ def _iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
     if start is None:
         start = {}
 
-    trace = _choose_backend(trace, chain, model=model)
+    strace = _choose_backend(trace, chain, model=model)
 
-    if len(trace) > 0:
-        _soft_update(start, trace.point(-1))
+    if len(strace) > 0:
+        _soft_update(start, strace.point(-1))
     else:
         _soft_update(start, model.test_point)
 
@@ -172,22 +172,22 @@ def _iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
 
     point = Point(start, model=model)
 
-    trace.setup(draws, chain)
+    strace.setup(draws, chain)
     for i in range(draws):
         if i == tune:
             step = stop_tuning(step)
         point = step.step(point)
-        trace.record(point)
-        yield trace
+        strace.record(point)
+        yield strace
     else:
-        trace.close()
+        strace.close()
 
 
 def _choose_backend(trace, chain, shortcuts=None, **kwds):
     if isinstance(trace, BaseTrace):
         return trace
     if isinstance(trace, MultiTrace):
-        return trace._traces[chain]
+        return trace._straces[chain]
     if trace is None:
         return NDArray(**kwds)
 

--- a/pymc3/tests/test_ndarray_backend.py
+++ b/pymc3/tests/test_ndarray_backend.py
@@ -48,18 +48,18 @@ class TestMultiTrace(bf.ModelBackendSetupTestCase):
 
     def setUp(self):
         super(TestMultiTrace, self).setUp()
-        self.trace0 = self.trace
+        self.strace0 = self.strace
 
         super(TestMultiTrace, self).setUp()
-        self.trace1 = self.trace
+        self.strace1 = self.strace
 
     def test_multitrace_nonunique(self):
         self.assertRaises(ValueError,
-                          base.MultiTrace, [self.trace0, self.trace1])
+                          base.MultiTrace, [self.strace0, self.strace1])
 
     def test_merge_traces_nonunique(self):
-        mtrace0 = base.MultiTrace([self.trace0])
-        mtrace1 = base.MultiTrace([self.trace1])
+        mtrace0 = base.MultiTrace([self.strace0])
+        mtrace1 = base.MultiTrace([self.strace1])
 
         self.assertRaises(ValueError,
                           base.merge_traces, [mtrace0, mtrace1])

--- a/pymc3/tests/test_text_backend.py
+++ b/pymc3/tests/test_text_backend.py
@@ -65,9 +65,9 @@ class TestTraceToDf(bf.ModelBackendSampledTestCase):
     name = 'text-db'
     shape = (2, 3)
 
-    def test_trace_to_df(self):
+    def test_strace_to_df(self):
         mtrace = self.mtrace
-        df = text._trace_to_df(mtrace._traces[0])
+        df = text._strace_to_df(mtrace._straces[0])
         self.assertEqual(len(mtrace), df.shape[0])
 
         checked = False


### PR DESCRIPTION
Previously, the variable name "trace" was confusingly used to refer to
both BaseTrace instances and MultiTrace instances, making readers
infer which type it was from context.

Change code to use the following conventions:
- Use "strace" for variable names of BaseTrace instances to indicate a
  single-chain trace (where "single-chain" trace refers to an object
  derived from BaseTrace, but not a MultiTrace object with only one
  chain).
- MultiTrace instances are called either "mtrace" or "trace".

All changes in this commit are purely variable renames and are not
user-facing.
