### PR TITLE
Replaced seed with random_seed in advi

### DIFF
--- a/pymc3/tests/test_advi.py
+++ b/pymc3/tests/test_advi.py
@@ -21,7 +21,7 @@ def test_elbo():
 
     # Create variational gradient tensor
     grad, elbo, shared, uw = variational_gradient_estimate(
-        vars, model, n_mcsamples=10000, seed=1)
+        vars, model, n_mcsamples=10000, random_seed=1)
 
     # Variational posterior parameters
     uw_ = np.array([1.88, np.log(1)])
@@ -110,7 +110,7 @@ def test_advi():
 
     means, sds, elbos = advi(
         model=model, n=1000, accurate_elbo=False, learning_rate=1e-1, 
-        seed=1)
+        random_seed=1)
 
     np.testing.assert_allclose(means['mu'], mu_post, rtol=0.1)
 
@@ -150,7 +150,7 @@ def test_advi_minibatch():
     means, sds, elbos = advi_minibatch(
         model=model, n=1000, minibatch_tensors=minibatch_tensors, 
         minibatch_RVs=minibatch_RVs, minibatches=minibatches, 
-        total_size=n, learning_rate=1e-1, seed=1
+        total_size=n, learning_rate=1e-1, random_seed=1
     )
 
     np.testing.assert_allclose(means['mu'], mu_post, rtol=0.1)

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -47,7 +47,7 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
         Adagrad base learning rate. 
     epsilon : float
         Offset in denominator of the scale of learning rate in Adagrad.  
-    seed : int
+    random_seed : int
         Seed to initialize random state. 
 
     Returns
@@ -57,7 +57,7 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
 
     'means' and 'stds' include parameters of the variational posterior. 
     """
-    seed = seed if type(seed) is int else 12345
+    seed = random_seed if isinstance(seed, int) else 12345
 
     model = modelcontext(model)
     if start is None:
@@ -136,7 +136,7 @@ def advi_minibatch(vars=None, start=None, model=None, n=5000, n_mcsamples=1,
     ADVIFit
         Named tuple, which includes 'means', 'stds', and 'elbo_vals'. 
     """
-    seed = seed if type(seed) is int else 12345
+    seed = random_seed if isinstance(random_seed, int) else 12345
 
     model = modelcontext(model)
     if start is None:
@@ -223,7 +223,7 @@ def variational_gradient_estimate(
     n_mcsamples=1, random_seed=None):
     """Calculate approximate ELBO and its (stochastic) gradient. 
     """
-    seed = seed if type(seed) is int else 12345
+    seed = random_seed if isinstance(seed, int) else 12345
 
     theano.config.compute_test_value = 'ignore'
     shared = make_shared_replacements(vars, model)
@@ -250,7 +250,7 @@ def variational_gradient_estimate(
 
     return grad, elbo, shared, uw
 
-def elbo_t(logp, uw, inarray, n_mcsamples, seed):
+def elbo_t(logp, uw, inarray, n_mcsamples, random_seed):
     """Create Theano tensor of approximate ELBO by Monte Carlo sampling. 
     """
     l = (uw.size/2).astype('int64')
@@ -261,7 +261,7 @@ def elbo_t(logp, uw, inarray, n_mcsamples, seed):
     logp_ = lambda input: theano.clone(logp, {inarray: input}, strict=False)
 
     # Naive Monte-Carlo
-    r = MRG_RandomStreams(seed=seed)
+    r = MRG_RandomStreams(seed=random_seed)
 
     if n_mcsamples == 1:
         n = r.normal(size=inarray.tag.test_value.shape)

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -261,7 +261,7 @@ def elbo_t(logp, uw, inarray, n_mcsamples, seed):
     logp_ = lambda input: theano.clone(logp, {inarray: input}, strict=False)
 
     # Naive Monte-Carlo
-    r = MRG_RandomStreams(random_seed=seed)
+    r = MRG_RandomStreams(seed=seed)
 
     if n_mcsamples == 1:
         n = r.normal(size=inarray.tag.test_value.shape)

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -28,7 +28,7 @@ def check_discrete_rvs(vars):
         raise ValueError('Model should not include discrete RVs for ADVI.')
 
 def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False, 
-    learning_rate=.001, epsilon=.1, random_seed=None, verbose=1):
+    learning_rate=.001, epsilon=.1, random_seed=20090425, verbose=1):
     """Run ADVI. 
 
     Parameters
@@ -57,7 +57,6 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
 
     'means' and 'stds' include parameters of the variational posterior. 
     """
