### PR TITLE
GeneratorOp logic fix

### DIFF
--- a/pymc3/data.py
+++ b/pymc3/data.py
@@ -1,6 +1,6 @@
 import pkgutil
 import io
-
+from copy import copy
 import theano.tensor as tt
 from .vartypes import isgenerator
 
@@ -29,6 +29,28 @@ class DataGenerator(object):
     Helper class that helps to infer data type of generator with looking
     at the first item, preserving the order of the resulting generator
     """
+
+    class Variable(tt.TensorVariable):
+        def __init__(self, op, type, name=None):
+            super(DataGenerator.Variable, self).__init__(type=type, name=name)
+            self.op = op
+
+        def set_gen(self, gen):
+            self.op.set_gen(gen)
+
+        def set_default(self, value):
+            self.op.set_default(value)
+
+        def clone(self):
+            cp = self.__class__(self.op, self.type, self.name)
+            cp.tag = copy(self.tag)
+            return cp
+
+    def make_variable(self, gop, name=None):
+        var = self.Variable(gop, self.tensortype, name)
+        var.tag.test_value = self.test_value
+        return var
+
     def __init__(self, generator):
         if not isgenerator(generator):
             raise TypeError('Object should be generator like')

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -154,7 +154,7 @@ class TestScaling(unittest.TestCase):
         def true_dens():
             g = gen1()
             for i, point in enumerate(g):
-                yield stats.norm.logpdf(point * i).sum() * 10
+                yield stats.norm.logpdf(point).sum() * 10
         t = true_dens()
         # We have same size models
         with pm.Model() as model1:

--- a/pymc3/tests/test_theanof.py
+++ b/pymc3/tests/test_theanof.py
@@ -63,19 +63,19 @@ class TestGenerator(unittest.TestCase):
 
     def test_setvalue(self):
         def gen():
-            for _ in range(2):
-                yield np.ones((10, 10))
+            for i in range(2):
+                yield np.ones((10, 10)) * i
 
         gop = generator(gen())
         f = theano.function([], gop)
         res = [f() for _ in range(3)]
-        np.testing.assert_equal(np.ones((10, 10)), res[0])
-        np.testing.assert_equal(np.ones((10, 10)), res[1])
+        np.testing.assert_equal(np.ones((10, 10)) * 0, res[0])
+        np.testing.assert_equal(np.ones((10, 10)) * 1, res[1])
         self.assertTrue(res[2].shape == (10, 10))
         self.assertTrue(np.isnan(res[2]).all())
         gop.set_gen(gen())
         res = [f() for _ in range(3)]
-        np.testing.assert_equal(np.ones((10, 10)), res[0])
-        np.testing.assert_equal(np.ones((10, 10)), res[1])
+        np.testing.assert_equal(np.ones((10, 10)) * 0, res[0])
+        np.testing.assert_equal(np.ones((10, 10)) * 1, res[1])
         self.assertTrue(res[2].shape == (10, 10))
         self.assertTrue(np.isnan(res[2]).all())

--- a/pymc3/tests/test_theanof.py
+++ b/pymc3/tests/test_theanof.py
@@ -48,34 +48,29 @@ class TestGenerator(unittest.TestCase):
         f = theano.function([], res1)
         self.assertEqual(f(), np.float32(100))
 
-    def test_nans_produced(self):
+    def test_default_value(self):
         def gen():
-            for _ in range(2):
-                yield np.ones((10, 10))
+            for i in range(2):
+                yield np.ones((10, 10)) * i
 
-        gop = generator(gen())
+        gop = generator(gen(), np.ones((10, 10)) * 10)
         f = theano.function([], gop)
-        res = [f() for _ in range(3)]
-        np.testing.assert_equal(np.ones((10, 10)), res[0])
-        np.testing.assert_equal(np.ones((10, 10)), res[1])
-        self.assertTrue(res[2].shape == (10, 10))
-        self.assertTrue(np.isnan(res[2]).all())
+        np.testing.assert_equal(np.ones((10, 10)) * 0, f())
+        np.testing.assert_equal(np.ones((10, 10)) * 1, f())
+        np.testing.assert_equal(np.ones((10, 10)) * 10, f())
+        self.assertRaises(ValueError, gop.set_default, 1)
 
-    def test_setvalue(self):
+    def test_set_gen_and_exc(self):
         def gen():
             for i in range(2):
                 yield np.ones((10, 10)) * i
 
         gop = generator(gen())
         f = theano.function([], gop)
-        res = [f() for _ in range(3)]
-        np.testing.assert_equal(np.ones((10, 10)) * 0, res[0])
-        np.testing.assert_equal(np.ones((10, 10)) * 1, res[1])
-        self.assertTrue(res[2].shape == (10, 10))
-        self.assertTrue(np.isnan(res[2]).all())
+        np.testing.assert_equal(np.ones((10, 10)) * 0, f())
+        np.testing.assert_equal(np.ones((10, 10)) * 1, f())
+        self.assertRaises(StopIteration, f)
         gop.set_gen(gen())
-        res = [f() for _ in range(3)]
-        np.testing.assert_equal(np.ones((10, 10)) * 0, res[0])
-        np.testing.assert_equal(np.ones((10, 10)) * 1, res[1])
-        self.assertTrue(res[2].shape == (10, 10))
-        self.assertTrue(np.isnan(res[2]).all())
+        np.testing.assert_equal(np.ones((10, 10)) * 0, f())
+        np.testing.assert_equal(np.ones((10, 10)) * 1, f())
+        self.assertRaises(StopIteration, f)

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -244,10 +244,10 @@ identity = tt.Elemwise(scalar_identity, name='identity')
 
 class GeneratorOp(Op):
     """
