### PR TITLE
Sampling output check

### DIFF
--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -136,6 +136,6 @@ class TestSampleEstimates(unittest.TestCase):
             trace = sample(1000)
             
         
-        assert np.isclose(np.median(trace.beta, 0), beta_true, rtol=0.1)
+        assert np.isclose(np.median(trace.beta, 0), beta_true, rtol=0.1).all()
         assert np.isclose(np.median(trace.alpha), alpha_true, rtol=0.1)
         assert np.isclose(np.median(trace.sigma), sigma_true, rtol=0.1)

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -2,6 +2,7 @@ import unittest
 
 from .checks import close_to
 from .models import mv_simple, mv_simple_discrete, simple_2model
+from .helpers import SeededTest
 from pymc3.sampling import assign_step_methods, sample
 from pymc3.model import Model
 from pymc3.step_methods import (NUTS, BinaryGibbsMetropolis, Metropolis, Constant, Slice,
@@ -114,7 +115,7 @@ class TestAssignStepMethods(unittest.TestCase):
             steps = assign_step_methods(model, [])
         self.assertIsInstance(steps, Metropolis)
 
-class TestSampleEstimates(unittest.TestCase):
+class TestSampleEstimates(SeededTest):
     def test_parameter_estimate(self):
         
         alpha_true, sigma_true = 1, 0.5

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -125,17 +125,19 @@ class TestSampleEstimates(unittest.TestCase):
         X1 = np.random.randn(size)
         X2 = np.random.randn(size) * 0.2
         Y = alpha_true + beta_true[0] * X1 + beta_true[1] * X2 + np.random.randn(size) * sigma_true
+        
+        with step_method in (NUTS(), Metropolis(), Slice()):
 
-        with Model() as model:
-            alpha = Normal('alpha', mu=0, sd=10)
-            beta = Normal('beta', mu=0, sd=10, shape=2)
-            sigma = Uniform('sigma', lower=0.0, upper=1.0)
-            mu = alpha + beta[0]*X1 + beta[1]*X2
-            Y_obs = Normal('Y_obs', mu=mu, sd=sigma, observed=Y)
+            with Model() as model:
+                alpha = Normal('alpha', mu=0, sd=10)
+                beta = Normal('beta', mu=0, sd=10, shape=2)
+                sigma = Uniform('sigma', lower=0.0, upper=1.0)
+                mu = alpha + beta[0]*X1 + beta[1]*X2
+                Y_obs = Normal('Y_obs', mu=mu, sd=sigma, observed=Y)
             
-            trace = sample(1000)
+                trace = sample(1000, step=step_method)
             
         
-        assert np.isclose(np.median(trace.beta, 0), beta_true, rtol=0.1).all()
-        assert np.isclose(np.median(trace.alpha), alpha_true, rtol=0.1)
-        assert np.isclose(np.median(trace.sigma), sigma_true, rtol=0.1)
+            assert np.isclose(np.median(trace.beta, 0), beta_true, rtol=0.1).all()
+            assert np.isclose(np.median(trace.alpha), alpha_true, rtol=0.1)
+            assert np.isclose(np.median(trace.sigma), sigma_true, rtol=0.1)

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -117,14 +117,14 @@ class TestAssignStepMethods(unittest.TestCase):
 class TestSampleEstimates(unittest.TestCase):
     def test_parameter_estimate(self):
         
-        alpha, sigma = 1, 0.5
-        beta = [1, 2.5]
+        alpha_true, sigma_true = 1, 0.5
+        beta_true = np.array([1, 2.5])
 
         size = 100
 
         X1 = np.random.randn(size)
         X2 = np.random.randn(size) * 0.2
-        Y = alpha + beta[0] * X1 + beta[1] * X2 + np.random.randn(size) * sigma
+        Y = alpha_true + beta_true[0] * X1 + beta_true[1] * X2 + np.random.randn(size) * sigma_true
 
         with Model() as model:
             alpha = Normal('alpha', mu=0, sd=10)
@@ -136,6 +136,6 @@ class TestSampleEstimates(unittest.TestCase):
             trace = sample(1000)
             
         
-        assert np.isclose(np.median(trace.beta, 0), beta, rtol=0.1)
-        assert np.isclose(np.median(trace.alpha), alpha, rtol=0.1)
-        assert np.isclose(np.median(trace.sigma), sigma, rtol=0.1)
+        assert np.isclose(np.median(trace.beta, 0), beta_true, rtol=0.1)
+        assert np.isclose(np.median(trace.alpha), alpha_true, rtol=0.1)
+        assert np.isclose(np.median(trace.sigma), sigma_true, rtol=0.1)

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -127,18 +127,21 @@ class TestSampleEstimates(SeededTest):
         X2 = np.random.randn(size) * 0.2
         Y = alpha_true + beta_true[0] * X1 + beta_true[1] * X2 + np.random.randn(size) * sigma_true
         
-        for step_method in (NUTS(), Metropolis(), Slice()):
-
-            with Model() as model:
-                alpha = Normal('alpha', mu=0, sd=10)
-                beta = Normal('beta', mu=0, sd=10, shape=2)
-                sigma = Uniform('sigma', lower=0.0, upper=1.0)
-                mu = alpha + beta[0]*X1 + beta[1]*X2
-                Y_obs = Normal('Y_obs', mu=mu, sd=sigma, observed=Y)
+        with Model() as model:
+            alpha = Normal('alpha', mu=0, sd=10)
+            beta = Normal('beta', mu=0, sd=10, shape=2)
+            sigma = Uniform('sigma', lower=0.0, upper=1.0)
+            mu = alpha + beta[0]*X1 + beta[1]*X2
+            Y_obs = Normal('Y_obs', mu=mu, sd=sigma, observed=Y)
+        
+            for step_method in (NUTS(), Metropolis(), 
+                            [Slice([alpha, sigma]), Metropolis([beta])]):
             
-                trace = sample(1000, step=step_method)
+                trace = sample(1000, step=step_method, start={'alpha':0,
+                                                            'beta':np.zeros(2),
+                                                            'sigma':0.5})
             
         
-            assert np.isclose(np.median(trace.beta, 0), beta_true, rtol=0.1).all()
-            assert np.isclose(np.median(trace.alpha), alpha_true, rtol=0.1)
-            assert np.isclose(np.median(trace.sigma), sigma_true, rtol=0.1)
+                assert np.isclose(np.median(trace.beta, 0), beta_true, rtol=0.1).all()
+                assert np.isclose(np.median(trace.alpha), alpha_true, rtol=0.1)
+                assert np.isclose(np.median(trace.sigma), sigma_true, rtol=0.1)

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -37,7 +37,8 @@ class TestStepMethods(object):  # yield test doesn't work subclassing unittest.T
                     HamiltonianMC(scaling=C, is_cov=True, blocked=False)]),
             )
         for step in steps:
