### PR TITLE
WIP: remove transformed variables from the trace

### DIFF
--- a/pymc3/backends/ndarray.py
+++ b/pymc3/backends/ndarray.py
@@ -75,6 +75,17 @@ class NDArray(base.BaseTrace):
         self.samples = {var: vtrace[:self.draw_idx]
                         for var, vtrace in self.samples.items()}
 
+    def rm_transformed(self):
+        """Remove transformed variables from a trace.
+        """
+        transformed = [str(rv) for rv in self.model.free_RVs 
+        if hasattr(rv.distribution, 'transform_used')]
+        for i in transformed:
+            del self.samples[i]
+            del self.var_dtypes[i]
+            del self.var_shapes[i]
+            self.varnames.remove(i)
+
     ## Selection methods
 
     def __len__(self):

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -161,6 +161,7 @@ def _sample(draws, step=None, start=None, trace=None, chain=0, tune=None,
                 progress.update(i)
     except KeyboardInterrupt:
         strace.close()
+    strace.rm_transformed()
     return MultiTrace([strace])
 
 


### PR DESCRIPTION
Returning transformed variables in the trace is confusing for many users (I know from experience while giving a course). And, as far as I understand there is no good reason to have access to transformed variables, since transformation is just a computational trick. In this PR I remove the variables from the trace before returning  the trace to the user. I also tried just to not add the the variable to the trace in the first place but I only mess-up things, hence the current proposal.
