### PR TITLE
correct mistakes

### DIFF
--- a/docs/source/notebooks/howto_debugging.ipynb
+++ b/docs/source/notebooks/howto_debugging.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "There are various levels on which to debug a model. One of the simplest is to just print out the values that different variables are taking on.\n",
     "\n",
-    "Because `PyMC3` uses `Theano` expressions to build the model, and not functions, there is no way to place a `print` statement into a likelihood function. Instead, you can use the `Theano` `Print` operatator. For more information, see:  theano Print operator for htis before: http://deeplearning.net/software/theano/tutorial/debug_faq.html#how-do-i-print-an-intermediate-value-in-a-function.\n",
+    "Because `PyMC3` uses `Theano` expressions to build the model, and not functions, there is no way to place a `print` statement into a likelihood function. Instead, you can use the `Theano` `Print` operatator. For more information, see:  theano Print operator for this before: http://deeplearning.net/software/theano/tutorial/debug_faq.html#how-do-i-print-an-intermediate-value-in-a-function.\n",
     "\n",
     "Let's build a simple model with just two parameters:"
    ]

--- a/docs/source/notebooks/posterior_predictive.ipynb
+++ b/docs/source/notebooks/posterior_predictive.ipynb
@@ -96,7 +96,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This function will randomly draw 50 samples of parameters from the trace. Then, for each sample, it will draw 100 random numbers from a normal distribution specified by the values of `mu` and `std` in that sample."
+    "This function will randomly draw 500 samples of parameters from the trace. Then, for each sample, it will draw 100 random numbers from a normal distribution specified by the values of `mu` and `std` in that sample."
    ]
   },
   {


### PR DESCRIPTION
correct the mistake in [pymc3/docs/source/notebooks/howto_debugging.ipynb](pymc3/docs/source/notebooks/howto_debugging.ipynb) `for htis  -> for this`.
[pymc3/docs/source/notebooks/posterior_predictive.ipynb](pymc3/docs/source/notebooks/posterior_predictive.ipynb)`draw 50 examples -> draw 500 examples`