### PR TITLE
BUG: ValueError with complete data as MaskedArray

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -539,7 +539,7 @@ def as_tensor(data, name, model, distribution):
     dtype = distribution.dtype
     data = pandas_to_array(data).astype(dtype)
 
-    if hasattr(data, 'mask'):
+    if hasattr(data, 'mask') and data.mask.sum():
         from .distributions import NoDistribution
         testval = distribution.testval or data.mean().astype(dtype)
         fakedist = NoDistribution.dist(shape=data.mask.sum(), dtype=dtype,
@@ -553,6 +553,8 @@ def as_tensor(data, name, model, distribution):
         dataTensor.missing_values = missing_values
         return dataTensor
     else:
+        if hasattr(data, 'mask'):
+            data = data.data
         data = tt.as_tensor_variable(data, name=name)
         data.missing_values = None
         return data

--- a/pymc3/tests/test_missing.py
+++ b/pymc3/tests/test_missing.py
@@ -14,6 +14,10 @@ def test_missing():
 
     model.logp(model.test_point)
 
+def test_no_missing():
+    data = ma.masked_values([[1, 2], [3, 4]], value=-1)
+    with Model() as model:
+        x = Normal('x', observed=data)
 
 def test_missing_pandas():
     data = pd.DataFrame([1,2,numpy.nan,4,numpy.nan])


### PR DESCRIPTION
Similar to #529 but a distinct problem: I was passing in a MaskedArray that had no missing values and was getting `ValueError: array is not broadcastable to correct shape`

After bouncing around between pymc3 and Theano for a bit I tracked it down to this: when as_tensor is given a masked array with no mask (data.mask is False), it ends up raising that error. My solution here is to check for that case specifically, but this may not be the most elegant solution.

I'm not sure why the other test for masked data doesn't catch this. I can try to write a test for this case if desired.
