### PR TITLE
Update distribution.py to check for integer shape

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -36,7 +36,7 @@ class Distribution(object):
 
     def __init__(self, shape, dtype, testval=None, defaults=[], transform=None):
         self.shape = np.atleast_1d(shape)
-        if not np.issubdtype(self.shape.dtype, np.integer):
+        if False in (np.floor(self.shape) == self.shape):
             raise TypeError("Expected int elements in shape")
         self.dtype = dtype
         self.type = TensorType(self.dtype, self.shape)

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -37,7 +37,7 @@ class Distribution(object):
     def __init__(self, shape, dtype, testval=None, defaults=[], transform=None):
         self.shape = np.atleast_1d(shape)
         if np.array(list(self.shape)).dtype != "int32":
-            raise TypeError("Expected int elements in shape but got: " + str(shape))
+            raise TypeError("Expected int elements in shape but got: ", shape)
         self.dtype = dtype
         self.type = TensorType(self.dtype, self.shape)
         self.testval = testval

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -36,7 +36,7 @@ class Distribution(object):
 
     def __init__(self, shape, dtype, testval=None, defaults=[], transform=None):
         self.shape = np.atleast_1d(shape)
-        if np.array(list(self.shape)).dtype != "int32:
+        if np.array(list(self.shape)).dtype != "int32":
             raise TypeError("Expected int elements in shape but got: " + shape)
         self.dtype = dtype
         self.type = TensorType(self.dtype, self.shape)

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -36,7 +36,7 @@ class Distribution(object):
 
     def __init__(self, shape, dtype, testval=None, defaults=[], transform=None):
         self.shape = np.atleast_1d(shape)
-        if len(self.shape) > 0 and np.array(list(self.shape)).dtype != "int32":
+        if not np.issubdtype(self.shape.dtype, np.integer):
             raise TypeError("Expected int elements in shape")
         self.dtype = dtype
         self.type = TensorType(self.dtype, self.shape)

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -36,7 +36,7 @@ class Distribution(object):
 
     def __init__(self, shape, dtype, testval=None, defaults=[], transform=None):
         self.shape = np.atleast_1d(shape)
-        if np.array(list(self.shape)).dtype != "int32":
+        if len(self.shape) > 0 and np.array(list(self.shape)).dtype != "int32":
             raise TypeError("Expected int elements in shape")
         self.dtype = dtype
         self.type = TensorType(self.dtype, self.shape)

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -37,7 +37,7 @@ class Distribution(object):
     def __init__(self, shape, dtype, testval=None, defaults=[], transform=None):
         self.shape = np.atleast_1d(shape)
         if np.array(list(self.shape)).dtype != "int32":
-            raise TypeError("Expected int elements in shape but got: ", self.shape)
+            raise TypeError("Expected int elements in shape")
         self.dtype = dtype
         self.type = TensorType(self.dtype, self.shape)
         self.testval = testval

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -37,7 +37,7 @@ class Distribution(object):
     def __init__(self, shape, dtype, testval=None, defaults=[], transform=None):
         self.shape = np.atleast_1d(shape)
         if np.array(list(self.shape)).dtype != "int32":
-            raise TypeError("Expected int elements in shape but got: ", shape)
+            raise TypeError("Expected int elements in shape but got: ", self.shape)
         self.dtype = dtype
         self.type = TensorType(self.dtype, self.shape)
         self.testval = testval

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -36,6 +36,8 @@ class Distribution(object):
 
     def __init__(self, shape, dtype, testval=None, defaults=[], transform=None):
         self.shape = np.atleast_1d(shape)
+        if np.array(list(self.shape)).dtype != "int32:
+            raise TypeError("Expected int elements in shape but got: " + shape)
         self.dtype = dtype
         self.type = TensorType(self.dtype, self.shape)
         self.testval = testval

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -37,7 +37,7 @@ class Distribution(object):
     def __init__(self, shape, dtype, testval=None, defaults=[], transform=None):
         self.shape = np.atleast_1d(shape)
         if np.array(list(self.shape)).dtype != "int32":
-            raise TypeError("Expected int elements in shape but got: " + shape)
+            raise TypeError("Expected int elements in shape but got: " + str(shape))
         self.dtype = dtype
         self.type = TensorType(self.dtype, self.shape)
         self.testval = testval


### PR DESCRIPTION
Added additional check to see if the Distribution shape only contains integers. Raises TypeError.

See https://github.com/pymc-devs/pymc3/issues/836
