### PR TITLE
Python 3-compatible generators in advi

### DIFF
--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -93,7 +93,7 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
 
     result, elbos = run_adagrad(uw, grad, elbo, n, learning_rate=learning_rate, epsilon=epsilon, verbose=verbose)
 
-    l = result.size / 2
+    l = int(result.size / 2)
 
     u = bij.rmap(result[:l])
     w = bij.rmap(result[l:])
@@ -177,7 +177,7 @@ def advi_minibatch(vars=None, start=None, model=None, n=5000, n_mcsamples=1,
     # Run adagrad steps
     elbos = np.empty(n)
     for i in range(n):
-        uw_i, g, e = f(*[m.next() for m in minibatches])
+        uw_i, g, e = f(*[next(m) for m in minibatches])
         elbos[i] = e
         if verbose and not i % (n//10):
             print('Iteration {0} [{1}%]: ELBO = {2}'.format(i, 100*i//n, e.round(2)))
@@ -185,7 +185,7 @@ def advi_minibatch(vars=None, start=None, model=None, n=5000, n_mcsamples=1,
     if verbose:
         print('Finished [100%]: ELBO = {}'.format(elbos[-1].round(2)))
 
-    l = uw_i.size / 2
+    l = int(uw_i.size / 2)
 
     u = bij.rmap(uw_i[:l])
     w = bij.rmap(uw_i[l:])


### PR DESCRIPTION
For Python 3 compatibility, generators should use the `next` function, as the method no longer exists. Not sure how this made it past Travis, as I was unable to run ADVI mini batch on Py3.
