### PR TITLE
Fix imports necessary to run DirichletMultinomial sampling

### DIFF
--- a/pymc3/tuning/scaling.py
+++ b/pymc3/tuning/scaling.py
@@ -7,7 +7,8 @@ from __future__ import division
 import numpy as np
 from numpy import exp, log, sqrt
 from ..model import modelcontext, Point
-from ..theanof import hessian_diag
+from ..theanof import hessian_diag, inputvars
+from ..blocking import DictToArrayBijection, ArrayOrdering
 
 __all__ = ['approx_hessian', 'find_hessian', 'trace_cov', 'guess_scaling']
 


### PR DESCRIPTION
I'm not entirely sure if there's a better minimal example for this, but I'm getting a number of `NameError`s when I try to sample with the below code on the current HEAD (df627ea5bdd59):

``` python
import pymc3 as pm
import theano.tensor as tt
import theano
import scipy as sp
import numpy as np

def log_pmf_dm(x, alpha):
    gammaln = tt.gammaln
    _sum = tt.sum
    n = _sum(x)
    sum_alpha = _sum(alpha)
    const = (gammaln(n + 1) + gammaln(sum_alpha)) - gammaln(n + sum_alpha)
    series = gammaln(x + alpha) - (gammaln(x + 1) + gammaln(alpha))
    result = const + series.sum()
    return result

class DirichletMultinomial(pm.Discrete):
    """Dirichlet Multinomial Distribution

    Parameters
    ----------
    alpha : tensor
        dirichlet parameter
    n : tensor
        number of trials

    """
    def __init__(self, alpha, n, *args, **kwargs):
        super(DirichletMultinomial, self).__init__(*args, **kwargs)
        self.alpha = alpha
        self.mode = tt.floor((self.alpha / self.alpha.sum()) * n).astype('int64')

    def logp(self, x):
        result = theano.map(log_pmf_dm, sequences=(x,), non_sequences=(self.alpha))[0].sum()
        return result

def rv_dm(alpha, n, size=None):
    alpha = np.asarray(alpha)
    assert alpha.ndim == 1

    if size is None:
        s = 1
    else:
        s = size
    out = np.empty((s, alpha.shape[0]))
    for i in range(s):
        out[i, :] = sp.random.multinomial(n, sp.random.dirichlet(alpha))

    if size is None:
        return out[0,:]
    else:
        return out

# Params
comm = np.array([0.6, 0.2, 0.1, 0.05, 0.05])
k = len(comm)
m = 10
reps = 100

n = 1000

# Simulation
sim1 = rv_dm(comm * m, n, size=reps)

with pm.Model() as model1:
    pi = pm.Dirichlet('pi', np.ones(k))
    mu = pm.Lognormal('mu')
    obs = DirichletMultinomial('obs', alpha=pi * mu, n=n, observed=sim1)
    start1 = pm.find_MAP()
    trace1 = pm.sample(1e3, start=start1)
```

The errors all look like this (partial output; the `NotImplementedError` trace at the top is irrelevant):

```
Applied stickbreaking-transform to pi and added transformed pi_stickbreaking_ to model.
Applied log-transform to mu and added transformed mu_log_ to model.
Assigned NUTS to pi_stickbreaking_
Assigned NUTS to mu_log_
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
[...]
[THIS TRACE NOT RELEVANT]
[...]
NotImplementedError: 

During handling of the above exception, another exception occurred:

NameError                                 Traceback (most recent call last)
<ipython-input-5-0a62002ef7cf> in <module>()
      4     obs = DirichletMultinomial('obs', alpha=pi * mu, n=n, observed=sim1)
      5     start1 = pm.find_MAP()
----> 6     trace1 = pm.sample(1e3, start=start1)

/Users/bjsmith/Projects/dm-bayes/.venv/src/pymc3/pymc3/sampling.py in sample(draws, step, start, trace, chain, njobs, tune, progressbar, model, random_seed)
    127     model = modelcontext(model)
    128 
--> 129     step = assign_step_methods(model, step)
    130 
    131     if njobs is None:

/Users/bjsmith/Projects/dm-bayes/.venv/src/pymc3/pymc3/sampling.py in assign_step_methods(model, step, methods)
     72 
     73     # Instantiate all selected step methods
---> 74     steps += [s(vars=selected_steps[s]) for s in selected_steps if selected_steps[s]]
     75 
     76     if len(steps)==1:

/Users/bjsmith/Projects/dm-bayes/.venv/src/pymc3/pymc3/sampling.py in <listcomp>(.0)
     72 
     73     # Instantiate all selected step methods
---> 74     steps += [s(vars=selected_steps[s]) for s in selected_steps if selected_steps[s]]
     75 
     76     if len(steps)==1:

/Users/bjsmith/Projects/dm-bayes/.venv/src/pymc3/pymc3/step_methods/nuts.py in __init__(self, vars, scaling, step_scale, is_cov, state, Emax, target_accept, gamma, k, t0, model, profile, **kwargs)
     68 
     69         if isinstance(scaling, dict):
---> 70             scaling = guess_scaling(Point(scaling, model=model), model=model, vars = vars)
     71 
     72 

/Users/bjsmith/Projects/dm-bayes/.venv/src/pymc3/pymc3/tuning/scaling.py in guess_scaling(point, vars, model)
    110         h = find_hessian_diag(point, vars, model=model)
    111     except NotImplementedError:
--> 112         h = fixed_hessian(point, vars, model=model)
    113     return adjust_scaling(h)
    114 

/Users/bjsmith/Projects/dm-bayes/.venv/src/pymc3/pymc3/tuning/scaling.py in fixed_hessian(point, vars, model)
     63     if vars is None:
     64         vars = model.cont_vars
---> 65     vars = inputvars(vars)
     66 
     67 

NameError: name 'inputvars' is not defined
```

It looks like `inputvars`, `DictToArrayBijection`, and `ArrayOrdering` were all lost from the imports in some earlier commit (maybe df627ea5bdd59 ?)
I've added them all back in, and now my example runs.

I'm not sure if there are particular tests that should be added to prevent this from happening again...?  It must be the NUTS sampler that is calling this broken code, but I would have assumed that there was already test coverage for all that stuff.

Let me know if there are particular regression tests you'd like me to append to this PR.
