### PR TITLE
Fixed indentation in record

### DIFF
--- a/pymc3/backends/sqlite.py
+++ b/pymc3/backends/sqlite.py
@@ -148,8 +148,8 @@ class SQLite(base.BaseTrace):
             values = (self.draw_idx, self.chain) + tuple(np.ravel(value))
             self._queue[varname].append(values)
 
-        if len(self._queue[varname]) > self._queue_limit:
-            self._execute_queue()
+            if len(self._queue[varname]) > self._queue_limit:
+                self._execute_queue()
         self.draw_idx += 1
 
     def _execute_queue(self):


### PR DESCRIPTION
Found this indentation issue in the SQLite backend; can add it to next RC if one is required, otherwise can wait for merge post-3.0.