### PR TITLE
Fixes bug in initialization of m

### DIFF
--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -87,7 +87,7 @@ class NUTS(ArrayStepShared):
 
         self.Hbar = 0
         self.u = log(self.step_size*10)
-        self.m = 0
+        self.m = 1
 
 
 


### PR DESCRIPTION
Fixing self.m to start at 1 rather than 0 as seen in Algorithm 5 in the NUTS paper (http://arxiv.org/abs/1111.4246).

The previous behavior was to set step_size = step_size*10 after the first step (on line 134).
