### PR TITLE
Lint for unused variables

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -58,7 +58,7 @@ enable=import-error,
        bad-open-mode,
        redundant-unittest-assert,
        boolean-datetime,
-       unused-variable
+       # unused-variable
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -58,7 +58,7 @@ enable=import-error,
        bad-open-mode,
        redundant-unittest-assert,
        boolean-datetime,
-       # unused-variable
+       unused-variable
 
 
 [REPORTS]

--- a/pymc3/backends/tracetab.py
+++ b/pymc3/backends/tracetab.py
@@ -17,23 +17,23 @@ def trace_to_dataframe(trace, chains=None, varnames=None, hide_transformed_vars=
         Chains to include. If None, all chains are used. A single
         chain value can also be given.
     varnames : list of variable names
-        Variables to be included in the DataFrame, if None all variable are 
+        Variables to be included in the DataFrame, if None all variable are
         included.
     hide_transformed_vars: boolean
-        If true transformed variables will not be included in the resulting 
+        If true transformed variables will not be included in the resulting
         DataFrame.
     """
     var_shapes = trace._straces[0].var_shapes
-    
+
     if varnames is None:
         varnames = var_shapes.keys()
 
     flat_names = {v: create_flat_names(v, shape)
                     for v, shape in var_shapes.items()
                     if not (hide_transformed_vars and v.endswith('_'))}
-    
+
     var_dfs = []
-    for v, shape in var_shapes.items():
+    for v in var_shapes:
         if v in varnames:
             if not hide_transformed_vars or not v.endswith('_'):
                 vals = trace.get_values(v, combine=True, chains=chains)

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -217,8 +217,8 @@ class Normal(Continuous):
         super(Normal, self).__init__(**kwargs)
 
     def random(self, point=None, size=None, repeat=None):
-        mu, tau, sd = draw_values([self.mu, self.tau, self.sd],
-                                  point=point)
+        mu, tau, _ = draw_values([self.mu, self.tau, self.sd],
+                                 point=point)
         return generate_samples(stats.norm.rvs, loc=mu, scale=tau**-0.5,
                                 dist_shape=self.shape,
                                 size=size)
@@ -1287,7 +1287,7 @@ class SkewNormal(Continuous):
         assert_negative_support(sd, 'sd', 'SkewNormal')
 
     def random(self, point=None, size=None, repeat=None):
-        mu, tau, sd, alpha = draw_values(
+        mu, tau, _, alpha = draw_values(
             [self.mu, self.tau, self.sd, self.alpha], point=point)
         return generate_samples(stats.skewnorm.rvs,
                                 a=alpha, loc=mu, scale=tau**-0.5,

--- a/pymc3/examples/arma_example.py
+++ b/pymc3/examples/arma_example.py
@@ -70,7 +70,7 @@ def build_model():
                       non_sequences=[mu, phi, theta])
 
         Potential('like', Normal.dist(0, sd=sigma).logp(err))
-        mu, sds, elbo = variational.advi(n=2000)
+        variational.advi(n=2000)
     return arma_model
 
 

--- a/pymc3/examples/custom_dists.py
+++ b/pymc3/examples/custom_dists.py
@@ -48,7 +48,6 @@ def compute_sigma_level(trace1, trace2, nbins=20):
     """From a set of traces, bin by number of standard deviations"""
     L, xbins, ybins = np.histogram2d(trace1, trace2, nbins)
     L[L == 0] = 1E-16
-    logL = np.log(L)
 
     shape = L.shape
     L = L.ravel()
@@ -95,7 +94,7 @@ def plot_MCMC_model(ax, xdata, ydata, trace):
 
 def plot_MCMC_results(xdata, ydata, trace, colors='k'):
     """Plot both the trace and the model together"""
-    fig, ax = plt.subplots(1, 2, figsize=(10, 4))
+    _, ax = plt.subplots(1, 2, figsize=(10, 4))
     plot_MCMC_trace(ax[0], xdata, ydata, trace, True, colors=colors)
     plot_MCMC_model(ax[1], xdata, ydata, trace)
 

--- a/pymc3/examples/factor_potential.py
+++ b/pymc3/examples/factor_potential.py
@@ -13,7 +13,7 @@ def run(n=3000):
     if n == "short":
         n = 50
     with model:
-        trace = pm.sample(n, step=step, start=start)
+        pm.sample(n, step=step, start=start)
 
 if __name__ == '__main__':
     run()

--- a/pymc3/examples/gelman_bioassay.py
+++ b/pymc3/examples/gelman_bioassay.py
@@ -25,7 +25,7 @@ def run(n=1000):
     if n == "short":
         n = 50
     with model:
-        trace = pm.sample(n, step)
+        pm.sample(n, step)
 
 if __name__ == '__main__':
     run()

--- a/pymc3/examples/gelman_schools.py
+++ b/pymc3/examples/gelman_schools.py
@@ -4,12 +4,12 @@ import numpy as np
 '''Original Stan model
 
 data {
-  int<lower=0> J; // number of schools 
+  int<lower=0> J; // number of schools
   real y[J]; // estimated treatment effects
-  real<lower=0> sigma[J]; // s.e. of effect estimates 
+  real<lower=0> sigma[J]; // s.e. of effect estimates
 }
 parameters {
-  real mu; 
+  real mu;
   real<lower=0> tau;
   real eta[J];
 }
@@ -44,7 +44,7 @@ def run(n=1000):
         n = 50
     with schools:
         tr = sample(n)
-        l = loo(tr)
+        loo(tr)
 
 if __name__ == '__main__':
     run()

--- a/pymc3/examples/lasso_missing.py
+++ b/pymc3/examples/lasso_missing.py
@@ -52,7 +52,7 @@ def run(n=5000):
     if n == 'short':
         n = 100
     with model:
-        pm.trace = pm.sample(n, [step1, step2], start)
+        pm.sample(n, [step1, step2], start)
 
 
 if __name__ == '__main__':

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -652,7 +652,7 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor)):
         if point is None:
             point = self.test_point
 
-        for i in range(n):
+        for _ in range(n):
             f(**point)
 
         return f.profile

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -73,7 +73,7 @@ def traceplot(trace, varnames=None, transform=lambda x: x, figsize=None,
         figsize = (12, n * 2)
 
     if ax is None:
-        fig, ax = plt.subplots(n, 2, squeeze=False, figsize=figsize)
+        _, ax = plt.subplots(n, 2, squeeze=False, figsize=figsize)
     elif ax.shape != (n, 2):
         pm._log.warning('traceplot requires n*2 subplots')
         return None
@@ -166,14 +166,14 @@ def kde2plot_op(ax, x, y, grid=200, **kwargs):
 
 def kdeplot(data, ax=None):
     if ax is None:
-        f, ax = plt.subplots(1, 1, squeeze=True)
+        _, ax = plt.subplots(1, 1, squeeze=True)
     kdeplot_op(ax, data)
     return ax
 
 
 def kde2plot(x, y, grid=200, ax=None, **kwargs):
     if ax is None:
-        f, ax = plt.subplots(1, 1, squeeze=True)
+        _, ax = plt.subplots(1, 1, squeeze=True)
     kde2plot_op(ax, x, y, grid, **kwargs)
     return ax
 
@@ -232,8 +232,8 @@ def autocorrplot(trace, varnames=None, max_lag=100, burn=0, plot_transformed=Fal
         figsize = (12, len(varnames) * 2)
 
     if ax is None:
-        fig, ax = plt.subplots(len(varnames), nchains, squeeze=False,
-                               sharex=True, sharey=True, figsize=figsize)
+        _, ax = plt.subplots(len(varnames), nchains, squeeze=False,
+                             sharex=True, sharey=True, figsize=figsize)
     elif ax.shape != (len(varnames), nchains):
         raise ValueError('autocorrplot requires {}*{} subplots'.format(
             len(varnames), nchains))
@@ -300,7 +300,7 @@ def forestplot(trace_obj, varnames=None, transform=lambda x: x, alpha=0.05, quar
 
     Parameters
     ----------
-    
+
     trace_obj: NpTrace or MultiTrace object
         Trace(s) from an MCMC sample.
     varnames: list
@@ -311,7 +311,7 @@ def forestplot(trace_obj, varnames=None, transform=lambda x: x, alpha=0.05, quar
     alpha (optional): float
         Alpha value for (1-alpha)*100% credible intervals (defaults to 0.05).
     quartiles (optional): bool
-        Flag for plotting the interquartile range, in addition to the 
+        Flag for plotting the interquartile range, in addition to the
         (1-alpha)*100% intervals (defaults to True).
     rhat (optional): bool
         Flag for plotting Gelman-Rubin statistics. Requires 2 or more chains
@@ -778,13 +778,13 @@ def plot_posterior(trace, varnames=None, transform=lambda x: x, figsize=None,
         fig.tight_layout()
     return ax
 
-    
+
 def fast_kde(x):
     """
     A fft-based Gaussian kernel density estimate (KDE) for computing
     the KDE on a regular grid.
     The code was adapted from https://github.com/mfouesneau/faststats
-    
+
     Parameters
     ----------
 
@@ -796,13 +796,13 @@ def fast_kde(x):
     grid: A gridded 1D KDE of the input points (x).
     xmin: minimum value of x
     xmax: maximum value of x
-    
+
     """
     # add small jitter in case input values are the same
     x = np.random.normal(x, 1e-12)
-    
+
     xmin, xmax = x.min(), x.max()
-    
+
     n = len(x)
     nx = 256
 

--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -45,8 +45,6 @@ class ElemwiseCategorical(ArrayStep):
 
     @staticmethod
     def competence(var):
-        distribution = getattr(
-            var.distribution, 'parent_dist', var.distribution)
         if isinstance(var.distribution, Categorical):
             return Competence.COMPATIBLE
         return Competence.INCOMPATIBLE
@@ -66,7 +64,7 @@ def categorical(prob, shape):
                             op_flags=[['readonly'], ['readwrite']],
                             flags=['reduce_ok'])
 
-    for i in it0:
+    for _ in it0:
         p, o = it1.itviews
         p = cumsum(exp(p - max(p, axis=0)))
         r = uniform() * p[-1]

--- a/pymc3/tests/models.py
+++ b/pymc3/tests/models.py
@@ -43,8 +43,7 @@ def simple_arbitrary_det():
     with Model() as model:
         a = Normal('a')
         b = arbitrary_det(a)
-        c = Normal('obs', mu=b.astype('float64'),
-                   observed=np.array([1, 3, 5]))
+        Normal('obs', mu=b.astype('float64'), observed=np.array([1, 3, 5]))
 
     return model.test_point, model
 

--- a/pymc3/tests/test_dist_math.py
+++ b/pymc3/tests/test_dist_math.py
@@ -104,11 +104,11 @@ def test_multinomial_bound():
 
     with pm.Model() as modelA:
         p_a = pm.Dirichlet('p', np.ones(2))
-        x_obs_a = MultinomialA('x', n, p_a, observed=x)
+        MultinomialA('x', n, p_a, observed=x)
 
     with pm.Model() as modelB:
         p_b = pm.Dirichlet('p', np.ones(2))
-        x_obs_b = MultinomialB('x', n, p_b, observed=x)
+        MultinomialB('x', n, p_b, observed=x)
 
     assert np.isclose(modelA.logp({'p_stickbreaking_': [0]}),
                       modelB.logp({'p_stickbreaking_': [0]}))

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -55,7 +55,7 @@ def pymc3_random_discrete(dist, paramdomains,
             if np.all(k[:, 0] == k[:, 1]):
                 p = 1.
             else:
-                _chi, p = st.chisquare(k[:, 0], k[:, 1])
+                _, p = st.chisquare(k[:, 0], k[:, 1])
             f -= 1
         assert p > alpha, str(pt)
 

--- a/pymc3/tests/test_distributions_timeseries.py
+++ b/pymc3/tests/test_distributions_timeseries.py
@@ -34,7 +34,7 @@ def test_linear():
     with Model() as model:
         lamh = Flat('lamh')
         xh = EulerMaruyama('xh', dt, sde, (lamh,), shape=N + 1, testval=x)
-        zh = Normal('zh', mu=xh, sd=5e-3, observed=z)
+        Normal('zh', mu=xh, sd=5e-3, observed=z)
     # invert
     with model:
         start = find_MAP(vars=[xh], fmin=fmin_l_bfgs_b)

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -198,7 +198,7 @@ class TestGLMLinear(SeededTest):
     def test_run(self):
         with self.build_model():
             start = pm.find_MAP(fmin=opt.fmin_powell)
-            trace = pm.sample(50, pm.Slice(), start=start)
+            pm.sample(50, pm.Slice(), start=start)
 
 
 class TestLatentOccupancy(SeededTest):

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -1,3 +1,4 @@
+#  pylint:disable=unused-variable
 import unittest
 from pymc3 import Model, gp
 import theano
@@ -7,21 +8,21 @@ import numpy as np
 class ExpQuadTest(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model():
+        with Model() as model:
             cov = gp.cov.ExpQuad(1, 0.1)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.53940, 3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.ExpQuad(2, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.820754, 3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.ExpQuad(2, np.array([1, 2]))
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.969607, 3)
@@ -30,21 +31,21 @@ class ExpQuadTest(unittest.TestCase):
 class RatQuadTest(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model():
+        with Model() as model:
             cov = gp.cov.RatQuad(1, 0.1, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.66896, 3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.RatQuad(2, 0.5, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.84664, 3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.RatQuad(2, np.array([1, 2]), 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.97049, 3)
@@ -53,21 +54,21 @@ class RatQuadTest(unittest.TestCase):
 class ExponentialTest(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model():
+        with Model() as model:
             cov = gp.cov.Exponential(1, 0.1)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.57375, 3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.Exponential(2, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.73032, 3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.Exponential(2, np.array([1, 2]))
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.88318, 3)
@@ -76,21 +77,21 @@ class ExponentialTest(unittest.TestCase):
 class Matern52Test(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model():
+        with Model() as model:
             cov = gp.cov.Matern52(1, 0.1)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.46202, 3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.Matern52(2, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.75143, 3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.Matern52(2, np.array([1, 2]))
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.95153, 3)
@@ -99,21 +100,21 @@ class Matern52Test(unittest.TestCase):
 class Matern32Test(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model():
+        with Model() as model:
             cov = gp.cov.Matern32(1, 0.1)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.42682, 3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.Matern32(2, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.70318, 3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.Matern32(2, np.array([1, 2]))
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.930135, 3)
@@ -122,21 +123,21 @@ class Matern32Test(unittest.TestCase):
 class LinearTest(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model():
+        with Model() as model:
             cov = gp.cov.Linear(1, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.19444, 3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.Linear(2, 0.2)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], -0.01629, 3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.Linear(2, np.array([0.2, -0.1]))
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.08703, 3)
@@ -145,21 +146,21 @@ class LinearTest(unittest.TestCase):
 class PolynomialTest(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model():
+        with Model() as model:
             cov = gp.cov.Polynomial(1, 0.5, 2, 0)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.03780, 4)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.Polynomial(2, 0.2, 2, 0)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.00026, 4)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model():
+        with Model() as model:
             cov = gp.cov.Polynomial(2, np.array([0.2, -0.1]), 2, 0)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.00757, 4)
@@ -171,7 +172,7 @@ class WarpedInputTest(unittest.TestCase):
 
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model():
+        with Model() as model:
             cov_m52 = gp.cov.Matern52(1, 0.2)
             cov = gp.cov.WarpedInput(1, warp_func=self.warp_func, args=(1,10,1), cov_func=cov_m52)
         K = theano.function([], cov.K(X))()

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -7,21 +7,21 @@ import numpy as np
 class ExpQuadTest(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model() as model:
+        with Model():
             cov = gp.cov.ExpQuad(1, 0.1)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.53940, 3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.ExpQuad(2, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.820754, 3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.ExpQuad(2, np.array([1, 2]))
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.969607, 3)
@@ -30,21 +30,21 @@ class ExpQuadTest(unittest.TestCase):
 class RatQuadTest(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model() as model:
+        with Model():
             cov = gp.cov.RatQuad(1, 0.1, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.66896, 3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.RatQuad(2, 0.5, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.84664, 3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.RatQuad(2, np.array([1, 2]), 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.97049, 3)
@@ -53,21 +53,21 @@ class RatQuadTest(unittest.TestCase):
 class ExponentialTest(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model() as model:
+        with Model():
             cov = gp.cov.Exponential(1, 0.1)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.57375, 3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.Exponential(2, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.73032, 3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.Exponential(2, np.array([1, 2]))
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.88318, 3)
@@ -76,21 +76,21 @@ class ExponentialTest(unittest.TestCase):
 class Matern52Test(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model() as model:
+        with Model():
             cov = gp.cov.Matern52(1, 0.1)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.46202, 3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.Matern52(2, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.75143, 3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.Matern52(2, np.array([1, 2]))
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.95153, 3)
@@ -99,21 +99,21 @@ class Matern52Test(unittest.TestCase):
 class Matern32Test(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model() as model:
+        with Model():
             cov = gp.cov.Matern32(1, 0.1)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.42682, 3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.Matern32(2, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.70318, 3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.Matern32(2, np.array([1, 2]))
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.930135, 3)
@@ -122,21 +122,21 @@ class Matern32Test(unittest.TestCase):
 class LinearTest(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model() as model:
+        with Model():
             cov = gp.cov.Linear(1, 0.5)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.19444, 3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.Linear(2, 0.2)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], -0.01629, 3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.Linear(2, np.array([0.2, -0.1]))
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.08703, 3)
@@ -145,21 +145,21 @@ class LinearTest(unittest.TestCase):
 class PolynomialTest(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model() as model:
+        with Model():
             cov = gp.cov.Polynomial(1, 0.5, 2, 0)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.03780, 4)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.Polynomial(2, 0.2, 2, 0)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.00026, 4)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
+        with Model():
             cov = gp.cov.Polynomial(2, np.array([0.2, -0.1]), 2, 0)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.00757, 4)
@@ -171,10 +171,8 @@ class WarpedInputTest(unittest.TestCase):
 
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
-        with Model() as model:
+        with Model():
             cov_m52 = gp.cov.Matern52(1, 0.2)
             cov = gp.cov.WarpedInput(1, warp_func=self.warp_func, args=(1,10,1), cov_func=cov_m52)
         K = theano.function([], cov.K(X))()
         self.assertAlmostEqual(K[0,1], 0.79593, 4)
-
-

--- a/pymc3/tests/test_hmc.py
+++ b/pymc3/tests/test_hmc.py
@@ -29,7 +29,7 @@ def test_leapfrog_reversible():
 def test_nuts_tuning():
     model = pymc3.Model()
     with model:
-        mu = pymc3.Normal("mu", mu=0, sd=1)
+        pymc3.Normal("mu", mu=0, sd=1)
         step = pymc3.NUTS()
-        trace = pymc3.sample(10, step=step, tune=5, progressbar=False)
+        pymc3.sample(10, step=step, tune=5, progressbar=False)
     assert not step.tune

--- a/pymc3/tests/test_mixture.py
+++ b/pymc3/tests/test_mixture.py
@@ -35,17 +35,13 @@ class TestMixture(SeededTest):
         cls.pois_x = generate_poisson_mixture_data(cls.pois_w, cls.pois_mu, size=1000)
 
     def test_mixture_list_of_normals(self):
-        with Model() as model:
+        with Model():
             w = Dirichlet('w', np.ones_like(self.norm_w))
-
             mu = Normal('mu', 0., 10., shape=self.norm_w.size)
             tau = Gamma('tau', 1., 1., shape=self.norm_w.size)
-
-            x_obs = Mixture('x_obs', w,
-                            [Normal.dist(mu[0], tau=tau[0]),
-                             Normal.dist(mu[1], tau=tau[1])],
-                            observed=self.norm_x)
-
+            Mixture('x_obs', w,
+                    [Normal.dist(mu[0], tau=tau[0]), Normal.dist(mu[1], tau=tau[1])],
+                    observed=self.norm_x)
             step = Metropolis()
             trace = sample(5000, step, random_seed=self.random_seed, progressbar=False)
 
@@ -57,14 +53,11 @@ class TestMixture(SeededTest):
                         rtol=0.1, atol=0.1)
 
     def test_normal_mixture(self):
-        with Model() as model:
+        with Model():
             w = Dirichlet('w', np.ones_like(self.norm_w))
-
             mu = Normal('mu', 0., 10., shape=self.norm_w.size)
             tau = Gamma('tau', 1., 1., shape=self.norm_w.size)
-
-            x_obs = NormalMixture('x_obs', w, mu, tau=tau, observed=self.norm_x)
-
+            NormalMixture('x_obs', w, mu, tau=tau, observed=self.norm_x)
             step = Metropolis()
             trace = sample(5000, step, random_seed=self.random_seed, progressbar=False)
 
@@ -76,13 +69,10 @@ class TestMixture(SeededTest):
                         rtol=0.1, atol=0.1)
 
     def test_poisson_mixture(self):
-        with Model() as model:
+        with Model():
             w = Dirichlet('w', np.ones_like(self.pois_w))
-
             mu = Gamma('mu', 1., 1., shape=self.pois_w.size)
-
-            x_obs = Mixture('x_obs', w, Poisson.dist(mu), observed=self.pois_x)
-
+            Mixture('x_obs', w, Poisson.dist(mu), observed=self.pois_x)
             step = Metropolis()
             trace = sample(5000, step, random_seed=self.random_seed, progressbar=False)
 
@@ -94,15 +84,12 @@ class TestMixture(SeededTest):
                         rtol=0.1, atol=0.1)
 
     def test_mixture_list_of_poissons(self):
-        with Model() as model:
+        with Model():
             w = Dirichlet('w', np.ones_like(self.pois_w))
-
             mu = Gamma('mu', 1., 1., shape=self.pois_w.size)
-
-            x_obs = Mixture('x_obs', w,
-                            [Poisson.dist(mu[0]), Poisson.dist(mu[1])],
-                            observed=self.pois_x)
-
+            Mixture('x_obs', w,
+                    [Poisson.dist(mu[0]), Poisson.dist(mu[1])],
+                    observed=self.pois_x)
             step = Metropolis()
             trace = sample(5000, step, random_seed=self.random_seed, progressbar=False)
 

--- a/pymc3/tests/test_mixture.py
+++ b/pymc3/tests/test_mixture.py
@@ -35,7 +35,7 @@ class TestMixture(SeededTest):
         cls.pois_x = generate_poisson_mixture_data(cls.pois_w, cls.pois_mu, size=1000)
 
     def test_mixture_list_of_normals(self):
-        with Model():
+        with Model() as model:
             w = Dirichlet('w', np.ones_like(self.norm_w))
             mu = Normal('mu', 0., 10., shape=self.norm_w.size)
             tau = Gamma('tau', 1., 1., shape=self.norm_w.size)
@@ -53,7 +53,7 @@ class TestMixture(SeededTest):
                         rtol=0.1, atol=0.1)
 
     def test_normal_mixture(self):
-        with Model():
+        with Model() as model:
             w = Dirichlet('w', np.ones_like(self.norm_w))
             mu = Normal('mu', 0., 10., shape=self.norm_w.size)
             tau = Gamma('tau', 1., 1., shape=self.norm_w.size)
@@ -69,7 +69,7 @@ class TestMixture(SeededTest):
                         rtol=0.1, atol=0.1)
 
     def test_poisson_mixture(self):
-        with Model():
+        with Model() as model:
             w = Dirichlet('w', np.ones_like(self.pois_w))
             mu = Gamma('mu', 1., 1., shape=self.pois_w.size)
             Mixture('x_obs', w, Poisson.dist(mu), observed=self.pois_x)
@@ -84,7 +84,7 @@ class TestMixture(SeededTest):
                         rtol=0.1, atol=0.1)
 
     def test_mixture_list_of_poissons(self):
-        with Model():
+        with Model() as model:
             w = Dirichlet('w', np.ones_like(self.pois_w))
             mu = Gamma('mu', 1., 1., shape=self.pois_w.size)
             Mixture('x_obs', w,

--- a/pymc3/tests/test_model_func.py
+++ b/pymc3/tests/test_model_func.py
@@ -18,7 +18,7 @@ def test_dlogp():
 
 
 def test_dlogp2():
-    start, model, (mu, sig) = mv_simple()
+    start, model, (_, sig) = mv_simple()
     H = np.linalg.inv(sig)
     d2logp = model.fastd2logp()
     close_to(d2logp(start), H, np.abs(H / 100.))

--- a/pymc3/tests/test_modelcontext.py
+++ b/pymc3/tests/test_modelcontext.py
@@ -14,7 +14,7 @@ class TestModelContext(unittest.TestCase):
         that thread A enters the context manager first, then B,
         then A attempts to declare a variable while B is still in the context manager.
         """
-        aInCtxt,bInCtxt,aDone = [threading.Event() for k in range(3)]
+        aInCtxt,bInCtxt,aDone = [threading.Event() for _ in range(3)]
         modelA = Model()
         modelB = Model()
         def make_model_a():

--- a/pymc3/tests/test_modelcontext.py
+++ b/pymc3/tests/test_modelcontext.py
@@ -21,14 +21,14 @@ class TestModelContext(unittest.TestCase):
             with modelA:
                 aInCtxt.set()
                 bInCtxt.wait()
-                a = Normal('a',0,1)
+                Normal('a',0,1)
             aDone.set()
         def make_model_b():
             aInCtxt.wait()
             with modelB:
                 bInCtxt.set()
                 aDone.wait()
-                b = Normal('b', 0, 1)
+                Normal('b', 0, 1)
         threadA = threading.Thread(target=make_model_a)
         threadB = threading.Thread(target=make_model_b)
         threadA.start()

--- a/pymc3/tests/test_pickling.py
+++ b/pymc3/tests/test_pickling.py
@@ -13,9 +13,9 @@ class TestPickling(unittest.TestCase):
         for proto in range(pickle.HIGHEST_PROTOCOL+1):
             try:
                 s = pickle.dumps(m, proto)
-                n = pickle.loads(s)
-            except Exception as ex:
+                pickle.loads(s)
+            except Exception:
                 raise AssertionError(
-                    "Exception while trying roundtrip with pickle protocol %d:\n"%proto +
+                    "Exception while trying roundtrip with pickle protocol %d:\n" % proto +
                     ''.join(traceback.format_exc())
                 )

--- a/pymc3/tests/test_plots.py
+++ b/pymc3/tests/test_plots.py
@@ -68,7 +68,7 @@ def test_make_2d():
 
 
 def test_plots_transformed():
-    with pm.Model():
+    with pm.Model() as model:
         pm.Uniform('x', 0, 1)
         step = pm.Metropolis()
         trace = pm.sample(100, step=step)

--- a/pymc3/tests/test_plots.py
+++ b/pymc3/tests/test_plots.py
@@ -31,7 +31,7 @@ def test_plots():
 def test_plots_multidimensional():
     # Test single trace
     start, model, _ = multidimensional_model()
-    with model as model:
+    with model:
         h = np.diag(find_hessian(start))
         step = Metropolis(model.vars, h)
         trace = sample(3000, step=step, start=start)
@@ -68,7 +68,7 @@ def test_make_2d():
 
 
 def test_plots_transformed():
-    with pm.Model() as model:
+    with pm.Model():
         pm.Uniform('x', 0, 1)
         step = pm.Metropolis()
         trace = pm.sample(100, step=step)

--- a/pymc3/tests/test_quadpotential.py
+++ b/pymc3/tests/test_quadpotential.py
@@ -121,7 +121,7 @@ def test_random_diag():
         quadpotential.quad_potential(np.diag(1./d), False, False),
     ]
     if quadpotential.chol_available:
