### PR TITLE
Reverse order of tau and sd in Normal-related likelihoods

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,9 +3,11 @@
 
 We are proud and excited to release the first stable version of PyMC3, the product of more than [5 years](https://github.com/pymc-devs/pymc3/commit/85c7e06b6771c0d99cbc09cb68885cda8f7785cb) of ongoing development and contributions from over 80 individuals. PyMC3 is a Python module for Bayesian modeling which focuses on modern Bayesian computational methods, primarily gradient-based (Hamiltonian) MCMC sampling and variational inference. Models are specified in Python, which allows for great flexibility. The main technological difference in PyMC3 relative to previous versions is the reliance on Theano for the computational backend, rather than on Fortran extensions.
 
+### New features
+
 Since the beta release last year, the following improvements have been implemented:
 
-* Added `variational` submodule, which features the automatic differentiation variational inference (ADVI) fitting method. Much of this work was due to the efforts of Taku Yoshioka, and important guidance was provided by the Stan team (specifically Alp Kucukelbir and Daniel Lee).
+* Added `variational` submodule, which features the automatic differentiation variational inference (ADVI) fitting method. Also supports mini-batch ADVI for large data sets. Much of this work was due to the efforts of Taku Yoshioka, and important guidance was provided by the Stan team (specifically Alp Kucukelbir and Daniel Lee).
 
 * Added model checking utility functions, including leave-one-out (LOO) cross-validation, BPIC, WAIC, and DIC.
 
@@ -21,15 +23,29 @@ Since the beta release last year, the following improvements have been implement
 
 * Refactored test suite for better efficiency.
 
-* Added von Mises, zero-inflated negative binomial, and Lewandowski, Kurowicka and Joe (LKJ)  distributions.
+* Added von Mises, zero-inflated negative binomial, and Lewandowski, Kurowicka and Joe (LKJ) distributions.
 
 * Adopted `joblib` for managing parallel computation of chains.
 
 * Added contributor guidelines, contributor code of conduct and governance document.
 
-We on the PyMC3 core team would like to thank everyone for contributing and now feel that this is ready for the big time. We look forward to hearing about all the cool stuff you use PyMC3 for, and look forward to continued development on the package. 
+### Deprecations
 
-## Contributors
+* Argument order of tau and sd was switched for distributions of the normal family:
+- `Normal()`
+- `Lognormal()`
+- `HalfNormal()`
+
+Old: `Normal(name, mu, tau)`
+New: `Normal(name, mu, sd)` (supplying keyword arguments is unaffected).
+
+* `MvNormal` calling signature changed: 
+Old: `MvNormal(name, mu, tau)`
+New: `MvNormal(name, mu, cov)` (supplying keyword arguments is unaffected).
+
+We on the PyMC3 core team would like to thank everyone for contributing and now feel that this is ready for the big time. We look forward to hearing about all the cool stuff you use PyMC3 for, and look forward to continued development on the package.
+
+### Contributors
 
 A Kuz <for.akuz@gmail.com>
 A. Flaxman <abie@alum.mit.edu>
@@ -38,48 +54,48 @@ Alexey Goldin <alexey.goldin@gmail.com>
 Anand Patil <anand.prabhakar.patil@gmail.com>
 Andrea Zonca <code@andreazonca.com>
 Andreas Klostermann <andreasklostermann@googlemail.com>
-Andres Asensio Ramos 
+Andres Asensio Ramos
 Andrew Clegg <andrew.clegg@pearson.com>
-Anjum48 
+Anjum48
 AustinRochford <arochford@monetate.com>
 Benjamin Edwards <bedwards@cs.unm.edu>
 Boris Avdeev <borisaqua@gmail.com>
 Brian Naughton <briannaughton@gmail.com>
-Byron Smith 
+Byron Smith
 Chad Heyne <chadheyne@gmail.com>
 Chris Fonnesbeck <chris.fonnesbeck@vanderbilt.edu>
-Colin 
+Colin
 Corey Farwell <coreyf@rwell.org>
 David Huard <david.huard@gmail.com>
 David Huard <huardda@angus.meteo.mcgill.ca>
 David Stück <dstuck@users.noreply.github.com>
 DeliciousHair <mshepit@gmail.com>
-Dustin Tran 
+Dustin Tran
 Eigenblutwurst <Hannes.Bathke@gmx.net>
 Gideon Wulfsohn <gideon.wulfsohn@gmail.com>
 Gil Raphaelli <g@raphaelli.com>
 Gogs <gogitservice@gmail.com>
-Ilan Man 
+Ilan Man
 Imri Sofer <imrisofer@gmail.com>
 Jake Biesinger <jake.biesinger@gmail.com>
 James Webber <jamestwebber@gmail.com>
 John McDonnell <john.v.mcdonnell@gmail.com>
 John Salvatier <jsalvatier@gmail.com>
-Jordi Diaz 
+Jordi Diaz
 Jordi Warmenhoven <jordi.warmenhoven@gmail.com>
 Karlson Pfannschmidt <kiudee@mail.uni-paderborn.de>
 Kyle Bishop <citizenphnix@gmail.com>
 Kyle Meyer <kyle@kyleam.com>
-Lin Xiao  
+Lin Xiao
 Mack Sweeney <mackenzie.sweeney@gmail.com>
 Matthew Emmett <memmett@unc.edu>
-Maxim 
+Maxim
 Michael Gallaspy <gallaspy.michael@gmail.com>
 Nick <nalourie@example.com>
 Osvaldo Martin <aloctavodia@gmail.com>
 Patricio Benavente <patbenavente@gmail.com>
 Peadar Coyle (springcoil) <peadarcoyle@googlemail.com>
-Raymond Roberts 
+Raymond Roberts
 Rodrigo Benenson <rodrigo.benenson@gmail.com>
 Sergei Lebedev <superbobry@gmail.com>
 Skipper Seabold <chris.fonnesbeck@vanderbilt.edu>
@@ -88,8 +104,8 @@ The Gitter Badger <badger@gitter.im>
 Thomas Kluyver <takowl@gmail.com>
 Thomas Wiecki <thomas.wiecki@gmail.com>
 Tobias Knuth <mail@tobiasknuth.de>
-Volodymyr 
-Volodymyr Kazantsev 
+Volodymyr
+Volodymyr Kazantsev
 Wes McKinney <wesmckinn@gmail.com>
 Zach Ploskey <zploskey@gmail.com>
 akuz <for.akuz@gmail.com>

--- a/docs/source/notebooks/dp_mix.ipynb
+++ b/docs/source/notebooks/dp_mix.ipynb
@@ -580,8 +580,8 @@
     "\n",
     "    tau = pm.Gamma('tau', 1., 1., shape=K)\n",
     "    lambda_ = pm.Uniform('lambda', 0, 5, shape=K)\n",
-    "    mu = pm.Normal('mu', 0, lambda_ * tau, shape=K)\n",
-    "    obs = pm.Normal('obs', mu[component], lambda_[component] * tau[component],\n",
+    "    mu = pm.Normal('mu', 0, tau=lambda_ * tau, shape=K)\n",
+    "    obs = pm.Normal('obs', mu[component], tau=lambda_[component] * tau[component],\n",
     "                    observed=old_faithful_df.std_waiting.values)"
    ]
   },
