### PR TITLE
Install libav-tools and seaborn in the Docker container

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -2,6 +2,14 @@ FROM jupyter/minimal-notebook
 
 MAINTAINER Austin Rochford <austin.rochford@gmail.com>
 
+USER root
+
+# install libav-tools to support matplotlib animations
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libav-tools && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 USER $NB_USER
 
 COPY create_testenv.sh /tmp/create_testenv.sh
@@ -10,6 +18,8 @@ RUN /bin/bash /tmp/create_testenv.sh --global --no-setup
 #  matplotlib nonsense
 ENV XDG_CACHE_HOME /home/$NB_USER/.cache/
 ENV MPLBACKEND=Agg
+# for prettier default plot styling
+RUN pip3 install seaborn
 # Import matplotlib the first time to build the font cache.
 RUN python -c "import matplotlib.pyplot"
 


### PR DESCRIPTION
This adds `libav-tools` (for `matplotlib` animation support) and `seaborn` (which is used in many of the examples) to the Docker container.