### PR TITLE
WIP Enforce sum-to-one for Categorical and Multinomial probabilities

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -366,6 +366,8 @@ class Categorical(Discrete):
             self.k = np.shape(p)[-1].tag.test_value
         except AttributeError:
             self.k = np.shape(p)[-1]
+        if np.any(abs(1 - np.sum(p, -1))):
+            raise ValueError('Categorical probabilities must sum to one.')
         self.p = T.as_tensor_variable(p)
         self.mode = T.argmax(p)
 

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -168,6 +168,8 @@ class Multinomial(Discrete):
     def __init__(self, n, p, *args, **kwargs):
         super(Multinomial, self).__init__(*args, **kwargs)
         self.n = n
+        if abs(1 - sum(p)):
+            raise ValueError('Multinomial probabilities must sum to one.')
         self.p = p
         self.mean = n * p
         self.mode = T.cast(T.round(n * p), 'int32')

--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -43,12 +43,11 @@ class ElemwiseCategorical(ArrayStep):
     @staticmethod
     def competence(var):
         distribution = getattr(var.distribution, 'parent_dist', var.distribution)
-        # if isinstance(var.distribution, Categorical):
-        #     if var.distribution.k>2:
-        #         return Competence.ideal
-        #     else:
-        #         return Competence.compatible
-        return Competence.INCOMPATIBLE
+        if isinstance(var.distribution, Categorical):
+            if var.distribution.k>2:
+                return Competence.IDEAL
+            else:
+                return Competence.COMPATIBLE
 
 def elemwise_logp(model, var):
     terms = [v.logp_elemwiset for v in model.basic_RVs if var in inputs([v.logpt])]


### PR DESCRIPTION
This solves at least one of the issues causing `ElemwiseCategorical` to fail. I have restored this step method to be chosen automatically by `sample`. Took care of Multinomial as well. 

Closes #1096 
