### PR TITLE
Append underscore to transformed variable names

### DIFF
--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -33,7 +33,6 @@ class BaseTrace(object):
             vars = model.unobserved_RVs
         self.vars = vars
         self.varnames = [str(var) for var in vars]
-        self.original_varnames = [str(var) for var in model.untransformed_RVs]
         self.fn = model.fastfn(vars)
 
 
@@ -191,7 +190,7 @@ class MultiTrace(object):
             burn, thin = 0, 1
         return self.get_values(var, burn=burn, thin=thin)
 
-    _attrs = set(['_straces', 'varnames', 'original_varnames', 'chains'])
+    _attrs = set(['_straces', 'varnames', 'chains'])
 
     def __getattr__(self, name):
         # Avoid infinite recursion when called before __init__
@@ -212,11 +211,6 @@ class MultiTrace(object):
     def varnames(self):
         chain = self.chains[-1]
         return self._straces[chain].varnames
-        
-    @property
-    def original_varnames(self):
-        chain = self.chains[-1]
-        return self._straces[chain].original_varnames
 
     def get_values(self, varname, burn=0, thin=1, combine=True, chains=None,
                    squeeze=True):

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -497,8 +497,8 @@ class FreeRV(Factor, TensorVariable):
         if type is None:
             type = distribution.type
         if name.endswith('_'):
-            warning = 'Variable names ending with underscore will be hidden from output '
-            warning += 'processing functions by default. Consider renaming {}.'.format(name)
+            _warning = 'Variable names ending with underscore will be hidden from output '
+            _warning += 'processing functions by default. Consider renaming {}.'.format(name)
             warnings.warn(_warning)
         super(FreeRV, self).__init__(type, owner, index, name)
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -180,7 +180,6 @@ class Model(Context, Factor):
         self.named_vars = {}
         self.free_RVs = []
         self.observed_RVs = []
-        self.hidden_RVs = []
         self.deterministics = []
         self.potentials = []
         self.missing_values = []
@@ -246,12 +245,7 @@ class Model(Context, Factor):
     def unobserved_RVs(self):
         """List of all random variable, including deterministic ones."""
         return self.vars + self.deterministics
-
-    @property
-    def untransformed_RVs(self):
-        """All variables except those transformed for MCMC"""
-        return [v for v in self.vars if v not in self.hidden_RVs] + self.deterministics
-
+        
     @property
     def test_point(self):
         """Test point used to check that the model doesn't generate errors"""
@@ -680,9 +674,8 @@ class TransformedRV(TensorVariable):
         if distribution is not None:
             self.model = model
 
-            self.transformed = model.Var(name + "_" + transform.name, transform.apply(distribution))
-
-            self.model.hidden_RVs.append(self.transformed)
+            transformed_name = "{}_{}_".format(name, transform.name)
+            self.transformed = model.Var(transformed_name, transform.apply(distribution))
 
             normalRV = transform.backward(self.transformed)
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -2,6 +2,7 @@ import numpy as np
 import theano
 import theano.tensor as tt
 from theano.tensor.var import TensorVariable
+import warnings
 
 from .memoize import memoize
 from .theanof import gradient, hessian, inputvars
@@ -495,6 +496,10 @@ class FreeRV(Factor, TensorVariable):
         model : Model"""
         if type is None:
             type = distribution.type
+        if name.endswith('_'):
+            warning = 'Variable names ending with underscore will be hidden from output '
+            warning += 'processing functions by default. Consider renaming {}.'.format(name)
+            warnings.warn(_warning)
         super(FreeRV, self).__init__(type, owner, index, name)
 
         if distribution is not None:

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -2,7 +2,6 @@ import numpy as np
 import theano
 import theano.tensor as tt
 from theano.tensor.var import TensorVariable
-import warnings
 
 from .memoize import memoize
 from .theanof import gradient, hessian, inputvars
@@ -496,10 +495,6 @@ class FreeRV(Factor, TensorVariable):
         model : Model"""
         if type is None:
             type = distribution.type
-        if name.endswith('_'):
-            _warning = 'Variable names ending with underscore will be hidden from output '
-            _warning += 'processing functions by default. Consider renaming {}.'.format(name)
-            warnings.warn(_warning)
         super(FreeRV, self).__init__(type, owner, index, name)
 
         if distribution is not None:

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -172,7 +172,7 @@ def kde2plot(x, y, grid=200, ax=None):
     return ax
 
 
