### PR TITLE
Fix init of MvStudentT when no mu is provided.

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -101,7 +101,7 @@ class MvStudentT(Continuous):
     def __init__(self, nu, Sigma, mu=None, *args, **kwargs):
         super(MvStudentT, self).__init__(*args, **kwargs)
         self.nu = nu
-        self.mu = np.zeros(S.shape[0]) if mu is None else mu
+        self.mu = np.zeros(Sigma.shape[0]) if mu is None else mu
         self.Sigma = Sigma
         
         self.mean = self.median = self.mode = self.mu = mu


### PR DESCRIPTION
The current code references a variable `S` which is now called `Sigma`.
