### PR TITLE
prior plots for traceplot

### DIFF
--- a/pymc3/examples/disaster_model.py
+++ b/pymc3/examples/disaster_model.py
@@ -54,7 +54,7 @@ def run(n=1000):
         
         tr = sample(n, tune=500, start=start)
         
-        traceplot(tr, vars=[early_mean, late_mean], priors=[Exponential.dist(1)]*2)
+        traceplot(tr, varnames=[early_mean, late_mean], priors=[Exponential.dist(1)]*2)
     
         if n!=50:
             summary(tr)

--- a/pymc3/examples/disaster_model.py
+++ b/pymc3/examples/disaster_model.py
@@ -53,6 +53,8 @@ def run(n=1000):
         start = {'early_mean': 2., 'late_mean': 3.}
         
         tr = sample(n, tune=500, start=start)
+        
+        traceplot(tr, vars=[early_mean, late_mean], priors=[Exponential.dist(1)]*2)
     
         if n!=50:
             summary(tr)

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -6,7 +6,7 @@ from numpy.linalg import LinAlgError
 __all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot']
 
 
-def traceplot(trace, vars=None, figsize=None,
+def traceplot(trace, varsnames=None, figsize=None,
               lines=None, combined=False, alpha=0.35, grid=False, 
               priors=None, prior_alpha=1, prior_style='--',
               ax=None):
@@ -16,7 +16,7 @@ def traceplot(trace, vars=None, figsize=None,
     ----------
 
     trace : result of MCMC run
-    vars : list of variable names
+    varnames : list of variable names
         Variables to be plotted, if None all variable are plotted
     figsize : figure size tuple
         If None, size is (12, num of variables * 2) inch

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -7,8 +7,9 @@ __all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot']
 
 
 def traceplot(trace, vars=None, figsize=None,
-              lines=None, combined=False, grid=True,
-              alpha=0.35, ax=None):
+              lines=None, combined=False, alpha=0.35, grid=False, 
+              priors=None, prior_alpha=1, prior_style='--',
+              ax=None):
     """Plot samples histograms and values
 
     Parameters
@@ -26,8 +27,17 @@ def traceplot(trace, vars=None, figsize=None,
     combined : bool
         Flag for combining multiple chains into a single chain. If False
         (default), chains will be plotted separately.
+    alpha : float
+        Alpha value for plot line. Defaults to 0.35.
     grid : bool
         Flag for adding gridlines to histogram. Defaults to True.
+    priors : iterable of PyMC distributions
+        PyMC prior distribution(s) to be plotted alongside poterior. Defaults 
+        to None (no prior plots).
+    prior_alpha : float
+        Alpha value for prior plot. Defaults to 1.
+    prior_style : str
+        Line style for prior plot. Defaults to '--' (dashed line).
     ax : axes
         Matplotlib axes. Defaults to None.
 
@@ -53,13 +63,16 @@ def traceplot(trace, vars=None, figsize=None,
         return None
 
     for i, v in enumerate(vars):
+        prior = None
+        if priors is not None:
+            prior = priors[i]
         for d in trace.get_values(v, combine=combined, squeeze=False):
             d = np.squeeze(d)
             d = make_2d(d)
             if d.dtype.kind == 'i':
                 histplot_op(ax[i, 0], d, alpha=alpha)
             else:
-                kdeplot_op(ax[i, 0], d)
+                kdeplot_op(ax[i, 0], d, prior, prior_alpha, prior_style)
             ax[i, 0].set_title(str(v))
             ax[i, 0].grid(grid)
             ax[i, 1].set_title(str(v))
@@ -88,7 +101,7 @@ def histplot_op(ax, data, alpha=.35):
         ax.hist(d, bins=range(mind, maxd + 2, step), alpha=alpha, align='left')
         ax.set_xlim(mind - .5, maxd + .5)
 
-def kdeplot_op(ax, data):
+def kdeplot_op(ax, data, prior=None, prior_alpha=1, prior_style='--'):
     errored = []
     for i in range(data.shape[1]):
         d = data[:, i]
@@ -97,6 +110,10 @@ def kdeplot_op(ax, data):
             l = np.min(d)
             u = np.max(d)
             x = np.linspace(0, 1, 100) * (u - l) + l
+            
+            if prior is not None:
+                p = prior.logp(x).eval()
+                ax.plot(x, np.exp(p), alpha=prior_alpha, ls=prior_style)
 
             ax.plot(x, density(x))
 

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -7,8 +7,9 @@ __all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot']
 
 
 def traceplot(trace, varnames=None, figsize=None,
-              lines=None, combined=False, grid=True,
-              alpha=0.35, ax=None):
+              lines=None, combined=False, alpha=0.35, grid=False, 
+              priors=None, prior_alpha=1, prior_style='--',
+              ax=None):
     """Plot samples histograms and values
 
     Parameters
@@ -26,8 +27,17 @@ def traceplot(trace, varnames=None, figsize=None,
     combined : bool
         Flag for combining multiple chains into a single chain. If False
         (default), chains will be plotted separately.
+    alpha : float
+        Alpha value for plot line. Defaults to 0.35.
     grid : bool
         Flag for adding gridlines to histogram. Defaults to True.
+    priors : iterable of PyMC distributions
+        PyMC prior distribution(s) to be plotted alongside poterior. Defaults 
+        to None (no prior plots).
+    prior_alpha : float
+        Alpha value for prior plot. Defaults to 1.
+    prior_style : str
+        Line style for prior plot. Defaults to '--' (dashed line).
     ax : axes
         Matplotlib axes. Defaults to None.
 
@@ -53,13 +63,16 @@ def traceplot(trace, varnames=None, figsize=None,
         return None
 
     for i, v in enumerate(varnames):
+        prior = None
+        if priors is not None:
+            prior = priors[i]
         for d in trace.get_values(v, combine=combined, squeeze=False):
             d = np.squeeze(d)
             d = make_2d(d)
             if d.dtype.kind == 'i':
                 histplot_op(ax[i, 0], d, alpha=alpha)
             else:
-                kdeplot_op(ax[i, 0], d)
+                kdeplot_op(ax[i, 0], d, prior, prior_alpha, prior_style)
             ax[i, 0].set_title(str(v))
             ax[i, 0].grid(grid)
             ax[i, 1].set_title(str(v))
@@ -88,7 +101,7 @@ def histplot_op(ax, data, alpha=.35):
         ax.hist(d, bins=range(mind, maxd + 2, step), alpha=alpha, align='left')
         ax.set_xlim(mind - .5, maxd + .5)
 
-def kdeplot_op(ax, data):
+def kdeplot_op(ax, data, prior=None, prior_alpha=1, prior_style='--'):
     errored = []
     for i in range(data.shape[1]):
         d = data[:, i]
@@ -97,6 +110,10 @@ def kdeplot_op(ax, data):
             l = np.min(d)
             u = np.max(d)
             x = np.linspace(0, 1, 100) * (u - l) + l
+            
+            if prior is not None:
+                p = prior.logp(x).eval()
+                ax.plot(x, np.exp(p), alpha=prior_alpha, ls=prior_style)
 
             ax.plot(x, density(x))
 


### PR DESCRIPTION
Permits optional plotting of prior along with traceplot's kde plot. 
