### PR TITLE
Remove `verbose` argument

### DIFF
--- a/docs/source/notebooks/NUTS_scaling_using_ADVI.ipynb
+++ b/docs/source/notebooks/NUTS_scaling_using_ADVI.ipynb
@@ -490,7 +490,7 @@
    ],
    "source": [
     "with mdl:\n",
-    "    v_params = pm.variational.advi(n=100000, verbose=False) \n",
+    "    v_params = pm.variational.advi(n=100000) \n",
     "\n",
     "_ = plt.plot(-np.log10(-v_params.elbo_vals))"
    ]

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -169,17 +169,9 @@ class Factor(object):
 
 
 class Model(Context, Factor):
-    """Encapsulates the variables and likelihood factors of a model.
+    """Encapsulates the variables and likelihood factors of a model."""
 
-    Parameters
-    ----------
-    verbose : int
-        Model verbosity setting, determining how much feedback various
-        operations provide. Normal verbosity is verbose=1 (default), silence
-        is verbose=0, high is any value greater than 1.
-    """
-
-    def __init__(self, verbose=1):
+    def __init__(self):
         self.named_vars = {}
         self.free_RVs = []
         self.observed_RVs = []
@@ -187,7 +179,6 @@ class Model(Context, Factor):
         self.potentials = []
         self.missing_values = []
         self.model = self
-        self.verbose = verbose
 
     @property
     @memoize
@@ -288,7 +279,7 @@ class Model(Context, Factor):
                 var = TransformedRV(name=name, distribution=dist, model=self,
                                     transform=dist.transform)
                 pm._log.debug('Applied {transform}-transform to {name}'
-                             ' and added transformed {orig_name} to model.'.format(
+                              ' and added transformed {orig_name} to model.'.format(
                                 transform=dist.transform.name,
                                 name=name,
                                 orig_name='{}_{}_'.format(name, dist.transform.name)))
@@ -623,8 +614,8 @@ class MultiObservedRV(Factor):
         self.data = {name: as_tensor(data, name, model, distribution)
                      for name, data in data.items()}
 
-        self.missing_values = [data.missing_values for data in self.data.values()
-                               if data.missing_values is not None]
+        self.missing_values = [datum.missing_values for datum in self.data.values()
+                               if datum.missing_values is not None]
         self.logp_elemwiset = distribution.logp(**self.data)
         self.model = model
         self.distribution = distribution

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -69,8 +69,7 @@ def assign_step_methods(model, step=None, methods=(NUTS, HamiltonianMC, Metropol
     for var in model.free_RVs:
         if var not in assigned_vars:
             selected = max(methods, key=lambda method: method._competence(var))
-            if model.verbose:
-                pm._log.info('Assigned {0} to {1}'.format(selected.__name__, var))
+            pm._log.info('Assigned {0} to {1}'.format(selected.__name__, var))
             selected_steps[selected].append(var)
 
     # Instantiate all selected step methods

--- a/pymc3/tests/test_advi.py
+++ b/pymc3/tests/test_advi.py
@@ -95,7 +95,7 @@ class TestADVI(SeededTest):
 
             with self.assertRaises(ValueError):
                 advi_minibatch(n=10, minibatch_RVs=[disasters], minibatch_tensors=[disaster_data_t],
-                               minibatches=create_minibatches(), verbose=False)
+                               minibatches=create_minibatches())
 
     def test_advi(self):
         n = 1000
@@ -201,7 +201,7 @@ class TestADVI(SeededTest):
             mu_ = Normal('mu', mu=mu0, sd=sd0, testval=0)
             x = Normal('x', mu=mu_, sd=sd, observed=data_t)
             advi_fit = advi_minibatch(
-                n=1000, minibatch_tensors=[data_t], encoder_params=[], 
+                n=1000, minibatch_tensors=[data_t], encoder_params=[],
                 minibatch_RVs=[x], minibatches=create_minibatches(data),
                 total_size=n, learning_rate=1e-1)
             np.testing.assert_allclose(advi_fit.means['mu'], mu_post, rtol=0.1)

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -55,9 +55,7 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
 
     disc_vars = list(typefilter(vars, discrete_types))
 
-    kwargs["disp"] = model.verbose > 1
-
-    if disc_vars and kwargs["disp"]:
+    if disc_vars:
         pm._log.warning("Warning: vars contains discrete variables. MAP " +
                         "estimates may not be accurate for the default " +
                         "parameters. Defaulting to non-gradient minimization " +


### PR DESCRIPTION
Came up on #1516, I removed the `verbose` argument in favor of setting logging levels (so the end user can globally set the level to log at).  @taku-y might take a look at the ADVI changes -- I swapped out printing for `tqdm` there, and update the ELBO at the same rate using the `tqdm` api.

This is a breaking change!  But it'll break early and loudly (as soon as `Model` is initialized). If we wanted to give some warning, I can leave the `verbose` argument in `Model` for a while, and just raise a DeprecationWarning whenever it is set.