### PR TITLE
Fix invlogit

### DIFF
--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -10,13 +10,15 @@ import theano
 import theano.tensor as tt
 import sys
 
+def logsumexp(x, axis=None):
+     # Adapted from https://github.com/Theano/Theano/issues/1563
+     x_max = tt.max(x, axis=axis, keepdims=True)
+     return tt.log(tt.sum(tt.exp(x - x_max), axis=axis, keepdims=True)) + x_max
+
 def invlogit(x):
-    x_max = -tt.log(sys.float_info.epsilon)
-    if (x > x_max): 
-        return 1.0
-    elif (x < 1-x_max): 
-        return 0.0
-    return 1/(1 + tt.exp(-x))
-    
+    p_min = sys.float_info.epsilon
+
+    return (1 - 2 * p_min) / (1 + tt.exp(-x)) + p_min
+
 def logit(p):
     return tt.log(p/(1-p))


### PR DESCRIPTION
Fix for #1149. 

In #1147, I intended to confine the range of the output of invlogit to (eps, 1-eps). 
Could you check this fix makes sense?

And I reverted a deletion of LogSumExp() with changing the name of the function: 
logsumexp(). 

BTW, If we want to apply conditional expressions in Theano, use switch(). 
http://deeplearning.net/software/theano/library/tensor/basic.html#condition

Example:

``` python
a = tt.switch(x > 0, 1, 0) # step function
```