@@ -1188,8 +1188,9 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },

--- a/docs/source/notebooks/pmf-pymc.ipynb
+++ b/docs/source/notebooks/pmf-pymc.ipynb
@@ -1529,8 +1529,9 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -1544,7 +1545,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/rugby_analytics.ipynb
+++ b/docs/source/notebooks/rugby_analytics.ipynb
@@ -243,10 +243,10 @@
     "model = pm.Model()\n",
     "with pm.Model() as model:\n",
     "    # global model parameters\n",
-    "    home        = pm.Normal('home',      0, .0001)\n",
+    "    home        = pm.Normal('home',      0, tau=.0001)\n",
     "    tau_att     = pm.Gamma('tau_att',   .1, .1)\n",
     "    tau_def     = pm.Gamma('tau_def',   .1, .1)\n",
-    "    intercept   = pm.Normal('intercept', 0, .0001)\n",
+    "    intercept   = pm.Normal('intercept', 0, tau=.0001)\n",
     "    \n",
     "    # team-specific model parameters\n",
     "    atts_star   = pm.Normal(\"atts_star\", \n",
@@ -464,8 +464,9 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -479,7 +480,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -20,6 +20,41 @@ from .dist_math import bound, logpow, factln
 __all__ = ['MvNormal', 'MvStudentT', 'Dirichlet',
            'Multinomial', 'Wishart', 'WishartBartlett', 'LKJCorr']
 
