### PR TITLE
Only set random seed on purpose in advi

### DIFF
--- a/pymc3/tests/test_advi.py
+++ b/pymc3/tests/test_advi.py
@@ -8,254 +8,216 @@ from pymc3.theanof import CallableTensor
 from theano import function, shared
 import theano.tensor as tt
 
-from nose.tools import assert_raises
-
-
-def test_elbo():
-    mu0 = 1.5
-    sigma = 1.0
-    y_obs = np.array([1.6, 1.4])
-
-    # Create a model for test
-    with Model() as model:
-        mu = Normal('mu', mu=mu0, sd=sigma)
-        Normal('y', mu=mu, sd=1, observed=y_obs)
-
-    vars = inputvars(model.vars)
-
-    # Create variational gradient tensor
-    elbo, _ = _calc_elbo(vars, model, n_mcsamples=10000, random_seed=1)
-
-    # Variational posterior parameters
-    uw_ = np.array([1.88, np.log(1)])
-
-    # Calculate elbo computed with MonteCarlo
-    uw_shared = shared(uw_, 'uw_shared')
-    elbo = CallableTensor(elbo)(uw_shared)
-    f = function([], elbo)
-    elbo_mc = f()
-
-    # Exact value
-    elbo_true = (-0.5 * (
-        3 + 3 * uw_[0]**2 - 2 * (y_obs[0] + y_obs[1] + mu0) * uw_[0] +
-        y_obs[0]**2 + y_obs[1]**2 + mu0**2 + 3 * np.log(2 * np.pi)) +
-        0.5 * (np.log(2 * np.pi) + 1))
-
-    np.testing.assert_allclose(elbo_mc, elbo_true, rtol=0, atol=1e-1)
-
-disaster_data = np.ma.masked_values([4, 5, 4, 0, 1, 4, 3, 4, 0, 6, 3, 3, 4, 0, 2, 6,
-                                     3, 3, 5, 4, 5, 3, 1, 4, 4, 1, 5, 5, 3, 4, 2, 5,
-                                     2, 2, 3, 4, 2, 1, 3, -999, 2, 1, 1, 1, 1, 3, 0, 0,
-                                     1, 0, 1, 1, 0, 0, 3, 1, 0, 3, 2, 2, 0, 1, 1, 1,
-                                     0, 1, 0, 1, 0, 0, 0, 2, 1, 0, 0, 0, 1, 1, 0, 2,
-                                     3, 3, 1, -999, 2, 1, 1, 1, 1, 2, 4, 2, 0, 0, 1, 4,
-                                     0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1], value=-999)
-year = np.arange(1851, 1962)
-
-
-def test_check_discrete():
-    with Model() as disaster_model:
-        switchpoint = DiscreteUniform(
-            'switchpoint', lower=year.min(), upper=year.max(), testval=1900)
-
-        # Priors for pre- and post-switch rates number of disasters
-        early_rate = Exponential('early_rate', 1)
-        late_rate = Exponential('late_rate', 1)
-
-        # Allocate appropriate Poisson rates to years before and after current
-        rate = switch(switchpoint >= year, early_rate, late_rate)
-        Poisson('disasters', rate, observed=disaster_data)
-
-    # This should raise ValueError
-    assert_raises(ValueError, advi, model=disaster_model, n=10)
-
-
-def test_check_discrete_minibatch():
-    disaster_data_t = tt.vector()
-    disaster_data_t.tag.test_value = np.zeros(len(disaster_data))
-
-    with Model() as disaster_model:
-
-        switchpoint = DiscreteUniform(
-            'switchpoint', lower=year.min(), upper=year.max(), testval=1900)
-
-        # Priors for pre- and post-switch rates number of disasters
-        early_rate = Exponential('early_rate', 1)
-        late_rate = Exponential('late_rate', 1)
-
-        # Allocate appropriate Poisson rates to years before and after current
-        rate = switch(switchpoint >= year, early_rate, late_rate)
-
-        disasters = Poisson('disasters', rate, observed=disaster_data_t)
-
-    def create_minibatch():
-        while True:
-            return (disaster_data,)
-
-    # This should raise ValueError
-    assert_raises(
-        ValueError, advi_minibatch, model=disaster_model, n=10,
-        minibatch_RVs=[disasters], minibatch_tensors=[disaster_data_t],
-        minibatches=create_minibatch(), verbose=False)
-
-
-def test_advi():
-    n = 1000
-    sd0 = 2.
-    mu0 = 4.
-    sd = 3.
-    mu = -5.
-
-    data = sd * np.random.RandomState(0).randn(n) + mu
-
-    d = n / sd**2 + 1 / sd0**2
-    mu_post = (n * np.mean(data) / sd**2 + mu0 / sd0**2) / d
-
-    with Model() as model:
-        mu_ = Normal('mu', mu=mu0, sd=sd0, testval=0)
-        Normal('x', mu=mu_, sd=sd, observed=data)
-
-    advi_fit = advi(
-        model=model, n=1000, accurate_elbo=False, learning_rate=1e-1,
-        random_seed=1)
-
-    np.testing.assert_allclose(advi_fit.means['mu'], mu_post, rtol=0.1)
-
-    trace = sample_vp(advi_fit, 10000, model)
-
-    np.testing.assert_allclose(np.mean(trace['mu']), mu_post, rtol=0.4)
-    np.testing.assert_allclose(np.std(trace['mu']), np.sqrt(1. / d), rtol=0.4)
-
-
-def test_advi_optimizer():
-    n = 1000
-    sd0 = 2.
-    mu0 = 4.
-    sd = 3.
-    mu = -5.
-
-    data = sd * np.random.RandomState(0).randn(n) + mu
-
-    d = n / sd**2 + 1 / sd0**2
-    mu_post = (n * np.mean(data) / sd**2 + mu0 / sd0**2) / d
-
-    with Model() as model:
-        mu_ = Normal('mu', mu=mu0, sd=sd0, testval=0)
-        Normal('x', mu=mu_, sd=sd, observed=data)
-
-    optimizer = adagrad_optimizer(learning_rate=0.1, epsilon=0.1)
-    advi_fit = advi(model=model, n=1000, optimizer=optimizer, random_seed=1)
-
-    np.testing.assert_allclose(advi_fit.means['mu'], mu_post, rtol=0.1)
-
-    trace = sample_vp(advi_fit, 10000, model)
-
-    np.testing.assert_allclose(np.mean(trace['mu']), mu_post, rtol=0.4)
-    np.testing.assert_allclose(np.std(trace['mu']), np.sqrt(1. / d), rtol=0.4)
-
-
-def test_advi_minibatch():
-    n = 1000
-    sd0 = 2.
-    mu0 = 4.
-    sd = 3.
-    mu = -5.
-
-    data = sd * np.random.RandomState(0).randn(n) + mu
-
-    d = n / sd**2 + 1 / sd0**2
-    mu_post = (n * np.mean(data) / sd**2 + mu0 / sd0**2) / d
-
-    data_t = tt.vector()
-    data_t.tag.test_value = np.zeros(1,)
-
-    with Model() as model:
-        mu_ = Normal('mu', mu=mu0, sd=sd0, testval=0)
-        x = Normal('x', mu=mu_, sd=sd, observed=data_t)
-
-    minibatch_RVs = [x]
-    minibatch_tensors = [data_t]
-
-    def create_minibatch(data):
-        while True:
-            data = np.roll(data, 100, axis=0)
-            yield (data[:100],)
-
-    minibatches = create_minibatch(data)
-
-    with model:
-        advi_fit = advi_minibatch(
-            n=1000, minibatch_tensors=minibatch_tensors,
-            minibatch_RVs=minibatch_RVs, minibatches=minibatches,
-            total_size=n, learning_rate=1e-1, random_seed=1
-        )
-
-        np.testing.assert_allclose(advi_fit.means['mu'], mu_post, rtol=0.1)
-
-        trace = sample_vp(advi_fit, 10000)
-
-    np.testing.assert_allclose(np.mean(trace['mu']), mu_post, rtol=0.4)
-    np.testing.assert_allclose(np.std(trace['mu']), np.sqrt(1. / d), rtol=0.4)
-
-
-def test_advi_minibatch_shared():
-    n = 1000
-    sd0 = 2.
-    mu0 = 4.
-    sd = 3.
-    mu = -5.
-
-    data = sd * np.random.RandomState(0).randn(n) + mu
-
-    d = n / sd**2 + 1 / sd0**2
-    mu_post = (n * np.mean(data) / sd**2 + mu0 / sd0**2) / d
-
-    data_t = shared(np.zeros(1,))
-
-    with Model() as model:
-        mu_ = Normal('mu', mu=mu0, sd=sd0, testval=0)
-        x = Normal('x', mu=mu_, sd=sd, observed=data_t)
-
-    minibatch_RVs = [x]
-    minibatch_tensors = [data_t]
-
-    def create_minibatch(data):
-        while True:
-            data = np.roll(data, 100, axis=0)
-            yield (data[:100],)
-
-    minibatches = create_minibatch(data)
-
-    with model:
-        advi_fit = advi_minibatch(
-            n=1000, minibatch_tensors=minibatch_tensors,
-            minibatch_RVs=minibatch_RVs, minibatches=minibatches,
-            total_size=n, learning_rate=1e-1, random_seed=1
-        )
-
-        np.testing.assert_allclose(advi_fit.means['mu'], mu_post, rtol=0.1)
-
-        trace = sample_vp(advi_fit, 10000)
-
-    np.testing.assert_allclose(np.mean(trace['mu']), mu_post, rtol=0.4)
-    np.testing.assert_allclose(np.std(trace['mu']), np.sqrt(1. / d), rtol=0.4)
-
-
-def test_sample_vp():
-    n_samples = 100
-
-    rng = np.random.RandomState(0)
-    xs = rng.binomial(n=1, p=0.2, size=n_samples)
-
-    with pm.Model() as model:
-        p = pm.Beta('p', alpha=1, beta=1)
-        pm.Binomial('xs', n=1, p=p, observed=xs)
-        v_params = advi(n=1000)
-
-    with model:
-        trace = sample_vp(v_params, hide_transformed=True)
-    assert(set(trace.varnames) == set('p'))
-
-    with model:
-        trace = sample_vp(v_params, hide_transformed=False)
-    assert(set(trace.varnames) == set(('p', 'p_logodds_')))
+from .helpers import SeededTest
+
+
+class TestADVI(SeededTest):
+    def setUp(self):
+        super(TestADVI, self).setUp()
+        self.disaster_data = np.ma.masked_values([4, 5, 4, 0, 1, 4, 3, 4, 0, 6, 3, 3, 4, 0, 2, 6,
+                                                 3, 3, 5, 4, 5, 3, 1, 4, 4, 1, 5, 5, 3, 4, 2, 5,
+                                                 2, 2, 3, 4, 2, 1, 3, -999, 2, 1, 1, 1, 1, 3, 0, 0,
+                                                 1, 0, 1, 1, 0, 0, 3, 1, 0, 3, 2, 2, 0, 1, 1, 1,
+                                                 0, 1, 0, 1, 0, 0, 0, 2, 1, 0, 0, 0, 1, 1, 0, 2,
+                                                 3, 3, 1, -999, 2, 1, 1, 1, 1, 2, 4, 2, 0, 0, 1, 4,
+                                                 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1],
+                                                 value=-999)
+        self.year = np.arange(1851, 1962)
+
+    def test_elbo(self):
+        mu0 = 1.5
+        sigma = 1.0
+        y_obs = np.array([1.6, 1.4])
+
+        # Create a model for test
+        with Model() as model:
+            mu = Normal('mu', mu=mu0, sd=sigma)
+            Normal('y', mu=mu, sd=1, observed=y_obs)
+
+        model_vars = inputvars(model.vars)
+
+        # Create variational gradient tensor
+        elbo, _ = _calc_elbo(model_vars, model, n_mcsamples=10000, random_seed=self.random_seed)
+
+        # Variational posterior parameters
+        uw_ = np.array([1.88, np.log(1)])
+
+        # Calculate elbo computed with MonteCarlo
+        uw_shared = shared(uw_, 'uw_shared')
+        elbo = CallableTensor(elbo)(uw_shared)
+        f = function([], elbo)
+        elbo_mc = f()
+
+        # Exact value
+        elbo_true = (-0.5 * (
+            3 + 3 * uw_[0]**2 - 2 * (y_obs[0] + y_obs[1] + mu0) * uw_[0] +
+            y_obs[0]**2 + y_obs[1]**2 + mu0**2 + 3 * np.log(2 * np.pi)) +
+            0.5 * (np.log(2 * np.pi) + 1))
+
+        np.testing.assert_allclose(elbo_mc, elbo_true, rtol=0, atol=1e-1)
+
+    def test_check_discrete(self):
+        with Model():
+            switchpoint = DiscreteUniform(
+                'switchpoint', lower=self.year.min(), upper=self.year.max(), testval=1900)
+
+            # Priors for pre- and post-switch rates number of disasters
+            early_rate = Exponential('early_rate', 1)
+            late_rate = Exponential('late_rate', 1)
+
+            # Allocate appropriate Poisson rates to years before and after current
+            rate = switch(switchpoint >= self.year, early_rate, late_rate)
+            Poisson('disasters', rate, observed=self.disaster_data)
+
+            # This should raise ValueError
+            with self.assertRaises(ValueError):
+                advi(n=10)
+
+    def test_check_discrete_minibatch(self):
+        disaster_data_t = tt.vector()
+        disaster_data_t.tag.test_value = np.zeros(len(self.disaster_data))
+
+        def create_minibatches():
+            while True:
+                return (self.disaster_data,)
+
+        with Model():
+            switchpoint = DiscreteUniform(
+                'switchpoint', lower=self.year.min(), upper=self.year.max(), testval=1900)
+
+            # Priors for pre- and post-switch rates number of disasters
+            early_rate = Exponential('early_rate', 1)
+            late_rate = Exponential('late_rate', 1)
+
+            # Allocate appropriate Poisson rates to years before and after current
+            rate = switch(switchpoint >= self.year, early_rate, late_rate)
+            disasters = Poisson('disasters', rate, observed=disaster_data_t)
+
+            with self.assertRaises(ValueError):
+                advi_minibatch(n=10, minibatch_RVs=[disasters], minibatch_tensors=[disaster_data_t],
+                               minibatches=create_minibatches(), verbose=False)
+
+    def test_advi(self):
+        n = 1000
+        sd0 = 2.
+        mu0 = 4.
+        sd = 3.
+        mu = -5.
+
+        data = sd * np.random.randn(n) + mu
+
+        d = n / sd**2 + 1 / sd0**2
+        mu_post = (n * np.mean(data) / sd**2 + mu0 / sd0**2) / d
+
+        with Model():
+            mu_ = Normal('mu', mu=mu0, sd=sd0, testval=0)
+            Normal('x', mu=mu_, sd=sd, observed=data)
+            advi_fit = advi(n=1000, accurate_elbo=False, learning_rate=1e-1)
+            np.testing.assert_allclose(advi_fit.means['mu'], mu_post, rtol=0.1)
+            trace = sample_vp(advi_fit, 10000)
+
+        np.testing.assert_allclose(np.mean(trace['mu']), mu_post, rtol=0.4)
+        np.testing.assert_allclose(np.std(trace['mu']), np.sqrt(1. / d), rtol=0.4)
+
+    def test_advi_optimizer(self):
+        n = 1000
+        sd0 = 2.
+        mu0 = 4.
+        sd = 3.
+        mu = -5.
+
+        data = sd * np.random.randn(n) + mu
+
+        d = n / sd**2 + 1 / sd0**2
+        mu_post = (n * np.mean(data) / sd**2 + mu0 / sd0**2) / d
+
+        with Model():
+            mu_ = Normal('mu', mu=mu0, sd=sd0, testval=0)
+            Normal('x', mu=mu_, sd=sd, observed=data)
+            optimizer = adagrad_optimizer(learning_rate=0.1, epsilon=0.1)
+            advi_fit = advi(n=1000, optimizer=optimizer)
+            np.testing.assert_allclose(advi_fit.means['mu'], mu_post, rtol=0.1)
+            trace = sample_vp(advi_fit, 10000)
+
+        np.testing.assert_allclose(np.mean(trace['mu']), mu_post, rtol=0.4)
+        np.testing.assert_allclose(np.std(trace['mu']), np.sqrt(1. / d), rtol=0.4)
+
+    def test_advi_minibatch(self):
+        n = 1000
+        sd0 = 2.
+        mu0 = 4.
+        sd = 3.
+        mu = -5.
+
+        data = sd * np.random.randn(n) + mu
+
+        d = n / sd**2 + 1 / sd0**2
+        mu_post = (n * np.mean(data) / sd**2 + mu0 / sd0**2) / d
+
+        data_t = tt.vector()
+        data_t.tag.test_value = np.zeros(1,)
+
+        def create_minibatch(data):
+            while True:
+                data = np.roll(data, 100, axis=0)
+                yield (data[:100],)
+
+        minibatches = create_minibatch(data)
+
+        with Model():
+            mu_ = Normal('mu', mu=mu0, sd=sd0, testval=0)
+            x = Normal('x', mu=mu_, sd=sd, observed=data_t)
+            advi_fit = advi_minibatch(
+                n=1000, minibatch_tensors=[data_t],
+                minibatch_RVs=[x], minibatches=minibatches,
+                total_size=n, learning_rate=1e-1)
+
+            np.testing.assert_allclose(advi_fit.means['mu'], mu_post, rtol=0.1)
+            trace = sample_vp(advi_fit, 10000)
+
+        np.testing.assert_allclose(np.mean(trace['mu']), mu_post, rtol=0.4)
+        np.testing.assert_allclose(np.std(trace['mu']), np.sqrt(1. / d), rtol=0.4)
+
+    def test_advi_minibatch_shared(self):
+        n = 1000
+        sd0 = 2.
+        mu0 = 4.
+        sd = 3.
+        mu = -5.
+
+        data = sd * np.random.randn(n) + mu
+
+        d = n / sd**2 + 1 / sd0**2
+        mu_post = (n * np.mean(data) / sd**2 + mu0 / sd0**2) / d
+
+        data_t = shared(np.zeros(1,))
+
+        def create_minibatches(data):
+            while True:
+                data = np.roll(data, 100, axis=0)
+                yield (data[:100],)
+
+        with Model():
+            mu_ = Normal('mu', mu=mu0, sd=sd0, testval=0)
+            x = Normal('x', mu=mu_, sd=sd, observed=data_t)
+            advi_fit = advi_minibatch(
+                n=1000, minibatch_tensors=[data_t],
+                minibatch_RVs=[x], minibatches=create_minibatches(data),
+                total_size=n, learning_rate=1e-1)
+            np.testing.assert_allclose(advi_fit.means['mu'], mu_post, rtol=0.1)
+            trace = sample_vp(advi_fit, 10000)
+
+        np.testing.assert_allclose(np.mean(trace['mu']), mu_post, rtol=0.4)
+        np.testing.assert_allclose(np.std(trace['mu']), np.sqrt(1. / d), rtol=0.4)
+
+    def test_sample_vp(self):
+        n_samples = 100
+        xs = np.random.binomial(n=1, p=0.2, size=n_samples)
+        with pm.Model():
+            p = pm.Beta('p', alpha=1, beta=1)
+            pm.Binomial('xs', n=1, p=p, observed=xs)
+            v_params = advi(n=1000)
+            trace = sample_vp(v_params, draws=1, hide_transformed=True)
+            self.assertListEqual(trace.varnames, ['p'])
+            trace = sample_vp(v_params, draws=1, hide_transformed=False)
+            self.assertListEqual(sorted(trace.varnames), ['p', 'p_logodds_'])

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -2,19 +2,14 @@
 '''
 (c) 2016, John Salvatier & Taku Yoshioka
 '''
