### PR TITLE
Fix flat jacobian bug in transforms

### DIFF
--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -29,7 +29,7 @@ class Transform(object):
 
 class ElemwiseTransform(Transform):
     def jacobian_det(self, x):
-        grad = gradient(t.sum(self.backward(x)), [x])
+        grad = t.reshape(gradient(t.sum(self.backward(x)), [x]),x.shape)
 
         j = t.log(t.abs_(grad))
         return j

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -629,3 +629,8 @@ def check_ex_gaussian(value, mu, sigma, nu, logp):
     pt = {'eg': value}
     assert_almost_equal(model.fastlogp(pt),
                 logp, decimal=6, err_msg=str(pt))
+
+
+def test_multidimensional_beta_construction():
+    with Model() as m:
+        testMultiBeta = Beta('beta', alpha = 1., beta = 1., shape=(10,20))


### PR DESCRIPTION
Fixes failure for multivariate transformed distributions, where the jacobian determinant would be flattened leading to shape mismatch.

The following snippet would fail:
with pymc3.Model() as model:
    testMultiBeta = pymc3.Beta('beta', alpha = 1., beta = 1., shape=(10,20))
