### PR TITLE
Suggestion to fix the TypeError issue #994 on Windows.

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -100,6 +100,8 @@ class Discrete(Distribution):
     """Base class for discrete distributions"""
 
     def __init__(self, shape=(), dtype='int64', defaults=['mode'], *args, **kwargs):
+        if dtype != 'int64':
+            raise TypeError('Discrete classes expect dtype to be int64.')
         super(Discrete, self).__init__(
             shape, dtype, defaults=defaults, *args, **kwargs)
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -111,13 +111,13 @@ class Metropolis(ArrayStepShared):
 
         if self.any_discrete:
             if self.all_discrete:
-                delta = np.round(delta, 0).astype(int)
-                q0 = q0.astype(int)
-                q = (q0 + delta).astype(int)
+                delta = np.round(delta, 0).astype('int64')
+                q0 = q0.astype('int64')
+                q = (q0 + delta).astype('int64')
             else:
                 delta[self.discrete] = np.round(
-                    delta[self.discrete], 0).astype(int)
-                q = q0 + delta
+                    delta[self.discrete], 0).astype('int64')
+                q = (q0 + delta).astype('int64')
         else:
             q = q0 + delta
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -431,5 +431,5 @@ def delta_logp(logp, vars, shared):
     logp1 = pm.CallableTensor(logp0)(inarray1)
 
     f = theano.function([inarray1, inarray0], logp1 - logp0)
-    f.trust_input = True
+    # f.trust_input = True
     return f


### PR DESCRIPTION
Hello ! This is a working suggestion (and some remarks) to fix the issue 994 related to theano TypeError https://github.com/pymc-devs/pymc3/issues/994 .

I fixed the issue on my computer (Python `2.7.12 |Continuum Analytics, Inc.| (default, Jun 29 2016, 11:07:13) [MSC v.1500 64 bit (AMD64)]`, OS `Windows-8.1-6.3.9600`). As test code, I extracted the python code from the notebook of @napsternxg : https://gist.github.com/notoraptor/75fd0db142a21710a11b7a2e17f38cba

After further investigations, I found that the error comes from 2 problems.

First, the pymc3 function `delta_logp`, which is in fact a theano function, expects int64 arrays as input, but receives int32 arrays on Windows. These arrays are `q` and `q0` passed here: https://github.com/pymc-devs/pymc3/blob/master/pymc3/step_methods/metropolis.py#L124 :
```
 q_new = metrop_select(self.delta_logp(q, q0), q, q0)
```
`q` and `q0` are casted in previous lines with `.astype(int)`, but on Windows, the Python type `int` is treated as an int32 by NumPy.

The second problem is in the function `delta_logp`. When it generates the associated theano function, it deactivates the input verification done in Theano by setting `trust_input` to true: https://github.com/pymc-devs/pymc3/blob/master/pymc3/step_methods/metropolis.py#L434
``` 
f.trust_input = True
```
As mentionned in theano documentation: https://github.com/Theano/Theano/blob/master/theano/compile/function_module.py

>     A Function instance have a ``trust_input`` field that default to
>     False. When True, we don't do extra check of the input to give
>     better error message. In some case, python code will still return
>     the good results if you pass a python or numpy scalar instead of a
>     numpy tensor.  C code should raise an error if you pass an object
>     of the wrong type.

Therefore, it is the C code that returns the TypeError when it detects the int32 vs int64 mismatch.

So, there is two solutions: either cast explicitely `q` and `q0` to int64, or remove the line with `f.trust_input = True` in function `delta_logp`. In this pull request I suggest the later solution, as the type of the inputs of `delta_logp` does not seem easy to guarantee in any case (that is, is it always int64?).

@nouiz @lamblin !