### PR TITLE
correction for progressbar ending with i > iterations

### DIFF
--- a/pymc3/progressbar.py
+++ b/pymc3/progressbar.py
@@ -34,9 +34,9 @@ class ProgressBar(object):
         i += 1
 
         if elapsed - self.last > self.animation_interval:
-            self.animate(i + 1, elapsed)
+            self.animate(i, elapsed)
             self.last = elapsed
-        elif i == self.iterations:
+        elif i == self.iterations and i != 1:
             self.animate(i, elapsed)
 
 


### PR DESCRIPTION
Fixes the fact, that the progressbar count ends always with one index higher than the maximum amount of iterations (example 41 of 40). 
Also fixes that it is displayed if iterations == 1 during `__init__`