-import numpy as np
-from ..blocking import DictToArrayBijection, ArrayOrdering
-from ..theanof import inputvars
-from ..model import ObservedRV, modelcontext
-from ..vartypes import discrete_types
+from collections import OrderedDict, namedtuple
 
+import numpy as np
 import theano
-from ..theanof import make_shared_replacements, join_nonshared_inputs, CallableTensor
-from theano.tensor import exp, dvector
 import theano.tensor as tt
 from theano.sandbox.rng_mrg import MRG_RandomStreams
-from collections import OrderedDict, namedtuple
-from pymc3.sampling import NDArray
+
+import pymc3 as pm
 from pymc3.backends.base import MultiTrace
 
 __all__ = ['advi', 'sample_vp']
@@ -25,39 +20,46 @@ ADVIFit = namedtuple('ADVIFit', 'means, stds, elbo_vals')
 def check_discrete_rvs(vars):
     """Check that vars not include discrete variables, excepting ObservedRVs.
     """
-    vars_ = [var for var in vars if not isinstance(var, ObservedRV)]
-    if any([var.dtype in discrete_types for var in vars_]):
+    vars_ = [var for var in vars if not isinstance(var, pm.model.ObservedRV)]
+    if any([var.dtype in pm.discrete_types for var in vars_]):
         raise ValueError('Model should not include discrete RVs for ADVI.')
 
 
