### PR TITLE
Generalize find_MAP to accept more scipy.optimize functions

### DIFF
--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -83,7 +83,11 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
         r = fmin(logp_o, bij.map(
             start), fprime=grad_logp_o, *args, **kwargs)
     else:
-        r = fmin(logp_o, bij.map(start), *args, **kwargs)
+        # Check to see if minimization function uses a starting value
+        if 'x0' in getargspec(fmin).args:
+            r = fmin(logp_o, bij.map(start), *args, **kwargs)
+        else:
+            r = fmin(logp_o, *args, **kwargs)
 
     if isinstance(r, tuple):
         mx0 = r[0]


### PR DESCRIPTION
This will allow for methods like basin hopping and brute force optimization to be used, which do not expect `x0` arguments.

Addresses #1469 
