### PR TITLE
added missing import alias for njobs=None condition

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -128,7 +128,7 @@ def sample(draws, step=None, start=None, trace=None, chain=0, njobs=1, tune=None
     step = assign_step_methods(model, step)
 
     if njobs is None:
-        import multiprocessing
+        import multiprocessing as mp
         njobs = max(mp.cpu_count() - 2, 1)
 
     sample_args = {'draws':draws, 


### PR DESCRIPTION
This is a simple fix in response to #1064.  Wasn't sure about adding a test, since I'm not clear on what's happening with the parallel pieces of [test_sampling.py](https://github.com/pymc-devs/pymc3/blob/master/pymc3/tests/test_sampling.py) (e.g. [here](https://github.com/pymc-devs/pymc3/blob/master/pymc3/tests/test_sampling.py#L18) and [here](https://github.com/pymc-devs/pymc3/blob/master/pymc3/tests/test_sampling.py#L30)).