-    seed = random_seed if isinstance(random_seed, int) else 12345
 
     model = modelcontext(model)
     if start is None:
@@ -73,7 +72,7 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
 
     # Create variational gradient tensor
     grad, elbo, shared, _ = variational_gradient_estimate(
-        vars, model, n_mcsamples=n_mcsamples, random_seed=seed)
+        vars, model, n_mcsamples=n_mcsamples, random_seed=random_seed)
 
     # Set starting values
     for var, share in shared.items():
@@ -98,7 +97,7 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
 
 def advi_minibatch(vars=None, start=None, model=None, n=5000, n_mcsamples=1, 
     minibatch_RVs=None, minibatch_tensors=None, minibatches=None, total_size=None, 
-    learning_rate=.001, epsilon=.1, random_seed=None, verbose=1):
+    learning_rate=.001, epsilon=.1, random_seed=20090425, verbose=1):
     """Run mini-batch ADVI. 
 
     minibatch_RVs, minibatch_tensors and minibatches should be in the 
@@ -128,7 +127,7 @@ def advi_minibatch(vars=None, start=None, model=None, n=5000, n_mcsamples=1,
         Adagrad base learning rate. 
     epsilon : float
         Offset in denominator of the scale of learning rate in Adagrad.  
-    seed : int
+    random_seed : int
         Seed to initialize random state. 
 
     Returns
@@ -136,7 +135,6 @@ def advi_minibatch(vars=None, start=None, model=None, n=5000, n_mcsamples=1,
     ADVIFit
         Named tuple, which includes 'means', 'stds', and 'elbo_vals'. 
     """
-    seed = random_seed if isinstance(random_seed, int) else 12345
 
     model = modelcontext(model)
     if start is None:
@@ -152,7 +150,7 @@ def advi_minibatch(vars=None, start=None, model=None, n=5000, n_mcsamples=1,
     # Create variational gradient tensor
     grad, elbo, shared, uw = variational_gradient_estimate(
         vars, model, minibatch_RVs, minibatch_tensors, total_size, 
-        n_mcsamples=n_mcsamples, random_seed=seed)
+        n_mcsamples=n_mcsamples, random_seed=random_seed)
 
     # Set starting values
     for var, share in shared.items():
@@ -220,10 +218,9 @@ def run_adagrad(uw, grad, elbo, n, learning_rate=.001, epsilon=.1, verbose=1):
 
 def variational_gradient_estimate(
     vars, model, minibatch_RVs=[], minibatch_tensors=[], total_size=None, 
-    n_mcsamples=1, random_seed=None):
+    n_mcsamples=1, random_seed=20090425):
     """Calculate approximate ELBO and its (stochastic) gradient. 
     """
-    seed = random_seed if isinstance(random_seed, int) else 12345
 
     theano.config.compute_test_value = 'ignore'
     shared = make_shared_replacements(vars, model)
