### PR TITLE
Replaced fixed kappa with passed value in NUTS

### DIFF
--- a/pymc3/step_methods/nuts.py
+++ b/pymc3/step_methods/nuts.py
@@ -157,7 +157,7 @@ class NUTS(ArrayStepShared):
         self.Hbar = (1 - w) * self.Hbar + w * \
             (self.target_accept - a * 1. / na)
 
-        self.step_size = exp(self.u - (self.m**.5 / self.gamma) * self.Hbar)
+        self.step_size = exp(self.u - (self.m**self.k / self.gamma) * self.Hbar)
         self.m += 1
 
         return q


### PR DESCRIPTION
Currently, the adaptation relaxation exponent has been fixed to 0.5, and does not use the passed value of `k` (kappa) that defaults to 0.75. This replaces the fixed value with the variable.