### PR TITLE
Correct column names for the HPD interval in df_summary

### DIFF
--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -411,8 +411,8 @@ def df_summary(trace, vars=None, stat_funcs=None, extend=False,
 
 
 def _hpd_df(x, alpha):
-    cnames = ['hpd_{0:g}'.format(100 * alpha),
-              'hpd_{0:g}'.format(100 * (1 - alpha))]
+    cnames = ['hpd_{0:g}'.format(100 * alpha/2),
+              'hpd_{0:g}'.format(100 * (1 - alpha/2))]
     return pd.DataFrame(hpd(x, alpha), columns=cnames)
 
 


### PR DESCRIPTION
The interval for a 95% HPD (the default value) should be 2.5-97.5 and not 5-95.
