### PR TITLE
Corrected Categorical docstring to specify array argument for parameter

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -357,7 +357,7 @@ class Categorical(Discrete):
 
     Parameters
     ----------
-    p : float
+    p : array of floats
         p > 0 and the elements of p must sum to 1. They will be automatically
         rescaled otherwise.
     """


### PR DESCRIPTION
Closes #1232 
