### PR TITLE
Clean up imports in math.py

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -2,7 +2,7 @@ __version__ = "3.0.rc1"
 
 from .blocking import *
 from .distributions import *
-from .math import *
+from .math import logsumexp, logit, invlogit
 from .model import *
 from .stats import *
 from .sampling import *

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -1,15 +1,13 @@
 from __future__ import division
-from theano.tensor import constant, flatten, zeros_like, ones_like, stack, concatenate, sum, prod, lt, gt, le, ge, eq, \
-    neq, switch, clip, where, and_, or_, abs_
-from theano.tensor import exp, log, cos, sin, tan, cosh, sinh, \
-    tanh, sqr, sqrt, erf, erfinv, dot
-from theano.tensor import maximum, minimum, sgn, ceil, floor
-from theano.tensor.nlinalg import det, matrix_inverse, \
-    extract_diag, matrix_dot, trace
-from theano.tensor.nnet import sigmoid
+import sys
 import theano
 import theano.tensor as tt
-import sys
+from theano.tensor import (constant, flatten, zeros_like, ones_like, stack, concatenate, sum, prod,
+                           lt, gt, le, ge, eq, neq, switch, clip, where, and_, or_, abs_, exp, log,
+                           cos, sin, tan, cosh, sinh, tanh, sqr, sqrt, erf, erfinv, dot, maximum,
+                           minimum, sgn, ceil, floor)
+from theano.tensor.nlinalg import det, matrix_inverse, extract_diag, matrix_dot, trace
+from theano.tensor.nnet import sigmoid
 
 
 def logsumexp(x, axis=None):

--- a/pymc3/tests/models.py
+++ b/pymc3/tests/models.py
@@ -2,7 +2,7 @@ from pymc3 import Model, Normal, Metropolis
 import numpy as np
 import pymc3 as pm
 from itertools import product
-from theano.tensor import log
+import theano.tensor as tt
 
 
 def simple_model():
@@ -35,7 +35,7 @@ def simple_2model():
     p = .4
     with Model() as model:
         x = pm.Normal('x', mu, tau=tau, testval=.1)
-        pm.Deterministic('logx', log(x))
+        pm.Deterministic('logx', tt.log(x))
         pm.Bernoulli('y', p)
     return model.test_point, model
 
@@ -48,7 +48,7 @@ def mv_simple():
         [1., -0.05, 5.5]])
     tau = np.dot(p, p.T)
     with pm.Model() as model:
-        pm.MvNormal('x', pm.constant(mu), tau=pm.constant(tau),
+        pm.MvNormal('x', tt.constant(mu), tau=tt.constant(tau),
                     shape=3, testval=np.array([.1, 1., .8]))
     H = tau
     C = np.linalg.inv(H)
@@ -60,7 +60,7 @@ def mv_simple_discrete():
     n = 5
     p = np.array([.15, .85])
     with pm.Model() as model:
-        pm.Multinomial('x', n, pm.constant(p), shape=d, testval=np.array([1, 4]))
+        pm.Multinomial('x', n, tt.constant(p), shape=d, testval=np.array([1, 4]))
         mu = n * p
         # covariance matrix
         C = np.zeros((d, d))

--- a/pymc3/tests/test_advi.py
+++ b/pymc3/tests/test_advi.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pymc3 as pm
-from pymc3 import Model, Normal, DiscreteUniform, Poisson, switch, Exponential
+from pymc3 import Model, Normal, DiscreteUniform, Poisson, Exponential
 from pymc3.theanof import inputvars
 from pymc3.variational import advi, advi_minibatch, sample_vp
 from pymc3.variational.advi import _calc_elbo, adagrad_optimizer
@@ -66,7 +66,7 @@ class TestADVI(SeededTest):
             late_rate = Exponential('late_rate', 1)
 
             # Allocate appropriate Poisson rates to years before and after current
-            rate = switch(switchpoint >= self.year, early_rate, late_rate)
+            rate = tt.switch(switchpoint >= self.year, early_rate, late_rate)
             Poisson('disasters', rate, observed=self.disaster_data)
 
             # This should raise ValueError
@@ -90,7 +90,7 @@ class TestADVI(SeededTest):
             late_rate = Exponential('late_rate', 1)
 
             # Allocate appropriate Poisson rates to years before and after current
-            rate = switch(switchpoint >= self.year, early_rate, late_rate)
+            rate = tt.switch(switchpoint >= self.year, early_rate, late_rate)
             disasters = Poisson('disasters', rate, observed=disaster_data_t)
 
             with self.assertRaises(ValueError):

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -41,7 +41,7 @@ class ARM5_4(SeededTest):
 
         with pm.Model() as model:
             effects = pm.Normal('effects', mu=0, tau=100. ** -2, shape=len(P.columns))
-            p = pm.sigmoid(pm.dot(np.array(P), effects))
+            p = tt.nnet.sigmoid(tt.dot(np.array(P), effects))
             pm.Bernoulli('s', p, observed=np.array(data.switch))
         return model
 
@@ -154,7 +154,7 @@ def build_disaster_model(masked=False):
         # Allocate appropriate Poisson rates to years before and after current
         # switchpoint location
         idx = np.arange(years)
-        rate = pm.switch(switchpoint >= idx, early_mean, late_mean)
+        rate = tt.switch(switchpoint >= idx, early_mean, late_mean)
         # Data likelihood
         pm.Poisson('disasters', rate, observed=disasters_data)
     return model


### PR DESCRIPTION
Seems like this was unintended behavior:

```
In [1]: from pymc3 import *
In [2]: sum([1,2,3])
Out[2]: Sum{acc_dtype=int64}.0
```

This removes those imports, which weren't used anywhere else in the library (except a few tests).  
