### PR TITLE
Remove sample_vp progressbar for ADVI initialization

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -430,7 +430,7 @@ def init_nuts(init='advi', n_init=500000, model=None):
 
     if init == 'advi':
         v_params = pm.variational.advi(n=n_init)
-        start = pm.variational.sample_vp(v_params, 1)[0]
+        start = pm.variational.sample_vp(v_params, 1, progressbar=False)[0]
         cov = np.power(model.dict_to_array(v_params.stds), 2)
     elif init == 'advi_map':
         start = pm.find_MAP()


### PR DESCRIPTION
A very small modification to @twiecki's excellent ADVI init code to remove an extraneous progress bar.