### PR TITLE
[WIP] Implement higher order hmc integration

### DIFF
--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -12,7 +12,7 @@ class BaseHMC(ArrayStepShared):
 
     def __init__(self, vars=None, scaling=None, step_scale=0.25, is_cov=False,
                  model=None, blocked=True, use_single_leapfrog=False,
-                 potential=None, **theano_kwargs):
+                 potential=None, step_method="leapfrog", **theano_kwargs):
         """Superclass to implement Hamiltonian/hybrid monte carlo
 
         Parameters
@@ -60,6 +60,6 @@ class BaseHMC(ArrayStepShared):
             theano_kwargs = {}
 
         self.H, self.compute_energy, self.leapfrog, self.dlogp = get_theano_hamiltonian_functions(
-            vars, shared, model.logpt, self.potential, use_single_leapfrog, **theano_kwargs)
+            vars, shared, model.logpt, self.potential, use_single_leapfrog, step_method, **theano_kwargs)
 
         super(BaseHMC, self).__init__(vars, shared, blocked=blocked)

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -12,7 +12,7 @@ class BaseHMC(ArrayStepShared):
 
     def __init__(self, vars=None, scaling=None, step_scale=0.25, is_cov=False,
                  model=None, blocked=True, use_single_leapfrog=False,
-                 potential=None, step_method="leapfrog", **theano_kwargs):
+                 potential=None, integrator="leapfrog", **theano_kwargs):
         """Superclass to implement Hamiltonian/hybrid monte carlo
 
         Parameters
@@ -60,6 +60,6 @@ class BaseHMC(ArrayStepShared):
             theano_kwargs = {}
 
         self.H, self.compute_energy, self.leapfrog, self.dlogp = get_theano_hamiltonian_functions(
-            vars, shared, model.logpt, self.potential, use_single_leapfrog, step_method, **theano_kwargs)
+            vars, shared, model.logpt, self.potential, use_single_leapfrog, integrator, **theano_kwargs)
 
         super(BaseHMC, self).__init__(vars, shared, blocked=blocked)

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -99,6 +99,10 @@ class NUTS(BaseHMC):
         adapt_step_size : bool
             Whether step size should be enabled. If this is disabled,
             `k`, `t0`, `gamma` and `target_accept` are ignored.
+        integrator : str, default "leapfrog"
+            The integrator to use for the trajectories. One of "leapfrog",
+            "two-stage" or "three-stage". The second two can increase
+            sampling speed for some high dimensional problems.
         kwargs: passed to BaseHMC
 
         The step size adaptation stops when `self.tune` is set to False.

--- a/pymc3/step_methods/hmc/trajectory.py
+++ b/pymc3/step_methods/hmc/trajectory.py
@@ -187,14 +187,14 @@ def _theano_single_threestage(H, q, p, q_grad, **theano_kwargs):
 
     References
     ----------
-    Blanes, Sergio, Fernando Casas, and J. M. Sanz-Serna. “Numerical
-    Integrators for the Hybrid Monte Carlo Method.” SIAM Journal on
-    Scientific Computing 36, no. 4 (January 2014): A1556–80.
+    Blanes, Sergio, Fernando Casas, and J. M. Sanz-Serna. "Numerical
+    Integrators for the Hybrid Monte Carlo Method." SIAM Journal on
+    Scientific Computing 36, no. 4 (January 2014): A1556-80.
     doi:10.1137/130932740.
 
-    Mannseth, Janne, Tore Selland Kleppe, and Hans J. Skaug. “On the
+    Mannseth, Janne, Tore Selland Kleppe, and Hans J. Skaug. "On the
     Application of Higher Order Symplectic Integrators in