+def gen_random_state():
+    """Helper to generate a random state for MRG_RandomStreams"""
+    M1 = 2147483647
+    M2 = 2147462579
+    return np.random.randint(0, M1, 3).tolist() + np.random.randint(0, M2, 3).tolist()
+
+
 def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
-         optimizer=None, learning_rate=.001, epsilon=.1, random_seed=20090425,
+         optimizer=None, learning_rate=.001, epsilon=.1, random_seed=None,
          verbose=1):
-    """Perform automatic differentiation variational inference (ADVI). 
+    """Perform automatic differentiation variational inference (ADVI).
 
-    This function implements the meanfield ADVI, where the variational 
-    posterior distribution is assumed to be spherical Gaussian without 
-    correlation of parameters and fit to the true posterior distribution. 
-    The means and standard deviations of the variational posterior are referred 
-    to as variational parameters. 
+    This function implements the meanfield ADVI, where the variational
+    posterior distribution is assumed to be spherical Gaussian without
+    correlation of parameters and fit to the true posterior distribution.
+    The means and standard deviations of the variational posterior are referred
+    to as variational parameters.
 
-    The return value of this function is an :code:`ADVIfit` object, which has 
-    variational parameters. If you want to draw samples from the variational 
-    posterior, you need to pass the :code:`ADVIfit` object to 
-    :code:`pymc3.variational.sample_vp()`. 
+    The return value of this function is an :code:`ADVIfit` object, which has
+    variational parameters. If you want to draw samples from the variational
+    posterior, you need to pass the :code:`ADVIfit` object to
+    :code:`pymc3.variational.sample_vp()`.
 
