### PR TITLE
CategorialGibbsMetropolis accepts custom categorical distributions (#1739)

### DIFF
--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -238,7 +238,7 @@ class BinaryMetropolis(ArrayStep):
             var.distribution, 'parent_dist', var.distribution)
         if isinstance(distribution, pm.Bernoulli) or (var.dtype in pm.bool_types):
             return Competence.COMPATIBLE
-        elif isinstance(distribution, pm.Categorical) and (distribution.k == 2):
+        elif hasattr(distribution, 'k') and (distribution.k == 2):
             return Competence.COMPATIBLE
         return Competence.INCOMPATIBLE
 
@@ -294,7 +294,7 @@ class BinaryGibbsMetropolis(ArrayStep):
             var.distribution, 'parent_dist', var.distribution)
         if isinstance(distribution, pm.Bernoulli) or (var.dtype in pm.bool_types):
             return Competence.IDEAL
-        elif isinstance(distribution, pm.Categorical) and (distribution.k == 2):
+        elif hasattr(distribution, 'k') and (distribution.k == 2):
             return Competence.IDEAL
         return Competence.INCOMPATIBLE
 
@@ -319,7 +319,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
         # categories, we will have dimcats = [(0, M), (1, M), (2, N), (3, N), (4, N)].
         for v in vars:
             distr = getattr(v.distribution, 'parent_dist', v.distribution)
-            if isinstance(distr, pm.Categorical):
+            if hasattr(distr, 'k'):
                 k = draw_values([distr.k])[0]
             elif isinstance(distr, pm.Bernoulli) or (v.dtype in pm.bool_types):
                 k = 2
@@ -407,7 +407,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
         '''
         distribution = getattr(
             var.distribution, 'parent_dist', var.distribution)
-        if isinstance(distribution, pm.Categorical):
+        if hasattr(distribution, 'k'):
             if distribution.k > 2:
                 return Competence.IDEAL
             return Competence.COMPATIBLE


### PR DESCRIPTION
made changes to how Binary and Categorial Metropolis stepper methods check which distributions are compatible.  Instead of checking whether a distribution is pm.Categorial, I check whether it has an attribute k, and then whether k is in the right range.

This change will allow CategorialGibbsMetropolis to accept custom distributions that use Categorial distributions (see #1739) and the original StackExchange [question](http://stackoverflow.com/questions/41899454/what-pymc3-monte-carlo-stepper-can-i-use-for-a-custom-categorial-distribution).

I tested the changes on my code that can be found [here](https://github.com/hstrey/Hidden-Markov-Models-pymc3/blob/master/HMM_2state_Gaussian.ipynb).