### PR TITLE
List type allowed for p in Categorical

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -345,7 +345,7 @@ class Categorical(Discrete):
     """
     def __init__(self, p, *args, **kwargs):
         super(Categorical, self).__init__(*args, **kwargs)
-        self.k = p.shape[-1]
+        self.k = np.shape(p)[-1]
         self.p = as_tensor_variable(p)
         self.mode = argmax(p)
 


### PR DESCRIPTION
Fixed a minor but annoying issue with `Categorical` not allowing probabilities to be specified as a list or tuple.
