### PR TITLE
re-add imports lost in removal from core.py

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -1,5 +1,6 @@
 __version__ = "3.0"
 
+from .blocking import *
 from .distributions import *
 from .math import *
 from .model import *
@@ -7,8 +8,10 @@ from .stats import *
 from .sampling import *
 from .interactive_sampling import *
 from .step_methods import *
+from .theanof import *
 from .tuning import *
 from .variational import *
+from .vartypes import *
 from . import sampling
 
 from .debug import *


### PR DESCRIPTION
fixes #1271.

This re-adds the modules that were previously included in `core.py` and were removed during the import clean-up of #1257.
