### PR TITLE
[WIP] Dense covariance using krylov methods

### DIFF
--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -44,7 +44,7 @@ class BaseHMC(ArrayStepShared):
         if isinstance(scaling, dict):
             scaling = guess_scaling(Point(scaling, model=model), model=model, vars=vars)
 
-        n = scaling.shape[0]
+        n = model.dict_to_array(model.test_point).shape[0]
         self.step_size = step_scale / (n ** 0.25)
         self.potential = quad_potential(scaling, is_cov, as_cov=False)
 


### PR DESCRIPTION
I'm not really sure about this pull request, as it does not really seem to help in any of the models I tried, but I still thought it might be interesting enough to put it out there. Also, this might be helpful when someone implements Riemannian MCMC.

Right now, we have four options to specify the global mass matrix in hmc: Using a diagonal matrix (either as covariance or as precision matrix), a dense covariance or precision matrix, or a sparse covariance matrix in csr format. This pull request adds an additional option: defining the covariance matrix through samples X from the posterior. This allows us to use a full covariance matrix in high dimensional setting, and avoid having to store the full covariance matrix. To implement the potential we need matrix-vector products Ax and samples from N(0, A^-1), were A is the covariance matrix. We can compute the first, using Ax = X^tXx. Sampling from the normal distribution is a bit more difficult, I implemented a krylov subspace based algorithm described in [1]. As high dimensional sample covariances are usually problematic, I used a simple stein-type estimator to shrink it towards the diagonal matrix containing the variances.

However, this does not seem to help as much as I hoped it would. Possible reasons I could think of are:

- I tried the wrong models, it just helps in other models :-)
- The covariance estimates are bad. Maybe something more sophisticated than the stein estimator might help then.
- Computing Ax in every transition is quite expensive (2 * s * n multiplications). It parallelizes quite well, however (not on my laptop).
- Maybe sampling from the normal distribution does not work as well as I think it does. The Lanczos algorithm is not particularly stable, and I do not use reorthogonalization or restarting to address this.

[1] Chow, E., and Y. Saad. “Preconditioned Krylov Subspace Methods for Sampling Multivariate Gaussian Distributions.” SIAM Journal on Scientific Computing 36, no. 2 (January 1, 2014): A588–608. doi:10.1137/130920587.