### PR TITLE
Pin theano version for now

### DIFF
--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -17,7 +17,7 @@ fi
 
 pip install tqdm
 pip install --no-deps numdifftools
-pip install git+https://github.com/Theano/Theano.git
+pip install https://github.com/Theano/Theano/archive/rel-0.8.2.zip
 pip install git+https://github.com/mahmoudimus/nose-timer.git
 
 python setup.py build_ext --inplace


### PR DESCRIPTION
I believe this will fix travis -- it looks like tests were passing on `Theano==0.9.0.dev3`, but not on `Theano==0.9.0.dev4`.  I'll take a closer look at what is breaking and whether it is a Theano problem or pymc problem.  

@fonnesbeck is there a reason for installing from master instead of a pypi release (or pinning to a git sha)?