### PR TITLE
Added output for pointwise predictive accuracy in waic.

### DIFF
--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -105,7 +105,7 @@ def log_post_trace(trace, model):
     return np.vstack([obs.logp_elemwise(pt) for obs in model.observed_RVs] for pt in trace)
 
 
-def waic(trace, model=None, n_eff=False):
+def waic(trace, model=None, n_eff=False, pointwise=False):
     """
     Calculate the widely available information criterion, its standard error
     and the effective number of parameters of the samples in trace from model.
@@ -120,6 +120,9 @@ def waic(trace, model=None, n_eff=False):
         Optional model. Default None, taken from context.
     n_eff: bool
         if True the effective number parameters will be returned.
+        Default False
+    pointwise: bool
+        if True the pointwise predictive accuracy will be returned.
         Default False
 
 
@@ -152,6 +155,8 @@ def waic(trace, model=None, n_eff=False):
 
     if n_eff:
         return waic, waic_se, p_waic
+    elif pointwise:
+        return waic, waic_se, waic_i, p_waic
     else:
         return waic, waic_se
 


### PR DESCRIPTION
In order to estimate the difference in the predictive accuracy of two models using waic you need the pointwise predictive accuracy. These values can also be used to compute the standard error of the difference. I only changed what is to be returned.

For more on how to do this check out the pymc3 implementation of [Chapter 7.5](https://github.com/gladomat/Statistical-Rethinking-with-Python-and-PyMC3/blob/master/Chp_07.ipynb) from McElreath 2016.

Edit: Or better yet, check out the [compare.R](https://github.com/stan-dev/loo/blob/master/R/compare.R) function from the stan-dev repository.