### PR TITLE
shape problem when sampling

### DIFF
--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -96,20 +96,22 @@ class BaseTestCases(object):
             super(BaseTestCases.BaseTestCase, self).__init__(*args, **kwargs)
             self.model = pm.Model()
 
-        def get_random_variable(self, shape, with_vector_params=False):
+        def get_random_variable(self, shape, with_vector_params=False, name=None):
             if with_vector_params:
                 params = {key: value * np.ones(self.shape, dtype=np.dtype(type(value))) for
                           key, value in self.params.items()}
             else:
                 params = self.params
-            name = self.distribution.__name__
+            if name is None:
+                name = self.distribution.__name__
             with self.model:
                 if shape is None:
                     return self.distribution(name, transform=None, **params)
                 else:
                     return self.distribution(name, shape=shape, transform=None, **params)
 
-        def sample_random_variable(self, random_variable, size):
+        @staticmethod
+        def sample_random_variable(random_variable, size):
             try:
                 return random_variable.random(size=size)
             except AttributeError:
@@ -145,7 +147,7 @@ class BaseTestCases(object):
                 else:
                     expected = np.atleast_1d(size).tolist()
                 expected.append(self.shape)
-                actual = np.atleast_1d(self.sample_random_variable(rv, size)).shape
+                actual = self.sample_random_variable(rv, size).shape
                 self.assertSequenceEqual(expected, actual)
 
         def test_broadcast_shape(self):
@@ -159,6 +161,26 @@ class BaseTestCases(object):
                 expected.extend(broadcast_shape)
                 actual = np.atleast_1d(self.sample_random_variable(rv, size)).shape
                 self.assertSequenceEqual(expected, actual)
+
+        def test_different_shapes_and_sample_sizes(self):
+            shapes = [(), (1,), (1, 1), (1, 2), (10, 10, 1), (10, 10, 2)]
+            prefix = self.distribution.__name__
+            expected = []
+            actual = []
+            for shape in shapes:
+                rv = self.get_random_variable(shape, name='%s_%s' % (prefix, shape))
+                for size in (None, 1, 5, (4, 5)):
+                    if size is None:
+                        s = []
+                    else:
+                        try:
+                            s = list(size)
+                        except TypeError:
+                            s = [size]
+                    s.extend(shape)
+                    expected.append(tuple(s))
+                    actual.append(self.sample_random_variable(rv, size).shape)
+            self.assertSequenceEqual(expected, actual)
 
 
 class TestNormal(BaseTestCases.BaseTestCase):

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -178,8 +178,10 @@ class BaseTestCases(object):
                         except TypeError:
                             s = [size]
                     s.extend(shape)
-                    expected.append(tuple(s))
-                    actual.append(self.sample_random_variable(rv, size).shape)
+                    e = tuple(s)
+                    a = self.sample_random_variable(rv, size).shape
+                    expected.append(e)
+                    actual.append(a)
             self.assertSequenceEqual(expected, actual)
 
 
@@ -332,8 +334,8 @@ class TestCategorical(BaseTestCases.BaseTestCase):
     distribution = pm.Categorical
     params = {'p': np.ones(BaseTestCases.BaseTestCase.shape)}
 
-    def get_random_variable(self, shape, with_vector_params=False):  # don't transform categories
-        return super(TestCategorical, self).get_random_variable(shape, with_vector_params=False)
+    def get_random_variable(self, shape, with_vector_params=False, **kwargs):  # don't transform categories
+        return super(TestCategorical, self).get_random_variable(shape, with_vector_params=False, **kwargs)
 
 
 @attr('scalar_parameter_samples')


### PR DESCRIPTION
When constructing neural networks I met a problem that when I generate samples for initial values I get unexpected shape for tensor.

For example for random variable with shape (1, 1) (needed for matmul) yields a sample (1,). In general all samples seem to be [squeesed](https://docs.scipy.org/doc/numpy-1.10.0/reference/generated/numpy.squeeze.html#numpy-squeeze), I do not know how to hotfix it.

I've added a test suite to reproduce the problem