### PR TITLE
Adaptive Transitional Markov Chain Monte Carlo

### DIFF
--- a/pymc3/examples/ATMIP_2gaussians.py
+++ b/pymc3/examples/ATMIP_2gaussians.py
@@ -1,13 +1,13 @@
 import pymc3 as pm
 import numpy as num
-import ATMCMC as atmcmc
+from pymc3.step_methods import ATMCMC as atmcmc
 import theano.tensor as tt
 from matplotlib import pylab as pl
 
 test_folder = ('ATMIP_TEST')
 
-N_chains = 500
-N_steps = 100
+n_chains = 500
+n_steps = 100
 tune_interval = 25
 njobs = 1
 
@@ -45,11 +45,11 @@ with pm.Model() as ATMIP_test:
     llk = pm.Potential('like', like)
 
 with ATMIP_test:
-    step = atmcmc.ATMCMC(N_chains=N_chains, tune_interval=tune_interval,
+    step = atmcmc.ATMCMC(n_chains=n_chains, tune_interval=tune_interval,
                          likelihood_name=ATMIP_test.deterministics[0].name)
 
 trcs = atmcmc.ATMIP_sample(
-                        N_steps=N_steps,
+                        n_steps=n_steps,
                         step=step,
                         njobs=njobs,
                         progressbar=True,

--- a/pymc3/examples/ATMIP_2gaussians.py
+++ b/pymc3/examples/ATMIP_2gaussians.py
@@ -1,0 +1,61 @@
+import pymc3 as pm
+import numpy as num
+import ATMCMC as atmcmc
+import theano.tensor as tt
+from matplotlib import pylab as pl
+
+test_folder = ('ATMIP_TEST')
+
+N_chains = 500
+N_steps = 100
+tune_interval = 25
+njobs = 1
+
+n = 4
+
+mu1 = num.ones(n) * (1. / 2)
+mu2 = -mu1
+
+stdev = 0.1
+sigma = num.power(stdev, 2) * num.eye(n)
+isigma = num.linalg.inv(sigma)
+dsigma = num.linalg.det(sigma)
+
+w1 = stdev
+w2 = (1 - stdev)
+
+
+def two_gaussians(x):
+    log_like1 = - 0.5 * n * tt.log(2 * num.pi) \
+                - 0.5 * tt.log(dsigma) \
+                - 0.5 * (x - mu1).T.dot(isigma).dot(x - mu1)
+    log_like2 = - 0.5 * n * tt.log(2 * num.pi) \
+                - 0.5 * tt.log(dsigma) \
+                - 0.5 * (x - mu2).T.dot(isigma).dot(x - mu2)
+    return tt.log(w1 * tt.exp(log_like1) + w2 * tt.exp(log_like2))
+
+with pm.Model() as ATMIP_test:
+    X = pm.Uniform('X',
+                   shape=n,
+                   lower=-2. * num.ones_like(mu1),
+                   upper=2. * num.ones_like(mu1),
+                   testval=-1. * num.ones_like(mu1),
+                   transform=None)
+    like = pm.Deterministic('like', two_gaussians(X))
+    llk = pm.Potential('like', like)
+
+with ATMIP_test:
+    step = atmcmc.ATMCMC(N_chains=N_chains, tune_interval=tune_interval,
+                         likelihood_name=ATMIP_test.deterministics[0].name)
+
+trcs = atmcmc.ATMIP_sample(
+                        N_steps=N_steps,
+                        step=step,
+                        njobs=njobs,
+                        progressbar=True,
+                        trace=test_folder,
+                        model=ATMIP_test)
+
+pm.summary(trcs)
+Pltr = pm.traceplot(trcs, combined=True)
+pl.show(Pltr[0][0])

--- a/pymc3/examples/ATMIP_2gaussians.py
+++ b/pymc3/examples/ATMIP_2gaussians.py
@@ -1,8 +1,8 @@
 import pymc3 as pm
-import numpy as num
+import numpy as np
 from pymc3.step_methods import ATMCMC as atmcmc
 import theano.tensor as tt
-from matplotlib import pylab as pl
+from matplotlib import pylab as plt
 
 test_folder = ('ATMIP_TEST')
 
@@ -13,23 +13,23 @@ njobs = 1
 
 n = 4
 
-mu1 = num.ones(n) * (1. / 2)
+mu1 = np.ones(n) * (1. / 2)
 mu2 = -mu1
 
 stdev = 0.1
-sigma = num.power(stdev, 2) * num.eye(n)
-isigma = num.linalg.inv(sigma)
-dsigma = num.linalg.det(sigma)
+sigma = np.power(stdev, 2) * np.eye(n)
+isigma = np.linalg.inv(sigma)
+dsigma = np.linalg.det(sigma)
 
 w1 = stdev
 w2 = (1 - stdev)
 
 
 def two_gaussians(x):
-    log_like1 = - 0.5 * n * tt.log(2 * num.pi) \
+    log_like1 = - 0.5 * n * tt.log(2 * np.pi) \
                 - 0.5 * tt.log(dsigma) \
                 - 0.5 * (x - mu1).T.dot(isigma).dot(x - mu1)
-    log_like2 = - 0.5 * n * tt.log(2 * num.pi) \
+    log_like2 = - 0.5 * n * tt.log(2 * np.pi) \
                 - 0.5 * tt.log(dsigma) \
                 - 0.5 * (x - mu2).T.dot(isigma).dot(x - mu2)
     return tt.log(w1 * tt.exp(log_like1) + w2 * tt.exp(log_like2))
@@ -37,9 +37,9 @@ def two_gaussians(x):
 with pm.Model() as ATMIP_test:
     X = pm.Uniform('X',
                    shape=n,
-                   lower=-2. * num.ones_like(mu1),
-                   upper=2. * num.ones_like(mu1),
-                   testval=-1. * num.ones_like(mu1),
+                   lower=-2. * np.ones_like(mu1),
+                   upper=2. * np.ones_like(mu1),
+                   testval=-1. * np.ones_like(mu1),
                    transform=None)
     like = pm.Deterministic('like', two_gaussians(X))
     llk = pm.Potential('like', like)
@@ -58,4 +58,4 @@ trcs = atmcmc.ATMIP_sample(
 
 pm.summary(trcs)
 Pltr = pm.traceplot(trcs, combined=True)
-pl.show(Pltr[0][0])
+plt.show(Pltr[0][0])

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -193,6 +193,13 @@ class Model(Context, Factor):
         return T.add(*map(T.sum, factors))
 
     @property
+    def varlogpt(self):
+        """Theano scalar of log-probability of the unobserved random variables 
+           (excluding deterministic)."""
+        factors = [var.logpt for var in self.vars]
+        return T.add(*map(T.sum, factors))
+
+    @property
     def vars(self):
         """List of unobserved random variables used as inputs to the model
         (which excludes deterministics).

--- a/pymc3/step_methods/ATMCMC.py
+++ b/pymc3/step_methods/ATMCMC.py
@@ -8,7 +8,6 @@ import numpy as np
 import pymc3 as pm
 
 import os
-import copy
 import theano
 
 from pymc3.theanof import make_shared_replacements, join_nonshared_inputs
@@ -29,7 +28,9 @@ class ATMCMC(pm.arraystep.ArrayStepShared):
                 Journal of Engineering Mechanics 2007
                 DOI:10.1016/(ASCE)0733-9399(2007)133:7(816)
     http://ascelibrary.org/doi/abs/10.1061/%28ASCE%290733-9399%282007%29133:7%28816%29
+
     Creates initial samples and framework around the (C)ATMIP parameters
+
     Parameters
     ----------
     vars : list
@@ -211,9 +212,9 @@ class ATMCMC(pm.arraystep.ArrayStepShared):
             for var, slc, shp, _ in self.ordering.vmap:
                 if len(shp) == 0:
                     array_population[:, slc] = np.atleast_2d(
-                        mtrace.get_values(varname=var,
-                                          burn=n_steps - 1,
-                                          combine=True)).T
+                                        mtrace.get_values(varname=var,
+                                                    burn=n_steps - 1,
+                                                    combine=True)).T
                 else:
                     array_population[:, slc] = mtrace.get_values(
                                                         varname=var,

--- a/pymc3/step_methods/ATMCMC.py
+++ b/pymc3/step_methods/ATMCMC.py
@@ -1,0 +1,447 @@
+'''
+Created on March, 2016
+
+@author: Hannes Vasyura-Bathke
+'''
+
+import numpy as num
+import pymc3 as pm
+
+import theano
+
+from pymc3.theanof import make_shared_replacements, join_nonshared_inputs
+from pymc3.step_methods.metropolis import MultivariateNormalProposal as MvNPd
+from numpy.random import seed
+from joblib import Parallel, delayed
+
+__all__ = ['ATMCMC', 'ATMIP_sample']
+
+
+class ATMCMC(pm.arraystep.ArrayStepShared):
+    """
+    Transitional Marcov-Chain Monte-Carlo
+    following: Ching & Chen 2007: Transitional Markov chain Monte Carlo method
+                for Bayesian model updating, model class selection and model
+                averaging
+                Journal of Engineering Mechanics 2007
+                DOI:10.1016/(ASCE)0733-9399(2007)133:7(816)
+    Creates initial samples and framework around the CATMIP parameters
+    Parameters
+    ----------
+    vars : list
+        List of variables for sampler
+    N_chains : (integer) Number of chains per stage has to be a large number
+               of number of njobs (processors to be used) on the machine.
+    Covariance - Initial Covariance matrix for proposal distribution,
+        if None - identity matrix taken
+    proposal_dist - Type of proposal distribution, see metropolis.py for
+                    options
+    model : PyMC Model
+        Optional model for sampling step.
+        Defaults to None (taken from context).
+    """
+    default_blocked = True
+
+    def __init__(self, vars=None, Covariance=None, scaling=1., N_chains=100,
+                 tune=True, tune_interval=100, model=None,
+                 proposal_dist=MvNPd,
+                 N_steps=1000, **kwargs):
+
+        model = pm.modelcontext(model)
+
+        if vars is None:
+            vars = model.vars
+        vars = pm.inputvars(vars)
+
+        if Covariance is None:
+            self.Covariance = num.eye(sum(v.dsize for v in vars))
+        self.scaling = num.atleast_1d(scaling)
+        self.tune = tune
+        self.tune_interval = tune_interval
+        self.steps_until_tune = tune_interval
+        self.proposal_dist = proposal_dist(self.Covariance)
+        self.accepted = 0
+        self.beta = 0
+        self.stage = 0
+        self.N_chains = N_chains
+        self.likelihoods = []
+        self.discrete = num.ravel(
+            [[v.dtype in pm.discrete_types] * (v.dsize or 1) for v in vars])
+        self.any_discrete = self.discrete.any()
+        self.all_discrete = self.discrete.all()
+        # create initial population
+        self.population = []
+        self.array_population = num.zeros(N_chains)
+        for i in range(self.N_chains):
+            dummy = pm.Point({v.name: v.random() for v in vars},
+                                                            model=model)
+            self.population.append(dummy)
+
+        shared = make_shared_replacements(vars, model)
+        self.logp_forw = logp_forw(model.logpt, vars, shared)
+        self.check_bnd = logp_forw(model.varlogpt, vars, shared)
+        self.delta_logp = pm.metropolis.delta_logp(model.logpt, vars, shared)
+
+        super(ATMCMC, self).__init__(vars, shared)
+
+    def astep(self, q0):
+        if self.stage == 0:
+            self.likelihoods.append(self.logp_forw(q0))
+            q_new = q0
+        else:
+            if not self.steps_until_tune and self.tune:
+                # Tune scaling parameter
+                R = self.accepted / float(self.tune_interval)
+                # a and b after Muto & Beck 2008 .
+                a = 1. / 9
+                b = 8. / 9
+                self.scaling = num.power((a + (b * R)), 2)
+
+                # Reset counter
+                self.steps_until_tune = self.tune_interval
+                self.accepted = 0
+
+            delta = self.proposal_dist() * self.scaling
+            check_bnd = True
+            while check_bnd:
+                if self.any_discrete:
+                    if self.all_discrete:
+                        delta = round(delta, 0)
+                        q0 = q0.astype(int)
+                        q = (q0 + delta).astype(int)
+                        varlogp = self.check_bnd(q)
+                    else:
+                        delta[self.discrete] = round(
+                                        delta[self.discrete], 0).astype(int)
+                        q = q0 + delta
+                        varlogp = self.check_bnd(q[self.discrete].astype(int))
+                else:
+                    q = q0 + delta
+                    varlogp = self.check_bnd(q)
+
+                if num.isfinite(varlogp):
+                    check_bnd = False
+                else:
+                    delta = self.proposal_dist() * self.scaling
+
+            q = q0 + delta
+            q_new = pm.metropolis.metrop_select(self.delta_logp(q, q0), q, q0)
+
+            if q_new is q:
+                self.accepted += 1
+
+            self.steps_until_tune -= 1
+        return q_new
+
+    def calc_beta(self):
+        '''Calculate next tempering beta and importance weights.
+            Inputs: beta(m) - tempering parameter (float 0 <= beta <= 1)
+                    log_likelihoods of stage samples
+                                (Ndarray[N_chains * N_sample])
+            returns: beta(m+1), NdArray Importance weights'''
+
+        low_beta = self.beta
+        up_beta = 2.
+        old_beta = self.beta
+
+        while up_beta - low_beta > 1e-6:
+            current_beta = (low_beta + up_beta) / 2.
+            temp = num.exp((current_beta - self.beta) * \
+                           (self.likelihoods - self.likelihoods.max()))
+            cov_temp = num.std(temp) / num.mean(temp)
+            if cov_temp > 1:
+                up_beta = current_beta
+            else:
+                low_beta = current_beta
+
+        beta = current_beta
+        weights = temp / num.sum(temp)
+        return beta, old_beta, weights
+
+    def calc_covariance(self):
+        '''Calculate covariance based on importance weights.'''
+        return num.cov(self.array_population, aweights=self.weights, rowvar=0)
+
+    def select_end_points(self, mtrace):
+        '''Read trace results and take end points for each chain and set as
+           start population for the next stage.
+            Input: Multitrace object
+            Returns: population
+                     array_population
+                     likelihoods'''
+        array_population = num.zeros((self.N_chains,
+                                                     self.ordering.dimensions))
+        N_steps = len(mtrace)
+
+        if self.stage > 0:
+            # collect end points of each chain and put into array
+            for var, slc, _, _ in self.ordering.vmap:
+                array_population[:, slc] = mtrace.get_values(
+                                    varname=var,
+                                    burn=N_steps - 1,
+                                    combine=True)
+
+            population = []
+            likelihoods = []
+            # collect end points of each chain
+            for i in range(self.N_chains):
+                point = mtrace.point(-1, chain=i)
+                likelihoods.append(point.pop('llk'))
+                population.append(point)
+
+            likelihoods = num.array(likelihoods)
+        else:
+            # for initial stage only one trace that contains all points for
+            # each chain
+            population = self.population
+            likelihoods = mtrace.get_values('llk')
+            for var, slc, _, _ in self.ordering.vmap:
+                array_population[:, slc] = mtrace.get_values(var)
+
+        return population, array_population, likelihoods
+
+    def resample(self):
+        '''Resample pdf based on importance weights.
+           based on Kitagawas deterministic resampling algorithm.
+            Input: self.N_chains - Integer Number of samples
+                   self.weights - Ndarray of importance weights
+            returns: Ndarray of resampled trace indexes'''
+        parents = num.array(range(self.N_chains))
+        N_childs = num.zeros(self.N_chains, dtype=int)
+
+        cum_dist = num.cumsum(self.weights)
+        aux = num.random.rand(1)
+        u = parents + aux
+        u /= self.N_chains
+        j = 0
+        for i in parents:
+            while u[i] > cum_dist[j]:
+                j += 1
+
+            N_childs[j] += 1
+
+        indx = 0
+        outindx = num.zeros(self.N_chains, dtype=int)
+        for i in parents:
+            if N_childs[i] > 0:
+                for j in range(indx, (indx + N_childs[i])):
+                    outindx[j] = parents[i]
+
+            indx += N_childs[i]
+
+        return outindx
+
+
+def ATMIP_sample(N_steps, step=None, start=None, trace=None, chain=0,
+                  stage=None, njobs=1, tune=None, progressbar=False,
+                  model=None, random_seed=None):
+    """
+    (C)ATMIP sampling algorithm from Minson et al. 2013:
+    Bayesian inversion for finite fault earthquake source models I-
+        Theory and algorithm
+    (without cascading- C)
+    Parameters
+    ----------
+
+    N_steps : int
+        The number of samples to draw for each Markov-chain per stage
+    step : function from TMCMC initialisation
+    start : dict
+        Starting point in parameter space (or partial point)
+        Defaults to trace.point(-1)) if there is a trace provided and
+        model.test_point if not (defaults to empty dict)
+    trace : backend
+        This should be a backend instance.
+        Passing either "text" or "sqlite" is taken as a shortcut to set
+        up the corresponding backend (with "mcmc" used as the base
+        name).
+    chain : int
+        Chain number used to store sample in backend. If `njobs` is
+        greater than one, chain numbers will start here.
+    stage : int
+        Stage where to start or continue the calculation. If None the start
+        will be at stage = 0.
+    njobs : int recommended njobs=1 Some internal parallelisation in Theano?
+                njobs=1  ca. 3 times faster with 12 cores on station than
+                njobs=10
+        step.N_chains / njobs has to be an integer number!
+    tune : int
+        Number of iterations to tune, if applicable (defaults to None)
+    trace : result_folder for storing stages
+    progressbar : bool
+        Flag for progress bar
+    model : Model (optional if in `with` context) has to contain deterministic
+            variable 'llk' that contains model likelihood
+    random_seed : int or list of ints
+        A list is accepted if more if `njobs` is greater than one.
+
+    Returns
+    -------
+    MultiTrace object with access to sampling values
+    """
+
+    model = pm.modelcontext(model)
+    N_steps = int(N_steps)
+    seed(random_seed)
+
+    if N_steps < 1:
+        raise ValueError('Argument `N_steps` should be above 0.')
+
+    if step is None:
+        raise Exception('Argument `step` has to be a TMCMC step object.')
+
+    if trace is None:
+        raise Exception('Argument `trace` should be either sqlite or text \
+                        backend object.')
+
+    if start is None:
+        start = {}
+
+    if stage is not None:
+        step.stage = stage
+
+    if progressbar:
+        verbosity = 5
+        if njobs > 1:
+            progressbar = False
+    else:
+        verbosity = 0
+
+    homepath = trace
+
+    with model:
+        with Parallel(n_jobs=njobs, verbose=verbosity) as parallel:
+            while step.beta < 1.:
+                print 'Beta:', str(step.beta), 'Stage', str(step.stage)
+                if step.stage == 0:
+                    # Initial stage
+                    print 'Sample initial stage: ...'
+                    stage_path = homepath + '/stage_' + str(step.stage)
+                    trace = pm.backends.Text(stage_path, model=model)
+                    initial = _iter_initial(step, chain=chain, trace=trace,
+                                            start=None)
+                    progress = pm.progressbar.progress_bar(step.N_chains)
+                    try:
+                        for i, strace in enumerate(initial):
+                            if progressbar:
+                                progress.update(i)
+                    except KeyboardInterrupt:
+                        strace.close()
+                    mtrace = pm.backends.base.MultiTrace([strace])
+                    step.population, step.array_population, step.likelihoods = \
+                                            step.select_end_points(mtrace)
+                    step.beta, step.old_beta, step.weights = step.calc_beta()
+                    step.Covariance = step.calc_covariance()
+                    step.res_indx = step.resample()
+                    step.stage += 1
+                    del(strace, mtrace, trace)
+                else:
+                    # Metropolis sampling intermediate stages
+                    stage_path = homepath + '/stage_' + str(step.stage)
+                    step.proposal_dist = MvNPd(step.Covariance)
+                    sample_args = {
+                            'draws': N_steps,
+                            'step': step,
+                            'stage_path': stage_path,
+                            'progressbar': progressbar,
+                            'model': model}
+                    mtrace = _iter_parallel_chains(parallel, **sample_args)
+
+                    step.population, step.array_population, step.likelihoods = \
+                                            step.select_end_points(mtrace)
+                    step.beta, step.old_beta, step.weights = step.calc_beta()
+                    if step.beta > 1.:
+                        print 'Beta above 1.:', str(step.beta)
+                        break
+
+                    step.Covariance = step.calc_covariance()
+                    step.res_indx = step.resample()
+                    step.stage += 1
+
+            # Metropolis sampling final stage
+            print 'Sample final stage'
+            stage_path = homepath + '/stage_final'
+            temp = num.exp((1 - step.old_beta) * \
+                               (step.likelihoods - step.likelihoods.max()))
+            step.weights = temp / num.sum(temp)
+            step.Covariance = step.calc_covariance()
+            step.proposal_dist = MvNPd(step.Covariance)
+            step.res_indx = step.resample()
+
+            sample_args['step'] = step
+            sample_args['stage_path'] = stage_path
+            mtrace = _iter_parallel_chains(parallel, **sample_args)
+
+            return mtrace
+
+
+def _iter_initial(step, chain=0, trace=None, model=None, start=None):
+    '''Yields generator for Iteration over initial stage similar to
+       _iter_sample, just different input to loop over.'''
+
+    if start is None:
+        start = {}
+
+    strace = pm.sampling._choose_backend(trace, chain, model=model)
+    l_tr = len(strace)
+
+    if l_tr > 0:
+        pm.sampling._soft_update(start, strace.point(-1))
+    else:
+        pm.sampling._soft_update(start, step.population[0])
+
+    strace.setup(step.N_chains, chain=0)
+    for i in range(l_tr, step.N_chains):
+        point = step.step(step.population[i])
+        strace.record(point)
+        yield strace
+    else:
+        strace.close()
+
+
+def _iter_serial_chains(draws, step=None, stage_path=None,
+                        progressbar=True, model=None):
+    '''Do Metropolis sampling over all the chains with each chain being
+       sampled 'draws' times. Serial execution one after another.'''
+    mtraces = []
+    progress = pm.progressbar.progress_bar(step.N_chains)
+    for chain in range(step.N_chains):
+        if progressbar:
+            progress.update(chain)
+        trace = pm.backends.Text(stage_path, model=model)
+        mtraces.append(pm.sampling._sample(
+                draws=draws,
+                step=step,
+                chain=chain,
+                trace=trace,
+                model=model,
+                progressbar=False,
+                start=step.population[step.res_indx[chain]]))
+
+    return pm.sampling.merge_traces(mtraces)
+
+
+def _iter_parallel_chains(parallel, **kwargs):
+    '''Do Metropolis sampling over all the chains with each chain being
+       sampled 'draws' times. Parallel execution according to after another.'''
+    stage_path = kwargs.pop('stage_path')
+    step = kwargs['step']
+    chains = list(range(step.N_chains))
+    trace_list = []
+    for chain in chains:
+        trace_list.append(pm.backends.Text(stage_path))
+
+    traces = parallel(delayed(
+                    pm.sampling._sample)(
+                        chain=chain,
+                        trace=trace_list[chain],
+                        start=step.population[step.res_indx[chain]],
+                        **kwargs) for chain in chains)
+    return pm.sampling.merge_traces(traces)
+
+
+def logp_forw(logp, vars, shared):
+    [logp0], inarray0 = join_nonshared_inputs([logp], vars, shared)
+    f = theano.function([inarray0], logp0)
+    f.trust_input = True
+    return f

--- a/pymc3/step_methods/ATMCMC.py
+++ b/pymc3/step_methods/ATMCMC.py
@@ -410,10 +410,10 @@ def ATMIP_sample(n_steps, step=None, start=None, trace=None, chain=0,
     with model:
         with Parallel(n_jobs=njobs, verbose=verbosity) as parallel:
             while step.beta < 1.:
-                print 'Beta:', str(step.beta), 'Stage', str(step.stage)
+                print('Beta: ', str(step.beta), ' Stage: ', str(step.stage))
                 if step.stage == 0:
                     # Initial stage
-                    print 'Sample initial stage: ...'
+                    print('Sample initial stage: ...')
                     stage_path = homepath + '/stage_' + str(step.stage)
                     trace = pm.backends.Text(stage_path, model=model)
                     initial = _iter_initial(step, chain=chain, trace=trace)
@@ -453,7 +453,7 @@ def ATMIP_sample(n_steps, step=None, start=None, trace=None, chain=0,
                     step.stage += 1
 
                     if step.beta > 1.:
-                        print 'Beta > 1.:', str(step.beta)
+                        print('Beta > 1.: ' + str(step.beta))
                         step.beta = 1.
                         break
 
@@ -461,7 +461,7 @@ def ATMIP_sample(n_steps, step=None, start=None, trace=None, chain=0,
                     step.res_indx = step.resample()
 
             # Metropolis sampling final stage
-            print 'Sample final stage'
+            print('Sample final stage')
             stage_path = homepath + '/stage_final'
             temp = np.exp((1 - step.old_beta) * \
                                (step.likelihoods - step.likelihoods.max()))
@@ -495,7 +495,7 @@ def _iter_initial(step, chain=0, trace=None, model=None):
     if l_tr == step.n_chains:
         # only return strace
         for i in range(1):
-            print 'Using results of previous run'
+            print('Using results of previous run!')
             yield strace
     else:
         for i in range(l_tr, step.n_chains):
@@ -540,11 +540,11 @@ def _iter_parallel_chains(parallel, **kwargs):
     chains = list(range(step.n_chains))
     trace_list = []
 
-    print 'Initialising chain traces ...'
+    print('Initialising chain traces ...')
     for chain in chains:
         trace_list.append(pm.backends.Text(stage_path))
 
-    print 'Sampling ...'
+    print('Sampling ...')
     traces = parallel(delayed(
                     pm.sampling._sample)(
                         chain=chain,

--- a/pymc3/step_methods/ATMCMC.py
+++ b/pymc3/step_methods/ATMCMC.py
@@ -410,7 +410,7 @@ def ATMIP_sample(n_steps, step=None, start=None, trace=None, chain=0,
     with model:
         with Parallel(n_jobs=njobs, verbose=verbosity) as parallel:
             while step.beta < 1.:
-                print('Beta: ', str(step.beta), ' Stage: ', str(step.stage))
+                print('Beta: ' + str(step.beta), ' Stage: ' + str(step.stage))
                 if step.stage == 0:
                     # Initial stage
                     print('Sample initial stage: ...')

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -45,8 +45,8 @@ class PoissonProposal(Proposal):
 
 
 class MultivariateNormalProposal(Proposal):
-    def __call__(self):
-        return np.random.multivariate_normal(mean=np.zeros(self.s.shape[0]), cov=self.s)
+    def __call__(self, num_draws=None):
+        return np.random.multivariate_normal(mean=np.zeros(self.s.shape[0]), cov=self.s, size=num_draws)
 
 
 class Metropolis(ArrayStepShared):


### PR DESCRIPTION
Renamed the branch to ATMCMC because of @twiecki 's confusion - so therefore this:
https://github.com/pymc-devs/pymc3/pull/1025
is deprecated.
Now it definitely works on real data and this synthetic test.
The parallel implementation does work for simple models. But I get segmentation faults for my complex model for njobs > 1 as mentioned here https://github.com/pymc-devs/pymc3/issues/879. But this also happens for the other standard algorithms implemented in pymc3.
Here again the test script:

``` javascript
import pymc3 as pm
import numpy as num
from pymc3.step_methods import ATMCMC as atmcmc
import theano.tensor as tt
from matplotlib import pylab as pl

test_folder = ('/data/SAR_data/Aqaba1995/subsampled/model_result_InSAR_Seis/'
               'ATMIP_TEST')

N_chains = 1000
N_steps = 100
tune_interval = 25
njobs = 1

n = 10

mu1 = num.ones(n) * (1. / 2)
mu2 = -mu1

stdev = 0.1
sigma = num.power(stdev, 2) * num.eye(n)
isigma = num.linalg.inv(sigma)
dsigma = num.linalg.det(sigma)

w1 = stdev
w2 = (1 - stdev)


def two_gaussians(x):
    log_like1 = - 0.5 * n * tt.log(2 * num.pi) \
                - 0.5 * tt.log(dsigma) \
                - 0.5 * (x - mu1).T.dot(isigma).dot(x - mu1)
    log_like2 = - 0.5 * n * tt.log(2 * num.pi) \
                - 0.5 * tt.log(dsigma) \
                - 0.5 * (x - mu2).T.dot(isigma).dot(x - mu2)
    return tt.log(w1 * tt.exp(log_like1) + w2 * tt.exp(log_like2))

with pm.Model() as ATMIP_test:
    X = pm.Uniform('X',
                   shape=n,
                   lower=-2. * num.ones_like(mu1),
                   upper=2. * num.ones_like(mu1),
                   testval=-1. * num.ones_like(mu1),
                   transform=None)
    like = pm.Deterministic('like', two_gaussians(X))
    llk = pm.Potential('like', like)

with ATMIP_test:
    step = atmcmc.ATMCMC(N_chains=N_chains, tune_interval=tune_interval,
                         likelihood_name=ATMIP_test.deterministics[0].name)

trcs = atmcmc.ATMIP_sample(
                        N_steps=N_steps,
                        step=step,
                        njobs=njobs,
                        progressbar=True,
                        trace=test_folder,
                        model=ATMIP_test)

pm.summary(trcs)
Pltr = pm.traceplot(trcs, combined=True)
pl.show(Pltr[0][0])
```

Run with the parameters from script above.
![atmip_2gaussians_10d](https://cloud.githubusercontent.com/assets/11273616/13906622/224f6304-eeec-11e5-8155-1e4ad1658d64.png)

Chain result: It even gets the relative weight correctly. With longer chains it would be even better.
