### PR TITLE
add varnames argument for consintency

### DIFF
--- a/pymc3/backends/text.py
+++ b/pymc3/backends/text.py
@@ -192,12 +192,8 @@ def dump(name, trace, chains=None):
     if chains is None:
         chains = trace.chains
 
-    var_shapes = trace._straces[chains[0]].var_shapes
-    flat_names = {v: ttab.create_flat_names(v, shape)
-                  for v, shape in var_shapes.items()}
-
     for chain in chains:
         filename = os.path.join(name, 'chain-{}.csv'.format(chain))
         df = ttab.trace_to_dataframe(
-            trace, chains=chain, flat_names=flat_names,hide_transformed_vars=False)
+            trace, chains=chain, hide_transformed_vars=False)
         df.to_csv(filename, index=False)


### PR DESCRIPTION
Other functions in PyMC3 include a `varnames` argument. So it make sense that `trace_to_dataframe` includes this option too. In my experience `flat_names` is not a really useful and can be confusing for many users, and hence I am removing this argument.  I also add a reference to hide_transformed_vars in the docstring.

BTW `_create_shape` is only used during tests. There is any reason to keep this function?