### PR TITLE
add circular transform to von Mises

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1136,11 +1136,15 @@ class VonMises(Continuous):
     kappa : float
         Concentration (\frac{1}{kappa} is analogous to \sigma^2).
     """
-    def __init__(self, mu=0.0, kappa=None, *args, **kwargs):
+    def __init__(self, mu=0.0, kappa=None, transform='circular',
+    *args, **kwargs):
         super(VonMises, self).__init__(*args, **kwargs)
         self.mean = self.median = self.mode = self.mu = mu
         self.kappa = kappa 
         self.variance = 1 - i1(kappa)/i0(kappa)
+        
+        if transform == 'circular':
+            self.transform = transforms.Circular()
             
     def random(self, point=None, size=None, repeat=None):
         mu, kappa = draw_values([self.mu, self.kappa],

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -3,6 +3,7 @@ import theano.tensor as T
 from ..model import FreeRV
 from ..theanof import gradient
 from .distribution import Distribution
+import numpy as np
 
 __all__ = ['transform', 'stick_breaking', 'logodds', 'log']
 
@@ -180,3 +181,17 @@ class StickBreaking(Transform):
                      0)
 
 stick_breaking = StickBreaking()
+
+
+class Circular(ElemwiseTransform):
+    """Transforms a linear space into a circular one.
+    """
+    name = "circular"
+
+    def backward(self, y):
+        return T.arctan2(T.sin(y), T.cos(y))
+
+    def forward(self, x): 
+        return x
+
+circular = Circular()


### PR DESCRIPTION
This transformation ensures that proposed values in the range `[-inf, inf]` are converted to values in the range `[-pi, pi]`. This is specially important when `mu` is close to the _boundaries_ (_i.e._ to `-pi` or `pi`) and `kappa` is larger than 1. 
