### PR TITLE
PreProposal Generation

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -235,6 +235,11 @@ def _iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
         for i in step.methods:
             if isinstance(i, Metropolis):
                 i.draws = draws
+            # compound step within compound step
+            elif isinstance(i, CompoundStep):
+                for j in i.methods:
+                    if isinstance(j, Metropolis):
+                        j.draws = draws
     else:
         if isinstance(step, Metropolis):
             step.draws = draws

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -125,6 +125,7 @@ def sample(draws, step=None, start=None, trace=None, chain=0, njobs=1, tune=None
     model = modelcontext(model)
 
     step = assign_step_methods(model, step)
+    step.draws = draws
 
     if njobs is None:
         import multiprocessing

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -125,7 +125,6 @@ def sample(draws, step=None, start=None, trace=None, chain=0, njobs=1, tune=None
     model = modelcontext(model)
 
     step = assign_step_methods(model, step)
-    step.draws = draws
 
     if njobs is None:
         import multiprocessing
@@ -231,6 +230,14 @@ def _iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
         step = CompoundStep(step)
     except TypeError:
         pass
+
+    if isinstance(step, CompoundStep):
+        for i in step.methods:
+            if isinstance(i, Metropolis):
+                i.draws = draws
+    else:
+        if isinstance(step, Metropolis):
+            step.draws = draws
 
     point = Point(start, model=model)
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -125,7 +125,7 @@ class Metropolis(ArrayStepShared):
             self.steps_until_tune = self.tune_interval
             self.accepted = 0
 
-        delta = self.delta_array[self.sample_num,:] * self.scaling
+        delta = self.delta_array[self.sample_num, :].ravel() * self.scaling
 
         if self.any_discrete:
             if self.all_discrete:

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -145,6 +145,9 @@ class Metropolis(ArrayStepShared):
 
         self.steps_until_tune -= 1
         self.sample_num += 1
+        # reset sample counter
+        if self.sample_num == self.draws:
+            self.sample_num = 0
 
         return q_new
 


### PR DESCRIPTION
Again ... sorry for my Unfaehigkeit.
Move proposal step generation to the beginning of the sampling. Create all samples at once, rather then repeated. Done for metropolis.
Speeds up sampling significantly:
https://github.com/pymc-devs/pymc3/issues/1034
