### PR TITLE
Replaced multinomial probability bounds test in logp

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -305,13 +305,13 @@ class Multinomial(Discrete):
         else:
             x_sum = x
             n_sum = n
-
         return bound(
             factln(n_sum) + tt.sum(x_sum * tt.log(p) - factln(x_sum)),
             tt.all(x >= 0),
             tt.all(x <= n),
             tt.eq(tt.sum(x_sum), n_sum),
-            tt.isclose(p.sum(), 1),
+            tt.all(p <= 1),
+            tt.eq(p.sum(), 1),
             n >= 0)
 
 


### PR DESCRIPTION
The `isclose` condition caused `nan` gradient values for at least one model. This alternative seems to work.

Closes #1435 