+def get_tau_cov(mu, tau=None, cov=None):
+    """
+    Find precision and standard deviation
+
+    .. math::
+        \Tau = \Sigma^-1
+
+    Parameters
+    ----------
+    mu : array-like
+    tau : array-like, optional
+    cov : array-like, optional
+
+    Results
+    -------
+    Returns tuple (tau, sd)
+
+    Notes
+    -----
+    If neither tau nor cov is provided, returns an identity matrix.
+    """
+    if tau is None:
+        if cov is None:
+            cov = np.eye(len(mu))
+            tau = np.eye(len(mu))
+        else:
+            tau = tt.nlinalg.matrix_inverse(cov)
+
+    else:
+        if cov is not None:
+            raise ValueError("Can't pass both tau and sd")
+        else:
+            cov = tt.nlinalg.matrix_inverse(tau)
+
+    return (tau, cov)
 
 class MvNormal(Continuous):
     R"""
@@ -41,25 +76,30 @@ class MvNormal(Continuous):
     ----------
     mu : array
         Vector of means.
-    tau : array
+    cov : array, optional
+        Covariance matrix.
+    tau : array, optional
         Precision matrix.
     """
 
-    def __init__(self, mu, tau, *args, **kwargs):
+    def __init__(self, mu, cov=None, tau=None, *args, **kwargs):
         super(MvNormal, self).__init__(*args, **kwargs)
+        warnings.warn(('The calling signature of MvNormal() has changed. The new signature is:\n'
+                       'MvNormal(name, mu, cov) instead of MvNormal(name, mu, tau).'
+                       'You do not need to explicitly invert the covariance matrix anymore.'),
+                      DeprecationWarning)
         self.mean = self.median = self.mode = self.mu = mu
-        self.tau = tau
+        self.tau, self.cov = get_tau_cov(mu, tau=tau, cov=cov)
 
     def random(self, point=None, size=None):
-        mu, tau = draw_values([self.mu, self.tau], point=point)
+        mu, cov = draw_values([self.mu, self.cov], point=point)
 
         def _random(mean, cov, size=None):
-            # FIXME: cov here is actually precision?
             return stats.multivariate_normal.rvs(
                 mean, cov, None if size == mean.shape else size)
 
         samples = generate_samples(_random,
-                                   mean=mu, cov=tau,
+                                   mean=mu, cov=cov,
                                    dist_shape=self.shape,
                                    broadcast_shape=mu.shape,
                                    size=size)
@@ -352,9 +392,9 @@ class Wishart(Continuous):
         warnings.warn('The Wishart distribution can currently not be used '
                       'for MCMC sampling. The probability of sampling a '
                       'symmetric matrix is basically zero. Instead, please '
-                      'use the LKJCorr prior. For more information on the '
-                      'issues surrounding the Wishart see here: '
-                      'https://github.com/pymc-devs/pymc3/issues/538.',
+                      'use WishartBartlett or better yet, LKJCorr.'
+                      'For more information on the issues surrounding the '
+                      'Wishart see here: https://github.com/pymc-devs/pymc3/issues/538.',
                       UserWarning)
         self.n = n
         self.p = p = V.shape[0]

