### PR TITLE
WIP: allow ElemwiseCategorical to be assigned to categorical variables

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -544,6 +544,7 @@ def as_tensor(data, name, model, distribution):
         testval = distribution.testval or data.mean().astype(dtype)
         fakedist = NoDistribution.dist(shape=data.mask.sum(), dtype=dtype,
                                        testval=testval, parent_dist=distribution)
+        
         missing_values = FreeRV(name=name + '_missing', distribution=fakedist,
                                 model=model)
         constant = tt.as_tensor_variable(data.filled())

--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -43,8 +43,8 @@ class ElemwiseCategorical(ArrayStep):
     @staticmethod
     def competence(var):
         distribution = getattr(var.distribution, 'parent_dist', var.distribution)
-        if isinstance(var.distribution, Categorical):
-            if var.distribution.k>2:
+        if isinstance(distribution, Categorical):
+            if distribution.k>2:
                 return Competence.IDEAL
             else:
                 return Competence.COMPATIBLE


### PR DESCRIPTION
This addresses one problem causing #1218, but fails because the `logp`passed to `astep` is hard-wired to the shape of the original (observed+unobserved) variable. This is hard to debug because it is not clear where `logp` comes from. Needs clarified documentation along with the fix. Perhaps someone more familiar with this step method can have a go.

This one definitely requires a test.

Fixes #1218 
