### PR TITLE
WIP Allow downcast in metropolis and nuts functions.

### DIFF
--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -182,7 +182,7 @@ def tune(scale, acc_rate):
 
 class BinaryMetropolis(ArrayStep):
     """Metropolis-Hastings optimized for binary variables
-    
+
     Parameters
     ----------
     vars : list
@@ -195,7 +195,7 @@ class BinaryMetropolis(ArrayStep):
         The frequency of tuning. Defaults to 100 iterations.
     model : PyMC Model
         Optional model for sampling step. Defaults to None (taken from context).
-    
+
     """
 
     def __init__(self, vars, scaling=1., tune=True, tune_interval=100, model=None):
@@ -294,6 +294,6 @@ def delta_logp(logp, vars, shared):
 
     logp1 = CallableTensor(logp0)(inarray1)
 
-    f = theano.function([inarray1, inarray0], logp1 - logp0)
+    f = theano.function([inarray1, inarray0], logp1 - logp0, allow_input_downcast=True)
     f.trust_input = True
     return f

--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -212,6 +212,6 @@ def leapfrog1_dE(logp, vars, shared, pot, profile):
     E0 = energy(H, q0, p0)
     dE = E - E0
 
-    f = theano.function([q, p, e, q0, p0], [q1, p1, dE], profile=profile)
+    f = theano.function([q, p, e, q0, p0], [q1, p1, dE], profile=profile, allow_input_downcast=True)
     f.trust_input = True
     return f


### PR DESCRIPTION
Alternative to https://github.com/pymc-devs/pymc3/pull/1253, related to https://github.com/pymc-devs/pymc3/issues/1246.

Unfortunately, the same error is also thrown if downcast is set to true:
`TypeError: expected type_num 11 (NPY_FLOAT32) got 12
Apply node that caused the error: Elemwise{mul,no_inplace}(TensorConstant{(1, 1, 1, 1) of -2.0}, Reshape{4}.0)`

@fhuszar Any ideas?
