### PR TITLE
Issue #899 fix

### DIFF
--- a/pymc3/examples/GHME 2013.ipynb
+++ b/pymc3/examples/GHME 2013.ipynb
@@ -723,7 +723,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "autocorrplot(trace, vars = [coeff_sd,sd ])"
+      "autocorrplot(trace, varnames = [coeff_sd,sd ])"
      ],
      "language": "python",
      "metadata": {},

--- a/pymc3/examples/GHME_2013.py
+++ b/pymc3/examples/GHME_2013.py
@@ -112,7 +112,7 @@ def run(n=3000):
 
     # <codecell>
 
-    autocorrplot(trace, vars = [coeff_sd,sd ])
+    autocorrplot(trace, varnames = [coeff_sd,sd ])
 
 if __name__ == '__main__':
     run()

--- a/pymc3/examples/gaussian_mixture_model.ipynb
+++ b/pymc3/examples/gaussian_mixture_model.ipynb
@@ -242,7 +242,7 @@
    ],
    "source": [
     "# I prefer autocorrelation plots for serious confirmation of MCMC convergence\n",
-    "pm.autocorrplot(tr[5000::5], ['sd'])"
+    "pm.autocorrplot(tr[5000::5], varnames=['sd'])"
    ]
   },
   {

--- a/pymc3/examples/survival_analysis.ipynb
+++ b/pymc3/examples/survival_analysis.ipynb
@@ -580,7 +580,7 @@
     }
    ],
    "source": [
-    "pm.autocorrplot(trace, vars=['beta']);"
+    "pm.autocorrplot(trace, varnames=['beta']);"
    ]
   },
   {

--- a/pymc3/tests/test_plots.py
+++ b/pymc3/tests/test_plots.py
@@ -56,7 +56,7 @@ def test_multichain_plots():
 
     forestplot(ptrace, vars=['early_mean', 'late_mean'])
 
-    autocorrplot(ptrace, vars=['switchpoint'])
+    autocorrplot(ptrace, varnames=['switchpoint'])
 
 def test_make_2d():
 


### PR DESCRIPTION
Added handling for `ax` kwarg, as per issue https://github.com/pymc-devs/pymc3/issues/899

Also:
1. Added `figsize` kwarg with handling similar to `traceplot()`
2. Renamed kwarg `vars` to `varnames` because `vars` is an alias for
`locals` in iPython
3. Replaced `xrange` with `range` for Python3 compliance
4. Changed return object from tuple of `(fig,ax)` to simply `ax`
similar to `traceplot()`
5. Clarified a couple of variables to indicate their purpose: `chains`
`nchains`, `val` to `varname`.
