### PR TITLE
Limit size of Cartesian product

### DIFF
--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -64,12 +64,26 @@ class Domain(object):
             self.shape)
 
 
-def product(domains):
-    names = [name for (name, domain) in domains.items()]
-    domains = [domain for (name, domain) in domains.items()]
+def product(domains, n_samples=-1):
+    """Get an iterator over a product of domains.
 
-    for val in itertools.product(*[d.vals for d in domains]):
-        yield zip(names, val)
+    Args:
+        domains: a dictionary of (name, object) pairs, where the objects
+                 must be "domain-like", as in, have a `.vals` property
+        n_samples: int, maximum samples to return.  -1 to return whole product
+
+    Returns:
+        list of the cartesian product of the domains
+    """
+    try:
+        names, domains = zip(*domains.items())
+    except ValueError:  # domains.items() is empty
+        return []
+    all_vals = [zip(names, val) for val in itertools.product(*[d.vals for d in domains])]
+    if n_samples > 0 and len(all_vals) > n_samples:
+            return nr.choice(all_vals, n_samples, replace=False)
+    return all_vals
+
 
 R = Domain([-inf, -2.1, -1, -.01, .0, .01, 1, 2.1, inf])
 Rplus = Domain([0, .01, .1, .9, .99, 1, 1.5, 2, 100, inf])
@@ -532,7 +546,7 @@ def test_get_tau_sd():
 def check_int_to_1(model, value, domain, paramdomains):
     pdf = model.fastfn(exp(model.logpt))
 
-    for pt in product(paramdomains):
+    for pt in product(paramdomains, n_samples=100):
         pt = Point(pt, value=value.tag.test_value, model=model)
 
         bij = DictToVarBijection(value, (), pt)
@@ -595,11 +609,9 @@ def check_dlogp(model, value, domain, paramdomains):
 
     ndlogp = Gradient(wrapped_logp)
 
-    for pt in product(domains):
+    for pt in product(domains, n_samples=100):
         pt = Point(pt, model=model)
-
         pt = bij.map(pt)
-
         assert_almost_equal(dlogp(pt), ndlogp(pt),
                             decimal=6, err_msg=str(pt))
 
@@ -608,7 +620,8 @@ def check_logp(model, value, domain, paramdomains, logp_reference):
     domains = paramdomains.copy()
     domains['value'] = domain
     logp = model.fastlogp
-    for pt in product(domains):
+
+    for pt in product(domains, n_samples=100):
         pt = Point(pt, model=model)
         assert_almost_equal(logp(pt), logp_reference(pt),
                             decimal=6, err_msg=str(pt))

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -27,7 +27,7 @@ def pymc3_random(dist, paramdomains, ref_rand, valuedomain=Domain([0]),
                  size=10000, alpha=0.05, fails=10):
     model = build_model(dist, valuedomain, paramdomains)
     domains = paramdomains.copy()
-    for pt in product(domains):
+    for pt in product(domains, n_samples=100):
         pt = Point(pt, model=model)
         p = alpha
         # Allow KS test to fail (i.e., the samples be different)
@@ -47,7 +47,7 @@ def pymc3_random_discrete(dist, paramdomains,
                           size=100000, alpha=0.05, fails=20):
     model = build_model(dist, valuedomain, paramdomains)
     domains = paramdomains.copy()
-    for pt in product(domains):
+    for pt in product(domains, n_samples=100):
         pt = Point(pt, model=model)
         p = alpha
         # Allow Chisq test to fail (i.e., the samples be different)


### PR DESCRIPTION
On my machine, this speeds up one of the test runs (`-vv --with-timer pymc3.tests.test_distributions`) from just over 4 minutes to just under 1 minute.  The tradeoff is that for large domains, it will "randomly" sample the Cartesian product down to 1000 examples.  There were a few test cases slowing everything down by having ~100k examples in the product, and that is where all the gains are.  

I put randomly in quotes, since I believe the `nr.seed` means it will be the same sample every run, and it would be nice to get more randomness for this choice.