--- a/pymc3/examples/LKJ_correlation.py
+++ b/pymc3/examples/LKJ_correlation.py
@@ -34,7 +34,7 @@ tri_index[np.triu_indices(n_var, k=1)[::-1]] = np.arange(n_elem)
 
 with Model() as model:
 
-    mu = Normal('mu', mu=0, tau=1 ** -2, shape=n_var)
+    mu = Normal('mu', mu=0, sd=1, shape=n_var)
 
     # We can specify separate priors for sigma and the correlation matrix:
     sigma = Uniform('sigma', shape=n_var)
@@ -44,7 +44,7 @@ with Model() as model:
 
     cov_matrix = tt.diag(sigma).dot(corr_matrix.dot(tt.diag(sigma)))
 
-    like = MvNormal('likelihood', mu=mu, tau=inv(cov_matrix), observed=dataset)
+    like = MvNormal('likelihood', mu=mu, cov=cov_matrix, observed=dataset)
 
 
 def run(n=1000):

--- a/pymc3/examples/gelman_bioassay.py
+++ b/pymc3/examples/gelman_bioassay.py
@@ -9,8 +9,8 @@ dose = array([-.86, -.3, -.05, .73])
 with Model() as model:
 
     # Logit-linear model parameters
-    alpha = Normal('alpha', 0, 0.01)
-    beta = Normal('beta', 0, 0.01)
+    alpha = Normal('alpha', 0, tau=0.01)
+    beta = Normal('beta', 0, tau=0.01)
 
     # Calculate probabilities of death
     theta = Deterministic('theta', invlogit(alpha + beta * dose))

--- a/pymc3/examples/lasso_missing.py
+++ b/pymc3/examples/lasso_missing.py
@@ -36,7 +36,7 @@ with Model() as model:
                       beta[4] * age + beta[5] * mother_imp + beta[6] * early_ident)
 
     observed_score = Normal(
-        'observed_score', expected_score, s ** -2, observed=score)
+        'observed_score', expected_score, s, observed=score)
 
 
 with model:

--- a/pymc3/tests/models.py
+++ b/pymc3/tests/models.py
@@ -9,7 +9,7 @@ def simple_model():
     mu = -2.1
     tau = 1.3
     with Model() as model:
-        Normal('x', mu, tau, shape=2, testval=[.1] * 2)
+        Normal('x', mu, tau=tau, shape=2, testval=[.1] * 2)
 
     return model.test_point, model, (mu, tau ** -1)
 
@@ -18,7 +18,7 @@ def multidimensional_model():
     mu = -2.1
     tau = 1.3
     with Model() as model:
-        Normal('x', mu, tau, shape=(3, 2), testval=.1 * np.ones((3, 2)))
+        Normal('x', mu, tau=tau, shape=(3, 2), testval=.1 * np.ones((3, 2)))
 
     return model.test_point, model, (mu, tau ** -1)
 
@@ -34,7 +34,7 @@ def simple_2model():
     tau = 1.3
     p = .4
     with Model() as model:
-        x = pm.Normal('x', mu, tau, testval=.1)
+        x = pm.Normal('x', mu, tau=tau, testval=.1)
         pm.Deterministic('logx', log(x))
         pm.Bernoulli('y', p)
     return model.test_point, model
@@ -48,7 +48,8 @@ def mv_simple():
         [1., -0.05, 5.5]])
     tau = np.dot(p, p.T)
     with pm.Model() as model:
-        pm.MvNormal('x', pm.constant(mu), pm.constant(tau), shape=3, testval=np.array([.1, 1., .8]))
+        pm.MvNormal('x', pm.constant(mu), tau=pm.constant(tau),
+                    shape=3, testval=np.array([.1, 1., .8]))
     H = tau
     C = np.linalg.inv(H)
     return model.test_point, model, (mu, C)

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -13,7 +13,7 @@ from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Di
                              Geometric, Exponential, ExGaussian, Normal, Flat, LKJCorr, Wald,
                              ChiSquared, HalfNormal, DiscreteUniform, Bound, Uniform,
                              Binomial, Wishart, SkewNormal)
