### PR TITLE
Add coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,15 @@ before_install:
 
 install:
   - . ./scripts/create_testenv.sh
+  - pip install coveralls
 
 env:
-  - TESTCMD=" -vv --with-timer -e test_examples -e test_distributions" PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
-  - TESTCMD=" -vv --with-timer pymc3.tests.test_distributions" PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
-  - TESTCMD=" -vv --with-timer pymc3.tests.test_distributions_random" PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
+  - TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 -e test_examples -e test_distributions" PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
+  - TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 pymc3.tests.test_distributions" PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
+  - TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 pymc3.tests.test_distributions_random" PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
 
 script:
   - . ./scripts/test.sh $TESTCMD
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - coveralls

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -8,7 +8,7 @@ conda create -n testenv --yes pip python=${PYTHON_VERSION}
 
 source activate testenv
 
-conda install --yes pyqt=4.11.4 jupyter pyzmq numpy scipy nose matplotlib pandas Cython patsy statsmodels joblib
+conda install --yes pyqt=4.11.4 jupyter pyzmq numpy scipy nose matplotlib pandas Cython patsy statsmodels joblib coverage
 if [ ${PYTHON_VERSION} == "2.7" ]; then
   conda install --yes mock enum34;
 fi


### PR DESCRIPTION
Coveralls can be plugged in pretty transparently to report on code coverage.  

See https://coveralls.io/github/ColCarroll/pymc3 for current output.  A maintainer would need to be signed up with coveralls and tell it to watch the repo, and the badge ought to be added to the README.  

Sklearn has a longer history: https://coveralls.io/github/scikit-learn/scikit-learn
