### PR TITLE
Fixed `redefined-builtins` pylint errors

### DIFF
--- a/pymc3/examples/GHME_2013.py
+++ b/pymc3/examples/GHME_2013.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from pyplot import plot, ylim, subplot, title
+from pylab import plot, ylim, subplot, title
 
 import pymc3 as pm
 

--- a/pymc3/glm/glm.py
+++ b/pymc3/glm/glm.py
@@ -228,13 +228,13 @@ class glm(namedtuple('Estimate', 'y_est,coeffs')):
                    )
 
 
-def plot_posterior_predictive(trace, eval=None, lm=None, samples=30, **kwargs):
+def plot_posterior_predictive(trace, eval_over=None, lm=None, samples=30, **kwargs):
     """Plot posterior predictive of a linear model.
 
     :Arguments:
         trace : <array>
             Array of posterior samples with columns
-        eval : <array>
+        eval_over : <array>
             Array over which to evaluate lm
         lm : function <default: linear function>
             Function mapping parameters at different points
@@ -252,8 +252,8 @@ def plot_posterior_predictive(trace, eval=None, lm=None, samples=30, **kwargs):
     if lm is None:
         lm = lambda x, sample: sample['Intercept'] + sample['x'] * x
 
-    if eval is None:
-        eval = np.linspace(0, 1, 100)
+    if eval_over is None:
+        eval_over = np.linspace(0, 1, 100)
 
     # Set default plotting arguments
     if 'lw' not in kwargs and 'linewidth' not in kwargs:
@@ -263,7 +263,7 @@ def plot_posterior_predictive(trace, eval=None, lm=None, samples=30, **kwargs):
 
     for rand_loc in np.random.randint(0, len(trace), samples):
         rand_sample = trace[rand_loc]
-        plt.plot(eval, lm(eval, rand_sample), **kwargs)
+        plt.plot(eval_over, lm(eval_over, rand_sample), **kwargs)
         # Make sure to not plot label multiple times
         kwargs.pop('label', None)
 

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -1,7 +1,7 @@
 from __future__ import division
 import sys
 import theano.tensor as tt
-# pylint: disable=unused-import
+# pylint: disable=unused-import, redefined-builtin
 import theano
 from theano.tensor import (
     constant, flatten, zeros_like, ones_like, stack, concatenate, sum, prod,
@@ -10,7 +10,7 @@ from theano.tensor import (
     minimum, sgn, ceil, floor)
 from theano.tensor.nlinalg import det, matrix_inverse, extract_diag, matrix_dot, trace
 from theano.tensor.nnet import sigmoid
-# pylint: enable=unused-import
+# pylint: enable=unused-import, redefined-builtin
 
 
 def logsumexp(x, axis=None):

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -736,12 +736,12 @@ compilef = fastfn
 class FreeRV(Factor, TensorVariable):
     """Unobserved random variable that a model is specified in terms of."""
 
-    def __init__(self, type=None, owner=None, index=None, name=None,
+    def __init__(self, dtype=None, owner=None, index=None, name=None,
                  distribution=None, total_size=None, model=None):
         """
         Parameters
         ----------
-        type : theano type (optional)
+        dtype : theano type (optional)
         owner : theano owner (optional)
         name : str
         distribution : Distribution
@@ -749,9 +749,9 @@ class FreeRV(Factor, TensorVariable):
         total_size : scalar Tensor (optional)
             needed for upscaling logp
         """
-        if type is None:
-            type = distribution.type
-        super(FreeRV, self).__init__(type, owner, index, name)
+        if dtype is None:
+            dtype = distribution.type
+        super(FreeRV, self).__init__(dtype, owner, index, name)
 
         if distribution is not None:
             self.dshape = tuple(distribution.shape)
@@ -817,25 +817,28 @@ class ObservedRV(Factor, TensorVariable):
     Potentially partially observed.
     """
 
