### PR TITLE
remove unused imports from examples

### DIFF
--- a/pymc3/examples/ARM5_4.py
+++ b/pymc3/examples/ARM5_4.py
@@ -5,7 +5,6 @@ Created on May 18, 2012
 '''
 import numpy as np
 from pymc3 import *
-import theano.tensor as t
 import pandas as pd
 
 wells = get_data_file('pymc3.examples', 'data/wells.dat')

--- a/pymc3/examples/banana.py
+++ b/pymc3/examples/banana.py
@@ -4,10 +4,8 @@ Created on May 10, 2012
 @author: jsalvatier
 '''
 from pymc3 import *
-from numpy.random import normal
 import numpy as np
 import pylab as pl
-from itertools import product
 
 
 """
@@ -49,7 +47,6 @@ def run(n = 3000):
 
 
         # lets plot the samples vs. the actual distribution
-        from theano import function
         xn = 1500
         yn = 1000
 

--- a/pymc3/examples/disaster_model.py
+++ b/pymc3/examples/disaster_model.py
@@ -10,9 +10,7 @@ disasters[t] ~ Po(early_mean if t <= switchpoint, late_mean otherwise)
 
 from pymc3 import *
 
-import theano.tensor as t
-from numpy import arange, array, ones, concatenate
-from numpy.random import randint
+from numpy import arange, array
 
 __all__ = ['disasters_data', 'switchpoint', 'early_mean', 'late_mean', 'rate',
              'disasters']

--- a/pymc3/examples/disaster_model_arbitrary_deterministic.py
+++ b/pymc3/examples/disaster_model_arbitrary_deterministic.py
@@ -7,8 +7,7 @@ Note that gradient based samplers will not work.
 
 from pymc3 import *
 import theano.tensor as t
-from numpy import arange, array, ones, concatenate, empty
-from numpy.random import randint
+from numpy import arange, array, empty
 
 __all__ = ['disasters_data', 'switchpoint', 'early_mean', 'late_mean', 'rate',
              'disasters']

--- a/pymc3/examples/disaster_model_missing.py
+++ b/pymc3/examples/disaster_model_missing.py
@@ -10,9 +10,7 @@ disasters[t] ~ Po(early_mean if t <= switchpoint, late_mean otherwise)
 
 from pymc3 import *
 
-import theano.tensor as t
-from numpy import arange, array, ones, concatenate
-from numpy.random import randint
+from numpy import arange, array
 from numpy.ma import masked_values
 
 __all__ = ['disasters_data', 'switchpoint', 'early_mean', 'late_mean', 'rate',

--- a/pymc3/examples/gelman_bioassay.py
+++ b/pymc3/examples/gelman_bioassay.py
@@ -1,6 +1,5 @@
 from pymc3 import *
 from numpy import ones, array
-import theano.tensor as t
 
 # Samples for each dose level
 n = 5 * ones(4, dtype=int)

--- a/pymc3/examples/glm_linear.py
+++ b/pymc3/examples/glm_linear.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 import scipy.optimize as opt
 

--- a/pymc3/examples/glm_robust.py
+++ b/pymc3/examples/glm_robust.py
@@ -1,5 +1,4 @@
 import numpy as np
-import sys
 
 from pymc3 import *
 

--- a/pymc3/examples/hierarchical.py
+++ b/pymc3/examples/hierarchical.py
@@ -1,6 +1,6 @@
 from pymc3 import *
 import theano.tensor as tt
-from numpy import random, sum as nsum, ones, concatenate, newaxis, dot, arange
+from numpy import random, sum as nsum, concatenate, newaxis, dot
 import numpy as np
 
 random.seed(1)

--- a/pymc3/examples/lasso_missing.py
+++ b/pymc3/examples/lasso_missing.py
@@ -1,5 +1,4 @@
 from pymc3 import *
-import numpy as np
 import pandas as pd
 from numpy.ma import masked_values
 

--- a/pymc3/examples/latent_occupancy.py
+++ b/pymc3/examples/latent_occupancy.py
@@ -33,7 +33,6 @@ Copyright (c) 2008 University of Otago. All rights reserved.
 # Import statements
 from pymc3 import *
 from numpy import random, array, arange, ones
-import theano.tensor as t
 # Sample size
 n = 100
 # True mean count, given occupancy

--- a/pymc3/examples/normal.py
+++ b/pymc3/examples/normal.py
@@ -1,6 +1,5 @@
 from pymc3 import *
 import numpy as np
-import theano
 
 # import pydevd
 # pydevd.set_pm_excepthook()

--- a/pymc3/examples/nutstest.py
+++ b/pymc3/examples/nutstest.py
@@ -5,9 +5,7 @@
 
 from matplotlib.pylab import *
 from pymc3 import *
-import numpy as np 
-from numpy.random import normal, beta
-import theano 
+from numpy.random import normal
 
 
 

--- a/pymc3/examples/python_vs_c.py
+++ b/pymc3/examples/python_vs_c.py
@@ -1,6 +1,5 @@
 from pymc3 import *
 import numpy as np
-import theano.tensor as t
 
 # import pydevd
 # pydevd.set_pm_excepthook()

--- a/pymc3/examples/simpletest.py
+++ b/pymc3/examples/simpletest.py
@@ -1,7 +1,6 @@
 import matplotlib.pyplot as plt
 from pymc3 import *
 import numpy as np
-import theano
 
 # import pydevd
 # pydevd.set_pm_excepthook()

--- a/pymc3/examples/speedtest_pymc3.py
+++ b/pymc3/examples/speedtest_pymc3.py
@@ -32,8 +32,7 @@ Copyright (c) 2008 University of Otago. All rights reserved.
 
 # Import statements
 from pymc3 import *
-from numpy import random, array, arange, ones
-import theano.tensor as t
+from numpy import random, array
 # Sample size
 n = 100000
 # True mean count, given occupancy

--- a/pymc3/examples/stochastic_volatility.py
+++ b/pymc3/examples/stochastic_volatility.py
@@ -8,7 +8,6 @@ import numpy as np
 from pymc3 import *
 from pymc3.distributions.timeseries import *
 
-from scipy.sparse import csc_matrix
 from scipy import optimize
 
 # <markdowncell>


### PR DESCRIPTION
I was looking at the glm example code and noticed there was an unused import. I decided to go ahead and remove unused imports from all the example scripts.

There are a number of other unused imports throughout the project, but I didn't want to risk creating merge conflicts with your unpushed edits.
