### PR TITLE
Add mkl-service to build

### DIFF
--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -23,7 +23,7 @@ then
     source activate testenv
 fi
 
-conda install --yes pyqt=4.11.4 jupyter pyzmq numpy scipy nose matplotlib pandas Cython patsy statsmodels joblib coverage
+conda install --yes pyqt=4.11.4 jupyter pyzmq numpy scipy nose matplotlib pandas Cython patsy statsmodels joblib coverage mkl-service
 if [ ${PYTHON_VERSION} == "2.7" ]; then
     conda install --yes mock enum34;
 fi


### PR DESCRIPTION
Theano added a warning to install `[mkl](https://docs.continuum.io/mkl-optimizations/)` in https://github.com/Theano/Theano/pull/5290 .  This installs it on travis and anywhere else `create_testenv.sh` is used (for example, the docker build),  but won't install by default when pymc3 is installed.

I don't see any speedup from using it (in particular, the test suite takes almost exactly the same amount of time to run), and don't know much about it beyond continuum's webpage on it, but maybe someone else has a strong opinion?