### PR TITLE
add modelcontext to DIC

### DIFF
--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -74,10 +74,12 @@ def autocov(x, lag=1):
         raise ValueError("Autocovariance lag must be a positive integer")
     return np.cov(x[:-lag], x[lag:], bias=1)
 
-def dic(model, trace):
+def dic(trace, model=None):
     """
     Calculate the deviance information criterion of the samples in trace from model
     """
+    model = modelcontext(model)
+
     transformed_rvs = [rv for rv in model.free_RVs if hasattr(rv.distribution, 'transform_used')]
     if transformed_rvs:
         warnings.warn("""

--- a/pymc3/tests/test_stats.py
+++ b/pymc3/tests/test_stats.py
@@ -32,8 +32,7 @@ def test_dic():
 
         step = pm.Metropolis()
         trace = pm.sample(100, step)
-
-    calculated = dic(model, trace)
+        calculated = pm.dic(trace)
 
     mean_deviance = -2 * st.binom.logpmf(np.repeat(np.atleast_2d(x_obs), 100, axis=0), 5,
                                          np.repeat(np.atleast_2d(trace['p']), 6, axis=0).T).sum(axis=1).mean()
@@ -57,7 +56,7 @@ def test_dic_warns_on_transformed_rv():
         trace = pm.sample(100, step)
 
     with warnings.catch_warnings(record=True) as w:
-        calculated = dic(model, trace)
+        calculated = pm.dic(trace, model)
 
         assert(len(w) == 1)
 


### PR DESCRIPTION
Add modelcontext to DIC, in order to make it consistent with the syntax of waic. Now is possible to call dic like `with model: dic(trace)`