-    Generaror Op is designed for storing python generators inside theano graph.
+    Generator Op is designed for storing python generators inside theano graph.
 
     __call__ creates TensorVariable
-        It has 2 new methods (assigned externally)
+        It has 2 new methods
         - var.set_gen(gen) : sets new generator
         - var.set_default(value) : sets new default value (None erases default value)
 
@@ -320,7 +320,7 @@ def generator(gen, default=None):
     Returns
     -------
     TensorVariable
-        It has 2 new methods (assigned externally)
+        It has 2 new methods
         - var.set_gen(gen) : sets new generator
         - var.set_default(value) : sets new default value (None erases default value)
     """

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -244,13 +244,15 @@ identity = tt.Elemwise(scalar_identity, name='identity')
 
 class GeneratorOp(Op):
     """
-    Generaror Op is designed for storing python generators
-    inside theano graph. The main limitation is generator itself.
+    Generaror Op is designed for storing python generators inside theano graph.
 
     __call__ creates TensorVariable
         It has 2 new methods (assigned externally)
         - var.set_gen(gen) : sets new generator
         - var.set_default(value) : sets new default value (None erases default value)
+
+    If generator is exhausted, variable will produce default value if it is not None,
+    else raises `StopIteration` exception that can be caught on runtime.
 
     Parameters
     ----------
@@ -328,7 +330,8 @@ class GeneratorOp(Op):
 def generator(gen, default=None):
     """
     Generator variable with possibility to set default value and new generator.
-    Raises StopIteration if generator is exhausted
+    If generator is exhausted variable will produce default value if it is not None,
+    else raises `StopIteration` exception that can be caught on runtime.
 
     Parameters
     ----------

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -267,10 +267,7 @@ class GeneratorOp(Op):
         self._nan[...] = np.nan
 
     def perform(self, node, inputs, output_storage, params=None):
-        try:
-            output_storage[0][0] = next(self.generator)
-        except StopIteration:
-            output_storage[0][0] = self._nan
+        output_storage[0][0] = next(self.generator, self._nan)
 
     def do_constant_folding(self, node):
         return False

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -328,7 +328,7 @@ class GeneratorOp(Op):
 def generator(gen, default=None):
     """
     Generator variable with possibility to set default value and new generator.
-    Raises StopIteration if generator is exhausted and
+    Raises StopIteration if generator is exhausted
 
     Parameters
     ----------

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -4,7 +4,7 @@ import theano
 from .vartypes import typefilter, continuous_types
 from theano import theano, scalar, tensor as tt
 from theano.gof.graph import inputs
-from theano.gof import Op, Container
+from theano.gof import Op
 from theano.configparser import change_flags
 from .memoize import memoize
 from .blocking import ArrayOrdering


### PR DESCRIPTION
I was playing with minibatch OPVI and mnist but was so lucky to break generator so it began to yield nans as I expected. As result I've lost all the weights and there was no single chance to detect this beforehand. That is the reason of changing logics of GeneratorOp when generator is exhausted. Now it raises `StopIteration` and thus can be detected.

CC @nouiz, recently I wrote to theano-users group about GeneratorOp and you replied, I made some working example finally. Could you please review my implementation? I'm not sure that my approach is good enough as I use some hacks to make it work.