### PR TITLE
Replaced lower case with upper case R in raw string blocks

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -77,7 +77,7 @@ def get_tau_sd(tau=None, sd=None):
 
 
 class Uniform(Continuous):
-    r"""
+    R"""
     Continuous uniform log-likelihood.
 
     .. math::
@@ -141,7 +141,7 @@ class Flat(Continuous):
 
 
 class Normal(Continuous):
-    r"""
+    R"""
     Univariate normal log-likelihood.
 
     .. math::
@@ -195,7 +195,7 @@ class Normal(Continuous):
 
 
 class HalfNormal(PositiveContinuous):
-    r"""
+    R"""
     Half-normal log-likelihood.
 
     .. math::
@@ -238,7 +238,7 @@ class HalfNormal(PositiveContinuous):
 
 
 class Wald(PositiveContinuous):
-    r"""
+    R"""
     Wald log-likelihood.
 
     .. math::
@@ -350,7 +350,7 @@ class Wald(PositiveContinuous):
 
 
 class Beta(UnitContinuous):
-    r"""
+    R"""
     Beta log-likelihood.
 
     .. math::
@@ -430,7 +430,7 @@ class Beta(UnitContinuous):
 
 
 class Exponential(PositiveContinuous):
-    r"""
+    R"""
     Exponential log-likelihood.
 
     .. math::
@@ -469,7 +469,7 @@ class Exponential(PositiveContinuous):
 
 
 class Laplace(Continuous):
-    r"""
+    R"""
     Laplace log-likelihood.
 
     .. math::
@@ -511,7 +511,7 @@ class Laplace(Continuous):
 
 
 class Lognormal(PositiveContinuous):
-    r"""
+    R"""
     Log-normal log-likelihood.
 
     Distribution of any random variable whose logarithm is normally
@@ -568,7 +568,7 @@ class Lognormal(PositiveContinuous):
 
 
 class StudentT(Continuous):
-    r"""
+    R"""
     Non-central Student's T log-likelihood.
 
     Describes a normal variable whose precision is gamma distributed.
@@ -626,7 +626,7 @@ class StudentT(Continuous):
 
 
 class Pareto(PositiveContinuous):
-    r"""
+    R"""
     Pareto log-likelihood.
 
     Often used to characterize wealth distribution, or other examples of the
@@ -681,7 +681,7 @@ class Pareto(PositiveContinuous):
 
 
 class Cauchy(Continuous):
-    r"""
+    R"""
     Cauchy log-likelihood.
 
     Also known as the Lorentz or the Breit-Wigner distribution.
@@ -730,7 +730,7 @@ class Cauchy(Continuous):
 
 
 class HalfCauchy(PositiveContinuous):
-    r"""
+    R"""
     Half-Cauchy log-likelihood.
 
     .. math::
@@ -773,7 +773,7 @@ class HalfCauchy(PositiveContinuous):
 
 
 class Gamma(PositiveContinuous):
-    r"""
+    R"""
     Gamma log-likelihood.
 
     Represents the sum of alpha exponentially distributed random variables,
@@ -853,7 +853,7 @@ class Gamma(PositiveContinuous):
 
 
 class InverseGamma(PositiveContinuous):
-    r"""
+    R"""
     Inverse gamma log-likelihood, the reciprocal of the gamma distribution.
 
     .. math::
@@ -902,7 +902,7 @@ class InverseGamma(PositiveContinuous):
 
 
 class ChiSquared(Gamma):
-    r"""
+    R"""
     :math:`\chi^2` log-likelihood.
 
     .. math::
@@ -927,7 +927,7 @@ class ChiSquared(Gamma):
 
 
 class Weibull(PositiveContinuous):
-    r"""
+    R"""
     Weibull log-likelihood.
 
     .. math::
@@ -1035,7 +1035,7 @@ StudentTpos = Bound(StudentT, 0)
 
 
 class ExGaussian(Continuous):
-    r"""
+    R"""
     Exponentially modified Gaussian log-likelihood.
 
     Results from the convolution of a normal distribution with an exponential

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -14,7 +14,7 @@ __all__ = ['Binomial',  'BetaBinomial',  'Bernoulli',  'Poisson',
 
 
 class Binomial(Discrete):
-    r"""
+    R"""
     Binomial log-likelihood.
 
     The discrete probability distribution of the number of successes
@@ -59,7 +59,7 @@ class Binomial(Discrete):
 
 
 class BetaBinomial(Discrete):
-    r"""
+    R"""
     Beta-binomial log-likelihood.
 
     Equivalent to binomial random variable with success probability
@@ -123,7 +123,7 @@ class BetaBinomial(Discrete):
 
 
 class Bernoulli(Discrete):
-    r"""Bernoulli log-likelihood
+    R"""Bernoulli log-likelihood
 
     The Bernoulli distribution describes the probability of successes
     (x=1) and failures (x=0).
@@ -161,7 +161,7 @@ class Bernoulli(Discrete):
 
 
 class Poisson(Discrete):
-    r"""
+    R"""
     Poisson log-likelihood.
 
     Often used to model the number of events occurring in a fixed period
@@ -205,7 +205,7 @@ class Poisson(Discrete):
 
 
 class NegativeBinomial(Discrete):
-    r"""
+    R"""
     Negative binomial log-likelihood.
 
     The negative binomial distribution describes a Poisson random variable
@@ -258,7 +258,7 @@ class NegativeBinomial(Discrete):
 
 
 class Geometric(Discrete):
-    r"""
+    R"""
     Geometric log-likelihood.
 
     The probability that the first success in a sequence of Bernoulli
@@ -295,7 +295,7 @@ class Geometric(Discrete):
 
 
 class DiscreteUniform(Discrete):
-    r"""
+    R"""
     Discrete uniform distribution.
 
     .. math:: f(x \mid lower, upper) = \frac{1}{upper-lower}
@@ -341,7 +341,7 @@ class DiscreteUniform(Discrete):
 
 
 class Categorical(Discrete):
-    r"""
+    R"""
     Categorical log-likelihood.
 
     The most general discrete distribution.

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -16,7 +16,7 @@ __all__ = ['MvNormal', 'Dirichlet', 'Multinomial', 'Wishart', 'LKJCorr']
 
 
 class MvNormal(Continuous):
-    r"""
+    R"""
     Multivariate normal log-likelihood.
 
     .. math::
@@ -71,7 +71,7 @@ class MvNormal(Continuous):
 
 
 class Dirichlet(Continuous):
-    r"""
+    R"""
     Dirichlet log-likelihood.
 
     .. math::
@@ -136,7 +136,7 @@ class Dirichlet(Continuous):
 
 
 class Multinomial(Discrete):
-    r"""
+    R"""
     Multinomial log-likelihood.
 
     Generalizes binomial distribution, but instead of each trial resulting
@@ -244,7 +244,7 @@ matrix_pos_def = PosDefMatrix()
 
 
 class Wishart(Continuous):
-    r"""
+    R"""
     Wishart log-likelihood.
 
     The Wishart distribution is the probability
@@ -312,7 +312,7 @@ class Wishart(Continuous):
 
     
 class LKJCorr(Continuous):
-    r"""
+    R"""
     The LKJ (Lewandowski, Kurowicka and Joe) log-likelihood.
 
     The LKJ distribution is a prior distribution for correlation matrices.


### PR DESCRIPTION
For some reason lower case r for raw string block (i.e. r""") screws up syntax highlighting in some editors. Upper case R fixes this and does not affect interpretation of raw string.
