### PR TITLE
Added disc_vars property

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -123,6 +123,11 @@ class Model(Context, Factor):
                      model=self)
 
     @property
+    def disc_vars(self):
+        """All the discrete variables in the model"""
+        return list(typefilter(self.vars, discrete_types))
+        
+    @property
     def cont_vars(self):
         """All the continuous variables in the model"""
         return list(typefilter(self.vars, continuous_types))


### PR DESCRIPTION
Useful for assigning discretes to a Metropolis sampler, for example.
