### PR TITLE
Fix SIGINT hadling while sampling

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -192,11 +192,14 @@ def _sample(draws, step=None, start=None, trace=None, chain=0, tune=None,
         strace = None
         for strace in sampling:
             pass
-        result = [] if strace is None else [strace]
-    except KeyboardInterrupt as exc:
-        if strace is not None:
-            strace.close()
-        raise exc
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if progressbar:
+            sampling.close()
+    if strace is not None:
+        strace.close()
+    result = [] if strace is None else [strace]
     return MultiTrace(result)
 
 


### PR DESCRIPTION
This was broken in #1713.
Was there a good reason, why `strace.close()` was only called when the iteration was interrupted?