### PR TITLE
Auto-assignment of ElemwiseCategoricalStep to Categorical variables

### DIFF
--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -26,11 +26,15 @@ class ElemwiseCategoricalStep(ArrayStep):
     # variables)
     def __init__(self, vars, values=None, model=None):
         model = modelcontext(model)
-        self.sh = ones(vars.dshape, vars.dtype)
-        self.values = values
-        self.vars = vars
+        self.var = vars[0]
+        self.sh = ones(self.var.dshape, self.var.dtype)
+        if values is None:
+            self.values = list(range(self.var.distribution.k))
+        else:
+            self.values = values
+        
 
-        super(ElemwiseCategoricalStep, self).__init__([vars], [elemwise_logp(model, vars)])
+        super(ElemwiseCategoricalStep, self).__init__(vars, [elemwise_logp(model, self.var)])
 
     def astep(self, q, logp):
         p = array([logp(v * self.sh) for v in self.values])

--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -43,7 +43,10 @@ class ElemwiseCategoricalStep(ArrayStep):
     @staticmethod
     def competence(var):
         if isinstance(var.distribution, Categorical):
-            return Competence.ideal
+            if var.distribution.k>2:
+                return Competence.ideal
+            else:
+                return Competence.compatible
         return Competence.incompatible
 
 def elemwise_logp(model, var):

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -4,7 +4,7 @@ from theano.tensor import constant
 from scipy.stats.mstats import moment
 from pymc3.sampling import assign_step_methods
 from pymc3.model import Model
-from pymc3.step_methods import NUTS, BinaryMetropolis, Metropolis, Constant
+from pymc3.step_methods import NUTS, BinaryMetropolis, Metropolis, Constant, ElemwiseCategoricalStep
 from pymc3.distributions import Binomial, Normal, Bernoulli, Categorical
 from numpy.testing import assert_almost_equal
 

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -127,7 +127,7 @@ def test_assign_step_methods():
         x = Categorical('x', np.array([0.25, 0.70, 0.05]))
         steps = assign_step_methods(model, [])
     
-        assert isinstance(steps, Metropolis)
+        assert isinstance(steps, ElemwiseCategoricalStep)
         
     with Model() as model:
         x = Binomial('x', 10, 0.5)


### PR DESCRIPTION
ElemwiseCategoricalStep now has a working `competence` method. Fixes #894 
