### PR TITLE
Pin pyqt to version 4 (as matplotlib expects)

### DIFF
--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -8,7 +8,7 @@ conda create -n testenv --yes pip python=${PYTHON_VERSION}
 
 source activate testenv
 
-conda install --yes jupyter pyzmq numpy scipy nose matplotlib pandas Cython patsy statsmodels joblib
+conda install --yes pyqt=4.11.4 jupyter pyzmq numpy scipy nose matplotlib pandas Cython patsy statsmodels joblib
 if [ ${PYTHON_VERSION} == "2.7" ]; then
   conda install --yes mock enum34;
 fi


### PR DESCRIPTION
Looks like yesterday [conda bumped the "standard" install for pyqt](https://anaconda.org/anaconda/pyqt/files).  I'm sort of surprised this isn't reported in their issues (yet!), but it would probably be best if all pymc3's testing requirements were pinned. 

This should fix problems with existing builds #1367, #1371 .
