### PR TITLE
Fix stickbreaking transform dtype

### DIFF
--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -209,7 +209,7 @@ class StickBreaking(Transform):
         z = x0 / s
         Km1 = x.shape[0] - 1
         k = tt.arange(Km1)[(slice(None), ) + (None, ) * (x.ndim - 1)]
-        eq_share = logit(1. / (Km1 + 1 - k))  # - tt.log(Km1 - k)
+        eq_share = logit(1. / (Km1 + 1 - k).astype(str(x_.dtype)))
         y = logit(z) - eq_share
         return y.T
 
@@ -217,7 +217,7 @@ class StickBreaking(Transform):
         y = y_.T
         Km1 = y.shape[0]
         k = tt.arange(Km1)[(slice(None), ) + (None, ) * (y.ndim - 1)]
-        eq_share = logit(1. / (Km1 + 1 - k))  # - tt.log(Km1 - k)
+        eq_share = logit(1. / (Km1 + 1 - k).astype(str(y_.dtype)))
         z = invlogit(y + eq_share, self.eps)
         yl = tt.concatenate([z, tt.ones(y[:1].shape)])
         yu = tt.concatenate([tt.ones(y[:1].shape), 1 - z])
@@ -229,7 +229,7 @@ class StickBreaking(Transform):
         y = y_.T
         Km1 = y.shape[0]
         k = tt.arange(Km1)[(slice(None), ) + (None, ) * (y.ndim - 1)]
-        eq_share = logit(1. / (Km1 + 1 - k))  # -tt.log(Km1 - k)
+        eq_share = logit(1. / (Km1 + 1 - k).astype(str(y_.dtype)))
         yl = y + eq_share
         yu = tt.concatenate([tt.ones(y[:1].shape), 1 - invlogit(yl, self.eps)])
         S = tt.extra_ops.cumprod(yu, 0)


### PR DESCRIPTION
The following code results in conflicting dtypes of the tensor and its test value.

```
import pymc3 as pm
import numpy as np

with pm.Model() as model:
        pi = pm.Dirichlet(
            'pi', a=(np.ones(5) * (1.0 / 5)).astype('float32'), 
            shape=(20, 5), dtype='float32'
        )

        print(pi.dtype, pi.tag.test_value.dtype)

# Output
float32 float64
```

This problem is caused in StickBreakingTransform. In the code, an integer vector is added to a float vector. This addition changes dtype to float64 regardless of the dtype of the float vector. This PR fixes the problem by explicitly casting the dtype of the result of the addition to the same one of the input value. 