### PR TITLE
plot_posterior() added to plots.py

### DIFF
--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -2,8 +2,9 @@ import numpy as np
 from scipy.stats import kde
 from .stats import *
 from numpy.linalg import LinAlgError
+import matplotlib.pyplot as plt
 
-__all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot']
+__all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot','plot_posterior']
 
 
 def traceplot(trace, varnames=None, figsize=None,
@@ -37,7 +38,7 @@ def traceplot(trace, varnames=None, figsize=None,
     ax : matplotlib axes
 
     """
-    import matplotlib.pyplot as plt
+
     if varnames is None:
         varnames = trace.original_varnames
 
@@ -177,8 +178,6 @@ def autocorrplot(trace, varnames=None, max_lag=100, burn=0,
     ax : matplotlib axes
     """
 
-    import matplotlib.pyplot as plt
-
     def _handle_array_varnames(varname):
         if trace[0][varname].__class__ is np.ndarray:
             k = trace[varname].shape[1]
@@ -316,7 +315,6 @@ def forestplot(trace_obj, varnames=None, alpha=0.05, quartiles=True, rhat=True,
         gs : matplotlib GridSpec
 
     """
-    import matplotlib.pyplot as plt
     from matplotlib import gridspec
 
     # Quantiles to be calculated
@@ -563,3 +561,139 @@ def forestplot(trace_obj, varnames=None, alpha=0.05, quartiles=True, rhat=True,
                 spine.set_color('none')  # don't draw spine
 
     return gs
+
+
+def plot_posterior(trace, varnames=None, figsize=None, alpha_level=0.05, round_to=3,
+                   point_estimate='mean', greater_than_zero=None, ax=None, **kwargs):
+    """Plot Posterior densities in style of John K. Kruschke book
+
+    Parameters
+    ----------
+
+    trace : result of MCMC run
+    varnames : list of variable names
+        Variables to be plotted, if None all variable are plotted
+    figsize : figure size tuple
+        If None, size is (12, num of variables * 2) inch
+    alpha_level : float
+        Defines range for High Posterior Density
+    round_to : int
+        Controls formatting for floating point numbers
+    point_estimate: str
+        Must be in ('mode', 'mean', 'median')
+    greater_than_zero: bool
+        Whether to display x% < 0 < (1-x)%
+    ax : axes
+        Matplotlib axes. Defaults to None.
+    **kwargs
+        Passed as-is to plt.hist() function
+        Some defaults are added, if not specified
+        color='#87ceeb' will match the style in the book
+
+
+    Returns
+    -------
+
+    ax : matplotlib axes
+
+    """
+
+    def plot_posterior_op(trace_values, ax):
+
+        def format_as_percent(x, round_to=0):
+            value = np.round(100 * x, round_to)
+            if round_to == 0:
+                value = int(value)
+            return '{}%'.format(value)
+
+        def display_zero_difference():
+            less_than_zero_probability = (trace_values < 0).mean()
+            greater_than_zero_probability = (trace_values > 0).mean()
+            if greater_than_zero or (greater_than_zero is None and greater_than_zero_probability < 1.0):
+                zero_in_posterior = format_as_percent(less_than_zero_probability, 1) + ' <0< ' + format_as_percent(
+                    greater_than_zero_probability, 1)
+                ax.text(trace_values.mean(), plot_height * 0.6, zero_in_posterior,
+                        # color='#006400',
+                        size=14, horizontalalignment='center')
+
+        def display_point_estimate():
+            if not point_estimate:
+                return
+            if point_estimate not in ('mode', 'mean', 'median'):
+                raise ValueError("Point Estimate should be in ('mode','mean','median', None)")
+            if point_estimate == 'mean':
+                point_value = trace_values.mean()
+                point_text = '{}={}'.format(point_estimate, point_value.round(round_to))
+            elif point_estimate == 'mode':
+                point_value = stats.mode(trace_values.round(round_to))[0][0]
+                point_text = '{}={}'.format(point_estimate, point_value.round(round_to))
+            elif point_estimate == 'median':
+                point_value = np.median(trace_values)
+                point_text = '{}={}'.format(point_estimate, point_value.round(round_to))
+
+            ax.text(point_value, plot_height * 0.8, point_text,
+                    size=16, horizontalalignment='center')
+
+        def display_hpd():
+            hpd_intervals = hpd(trace_values, alpha=alpha_level)
+            ax.plot(hpd_intervals, (plot_height * 0.02, plot_height * 0.01), linewidth=4, color='0.4')
+            text_props = dict(size=16, horizontalalignment='center')
+            ax.text(hpd_intervals[0], plot_height * 0.07, hpd_intervals[0].round(round_to), **text_props)
+            ax.text(hpd_intervals[1], plot_height * 0.07, hpd_intervals[1].round(round_to), **text_props)
+            ax.text((hpd_intervals[0] + hpd_intervals[1]) / 2, plot_height * 0.2,
+                    format_as_percent(1 - alpha_level) + ' HPD', **text_props)
+
+        def format_axes():
+            ax.yaxis.set_ticklabels([])
+            ax.grid(b=False)
+            ax.spines['top'].set_visible(False)
+            ax.spines['right'].set_visible(False)
+            ax.spines['left'].set_visible(False)
+            ax.spines['bottom'].set_visible(True)
+            ax.yaxis.set_ticks_position('none')
+            ax.xaxis.set_ticks_position('bottom')
+            ax.tick_params(axis='x', direction='out', width=1, length=3,
+                           color='0.5')
+            ax.spines['bottom'].set_color('0.5')
+            ax.set_axis_bgcolor('w')
+
+        def set_key_if_doesnt_exist(d, key, value):
+            if key not in d:
+                d[key] = value
+
+        set_key_if_doesnt_exist(kwargs, 'bins', 30)
+        set_key_if_doesnt_exist(kwargs, 'edgecolor', 'w')
+        set_key_if_doesnt_exist(kwargs, 'align', 'right')
+
+        ax.hist(trace_values, **kwargs)
+        plot_height = ax.get_ylim()[1]
+
+        format_axes()
+        display_hpd()
+        display_point_estimate()
+        display_zero_difference()
+
+    def create_axes_grid(figsize, varnames):
+        n = np.ceil(len(varnames) / 2.0).astype(int)
+        if figsize is None:
+            figsize = (12, n * 2.5)
+        fig, ax = plt.subplots(n, 2, figsize=figsize)
+        ax = ax.reshape(2 * n)
+        if len(varnames) % 2 == 1:
+            ax[-1].set_axis_off()
+            ax = ax[:-1]
+        return ax, fig
+
+    if varnames is None:
+        varnames = trace.original_varnames
+
+    if ax is None:
+        ax, fig = create_axes_grid(figsize, varnames)
+
+    for a, v in zip(ax, varnames):
+        tr_values = trace.get_values(v, combine=True, squeeze=True)
+        plot_posterior_op(tr_values, ax=a)
+        a.set_title(v)
+
+    fig.tight_layout()
+    return ax


### PR DESCRIPTION
`pm.plot_posterior(sample_trace)`
 produces pretty-looking plots in style of J. K. Kruschke's book

`import matplotlib.pyplot as plt` was moved to the top of plots.py, since `__all__` is used to limit namespace pollution anyway.

<img width="968" alt="plot_posterior" src="https://cloud.githubusercontent.com/assets/5244286/15271084/0a2b4dd2-1a30-11e6-8e9a-a4265b490d95.png">

http://www.indiana.edu/~kruschke/BEST/BEST.pdf
