### PR TITLE
Automatic scaling of categorical and multinomial probabilities

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -358,17 +358,17 @@ class Categorical(Discrete):
     Parameters
     ----------
     p : float
-        p > 0 and the elements of p must sum to 1.
+        p > 0 and the elements of p must sum to 1. They will be automatically
+        rescaled otherwise.
     """
     def __init__(self, p, *args, **kwargs):
         super(Categorical, self).__init__(*args, **kwargs)
         try:
-            self.k = np.shape(p)[-1].tag.test_value
+            self.k = T.shape(p)[-1].tag.test_value
         except AttributeError:
-            self.k = np.shape(p)[-1]
-        if np.any(abs(1 - np.sum(p, -1))):
-            raise ValueError('Categorical probabilities must sum to one.')
-        self.p = T.as_tensor_variable(p)
+            self.k = T.shape(p)[-1]
+        #self.p = T.as_tensor_variable(p)
+        self.p = (p.T/T.sum(p,-1)).T    
         self.mode = T.argmax(p)
 
 

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -358,15 +358,17 @@ class Categorical(Discrete):
     Parameters
     ----------
     p : float
-        p > 0 and the elements of p must sum to 1.
+        p > 0 and the elements of p must sum to 1. They will be automatically
+        rescaled otherwise.
     """
     def __init__(self, p, *args, **kwargs):
         super(Categorical, self).__init__(*args, **kwargs)
         try:
-            self.k = np.shape(p)[-1].tag.test_value
+            self.k = T.shape(p)[-1].tag.test_value
         except AttributeError:
-            self.k = np.shape(p)[-1]
-        self.p = T.as_tensor_variable(p)
+            self.k = T.shape(p)[-1]
+        #self.p = T.as_tensor_variable(p)
+        self.p = (p.T/T.sum(p,-1)).T    
         self.mode = T.argmax(p)
 
 

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -163,14 +163,12 @@ class Multinomial(Discrete):
         Number of trials (n > 0).
     p : array
         Probability of each one of the different outcomes. Elements must
-        be non-negative and sum to 1.
+        be non-negative and sum to 1. They will be automatically rescaled otherwise.
     """
     def __init__(self, n, p, *args, **kwargs):
         super(Multinomial, self).__init__(*args, **kwargs)
         self.n = n
-        if abs(1 - sum(p)):
-            raise ValueError('Multinomial probabilities must sum to one.')
-        self.p = p
+        self.p = p/T.sum(p)
         self.mean = n * p
         self.mode = T.cast(T.round(n * p), 'int32')
 

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -163,12 +163,12 @@ class Multinomial(Discrete):
         Number of trials (n > 0).
     p : array
         Probability of each one of the different outcomes. Elements must
-        be non-negative and sum to 1.
+        be non-negative and sum to 1. They will be automatically rescaled otherwise.
     """
     def __init__(self, n, p, *args, **kwargs):
         super(Multinomial, self).__init__(*args, **kwargs)
         self.n = n
-        self.p = p
+        self.p = p/T.sum(p)
         self.mean = n * p
         self.mode = T.cast(T.round(n * p), 'int32')
 


### PR DESCRIPTION
It turned out to be easier just to automatically enforce sum-to-1 by scaling. I added this information to the docstring to avoid confusion.

Closes #1096 #1098 
