### PR TITLE
Speed up tests

### DIFF
--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -27,7 +27,7 @@ def pymc3_random(dist, paramdomains, ref_rand, valuedomain=Domain([0]),
                  size=10000, alpha=0.05, fails=10):
     model = build_model(dist, valuedomain, paramdomains)
     domains = paramdomains.copy()
-    for pt in product(domains):
+    for pt in product(domains, n_samples=100):
         pt = Point(pt, model=model)
         p = alpha
         # Allow KS test to fail (i.e., the samples be different)
@@ -47,7 +47,7 @@ def pymc3_random_discrete(dist, paramdomains,
                           size=100000, alpha=0.05, fails=20):
     model = build_model(dist, valuedomain, paramdomains)
     domains = paramdomains.copy()
-    for pt in product(domains):
+    for pt in product(domains, n_samples=100):
         pt = Point(pt, model=model)
         p = alpha
         # Allow Chisq test to fail (i.e., the samples be different)


### PR DESCRIPTION
This speeds things up significantly on local tests, and reasonably quickly in travis tests.  Locally, `nosetests -vv --with-timer pymc3.tests.test_distributions` went from `Ran 74 tests in 227.944s` to `Ran 74 tests in 43.908s`.  

Ran the builds a few times on travis, and they went from ~55mins to ~45mins in total time.  Elapsed time remains ~12minutes, but could be sped up by speeding up the remaining set of tests (`-e test_examples -e test_distributions`).

The gains were mostly made via a tradeoff in randomly sampling test cases where product domains were quite large (~100k).
