### PR TITLE
Added drift (mu) to GaussianRandomWalk.

### DIFF
--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -41,19 +41,24 @@ class GaussianRandomWalk(Continuous):
 
     Parameters
     ----------
+    mu: tensor
+        innovation drift
     tau : tensor
         tau > 0, innovation precision
+    sd : tensor
+        sd > 0, innovation standard deviation (alternative to specifying tau)
     init : distribution
         distribution for initial value (Defaults to Flat())
     """
-    def __init__(self, tau=None, init=Flat.dist(), sd=None, *args, **kwargs):
+    def __init__(self, mu=0., tau=None, init=Flat.dist(), sd=None, *args, **kwargs):
         super(GaussianRandomWalk, self).__init__(*args, **kwargs)
+        self.mu = mu
         self.tau = tau
         self.sd = sd
         self.init = init
-        self.mean = 0.
 
     def logp(self, x):
+        mu = self.mu
         tau = self.tau
         sd = self.sd
         init = self.init
@@ -61,5 +66,5 @@ class GaussianRandomWalk(Continuous):
         x_im1 = x[:-1]
         x_i = x[1:]
 
-        innov_like = Normal.dist(x_im1, tau, sd=sd).logp(x_i)
+        innov_like = Normal.dist(x_im1, mu=mu, tau=tau, sd=sd).logp(x_i)
         return init.logp(x[0]) + sum(innov_like)

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -41,7 +41,7 @@ class GaussianRandomWalk(Continuous):
 
     Parameters
     ----------
-    mu: tensor
+    drift: tensor
         innovation drift, defaults to 0.0
     tau : tensor
         tau > 0, innovation precision
@@ -50,16 +50,16 @@ class GaussianRandomWalk(Continuous):
     init : distribution
         distribution for initial value (Defaults to Flat())
     """
-    def __init__(self, mu=0., tau=None, init=Flat.dist(), sd=None, *args, **kwargs):
+    def __init__(self, tau=None, init=Flat.dist(), sd=None, drift=0., *args, **kwargs):
         super(GaussianRandomWalk, self).__init__(*args, **kwargs)
-        self.mu = mu
+        self.drift = drift
         self.tau = tau
         self.sd = sd
         self.init = init
         self.mean = 0.
 
     def logp(self, x):
-        mu = self.mu
+        drift = self.drift
         tau = self.tau
         sd = self.sd
         init = self.init
@@ -67,5 +67,5 @@ class GaussianRandomWalk(Continuous):
         x_im1 = x[:-1]
         x_i = x[1:]
 
-        innov_like = Normal.dist(mu=x_im1 + mu, tau=tau, sd=sd).logp(x_i)
+        innov_like = Normal.dist(mu=x_im1 + drift, tau=tau, sd=sd).logp(x_i)
         return init.logp(x[0]) + sum(innov_like)

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -42,7 +42,7 @@ class GaussianRandomWalk(Continuous):
     Parameters
     ----------
     mu: tensor
-        innovation drift
+        innovation drift, defaults to 0.0
     tau : tensor
         tau > 0, innovation precision
     sd : tensor
@@ -56,6 +56,7 @@ class GaussianRandomWalk(Continuous):
         self.tau = tau
         self.sd = sd
         self.init = init
+        self.mean = 0.
 
     def logp(self, x):
         mu = self.mu

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -67,5 +67,5 @@ class GaussianRandomWalk(Continuous):
         x_im1 = x[:-1]
         x_i = x[1:]
 
-        innov_like = Normal.dist(x_im1, mu=mu, tau=tau, sd=sd).logp(x_i)
+        innov_like = Normal.dist(mu=x_im1 + mu, tau=tau, sd=sd).logp(x_i)
         return init.logp(x[0]) + sum(innov_like)

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -41,31 +41,31 @@ class GaussianRandomWalk(Continuous):
 
     Parameters
     ----------
-    drift: tensor
-        innovation drift, defaults to 0.0
     tau : tensor
         tau > 0, innovation precision
     sd : tensor
         sd > 0, innovation standard deviation (alternative to specifying tau)
+    mu: tensor
+        innovation drift, defaults to 0.0
     init : distribution
         distribution for initial value (Defaults to Flat())
     """
-    def __init__(self, tau=None, init=Flat.dist(), sd=None, drift=0., *args, **kwargs):
+    def __init__(self, tau=None, init=Flat.dist(), sd=None, mu=0., *args, **kwargs):
         super(GaussianRandomWalk, self).__init__(*args, **kwargs)
-        self.drift = drift
         self.tau = tau
         self.sd = sd
+        self.mu = mu
         self.init = init
         self.mean = 0.
 
     def logp(self, x):
-        drift = self.drift
         tau = self.tau
         sd = self.sd
+        mu = self.mu
         init = self.init
 
         x_im1 = x[:-1]
         x_i = x[1:]
 
-        innov_like = Normal.dist(mu=x_im1 + drift, tau=tau, sd=sd).logp(x_i)
+        innov_like = Normal.dist(mu=x_im1 + mu, tau=tau, sd=sd).logp(x_i)
         return init.logp(x[0]) + sum(innov_like)


### PR DESCRIPTION
This change would allow specifying drift (mu) for a GaussianRandomWalk. So, now the value for (or a prior over) can be defined over mu as well. Note, the default behaviour is unchanged as the default value for mu is 0.0. Also, I deleted self.mean = 0.0 assignment, because it doesn't look like it's used anywhere.
