### PR TITLE
Remove import * statements

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -1,9 +1,8 @@
 __version__ = "3.0"
 
-from .core import *
 from .distributions import *
 from .math import *
-
+from .model import *
 from .stats import *
 from .sampling import *
 from .interactive_sampling import *

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -9,6 +9,7 @@ from .interactive_sampling import *
 from .step_methods import *
 from .tuning import *
 from .variational import *
+import sampling
 
 from .debug import *
 

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -9,7 +9,7 @@ from .interactive_sampling import *
 from .step_methods import *
 from .tuning import *
 from .variational import *
-import sampling
+from . import sampling
 
 from .debug import *
 

--- a/pymc3/core.py
+++ b/pymc3/core.py
@@ -1,5 +1,0 @@
-from .vartypes import *
-from .model import *
-from .theanof import *
-from .blocking import *
-import numpy as np

--- a/pymc3/debug.py
+++ b/pymc3/debug.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .blocking import *
+from .blocking import DictToVarBijection
 
 # TODO I could not locate this function used anywhere in the code base
 # do we need it?

--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -1,8 +1,106 @@
 from . import timeseries
 from . import transforms
 
-from .continuous import *
-from .discrete import *
-from .distribution import *
-from .multivariate import *
-from .timeseries import *
+from .continuous import Uniform
+from .continuous import Flat
+from .continuous import Normal
+from .continuous import Beta
+from .continuous import Exponential
+from .continuous import Laplace
+from .continuous import StudentT
+from .continuous import Cauchy
+from .continuous import HalfCauchy
+from .continuous import Gamma
+from .continuous import Weibull
+from .continuous import Bound
+from .continuous import StudentTpos
+from .continuous import Lognormal
+from .continuous import ChiSquared
+from .continuous import HalfNormal
+from .continuous import Wald
+from .continuous import Pareto
+from .continuous import InverseGamma
+from .continuous import ExGaussian
+from .continuous import VonMises
+
+from .discrete import Binomial
+from .discrete import BetaBinomial
+from .discrete import Bernoulli
+from .discrete import Poisson
+from .discrete import NegativeBinomial
+from .discrete import ConstantDist
+from .discrete import ZeroInflatedPoisson
+from .discrete import DiscreteUniform
+from .discrete import Geometric
+from .discrete import Categorical
+
+from .distribution import DensityDist
+from .distribution import Distribution
+from .distribution import Continuous
+from .distribution import Discrete
+from .distribution import NoDistribution
+from .distribution import TensorType
+from .distribution import draw_values
+
+from .multivariate import MvNormal
+from .multivariate import MvStudentT
+from .multivariate import Dirichlet
+from .multivariate import Multinomial
+from .multivariate import Wishart
+from .multivariate import WishartBartlett
+from .multivariate import LKJCorr
+
+from .timeseries import AR1
+from .timeseries import GaussianRandomWalk
+from .timeseries import GARCH11
+
+__all__ = ['Uniform',
+    'Flat',
+    'Normal',
+    'Beta',
+    'Exponential',
+    'Laplace',
+    'StudentT',
+    'Cauchy',
+    'HalfCauchy',
+    'Gamma',
+    'Weibull',
+    'Bound',
+    'StudentTpos',
+    'Lognormal',
+    'ChiSquared',
+    'HalfNormal',
+    'Wald',
+    'Pareto',
+    'InverseGamma',
+    'ExGaussian',
+    'VonMises',
+    'Binomial',
+    'BetaBinomial',
+    'Bernoulli',
+    'Poisson',
+    'NegativeBinomial',
+    'ConstantDist',
+    'ZeroInflatedPoisson',
+    'DiscreteUniform',
+    'Geometric',
+    'Categorical',
+    'DensityDist',
+    'Distribution',
+    'Continuous',
+    'Discrete',
+    'NoDistribution',
+    'TensorType',
+    'MvNormal',
+    'MvStudentT',
+    'Dirichlet',
+    'Multinomial',
+    'Wishart',
+    'WishartBartlett',
+    'LKJCorr',
+    'AR1',
+    'GaussianRandomWalk',
+    'GARCH11'
+]
+           
+           

--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -54,6 +54,12 @@ from .timeseries import AR1
 from .timeseries import GaussianRandomWalk
 from .timeseries import GARCH11
 
