### PR TITLE
Re-implemented zero-inflated Poisson to use standard parameterization

### DIFF
--- a/pymc3/examples/latent_occupancy.py
+++ b/pymc3/examples/latent_occupancy.py
@@ -53,7 +53,7 @@ with model:
     theta = Uniform('theta', 0, 100)
 
     # Poisson likelihood
-    yd = ZeroInflatedPoisson('y', theta, p, observed=y)
+    yd = ZeroInflatedPoisson('y', theta, psi, observed=y)
 
 
 point = model.test_point

--- a/pymc3/examples/latent_occupancy.py
+++ b/pymc3/examples/latent_occupancy.py
@@ -47,16 +47,13 @@ model = Model()
 with model:
     # Estimated occupancy
 
-    p = Beta('p', 1, 1)
-
-    # Latent variable for occupancy
-    z = Bernoulli('z', p, y.shape)
+    psi = Beta('psi', 1, 1)
 
     # Estimated mean count
     theta = Uniform('theta', 0, 100)
 
     # Poisson likelihood
-    yd = ZeroInflatedPoisson('y', theta, z, observed=y)
+    yd = ZeroInflatedPoisson('y', theta, p, observed=y)
 
 
 point = model.test_point
@@ -77,11 +74,9 @@ def run(n=5000):
     if n == "short":
         n = 50
     with model:
-        start = {'p': 0.5, 'z': (y > 0).astype(int), 'theta': 5}
+        start = {'psi': 0.5, 'z': (y > 0).astype(int), 'theta': 5}
 
-        step1 = Metropolis([theta, p])
-
-        step2 = BinaryMetropolis([z])
+        step1 = Metropolis([theta, psi])
 
         trace = sample(n, [step1, step2], start)
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -380,7 +380,7 @@ def test_constantdist():
             )
 
 def test_zeroinflatedpoisson():
-    checkd(ZeroInflatedPoisson, I, {'theta': Rplus, 'z': Bool})
+    checkd(ZeroInflatedPoisson, I, {'theta': Rplus, 'psi': Unit})
 
 def test_mvnormal():
     for n in [1, 2]:

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -380,7 +380,7 @@ def test_constantdist():
             )
 
 def test_zeroinflatedpoisson():
-    checkd(ZeroInflatedPoisson, I, {'theta': Rplus, 'psi': Unit})
+    checkd(ZeroInflatedPoisson, Nat, {'theta': Rplus, 'psi': Unit})
 
 def test_mvnormal():
     for n in [1, 2]:

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -201,11 +201,8 @@ class ScalarParameterShape(unittest.TestCase):
         self.check(ConstantDist, c=3)
 
     def test_zero_inflated_poisson(self):
-        # To do: implement ZIP random
-        #self.check(ZeroInflatedPoisson)
-        raise SkipTest(
-            'ZeroInflatedPoisson random sampling not yet implemented.')
-
+        self.check(ZeroInflatedPoisson, theta=1, psi=0.3)
+        
     def test_discrete_uniform(self):
         self.check(DiscreteUniform, lower=0., upper=10)
 
@@ -297,9 +294,7 @@ class ScalarShape(unittest.TestCase):
         self.check(ConstantDist, c=3)
 
     def test_zero_inflated_poisson(self):
-        # To do: implement ZIP random
-        raise SkipTest(
-            'ZeroInflatedPoisson random sampling not yet implemented.')
+       self.check(ZeroInflatedPoisson, theta=1, psi=0.3)
 
     def test_discrete_uniform(self):
         self.check(DiscreteUniform, lower=0., upper=10)
@@ -402,10 +397,7 @@ class Parameters1dShape(unittest.TestCase):
         self.check(ConstantDist, c=(self.ones * 3).astype(int))
 
     def test_zero_inflated_poisson(self):
-        # To do: implement ZIP random
-        raise SkipTest(
-            'ZeroInflatedPoisson random sampling not yet implemented.')
-        self.check(ZeroInflatedPoisson, {}, SkipTest)
+        self.check(ZeroInflatedPoisson, theta=self.ones, psi=self.ones/2)
 
     def test_discrete_uniform(self):
         self.check(DiscreteUniform,
@@ -515,10 +507,7 @@ class BroadcastShape(unittest.TestCase):
         self.check(ConstantDist, c=(self.ones * 3).astype(int))
 
     def test_zero_inflated_poisson(self):
-        # To do: implement ZIP random
-        raise SkipTest(
-            'ZeroInflatedPoisson random sampling not yet implemented.')
-        self.check(ZeroInflatedPoisson, {})
+        self.check(ZeroInflatedPoisson, theta=self.ones*2, psi=self.ones/3)
 
     def test_discrete_uniform(self):
         self.check(DiscreteUniform, lower=self.zeros.astype(int),


### PR DESCRIPTION
Rather than passing a vector of indicators, this ZIP uses a parameter `psi` which is the proportion of Poisson observations (i.e. 1-`psi` are non-Poisson zeros). 

This also aims to replace #1295
