### PR TITLE
fixed missing import statement of modelcontext in gibbs.py

### DIFF
--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -10,7 +10,7 @@ from numpy.random import uniform
 
 from theano.gof.graph import inputs
 from theano.tensor import add 
-
+from ..model import modelcontext
 __all__ = ['ElemwiseCategorical']
 
 


### PR DESCRIPTION
importing modelcontext in gibbs.py went missing. 
needed in `ElemwiseCategorical.__init__`
