### PR TITLE
Build bugfix: Add another level to doc folder copying in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
                     'pymc3.backends', 'pymc3.variational', 'docs', '.'],
           package_data={'pymc3.examples': ['data/*.*'],
                         '.': ['requirements.txt', '*.md'],
-                        'docs': ['source/*/*/*']},
+                        'docs': ['source/*/*', 'source/*/*/*']},
           classifiers=classifiers,
           install_requires=install_reqs,
           tests_require=test_reqs,

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
                     'pymc3.backends', 'pymc3.variational', 'docs', '.'],
           package_data={'pymc3.examples': ['data/*.*'],
                         '.': ['requirements.txt', '*.md'],
-                        'docs': ['source/*/*']},
+                        'docs': ['source/*/*/*']},
           classifiers=classifiers,
           install_requires=install_reqs,
           tests_require=test_reqs,


### PR DESCRIPTION
Package data wasn't copied correctly because of the behaviour of
python's glob module, which needed a further '/*' appended to it.

This affects docs/source/data/6bb8d06c69c0666e6da14c094d4320d115f1ffc8
which is a directory but isn't processed as such by glob, resulting in a
build error.

Build error before this fix was applied:

```
copying setup.py -> build/lib
copying setupegg.py -> build/lib
creating build/lib/pymc3/examples/data
copying pymc3/examples/data/__init__.py -> build/lib/pymc3/examples/data
copying pymc3/examples/data/cty.dat -> build/lib/pymc3/examples/data
copying pymc3/examples/data/Guber1999data.txt -> build/lib/pymc3/examples/data
copying pymc3/examples/data/HtWt.csv -> build/lib/pymc3/examples/data
copying pymc3/examples/data/jester-dataset-v1-dense-first-1000.csv -> build/lib/pymc3/examples/data
copying pymc3/examples/data/pancreatitis.csv -> build/lib/pymc3/examples/data
copying pymc3/examples/data/radon.csv -> build/lib/pymc3/examples/data
copying pymc3/examples/data/SP500.csv -> build/lib/pymc3/examples/data
copying pymc3/examples/data/srrs2.dat -> build/lib/pymc3/examples/data
copying pymc3/examples/data/test_scores.csv -> build/lib/pymc3/examples/data
copying pymc3/examples/data/wells.dat -> build/lib/pymc3/examples/data
creating build/lib/docs
creating build/lib/docs/source
creating build/lib/docs/source/data
error: can't copy 'docs/source/data/6bb8d06c69c0666e6da14c094d4320d115f1ffc8': doesn't exist or not a regular file

----------------------------------------
```

Command "/Users/ehurrell/anaconda3/bin/python -u -c "import setuptools, tokenize;**file**='/var/folders/6w/ql9m8kjj2pbdnmdhdtl2mrg40000gn/T/pip-obj34ksi-build/setup.py';exec(compile(getattr(tokenize, 'open', open)(**file**).read().replace('\r\n', '\n'), **file**, 'exec'))" install --record /var/folders/6w/ql9m8kjj2pbdnmdhdtl2mrg40000gn/T/pip-6ajnwm43-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /var/folders/6w/ql9m8kjj2pbdnmdhdtl2mrg40000gn/T/pip-obj34ksi-build/

I'm currently using Python 3.5 from Anaconda3, fairly vanilla but I'm attaching the output of pip freeze in case that's of use.
[list.txt](https://github.com/pymc-devs/pymc3/files/462268/list.txt)