+from .transforms import transform
+from .transforms import stick_breaking
+from .transforms import logodds
+from .transforms import log
+from .transforms import sum_to_1
+
 __all__ = ['Uniform',
     'Flat',
     'Normal',

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -6,7 +6,7 @@ from ..memoize import memoize
 from ..model import Model, get_named_nodes
 
 
-__all__ = ['DensityDist', 'Distribution', 'Continuous', 'Discrete', 'NoDistribution', 'TensorType']
+__all__ = ['DensityDist', 'Distribution', 'Continuous', 'Discrete', 'NoDistribution', 'TensorType', 'draw_values']
 
 
 class Distribution(object):

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -6,7 +6,7 @@ from .distribution import Distribution
 from ..math import logit
 import numpy as np
 
-__all__ = ['transform', 'stick_breaking', 'logodds', 'log']
+__all__ = ['transform', 'stick_breaking', 'logodds', 'log', 'sum_to_1']
 
 
 class Transform(object):

--- a/pymc3/examples/ARM12_6uranium.py
+++ b/pymc3/examples/ARM12_6uranium.py
@@ -55,8 +55,8 @@ def run(n=3000):
 
         start = Point({
                  'groupmean': obs_means.mean(),
-                 'groupsd_interval': 0,
-                 'sd_interval': 0,
+                 'groupsd_interval_': 0,
+                 'sd_interval_': 0,
                  'means': np.array(obs_means),
                  'u_m': np.array([.72]),
                  'floor_m': 0.,

--- a/pymc3/examples/ATMIP_2gaussians.py
+++ b/pymc3/examples/ATMIP_2gaussians.py
@@ -1,6 +1,6 @@
 import pymc3 as pm
 import numpy as np
-from pymc3.step_methods import ATMCMC as atmcmc
+from ..step_methods import ATMCMC, ATMIP_sample
 import theano.tensor as tt
 from matplotlib import pylab as plt
 
@@ -28,7 +28,7 @@ w2 = (1 - stdev)
 def two_gaussians(x):
     log_like1 = - 0.5 * n * tt.log(2 * np.pi) \
                 - 0.5 * tt.log(dsigma) \
-                - 0.5 * (x - mu1).tt.dot(isigma).dot(x - mu1)
+                - 0.5 * (x - mu1).T.dot(isigma).dot(x - mu1)
     log_like2 = - 0.5 * n * tt.log(2 * np.pi) \
                 - 0.5 * tt.log(dsigma) \
                 - 0.5 * (x - mu2).T.dot(isigma).dot(x - mu2)
@@ -45,10 +45,10 @@ with pm.Model() as ATMIP_test:
     llk = pm.Potential('like', like)
 
 with ATMIP_test:
-    step = atmcmc.ATMCMC(n_chains=n_chains, tune_interval=tune_interval,
+    step = ATMCMC(n_chains=n_chains, tune_interval=tune_interval,
                          likelihood_name=ATMIP_test.deterministics[0].name)
 
-trcs = atmcmc.ATMIP_sample(
+trcs = ATMIP_sample(
                         n_steps=n_steps,
                         step=step,
                         njobs=njobs,

--- a/pymc3/examples/GHME_2013.py
+++ b/pymc3/examples/GHME_2013.py
@@ -62,7 +62,7 @@ def interpolate(x0,y0, x, group):
 with Model() as model:
     coeff_sd = StudentT('coeff_sd', 10, 1, 5**-2)
 
-    y = GaussianRandomWalk('y', sd=coeff_sd, shape = (nknots, ncountries))
+    y = GaussianRandomWalk('y', sd=coeff_sd, shape=(nknots, ncountries))
 
     p = interpolate(knots, y, age, group)
 
@@ -78,14 +78,14 @@ with Model() as model:
 # <codecell>
 
 with model:
-    s = find_MAP( vars=[sd, y])
+    s = find_MAP(vars=[sd, y])
 
     step = NUTS(scaling = s)
     trace = sample(100, step, s)
 
     s = trace[-1]
 
-    step = NUTS(scaling = s)
+    step = NUTS(scaling=s)
 
 def run(n=3000):
     if n == "short":
@@ -106,13 +106,6 @@ def run(n=3000):
 
         ylim(0,rate.max())
 
-    # <codecell>
-
-    traceplot(trace[100:], varnames = [coeff_sd,sd ]);
-
-    # <codecell>
-
-    autocorrplot(trace, varnames = [coeff_sd,sd ])
 
 if __name__ == '__main__':
     run()

--- a/pymc3/examples/glm_linear.py
+++ b/pymc3/examples/glm_linear.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.optimize as opt
 
-from pymc3 import *
+from pymc3 import Model, glm, find_MAP, sample
 
 # Generate data
 size = 50

--- a/pymc3/glm/__init__.py
+++ b/pymc3/glm/__init__.py
@@ -1,5 +1,3 @@
-try:
-    from . import families
-    from .glm import glm, linear_component, plot_posterior_predictive
-except ImportError:
-    print("Warning: patsy not found, not importing glm submodule.")
+from . import families
+from .glm import glm, linear_component, plot_posterior_predictive
+

--- a/pymc3/glm/__init__.py
+++ b/pymc3/glm/__init__.py
@@ -1,5 +1,5 @@
 try:
     from . import families
-    from .glm import *
+    from .glm import glm, linear_component, plot_posterior_predictive
 except ImportError:
     print("Warning: patsy not found, not importing glm submodule.")

--- a/pymc3/glm/glm.py
+++ b/pymc3/glm/glm.py
@@ -1,6 +1,5 @@
 import numpy as np
-from ..core import *
-from ..distributions import *
+from ..distributions import Normal
 from ..tuning.starting import find_MAP
 import patsy
 import theano

--- a/pymc3/glm/glm.py
+++ b/pymc3/glm/glm.py
@@ -1,6 +1,7 @@
 import numpy as np
 from ..distributions import Normal
 from ..tuning.starting import find_MAP
+from ..model import modelcontext
 import patsy
 import theano
 import pandas as pd
@@ -8,6 +9,8 @@ from collections import defaultdict
 from pandas.tools.plotting import scatter_matrix
 
 from . import families
+
+__all__ = ['glm', 'linear_component', 'plot_posterior_predictive']
 
 def linear_component(formula, data, priors=None,
                      intercept_prior=None,

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.stats import kde, mode
-from .stats import *
+from .stats import autocorr
 from numpy.linalg import LinAlgError
 import matplotlib.pyplot as plt
 

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.stats import kde, mode
-from .stats import autocorr, quantiles
+from .stats import autocorr, quantiles, hpd
 from numpy.linalg import LinAlgError
 import matplotlib.pyplot as plt
 
@@ -31,14 +31,14 @@ def traceplot(trace, varnames=None, transform=lambda x: x, figsize=None,
         Flag for combining multiple chains into a single chain. If False
         (default), chains will be plotted separately.
     plot_transformed : bool
-        Flag for plotting automatically transformed variables in addition to 
+        Flag for plotting automatically transformed variables in addition to
         original variables (defaults to False).
     grid : bool
         Flag for adding gridlines to histogram. Defaults to True.
     alpha : float
         Alpha value for plot line. Defaults to 0.35.
     priors : iterable of PyMC distributions
-        PyMC prior distribution(s) to be plotted alongside poterior. Defaults 
+        PyMC prior distribution(s) to be plotted alongside poterior. Defaults
         to None (no prior plots).
     prior_alpha : float
         Alpha value for prior plot. Defaults to 1.
@@ -116,7 +116,7 @@ def kdeplot_op(ax, data, prior=None, prior_alpha=1, prior_style='--'):
             l = np.min(d)
             u = np.max(d)
             x = np.linspace(0, 1, 100) * (u - l) + l
-            
+
             if prior is not None:
                 p = prior.logp(x).eval()
                 ax.plot(x, np.exp(p), alpha=prior_alpha, ls=prior_style)
@@ -188,7 +188,7 @@ def autocorrplot(trace, varnames=None, max_lag=100, burn=0, plot_transformed=Fal
         Number of samples to discard from the beginning of the trace.
         Defaults to 0.
     plot_transformed : bool
-        Flag for plotting automatically transformed variables in addition to 
+        Flag for plotting automatically transformed variables in addition to
         original variables (defaults to False).
     symmetric_plot : boolean
         Plot from either [0, +lag] or [-lag, lag]. Defaults to False, [-, +lag].
@@ -296,7 +296,7 @@ def forestplot(trace_obj, varnames=None, transform=lambda x: x, alpha=0.05, quar
         varnames: list
             List of variables to plot (defaults to None, which results in all
             variables plotted).
-               
+
         transform : callable
             Function to transform data (defaults to identity)
 
@@ -589,8 +589,8 @@ def forestplot(trace_obj, varnames=None, transform=lambda x: x, alpha=0.05, quar
     return gs
 
 
-def plot_posterior(trace, varnames=None, transform=lambda x: x, figsize=None, 
-                    alpha_level=0.05, round_to=3, point_estimate='mean', rope=None, 
+def plot_posterior(trace, varnames=None, transform=lambda x: x, figsize=None,
+                    alpha_level=0.05, round_to=3, point_estimate='mean', rope=None,
                     ref_val=None, kde_plot=False, plot_transformed=False, ax=None, **kwargs):
     """Plot Posterior densities in style of John K. Kruschke book
 
@@ -617,12 +617,12 @@ def plot_posterior(trace, varnames=None, transform=lambda x: x, figsize=None,
     kde_plot: bool
         if True plot a KDE instead of a histogram
     plot_transformed : bool
-        Flag for plotting automatically transformed variables in addition to 
+        Flag for plotting automatically transformed variables in addition to
         original variables (defaults to False).
     ax : axes
         Matplotlib axes. Defaults to None.
     **kwargs
-        Passed as-is to plt.hist() or plt.plot() function, depending on the 
+        Passed as-is to plt.hist() or plt.plot() function, depending on the
         value of the argument kde_plot
         Some defaults are added, if not specified
         color='#87ceeb' will match the style in the book
@@ -648,15 +648,15 @@ def plot_posterior(trace, varnames=None, transform=lambda x: x, figsize=None,
             greater_than_ref_probability = (trace_values >= ref_val).mean()
             ref_in_posterior = format_as_percent(less_than_ref_probability, 1) + ' <{:g}< '.format(ref_val) + format_as_percent(
                 greater_than_ref_probability, 1)
-            ax.axvline(ref_val, ymin=0.02, ymax=.75, color='g', 
+            ax.axvline(ref_val, ymin=0.02, ymax=.75, color='g',
             linewidth=4, alpha=0.65)
             ax.text(trace_values.mean(), plot_height * 0.6, ref_in_posterior,
                         size=14, horizontalalignment='center')
-                        
+
         def display_rope(rope):
-            pc_in_rope = format_as_percent(np.sum((trace_values > rope[0]) & 
+            pc_in_rope = format_as_percent(np.sum((trace_values > rope[0]) &
             (trace_values < rope[1]))/len(trace_values), round_to)
-            ax.plot(rope, (plot_height * 0.02, plot_height * 0.02), 
+            ax.plot(rope, (plot_height * 0.02, plot_height * 0.02),
             linewidth=20, color='r', alpha=0.75)
             text_props = dict(size=16, horizontalalignment='center', color='r')
             ax.text(rope[0], plot_height * 0.14, rope[0], **text_props)
@@ -711,11 +711,11 @@ def plot_posterior(trace, varnames=None, transform=lambda x: x, figsize=None,
             l = np.min(trace_values)
             u = np.max(trace_values)
             x = np.linspace(0, 1, 100) * (u - l) + l
-            ax.plot(x, density(x), **kwargs)    
+            ax.plot(x, density(x), **kwargs)
         else:
             set_key_if_doesnt_exist(kwargs, 'bins', 30)
             set_key_if_doesnt_exist(kwargs, 'edgecolor', 'w')
-            set_key_if_doesnt_exist(kwargs, 'align', 'right')        
+            set_key_if_doesnt_exist(kwargs, 'align', 'right')
             ax.hist(trace_values, **kwargs)
 
         plot_height = ax.get_ylim()[1]

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.stats import kde, mode
-from .stats import autocorr
+from .stats import autocorr, quantiles
 from numpy.linalg import LinAlgError
 import matplotlib.pyplot as plt
 

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.stats import kde, mode
-from .stats import autocorr, quantiles
+from .stats import autocorr, quantiles, hpd
 from numpy.linalg import LinAlgError
 import matplotlib.pyplot as plt
 

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -3,11 +3,12 @@ from .backends.base import merge_traces, BaseTrace, MultiTrace
 from .backends.ndarray import NDArray
 from joblib import Parallel, delayed
 from time import time
-from .core import *
-from .step_methods import *
+from .model import modelcontext, Point
+from .step_methods import (NUTS, HamiltonianMC, Metropolis, BinaryMetropolis,
+                         BinaryGibbsMetropolis, Slice, ElemwiseCategorical, CompoundStep)
 from .progressbar import progress_bar
 from numpy.random import randint, seed
-from numpy import shape
+from numpy import shape, append, asarray
 from collections import defaultdict
 
 import sys
@@ -48,7 +49,7 @@ def assign_step_methods(model, step=None,
     steps = []
     assigned_vars = set()
     if step is not None:
-        steps = np.append(steps, step).tolist()
+        steps = append(steps, step).tolist()
         for s in steps:
             try:
                 assigned_vars = assigned_vars | set(s.vars)
@@ -346,4 +347,4 @@ def sample_ppc(trace, samples=None, model=None, vars=None, size=None):
             ppc[var.name].append(var.distribution.random(point=param,
                                                          size=size))
 
-    return {k: np.asarray(v) for k, v in ppc.items()}
+    return {k: asarray(v) for k, v in ppc.items()}

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -156,12 +156,12 @@ def _sample(draws, step=None, start=None, trace=None, chain=0, tune=None,
     sampling = _iter_sample(draws, step, start, trace, chain,
                             tune, model, random_seed)
     progress = progress_bar(draws)
-    try:
-        for i, strace in enumerate(sampling):
+    for i, strace in enumerate(sampling):
+        try:
             if progressbar:
                 progress.update(i)
-    except KeyboardInterrupt:
-        strace.close()
+        except KeyboardInterrupt:
+            strace.close()
     return MultiTrace([strace])
 
 

--- a/pymc3/step_methods/ATMCMC.py
+++ b/pymc3/step_methods/ATMCMC.py
@@ -14,7 +14,7 @@ from ..blocking import DictToArrayBijection
 from ..backends import Text
 from ..backends.base import merge_traces, BaseTrace, MultiTrace
 from ..backends.ndarray import NDArray
-import ..backends
+from .. import backends
 from ..progressbar import progress_bar
 
 import os

--- a/pymc3/step_methods/ATMCMC.py
+++ b/pymc3/step_methods/ATMCMC.py
@@ -14,7 +14,7 @@ from ..blocking import DictToArrayBijection
 from ..backends import Text
 from ..backends.base import MultiTrace
 from ..progressbar import progress_bar
-from .. import sampling
+from pymc3 import sampling
 
 import os
 import theano

--- a/pymc3/step_methods/ATMCMC.py
+++ b/pymc3/step_methods/ATMCMC.py
@@ -14,13 +14,13 @@ from ..blocking import DictToArrayBijection
 from ..backends import Text
 from ..backends.base import MultiTrace
 from ..progressbar import progress_bar
-from .. import sampling
+from pymc3 import sampling
 
 import os
 import theano
 
-from pymc3.theanof import make_shared_replacements, join_nonshared_inputs
-from pymc3.step_methods.metropolis import MultivariateNormalProposal as MvNPd
+from ..theanof import make_shared_replacements, join_nonshared_inputs
+from ..step_methods.metropolis import MultivariateNormalProposal as MvNPd
 from numpy.random import seed
 from joblib import Parallel, delayed
 

--- a/pymc3/step_methods/ATMCMC.py
+++ b/pymc3/step_methods/ATMCMC.py
@@ -14,7 +14,7 @@ from ..blocking import DictToArrayBijection
 from ..backends import Text
 from ..backends.base import MultiTrace
 from ..progressbar import progress_bar
-from pymc3 import sampling
+from ..sampling import _choose_backend
 
 import os
 import theano
@@ -491,7 +491,7 @@ def _iter_initial(step, chain=0, trace=None, model=None):
     _iter_sample, just different input to loop over.
     """
 
-    strace = sampling._choose_backend(trace, chain, model=model)
+    strace = _choose_backend(trace, chain, model=model)
     # check if trace file already exists before setup
     filename = os.path.join(strace.name, 'chain-{}.csv'.format(chain))
     if os.path.exists(filename):

--- a/pymc3/step_methods/ATMCMC.py
+++ b/pymc3/step_methods/ATMCMC.py
@@ -14,7 +14,7 @@ from ..blocking import DictToArrayBijection
 from ..backends import Text
 from ..backends.base import MultiTrace
 from ..progressbar import progress_bar
-from ..sampling import _choose_backend
+from .. import sampling
 
 import os
 import theano
@@ -491,7 +491,7 @@ def _iter_initial(step, chain=0, trace=None, model=None):
     _iter_sample, just different input to loop over.
     """
 
-    strace = _choose_backend(trace, chain, model=model)
+    strace = sampling._choose_backend(trace, chain, model=model)
     # check if trace file already exists before setup
     filename = os.path.join(strace.name, 'chain-{}.csv'.format(chain))
     if os.path.exists(filename):

--- a/pymc3/step_methods/ATMCMC.py
+++ b/pymc3/step_methods/ATMCMC.py
@@ -5,7 +5,7 @@ Created on March, 2016
 '''
 
 import numpy as np
-from .arraystep import ArrayStep, ArrayStepShared
+from .arraystep import ArrayStep, ArrayStepShared, Competence
 from ..model import modelcontext, Point
 from ..theanof import inputvars
 from ..vartypes import discrete_types

--- a/pymc3/step_methods/__init__.py
+++ b/pymc3/step_methods/__init__.py
@@ -1,7 +1,23 @@
-from .compound import *
-from .hmc import *
-from .metropolis import *
-from .gibbs import *
-from .slicer import *
-from .nuts import *
+from .compound import CompoundStep
+
+from .hmc import HamiltonianMC
+
+from .metropolis import Metropolis
+from .metropolis import BinaryMetropolis
+from .metropolis import BinaryGibbsMetropolis
+from .metropolis import NormalProposal
+from .metropolis import CauchyProposal
+from .metropolis import LaplaceProposal
+from .metropolis import PoissonProposal
+from .metropolis import MultivariateNormalProposal
+
+from .gibbs import ElemwiseCategorical
+
+from .slicer import Slice
+
+from .nuts import NUTS
+
+from .ATMCMC import ATMCMC
+from .ATMCMC import ATMIP_sample
+
 from .arraystep import Constant

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -1,7 +1,7 @@
-from ..core import *
 from .compound import CompoundStep
-from ..vartypes import *
-
+from ..model import modelcontext
+from ..theanof import inputvars
+from ..blocking import ArrayOrdering, DictToArrayBijection
 import numpy as np
 from numpy.random import uniform
 from numpy import log, isfinite

--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -3,7 +3,7 @@ Created on May 12, 2012
 
 @author: john
 '''
-from .arraystep import ArrayStep
+from .arraystep import ArrayStep, Competence
 from ..distributions.discrete import Categorical
 from numpy import array, max, exp, cumsum, nested_iters, empty, searchsorted, ones, arange
 from numpy.random import uniform

--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -3,8 +3,7 @@ Created on May 12, 2012
 
 @author: john
 '''
-from ..core import *
-from .arraystep import *
+from .arraystep import ArrayStep
 from ..distributions.discrete import Categorical
 from numpy import array, max, exp, cumsum, nested_iters, empty, searchsorted, ones, arange
 from numpy.random import uniform

--- a/pymc3/step_methods/hmc.py
+++ b/pymc3/step_methods/hmc.py
@@ -5,7 +5,7 @@ Created on Mar 7, 2011
 '''
 from numpy import floor
 from .quadpotential import quad_potential
-from .arraystep import ArrayStep
+from .arraystep import ArrayStep, SamplerHist, metrop_select
 from ..tuning import guess_scaling
 from ..model import modelcontext
 from ..theanof import inputvars

--- a/pymc3/step_methods/hmc.py
+++ b/pymc3/step_methods/hmc.py
@@ -4,11 +4,11 @@ Created on Mar 7, 2011
 @author: johnsalvatier
 '''
 from numpy import floor
-from .quadpotential import *
-from .arraystep import *
-from ..core import *
+from .quadpotential import quad_potential
+from .arraystep import ArrayStep
 from ..tuning import guess_scaling
-from ..distributions import *
+from ..model import modelcontext
+from ..theanof import inputvars
 
 import numpy as np
 from scipy.sparse import issparse

--- a/pymc3/step_methods/hmc.py
+++ b/pymc3/step_methods/hmc.py
@@ -7,7 +7,7 @@ from numpy import floor
 from .quadpotential import quad_potential
 from .arraystep import ArrayStep, SamplerHist, metrop_select, Competence
 from ..tuning import guess_scaling
-from ..model import modelcontext
+from ..model import modelcontext, Point
 from ..theanof import inputvars
 from ..vartypes import discrete_types
 
@@ -98,7 +98,7 @@ class HamiltonianMC(ArrayStep):
         if var.dtype in discrete_types:
             return Competence.INCOMPATIBLE
         return Competence.COMPATIBLE
-            
+
 
 
 def bern(p):

--- a/pymc3/step_methods/hmc.py
+++ b/pymc3/step_methods/hmc.py
@@ -5,10 +5,11 @@ Created on Mar 7, 2011
 '''
 from numpy import floor
 from .quadpotential import quad_potential
-from .arraystep import ArrayStep, SamplerHist, metrop_select
+from .arraystep import ArrayStep, SamplerHist, metrop_select, Competence
 from ..tuning import guess_scaling
 from ..model import modelcontext
 from ..theanof import inputvars
+from ..vartypes import discrete_types
 
 import numpy as np
 from scipy.sparse import issparse

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -1,13 +1,13 @@
 from numpy.linalg import cholesky
 
-from ..core import *
 from .quadpotential import quad_potential
-
-from ..distributions import *
-
-from .arraystep import *
-from numpy.random import normal, standard_cauchy, standard_exponential, poisson, random
-from numpy import round, exp, copy, where
+from ..model import modelcontext
+from ..theanof import inputvars
+from ..vartypes import discrete_types
+from .arraystep import ArrayStepShared, ArrayStep, metrop_select
+from numpy.random import (normal, standard_cauchy, standard_exponential, poisson, random,
+                        multivariate_normal, shuffle)
+from numpy import round, exp, copy, where, size, zeros, ones, atleast_1d, concatenate
 import theano
 
 from ..theanof import make_shared_replacements, join_nonshared_inputs, CallableTensor
@@ -30,23 +30,23 @@ class NormalProposal(Proposal):
 
 class CauchyProposal(Proposal):
     def __call__(self):
-        return standard_cauchy(size=np.size(self.s)) * self.s
+        return standard_cauchy(size=size(self.s)) * self.s
 
 
 class LaplaceProposal(Proposal):
     def __call__(self):
-        size = np.size(self.s)
+        size = size(self.s)
         return (standard_exponential(size=size) - standard_exponential(size=size)) * self.s
 
 
 class PoissonProposal(Proposal):
     def __call__(self):
-        return poisson(lam=self.s, size=np.size(self.s)) - self.s
+        return poisson(lam=self.s, size=size(self.s)) - self.s
 
 
 class MultivariateNormalProposal(Proposal):
     def __call__(self, num_draws=None):
-        return np.random.multivariate_normal(mean=np.zeros(self.s.shape[0]), cov=self.s, size=num_draws)
+        return multivariate_normal(mean=zeros(self.s.shape[0]), cov=self.s, size=num_draws)
 
 
 class Metropolis(ArrayStepShared):
@@ -84,16 +84,16 @@ class Metropolis(ArrayStepShared):
         vars = inputvars(vars)
 
         if S is None:
-            S = np.ones(sum(v.dsize for v in vars))
+            S = ones(sum(v.dsize for v in vars))
         self.proposal_dist = proposal_dist(S)
-        self.scaling = np.atleast_1d(scaling)
+        self.scaling = atleast_1d(scaling)
         self.tune = tune
         self.tune_interval = tune_interval
         self.steps_until_tune = tune_interval
         self.accepted = 0
 
         # Determine type of variables
-        self.discrete = np.concatenate([[v.dtype in discrete_types ] * (v.dsize or 1) for v in vars])
+        self.discrete = concatenate([[v.dtype in discrete_types ] * (v.dsize or 1) for v in vars])
         self.any_discrete = self.discrete.any()
         self.all_discrete = self.discrete.all()
 
@@ -260,7 +260,7 @@ class BinaryGibbsMetropolis(ArrayStep):
     def astep(self, q0, logp):
         order = list(range(self.dim))
         if self.order == 'random':
-            np.random.shuffle(order)
+            shuffle(order)
 
         q_prop = copy(q0)
         q_cur = copy(q0)

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -3,10 +3,11 @@ from numpy.linalg import cholesky
 from .quadpotential import quad_potential
 from ..model import modelcontext
 from ..theanof import inputvars
-from ..vartypes import discrete_types
-from .arraystep import ArrayStepShared, ArrayStep, metrop_select
+from ..vartypes import discrete_types, bool_types
+from .arraystep import ArrayStepShared, ArrayStep, metrop_select, Competence
 from numpy.random import (normal, standard_cauchy, standard_exponential, poisson, random,
                         multivariate_normal, shuffle)
+from ..distributions import Bernoulli, Categorical
 from numpy import round, exp, copy, where, size, zeros, ones, atleast_1d, concatenate
 import theano
 

--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -1,13 +1,13 @@
-from .quadpotential import *
-from .arraystep import *
-from ..core import *
-from numpy import exp, log
+from .quadpotential import quad_potential
+from .arraystep import ArrayStepShared, ArrayStep, SamplerHist
+from ..model import modelcontext, Point
+from numpy import exp, log, array
 from numpy.random import uniform
 from .hmc import leapfrog, Hamiltonian, bern, energy
-from ..distributions import *
 from ..tuning import guess_scaling
 import theano
-from ..theanof import make_shared_replacements, join_nonshared_inputs, CallableTensor
+from ..theanof import (make_shared_replacements, join_nonshared_inputs, CallableTensor,
+                        gradient, inputvars)
 import theano.tensor as tt
 
 __all__ = ['NUTS']
@@ -147,7 +147,7 @@ class NUTS(ArrayStepShared):
 def buildtree(H, q, p, u, v, j, e, Emax, q0, p0):
     if j == 0:
         leapfrog1_dE = H
-        q1, p1, dE = leapfrog1_dE(q, p, np.array(v*e), q0, p0)
+        q1, p1, dE = leapfrog1_dE(q, p, array(v*e), q0, p0)
 
         n1 = int(log(u) + dE <= 0)
         s1 = int(log(u) + dE < Emax)

--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -1,5 +1,5 @@
 from .quadpotential import quad_potential
-from .arraystep import ArrayStepShared, ArrayStep, SamplerHist
+from .arraystep import ArrayStepShared, ArrayStep, SamplerHist, Competence
 from ..model import modelcontext, Point
 from ..vartypes import continuous_types
 from numpy import exp, log, array

--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -1,6 +1,7 @@
 from .quadpotential import quad_potential
 from .arraystep import ArrayStepShared, ArrayStep, SamplerHist
 from ..model import modelcontext, Point
+from ..vartypes import continuous_types
 from numpy import exp, log, array
 from numpy.random import uniform
 from .hmc import leapfrog, Hamiltonian, bern, energy

--- a/pymc3/step_methods/slicer.py
+++ b/pymc3/step_methods/slicer.py
@@ -1,9 +1,9 @@
 # Modified from original implementation by Dominik Wabersich (2013)
 
-from ..core import *
-from .arraystep import *
-from ..distributions import *
-from numpy import floor, abs, atleast_1d, empty, isfinite, sum
+from .arraystep import ArrayStep
+from ..model import modelcontext
+from ..theanof import inputvars
+from numpy import floor, abs, atleast_1d, empty, isfinite, sum, resize
 from numpy.random import standard_exponential, random, uniform
 
 __all__ = ['Slice']
@@ -45,7 +45,7 @@ class Slice(ArrayStep):
     def astep(self, q0, logp):
 
         q = q0.copy()
-        self.w = np.resize(self.w, len(q))
+        self.w = resize(self.w, len(q))
 
         y = logp(q0) - standard_exponential()
 

--- a/pymc3/step_methods/slicer.py
+++ b/pymc3/step_methods/slicer.py
@@ -1,8 +1,9 @@
 # Modified from original implementation by Dominik Wabersich (2013)
 
-from .arraystep import ArrayStep
+from .arraystep import ArrayStep, Competence
 from ..model import modelcontext
 from ..theanof import inputvars
+from ..vartypes import continuous_types
 from numpy import floor, abs, atleast_1d, empty, isfinite, sum, resize
 from numpy.random import standard_exponential, random, uniform
 

--- a/pymc3/tests/checks.py
+++ b/pymc3/tests/checks.py
@@ -1,10 +1,4 @@
-import pymc3 as pm
 import numpy as np
-
-from pymc3 import sample
-
-from numpy.testing import assert_almost_equal
-
 
 def close_to(x, v, bound, name="value"):
     assert np.all(np.logical_or(

--- a/pymc3/tests/test_diagnostics.py
+++ b/pymc3/tests/test_diagnostics.py
@@ -1,6 +1,12 @@
-from pymc3 import *
-
+from ..theanof import inputvars
+from ..model import Model, modelcontext
+from ..step_methods import Slice, Metropolis, NUTS
+from ..distributions import Normal
+from ..tuning import find_MAP
+from ..sampling import sample
+from ..diagnostics import effective_n, geweke, gelman_rubin
 from pymc3.examples import disaster_model as dm
+from numpy import all, isclose
 
 def test_gelman_rubin(n=1000):
 
@@ -14,7 +20,7 @@ def test_gelman_rubin(n=1000):
 
     rhat = gelman_rubin(ptrace)
 
-    assert np.all([r < 1.5 for r in rhat.values()])
+    assert all([r < 1.5 for r in rhat.values()])
 
 
 def test_geweke(n=3000):
@@ -56,4 +62,4 @@ def test_effective_n(k=3, n=1000):
         
     n_eff = effective_n(ptrace)['x']
     
-    assert np.isclose(n_eff, k*n, 2).all()
+    assert isclose(n_eff, k*n, 2).all()

--- a/pymc3/tests/test_distribution_defaults.py
+++ b/pymc3/tests/test_distribution_defaults.py
@@ -1,8 +1,10 @@
 from __future__ import division
 
-from .checks import *
-from pymc3 import *
+from ..model import Model
+from ..distributions import DiscreteUniform, Continuous
+
 from numpy import array, inf
+import numpy as np
 from nose.tools import raises
 
 class DistTest(Continuous):
@@ -54,5 +56,5 @@ def test_default_b():
 
 def test_default_discrete_uniform():
     with Model():
-        x = pm.DiscreteUniform('x', lower=1, upper=2)
+        x = DiscreteUniform('x', lower=1, upper=2)
         assert x.init_value == 1

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -4,13 +4,13 @@ import unittest
 import itertools
 from ..vartypes import continuous_types
 from ..model import Model, Point, Potential
-from ..blocking import DictToVarBijection, DictToArrayBijection
+from ..blocking import DictToVarBijection, DictToArrayBijection, ArrayOrdering
 from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Dirichlet,
                             MvStudentT, MvNormal, ZeroInflatedPoisson, ConstantDist,
-                            Poisson, Bernoulli, Beta, BetaBinomial, StudentTpos, 
+                            Poisson, Bernoulli, Beta, BetaBinomial, StudentTpos,
                             StudentT, Weibull, Pareto, InverseGamma, Gamma, Cauchy,
                             HalfCauchy, Lognormal, Laplace, NegativeBinomial, Geometric,
-                            Exponential, ExGaussian, Normal, Flat, LKJCorr, Wald, 
+                            Exponential, ExGaussian, Normal, Flat, LKJCorr, Wald,
                             ChiSquared, HalfNormal, DiscreteUniform, Bound, Uniform,
                             Binomial)
 from ..distributions import continuous
@@ -405,20 +405,20 @@ def check_mvt(n):
             MvStudentT, Vector(R,n), {'nu': Rplus, 'Sigma': PdMatrix(n), 'mu':Vector(R,n)},
             mvt_logpdf
             )
-            
-def mvt_logpdf(value, nu, Sigma, mu=0): 
+
+def mvt_logpdf(value, nu, Sigma, mu=0):
 
     d = len(Sigma)
     n = len(value)
     X = np.atleast_2d(value ) - mu
-    
+
     Q = X.dot(np.linalg.inv(Sigma)).dot(X.T).sum()
     log_det = np.log(np.linalg.det(Sigma))
-    log_pdf = (scipy.special.gammaln((nu + d)/2.) 
-            - 0.5 * (d*np.log(np.pi*nu) + log_det) 
+    log_pdf = (scipy.special.gammaln((nu + d)/2.)
+            - 0.5 * (d*np.log(np.pi*nu) + log_det)
             - scipy.special.gammaln(nu/2.))
     log_pdf -= 0.5*(nu + d)*np.log(1 + Q/nu)
-    
+
     return log_pdf
 
 def test_wishart():

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -4,7 +4,7 @@ import unittest
 import itertools
 from ..vartypes import continuous_types
 from ..model import Model, Point, Potential
-from ..blocking import DictToVarBijection, DictToArrayBijection
+from ..blocking import DictToVarBijection, DictToArrayBijection, ArrayOrdering
 from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Dirichlet,
                             MvStudentT, MvNormal, ZeroInflatedPoisson, ConstantDist,
                             Poisson, Bernoulli, Beta, BetaBinomial, StudentTpos, 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -2,18 +2,26 @@ from __future__ import division
 import unittest
 
 import itertools
-from .checks import *
-from pymc3 import *
-from numpy import array, inf
-import numpy
+from ..vartypes import continuous_types
+from ..model import Model, Point, Potential
+from ..blocking import DictToVarBijection
+from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Dirichlet,
+                            MvStudentT, MvNormal, ZeroInflatedPoisson, ConstantDist,
+                            Poisson, Bernoulli, Beta, BetaBinomial, StudentTpos, 
+                            StudentT, Weibull, Pareto, InverseGamma, Gamma, Cauchy,
+                            HalfCauchy, Lognormal, Laplace, NegativeBinomial, Geometric,
+                            Exponential, ExGaussian, Normal, Flat, LKJCorr, Wald, 
+                            ChiSquared, HalfNormal, DiscreteUniform, Bound, Uniform,
+                            Binomial)
+from ..distributions import continuous
+from numpy import array, inf, log, exp
+import numpy as np
+from numpy.testing import assert_almost_equal
 from numpy.linalg import inv
 
 from scipy import integrate
 import scipy.stats.distributions  as sp
 import scipy.stats
-
-from .knownfailure import *
-
 
 
 class Domain(object):
@@ -322,7 +330,7 @@ def scipy_exponweib_sucks(value, alpha, beta):
     the Weibull PDF fails for some valid combinations of parameters, while the
     log-PDF fails for others.
     """
-    pdf = numpy.log(sp.exponweib.pdf(value, 1, alpha, scale=beta))
+    pdf = np.log(sp.exponweib.pdf(value, 1, alpha, scale=beta))
     logpdf = sp.exponweib.logpdf(value, 1, alpha, scale=beta)
 
     if np.isinf(pdf):
@@ -533,7 +541,7 @@ def pymc3_matches_scipy(pymc3_dist, domain, paramdomains, scipy_dist, extra_args
 
 def test_get_tau_sd():
     sd = np.array([2])
-    assert_almost_equal(distributions.continuous.get_tau_sd(sd=sd), [1./sd**2, sd])
+    assert_almost_equal(continuous.get_tau_sd(sd=sd), [1./sd**2, sd])
 
 def check_int_to_1(model, value, domain, paramdomains):
     pdf = model.fastfn(exp(model.logpt))

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -4,7 +4,7 @@ import unittest
 import itertools
 from ..vartypes import continuous_types
 from ..model import Model, Point, Potential
-from ..blocking import DictToVarBijection
+from ..blocking import DictToVarBijection, DictToArrayBijection
 from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Dirichlet,
                             MvStudentT, MvNormal, ZeroInflatedPoisson, ConstantDist,
                             Poisson, Bernoulli, Beta, BetaBinomial, StudentTpos, 

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -2,20 +2,23 @@
 from __future__ import division
 import unittest
 
-from .checks import *
-from .knownfailure import *
+from .knownfailure import knownfailure
 from nose import SkipTest
 from nose.plugins.attrib import attr
 
-from pymc3.tests.test_distributions import (build_model,
+from ..tests.test_distributions import (build_model,
     Domain, product, R, Rplus, Rplusbig, Unit, Nat, NatSmall,
     I, Simplex, Vector, PdMatrix)
 
-from pymc3.distributions.continuous import *
-from pymc3.distributions.discrete import *
-from pymc3.distributions.multivariate import *
-from pymc3.distributions.distribution import draw_values
-from pymc3 import Model, Point
+from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Dirichlet,
+                            MvStudentT, MvNormal, ZeroInflatedPoisson, ConstantDist,
+                            Poisson, Bernoulli, Beta, BetaBinomial, StudentTpos, 
+                            StudentT, Weibull, Pareto, InverseGamma, Gamma, Cauchy,
+                            HalfCauchy, Lognormal, Laplace, NegativeBinomial, Geometric,
+                            Exponential, ExGaussian, Normal, Flat, LKJCorr, Wald, 
+                            ChiSquared, HalfNormal, DiscreteUniform, Bound, Uniform,
+                            Binomial, draw_values)
+from ..model import Model, Point, Potential
 
 import numpy as np
 import scipy.stats as st

--- a/pymc3/tests/test_glm.py
+++ b/pymc3/tests/test_glm.py
@@ -1,7 +1,6 @@
 import unittest
 from nose import SkipTest
 
-from pymc3 import *
 import sys
 try:
     import statsmodels.api as sm

--- a/pymc3/tests/test_glm.py
+++ b/pymc3/tests/test_glm.py
@@ -1,6 +1,6 @@
 import unittest
 from nose import SkipTest
-
+import numpy as np
 import sys
 try:
     import statsmodels.api as sm

--- a/pymc3/tests/test_hmc.py
+++ b/pymc3/tests/test_hmc.py
@@ -1,8 +1,9 @@
 import pymc3 as pm
-
+import numpy as np
 from . import models
 from pymc3.step_methods.hmc import leapfrog, Hamiltonian
 from .checks import close_to
+from ..blocking import DictToArrayBijection
 
 
 def test_leapfrog_reversible():
@@ -13,7 +14,7 @@ def test_leapfrog_reversible():
         h = pm.find_hessian(start, model=model)
         step = pm.HamiltonianMC(model.vars, h, model=model)
 
-    bij = pm.DictToArrayBijection(step.ordering, start)
+    bij = DictToArrayBijection(step.ordering, start)
 
     logp, dlogp = list(map(bij.mapf, step.fs))
     H = Hamiltonian(logp, dlogp, step.potential)

--- a/pymc3/tests/test_hmc.py
+++ b/pymc3/tests/test_hmc.py
@@ -2,7 +2,7 @@ import pymc3 as pm
 
 from . import models
 from pymc3.step_methods.hmc import leapfrog, Hamiltonian
-from .checks import *
+from .checks import close_to
 
 
 def test_leapfrog_reversible():

--- a/pymc3/tests/test_model_func.py
+++ b/pymc3/tests/test_model_func.py
@@ -1,6 +1,6 @@
 import pymc3 as pm
-from .models import *
-from .checks import *
+from .models import simple_model
+from .checks import close_to
 
 
 def test_lop():

--- a/pymc3/tests/test_model_func.py
+++ b/pymc3/tests/test_model_func.py
@@ -1,7 +1,9 @@
 import pymc3 as pm
+import numpy as np
 from .models import simple_model
 from .checks import close_to
-
+from .models import simple_model, mv_simple
+from ..distributions import Normal
 
 def test_lop():
     start, model, _ = simple_model()

--- a/pymc3/tests/test_plots.py
+++ b/pymc3/tests/test_plots.py
@@ -4,7 +4,7 @@ matplotlib.use('Agg', warn=False)
 import numpy as np
 from .checks import close_to
 
-from ..plots import traceplot, forestplot, autocorrplot
+from ..plots import traceplot, forestplot, autocorrplot, make_2d
 from ..step_methods import Slice, Metropolis
 from ..sampling import sample
 from ..tuning.scaling import find_hessian
@@ -62,11 +62,11 @@ def test_multichain_plots():
 def test_make_2d():
 
     a = np.arange(4)
-    close_to(pymc3.plots.make_2d(a), a[:,None], 0)
+    close_to(make_2d(a), a[:,None], 0)
 
     n = 7
     a = np.arange(n*4*5).reshape((n,4,5))
-    res = pymc3.plots.make_2d(a)
+    res = make_2d(a)
 
     assert res.shape == (n,20)
     close_to(a[:,0,0], res[:,0], 0)

--- a/pymc3/tests/test_plots.py
+++ b/pymc3/tests/test_plots.py
@@ -4,9 +4,10 @@ matplotlib.use('Agg', warn=False)
 import numpy as np
 from .checks import close_to
 
-import pymc3.plots
-from pymc3.plots import *
-from pymc3 import Slice, Metropolis, find_hessian, sample
+from ..plots import traceplot, forestplot, autocorrplot
+from ..step_methods import Slice, Metropolis
+from ..sampling import sample
+from ..tuning.scaling import find_hessian
 
 
 def test_plots():

--- a/pymc3/tests/test_profile.py
+++ b/pymc3/tests/test_profile.py
@@ -1,6 +1,5 @@
 import pymc3 as pm
-from .models import *
-from .checks import *
+from .models import simple_model
 
 
 def test_profile_model():

--- a/pymc3/tests/test_starting.py
+++ b/pymc3/tests/test_starting.py
@@ -1,5 +1,6 @@
 from .checks import close_to
 from numpy import inf
+import numpy as np
 from pymc3.tuning import starting
 from pymc3 import find_MAP, Point, Model
 from pymc3 import Model, Uniform, Normal, Beta, Binomial

--- a/pymc3/tests/test_starting.py
+++ b/pymc3/tests/test_starting.py
@@ -1,4 +1,4 @@
-from .checks import *
+from .checks import close_to
 from numpy import inf
 from pymc3.tuning import starting
 from pymc3 import find_MAP, Point, Model

--- a/pymc3/tests/test_stats.py
+++ b/pymc3/tests/test_stats.py
@@ -1,11 +1,10 @@
-from ..stats import *
 from .models import Model, Normal, Metropolis
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pymc3 as pm
-from pymc3.tests import backend_fixtures as bf
-from pymc3.backends import ndarray
+from ..tests import backend_fixtures as bf
+from ..backends import ndarray
 from numpy.random import random, normal, seed
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_almost_equal
 from scipy import stats as st

--- a/pymc3/tests/test_stats.py
+++ b/pymc3/tests/test_stats.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pymc3 as pm
 from ..tests import backend_fixtures as bf
 from ..backends import ndarray
+from ..stats import df_summary, autocorr, hpd, mc_error, quantiles
 from numpy.random import random, normal, seed
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_almost_equal
 from scipy import stats as st

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -1,4 +1,4 @@
-from .checks import *
+from .checks import close_to
 from .models import simple_model, mv_simple, mv_simple_discrete, simple_2model
 from theano.tensor import constant
 from scipy.stats.mstats import moment

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -2,11 +2,12 @@ from .checks import close_to
 from .models import simple_model, mv_simple, mv_simple_discrete, simple_2model
 from theano.tensor import constant
 from scipy.stats.mstats import moment
-from pymc3.sampling import assign_step_methods
+from pymc3.sampling import assign_step_methods, sample
 from pymc3.model import Model
 from pymc3.step_methods import NUTS, BinaryMetropolis, BinaryGibbsMetropolis, Metropolis, Constant, ElemwiseCategorical
 from pymc3.distributions import Binomial, Normal, Bernoulli, Categorical
 from numpy.testing import assert_almost_equal
+import numpy as np
 
 def check_stat(name, trace, var, stat, value, bound):
     s = stat(trace[var][2000:], axis=0)
@@ -17,19 +18,19 @@ def test_step_continuous():
     start, model, (mu, C) = mv_simple()
 
     with model:
-        mh = pm.Metropolis()
-        slicer = pm.Slice()
-        hmc = pm.HamiltonianMC(scaling=C, is_cov=True, blocked=False)
-        nuts = pm.NUTS(scaling=C, is_cov=True, blocked=False)
+        mh = Metropolis()
+        slicer = Slice()
+        hmc = HamiltonianMC(scaling=C, is_cov=True, blocked=False)
+        nuts = NUTS(scaling=C, is_cov=True, blocked=False)
 
-        mh_blocked = pm.Metropolis(S=C,
-                                   proposal_dist=pm.MultivariateNormalProposal,
+        mh_blocked = Metropolis(S=C,
+                                   proposal_dist=MultivariateNormalProposal,
                                    blocked=True)
-        slicer_blocked = pm.Slice(blocked=True)
-        hmc_blocked = pm.HamiltonianMC(scaling=C, is_cov=True)
-        nuts_blocked = pm.NUTS(scaling=C, is_cov=True)
+        slicer_blocked = Slice(blocked=True)
+        hmc_blocked = HamiltonianMC(scaling=C, is_cov=True)
+        nuts_blocked = NUTS(scaling=C, is_cov=True)
 
-        compound = pm.CompoundStep([hmc_blocked, mh_blocked])
+        compound = CompoundStep([hmc_blocked, mh_blocked])
 
 
     steps = [slicer, hmc, nuts, mh_blocked, hmc_blocked,
@@ -53,34 +54,34 @@ def test_non_blocked():
 
     with model:
         # Metropolis and Slice are non-blocked by default
-        mh = pm.Metropolis()
-        assert isinstance(mh, pm.CompoundStep)
-        slicer = pm.Slice()
-        assert isinstance(slicer, pm.CompoundStep)
-        hmc = pm.HamiltonianMC(blocked=False)
-        assert isinstance(hmc, pm.CompoundStep)
-        nuts = pm.NUTS(blocked=False)
-        assert isinstance(nuts, pm.CompoundStep)
+        mh = Metropolis()
+        assert isinstance(mh, CompoundStep)
+        slicer = Slice()
+        assert isinstance(slicer, CompoundStep)
+        hmc = HamiltonianMC(blocked=False)
+        assert isinstance(hmc, CompoundStep)
+        nuts = NUTS(blocked=False)
+        assert isinstance(nuts, CompoundStep)
 
-        mh_blocked = pm.Metropolis(blocked=True)
-        assert isinstance(mh_blocked, pm.Metropolis)
-        slicer_blocked = pm.Slice(blocked=True)
-        assert isinstance(slicer_blocked, pm.Slice)
-        hmc_blocked = pm.HamiltonianMC()
-        assert isinstance(hmc_blocked, pm.HamiltonianMC)
-        nuts_blocked = pm.NUTS()
-        assert isinstance(nuts_blocked, pm.NUTS)
+        mh_blocked = Metropolis(blocked=True)
+        assert isinstance(mh_blocked, Metropolis)
+        slicer_blocked = Slice(blocked=True)
+        assert isinstance(slicer_blocked, Slice)
+        hmc_blocked = HamiltonianMC()
+        assert isinstance(hmc_blocked, HamiltonianMC)
+        nuts_blocked = NUTS()
+        assert isinstance(nuts_blocked, NUTS)
 
-        compound = pm.CompoundStep([hmc_blocked, mh_blocked])
+        compound = CompoundStep([hmc_blocked, mh_blocked])
 
 
 def test_step_discrete():
     start, model, (mu, C) = mv_simple_discrete()
 
     with model:
-        mh = pm.Metropolis(S=C,
-                           proposal_dist=pm.MultivariateNormalProposal)
-        slicer = pm.Slice()
+        mh = Metropolis(S=C,
+                           proposal_dist=MultivariateNormalProposal)
+        slicer = Slice()
 
 
     steps = [mh]

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -4,7 +4,7 @@ from theano.tensor import constant
 from scipy.stats.mstats import moment
 from pymc3.sampling import assign_step_methods, sample
 from pymc3.model import Model
-from pymc3.step_methods import NUTS, BinaryMetropolis, BinaryGibbsMetropolis, Metropolis, Constant, ElemwiseCategorical
+from pymc3.step_methods import NUTS, BinaryMetropolis, BinaryGibbsMetropolis, Metropolis, Constant, ElemwiseCategorical, Slice, CompoundStep, MultivariateNormalProposal, HamiltonianMC
 from pymc3.distributions import Binomial, Normal, Bernoulli, Categorical
 from numpy.testing import assert_almost_equal
 import numpy as np

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -1,10 +1,11 @@
 from .checks import close_to
 from .models import simple_model, mv_simple, mv_simple_discrete, simple_2model
+from ..step_methods import MultivariateNormalProposal
 from theano.tensor import constant
 from scipy.stats.mstats import moment
 from pymc3.sampling import assign_step_methods, sample
 from pymc3.model import Model
-from pymc3.step_methods import NUTS, BinaryMetropolis, BinaryGibbsMetropolis, Metropolis, Constant, ElemwiseCategorical
+from pymc3.step_methods import NUTS, BinaryMetropolis, BinaryGibbsMetropolis, Metropolis, Constant, ElemwiseCategorical, CompoundStep, Slice
 from pymc3.distributions import Binomial, Normal, Bernoulli, Categorical
 from numpy.testing import assert_almost_equal
 import numpy as np

--- a/pymc3/tests/test_transforms.py
+++ b/pymc3/tests/test_transforms.py
@@ -1,5 +1,6 @@
 import pymc3 as pm
 import pymc3.distributions.transforms as tr
+import numpy as np
 import theano
 import theano.tensor as tt
 from .test_distributions import Simplex, Rplusbig, Rminusbig, Unit, R, Vector, MultiSimplex

--- a/pymc3/tests/test_transforms.py
+++ b/pymc3/tests/test_transforms.py
@@ -4,7 +4,7 @@ import theano
 import theano.tensor as tt
 from .test_distributions import Simplex, Rplusbig, Rminusbig, Unit, R, Vector, MultiSimplex
 
-from .checks import *
+from .checks import close_to
 from ..theanof import jacobian
 
 tol = 1e-7

--- a/pymc3/tuning/__init__.py
+++ b/pymc3/tuning/__init__.py
@@ -1,2 +1,2 @@
-from .starting import *
-from .scaling import *
+from .starting import find_MAP
+from .scaling import approx_hessian, find_hessian, trace_cov, guess_scaling

--- a/pymc3/tuning/scaling.py
+++ b/pymc3/tuning/scaling.py
@@ -6,7 +6,8 @@ from __future__ import division
 '''
 import numpy as np
 from numpy import exp, log, sqrt
-from ..core import *
+from ..model import modelcontext, Point
+from ..theanof import hessian_diag
 
 __all__ = ['approx_hessian', 'find_hessian', 'trace_cov', 'guess_scaling']
 

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -6,12 +6,14 @@ Created on Mar 12, 2011
 from scipy import optimize
 import numpy as np
 from numpy import isfinite, nan_to_num, logical_not
-from ..core import *
 from ..vartypes import discrete_types, typefilter
+from ..model import modelcontext, Point
+from ..theanof import inputvars
+from ..blocking import DictToArrayBijection, ArrayOrdering
 
 from inspect import getargspec
 
-__all__ = ['find_MAP', 'scipyminimize']
+__all__ = ['find_MAP']
 
 
 def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
@@ -139,11 +141,6 @@ def allfinite(x):
 
 def nan_to_high(x):
     return np.where(isfinite(x), x, 1.0e100)
-
-
-def scipyminimize(f, x0, fprime, *args, **kwargs):
-    r = scipy.optimize.minimize(f, x0, jac=fprime, *args, **kwargs)
-    return r.x, r
 
 
 def allinmodel(vars, model):

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -5,8 +5,9 @@ Created on Mar 12, 2011
 @author: johnsalvatier
 '''
 import numpy as np
-from ..core import modelcontext, inputvars, ArrayOrdering, DictToArrayBijection
-from ..model import ObservedRV
+from ..blocking import DictToArrayBijection, ArrayOrdering
+from ..theanof import inputvars
+from ..model import ObservedRV, modelcontext
 from ..vartypes import discrete_types
 
 import theano

--- a/pymc3/vartypes.py
+++ b/pymc3/vartypes.py
@@ -1,3 +1,5 @@
+__all__ = ['bool_types', 'int_types', 'float_types', 'complex_types', 'continuous_types',
+        'discrete_types', 'default_type', 'typefilter']
 
 bool_types = set(['int8'])
 


### PR DESCRIPTION
I have removed `from foo import *` statements everywhere except:
- examples
- `pymc3.__init__.py`

We can discuss whether to remove them entirely from everywhere, but the above exceptions do not bother me particularly (especially the latter, if we want common PyMC functions and classes in the main namespace).

`core.py` has been removed entirely.

Passing most but not all tests.

Closes #1251 