@@ -243,7 +240,7 @@ def variational_gradient_estimate(
     uw.tag.test_value = np.concatenate([inarray.tag.test_value,
                                         inarray.tag.test_value])
 
-    elbo = elbo_t(logp, uw, inarray, n_mcsamples=n_mcsamples, random_seed=seed)
+    elbo = elbo_t(logp, uw, inarray, n_mcsamples=n_mcsamples, random_seed=random_seed)
 
     # Gradient
     grad = gradient(elbo, [uw])

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -28,7 +28,7 @@ def check_discrete_rvs(vars):
         raise ValueError('Model should not include discrete RVs for ADVI.')
 
 def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False, 
-    learning_rate=.001, epsilon=.1, seed=None, verbose=1):
+    learning_rate=.001, epsilon=.1, random_seed=None, verbose=1):
     """Run ADVI. 
 
     Parameters
@@ -73,7 +73,7 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
 
     # Create variational gradient tensor
     grad, elbo, shared, _ = variational_gradient_estimate(
-        vars, model, n_mcsamples=n_mcsamples, seed=seed)
+        vars, model, n_mcsamples=n_mcsamples, random_seed=seed)
 
     # Set starting values
     for var, share in shared.items():
@@ -98,7 +98,7 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
 
 def advi_minibatch(vars=None, start=None, model=None, n=5000, n_mcsamples=1, 
     minibatch_RVs=None, minibatch_tensors=None, minibatches=None, total_size=None, 
-    learning_rate=.001, epsilon=.1, seed=None, verbose=1):
+    learning_rate=.001, epsilon=.1, random_seed=None, verbose=1):
     """Run mini-batch ADVI. 
 
     minibatch_RVs, minibatch_tensors and minibatches should be in the 
@@ -152,7 +152,7 @@ def advi_minibatch(vars=None, start=None, model=None, n=5000, n_mcsamples=1,
     # Create variational gradient tensor
     grad, elbo, shared, uw = variational_gradient_estimate(
         vars, model, minibatch_RVs, minibatch_tensors, total_size, 
-        n_mcsamples=n_mcsamples, seed=seed)
+        n_mcsamples=n_mcsamples, random_seed=seed)
 
     # Set starting values
     for var, share in shared.items():
@@ -220,7 +220,7 @@ def run_adagrad(uw, grad, elbo, n, learning_rate=.001, epsilon=.1, verbose=1):
 
 def variational_gradient_estimate(
     vars, model, minibatch_RVs=[], minibatch_tensors=[], total_size=None, 
-    n_mcsamples=1, seed=None):
+    n_mcsamples=1, random_seed=None):
     """Calculate approximate ELBO and its (stochastic) gradient. 
     """
     seed = seed if type(seed) is int else 12345
@@ -243,7 +243,7 @@ def variational_gradient_estimate(
     uw.tag.test_value = np.concatenate([inarray.tag.test_value,
                                         inarray.tag.test_value])
 
-    elbo = elbo_t(logp, uw, inarray, n_mcsamples=n_mcsamples, seed=seed)
+    elbo = elbo_t(logp, uw, inarray, n_mcsamples=n_mcsamples, random_seed=seed)
 
     # Gradient
     grad = gradient(elbo, [uw])
@@ -261,7 +261,7 @@ def elbo_t(logp, uw, inarray, n_mcsamples, seed):
     logp_ = lambda input: theano.clone(logp, {inarray: input}, strict=False)
 
     # Naive Monte-Carlo
-    r = MRG_RandomStreams(seed=seed)
+    r = MRG_RandomStreams(random_seed=seed)
 
     if n_mcsamples == 1:
         n = r.normal(size=inarray.tag.test_value.shape)

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -57,7 +57,7 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
 
     'means' and 'stds' include parameters of the variational posterior. 
     """
-    seed = random_seed if isinstance(seed, int) else 12345
+    seed = random_seed if isinstance(random_seed, int) else 12345
 
     model = modelcontext(model)
     if start is None:
@@ -223,7 +223,7 @@ def variational_gradient_estimate(
     n_mcsamples=1, random_seed=None):
     """Calculate approximate ELBO and its (stochastic) gradient. 
     """
-    seed = random_seed if isinstance(seed, int) else 12345
+    seed = random_seed if isinstance(random_seed, int) else 12345
 
     theano.config.compute_test_value = 'ignore'
     shared = make_shared_replacements(vars, model)


### PR DESCRIPTION
The `seed` argument in `advi` was inconsistent with the rest of the package, where `random_seed` is the standard. This replaces all instances of `seed` with `random_seed`.
