### PR TITLE
Allow multi-dimensional dirichet

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -104,7 +104,7 @@ class Dirichlet(Continuous):
 
         # only defined for sum(value) == 1
         return bound(
-            sum(logpow(value, a - 1) - gammaln(a), axis=0) + gammaln(sum(a)),
+            sum(logpow(value, a - 1) - gammaln(a), axis=0) + gammaln(sum(a, axis=0)),
             k > 1,
             all(a > 0),
             all(value >= 0),

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -150,32 +150,32 @@ class StickBreaking(Transform):
     def forward(self, x):
         #reverse cumsum
         x0 = x[:-1]
-        s = t.extra_ops.cumsum(x0[::-1])[::-1] + x[-1]
+        s = t.extra_ops.cumsum(x0[::-1], 0)[::-1] + x[-1]
         z = x0/s
         Km1 = x.shape[0] - 1
-        k = arange(Km1)
+        k = arange(Km1)[(slice(None), ) + (None, ) * (x.ndim - 1)]
         eq_share = - t.log(Km1 - k) # logit(1./(Km1 + 1 - k)) 
         y =  logit(z) - eq_share
         return y
 
     def backward(self, y):
         Km1 = y.shape[0]
-        k = arange(Km1)
+        k = arange(Km1)[(slice(None), ) + (None, ) * (y.ndim - 1)]
         eq_share = - t.log(Km1 - k) # logit(1./(Km1 + 1 - k)) 
         z = logistic(y + eq_share)
-        yl = concatenate([z, [1]])
-        yu = concatenate([[1], 1-z])
-        S = t.extra_ops.cumprod(yu)
+        yl = concatenate([z, ones(y[:1].shape)])
+        yu = concatenate([ones(y[:1].shape), 1-z])
+        S = t.extra_ops.cumprod(yu, 0)
         x = S * yl
         return x
 
     def jacobian_det(self, y): 
         Km1 = y.shape[0]
-        k = arange(Km1)
+        k = arange(Km1)[(slice(None), ) + (None, ) * (y.ndim - 1)]
         eq_share =  -t.log(Km1 - k) #logit(1./(Km1 + 1 - k)) 
         yl = y + eq_share
-        yu = concatenate([[1], 1-logistic(yl)])
-        S = t.extra_ops.cumprod(yu)
-        return sum(t.log(S[:-1]) - t.log(1+exp(yl)) - t.log(1+exp(-yl)))
+        yu = concatenate([ones(y[:1].shape), 1-logistic(yl)])
+        S = t.extra_ops.cumprod(yu, 0)
+        return t.log(S[:-1]) - t.log(1+exp(yl)) - t.log(1+exp(-yl))
 
 stick_breaking = StickBreaking()


### PR DESCRIPTION
This alters the StickBreaking transformation to allow for multi-dimensional Dirichlet object. This should resolve #792 . The first dimension is treated as special and the sum along this dimension of the resultant variables are consistenlty one. Both the log(p) and the jacobian of the transformation are now multi-dimensional array with summation only over the first dimension, which means that a useful logp_elemwiset is created.
