### PR TITLE
Fixed DiscreteUniform initialization bug

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -320,7 +320,7 @@ class DiscreteUniform(Discrete):
         super(DiscreteUniform, self).__init__(*args, **kwargs)
         self.lower = tt.floor(lower).astype('int32')
         self.upper = tt.floor(upper).astype('int32')
-        self.mode = tt.max(tt.floor((upper - lower) / 2.).astype('int32'), self.lower)
+        self.mode = tt.maximum(tt.floor((upper - lower) / 2.).astype('int32'), self.lower)
 
     def _random(self, lower, upper, size=None):
         # This way seems to be the only to deal with lower and upper

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -320,7 +320,7 @@ class DiscreteUniform(Discrete):
         super(DiscreteUniform, self).__init__(*args, **kwargs)
         self.lower = tt.floor(lower).astype('int32')
         self.upper = tt.floor(upper).astype('int32')
-        self.mode = tt.max(tt.floor((upper - lower) / 2.).astype('int32'), lower)
+        self.mode = tt.max(tt.floor((upper - lower) / 2.).astype('int32'), self.lower)
 
     def _random(self, lower, upper, size=None):
         # This way seems to be the only to deal with lower and upper

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -320,7 +320,7 @@ class DiscreteUniform(Discrete):
         super(DiscreteUniform, self).__init__(*args, **kwargs)
         self.lower = tt.floor(lower).astype('int32')
         self.upper = tt.floor(upper).astype('int32')
-        self.mode = tt.floor((upper - lower) / 2.).astype('int32')
+        self.mode = tt.max(tt.floor((upper - lower) / 2.).astype('int32'), lower)
 
     def _random(self, lower, upper, size=None):
         # This way seems to be the only to deal with lower and upper

--- a/pymc3/tests/test_distribution_defaults.py
+++ b/pymc3/tests/test_distribution_defaults.py
@@ -51,3 +51,8 @@ def test_default_b():
         y = DistTest('y', 7, 8, testval=94)
         x = DistTest('x', y, 2, defaults=['a', 'b'])
         assert x.tag.test_value == 94
+
+def test_default_discrete_uniform():
+    with Model():
+        x = pm.DiscreteUniform('x', lower=1, upper=2)
+        assert x.init_value == 1


### PR DESCRIPTION
In some situations, the calculation of the mode for the initial value is lower than the lower bound. This fixes that, and adds a test for regression.

Closes #1194 
