### PR TITLE
add vonmises distribution and tests

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -13,7 +13,7 @@ from scipy import stats
 from scipy import special
 
 from . import transforms
-from .dist_math import bound, logpow, gammaln, betaln, std_cdf
+from .dist_math import bound, logpow, gammaln, betaln, std_cdf, i0, i1
 from .distribution import Continuous, draw_values, generate_samples
 
 __all__ = ['Uniform', 'Flat', 'Normal', 'Beta', 'Exponential', 'Laplace',
@@ -1141,9 +1141,7 @@ class VonMises(Continuous):
         super(VonMises, self).__init__(*args, **kwargs)
         self.mean = self.median = self.mode = self.mu = mu
         self.kappa = kappa 
-        self.variance = T.switch(T.lt(kappa, 1.5), 
-        1 - kappa/2 * (1 - 1/8*kappa**2 + 1/48*kappa**4), 
-        1/(2*kappa) + 1/(8*kappa**2) + 1/(8*kappa**3))
+        self.variance = 1 - i1(kappa)/i0(kappa)
             
     def random(self, point=None, size=None, repeat=None):
         mu, kappa = draw_values([self.mu, self.kappa],
@@ -1155,4 +1153,4 @@ class VonMises(Continuous):
     def logp(self, value):
         mu = self.mu
         kappa = self.kappa
-        return bound(kappa * T.cos(mu - value) - T.log(2 * np.pi * special.i0(kappa)), value >= -np.pi, value <= np.pi, kappa >= 0)
+        return bound(kappa * T.cos(mu - value) - T.log(2 * np.pi * i0(kappa)), value >= -np.pi, value <= np.pi, kappa >= 0)

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -10,7 +10,6 @@ from __future__ import division
 import numpy as np
 import theano.tensor as T
 from scipy import stats
-from scipy import special
 
 from . import transforms
 from .dist_math import bound, logpow, gammaln, betaln, std_cdf, i0, i1

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -60,3 +60,17 @@ def std_cdf(x):
     Calculates the standard normal cumulative distribution function.
     """
     return 0.5 + 0.5*T.erf(x / T.sqrt(2.))
+    
+
+def i0(x):
+    """
+    Calculates the 0 order modified Bessel function of the first kind""
+    """
+    return T.switch(T.lt(x, 5), 1 + x**2/4 + x**4/64 + x**6/2304 + x**8/147456, np.e**x/(2*np.pi*x)**0.5*(1+1/(8*x) + 9/(128*x**2) + 225/(3072*x**3) + 11025/(98304*x**4)))
+
+
+def i1(x):
+    """
+    Calculates the 1 order modified Bessel function of the first kind""
+    """
+    return T.switch(T.lt(x, 5),  x/2 + x**3/16 + x**5/384 + x**7/18432 + x**9/1474560, np.e**x/(2*np.pi*x)**0.5*(1-3/(8*x) + 15/(128*x**2) + 315/(3072*x**3) + 14175/(98304*x**4)))

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -66,11 +66,17 @@ def i0(x):
     """
     Calculates the 0 order modified Bessel function of the first kind""
     """
-    return T.switch(T.lt(x, 5), 1 + x**2/4 + x**4/64 + x**6/2304 + x**8/147456, np.e**x/(2*np.pi*x)**0.5*(1+1/(8*x) + 9/(128*x**2) + 225/(3072*x**3) + 11025/(98304*x**4)))
+    return T.switch(T.lt(x, 5), 1 + x**2/4 + x**4/64 + x**6/2304 + x**8/147456
+     + x**10/14745600 + x**12/2123366400, 
+     np.e**x/(2*np.pi*x)**0.5*(1+1/(8*x) + 9/(128*x**2) + 225/(3072*x**3)
+      + 11025/(98304*x**4)))
 
 
 def i1(x):
     """
     Calculates the 1 order modified Bessel function of the first kind""
     """
-    return T.switch(T.lt(x, 5),  x/2 + x**3/16 + x**5/384 + x**7/18432 + x**9/1474560, np.e**x/(2*np.pi*x)**0.5*(1-3/(8*x) + 15/(128*x**2) + 315/(3072*x**3) + 14175/(98304*x**4)))
+    return T.switch(T.lt(x, 5), x/2 + x**3/16 + x**5/384 + x**7/18432 + 
+    x**9/1474560 + x**11/176947200 +  x**13/29727129600 ,
+    np.e**x/(2*np.pi*x)**0.5*(1-3/(8*x) + 15/(128*x**2) + 315/(3072*x**3)
+     + 14175/(98304*x**4)))

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -653,6 +653,11 @@ def check_ex_gaussian(value, mu, sigma, nu, logp):
     assert_almost_equal(model.fastlogp(pt),
                 logp, decimal=6, err_msg=str(pt))
 
+def test_vonmises():
+    pymc3_matches_scipy(
+            VonMises, R, {'mu': R, 'kappa': Rplus},
+            lambda value, mu, kappa: sp.vonmises.logpdf(value, kappa, loc=mu)
+            )
 
 def test_multidimensional_beta_construction():
     with Model() as m:

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -173,6 +173,9 @@ class ScalarParameterShape(unittest.TestCase):
 
     def test_ex_gaussian(self):
         self.check(ExGaussian, mu=0., sigma=1., nu=1.)
+        
+    def test_vonmises(self):
+        self.check(VonMises, mu=0., kappa=1.)
 
     def test_binomial(self):
         self.check(Binomial,  n=5., p=0.5)
@@ -266,6 +269,9 @@ class ScalarShape(unittest.TestCase):
 
     def test_ex_gaussian(self):
         self.check(ExGaussian, mu=0., sigma=1., nu=1.)
+        
+    def test_vonmises(self):
+        self.check(VonMises, mu=0., kappa=1.)
 
     def test_binomial(self):
         self.check(Binomial,  n=5., p=0.5)
@@ -367,6 +373,9 @@ class Parameters1dShape(unittest.TestCase):
 
     def test_ex_gaussian(self):
         self.check(ExGaussian, mu=self.zeros, sigma=self.ones, nu=self.ones)
+        
+    def test_vonmises(self):
+        self.check(VonMises, mu=self.zeros, kappa=self.ones)
 
     def test_binomial(self):
         self.check(Binomial,  n=(self.ones * 5).astype(int), p=self.ones / 5)
@@ -477,6 +486,9 @@ class BroadcastShape(unittest.TestCase):
 
     def test_ex_gaussian(self):
         self.check(ExGaussian, mu=self.zeros, sigma=self.ones, nu=self.ones)
+        
+    def test_vonmises(self):
+        self.check(VonMises, mu=self.zeros, kappa=self.ones)
 
     def test_binomial(self):
         self.check(Binomial, n=(self.ones * 5).astype(int), p=self.ones / 5)
@@ -616,6 +628,10 @@ class ScalarParameterSamples(unittest.TestCase):
                 ref_rand=lambda size, mu=None, sigma=None, nu=None: \
                     nr.normal(mu, sigma, size=size) + nr.exponential(scale=nu, size=size)
                 )
+                
+    def test_vonmises(self):
+        pymc3_random(VonMises, {'mu':R, 'kappa':Rplus},
+                     ref_rand=lambda size, mu=None, kappa=None: st.vonmises.rvs(size=size,loc=mu, kappa=kappa))
 
     def test_bounded(self):
         # A bit crude...


### PR DESCRIPTION
I have implemented the [von Mises](https://en.wikipedia.org/wiki/Von_Mises_distribution), is similar to a gaussian distribution but defined on the circle, i.e. `[-pi, pi]`. 

I am not sure about the tests, I just tried to implement tests similar to those for other distributions.

Based on comparison with `scipy.stats.vonmises` I think the distribution is working correctly, in general. Although, some artifacts appear if you sample a von Mises close to `+-pi`. Since `-pi` and `pi` are really the same number (and the variable is restricted to a circular space) the density for these points should be the same. In practice, they differ and the magnitude of the difference decrease with the sample size. I guess this could improved if a transformation is applied to take into account the circularity of the variable. I will explore this idea further, in the next few days.