-        d_ = scipy.sparse.csc_matrix(np.diag(d))
+        d = scipy.sparse.csc_matrix(np.diag(d))
         pot = quadpotential.quad_potential(d, True, False)
         pots.append(pot)
     for pot in pots:

--- a/pymc3/tests/test_shared.py
+++ b/pymc3/tests/test_shared.py
@@ -20,9 +20,9 @@ class TestShared(SeededTest):
 
         x_shared = theano.shared(x)
 
-        with pm.Model() as model:
-            b = pm.Normal('b', 0., 10.)   
-            obs = pm.Normal('obs', b * x_shared, np.sqrt(1e-2), observed=y)
+        with pm.Model():
+            b = pm.Normal('b', 0., 10.)
+            pm.Normal('obs', b * x_shared, np.sqrt(1e-2), observed=y)
 
             trace = pm.sample(1000, init=None, progressbar=False)
 

--- a/pymc3/tests/test_shared.py
+++ b/pymc3/tests/test_shared.py
@@ -20,7 +20,7 @@ class TestShared(SeededTest):
 
         x_shared = theano.shared(x)
 
-        with pm.Model():
+        with pm.Model() as model:
             b = pm.Normal('b', 0., 10.)
             pm.Normal('obs', b * x_shared, np.sqrt(1e-2), observed=y)
 

