### PR TITLE
Remove --process-dependency-links in favor of requrements.txt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,10 +39,18 @@ PyMC3 is Beta software. Users should consider using [PyMC 2 repository](https://
 The latest version of PyMC3 can be installed from the master branch using pip:
 
 ```
-pip install --process-dependency-links git+https://github.com/pymc-devs/pymc3
+pip install git+https://github.com/pymc-devs/pymc3
 ```
 
-The `--process-dependency-links` flag ensures that the developmental branch of Theano, which PyMC3 requires, is installed. If a recent developmental version of Theano has been installed with another method, this flag can be dropped.
+To ensure the development branch of Theano is installed alongside PyMC3 (recommended), you can install PyMC3 using the `requirements.txt` file. This requires cloning the repository to your computer:
+
+```
+git clone https://github.com/pymc-devs/pymc3
+cd pymc3
+pip install -r requirements.txt
+```
+
+However, if a recent version of Theano has already been installed on your system, you can install PyMC3 directly from GitHub.
 
 Another option is to clone the repository and install PyMC3 using `python setup.py install` or `python setup.py develop`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.7.1
 scipy>=0.12.0
 matplotlib>=1.2.1
--e git+https://github.com/Theano/Theano.git#egg=Package
+theano>=0.8.2
 pandas>=0.15.0
 patsy>=0.4.0
 joblib>=0.9         

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy>=1.7.1
+scipy>=0.12.0
+matplotlib>=1.2.1
+-e git+https://github.com/Theano/Theano.git#egg=Package
+pandas>=0.15.0
+patsy>=0.4.0
+joblib>=0.9         

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,9 @@ classifiers = ['Development Status :: 4 - Beta',
                'Topic :: Scientific/Engineering :: Mathematics',
                'Operating System :: OS Independent']
 
-install_reqs = ['numpy>=1.7.1', 'scipy>=0.12.0', 'matplotlib>=1.2.1',
-                'Theano>=0.8.2', 'pandas>=0.15.0', 'patsy>=0.4.0', 'joblib>=0.9']
+with open('requirements.txt') as f:
+    install_reqs = f.read().splitlines()
+
 if sys.version_info < (3, 4):
     install_reqs.append('enum34')
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ classifiers = ['Development Status :: 4 - Beta',
                'Operating System :: OS Independent']
 
 install_reqs = ['numpy>=1.7.1', 'scipy>=0.12.0', 'matplotlib>=1.2.1',
-                'Theano>=0.7.1dev', 'pandas>=0.15.0', 'patsy>=0.4.0', 'joblib>=0.9']
+                'Theano>=0.8.2', 'pandas>=0.15.0', 'patsy>=0.4.0', 'joblib>=0.9']
 if sys.version_info < (3, 4):
     install_reqs.append('enum34')
 
@@ -35,7 +35,6 @@ test_reqs = ['nose']
 if sys.version_info[0] == 2:  # py3 has mock in stdlib
     test_reqs.append('mock')
 
-dep_links = ['https://github.com/Theano/Theano/tarball/master']
 
 if __name__ == "__main__":
     setup(name=DISTNAME,
@@ -53,6 +52,5 @@ if __name__ == "__main__":
           package_data = {'pymc3.examples': ['data/*.*']},
           classifiers=classifiers,
           install_requires=install_reqs,
-          dependency_links=dep_links,
           tests_require=test_reqs,
           test_suite='nose.collector')


### PR DESCRIPTION
The `--process-dependency-links` argument is deprecated in pip, so I have changed the documentation by substituting a `requirements.txt` file as the means for guaranteeing that the latest Theano is installed.

Closes #891 
