### PR TITLE
Nuts speed up ~1.5x

### DIFF
--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -206,7 +206,7 @@ def leapfrog1_dE(H, q, profile):
     ----------
     H : Hamiltonian
     q : theano.tensor
-    proifle : Boolean
+    profile : Boolean
 
     Returns
     -------

--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -199,16 +199,14 @@ def leapfrog1_dE(H, q, profile):
     """Computes a theano function that computes one leapfrog step and the energy difference between the beginning and end of the trajectory.
     Parameters
     ----------
-    logp : TensorVariable
-    vars : list of tensor variables
-    shared : list of shared variables not to compute leapfrog over
-    pot : quadpotential
-    porifle : Boolean
+    H : Hamiltonian
+    q : theano.tensor
+    proifle : Boolean
 
     Returns
     -------
     theano function which returns
-    q_new, p_new, E
+    q_new, p_new, dE
     """
     p = theano.tensor.dvector('p')
     p.tag.test_value = q.tag.test_value

--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -106,7 +106,7 @@ class NUTS(ArrayStepShared):
             p = theano.tensor.dvector('p')
             p.tag.test_value = q.tag.test_value
             E0 = energy(self.H, q, p)
-            E0_func = theano.function([q, p], [E0])
+            E0_func = theano.function([q, p], E0)
             E0_func.trust_input = True
 
             return E0_func
@@ -171,7 +171,7 @@ class NUTS(ArrayStepShared):
 
 def buildtree(leapfrog1_dE, q, p, u, v, j, e, Emax, q0, p0, E0):
     if j == 0:
-        q1, p1, dE = leapfrog1_dE(q, p, array(v * e), E0[0])
+        q1, p1, dE = leapfrog1_dE(q, p, array(v * e), E0)
 
         n1 = int(log(u) + dE <= 0)
         s1 = int(log(u) + dE < Emax)


### PR DESCRIPTION
With @jsalvatier I identified a speed-up in the implementation of NUTS where the energy E0 was recomputed unnecessarily (https://github.com/pymc-devs/pymc3/issues/1020). This PR moves that computation outside of the inner loop which gave a significant 1.5x speedup in my limited experiments (would be helpful if someone tries this on their own setup).