### PR TITLE
added vim swap files to .gitignore, removed disp duplication in starting.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.sw[op]
 examples/*.png
 build/*
 dist/*

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -78,9 +78,9 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
     # Check to see if minimization function actually uses the gradient
     if 'fprime' in getargspec(fmin).args:
         r = fmin(logp_o, bij.map(
-            start), fprime=grad_logp_o, disp=disp, *args, **kwargs)
+            start), fprime=grad_logp_o, *args, **kwargs)
     else:
-        r = fmin(logp_o, bij.map(start), disp=disp, *args, **kwargs)
+        r = fmin(logp_o, bij.map(start), *args, **kwargs)
 
     if isinstance(r, tuple):
         mx0 = r[0]

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -46,7 +46,7 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
 
     disc_vars = list(typefilter(vars, discrete_types))
     
-    disp = model.verbose > 1
+    kwargs["disp"] = model.verbose > 1
     
     if disc_vars and disp:
         print("Warning: vars contains discrete variables. MAP " +


### PR DESCRIPTION
Please merge with care. There are two changes:
- trivial: added file type to .gitignore
- nontrivial: see below

I was not able to reproduce [GLM-logistic.ipynb](https://github.com/pymc-devs/pymc3/blob/master/pymc3/examples/notebooks/GLM-logistic.ipynb), because I got this error:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-d1f71348626f> in <module>()
----> 1 models_lin, traces_lin = run_models(data, 1)

<ipython-input-2-c68c38709c91> in run_models(df, upper_order)
     19             pm.glm.glm(fml, df, family=pm.glm.families.Normal())
     20 
---> 21             start_MAP = pm.find_MAP(fmin=fmin_powell, disp=False)
     22             traces[nm] = pm.sample(2000, start=start_MAP, step=pm.NUTS(), progressbar=True)
     23 

/Users/tobiasknuth/Repositories/pymc3/pymc3/tuning/starting.py in find_MAP(start, vars, fmin, return_raw, model, *args, **kwargs)
     82             start), fprime=grad_logp_o, disp=disp, *args, **kwargs)
     83     else:
---> 84         r = fmin(logp_o, bij.map(start), *args, disp=disp, **kwargs)
     85 
     86     if isinstance(r, tuple):

TypeError: fmin_powell() got multiple values for keyword argument 'disp'
```

I believe it came up because `disp=disp` and also, within kwargs, there was `{disp: False}`. Thus, I removed the duplicated keyword argument.

**I am not sure whether that is okay. Can anyone check, please?**