-    The variational parameters are defined on the transformed space, which is 
-    required to do ADVI on an unconstrained parameter space as described in 
-    [KTR+2016]. The parameters in the :code:`ADVIfit` object are in the 
-    transformed space, while traces returned by :code:`sample_vp()` are in 
-    the original space as obtained by MCMC sampling methods in PyMC3. 
+    The variational parameters are defined on the transformed space, which is
+    required to do ADVI on an unconstrained parameter space as described in
+    [KTR+2016]. The parameters in the :code:`ADVIfit` object are in the
+    transformed space, while traces returned by :code:`sample_vp()` are in
+    the original space as obtained by MCMC sampling methods in PyMC3.
 
-    The variational parameters are optimized with given optimizer, which is a 
-    function that returns a dictionary of parameter updates as provided to 
-    Theano function. If no optimizer is provided, optimization is performed 
-    with a modified version of adagrad, where only the last (n_window) gradient 
-    vectors are used to control the learning rate and older gradient vectors 
-    are ignored. n_window denotes the size of time window and fixed to 10. 
+    The variational parameters are optimized with given optimizer, which is a
+    function that returns a dictionary of parameter updates as provided to
+    Theano function. If no optimizer is provided, optimization is performed
+    with a modified version of adagrad, where only the last (n_window) gradient
+    vectors are used to control the learning rate and older gradient vectors
+    are ignored. n_window denotes the size of time window and fixed to 10.
 
     Parameters
     ----------
