### PR TITLE
Added contact information to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ To ask a question regarding modeling or usage of PyMC3 we encourage posting to `
 
 To interact with PyMC3 developers, visit the `pymc Gitter channel <https://gitter.im/pymc-devs/pymc>`__.
 
-Finally, if you need to get in touch for non-technical information about the project, `send us an e-mail`__.
+Finally, if you need to get in touch for non-technical information about the project, `send us an e-mail <fonnesbeck+pymc@gmail.com>`__.
 
 License
 -------
@@ -170,4 +170,3 @@ Sponsors
    :target: http://www.numfocus.org/
 .. |Quantopian| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/master/docs/quantopianlogo.jpg
    :target: https://quantopian.com
-.. __send us an e-mail: fonnesbeck+pymc@gmail.com

--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,17 @@ Salvatier J, Wiecki TV, Fonnesbeck C. (2016) Probabilistic programming
 in Python using PyMC3. PeerJ Computer Science 2:e55
 https://doi.org/10.7717/peerj-cs.55
 
+Contact
+-------
+
+To report an issue with PyMC3 or to suggest a feature please use the `issue tracker <https://github.com/pymc-devs/pymc3/issues>`__.
+
+To ask a question regarding modeling or usage of PyMC3 we encourage posting to `StackOverflow using the "pymc" tag <http://stackoverflow.com/questions/tagged/pymc>`__.
+
+To interact with PyMC3 developers, visit the `pymc Gitter channel <https://gitter.im/pymc-devs/pymc>`__.
+
+Finally, if you need to get in touch for non-technical information about the project, `send us an e-mail`__.
+
 License
 -------
 
@@ -159,3 +170,4 @@ Sponsors
    :target: http://www.numfocus.org/
 .. |Quantopian| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/master/docs/quantopianlogo.jpg
    :target: https://quantopian.com
+.. __send us an e-mail: fonnesbeck+pymc@gmail.com


### PR DESCRIPTION
In response to a request on Gitter, I've added four avenues for contact to the README:

- issue tracker
- StackOverflow
- Gitter
- email

I think those are plenty. I am not in favor of establishing a mailing list.