-    Hamiltonian Monte Carlo.” arXiv:1608.07048 [Stat],
+    Hamiltonian Monte Carlo." arXiv:1608.07048 [Stat],
     August 25, 2016. http://arxiv.org/abs/1608.07048.
     """
     epsilon = tt.scalar('epsilon')
@@ -232,14 +232,14 @@ def _theano_single_twostage(H, q, p, q_grad, **theano_kwargs):
 
     References
     ----------
-    Blanes, Sergio, Fernando Casas, and J. M. Sanz-Serna. “Numerical
-    Integrators for the Hybrid Monte Carlo Method.” SIAM Journal on
-    Scientific Computing 36, no. 4 (January 2014): A1556–80.
+    Blanes, Sergio, Fernando Casas, and J. M. Sanz-Serna. "Numerical
+    Integrators for the Hybrid Monte Carlo Method." SIAM Journal on
+    Scientific Computing 36, no. 4 (January 2014): A1556-80.
     doi:10.1137/130932740.
 
-    Mannseth, Janne, Tore Selland Kleppe, and Hans J. Skaug. “On the
+    Mannseth, Janne, Tore Selland Kleppe, and Hans J. Skaug. "On the
     Application of Higher Order Symplectic Integrators in
-    Hamiltonian Monte Carlo.” arXiv:1608.07048 [Stat],
+    Hamiltonian Monte Carlo." arXiv:1608.07048 [Stat],
     August 25, 2016. http://arxiv.org/abs/1608.07048.
     """
     epsilon = tt.scalar('epsilon')

--- a/pymc3/step_methods/hmc/trajectory.py
+++ b/pymc3/step_methods/hmc/trajectory.py
@@ -89,7 +89,7 @@ def _theano_leapfrog_integrator(H, q, p, **theano_kwargs):
 
 def get_theano_hamiltonian_functions(model_vars, shared, logpt, potential,
                                      use_single_leapfrog=False,
-                                     step_method="leapfrog", **theano_kwargs):
+                                     integrator="leapfrog", **theano_kwargs):
     """Construct theano functions for the Hamiltonian, energy, and leapfrog integrator.
 
     Parameters
@@ -102,7 +102,7 @@ def get_theano_hamiltonian_functions(model_vars, shared, logpt, potential,
     use_single_leapfrog : bool
         if only 1 integration step is done at a time (as in NUTS), this
         provides a ~2x speedup
-    step_method : str
+    integrator : str
         Integration scheme to use. One of "leapfog", "two-stage", or
         "three-stage".
 
@@ -116,16 +116,16 @@ def get_theano_hamiltonian_functions(model_vars, shared, logpt, potential,
     H, q, dlogp = _theano_hamiltonian(model_vars, shared, logpt, potential)
     energy_function, p = _theano_energy_function(H, q, **theano_kwargs)
     if use_single_leapfrog:
-        if step_method == "leapfrog":
+        if integrator == "leapfrog":
             integrator = _theano_single_leapfrog(H, q, p, H.dlogp(q), **theano_kwargs)
-        elif step_method == "two-stage":
+        elif integrator == "two-stage":
             integrator = _theano_single_twostage(H, q, p, H.dlogp(q), **theano_kwargs)
-        elif step_method == "three-stage":
+        elif integrator == "three-stage":
             integrator = _theano_single_threestage(H, q, p, H.dlogp(q), **theano_kwargs)
         else:
             raise ValueError("Unknown step method %s" % step_method)
     else:
-        if step_method != "leapfrog":
+        if integrator != "leapfrog":
             raise ValueError("Only leapfrog is supported")
         integrator = _theano_leapfrog_integrator(H, q, p, **theano_kwargs)
     return H, energy_function, integrator, dlogp

--- a/pymc3/step_methods/hmc/trajectory.py
+++ b/pymc3/step_methods/hmc/trajectory.py
@@ -1,9 +1,10 @@
 from collections import namedtuple
 
-from pymc3.theanof import join_nonshared_inputs, gradient, CallableTensor
+from pymc3.theanof import join_nonshared_inputs, gradient, CallableTensor, floatX
 
 import theano
 import theano.tensor as tt
+import numpy as np
 
 
 Hamiltonian = namedtuple("Hamiltonian", "logp, dlogp, pot")
@@ -73,7 +74,7 @@ def _theano_leapfrog_integrator(H, q, p, **theano_kwargs):
     q_new, p_new, energy_new
     """
     epsilon = tt.scalar('epsilon')
-    epsilon.tag.test_value = 1
+    epsilon.tag.test_value = 1.
 
     n_steps = tt.iscalar('n_steps')
     n_steps.tag.test_value = 2
