### PR TITLE
Replace ADVI progress bar with ELBO monitoring

### DIFF
--- a/pymc3/examples/advi.ipynb
+++ b/pymc3/examples/advi.ipynb
@@ -69,16 +69,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Iteration 0 [0%]: ELBO = -1372.98\n",
-      "Iteration 2000 [10%]: ELBO = -294.57\n",
-      "Iteration 4000 [20%]: ELBO = -193.17\n",
-      "Iteration 6000 [30%]: ELBO = -166.75\n",
-      "Iteration 8000 [40%]: ELBO = -156.82\n",
-      "Iteration 10000 [50%]: ELBO = -154.36\n",
-      "Iteration 12000 [60%]: ELBO = -152.1\n",
-      "Iteration 14000 [70%]: ELBO = -151.64\n",
-      "Iteration 16000 [80%]: ELBO = -151.18\n",
-      "Iteration 18000 [90%]: ELBO = -151.24\n"
+      "Iteration 0 [0%]: ELBO = -1359.84\n",
+      "Iteration 2000 [10%]: ELBO = -291.4\n",
+      "Iteration 4000 [20%]: ELBO = -191.83\n",
+      "Iteration 6000 [30%]: ELBO = -165.56\n",
+      "Iteration 8000 [40%]: ELBO = -155.54\n",
+      "Iteration 10000 [50%]: ELBO = -153.04\n",
+      "Iteration 12000 [60%]: ELBO = -150.78\n",
+      "Iteration 14000 [70%]: ELBO = -150.32\n",
+      "Iteration 16000 [80%]: ELBO = -149.85\n",
+      "Iteration 18000 [90%]: ELBO = -149.91\n",
+      "Finished [100%]: ELBO = -149.73\n"
      ]
     }
    ],

--- a/pymc3/examples/advi.ipynb
+++ b/pymc3/examples/advi.ipynb
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -69,7 +69,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " [-----------------83%-----------       ] 16758 of 20000 complete in 18.5 sec"
+      "Iteration 0 [0%]: ELBO = -1372.98\n",
+      "Iteration 2000 [10%]: ELBO = -294.57\n",
+      "Iteration 4000 [20%]: ELBO = -193.17\n",
+      "Iteration 6000 [30%]: ELBO = -166.75\n",
+      "Iteration 8000 [40%]: ELBO = -156.82\n",
+      "Iteration 10000 [50%]: ELBO = -154.36\n",
+      "Iteration 12000 [60%]: ELBO = -152.1\n",
+      "Iteration 14000 [70%]: ELBO = -151.64\n",
+      "Iteration 16000 [80%]: ELBO = -151.18\n",
+      "Iteration 18000 [90%]: ELBO = -151.24\n"
      ]
     }
    ],
@@ -259,7 +268,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -71,7 +71,9 @@ def run_adagrad(uw, grad, elbo, inarray, n, learning_rate=.001, epsilon=.1,
         elbos[i] = e
         if verbose and not i % (n//10):
             print('Iteration {0} [{1}%]: ELBO = {2}'.format(i, 100*i//n, e.round(2)))
-
+    
+    if verbose:
+        print('Finished [100%]: ELBO = {}'.format(elbos[-1].round(2)))
     return uw_i, elbos
 
 def variational_gradient_estimate(vars, model, accurate_elbo=False):

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -70,7 +70,7 @@ def run_adagrad(uw, grad, elbo, inarray, n, learning_rate=.001, epsilon=.1,
         uw_i, g, e = f()
         elbos[i] = e
         if verbose and not i % (n//10):
-            print('Iteration {0} [{1}%]: ELBO = {2:.2f}'.format(i, 100*i/n, e))
+            print('Iteration {0} [{1}%]: ELBO = {2}'.format(i, 100*i//n, e.round(2)))
 
     return uw_i, elbos
 

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -15,14 +15,12 @@ import theano.tensor as T
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 from collections import OrderedDict, namedtuple
 
-from ..progressbar import progress_bar
-
 __all__ = ['advi']
 
 ADVIFit = namedtuple('ADVIFit', 'means, stds, elbo_vals')
 
-def advi(vars=None, start=None, model=None, n=5000, progressbar=True,
-         accurate_elbo=False, learning_rate=.001, epsilon=.1):
+def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False, 
+    learning_rate=.001, epsilon=.1, verbose=1):
     model = modelcontext(model)
     if start is None:
         start = model.test_point
@@ -44,7 +42,7 @@ def advi(vars=None, start=None, model=None, n=5000, progressbar=True,
     w_start = np.zeros_like(u_start)
     uw = np.concatenate([u_start, w_start])
 
-    result, elbos = run_adagrad(uw, grad, elbo, inarray, n, learning_rate=learning_rate, epsilon=epsilon, progressbar=progressbar)
+    result, elbos = run_adagrad(uw, grad, elbo, inarray, n, learning_rate=learning_rate, epsilon=epsilon, verbose=verbose)
 
     l = result.size / 2
 
@@ -56,7 +54,7 @@ def advi(vars=None, start=None, model=None, n=5000, progressbar=True,
     return ADVIFit(u, w, elbos)
 
 def run_adagrad(uw, grad, elbo, inarray, n, learning_rate=.001, epsilon=.1,
-                progressbar=True):
+                verbose=1):
     shared_inarray = theano.shared(uw, 'uw_shared')
     grad = CallableTensor(grad)(shared_inarray)
     elbo = CallableTensor(elbo)(shared_inarray)
@@ -66,16 +64,13 @@ def run_adagrad(uw, grad, elbo, inarray, n, learning_rate=.001, epsilon=.1,
     # Create in-place update function
     f = theano.function([], [shared_inarray, grad, elbo], updates=updates)
 
-    if progressbar:
-        progress = progress_bar(n)
-
     # Run adagrad steps
     elbos = np.empty(n)
     for i in range(n):
         uw_i, g, e = f()
         elbos[i] = e
-        if progressbar:
-            progress.update(i)
+        if verbose and not i % (n//10):
+            print('Iteration {0} [{1}%]: ELBO = {2:.2f}'.format(i, 100*i/n, e))
 
     return uw_i, elbos
 
@@ -93,7 +88,7 @@ def variational_gradient_estimate(vars, model, accurate_elbo=False):
     r = MRG_RandomStreams(seed=1)
     n = r.normal(size=inarray.tag.test_value.shape)
 
-    gradient_estimate, eblo_estimate = inner_gradients(logp, n, uw)
+    gradient_estimate, elbo_estimate = inner_gradients(logp, n, uw)
 
     # More accurate estimation of ELBO
     if accurate_elbo:


### PR DESCRIPTION
See if we like this instead of a progress bar.

```

Iteration 0 [0%]: ELBO = -1372.98
Iteration 2000 [10%]: ELBO = -294.57
Iteration 4000 [20%]: ELBO = -193.17
Iteration 6000 [30%]: ELBO = -166.75
Iteration 8000 [40%]: ELBO = -156.82
Iteration 10000 [50%]: ELBO = -154.36
Iteration 12000 [60%]: ELBO = -152.1
Iteration 14000 [70%]: ELBO = -151.64
Iteration 16000 [80%]: ELBO = -151.18
Iteration 18000 [90%]: ELBO = -151.24
Finished [100%]: ELBO = -149.73
```

It only ever prints out 10 lines, so it will not be lengthy output.
