### PR TITLE
Advi minibatch

### DIFF
--- a/pymc3/examples/advi.ipynb
+++ b/pymc3/examples/advi.ipynb
@@ -69,16 +69,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Iteration 0 [0%]: ELBO = -1372.98\n",
-      "Iteration 2000 [10%]: ELBO = -294.57\n",
-      "Iteration 4000 [20%]: ELBO = -193.17\n",
-      "Iteration 6000 [30%]: ELBO = -166.75\n",
-      "Iteration 8000 [40%]: ELBO = -156.82\n",
-      "Iteration 10000 [50%]: ELBO = -154.36\n",
-      "Iteration 12000 [60%]: ELBO = -152.1\n",
-      "Iteration 14000 [70%]: ELBO = -151.64\n",
-      "Iteration 16000 [80%]: ELBO = -151.18\n",
-      "Iteration 18000 [90%]: ELBO = -151.24\n"
+      "Iteration 0 [0%]: ELBO = -1359.84\n",
+      "Iteration 2000 [10%]: ELBO = -291.4\n",
+      "Iteration 4000 [20%]: ELBO = -191.83\n",
+      "Iteration 6000 [30%]: ELBO = -165.56\n",
+      "Iteration 8000 [40%]: ELBO = -155.54\n",
+      "Iteration 10000 [50%]: ELBO = -153.04\n",
+      "Iteration 12000 [60%]: ELBO = -150.78\n",
+      "Iteration 14000 [70%]: ELBO = -150.32\n",
+      "Iteration 16000 [80%]: ELBO = -149.85\n",
+      "Iteration 18000 [90%]: ELBO = -149.91\n",
+      "Finished [100%]: ELBO = -149.73\n"
      ]
     }
    ],

--- a/pymc3/examples/advi.ipynb
+++ b/pymc3/examples/advi.ipynb
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -69,7 +69,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " [-----------------83%-----------       ] 16758 of 20000 complete in 18.5 sec"
+      "Iteration 0 [0%]: ELBO = -1372.98\n",
+      "Iteration 2000 [10%]: ELBO = -294.57\n",
+      "Iteration 4000 [20%]: ELBO = -193.17\n",
+      "Iteration 6000 [30%]: ELBO = -166.75\n",
+      "Iteration 8000 [40%]: ELBO = -156.82\n",
+      "Iteration 10000 [50%]: ELBO = -154.36\n",
+      "Iteration 12000 [60%]: ELBO = -152.1\n",
+      "Iteration 14000 [70%]: ELBO = -151.64\n",
+      "Iteration 16000 [80%]: ELBO = -151.18\n",
+      "Iteration 18000 [90%]: ELBO = -151.24\n"
      ]
     }
    ],
@@ -259,7 +268,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/pymc3/tests/test_advi.py
+++ b/pymc3/tests/test_advi.py
@@ -1,0 +1,36 @@
+import numpy as np
+from pymc3 import Model, Normal
+from pymc3.theanof import inputvars
+from pymc3.variational.advi import variational_gradient_estimate
+from theano import function
+
+def test_advi():
+    mu0 = 1.5
+    sigma = 1.0
+    y_obs = np.array([1.6, 1.4])
+        
+    # Create a model for test
+    with Model() as model:
+        mu = Normal('mu', mu=mu0, sd=sigma)
+        y = Normal('y', mu=mu, sd=1, observed=y_obs)
+
+    vars = inputvars(model.vars)
+
+    # Create variational gradient tensor
+    grad, elbo, shared, uw = variational_gradient_estimate(
+        vars, model, n_mcsamples=1000000)
+
+    # Variational posterior parameters
+    uw_ = np.array([1.88, np.log(1)])
+
+    # Calculate elbo computed with MonteCarlo
+    f = function([uw], elbo)
+    elbo_mc = f(uw_)
+
+    # Exact value
+    elbo_true = (-0.5 * (
+        3 + 3 * uw_[0]**2 - 2 * (y_obs[0] + y_obs[1] + mu0) * uw_[0] +
+        y_obs[0]**2 + y_obs[1]**2 + mu0**2 + 3 * np.log(2 * np.pi)) +
+        0.5 * (np.log(2 * np.pi) + 1))
+
+    np.testing.assert_allclose(elbo_mc, elbo_true, rtol=0, atol=1e-1)

--- a/pymc3/variational/__init__.py
+++ b/pymc3/variational/__init__.py
@@ -1,1 +1,2 @@
 from .advi import advi
