### PR TITLE
Added samples per second and remaining time information to progress bar

### DIFF
--- a/pymc3/progressbar.py
+++ b/pymc3/progressbar.py
@@ -21,6 +21,7 @@ __all__ = ['progress_bar']
 
 
 class ProgressBar(object):
+
     def __init__(self, iterations, animation_interval=.5):
         self.iterations = iterations
         self.start = time.time()
@@ -42,6 +43,7 @@ class ProgressBar(object):
 
 
 class TextProgressBar(ProgressBar):
+
     def __init__(self, iterations, printer):
         self.fill_char = '-'
         self.width = 20
@@ -55,18 +57,17 @@ class TextProgressBar(ProgressBar):
 
     def progbar(self, i, elapsed):
         bar = self.bar(self.percentage(i))
-        sps = i / float(elapsed) 
+        sps = i / float(elapsed)
         eta = (self.iterations / sps) - elapsed
         its = self.iterations
 
         prog_str = "[{bar}] {it} of {its} in {s_elapsed} sec. " \
                    "| SPS: {sps} | ETA: {eta}" \
-                   "".format(bar=bar, it=i, its=its, 
+                   "".format(bar=bar, it=i, its=its,
                              s_elapsed=round(elapsed, 1),
                              sps=round(sps, 1), eta=round(eta, 1))
-               
-        return(prog_str)
 
+        return(prog_str)
 
     def bar(self, percent):
         all_full = self.width - 2
@@ -96,6 +97,7 @@ def ipythonprint(s):
 
 
 class IPythonNotebookPB(ProgressBar):
+
     def __init__(self, iterations):
         self.divid = str(uuid.uuid4())
         self.sec_id = str(uuid.uuid4())

--- a/pymc3/progressbar.py
+++ b/pymc3/progressbar.py
@@ -57,9 +57,15 @@ class TextProgressBar(ProgressBar):
         bar = self.bar(self.percentage(i))
         sps = i / float(elapsed) 
         eta = (self.iterations / sps) - elapsed
-        return ("[%s] %i of %i in %.1f sec | SPS: %.1f | ETA: %s" % 
-                (bar, i, self.iterations, round(elapsed, 1), sps, 
-                 str(datetime.timedelta(seconds=int(eta)))))
+        its = self.iterations
+
+        prog_str = "[{bar}] {it} of {its} in {s_elapsed} sec. " \
+                   "| SPS: {sps} | ETA: {eta}" \
+                   "".format(bar = bar, it = i, its = its, 
+                             s_elapsed = round(elapsed, 1),
+                             sps = round(sps, 1), eta = round(eta, 1))
+               
+        return(prog_str)
 
 
     def bar(self, percent):
@@ -74,7 +80,7 @@ class TextProgressBar(ProgressBar):
 
 
 def replace_at(str, new, start, stop):
-    return str[:start] + new + str[stop:]
+    return(str[:start] + new + str[stop:])
 
 
 def consoleprint(s):

--- a/pymc3/progressbar.py
+++ b/pymc3/progressbar.py
@@ -6,7 +6,7 @@ Modified from original code by Corey Goldberg (2010)
 from __future__ import print_function
 
 import warnings
-warnings.simplefilter(action = "ignore", category = FutureWarning)
+warnings.simplefilter(action="ignore", category=FutureWarning)
 import sys
 import time
 import datetime
@@ -61,9 +61,9 @@ class TextProgressBar(ProgressBar):
 
         prog_str = "[{bar}] {it} of {its} in {s_elapsed} sec. " \
                    "| SPS: {sps} | ETA: {eta}" \
-                   "".format(bar = bar, it = i, its = its, 
-                             s_elapsed = round(elapsed, 1),
-                             sps = round(sps, 1), eta = round(eta, 1))
+                   "".format(bar=bar, it=i, its=its, 
+                             s_elapsed=round(elapsed, 1),
+                             sps=round(sps, 1), eta=round(eta, 1))
                
         return(prog_str)
 

--- a/pymc3/progressbar.py
+++ b/pymc3/progressbar.py
@@ -9,6 +9,7 @@ import warnings
 warnings.simplefilter(action = "ignore", category = FutureWarning)
 import sys
 import time
+import datetime
 import uuid
 try:
     __IPYTHON__
@@ -43,7 +44,7 @@ class ProgressBar(object):
 class TextProgressBar(ProgressBar):
     def __init__(self, iterations, printer):
         self.fill_char = '-'
-        self.width = 40
+        self.width = 30
         self.printer = printer
 
         super(TextProgressBar, self).__init__(iterations)
@@ -54,7 +55,12 @@ class TextProgressBar(ProgressBar):
 
     def progbar(self, i, elapsed):
         bar = self.bar(self.percentage(i))
-        return "[%s] %i of %i complete in %.1f sec" % (bar, i, self.iterations, round(elapsed, 1))
+        sps = float(i) / float(elapsed) 
+        ete = (float(self.iterations) / sps) - elapsed
+        return ("[%s] %i of %i in %.1f sec | SPS: %.1f | ETE: %s" % 
+                (bar, i, self.iterations, round(elapsed, 1), sps, 
+                 str(datetime.timedelta(seconds=int(ete)))))
+
 
     def bar(self, percent):
         all_full = self.width - 2

--- a/pymc3/progressbar.py
+++ b/pymc3/progressbar.py
@@ -44,7 +44,7 @@ class ProgressBar(object):
 class TextProgressBar(ProgressBar):
     def __init__(self, iterations, printer):
         self.fill_char = '-'
-        self.width = 30
+        self.width = 20
         self.printer = printer
 
         super(TextProgressBar, self).__init__(iterations)
@@ -55,11 +55,11 @@ class TextProgressBar(ProgressBar):
 
     def progbar(self, i, elapsed):
         bar = self.bar(self.percentage(i))
-        sps = float(i) / float(elapsed) 
-        ete = (float(self.iterations) / sps) - elapsed
-        return ("[%s] %i of %i in %.1f sec | SPS: %.1f | ETE: %s" % 
+        sps = i / float(elapsed) 
+        eta = (self.iterations / sps) - elapsed
+        return ("[%s] %i of %i in %.1f sec | SPS: %.1f | ETA: %s" % 
                 (bar, i, self.iterations, round(elapsed, 1), sps, 
-                 str(datetime.timedelta(seconds=int(ete)))))
+                 str(datetime.timedelta(seconds=int(eta)))))
 
 
     def bar(self, percent):

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -89,7 +89,7 @@ def sample(draws, step=None, start=None, trace=None, chain=0, njobs=1, tune=None
     ----------
 
     draws : int
-        The number of samples to draw
+        The number of samples to draw.
     step : function or iterable of functions
         A step function or collection of functions. If no step methods are
         specified, or are partially specified, they will be assigned
@@ -97,7 +97,7 @@ def sample(draws, step=None, start=None, trace=None, chain=0, njobs=1, tune=None
     start : dict
         Starting point in parameter space (or partial point)
         Defaults to trace.point(-1)) if there is a trace provided and
-        model.test_point if not (defaults to empty dict)
+        model.test_point if not (defaults to empty dict).
     trace : backend, list, or MultiTrace
         This should be a backend instance, a list of variables to track,
         or a MultiTrace object with past values. If a MultiTrace object
@@ -115,7 +115,10 @@ def sample(draws, step=None, start=None, trace=None, chain=0, njobs=1, tune=None
     tune : int
         Number of iterations to tune, if applicable (defaults to None)
     progressbar : bool
-        Flag for progress bar
+        Whether or not to display a progress bar in the command line. The 
+        bar shows the percentage of completion, the sampling speed in 
+        samples per second (SPS), and the estimated remaining time until
+        completionvv("expected time of arrival"; ETA).
     model : Model (optional if in `with` context)
     random_seed : int or list of ints
         A list is accepted if more if `njobs` is greater than one.

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -118,7 +118,7 @@ def sample(draws, step=None, start=None, trace=None, chain=0, njobs=1, tune=None
         Whether or not to display a progress bar in the command line. The 
         bar shows the percentage of completion, the sampling speed in 
         samples per second (SPS), and the estimated remaining time until
-        completionvv("expected time of arrival"; ETA).
+        completion ("expected time of arrival"; ETA).
     model : Model (optional if in `with` context)
     random_seed : int or list of ints
         A list is accepted if more if `njobs` is greater than one.


### PR DESCRIPTION
I found myself quite often copying the "samples complete" and "time elapsed" info out of the terminal to calculate the sampling speed (to compare different step methods or computers) or the remaining time. (often accidentally aborting sampling by pressing ctrl+C...).

Therefore, I added SPS (samples per second) and ETE (estimated time enroute) to the progressbar... I find it quite helpful and would suggest something like this to be added (maybe optionally).
