### PR TITLE
fixes string checking for Python 2/3 compatibility; closes #1301

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -4,9 +4,16 @@ from theano import function
 
 from ..memoize import memoize
 from ..model import Model, get_named_nodes
+import sys
 
 
 __all__ = ['DensityDist', 'Distribution', 'Continuous', 'Discrete', 'NoDistribution', 'TensorType', 'draw_values']
+
+
+if sys.version_info[0] == 3:
+    string_types = str
+else:
+    string_types = basestring
 
 
 class Distribution(object):
@@ -19,7 +26,7 @@ class Distribution(object):
                             "use the Normal('x', 0,1) syntax. "
                             "Add a 'with model:' block")
 
-        if isinstance(name, str):
+        if isinstance(name, string_types):
             data = kwargs.pop('observed', None)
             dist = cls.dist(*args, **kwargs)
             return model.Var(name, dist, data)
@@ -65,7 +72,7 @@ class Distribution(object):
 
 
     def getattr_value(self, val):
-        if isinstance(val, str):
+        if isinstance(val, string_types):
             val = getattr(self, val)
 
         if isinstance(val, tt.TensorVariable):

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -4,16 +4,10 @@ from theano import function
 
 from ..memoize import memoize
 from ..model import Model, get_named_nodes
-import sys
+from ..vartypes import string_types
 
 
 __all__ = ['DensityDist', 'Distribution', 'Continuous', 'Discrete', 'NoDistribution', 'TensorType', 'draw_values']
-
-
-if sys.version_info[0] == 3:
-    string_types = str
-else:
-    string_types = basestring
 
 
 class Distribution(object):

--- a/pymc3/vartypes.py
+++ b/pymc3/vartypes.py
@@ -1,3 +1,5 @@
+import sys
+
 __all__ = ['bool_types', 'int_types', 'float_types', 'complex_types', 'continuous_types',
         'discrete_types', 'default_type', 'typefilter']
 
@@ -20,6 +22,11 @@ discrete_types = bool_types | int_types
 
 default_type = {'discrete': 'int64',
                 'continuous': 'float64'}
+
+if sys.version_info[0] == 3:
+    string_types = str
+else:
+    string_types = basestring
 
 
 def typefilter(vars, types):


### PR DESCRIPTION
Adds a six-like string_types variable that can be used in isinstance() calls to ensure compatibility with both 2.7 and 3. This addresses the problem of newly initialized Distributions failing in Python 2.7 if given a string as the name parameter. 