-from ..distributions import continuous
+from ..distributions import continuous, multivariate
 from numpy import array, inf, log, exp
 from numpy.testing import assert_almost_equal
 import numpy.random as nr
@@ -495,6 +495,10 @@ class TestMatchesScipy(SeededTest):
         self.pymc3_matches_scipy(MvNormal, Vector(R, n),
                                  {'mu': Vector(R, n), 'tau': PdMatrix(n)}, normal_logpdf)
 
+    def check_mvnormal_cov(self, n):
+        self.pymc3_matches_scipy(MvNormal, Vector(R, n),
+                                 {'mu': Vector(R, n), 'cov': PdMatrix(n)}, normal_logpdf)
+
     def test_mvt(self):
         for n in [1, 2]:
             yield self.check_mvt, n
@@ -582,6 +586,21 @@ class TestMatchesScipy(SeededTest):
     def test_get_tau_sd(self):
         sd = np.array([2])
         assert_almost_equal(continuous.get_tau_sd(sd=sd), [1. / sd**2, sd])
+
+    def test_get_tau_cov(self):
+        cov = np.random.randn(3, 3)
+        cov = np.dot(cov, cov.T)
+        mu = np.ones(3)
+        tau, cov = multivariate.get_tau_cov(mu, cov=cov)
+        assert_almost_equal(tau.eval(),
+                            np.linalg.inv(cov)
+        )
+
+        tau, cov = multivariate.get_tau_cov(mu)
+        assert_almost_equal(cov,
+                            np.eye(3)
+        )
+
 
     def test_ex_gaussian(self):
         # Log probabilities calculated using the dexGAUS function from the R package gamlss.

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -257,7 +257,7 @@ class ScalarShape(SeededTest):
 
     def test_normal(self):
         self.check(Normal, mu=0., tau=1.)
-        
+
     def test_skew_normal(self):
         self.check(SkewNormal, mu=0., sd=1., alpha=5.)
 
@@ -362,7 +362,7 @@ class Parameters1dShape(SeededTest):
 
     def test_normal(self):
         self.check(Normal, mu=self.zeros, tau=self.ones)
-        
+
     def test_skew_normal(self):
         self.check(SkewNormal, mu=self.zeros, sd=self.ones, alpha=self.ones * 5)
 
@@ -481,7 +481,7 @@ class BroadcastShape(SeededTest):
 
     def test_normal(self):
         self.check(Normal, mu=self.zeros, tau=self.ones)
-        
+
     def test_skew_normal(self):
         self.check(SkewNormal, mu=self.zeros, sd=self.ones, alpha=self.ones * 5)
 
@@ -766,10 +766,10 @@ class ScalarParameterSamples(SeededTest):
         pymc3_random_discrete(ConstantDist, {'c': I}, ref_rand=ref_rand)
 
     def test_mv_normal(self):
-        def ref_rand(size, mu, tau):
-            return st.multivariate_normal.rvs(mean=mu, cov=tau, size=size)
+        def ref_rand(size, mu, cov):
+            return st.multivariate_normal.rvs(mean=mu, cov=cov, size=size)
         for n in [2, 3]:
-            pymc3_random(MvNormal, {'mu': Vector(R, n), 'tau': PdMatrix(n)},
+            pymc3_random(MvNormal, {'mu': Vector(R, n), 'cov': PdMatrix(n)},
                          size=100, valuedomain=Vector(R, n), ref_rand=ref_rand)
 
     def test_mv_t(self):


### PR DESCRIPTION
Argument order of tau and sd was switched for distributions of the normal family:
- `Normal()`
- `Lognormal()`
- `HalfNormal()`

Old: `Normal(name, mu, tau)` 
New: `Normal(name, mu, sd)` (supplying keyword arguments is unaffected).

`MvNormal` calling signature also changed: 
Old: `MvNormal(name, mu, tau)` 
New: `MvNormal(name, mu, cov)` (supplying keyword arguments is unaffected).

Addresses https://github.com/pymc-devs/pymc3/issues/1385.