-def autocorrplot(trace, varnames=None, max_lag=100, burn=0,
+def autocorrplot(trace, varnames=None, max_lag=100, burn=0, plot_transformed=False,
                  symmetric_plot=False, ax=None, figsize=None):
     """Bar plot of the autocorrelation function for a trace
 
@@ -187,6 +187,9 @@ def autocorrplot(trace, varnames=None, max_lag=100, burn=0,
     burn : int
         Number of samples to discard from the beginning of the trace.
         Defaults to 0.
+    plot_transformed : bool
+        Flag for plotting automatically transformed variables in addition to 
+        original variables (defaults to False).
     symmetric_plot : boolean
         Plot from either [0, +lag] or [-lag, lag]. Defaults to False, [-, +lag].
     ax : axes
@@ -588,7 +591,7 @@ def forestplot(trace_obj, varnames=None, transform=lambda x: x, alpha=0.05, quar
 
 def plot_posterior(trace, varnames=None, transform=lambda x: x, figsize=None, 
                     alpha_level=0.05, round_to=3, point_estimate='mean', rope=None, 
-                    ref_val=None, kde_plot=False, ax=None, **kwargs):
+                    ref_val=None, kde_plot=False, plot_transformed=False, ax=None, **kwargs):
     """Plot Posterior densities in style of John K. Kruschke book
 
     Parameters
@@ -613,6 +616,9 @@ def plot_posterior(trace, varnames=None, transform=lambda x: x, figsize=None,
         display the percentage below and above ref_val
     kde_plot: bool
         if True plot a KDE instead of a histogram
+    plot_transformed : bool
+        Flag for plotting automatically transformed variables in addition to 
+        original variables (defaults to False).
     ax : axes
         Matplotlib axes. Defaults to None.
     **kwargs

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -8,7 +8,7 @@ __all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot','plo
 
 
 def traceplot(trace, varnames=None, transform=lambda x: x, figsize=None,
-              lines=None, combined=False, grid=False,
+              lines=None, combined=False, plot_transformed=False, grid=False,
               alpha=0.35, priors=None, prior_alpha=1, prior_style='--',
               ax=None):
     """Plot samples histograms and values
@@ -30,6 +30,9 @@ def traceplot(trace, varnames=None, transform=lambda x: x, figsize=None,
     combined : bool
         Flag for combining multiple chains into a single chain. If False
         (default), chains will be plotted separately.
+    plot_transformed : bool
+        Flag for plotting automatically transformed variables in addition to 
+        original variables (defaults to False).
     grid : bool
         Flag for adding gridlines to histogram. Defaults to True.
     alpha : float
@@ -52,7 +55,7 @@ def traceplot(trace, varnames=None, transform=lambda x: x, figsize=None,
     """
 
     if varnames is None:
-        varnames = trace.original_varnames
+        varnames = [name for name in trace.varnames if not name.endswith('_')]
 
     n = len(varnames)
 
@@ -206,9 +209,7 @@ def autocorrplot(trace, varnames=None, max_lag=100, burn=0,
             yield varname
 
     if varnames is None:
-        varnames = trace.original_varnames
-    else:
-        varnames = [str(v) for v in varnames]
+        varnames = [name for name in trace.varnames if not name.endswith('_')]
 
     varnames = [item for sub in [[i for i in _handle_array_varnames(v)]
                     for v in varnames] for item in sub]
@@ -740,7 +741,7 @@ def plot_posterior(trace, varnames=None, transform=lambda x: x, figsize=None,
         plot_posterior_op(transform(trace), ax)
     else:
         if varnames is None:
-            varnames = trace.original_varnames
+            varnames = [name for name in trace.varnames if not name.endswith('_')]
 
         if ax is None:
             ax, fig = create_axes_grid(figsize, varnames)

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -417,7 +417,7 @@ def df_summary(trace, varnames=None, stat_funcs=None, extend=False,
     mu__1  0.067513 -0.159097 -0.045637  0.062912
     """
     if varnames is None:
-        varnames = trace.original_varnames
+        varnames = [name for name in trace.varnames if not name.endswith('_')]
 
     funcs = [lambda x: pd.Series(np.mean(x, 0), name='mean'),
              lambda x: pd.Series(np.std(x, 0), name='sd'),
@@ -478,7 +478,7 @@ def summary(trace, varnames=None, alpha=0.05, start=0, batches=100, roundto=3,
 
     """
     if varnames is None:
-        varnames = trace.original_varnames
+        varnames = [name for name in trace.varnames if not name.endswith('_')]
 
     stat_summ = _StatSummary(roundto, batches, alpha)
     pq_summ = _PosteriorQuantileSummary(roundto, alpha)

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -342,7 +342,7 @@ def quantiles(x, qlist=(2.5, 25, 50, 75, 97.5), transform=lambda x: x):
         print("Too few elements for quantile calculation")
 
 
-def df_summary(trace, varnames=None, stat_funcs=None, extend=False,
+def df_summary(trace, varnames=None, stat_funcs=None, extend=False, include_transformed=False,
                alpha=0.05, batches=100):
     """Create a data frame with summary statistics.
 
@@ -372,6 +372,9 @@ def df_summary(trace, varnames=None, stat_funcs=None, extend=False,
         If True, use the statistics returned by `stat_funcs` in
         addition to, rather than in place of, the default statistics.
         This is only meaningful when `stat_funcs` is not None.
+    include_transformed : bool
+        Flag for reporting automatically transformed variables in addition to 
+        original variables (defaults to False).
     alpha : float
         The alpha level for generating posterior intervals. Defaults
         to 0.05. This is only meaningful when `stat_funcs` is None.
@@ -446,7 +449,7 @@ def _hpd_df(x, alpha):
 
 
 def summary(trace, varnames=None, alpha=0.05, start=0, batches=100, roundto=3,
-            to_file=None):
+            include_transformed=False, to_file=None):
     """
     Generate a pretty-printed summary of the node.
 
@@ -472,6 +475,10 @@ def summary(trace, varnames=None, alpha=0.05, start=0, batches=100, roundto=3,
 
     roundto : int
       The number of digits to round posterior statistics.
+            
+    include_transformed : bool
+      Flag for summarizing automatically transformed variables in addition to 
+      original variables (defaults to False).
 
     tofile : None or string
       File to write results to. If not given, print to stdout.


### PR DESCRIPTION
We no longer have to keep track of transformed variables due to this naming convention. Plots now exclude variables if the name contains an underscore (can be overridden with flag argument).

Closes #1168 
