### PR TITLE
Multiple truth lines for traceplot >1d variables

### DIFF
--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -28,7 +28,9 @@ def traceplot(trace, varnames=None, transform=lambda x: x, figsize=None,
     lines : dict
         Dictionary of variable name / value  to be overplotted as vertical
         lines to the posteriors and horizontal lines on sample values
-        e.g. mean of posteriors, true values of a simulation
+        e.g. mean of posteriors, true values of a simulation.
+        If an array of values, line colors are matched to posterior colors.
+        Otherwise, a default red line
     combined : bool
         Flag for combining multiple chains into a single chain. If False
         (default), chains will be plotted separately.
@@ -86,9 +88,11 @@ def traceplot(trace, varnames=None, transform=lambda x: x, figsize=None,
             d = np.squeeze(transform(d))
             d = make_2d(d)
             if d.dtype.kind == 'i':
-                colors = histplot_op(ax[i, 0], d, alpha=alpha)
+                hist_objs = histplot_op(ax[i, 0], d, alpha=alpha)
+                colors = [h[-1][0].get_color() for h in hist_objs]
             else:
-                colors = kdeplot_op(ax[i, 0], d, prior, prior_alpha, prior_style)
+                artists = kdeplot_op(ax[i, 0], d, prior, prior_alpha, prior_style)[0]
+                colors = [a[0].get_color() for a in artists]
             ax[i, 0].set_title(str(v))
             ax[i, 0].grid(grid)
             ax[i, 1].set_title(str(v))
@@ -99,7 +103,14 @@ def traceplot(trace, varnames=None, transform=lambda x: x, figsize=None,
 
             if lines:
                 try:
-                    for c, l in zip(colors, np.atleast_1d(lines[v]).ravel()):
+                    if isinstance(lines[v], (float, int)):
+                        line_values, colors = [lines[v]], ['r']
+                    else:
+                        line_values = np.atleast_1d(lines[v]).ravel()
+                        assert len(colors) == len(line_values), "An incorrect number of lines was specified " \
+                                                                "for '{}', give a iterable of length {} or " \
+                                                                "to draw a single red line, give a scalar".format(v, len(colors))
+                    for c, l in zip(colors, line_values):
                         ax[i, 0].axvline(x=l, color=c, lw=1.5, alpha=0.75)
                         ax[i, 1].axhline(y=l, color=c,
                                          lw=1.5, alpha=alpha)
@@ -111,21 +122,21 @@ def traceplot(trace, varnames=None, transform=lambda x: x, figsize=None,
 
 
 def histplot_op(ax, data, alpha=.35):
-    colors = []
+    hs = []
     for i in range(data.shape[1]):
         d = data[:, i]
 
         mind = np.min(d)
         maxd = np.max(d)
         step = max((maxd - mind) // 100, 1)
-        h = ax.hist(d, bins=range(mind, maxd + 2, step), alpha=alpha, align='left')
-        colors.append(h[2][0].get_facecolor())
+        hs.append(ax.hist(d, bins=range(mind, maxd + 2, step), alpha=alpha, align='left'))
         ax.set_xlim(mind - .5, maxd + .5)
-    return colors
+    return hs
 
 
 def kdeplot_op(ax, data, prior=None, prior_alpha=1, prior_style='--'):
-    colors = []
+    ls = []
+    pls = []
     for i in range(data.shape[1]):
         d = data[:, i]
         density, l, u = fast_kde(d)
@@ -133,11 +144,11 @@ def kdeplot_op(ax, data, prior=None, prior_alpha=1, prior_style='--'):
 
         if prior is not None:
             p = prior.logp(x).eval()
-            ax.plot(x, np.exp(p), alpha=prior_alpha, ls=prior_style)
+            pls.append(ax.plot(x, np.exp(p), alpha=prior_alpha, ls=prior_style))
 
-        l = ax.plot(x, density)
-        colors.append(l[0].get_color())
-    return colors
+        ls.append(ax.plot(x, density))
+    return ls, pls
+
 
 
 def make_2d(a):


### PR DESCRIPTION
Simple as title. Just a minor annoyance...

```
lines = {'mu': [1,2]}
pm.traceplot(trace, varnames, lines=lines)
```