### PR TITLE
Added warnings for non-positive support in positive parameters

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -38,8 +38,10 @@ class UnitContinuous(Continuous):
         super(UnitContinuous, self).__init__(
             transform=transform, *args, **kwargs)
 
-def assert_nonpos_support(var, label):
+def assert_nonpos_support(var, label, distname):
     # Checks for evidence of positive support for a variable
+    if var is None:
+        return
     try:
         # Transformed distribution
         support = np.isfinite(var.transformed.distribution.dist.logp(0).tag.test_value)
@@ -52,8 +54,9 @@ def assert_nonpos_support(var, label):
             support = False
                         
     if np.any(support):
-        warnings.warn(('The variable specified for {} has non-positive support,'.format(label),
-                        'likely making it unsuitable for this parameter.'))
+        msg = "The variable specified for {0} has non-positive support for {1}, ".format(label, distname)
+        msg += "likely making it unsuitable for this parameter."
+        warnings.warn(msg)
     
 
 def get_tau_sd(tau=None, sd=None):
@@ -223,7 +226,8 @@ class Normal(Continuous):
         self.tau, self.sd = get_tau_sd(tau=tau, sd=sd)
         self.variance = 1. / self.tau
         
-        assert_nonpos_support(self.tau, 'tau (sd)')
+        assert_nonpos_support(sd, 'sd', 'Normal')
+        assert_nonpos_support(tau, 'tau', 'Normal')
 
         super(Normal, self).__init__(**kwargs)
 
@@ -272,7 +276,8 @@ class HalfNormal(PositiveContinuous):
         self.mean = tt.sqrt(2 / (np.pi * self.tau))
         self.variance = (1. - 2 / np.pi) / self.tau
         
-        assert_nonpos_support(self.tau, 'tau (sd)')
+        assert_nonpos_support(tau, 'tau', 'HalfNormal')
+        assert_nonpos_support(sd, 'sd', 'HalfNormal')
 
     def random(self, point=None, size=None, repeat=None):
         sd = draw_values([self.sd], point=point)
@@ -353,7 +358,9 @@ class Wald(PositiveContinuous):
                                - 1.5 * self.mu / self.lam) + alpha
         self.variance = (self.mu**3) / self.lam
         
-        assert_nonpos_support(self.phi, 'phi (or mu, lam)')
+        assert_nonpos_support(phi, 'phi', 'Wald')
+        assert_nonpos_support(mu, 'mu', 'Wald')
+        assert_nonpos_support(lam, 'lam', 'Wald')
 
     def get_mu_lam_phi(self, mu, lam, phi):
         if mu is None:
@@ -457,8 +464,8 @@ class Beta(UnitContinuous):
         self.variance = alpha * beta / (
             (alpha + beta)**2 * (alpha + beta + 1))
             
-        assert_nonpos_support(self.alpha, 'alpha')
-        assert_nonpos_support(self.beta, 'beta')
+        assert_nonpos_support(alpha, 'alpha', 'Beta')
+        assert_nonpos_support(beta, 'beta', 'Beta')
 
     def get_alpha_beta(self, alpha=None, beta=None, mu=None, sd=None):
         if (alpha is not None) and (beta is not None):
@@ -519,7 +526,7 @@ class Exponential(PositiveContinuous):
 
         self.variance = lam**-2
         
-        assert_nonpos_support(self.lam, 'lam')
+        assert_nonpos_support(lam, 'lam', 'Exponential')
 
     def random(self, point=None, size=None, repeat=None):
         lam = draw_values([self.lam], point=point)
@@ -562,7 +569,7 @@ class Laplace(Continuous):
 
         self.variance = 2 * b**2
         
-        assert_nonpos_support(self.b, 'b')
+        assert_nonpos_support(b, 'b', 'Laplace')
 
     def random(self, point=None, size=None, repeat=None):
         mu, b = draw_values([self.mu, self.b], point=point)
@@ -617,7 +624,8 @@ class Lognormal(PositiveContinuous):
         self.mode = tt.exp(mu - 1. / self.tau)
         self.variance = (tt.exp(1. / self.tau) - 1) * tt.exp(2 * mu + 1. / self.tau)
         
-        assert_nonpos_support(self.tau, 'tau (sd)')
+        assert_nonpos_support(tau, 'tau', 'Lognormal')
+        assert_nonpos_support(sd, 'sd', 'Lognormal')
 
     def _random(self, mu, tau, size=None):
         samples = np.random.normal(size=size)
@@ -677,8 +685,8 @@ class StudentT(Continuous):
                                   (1 / self.lam) * (nu / (nu - 2)),
                                   np.inf)
                                   
-        assert_nonpos_support(self.lam, 'lam (sd)')
-        assert_nonpos_support(self.nu, 'nu')
+        assert_nonpos_support(lam, 'lam (sd)', 'StudentT')
+        assert_nonpos_support(nu, 'nu', 'StudentT')
 
     def random(self, point=None, size=None, repeat=None):
         nu, mu, lam = draw_values([self.nu, self.mu, self.lam],
@@ -738,8 +746,8 @@ class Pareto(PositiveContinuous):
             (alpha * m**2) / ((alpha - 2.) * (alpha - 1.)**2),
             np.inf)
             
