### PR TITLE
WIP: Garch model

### DIFF
--- a/pymc3/examples/garch_example.py
+++ b/pymc3/examples/garch_example.py
@@ -1,0 +1,55 @@
+from pymc3 import Normal, sample, Model, Bound
+import theano.tensor as tt
+import numpy as np
+import math
+"""
+Example from STAN
+// GARCH(1,1)
+
+data {
+  int<lower=0> T;
+  real r[T];
+  real<lower=0> sigma1;
+}
+parameters {
+  real mu;
+  real<lower=0> alpha0;
+  real<lower=0,upper=1> alpha1;
+  real<lower=0, upper=(1-alpha1)> beta1;
+}
+transformed parameters {
+  real<lower=0> sigma[T];
+  sigma[1] <- sigma1;
+  for (t in 2:T)
+    sigma[t] <- sqrt(alpha0
+                     + alpha1 * pow(r[t-1] - mu, 2)
+                     + beta1 * pow(sigma[t-1], 2));
+}
+model {
+  r ~ normal(mu,sigma);
+}
+"""
+T = 8
+r = np.array([28,  8, -3,  7, -1,  1, 18, 12])
+sigma1 = np.array([15, 10, 16, 11,  9, 11, 10, 18])
+alpha0 = np.array([10, 10, 16, 8,  9, 11, 12, 18])
+
+with Model() as garch:
+
+    alpha1 = Normal('alpha1', 0, 1, shape=T)
+    BoundedNormal = Bound(Normal, upper=(1-alpha1))
+    beta1 = BoundedNormal('beta1', 0, sd=1e6)
+    mu = Normal('mu', 0, sd=1e6)
+
+    theta = tt.sqrt(alpha0 + alpha1*tt.pow(r - mu, 2) + beta1 * tt.pow(sigma1, 2))
+
+    obs = Normal('obs', mu, sd=theta, observed=r)
+
+def run(n=1000):
+    if n == "short":
+        n = 50
+    with garch:
+        tr = sample(n)
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
This is an early draft - trying to add in a Garch model to the examples. 

Error message - 
(pymc3_examples)Peadars-MBP% python pymc3/examples/garch_example.py
Traceback (most recent call last):
  File "pymc3/examples/garch_example.py", line 39, in <module>
    beta1 = Normal('mu', 0, 1-alpha1, sd=1e6)
  File "/Users/peadarcoyle/anaconda/envs/pymc3_examples/lib/python3.5/site-packages/pymc3/distributions/distribution.py", line 24, in **new**
    dist = cls.dist(_args, *_kwargs)
  File "/Users/peadarcoyle/anaconda/envs/pymc3_examples/lib/python3.5/site-packages/pymc3/distributions/distribution.py", line 37, in dist
    dist.**init**(_args, *_kwargs)
  File "/Users/peadarcoyle/anaconda/envs/pymc3_examples/lib/python3.5/site-packages/pymc3/distributions/continuous.py", line 179, in **init**
    self.tau, self.sd = get_tau_sd(tau=tau, sd=sd)
  File "/Users/peadarcoyle/anaconda/envs/pymc3_examples/lib/python3.5/site-packages/pymc3/distributions/continuous.py", line 67, in get_tau_sd
    raise ValueError("Can't pass both tau and sd")
ValueError: Can't pass both tau and sd
