### PR TITLE
Add var cleanup to Constant step method

### DIFF
--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -156,6 +156,8 @@ class Constant(ArrayStep):
 
         self.model = model
 
+        vars = inputvars(vars)
+
         super(Constant, self).__init__(vars, [model.fastlogp], **kwargs)
 
     def astep(self, q0, logp):


### PR DESCRIPTION
The Constant step didn't work when passed a single variable or a TransformedRV. I believe adding the inputvars call is the proper way to clean this up. Hope these one line pull requests aren't a bother!