--- a/pymc3/tests/test_stats.py
+++ b/pymc3/tests/test_stats.py
@@ -372,7 +372,7 @@ class TestDfSummary(bf.ModelBackendSampledTestCase):
                 npt.assert_equal(val, ds.loc[vidx, 'mean'])
 
     def test_row_names(self):
-        with Model():
+        with Model() as model:
             pm.Uniform('x', 0, 1)
             step = Metropolis()
             trace = pm.sample(100, step=step)

--- a/pymc3/tests/test_stats.py
+++ b/pymc3/tests/test_stats.py
@@ -77,17 +77,17 @@ class TestStats(SeededTest):
 
             step = pm.Metropolis()
             trace = pm.sample(100, step)
-            calculated_waic, calculated_waic_se  = pm.waic(trace)
+            calculated_waic, calculated_waic_se = pm.waic(trace)
 
         log_py = st.binom.logpmf(np.atleast_2d(x_obs).T, 5, trace['p']).T
 
         lppd_i = np.log(np.mean(np.exp(log_py), axis=0))
         vars_lpd = np.var(log_py, axis=0)
         waic_i = - 2 * (lppd_i - vars_lpd)
-        
+
         actual_waic_se = np.sqrt(len(waic_i) * np.var(waic_i))
         actual_waic = np.sum(waic_i)
