### PR TITLE
Support slicing in SQlite and Text backends

### DIFF
--- a/pymc3/backends/__init__.py
+++ b/pymc3/backends/__init__.py
@@ -52,11 +52,15 @@ that are retrieved.
 
     >>> trace.get_values('x', burn=1000, chains=[0, 2])
 
-Some backends also suppport slicing the MultiTrace object. For example,
-the following call would return a new trace object without the first
-1000 sampling iterations for all traces and variables.
+MultiTrace objects also support slicing. For example, the following
+call would return a new trace object without the first 1000 sampling
+iterations for all traces and variables.
 
     >>> sliced_trace = trace[1000:]
+
+The backend for the new trace is always NDArray, regardless of the
+type of original trace.  Only the NDArray backend supports a stop
+value in the slice.
 
 Loading a saved backend
 -----------------------

--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -249,10 +249,7 @@ class MultiTrace(object):
     def _slice(self, idx):
         """Return a new MultiTrace object sliced according to `idx`."""
         new_traces = [trace._slice(idx) for trace in self._straces.values()]
-        # Some backends cannot slice, and warn instead.
-        new_traces = [tr for tr in new_traces if tr is not None]
-        if new_traces:
-            return MultiTrace(new_traces)
+        return MultiTrace(new_traces)
 
     def point(self, idx, chain=None):
         """Return a dictionary of point values at `idx`.

--- a/pymc3/backends/sqlite.py
+++ b/pymc3/backends/sqlite.py
@@ -18,9 +18,8 @@ The chain column denotes the chain index and starts at 0.
 """
 import numpy as np
 import sqlite3
-import warnings
 
-from ..backends import base
+from ..backends import base, ndarray
 
 TEMPLATES = {
     'table':            ('CREATE TABLE IF NOT EXISTS [{table}] '
@@ -228,7 +227,9 @@ class SQLite(base.BaseTrace):
         return values.reshape(shape)
 
     def _slice(self, idx):
-        warnings.warn('Slice for SQLite backend has no effect.')
+        if idx.stop is not None:
+            raise ValueError('Stop value in slice not supported.')
+        return ndarray._slice_as_ndarray(self, idx)
 
     def point(self, idx):
         """Return dictionary of point values at `idx` for current chain

--- a/pymc3/backends/text.py
+++ b/pymc3/backends/text.py
@@ -19,9 +19,8 @@ from glob import glob
 import numpy as np
 import os
 import pandas as pd
-import warnings
 
-from ..backends import base
+from ..backends import base, ndarray
 
 
 class Text(base.BaseTrace):
@@ -128,7 +127,9 @@ class Text(base.BaseTrace):
         return vals[burn::thin]
 
     def _slice(self, idx):
-        warnings.warn('Slice for Text backend has no effect.')
+        if idx.stop is not None:
+            raise ValueError('Stop value in slice not supported.')
+        return ndarray._slice_as_ndarray(self, idx)
 
     def point(self, idx):
         """Return dictionary of point values at `idx` for current chain

--- a/pymc3/tests/backend_fixtures.py
+++ b/pymc3/tests/backend_fixtures.py
@@ -177,9 +177,9 @@ class SelectionTestCase(ModelBackendSampledTestCase):
     def test_get_slice(self):
         expected = []
         for chain in [0, 1]:
-            expected.append({varname: self.expected[chain][varname][:2]
+            expected.append({varname: self.expected[chain][varname][2:]
                              for varname in self.mtrace.varnames})
-        result = self.mtrace[:2]
+        result = self.mtrace[2:]
         for chain in [0, 1]:
             for varname in self.test_point.keys():
                 npt.assert_equal(result.get_values(varname, chains=[chain]),
@@ -248,11 +248,6 @@ class SelectionTestCase(ModelBackendSampledTestCase):
                          mtrace[varname])
         npt.assert_equal(mtrace[varname],
                          mtrace.__getattr__(varname))
-
-
-class SelectionNoSliceTestCase(SelectionTestCase):
-    def test_get_slice(self):
-        pass
 
 
 class DumpLoadTestCase(ModelBackendSampledTestCase):

--- a/pymc3/tests/test_sqlite_backend.py
+++ b/pymc3/tests/test_sqlite_backend.py
@@ -25,19 +25,19 @@ class TestSQlite2dSampling(bf.SamplingTestCase):
     shape = (2, 3)
 
 
-class TestSQLite0dSelection(bf.SelectionNoSliceTestCase):
+class TestSQLite0dSelection(bf.SelectionTestCase):
     backend = sqlite.SQLite
     name = DBNAME
     shape = ()
 
 
-class TestSQLite1dSelection(bf.SelectionNoSliceTestCase):
+class TestSQLite1dSelection(bf.SelectionTestCase):
     backend = sqlite.SQLite
     name = DBNAME
     shape = 2
 
 
-class TestSQLite2dSelection(bf.SelectionNoSliceTestCase):
+class TestSQLite2dSelection(bf.SelectionTestCase):
     backend = sqlite.SQLite
     name = DBNAME
     shape = (2, 3)

--- a/pymc3/tests/test_text_backend.py
+++ b/pymc3/tests/test_text_backend.py
@@ -21,19 +21,19 @@ class TestText2dSampling(bf.SamplingTestCase):
     shape = (2, 3)
 
 
-class TestText0dSelection(bf.SelectionNoSliceTestCase):
+class TestText0dSelection(bf.SelectionTestCase):
     backend = text.Text
     name = 'text-db'
     shape = ()
 
 
-class TestText1dSelection(bf.SelectionNoSliceTestCase):
+class TestText1dSelection(bf.SelectionTestCase):
     backend = text.Text
     name = 'text-db'
     shape = 2
 
 
-class TestText2dSelection(bf.SelectionNoSliceTestCase):
+class TestText2dSelection(bf.SelectionTestCase):
     backend = text.Text
     name = 'text-db'
     shape = (2, 3)


### PR DESCRIPTION
Return a NDArray slice instead of warning when an out-of-memory backend
is sliced.

Fixes #790