@@ -72,17 +74,17 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
     accurate_elbo : bool
         If true, 100 MC samples are used for accurate calculation of ELBO.
     optimizer : (loss, tensor) -> dict or OrderedDict
-        A function that returns parameter updates given loss and parameter 
-        tensor. If :code:`None` (default), a default Adagrad optimizer is 
-        used with parameters :code:`learning_rate` and :code:`epsilon` below. 
+        A function that returns parameter updates given loss and parameter
+        tensor. If :code:`None` (default), a default Adagrad optimizer is
+        used with parameters :code:`learning_rate` and :code:`epsilon` below.
     learning_rate: float
         Base learning rate for adagrad. This parameter is ignored when
-        optimizer is given. 
+        optimizer is given.
     epsilon : float
         Offset in denominator of the scale of learning rate in Adagrad.
-        This parameter is ignored when optimizer is given. 
-    random_seed : int
-        Seed to initialize random state.
+        This parameter is ignored when optimizer is given.
+    random_seed : int or None
+        Seed to initialize random state. None uses current seed.
 
     Returns
     -------
@@ -90,21 +92,21 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
         Named tuple, which includes 'means', 'stds', and 'elbo_vals'.
 
     'means' is the mean. 'stds' is the standard deviation.
-    'elbo_vals' is the trace of ELBO values during optimizaiton. 
+    'elbo_vals' is the trace of ELBO values during optimizaiton.
 
     References
     ----------