-        
+
         assert_almost_equal(calculated_waic, actual_waic, decimal=2)
         assert_almost_equal(calculated_waic_se, actual_waic_se, decimal=2)
 
@@ -372,7 +372,7 @@ class TestDfSummary(bf.ModelBackendSampledTestCase):
                 npt.assert_equal(val, ds.loc[vidx, 'mean'])
 
     def test_row_names(self):
-        with Model() as model:
+        with Model():
             pm.Uniform('x', 0, 1)
             step = Metropolis()
             trace = pm.sample(100, step=step)

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -127,7 +127,7 @@ class TestStepMethods(object):  # yield test doesn't work subclassing unittest.T
             tqdm.write('Benchmarking {} with {:,d} samples'.format(step_method.__name__, n_steps))
         else:
             tqdm.write('Checking {} has same trace as on master'.format(step_method.__name__))
-        with Model():
+        with Model() as model:
             Normal('x', mu=0, sd=1)
             trace = sample(n_steps, step=step_method(), random_seed=1)
 

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -253,12 +253,12 @@ class TestSampleEstimates(SeededTest):
         Y = alpha_true + beta_true * X + np.random.randn(size) * sigma_true
 
         decimal = 1
-        with Model() as model:
+        with Model():
             alpha = Normal('alpha', mu=0, sd=100, testval=alpha_true)
             beta = Normal('beta', mu=0, sd=100, testval=beta_true)
             sigma = InverseGamma('sigma', 10., testval=sigma_true)
             mu = alpha + beta * X