@@ -87,7 +88,8 @@ def _theano_leapfrog_integrator(H, q, p, **theano_kwargs):
 
 
 def get_theano_hamiltonian_functions(model_vars, shared, logpt, potential,
-                                     use_single_leapfrog=False, **theano_kwargs):
+                                     use_single_leapfrog=False,
+                                     step_method="leapfrog", **theano_kwargs):
     """Construct theano functions for the Hamiltonian, energy, and leapfrog integrator.
 
     Parameters
@@ -97,8 +99,12 @@ def get_theano_hamiltonian_functions(model_vars, shared, logpt, potential,
     logpt : model log probability
     potential : Hamiltonian potential
     theano_kwargs : dictionary of keyword arguments to pass to theano functions
-    use_single_leapfrog : Boolean, if only 1 integration step is done at a time (as in NUTS),
-                          this provides a ~2x speedup
+    use_single_leapfrog : bool
+        if only 1 integration step is done at a time (as in NUTS), this
+        provides a ~2x speedup
+    step_method : str
+        Integration scheme to use. One of "leapfog", "two-stage", or
+        "three-stage".
 
     Returns
     -------
@@ -110,10 +116,19 @@ def get_theano_hamiltonian_functions(model_vars, shared, logpt, potential,
     H, q, dlogp = _theano_hamiltonian(model_vars, shared, logpt, potential)
     energy_function, p = _theano_energy_function(H, q, **theano_kwargs)
     if use_single_leapfrog:
-        leapfrog_integrator = _theano_single_leapfrog(H, q, p, H.dlogp(q), **theano_kwargs)
+        if step_method == "leapfrog":
+            integrator = _theano_single_leapfrog(H, q, p, H.dlogp(q), **theano_kwargs)
+        elif step_method == "two-stage":
+            integrator = _theano_single_twostage(H, q, p, H.dlogp(q), **theano_kwargs)
+        elif step_method == "three-stage":
+            integrator = _theano_single_threestage(H, q, p, H.dlogp(q), **theano_kwargs)
+        else:
+            raise ValueError("Unknown step method %s" % step_method)
     else:
-        leapfrog_integrator = _theano_leapfrog_integrator(H, q, p, **theano_kwargs)
-    return H, energy_function, leapfrog_integrator, dlogp
+        if step_method != "leapfrog":
+            raise ValueError("Only leapfrog is supported")
+        integrator = _theano_leapfrog_integrator(H, q, p, **theano_kwargs)
+    return H, energy_function, integrator, dlogp
 
 
 def energy(H, q, p):
@@ -165,6 +180,86 @@ def leapfrog(H, q, p, epsilon, n_steps):
         p, q = p_seq[-1], q_seq[-1]
     p += 0.5 * epsilon * H.dlogp(q)  # half momentum update
     return q, p
+
+
+def _theano_single_threestage(H, q, p, q_grad, **theano_kwargs):
+    """Perform a single step of a third order symplectic integration scheme.
+
+    References
+    ----------
+    Blanes, Sergio, Fernando Casas, and J. M. Sanz-Serna. “Numerical
+    Integrators for the Hybrid Monte Carlo Method.” SIAM Journal on
+    Scientific Computing 36, no. 4 (January 2014): A1556–80.
+    doi:10.1137/130932740.
+
+    Mannseth, Janne, Tore Selland Kleppe, and Hans J. Skaug. “On the
+    Application of Higher Order Symplectic Integrators in
+    Hamiltonian Monte Carlo.” arXiv:1608.07048 [Stat],
+    August 25, 2016. http://arxiv.org/abs/1608.07048.
+    """
+    epsilon = tt.scalar('epsilon')
+    epsilon.tag.test_value = 1.
+
+    a = 12127897.0 / 102017882
+    b = 4271554.0 / 14421423
+
+    # q_{a\epsilon}
+    p_ae = p + floatX(a) * epsilon * q_grad
+    q_be = q + floatX(b) * epsilon * H.pot.velocity(p_ae)
+
+    # q_{\epsilon / 2}
+    p_e2 = p_ae + floatX(0.5 - a) * epsilon * H.dlogp(q_be)
+
+    # p_{(1-b)\epsilon}
+    q_1be = q_be + floatX(1 - 2 * b) * epsilon * H.pot.velocity(p_e2)
+    p_1ae = p_e2 + floatX(0.5 - a) * epsilon * H.dlogp(q_1be)
+
+    q_e = q_1be + floatX(b) * epsilon * H.pot.velocity(p_1ae)
+    grad_e = H.dlogp(q_e)
+    p_e = p_1ae + floatX(a) * epsilon * grad_e
+
+    new_energy = energy(H, q_e, p_e)
+
+    f = theano.function(inputs=[q, p, q_grad, epsilon],
+                        outputs=[q_e, p_e, grad_e, new_energy],
+                        **theano_kwargs)
+    f.trust_input = True
+    return f
+
+
+def _theano_single_twostage(H, q, p, q_grad, **theano_kwargs):
+    """Perform a single step of a second order symplectic integration scheme.
+
+    References
+    ----------
+    Blanes, Sergio, Fernando Casas, and J. M. Sanz-Serna. “Numerical
+    Integrators for the Hybrid Monte Carlo Method.” SIAM Journal on
+    Scientific Computing 36, no. 4 (January 2014): A1556–80.
+    doi:10.1137/130932740.
+
+    Mannseth, Janne, Tore Selland Kleppe, and Hans J. Skaug. “On the
+    Application of Higher Order Symplectic Integrators in
+    Hamiltonian Monte Carlo.” arXiv:1608.07048 [Stat],
+    August 25, 2016. http://arxiv.org/abs/1608.07048.
+    """
+    epsilon = tt.scalar('epsilon')
+    epsilon.tag.test_value = 1.
+
+    a = floatX((3 - np.sqrt(3)) / 6)
+
+    p_ae = p + a * epsilon * q_grad
+    q_e2 = q + epsilon / 2 * H.pot.velocity(p_ae)
+    p_1ae = p_ae + (1 - 2 * a) * epsilon * H.dlogp(q_e2)
+    q_e = q_e2 + epsilon / 2 * H.pot.velocity(p_1ae)
+    grad_e = H.dlogp(q_e)
+    p_e = p_1ae + a * epsilon * grad_e
+
+    new_energy = energy(H, q_e, p_e)
+    f = theano.function(inputs=[q, p, q_grad, epsilon],
+                        outputs=[q_e, p_e, grad_e, new_energy],
+                        **theano_kwargs)
+    f.trust_input = True
+    return f
 
 
 def _theano_single_leapfrog(H, q, p, q_grad, **theano_kwargs):

--- a/pymc3/tests/test_hmc.py
+++ b/pymc3/tests/test_hmc.py
@@ -26,6 +26,35 @@ def test_leapfrog_reversible():
             close_to(-p, p0, 1e-8, str((n_steps, epsilon)))
 
 
+def test_leapfrog_reversible_single():
+    n = 3
+    start, model, _ = models.non_normal(n)
+
+    step_methods = ['leapfrog', 'two-stage', 'three-stage']
+    steps = [BaseHMC(vars=model.vars, model=model, step_method=method, use_single_leapfrog=True)
+             for method in step_methods]
+    for method, step in zip(step_methods, steps):
+        bij = DictToArrayBijection(step.ordering, start)
+        q0 = bij.map(start)
+        p0 = np.ones(n) * .05
+        for epsilon in [0.01, 0.1, 1.2]:
+            for n_steps in [1, 2, 3, 4, 20]:
+                dlogp0 = step.dlogp(q0)
+
+                q, p = q0, p0
+                dlogp = dlogp0
+
+                energy = step.compute_energy(q, p)
+                for _ in range(n_steps):
+                    q, p, dlogp, _ = step.leapfrog(q, p, dlogp, np.array(epsilon))
+                p = -p
+                for _ in range(n_steps):
+                    q, p, dlogp, _ = step.leapfrog(q, p, dlogp, np.array(epsilon))
+
+                close_to(q, q0, 1e-8, str(('q', method, n_steps, epsilon)))
+                close_to(-p, p0, 1e-8, str(('p', method, n_steps, epsilon)))
+
+
 def test_nuts_tuning():
     model = pymc3.Model()
     with model:

--- a/pymc3/tests/test_hmc.py
+++ b/pymc3/tests/test_hmc.py
@@ -30,10 +30,10 @@ def test_leapfrog_reversible_single():
     n = 3
     start, model, _ = models.non_normal(n)
 
-    step_methods = ['leapfrog', 'two-stage', 'three-stage']
-    steps = [BaseHMC(vars=model.vars, model=model, step_method=method, use_single_leapfrog=True)
-             for method in step_methods]
-    for method, step in zip(step_methods, steps):
+    integrators = ['leapfrog', 'two-stage', 'three-stage']
+    steps = [BaseHMC(vars=model.vars, model=model, integrator=method, use_single_leapfrog=True)
+             for method in integrators]
+    for method, step in zip(integrators, steps):
         bij = DictToArrayBijection(step.ordering, start)
         q0 = bij.map(start)
         p0 = np.ones(n) * .05

--- a/pymc3/tests/test_posteriors.py
+++ b/pymc3/tests/test_posteriors.py
@@ -33,6 +33,24 @@ class SliceUniform(sf.SliceFixture, sf.UniformFixture):
     atol = 0.05
 
 
+@attr('extra')
+class NUTSUniform2(NUTSUniform):
+    step_args = {'target_accept': 0.95, 'step_method': 'two-stage'}
+
+
+class NUTSUniform3(NUTSUniform):
+    step_args = {'target_accept': 0.80, 'step_method': 'two-stage'}
+
+
+@attr('extra')
+class NUTSUniform4(NUTSUniform):
+    step_args = {'target_accept': 0.95, 'step_method': 'three-stage'}
+
+
+class NUTSUniform5(NUTSUniform):
+    step_args = {'target_accept': 0.80, 'step_method': 'three-stage'}
+
+
 class NUTSNormal(sf.NutsFixture, sf.NormalFixture):
     n_samples = 10000
     tune = 1000

--- a/pymc3/tests/test_posteriors.py
+++ b/pymc3/tests/test_posteriors.py
@@ -35,20 +35,20 @@ class SliceUniform(sf.SliceFixture, sf.UniformFixture):
 
 @attr('extra')
 class NUTSUniform2(NUTSUniform):
-    step_args = {'target_accept': 0.95, 'step_method': 'two-stage'}
+    step_args = {'target_accept': 0.95, 'integrator': 'two-stage'}
 
 
 class NUTSUniform3(NUTSUniform):
-    step_args = {'target_accept': 0.80, 'step_method': 'two-stage'}
+    step_args = {'target_accept': 0.80, 'integrator': 'two-stage'}
 
 
 @attr('extra')
 class NUTSUniform4(NUTSUniform):
-    step_args = {'target_accept': 0.95, 'step_method': 'three-stage'}
+    step_args = {'target_accept': 0.95, 'integrator': 'three-stage'}
 
 
 class NUTSUniform5(NUTSUniform):
-    step_args = {'target_accept': 0.80, 'step_method': 'three-stage'}
+    step_args = {'target_accept': 0.80, 'integrator': 'three-stage'}
 
 
 class NUTSNormal(sf.NutsFixture, sf.NormalFixture):

--- a/pymc3/tests/test_quadpotential.py
+++ b/pymc3/tests/test_quadpotential.py
@@ -121,8 +121,8 @@ def test_random_diag():
         quadpotential.quad_potential(np.diag(1./d), False, False),
     ]
     if quadpotential.chol_available:
-        d = scipy.sparse.csc_matrix(np.diag(d))
-        pot = quadpotential.quad_potential(d, True, False)
+        d_ = scipy.sparse.csc_matrix(np.diag(d))
+        pot = quadpotential.quad_potential(d_, True, False)
         pots.append(pot)
     for pot in pots:
         vals = np.array([pot.random() for _ in range(1000)])


### PR DESCRIPTION
This patch implements two-stage and three-stage integration for nuts. According to [1] and [2] this should provide a reasonable advantage in many high dimensional problems. What takes me a bit by surprise is that stan does not seem to implement those. Do you know if there is a good reason for that?

[1] Blanes, Sergio, Fernando Casas, and J. M. Sanz-Serna. “Numerical
    Integrators for the Hybrid Monte Carlo Method.” SIAM Journal on
    Scientific Computing 36, no. 4 (January 2014): A1556–80.
    doi:10.1137/130932740.

[2] Mannseth, Janne, Tore Selland Kleppe, and Hans J. Skaug. “On the
    Application of Higher Order Symplectic Integrators in
    Hamiltonian Monte Carlo.” arXiv:1608.07048 [Stat],
    August 25, 2016. http://arxiv.org/abs/1608.07048.