-    .. [KTR+2016] Kucukelbir, A., Tran, D., Ranganath, R., Gelman, A., 
-        and Blei, D. M. (2016). Automatic Differentiation Variational Inference. 
+    .. [KTR+2016] Kucukelbir, A., Tran, D., Ranganath, R., Gelman, A.,
+        and Blei, D. M. (2016). Automatic Differentiation Variational Inference.
         arXiv preprint arXiv:1603.00788.
     """
-    model = modelcontext(model)
+    model = pm.modelcontext(model)
     if start is None:
         start = model.test_point
 
     if vars is None:
         vars = model.vars
-    vars = inputvars(vars)
+    vars = pm.inputvars(vars)
 
     check_discrete_rvs(vars)
 
@@ -122,15 +124,15 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
     for var, share in shared.items():
         share.set_value(start[str(var)])
 
-    order = ArrayOrdering(vars)
-    bij = DictToArrayBijection(order, start)
+    order = pm.ArrayOrdering(vars)
+    bij = pm.DictToArrayBijection(order, start)
     u_start = bij.map(start)
     w_start = np.zeros_like(u_start)
     uw = np.concatenate([u_start, w_start])
 
     # Create parameter update function used in the training loop
     uw_shared = theano.shared(uw, 'uw_shared')
-    elbo = CallableTensor(elbo)(uw_shared)
+    elbo = pm.CallableTensor(elbo)(uw_shared)
     updates = optimizer(loss=-1 * elbo, param=uw_shared)
     f = theano.function([], [uw_shared, elbo], updates=updates)
 
@@ -174,14 +176,14 @@ def _calc_elbo(vars, model, n_mcsamples, random_seed):
     """Calculate approximate ELBO.
     """
     theano.config.compute_test_value = 'ignore'
-    shared = make_shared_replacements(vars, model)
+    shared = pm.make_shared_replacements(vars, model)
 
     factors = [var.logpt for var in model.basic_RVs] + model.potentials
     logpt = tt.add(*map(tt.sum, factors))
 
-    [logp], inarray = join_nonshared_inputs([logpt], vars, shared)
+    [logp], inarray = pm.join_nonshared_inputs([logpt], vars, shared)
 
-    uw = dvector('uw')
+    uw = tt.dvector('uw')
     uw.tag.test_value = np.concatenate([inarray.tag.test_value,
                                         inarray.tag.test_value])
 
@@ -201,15 +203,18 @@ def _elbo_t(logp, uw, inarray, n_mcsamples, random_seed):
     logp_ = lambda input: theano.clone(logp, {inarray: input}, strict=False)
 
     # Naive Monte-Carlo
-    r = MRG_RandomStreams(seed=random_seed)
+    if random_seed is None:
+        r = MRG_RandomStreams(gen_random_state())
+    else:
+        r = MRG_RandomStreams(seed=random_seed)
 
     if n_mcsamples == 1:
         n = r.normal(size=inarray.tag.test_value.shape)
-        q = n * exp(w) + u
+        q = n * tt.exp(w) + u
         elbo = logp_(q) + tt.sum(w) + 0.5 * l * (1 + np.log(2.0 * np.pi))
     else:
         n = r.normal(size=(n_mcsamples, u.tag.test_value.shape[0]))
-        qs = n * exp(w) + u
+        qs = n * tt.exp(w) + u
         logps, _ = theano.scan(fn=lambda q: logp_(q),
                                outputs_info=None,
                                sequences=[qs])
@@ -219,27 +224,27 @@ def _elbo_t(logp, uw, inarray, n_mcsamples, random_seed):
 
 
 def adagrad_optimizer(learning_rate, epsilon, n_win=10):
-    """Returns a function that returns parameter updates. 
+    """Returns a function that returns parameter updates.
 
     Parameter
     ---------
     learning_rate : float
-        Learning rate. 
+        Learning rate.
     epsilon : float
-        Offset to avoid zero-division in the normalizer of adagrad. 
+        Offset to avoid zero-division in the normalizer of adagrad.
     n_win : int
-        Number of past steps to calculate scales of parameter gradients. 
+        Number of past steps to calculate scales of parameter gradients.
 
     Returns
     -------
     A function (loss, param) -> updates.
 
     loss : Theano scalar
-        Loss function to be minimized (e.g., negative ELBO). 
+        Loss function to be minimized (e.g., negative ELBO).
     param : Theano tensor
-        Parameters to be optimized. 
+        Parameters to be optimized.
     updates : OrderedDict
-        Parameter updates used in Theano functions. 
+        Parameter updates used in Theano functions.
     """
     def optimizer(loss, param):
         i = theano.shared(np.array(0))
