### PR TITLE
Allow specifying dsistributions in terms of theano TensorConstants

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -71,6 +71,9 @@ class Distribution(object):
         if isinstance(val, tt.TensorVariable):
             return val.tag.test_value
 
+        if isinstance(val, tt.TensorConstant):
+            return val.value
+
         return val
 
 


### PR DESCRIPTION
When values are sanitised using `theano.tensor.as_tensor` constants will be turned into `TensorConstant`. These are not properly recognised by the disitribution, such that models involving them will eventually fail in `get_test_val` since `np.isfinite` doesn't know what to do with a `TensorConstant`.