### PR TITLE
Refactor shape tests into parent class

### DIFF
--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -1,6 +1,3 @@
-import shutil
-import tempfile
-
 import matplotlib
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Removes four test cases from `test_distributions_random` in favor of a single test class that a distribution inherits from.  Creating a subclass of `unittest.TestCase` that contains test cases [is ugly](http://stackoverflow.com/questions/1323455/python-unit-test-with-base-and-sub-class), and I chose my favorite of the two options.  Seems reasonably easy to swap over if there are strong feelings.  

This takes care of one TODO, and it seems reasonable that `ScalarParameterSamples` could also be removed so that each distribution is in its own tidy test case.

The only change in test coverage should be fewer lines covered because this file is shorter, but I believe the functionality is the exact same.
