### PR TITLE
Eliminated VisibleDeprecationWarning from summary

### DIFF
--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -292,7 +292,7 @@ def mc_error(x, batches=5):
         if batches == 1: return np.std(x)/np.sqrt(len(x))
 
         try:
-            batched_traces = np.resize(x, (batches, len(x)/batches))
+            batched_traces = np.resize(x, (batches, int(len(x)/batches)))
         except ValueError:
             # If batches do not divide evenly, trim excess samples
             resid = len(x) % batches


### PR DESCRIPTION
Minor fix to eliminate a Numpy warning, like this:

```
/Users/fonnescj/anaconda3/lib/python3.5/site-packages/numpy/core/fromnumeric.py:225: 
VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  return reshape(newshape, order=order)
```
