### PR TITLE
Allow for multidimensional input to Categorical.random().

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -368,13 +368,22 @@ class Categorical(Discrete):
         except AttributeError:
             self.k = tt.shape(p)[-1]
         self.p = tt.as_tensor_variable(p)
-        self.p = (p.T/tt.sum(p,-1)).T   
+        self.p = (p.T/tt.sum(p,-1)).T
         self.mode = tt.argmax(p)
 
 
     def random(self, point=None, size=None, repeat=None):
+        def random_choice(k, *args, **kwargs):
+            if len(kwargs['p'].shape) > 1:
+                return np.asarray(
+                    [np.random.choice(k, p=p)
+                     for p in kwargs['p']]
+                )
+            else:
+                return np.random.choice(k, *args, **kwargs)
+
         p, k = draw_values([self.p, self.k], point=point)
-        return generate_samples(partial(np.random.choice, np.arange(k)),
+        return generate_samples(partial(random_choice, np.arange(k)),
                                 p=p,
                                 broadcast_shape=p.shape[:-1] or (1,),
                                 dist_shape=self.shape,

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -174,7 +174,7 @@ class ScalarParameterShape(unittest.TestCase):
 
     def test_ex_gaussian(self):
         self.check(ExGaussian, mu=0., sigma=1., nu=1.)
-        
+
     def test_vonmises(self):
         self.check(VonMises, mu=0., kappa=1.)
 
@@ -270,7 +270,7 @@ class ScalarShape(unittest.TestCase):
 
     def test_ex_gaussian(self):
         self.check(ExGaussian, mu=0., sigma=1., nu=1.)
-        
+
     def test_vonmises(self):
         self.check(VonMises, mu=0., kappa=1.)
 
@@ -374,7 +374,7 @@ class Parameters1dShape(unittest.TestCase):
 
     def test_ex_gaussian(self):
         self.check(ExGaussian, mu=self.zeros, sigma=self.ones, nu=self.ones)
-        
+
     def test_vonmises(self):
         self.check(VonMises, mu=self.zeros, kappa=self.ones)
 
@@ -413,9 +413,9 @@ class Parameters1dShape(unittest.TestCase):
 
     def test_categorical(self):
         # Categorical cannot be initialised with >1D probabilities
-        raise SkipTest(
-            'Categorical cannot be initialised with >1D probabilities')
-        self.check(Categorical, p=self.ones / n)
+        # raise SkipTest(
+        #     'Categorical cannot be initialised with >1D probabilities')
+        self.check(Categorical, p=self.ones / len(self.ones))
 
 
 @attr('broadcast_shape')
@@ -487,7 +487,7 @@ class BroadcastShape(unittest.TestCase):
 
     def test_ex_gaussian(self):
         self.check(ExGaussian, mu=self.zeros, sigma=self.ones, nu=self.ones)
-        
+
     def test_vonmises(self):
         self.check(VonMises, mu=self.zeros, kappa=self.ones)
 
@@ -554,7 +554,7 @@ class ScalarParameterSamples(unittest.TestCase):
     def test_beta(self):
         pymc3_random(
                 Beta, {'alpha': Rplus, 'beta': Rplus},
-                ref_rand=(lambda size, alpha=None, beta=None: 
+                ref_rand=(lambda size, alpha=None, beta=None:
                     st.beta.rvs(a=alpha, b=beta, size=size))
                 )
 
@@ -629,7 +629,7 @@ class ScalarParameterSamples(unittest.TestCase):
                 ref_rand=lambda size, mu=None, sigma=None, nu=None: \
                     nr.normal(mu, sigma, size=size) + nr.exponential(scale=nu, size=size)
                 )
-                
+
     def test_vonmises(self):
         pymc3_random(VonMises, {'mu':R, 'kappa':Rplus},
                      ref_rand=lambda size, mu=None, kappa=None: st.vonmises.rvs(size=size,loc=mu, kappa=kappa))
@@ -722,17 +722,17 @@ class ScalarParameterSamples(unittest.TestCase):
                      valuedomain=Vector(R,n),
                      ref_rand=lambda mu=None, tau=None, size=None: \
                         st.multivariate_normal.rvs(mean=mu, cov=tau, size=size))
-                        
+
     def test_mv_t(self):
         for n in [2, 3]:
             pymc3_random(MvStudentT, {'nu': Domain([5, 10, 25, 50]), 'Sigma': PdMatrix(n),
                                       'mu':Vector(R,n)}, size=100,
                      valuedomain=Vector(R,n),
-                     ref_rand=(lambda nu=None, Sigma=None, mu=None, size=None: 
-                        mu + np.sqrt(nu) 
+                     ref_rand=(lambda nu=None, Sigma=None, mu=None, size=None:
+                        mu + np.sqrt(nu)
                         * (st.multivariate_normal.rvs(cov=Sigma, size=size).T
                         / st.chi2.rvs(df=nu, size=size)).T))
-    
+
 
     def test_dirichlet(self):
        for n in [2, 3]:


### PR DESCRIPTION
Because `numpy.random.choice()` does not accept 2d inputs for probabilities, `Categorical` could only sample for single observations. This PR just concatenates the output of choice being called on each individual element. Worked fine for my use-case and also has a unit-test.

CC @stevenmanton