-        assert_nonpos_support(self.alpha, 'alpha')
-        assert_nonpos_support(self.m, 'm')
+        assert_nonpos_support(alpha, 'alpha', 'Pareto')
+        assert_nonpos_support(m, 'm', 'Pareto')
         
 
     def _random(self, alpha, m, size=None):
@@ -792,7 +800,7 @@ class Cauchy(Continuous):
         self.median = self.mode = self.alpha = alpha
         self.beta = beta
         
-        assert_nonpos_support(self.beta, 'beta')
+        assert_nonpos_support(beta, 'beta', 'Cauchy')
 
     def _random(self, alpha, beta, size=None):
         u = np.random.uniform(size=size)
@@ -840,7 +848,7 @@ class HalfCauchy(PositiveContinuous):
         self.median = beta
         self.beta = beta
         
-        assert_nonpos_support(self.beta, 'beta')
+        assert_nonpos_support(beta, 'beta', 'HalfCauchy')
 
     def _random(self, beta, size=None):
         u = np.random.uniform(size=size)
@@ -908,8 +916,8 @@ class Gamma(PositiveContinuous):
         self.mode = tt.maximum((alpha - 1) / beta, 0)
         self.variance = alpha / beta**2
         
-        assert_nonpos_support(self.alpha, 'alpha')
-        assert_nonpos_support(self.beta, 'beta')
+        assert_nonpos_support(alpha, 'alpha', 'Gamma')
+        assert_nonpos_support(beta, 'beta', 'Gamma')
 
     def get_alpha_beta(self, alpha=None, beta=None, mu=None, sd=None):
         if (alpha is not None) and (beta is not None):
@@ -977,8 +985,8 @@ class InverseGamma(PositiveContinuous):
         self.variance = tt.switch(tt.gt(alpha, 2),
                                   (beta**2) / (alpha * (alpha - 1.)**2),
                                   np.inf)
-        assert_nonpos_support(self.alpha, 'alpha')
-        assert_nonpos_support(self.beta, 'beta')
+        assert_nonpos_support(alpha, 'alpha', 'InverseGamma')
+        assert_nonpos_support(beta, 'beta', 'InverseGamma')
 
     def _calculate_mean(self):
         m = self.beta / (self.alpha - 1.)
@@ -1062,8 +1070,8 @@ class Weibull(PositiveContinuous):
         self.variance = (beta**2) * \
             tt.exp(gammaln(1 + 2. / alpha - self.mean**2))
             
-        assert_nonpos_support(self.alpha, 'alpha')
-        assert_nonpos_support(self.beta, 'beta')
+        assert_nonpos_support(alpha, 'alpha', 'Weibull')
+        assert_nonpos_support(beta, 'beta', 'Weibull')
 
     def random(self, point=None, size=None, repeat=None):
         alpha, beta = draw_values([self.alpha, self.beta],
@@ -1251,8 +1259,8 @@ class ExGaussian(Continuous):
         self.mean = mu + nu
         self.variance = (sigma**2) + (nu**2)
         
-        assert_nonpos_support(self.sigma, 'sigma')
-        assert_nonpos_support(self.nu, 'nu')
+        assert_nonpos_support(sigma, 'sigma', 'ExGaussian')
+        assert_nonpos_support(nu, 'nu', 'ExGaussian')
 
     def random(self, point=None, size=None, repeat=None):
         mu, sigma, nu = draw_values([self.mu, self.sigma, self.nu],
@@ -1312,7 +1320,7 @@ class VonMises(Continuous):
         if transform == 'circular':
             self.transform = transforms.Circular()
             
-        assert_nonpos_support(self.kappa, 'kappa')
+        assert_nonpos_support(kappa, 'kappa', 'VonMises')
 
     def random(self, point=None, size=None, repeat=None):
         mu, kappa = draw_values([self.mu, self.kappa],
@@ -1369,7 +1377,8 @@ class SkewNormal(Continuous):
         self.mean = mu + self.sd * (2 / np.pi)**0.5 * alpha / (1 + alpha**2)**0.5
         self.variance = self.sd**2 * (1 - (2 * alpha**2) / ((1 + alpha**2) * np.pi))
         
-        assert_nonpos_support(self.tau, 'tau (sd)')
+        assert_nonpos_support(tau, 'tau', 'SkewNormal')
+        assert_nonpos_support(sd, 'sd', 'SkewNormal')
 
     def random(self, point=None, size=None, repeat=None):
         mu, tau, sd, alpha = draw_values(


### PR DESCRIPTION
Since so many continuous variables have positive-valued parameters, this just generates a simple warning if you pass a parameter that has non-positive support. As best it can, it checks whether the `logp` at zero is finite. This should help users avoid mis-parameterizing models.
