### PR TITLE
Foresplot: hide transformed variables by default

### DIFF
--- a/pymc3/glm/glm.py
+++ b/pymc3/glm/glm.py
@@ -87,11 +87,10 @@ class linear_component(namedtuple('Estimate', 'y_est,coeffs')):
             priors = defaultdict(None)
 
         # Build patsy design matrix and get regressor names.
-        # Formula can be of form 'c ~ a + b' or 'a + b'.
-        if '~' in formula:
-            _, dmatrix = patsy.dmatrices(formula, data)
-        else:
-            dmatrix = patsy.dmatrix(formula, data)
+        try:
+            _, dmatrix = patsy.dmatrices(formula, data)  # 'c ~ a + b'
+        except patsy.PatsyError:
+            dmatrix = patsy.dmatrix(formula, data)  # 'a + b'
         reg_names = dmatrix.design_info.column_names
 
         if init_vals is None:

--- a/pymc3/glm/glm.py
+++ b/pymc3/glm/glm.py
@@ -42,6 +42,7 @@ class linear_component(namedtuple('Estimate', 'y_est,coeffs')):
     ----------
     formula : str
         Patsy linear model descriptor.
+        E.g. 'y ~ a + b' or simply 'a + b'
     data : array
         Labeled array (e.g. pandas DataFrame, recarray).
     priors : dict
@@ -86,7 +87,11 @@ class linear_component(namedtuple('Estimate', 'y_est,coeffs')):
             priors = defaultdict(None)
 
         # Build patsy design matrix and get regressor names.
-        _, dmatrix = patsy.dmatrices(formula, data)
+        # Formula can be of form 'c ~ a + b' or 'a + b'.
+        if '~' in formula:
+            _, dmatrix = patsy.dmatrices(formula, data)
+        else:
+            dmatrix = patsy.dmatrix(formula, data)
         reg_names = dmatrix.design_info.column_names
 
         if init_vals is None:

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -292,62 +292,54 @@ def var_str(name, shape):
 
 def forestplot(trace_obj, varnames=None, transform=lambda x: x, alpha=0.05, quartiles=True,
                rhat=True, main=None, xtitle=None, xrange=None, ylabels=None,
-               chain_spacing=0.05, vline=0, gs=None):
-    """ Forest plot (model summary plot)
-
+               chain_spacing=0.05, vline=0, gs=None, plot_transformed=False):
+    """
+    Forest plot (model summary plot)
     Generates a "forest plot" of 100*(1-alpha)% credible intervals for either
     the set of variables in a given model, or a specified set of nodes.
 
-    :Arguments:
-        trace_obj: NpTrace or MultiTrace object
-            Trace(s) from an MCMC sample.
+    Parameters
+    ----------
+    
+    trace_obj: NpTrace or MultiTrace object
+        Trace(s) from an MCMC sample.
+    varnames: list
+        List of variables to plot (defaults to None, which results in all
+        variables plotted).
+    transform : callable
+        Function to transform data (defaults to identity)
+    alpha (optional): float
+        Alpha value for (1-alpha)*100% credible intervals (defaults to 0.05).
+    quartiles (optional): bool
+        Flag for plotting the interquartile range, in addition to the 
+        (1-alpha)*100% intervals (defaults to True).
+    rhat (optional): bool
+        Flag for plotting Gelman-Rubin statistics. Requires 2 or more chains
+        (defaults to True).
+    main (optional): string
+        Title for main plot. Passing False results in titles being suppressed;
+        passing None (default) results in default titles.
+    xtitle (optional): string
+        Label for x-axis. Defaults to no label
+    xrange (optional): list or tuple
+        Range for x-axis. Defaults to matplotlib's best guess.
+    ylabels (optional): list or array
+        User-defined labels for each variable. If not provided, the node
+        __name__ attributes are used.
+    chain_spacing (optional): float
+        Plot spacing between chains (defaults to 0.05).
+    vline (optional): numeric
+        Location of vertical reference line (defaults to 0).
+    gs : GridSpec
+        Matplotlib GridSpec object. Defaults to None.
+    plot_transformed : bool
+        Flag for plotting automatically transformed variables in addition to
+        original variables (defaults to False).
 
-        varnames: list
-            List of variables to plot (defaults to None, which results in all
-            variables plotted).
+    Returns
+    -------
 
-        transform : callable
-            Function to transform data (defaults to identity)
-
-        alpha (optional): float
-            Alpha value for (1-alpha)*100% credible intervals (defaults to
-            0.05).
-
-        quartiles (optional): bool
-            Flag for plotting the interquartile range, in addition to the
-            (1-alpha)*100% intervals (defaults to True).
-
-        rhat (optional): bool
-            Flag for plotting Gelman-Rubin statistics. Requires 2 or more
-            chains (defaults to True).
-
-        main (optional): string
-            Title for main plot. Passing False results in titles being
-            suppressed; passing None (default) results in default titles.
-
-        xtitle (optional): string
-            Label for x-axis. Defaults to no label
-
-        xrange (optional): list or tuple
-            Range for x-axis. Defaults to matplotlib's best guess.
-
-        ylabels (optional): list or array
-            User-defined labels for each variable. If not provided, the node
-            __name__ attributes are used.
-
-        chain_spacing (optional): float
-            Plot spacing between chains (defaults to 0.05).
-
-        vline (optional): numeric
-            Location of vertical reference line (defaults to 0).
-
-        gs : GridSpec
-            Matplotlib GridSpec object. Defaults to None.
-
-        Returns
-        -------
-
-        gs : matplotlib GridSpec
+    gs : matplotlib GridSpec
 
     """
     from matplotlib import gridspec
@@ -376,7 +368,10 @@ def forestplot(trace_obj, varnames=None, transform=lambda x: x, alpha=0.05, quar
         rhat = False
 
     if varnames is None:
-        varnames = trace_obj.varnames
+            if plot_transformed:
+                varnames = [name for name in trace_obj.varnames]
+            else:
+                varnames = [name for name in trace_obj.varnames if not name.endswith('_')]
 
     # Empty list for y-axis labels
     labels = []


### PR DESCRIPTION
I also add the `plot_transformed=False` as for other plot functions. I also made some aesthetics changes in the docstring to make it look like the docstrings in the other functions.