-    def __init__(self, type=None, owner=None, index=None, name=None, data=None,
+    def __init__(self, dtype=None, owner=None, name=None, data=None,
                  distribution=None, total_size=None, model=None):
         """
         Parameters
         ----------
-        type : theano type (optional)
+        dtype : theano type (optional)
         owner : theano owner (optional)
         name : str
+        data : array_like (optional)
+           If data is provided, the variable is observed. If None,
+           the variable is unobserved.
         distribution : Distribution
-        model : Model
         total_size : scalar Tensor (optional)
             needed for upscaling logp
+        model : Model
         """
         from .distributions import TensorType
-        if type is None:
+        if dtype is None:
             data = pandas_to_array(data)
-            type = TensorType(distribution.dtype, data.shape)
+            dtype = TensorType(distribution.dtype, data.shape)
 
-        super(TensorVariable, self).__init__(type, None, None, name)
+        super(TensorVariable, self).__init__(dtype, None, None, name)
 
         if distribution is not None:
             data = as_tensor(data, name, model, distribution)
@@ -868,13 +871,12 @@ class MultiObservedRV(Factor):
         """
         Parameters
         ----------
-        type : theano type (optional)
-        owner : theano owner (optional)
         name : str
+        data : array_like
         distribution : Distribution
-        model : Model
         total_size : scalar Tensor (optional)
             needed for upscaling logp
+        model : Model
         """
         self.name = name
         self.data = {name: as_tensor(data, name, model, distribution)
@@ -927,14 +929,14 @@ def Potential(name, var, model=None):
 
 class TransformedRV(TensorVariable):
 
-    def __init__(self, type=None, owner=None, index=None, name=None,
+    def __init__(self, dtype=None, owner=None, index=None, name=None,
                  distribution=None, model=None, transform=None,
                  total_size=None):
         """
         Parameters
         ----------
 
-        type : theano type (optional)
+        dtype : theano type (optional)
         owner : theano owner (optional)
         name : str
         distribution : Distribution
@@ -942,9 +944,9 @@ class TransformedRV(TensorVariable):
         total_size : scalar Tensor (optional)
             needed for upscaling logp
         """
-        if type is None:
-            type = distribution.type
-        super(TransformedRV, self).__init__(type, owner, index, name)
+        if dtype is None:
+            dtype = distribution.type
+        super(TransformedRV, self).__init__(dtype, owner, index, name)
 
         if distribution is not None:
             self.model = model

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -232,15 +232,15 @@ class CallableTensor(object):
     def __init__(self, tensor):
         self.tensor = tensor
 
-    def __call__(self, input):
+    def __call__(self, sv_input):
         """ Replaces the single input of symbolic variable to be the passed argument.
 
         Parameters
         ----------
-        input : TensorVariable
+        sv_input : TensorVariable
         """
         oldinput, = inputvars(self.tensor)
-        return theano.clone(self.tensor, {oldinput: input}, strict=False)
+        return theano.clone(self.tensor, {oldinput: sv_input}, strict=False)
 
 scalar_identity = IdentityOp(scalar.upgrade_to_float, name='scalar_identity')
 identity = tt.Elemwise(scalar_identity, name='identity')

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -211,8 +211,8 @@ def _elbo_t(logp, uw, inarray, n_mcsamples, random_seed):
     w = uw[l_int:]
 
     # Callable tensor
-    def logp_(input):
-        return theano.clone(logp, {inarray: input}, strict=False)
+    def logp_(var):
+        return theano.clone(logp, {inarray: var}, strict=False)
 
     # Naive Monte-Carlo
     if random_seed is None:

--- a/pymc3/variational/advi_minibatch.py
+++ b/pymc3/variational/advi_minibatch.py
@@ -14,9 +14,9 @@ from .advi import ADVIFit, adagrad_optimizer, gen_random_state
 __all__ = ['advi_minibatch']
 
 
-def _value_error(cond, str):
+def _value_error(cond, msg):
     if not cond:
-        raise ValueError(str)
+        raise ValueError(msg)
 
 
 def _check_minibatches(minibatch_tensors, minibatches):


### PR DESCRIPTION
Diffing this separately, since it is pretty big, and the next check will be `unused-variable`, which is very big.

Biggest change was changing `type` to `dtype` (that file could also use some help with the documentation).  Left all uses of `vars` per discussion, left the check commented out, since it would be too noisy.  