### PR TITLE
remove conversion of tensor objects to str, replace with tensor name

### DIFF
--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -32,7 +32,7 @@ class BaseTrace(object):
         if vars is None:
             vars = model.unobserved_RVs
         self.vars = vars
-        self.varnames = [str(var) for var in vars]
+        self.varnames = [var.name for var in vars]
         self.fn = model.fastfn(vars)
 
 


### PR DESCRIPTION
Speeds up initalising of trace objects- which is for some reason horribly slow. Anyone knows why?
