### PR TITLE
hdf5 trace

### DIFF
--- a/pymc3/backends/__init__.py
+++ b/pymc3/backends/__init__.py
@@ -116,8 +116,11 @@ For specific examples, see pymc3.backends.{ndarray,text,sqlite}.py.
 from ..backends.ndarray import NDArray
 from ..backends.text import Text
 from ..backends.sqlite import SQLite
+from ..backends.hdf5 import HDF5
 
 _shortcuts = {'text': {'backend': Text,
                        'name': 'mcmc'},
               'sqlite': {'backend': SQLite,
-                         'name': 'mcmc.sqlite'}}
+                         'name': 'mcmc.sqlite'},
+              'hdf5': {'backend': HDF5,
+                       'name': 'mcmc.hdf5'}}

--- a/pymc3/backends/hdf5.py
+++ b/pymc3/backends/hdf5.py
@@ -152,7 +152,6 @@ class HDF5(base.BaseTrace):
     def record(self, point, sampler_stats=None):
         with self.activate_file:
             for varname, value in zip(self.varnames, self.fn(point)):
-                assert self.samples[varname].shape[1:] == value.shape, '{} {} {} {}'.format(varname, self.samples[varname].shape, self.var_shapes[varname], value.shape)
                 self.samples[varname][self.draw_idx] = value
 
             if self.records_stats and sampler_stats is None:

--- a/pymc3/backends/hdf5.py
+++ b/pymc3/backends/hdf5.py
@@ -1,5 +1,4 @@
-import ndarray
-import base
+from ..backends import base, ndarray
 import h5py
 import numpy as np
 from contextlib import contextmanager

--- a/pymc3/backends/hdf5.py
+++ b/pymc3/backends/hdf5.py
@@ -1,0 +1,98 @@
+from ndarray import NDArray
+import h5py
+import numpy as np
+from contextlib import contextmanager
+
+@contextmanager
+def activator(instance):
+    with instance.h5file as f:
+        instance.samples = f
+        yield
+    instance.samples = None
+
+
+class HDF5(NDArray):
+    """HDF5 trace object
+
+        Parameters
+        ----------
+        name : str
+            Name of backend. This has no meaning for the HDF5 backend.
+        model : Model
+            If None, the model is taken from the `with` context.
+        vars : list of variables
+            Sampling values will be stored for these variables. If None,
+            `model.unobserved_RVs` is used.
+        """
+    @property
+    def activate_file(self):
+        return activator(self)
+
+    @property
+    def h5file(self):
+        return h5py.File(self.name, 'a')
+
+    @property
+    def is_setup(self):
+        with self.h5file as f:
+            return 'chains' in f.attrs.keys()
+
+    def setup(self, draws, chain):
+        """Perform chain-specific setup.
+
+        Parameters
+        ----------
+        draws : int
+            Expected number of draws
+        chain : int
+            Chain number
+        """
+        self.chain = chain
+        if self.is_setup:  # Concatenate new array if chain is already present.
+            old_draws = len(self)
+            self.draws = old_draws + draws
+            self.draws_idx = old_draws
+            with self.h5file as file:
+                chs = file.attrs['chains']
+                if self.chain not in chs:
+                    file.attrs['chains'] = np.append(chs, self.chain)
+                    for v in file.itervalues():
+                        v.resize(len(chs), axis=0)
+                for v in file.itervalues():
+                    v.resize(self.draws, axis=1)
+                self.chain_dict = {c: i for i, c in enumerate(chs)}
+
+        else:  # Otherwise, make array of zeros for each variable.
+            self.draws = draws
+            with self.h5file as file:
+                file.attrs['chains'] = [self.chain]
+                for varname, shape in self.var_shapes.items():
+                    ds = file.create_dataset(varname, (1, draws) + shape, dtype=self.var_dtypes[varname], maxshape=(None, None)+shape)
+                self.chain_dict = {self.chain: 0}
+
+    def close(self):
+        with self.activate_file:
+            if self.draw_idx == self.draws:
+                return
+            # Remove trailing zeros if interrupted before completed all
+            # draws.
+            for ds in self.samples.itervalues():
+                self.samples.resize(self.draws_idx+1, axis=1)
+
+    def record(self, point):
+        with self.activate_file:
+            for varname, value in zip(self.varnames, self.fn(point)):
+                self.samples[varname][self.chain_dict[self.chain], self.draw_idx] = value
+            self.draw_idx += 1
+
+    def get_values(self, varname, burn=0, thin=1):
+        with self.activate_file:
+            return super(HDF5, self).get_values(varname, burn, thin)
+
+    def _slice(self, idx):
+        with self.activate_file:
+            return super(HDF5, self)._slice(idx)
+
+    def point(self, idx):
+        with self.activate_file:
+            return super(HDF5, self).point(idx)

--- a/pymc3/backends/hdf5.py
+++ b/pymc3/backends/hdf5.py
@@ -85,14 +85,14 @@ class HDF5(ndarray.NDArray):
             else:
                 if not self.chain_is_setup:
                     self.draws = draws
-                    for v in self.samples.itervalues():
+                    for v in self.samples.values():
                         v.resize(self.nchains+1, axis=0)
                     self.samples.attrs['chains'] = np.append(self.samples.attrs['chains'], self.chain)
                 else:
                     old_draws = len(self)
                     self.draws = old_draws + draws
                     self.draw_idx = old_draws  # tag onto end of chain
-                for v in self.samples.itervalues():
+                for v in self.samples.values():
                     v.resize(self.draws, axis=1)
 
 
@@ -102,7 +102,7 @@ class HDF5(ndarray.NDArray):
                 return
             # Remove trailing zeros if interrupted before completed all
             # draws.
