### PR TITLE
WIP Implement ZeroInflatedPoisson as a subclass of Mixture

### DIFF
--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -171,7 +171,7 @@ class NormalMixture(Mixture):
                                             *args, **kwargs)
 
 
-class Zero(pm.Discrete):
+class Zero(Discrete):
     def __init__(self, *args, **kwargs):
         super(Zero, self).__init__(*args, **kwargs)
         
@@ -186,9 +186,9 @@ class Zero(pm.Discrete):
                                 size=size).astype(self.dtype)
 
 
-class ZeroInflatedPoisson(pm.Mixture):
+class ZeroInflatedPoisson(Mixture):
     def __init__(self, theta, psi, *args, **kwargs):
         w = tt.stack([psi, 1 - psi])
-        comp_dists = [Zero.dist(), pm.Poisson.dist(theta)]
+        comp_dists = [Zero.dist(), Poisson.dist(theta)]
 
         super(ZeroInflatedPoisson, self).__init__(w, comp_dists, *args, **kwargs)

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -6,6 +6,8 @@ from .dist_math import bound
 from .distribution import Discrete, Distribution, draw_values, generate_samples
 from .continuous import get_tau_sd, Normal
 
+__all__ = ['Mixture', 'NormalMixture']
+
 
 def all_discrete(comp_dists):
     """
@@ -167,3 +169,26 @@ class NormalMixture(Mixture):
         
         super(NormalMixture, self).__init__(w, Normal.dist(mu, sd=sd),
                                             *args, **kwargs)
+
+
+class Zero(pm.Discrete):
+    def __init__(self, *args, **kwargs):
+        super(Zero, self).__init__(*args, **kwargs)
+        
+    def logp(self, value):
+        return tt.switch(tt.eq(value, 0), 0., -np.inf)
+
+    def random(self, point=None, size=None, repeat=None):
+        def _random(dtype=self.dtype, size=None):
+            return np.full(size, fill_value=0, dtype=dtype)
+
+        return generate_samples(_random, dist_shape=self.shape,
+                                size=size).astype(self.dtype)
+
+
+class ZeroInflatedPoisson(pm.Mixture):
+    def __init__(self, theta, psi, *args, **kwargs):
+        w = tt.stack([psi, 1 - psi])
+        comp_dists = [Zero.dist(), pm.Poisson.dist(theta)]
+
+        super(ZeroInflatedPoisson, self).__init__(w, comp_dists, *args, **kwargs)


### PR DESCRIPTION
Putting this up for feedback, as it is not quite as straightforward as I would have liked.

Due to #1449 and its fix #1452, we can't use `ConstantDist` for the zero component, since it no longer broadcasts the way we need it to in this instance.

More specifically, since #1452, if any of the elements of `pm.ConstantDist.dist(0).logp(value)` are non-zero, the result will be `-np.inf`.  The `Zero` hack included below restores the pre-#1452 broadcasting behavior by bypassing `bound` and using `tt.switch` directly.  Using this hack, `pm.Zero.dist().logp(value)` will be an array whose entries are zero when the corresponding entry in `value` is zero and `-np.inf` when the corresponding entry in `value` is non-zero.  The use of `logsumexp` in `Mixture` will gracefully handle these `-np.inf`s, as desired.

My question for other is if we want to use this `Zero` hack to implement `ZeroInflated`\* distributions as subclasses of `Mixture` or leave them as-is.  Obviously we do not need to export `Zero` to the global namespace.

If we decide to go forward with this approach, I will port `ZeroInflatedNegativeBinomial` as well and fix any test that this might break.
