### PR TITLE
Actually build on miniconda with python2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
 
-python:
-  - "2.7"
-  - "3.5"
-
 before_install:
   - . ./scripts/install_miniconda.sh
   - "export DISPLAY=:99.0"
@@ -17,10 +13,12 @@ install:
   - pip install coveralls
 
 env:
-  - TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 -e test_examples -e test_distributions" PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
-  - TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 pymc3.tests.test_distributions pymc3.tests.test_examples" PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
-  - TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 pymc3.tests.test_distributions_random" PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
-
+  - PYTHON_VERSION=2.7 TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 -e test_examples -e test_distributions"
+  - PYTHON_VERSION=2.7 TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 pymc3.tests.test_distributions pymc3.tests.test_examples"
+  - PYTHON_VERSION=2.7 TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 pymc3.tests.test_distributions_random"
+  - PYTHON_VERSION=3.5 TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 -e test_examples -e test_distributions"
+  - PYTHON_VERSION=3.5 TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 pymc3.tests.test_distributions pymc3.tests.test_examples"
+  - PYTHON_VERSION=3.5 TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 pymc3.tests.test_distributions_random"
 script:
   - . ./scripts/test.sh $TESTCMD
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -80,7 +80,7 @@ def product(domains, n_samples=-1):
         return []
     all_vals = [zip(names, val) for val in itertools.product(*[d.vals for d in domains])]
     if n_samples > 0 and len(all_vals) > n_samples:
-            return nr.choice(np.atleast_1d(all_vals), n_samples, replace=False)
+            return (all_vals[j] for j in nr.choice(len(all_vals), n_samples, replace=False))
     return all_vals
 
 
@@ -90,7 +90,7 @@ Rplusbig = Domain([0, .5, .9, .99, 1, 1.5, 2, 20, inf])
 Rminusbig = Domain([-inf, -2, -1.5, -1, -.99, -.9, -.5, -0.01, 0])
 Unit = Domain([0, .001, .1, .5, .75, .99, 1])
 
-Circ = Domain([-np.pi -2.1, -1, -.01, .0, .01, 1, 2.1, np.pi])
+Circ = Domain([-np.pi, -2.1, -1, -.01, .0, .01, 1, 2.1, np.pi])
 
 Runif = Domain([-1, -.4, 0, .4, 1])
 Rdunif = Domain([-10, 0, 10.])

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -80,7 +80,7 @@ def product(domains, n_samples=-1):
         return []
     all_vals = [zip(names, val) for val in itertools.product(*[d.vals for d in domains])]
     if n_samples > 0 and len(all_vals) > n_samples:
-            return nr.choice(all_vals, n_samples, replace=False)
+            return nr.choice(np.atleast_1d(all_vals), n_samples, replace=False)
     return all_vals
 
 

--- a/scripts/install_miniconda.sh
+++ b/scripts/install_miniconda.sh
@@ -3,7 +3,7 @@
 set -e # fail on first error
 
 if conda --version > /dev/null 2>&1; then
-   echo "conda appears to alreaday be installed"
+   echo "conda appears to already be installed"
    exit 0
  fi
 
@@ -22,10 +22,10 @@ DOWNLOAD_PATH="miniconda.sh"
 
 if [ ${PYTHON_VERSION} == "2.7" ]; then
   wget http://repo.continuum.io/miniconda/Miniconda-latest-$URL_OS-x86_64.sh -O ${DOWNLOAD_PATH};
-  INSTALL_FOLDER="$HOME/minconda2"
+  INSTALL_FOLDER="$HOME/miniconda2"
 else
   wget http://repo.continuum.io/miniconda/Miniconda3-latest-$URL_OS-x86_64.sh -O ${DOWNLOAD_PATH};
-  INSTALL_FOLDER="$HOME/minconda3"
+  INSTALL_FOLDER="$HOME/miniconda3"
 fi
 
 


### PR DESCRIPTION
For some reason setting the environment variable `export PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}` wasn't working, and *every* test run was using python3.5.  This fixes that by explicitly setting the expected values.  It might also turn up some bugs in the python2.7 version!

This should help with (some) test failures on #1569 