-            Y_obs = Normal('Y_obs', mu=mu, sd=sigma, observed=Y)
+            Normal('Y_obs', mu=mu, sd=sigma, observed=Y)
 
             for step_method, params in ((NUTS, {"target_accept": 0.95}), (Slice, {}), (Metropolis, {'scaling': 10.})):
                 trace = sample(100000, step=step_method(**params), tune=1000)

--- a/pymc3/tests/test_theanof.py
+++ b/pymc3/tests/test_theanof.py
@@ -27,7 +27,7 @@ class TestGenerator(unittest.TestCase):
         f = theano.function([], gop)
         self.assertEqual(f(), np.float32(0))
         self.assertEqual(f(), np.float32(1))
-        for i in range(2, 100):
+        for _ in range(2, 100):
             f()
         self.assertEqual(f(), np.float32(100))
 
@@ -51,7 +51,7 @@ class TestGenerator(unittest.TestCase):
 
     def test_nans_produced(self):
         def gen():
-            for i in range(2):
+            for _ in range(2):
                 yield np.ones((10, 10))
 
         gop = generator(gen())
@@ -64,7 +64,7 @@ class TestGenerator(unittest.TestCase):
 
     def test_setvalue(self):
         def gen():
-            for i in range(2):
+            for _ in range(2):
                 yield np.ones((10, 10))
 
         gop = generator(gen())

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -143,14 +143,10 @@ class IdentityOp(scalar.UnaryScalarOp):
         return x
 
     def grad(self, inp, grads):
-        x, = inp
-        gz, = grads
         return grads
 
     def c_code(self, node, name, inp, out, sub):
-        x, = inp
-        z, = out
-        return """%(z)s = %(x)s;""" % locals()
+        return "{z} = {x};".format(x=inp[0], z=out[0])
 
     def __eq__(self, other):
         return type(self) == type(other)

--- a/pymc3/tuning/scaling.py
+++ b/pymc3/tuning/scaling.py
@@ -67,8 +67,6 @@ def fixed_hessian(point, vars=None, model=None):
     point = Point(point, model=model)
 
     bij = DictToArrayBijection(ArrayOrdering(vars), point)
-    dlogp = bij.mapf(model.fastdlogp(vars))
-
     rval = np.ones(bij.map(point).size) / 10
     return rval
 


### PR DESCRIPTION
No more unused variables!  The most possibly objectionable part of this PR is a lot of examples go from:
```
with pm.Model() as model:
   mu = pm.SomeDistribution()
   trace = pm.sample()
```
into something like:
```
with pm.Model():
    pm.SomeDistribution()
    pm.sample()
```
I prefer the second (it makes it clear that state is being updated in place), but can close the PR if some of you who have taught more tutorials think it is worse.