### PR TITLE
Fixed minor bug in transforms

### DIFF
--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -25,7 +25,7 @@ class Transform(object):
         return TransformedDistribution.dist(dist, self)
 
     def __str__(self):
-        return name + " transform"
+        return self.name + " transform"
 
 class ElemwiseTransform(Transform):
     def jacobian_det(self, x):


### PR DESCRIPTION
The `name` variable is a class attribute, not a local variable.
