### PR TITLE
Changed varnames argument to vars in df_summary

### DIFF
--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -333,8 +333,8 @@ def df_summary(trace, vars=None, stat_funcs=None, extend=False,
     mu__0  0.066473  0.000312  0.105039  0.214242
     mu__1  0.067513 -0.159097 -0.045637  0.062912
     """
-    if varnames is None:
-        varnames = trace.varnames
+    if vars is None:
+        vars = trace.varnames
 
     funcs = [lambda x: pd.Series(np.mean(x, 0), name='mean'),
              lambda x: pd.Series(np.std(x, 0), name='sd'),
@@ -347,7 +347,7 @@ def df_summary(trace, vars=None, stat_funcs=None, extend=False,
         stat_funcs = funcs
 
     var_dfs = []
-    for var in varnames:
+    for var in vars:
         vals = trace.get_values(var, combine=True)
         flat_vals = vals.reshape(vals.shape[0], -1)
         var_df = pd.concat([f(flat_vals) for f in stat_funcs], axis=1)

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -259,14 +259,14 @@ def quantiles(x, qlist=(2.5, 25, 50, 75, 97.5)):
         print("Too few elements for quantile calculation")
 
 
-def df_summary(trace, varnames=None, stat_funcs=None, extend=False,
+def df_summary(trace, vars=None, stat_funcs=None, extend=False,
                alpha=0.05, batches=100):
     """Create a data frame with summary statistics.
 
     Parameters
     ----------
     trace : MultiTrace instance
-    varnames : list
+    vars : list
         Names of variables to include in summary
     stat_funcs : None or list
         A list of functions used to calculate statistics. By default,


### PR DESCRIPTION
In all other user-facing functions for generating output, the list of variable names to extract from the trace is `vars` except in `df_summary`, where it is `varnames`. Changed it to `vars` to address this inconsistency.
