### PR TITLE
Kde boundaries

### DIFF
--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -805,7 +805,7 @@ def fast_kde(x):
 
     grid: A gridded 1D KDE of the input points (x).
     xmin: minimum value of x
-    xmax: mmaximum value of x
+    xmax: maximum value of x
     
     """
     

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -4,6 +4,7 @@ from numpy.linalg import LinAlgError
 import matplotlib.pyplot as plt
 import pymc3 as pm
 from .stats import quantiles, hpd
+from scipy.signal import gaussian, convolve
 
 __all__ = ['traceplot', 'kdeplot', 'kde2plot',
            'forestplot', 'autocorrplot', 'plot_posterior']
@@ -120,16 +121,15 @@ def kdeplot_op(ax, data, prior=None, prior_alpha=1, prior_style='--'):
     for i in range(data.shape[1]):
         d = data[:, i]
         try:
-            density = kde.gaussian_kde(d)
-            l = np.min(d)
-            u = np.max(d)
-            x = np.linspace(0, 1, 100) * (u - l) + l
+            density, l, u = fast_kde(d)
+            x = np.linspace(l, u, len(density))
 
             if prior is not None:
                 p = prior.logp(x).eval()
                 ax.plot(x, np.exp(p), alpha=prior_alpha, ls=prior_style)
 
-            ax.plot(x, density(x))
+            ax.plot(x, density)
+            ax.set_ylim(bottom=0)
 
         except LinAlgError:
             errored.append(i)
@@ -721,11 +721,9 @@ def plot_posterior(trace, varnames=None, transform=lambda x: x, figsize=None,
                 d[key] = value
 
         if kde_plot:
-            density = kde.gaussian_kde(trace_values)
-            l = np.min(trace_values)
-            u = np.max(trace_values)
-            x = np.linspace(0, 1, 100) * (u - l) + l
-            ax.plot(x, density(x), **kwargs)
+            density, l, u = fast_kde(trace_values)
+            x = np.linspace(l, u, len(density))
+            ax.plot(x, density, **kwargs)
         else:
             set_key_if_doesnt_exist(kwargs, 'bins', 30)
             set_key_if_doesnt_exist(kwargs, 'edgecolor', 'w')
@@ -790,3 +788,57 @@ def plot_posterior(trace, varnames=None, transform=lambda x: x, figsize=None,
 
         fig.tight_layout()
     return ax
+    
+def fast_kde(x):
+    """
+    A fft-based Gaussian kernel density estimate (KDE) for computing
+    the KDE on a regular grid.
+    The code was adapted from https://github.com/mfouesneau/faststats
+    
+    Parameters
+    ----------
+
+    x : Numpy array or list
+
+    Returns
+    -------
+
+    grid: A gridded 1D KDE of the input points (x).
+    xmin: minimum value of x
+    xmax: mmaximum value of x
+    
+    """
+    
+    xmin, xmax = x.min(), x.max()
+    
+    n = len(x)
+    nx = 256
+
+    # compute histogram
+    bins = np.linspace(x.min(), x.max(), nx)
+    xyi = np.digitize(x, bins)
+    dx = (xmax - xmin) / (nx - 1)
+    grid = np.histogram(x, bins=nx)[0]
+
+    # Scaling factor for bandwidth
+    scotts_factor = n ** (-0.2)
+    # Determine the bandwidth using Scott's rule
+    std_x = np.std(xyi)
+    kern_nx = int(np.round(scotts_factor * 2 * np.pi * std_x))
+
+    # Evaluate the gaussian function on the kernel grid
+    kernel = np.reshape(gaussian(kern_nx, scotts_factor * std_x), kern_nx)
+
+
+    # Compute the KDE
+    # use symmetric padding to correct for data boundaries in the kde
+    npad = np.min((nx, 2 * kern_nx))
+
+    grid = np.concatenate([grid[npad: 0: -1], grid, grid[nx: nx - npad: -1]])
+    grid = convolve(grid, kernel, mode='same')[npad: npad + nx]
+
+    norm_factor = n * dx * (2 * np.pi * std_x ** 2 * scotts_factor ** 2) ** 0.5
+
+    grid /= norm_factor
+
+    return grid, xmin, xmax


### PR DESCRIPTION
This KDE implementation is faster than scipy.gaussian_kde. According to my test between ~10 times faster (for ~1000 points) and ~40 times faster (for ~10000 points). This implementation includes a boundary correction (using the reflection method). I think the only caveat is that it will not work very nice if the number of data points is low (probably lower than ~1000/500), in such a cases the tails of the distributions are not estimated very nice. Nevertheless I think this is OK, given that in general people uses at least 1000 samples.

The next image is an example of a KDE estimation without boundary corrections (the SciPy implementation)
![non_boundaries](https://cloud.githubusercontent.com/assets/1338958/20764085/6f62d5d0-b70b-11e6-8bb4-c9f1e77b5707.png)

And this is an example with boundary correction (the implementation in this PR)

![boundary_correction](https://cloud.githubusercontent.com/assets/1338958/20764127/93218e12-b70b-11e6-845e-7076906d559a.png)

I know is a small detail, but in my experience KDE plots without the correction can be confusing to those unaware of how KDE estimation works, or at least those unfamiliar with PyMC3/scipy-KDE.

This is an adaptation of the code from [this](https://github.com/mfouesneau/faststats) repository and made some modifications. I made this change following this suggestion https://github.com/mcmcplotlib/mcmcplotlib/issues/5
