### PR TITLE
Apply transform to a distribution's test value

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -694,7 +694,8 @@ class TransformedRV(TensorVariable):
 
             theano.Apply(theano.compile.view_op, inputs=[
                          normalRV], outputs=[self])
-            self.tag.test_value = normalRV.tag.test_value
+            self.tag.test_value = transform.forward(
+                normalRV.tag.test_value).eval()
 
             incorporate_methods(source=distribution, destination=self,
                                 methods=['random'],


### PR DESCRIPTION
I'm not 100% familiar with all inner workings of PyMC3, but I think this is a useful (tiny) fix. Users will typically specify a test value based on the distribution itself, but up to now this test value was copied directly to any (e.g. log-) transformed distribution. Oftentimes this will be harmless, but using something like `start=model.test_point` can be quite convenient and then starting values for transformed variables can be way off.

Let me know if this is appropriate! If not, feedback would also be welcome, I'm looking forward to learning more and potentially contributing more in the future.