+from .advi import advi_minibatch

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -71,7 +71,9 @@ def run_adagrad(uw, grad, elbo, inarray, n, learning_rate=.001, epsilon=.1,
         elbos[i] = e
         if verbose and not i % (n//10):
             print('Iteration {0} [{1}%]: ELBO = {2}'.format(i, 100*i//n, e.round(2)))
-
+    
+    if verbose:
+        print('Finished [100%]: ELBO = {}'.format(elbos[-1].round(2)))
     return uw_i, elbos
 
 def variational_gradient_estimate(vars, model, accurate_elbo=False):

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -70,7 +70,7 @@ def run_adagrad(uw, grad, elbo, inarray, n, learning_rate=.001, epsilon=.1,
         uw_i, g, e = f()
         elbos[i] = e
         if verbose and not i % (n//10):
-            print('Iteration {0} [{1}%]: ELBO = {2:.2f}'.format(i, 100*i/n, e))
+            print('Iteration {0} [{1}%]: ELBO = {2}'.format(i, 100*i//n, e.round(2)))
 
     return uw_i, elbos
 

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -29,8 +29,10 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
         vars = model.vars
     vars = inputvars(vars)
 
+    n_mcsamples = 100 if accurate_elbo else 1
+
     # Create variational gradient tensor
-    grad, elbo, inarray, shared = variational_gradient_estimate(vars, model, accurate_elbo=accurate_elbo)
+    grad, elbo, shared, _ = variational_gradient_estimate(vars, model, n_mcsamples=n_mcsamples)
 
     # Set starting values
     for var, share in shared.items():
@@ -42,7 +44,7 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
     w_start = np.zeros_like(u_start)
     uw = np.concatenate([u_start, w_start])
 
-    result, elbos = run_adagrad(uw, grad, elbo, inarray, n, learning_rate=learning_rate, epsilon=epsilon, verbose=verbose)
+    result, elbos = run_adagrad(uw, grad, elbo, n, learning_rate=learning_rate, epsilon=epsilon, verbose=verbose)
 
     l = result.size / 2
 
@@ -53,8 +55,62 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
         w[var] = np.exp(w[var])
     return ADVIFit(u, w, elbos)
 
-def run_adagrad(uw, grad, elbo, inarray, n, learning_rate=.001, epsilon=.1,
-                verbose=1):
+def advi_minibatch(vars=None, start=None, model=None, n=5000, accurate_elbo=False, 
+    minibatch_RVs=None, minibatch_tensors=None, minibatches=None, total_size=None, 
+    learning_rate=.001, epsilon=.1, verbose=1):
+    model = modelcontext(model)
+    if start is None:
+        start = model.test_point
+
+    if vars is None:
+        vars = model.vars
+
+    vars = set(inputvars(vars)) - set(minibatch_RVs)
+
+    # Create variational gradient tensor
+    grad, elbo, shared, uw = variational_gradient_estimate(
+        vars, model, minibatch_RVs, minibatch_tensors, total_size, 
+        accurate_elbo=accurate_elbo)
+
+    # Set starting values
+    for var, share in shared.items():
+        share.set_value(start[str(var)])
+
+    order = ArrayOrdering(vars)
+    bij = DictToArrayBijection(order, start)
+    u_start = bij.map(start)
+    w_start = np.zeros_like(u_start)
+    uw_start = np.concatenate([u_start, w_start])
+
+    shared_inarray = theano.shared(uw_start, 'uw_shared')
+    grad = theano.clone(grad, { uw : shared_inarray }, strict=False)
+    elbo = theano.clone(elbo, { uw : shared_inarray }, strict=False)
+    updates = adagrad(grad, shared_inarray, learning_rate=learning_rate, epsilon=epsilon, n=10)
+
+    # Create in-place update function
+    f = theano.function(minibatch_tensors, [shared_inarray, grad, elbo], updates=updates)
+
+    # Run adagrad steps
+    elbos = np.empty(n)
+    for i in range(n):
+        uw_i, g, e = f(*[m.next() for m in minibatches])
+        elbos[i] = e
+        if verbose and not i % (n//10):
+            print('Iteration {0} [{1}%]: ELBO = {2}'.format(i, 100*i//n, e.round(2)))
+    
+    if verbose:
+        print('Finished [100%]: ELBO = {}'.format(elbos[-1].round(2)))
+
+    l = uw_i.size / 2
+
+    u = bij.rmap(uw_i[:l])
+    w = bij.rmap(uw_i[l:])
+    # w is in log space
+    for var in w.keys():
+        w[var] = np.exp(w[var])
+    return ADVIFit(u, w, elbos)
+    
+def run_adagrad(uw, grad, elbo, n, learning_rate=.001, epsilon=.1, verbose=1):
     shared_inarray = theano.shared(uw, 'uw_shared')
     grad = CallableTensor(grad)(shared_inarray)
     elbo = CallableTensor(elbo)(shared_inarray)
@@ -76,62 +132,56 @@ def run_adagrad(uw, grad, elbo, inarray, n, learning_rate=.001, epsilon=.1,
         print('Finished [100%]: ELBO = {}'.format(elbos[-1].round(2)))
     return uw_i, elbos
 
-def variational_gradient_estimate(vars, model, accurate_elbo=False):
+def variational_gradient_estimate(
+    vars, model, minibatch_RVs=[], minibatch_tensors=[], total_size=None, 
+    accurate_elbo=False):
     theano.config.compute_test_value = 'ignore'
     shared = make_shared_replacements(vars, model)
-    [logp], inarray = join_nonshared_inputs([model.logpt], vars, shared)
-    logp = CallableTensor(logp)
+
+    # Correction sample size 
+    r = 1 if total_size is None else \
+        float(total_size) / minibatch_tensors[0].shape[0]
+
+    other_RVs = set(model.basic_RVs) - set(minibatch_RVs)
+    factors = [r * var.logpt for var in minibatch_RVs] + \
+              [var.logpt for var in other_RVs] + model.potentials
+    logpt = T.add(*map(T.sum, factors))
+    
+    [logp], inarray = join_nonshared_inputs([logpt], vars, shared)
 
     uw = dvector('uw')
     uw.tag.test_value = np.concatenate([inarray.tag.test_value,
                                         inarray.tag.test_value])
 
+    elbo = elbo_t(logp, uw, inarray, n_mcsamples=1)
+
+    # Gradient
+    grad = gradient(elbo, [uw])
+
+    return grad, elbo, shared, uw
+
+def elbo_t(logp, uw, inarray, n_mcsamples):
+    l = (uw.size/2).astype('int64')
+    u = uw[:l]
+    w = uw[l:]
+
+    # Callable tensor
+    logp_ = lambda input: theano.clone(logp, {inarray: input}, strict=False)
+
     # Naive Monte-Carlo
     r = MRG_RandomStreams(seed=1)
-    n = r.normal(size=inarray.tag.test_value.shape)
 
-    gradient_estimate, elbo_estimate = inner_gradients(logp, n, uw)
-
-    # More accurate estimation of ELBO
-    if accurate_elbo:
-        elbo_estimate = inner_elbo(logp, uw, 100)
-
-    return gradient_estimate, elbo_estimate, inarray, shared
-
-def inner_gradients(logp, n, uw):
-    # uw contains both, mean and diagonals
-    l = (uw.size/2).astype('int64')
-    u = uw[:l]
-    w = uw[l:]
-
-    # Formula 6 in the paper
-    q = n * exp(w) + u
-
-    duw = gradient(logp(q), [uw])
-    elbo = logp(q) + T.sum(w)
-
-    # Add gradient of entropy term (just equal to element-wise 1 here), formula 6
-    duw = theano.tensor.set_subtensor(duw[l:], duw[l:] + 1)
-    return duw, elbo
-
-# This function can be used to
-def inner_elbo(logp, uw, n_mcsamples_elbo):
-    """Compute get more accurate ELBO than the one in inner_gradients().
-
-    Draw the specified number of MC samples.
-    """
-    # uw contains both, mean and diagonals
-    l = (uw.size/2).astype('int64')
-    u = uw[:l]
-    w = uw[l:]
-
-    r = MRG_RandomStreams(seed=1)
-    n = r.normal(size=(n_mcsamples_elbo, u.tag.test_value.shape[0]))
-    qs = n * exp(w) + u
-    logps, _ = theano.scan(fn=lambda q: logp(q),
-                           outputs_info=None,
-                           sequences=[qs])
-    elbo = T.mean(logps) + T.sum(w)
+    if n_mcsamples == 1:
+        n = r.normal(size=inarray.tag.test_value.shape)
+        q = n * exp(w) + u
+        elbo = logp_(q) + T.sum(w)
+    else:
+        n = r.normal(size=(n_mcsamples, u.tag.test_value.shape[0]))
+        qs = n * exp(w) + u
+        logps, _ = theano.scan(fn=lambda q: logp_(q),
+                               outputs_info=None,
+                               sequences=[qs])
+        elbo = T.mean(logps) + T.sum(w)
 
     return elbo
 

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -145,7 +145,6 @@ def variational_gradient_estimate(
     other_RVs = set(model.basic_RVs) - set(minibatch_RVs)
     factors = [r * var.logpt for var in minibatch_RVs] + \
               [var.logpt for var in other_RVs] + model.potentials
-    print(minibatch_RVs, other_RVs) # debug
     logpt = tt.add(*map(tt.sum, factors))
     
     [logp], inarray = join_nonshared_inputs([logpt], vars, shared)


### PR DESCRIPTION
I have written code for mini-batch advi. #1038 
- Support mini-batch in advi.
- Add a test for ELBO on a Gaussian model, the same as in Stan. 
- Add a constant term to ELBO. 

To know usage, see my notebooks at gist (e.g., https://gist.github.com/taku-y/b4da34be310718a6ea02). Notebooks are not included this PR, because I'm note sure example notebooks should be included in the main repo, as discussed in gitter. 