-            trace = sample(8000, step=step, start=start, model=model, random_seed=1)
+            trace = sample(8000, step=step, start=start, model=model, 
+                    random_seed=1, progressbar=False)
             yield self.check_stat, check, trace
 
     def test_step_discrete(self):
@@ -50,14 +51,15 @@ class TestStepMethods(object):  # yield test doesn't work subclassing unittest.T
                 Metropolis(S=C, proposal_dist=MultivariateNormalProposal),
             )
         for step in steps:
-            trace = sample(20000, step=step, start=start, model=model, random_seed=1)
+            trace = sample(20000, step=step, start=start, model=model, 
+                    random_seed=1, progressbar=False)
             self.check_stat(check, trace)
 
     def test_constant_step(self):
         with Model():
             x = Normal('x', 0, 1)
             start = {'x': -1}
-            tr = sample(10, step=Constant([x]), start=start)
+            tr = sample(10, step=Constant([x]), start=start, progressbar=False)
         assert_almost_equal(tr['x'], start['x'], decimal=10)
 
 
@@ -102,12 +104,6 @@ class TestAssignStepMethods(unittest.TestCase):
             steps = assign_step_methods(model, [])
         self.assertIsInstance(steps, BinaryGibbsMetropolis)
 
-    # with Model() as model:
-    #     x = Categorical('x', np.array([0.25, 0.70, 0.05]))
-    #     steps = assign_step_methods(model, [])
-    #
-    #     assert isinstance(steps, ElemwiseCategoricalStep)
-
     def test_binomial(self):
         """Test binomial distribution is assigned metropolis method."""
         with Model() as model:
@@ -137,9 +133,7 @@ class TestSampleEstimates(SeededTest):
             for step_method in (NUTS(), Metropolis(), 
                             [Slice([alpha, sigma]), Metropolis([beta])]):
             
-                trace = sample(1000, step=step_method, start={'alpha':0,
-                                                            'beta':np.zeros(2),
-                                                            'sigma':0.5})
+                trace = sample(1000, step=step_method, progressbar=False)
             
         
                 assert np.isclose(np.median(trace.beta, 0), beta_true, rtol=0.1).all()

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -126,7 +126,7 @@ class TestSampleEstimates(unittest.TestCase):
         X2 = np.random.randn(size) * 0.2
         Y = alpha_true + beta_true[0] * X1 + beta_true[1] * X2 + np.random.randn(size) * sigma_true
         
-        with step_method in (NUTS(), Metropolis(), Slice()):
+        for step_method in (NUTS(), Metropolis(), Slice()):
 
             with Model() as model:
                 alpha = Normal('alpha', mu=0, sd=10)


### PR DESCRIPTION
I added a quick test in response to #1421 that uses the model in that issue report as a coarse check for sampling failures. It won't catch everything, but will hopefully help us detect the obvious stuff. Currently checks Metropolis, Slice and NUTS (as these were appropriate for this example). Can expand to other samples with the appropriate model.