@@ -266,9 +271,9 @@ def adagrad_optimizer(learning_rate, epsilon, n_win=10):
 
 
 def sample_vp(
-        vparams, draws=1000, model=None, local_RVs=None, random_seed=20090425,
+        vparams, draws=1000, model=None, local_RVs=None, random_seed=None,
         hide_transformed=True):
-    """Draw samples from variational posterior. 
+    """Draw samples from variational posterior.
 
     Parameters
     ----------
@@ -278,17 +283,17 @@ def sample_vp(
         Number of random samples.
     model : pymc3.Model
         Probabilistic model.
-    random_seed : int
-        Seed of random number generator.
+    random_seed : int or None
+        Seed of random number generator.  None to use current seed.
     hide_transformed : bool
-        If False, transformed variables are also sampled. Default is True. 
+        If False, transformed variables are also sampled. Default is True.
 
     Returns
     -------
     trace : pymc3.backends.base.MultiTrace
         Samples drawn from the variational posterior.
     """
-    model = modelcontext(model)
+    model = pm.modelcontext(model)
 
     if isinstance(vparams, ADVIFit):
         vparams = {
@@ -303,7 +308,10 @@ def sample_vp(
     global_RVs = list(set(model.free_RVs) - set(rvs(local_RVs)))
 
     # Make dict for replacements of random variables
-    r = MRG_RandomStreams(seed=random_seed)
+    if random_seed is None:
+        r = MRG_RandomStreams(gen_random_state())
+    else:
+        r = MRG_RandomStreams(seed=random_seed)
     updates = {}
     for v in global_RVs:
         u = theano.shared(vparams['means'][str(v)]).ravel()
@@ -333,7 +341,7 @@ def sample_vp(
                    [v for v in model.unobserved_RVs]
 
     varnames = [str(var) for var in model.unobserved_RVs]
-    trace = NDArray(model=model, vars=vars_sampled)
+    trace = pm.sampling.NDArray(model=model, vars=vars_sampled)
     trace.setup(draws=draws, chain=0)
 
     for i in range(draws):


### PR DESCRIPTION
Fixes #1395:
The random seeds being set here actually have a different, also probably unexpected side effect: the default argument was always passed to the random number generator, so a call to `check_advi` without setting a random seed will always use the same random number generator. This means that calling the function once, then calling `np.random.random()` will always result in the same number, unless you pass `np.random.get_state()` to the `random_seed` argument.  This diff fixes that to only set a random seed if asked.  

Another thing to note is that the default argument here is `None` rather than `-1`, since -1 is a valid argument to `MRG_RandomStreams` (but not to `np.random.set_seed`).

Apologies for the ugly diff -- my editor removes trailing whitespace.  I can mess with undoing that to make the diff cleaner if you'd like.  
