### PR TITLE
WIP robust interval transforms

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -217,10 +217,9 @@ class Normal(Continuous):
 
     def logp(self, value):
         tau = self.tau
-        sd = self.sd
         mu = self.mu
         return bound((-tau * (value - mu)**2 + tt.log(tau / np.pi / 2.)) / 2.,
-                     tau > 0, sd > 0)
+                     tau > 0)
 
 
 class HalfNormal(PositiveContinuous):

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -109,18 +109,19 @@ class Interval(ElemwiseTransform):
 
     name = "interval"
 
-    def __init__(self, a, b):
+    def __init__(self, a, b, eps=1e-6):
         self.a = a
         self.b = b
+        self.eps = eps
 
     def backward(self, x):
         a, b = self.a, self.b
-        r = (b - a) * tt.exp(x) / (1 + tt.exp(x)) + a
+        r = (b - a) / (1 + tt.exp(-x)) + a
         return r
 
     def forward(self, x):
-        a, b = self.a, self.b
-        r = tt.log((x - a) / (b - x))
+        a, b, e = self.a, self.b, self.eps
+        r = tt.log(tt.maximum((x - a) / tt.maximum(b - x, e), e))
         return r
 
 interval = Interval

--- a/pymc3/tuning/scaling.py
+++ b/pymc3/tuning/scaling.py
@@ -126,7 +126,7 @@ def adjust_scaling(s):
 def adjust_precision(tau):
     mag = sqrt(abs(tau))
 
-    bounded = bound(log(mag), log(1e-10), log(1e10))
+    bounded = bound(log(mag), log(0.1), log(10))
     return exp(bounded)**2
 
 


### PR DESCRIPTION
Currently the interval transformation does not properly transform the endpoints, making them `inf` and `-inf`. Also, `adjust_precision` has been modified to choose less extreme values if any Hessian elements are very large or small.

Closes #1428 
