### PR TITLE
Ignore SQLite file generated by tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ _build
 
 # Merge tool
 *.orig
+
+# Test artifacts
+mcmc.sqlite


### PR DESCRIPTION
Running the tests generates `mcmc.sqlite`, make `git` ignore it.
