### PR TITLE
disp changed to kwargs['dist'] where forgotten

### DIFF
--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -48,7 +48,7 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
     
     kwargs["disp"] = model.verbose > 1
     
-    if disc_vars and disp:
+    if disc_vars and kwargs["disp"]:
         print("Warning: vars contains discrete variables. MAP " +
               "estimates may not be accurate for the default " +
               "parameters. Defaulting to non-gradient minimization " +


### PR DESCRIPTION
@fonnesbeck Like this? Now disp isn't used anymore and `kwargs["disp"]` is overwritten for this class. How about a warning if the value in kwargs differs from `model.verbose > 1`?
