### PR TITLE
Fix return value of MvStudentT

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -131,7 +131,7 @@ class MvStudentT(Continuous):
         log_pdf = gammaln((nu + d)/2.) - 0.5 * (d*tt.log(np.pi*nu) + log_det) - gammaln(nu/2.)
         log_pdf -= 0.5*(nu + d)*tt.log(1 + Q/nu)
     
-        return(tt.exp(log_pdf))
+        return log_pdf
     
         
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -406,7 +406,7 @@ def mvt_logpdf(value, nu, Sigma, mu=0):
             - scipy.special.gammaln(nu/2.))
     log_pdf -= 0.5*(nu + d)*np.log(1 + Q/nu)
     
-    return(np.exp(log_pdf))
+    return log_pdf
 
 def test_wishart():
     # for n in [2,3]:


### PR DESCRIPTION
The return value should not be exponentiated, since we are returning the value of the log pdf.

The MvStudentT otherwise does not even work in this minimal example:

``` python
with pm.Model() as model:
    stud = pm.MvStudentT('stud', nu=3., Sigma=np.eye(3), mu=np.zeros(3), shape=3)
    trace = pm.sample(100)
```

This pull request is just a quick fix, the tests might have to be adjusted.