-            for ds in self.samples.itervalues():
+            for ds in self.samples.values():
                 ds.resize(self.draw_idx, axis=1)
 
     def record(self, point):
@@ -143,7 +143,7 @@ class HDF5(ndarray.NDArray):
     def __len__(self):
         if self.chain_is_setup:
             with self.activate_file:
-                return self.samples.values()[0].shape[1]
+                return list(self.samples.values())[0].shape[1]
         return 0
 
 

--- a/pymc3/backends/hdf5.py
+++ b/pymc3/backends/hdf5.py
@@ -204,7 +204,7 @@ class HDF5(base.BaseTrace):
         with self.activate_file:
             idx = int(idx)
             r = {}
-            for varname, values in self.samples.iteritems():
+            for varname, values in self.samples.items():
                 r[varname] = values[idx]
             return r
 

--- a/pymc3/tests/test_hdf5_backend.py
+++ b/pymc3/tests/test_hdf5_backend.py
@@ -18,10 +18,23 @@ STATS2 = [{
 
 DBNAME = os.path.join(tempfile.gettempdir(), 'test.h5')
 
-
 class TestHDF50dSampling(bf.SamplingTestCase):
     backend = hdf5.HDF5
     name = DBNAME
+    shape = ()
+
+
+class TestHDF50dSamplingStats1(bf.SamplingTestCase):
+    backend = hdf5.HDF5
+    name = DBNAME
+    sampler_vars = STATS1
+    shape = ()
+
+
+class TestHDF50dSamplingStats2(bf.SamplingTestCase):
+    backend = hdf5.HDF5
+    name = DBNAME
+    sampler_vars = STATS2
     shape = ()
 
 
@@ -37,10 +50,30 @@ class TestHDF52dSampling(bf.SamplingTestCase):
     shape = (2, 3)
 
 
+class TestHDF5Stats(bf.StatsTestCase):
+    backend = hdf5.HDF5
+    name = DBNAME
+    shape = (2, 3)
+
+
 class TestHDF50dSelection(bf.SelectionTestCase):
     backend = hdf5.HDF5
     name = DBNAME
     shape = ()
+
+
+class TestHDF50dSelectionStats1(bf.SelectionTestCase):
+    backend = hdf5.HDF5
+    name = DBNAME
+    shape = ()
+    sampler_vars = STATS1
+
+
+class TestHDF50dSelectionStats2(bf.SelectionTestCase):
+    backend = hdf5.HDF5
+    name = DBNAME
+    shape = ()
+    sampler_vars = STATS2
 
 
 class TestHDF51dSelection(bf.SelectionTestCase):

--- a/pymc3/tests/test_hdf5_backend.py
+++ b/pymc3/tests/test_hdf5_backend.py
@@ -1,0 +1,57 @@
+import os
+from pymc3.tests import backend_fixtures as bf
+from pymc3.backends import ndarray, hdf5
+import tempfile
+
+DBNAME = os.path.join(tempfile.gettempdir(), 'test.h5')
+
+
+class TestHDF50dSampling(bf.SamplingTestCase):
+    backend = hdf5.HDF5
+    name = DBNAME
+    shape = ()
+
+
+class TestHDF51dSampling(bf.SamplingTestCase):
+    backend = hdf5.HDF5
+    name = DBNAME
+    shape = 2
+
+
+class TestHDF52dSampling(bf.SamplingTestCase):
+    backend = hdf5.HDF5
+    name = DBNAME
+    shape = (2, 3)
+
+
+class TestHDF50dSelection(bf.SelectionTestCase):
+    backend = hdf5.HDF5
+    name = DBNAME
+    shape = ()
+
+
+class TestHDF51dSelection(bf.SelectionTestCase):
+    backend = hdf5.HDF5
+    name = DBNAME
+    shape = 2
+
+
+class TestHDF52dSelection(bf.SelectionTestCase):
+    backend = hdf5.HDF5
+    name = DBNAME
+    shape = (2, 3)
+
+
+class TestHDF5DumpLoad(bf.DumpLoadTestCase):
+    backend = hdf5.HDF5
+    load_func = staticmethod(hdf5.load)
+    name = DBNAME
+    shape = (2, 3)
+
+
+class TestNDArrayHDF5Equality(bf.BackendEqualityTestCase):
+    backend0 = ndarray.NDArray
+    name0 = None
+    backend1 = hdf5.HDF5
+    name1 = DBNAME
+    shape = (2, 3)

--- a/pymc3/tests/test_hdf5_backend.py
+++ b/pymc3/tests/test_hdf5_backend.py
@@ -1,7 +1,20 @@
-import os
+import numpy as np
 from pymc3.tests import backend_fixtures as bf
 from pymc3.backends import ndarray, hdf5
+import os
 import tempfile
+
+STATS1 = [{
+    'a': np.float64,
+    'b': np.bool
+}]
+
+STATS2 = [{
+    'a': np.float64
+}, {
+    'a': np.float64,
+    'b': np.int64,
+}]
 
 DBNAME = os.path.join(tempfile.gettempdir(), 'test.h5')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ nbsphinx
 numdifftools
 numpydoc
 six
+h5py

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -36,6 +36,7 @@ pip install nose_parameterized
 pip install --no-deps numdifftools
 pip install git+https://github.com/Theano/Theano.git
 pip install git+https://github.com/mahmoudimus/nose-timer.git
+pip install h5py
 
 if [ -z ${NO_SETUP} ]
 then


### PR DESCRIPTION
An hdf5 trace based on `h5py`. `H5py`'s array structure makes it's api effectively the same as `NDArray`.
Example:
```
trace = pm.sample(5000, trace='hdf5')
```