### PR TITLE
Combine headers for GLM negative binomial example

### DIFF
--- a/docs/source/notebooks/GLM-negative-binomial-regression.ipynb
+++ b/docs/source/notebooks/GLM-negative-binomial-regression.ipynb
@@ -57,8 +57,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Convenience Functions\n",
-    "#### (Taken from the Poisson regression example)"
+    "### Convenience Functions (Taken from the Poisson regression example)"
    ]
   },
   {
@@ -644,7 +643,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Having two headers for one section made it look like they were for two different sections in the [automatically generated index](https://pymc-devs.github.io/pymc3/examples.html#glm).

edit: Sorry, accidentally closed then force pushed which prevents re-opening.