### PR TITLE
Fix elliptical slice sampler tests

### DIFF
--- a/pymc3/tests/models.py
+++ b/pymc3/tests/models.py
@@ -100,17 +100,28 @@ def mv_simple_discrete():
 
 def mv_prior_simple():
     n = 3
-    noise = 1e-10
+    noise = 0.1
     X = np.linspace(0, 1, n)[:, None]
-    mu = np.sin(3 * X).flatten()
-    K = pm.gp.cov.ExpQuad(1, 1).K(X)
+
+    K = pm.gp.cov.ExpQuad(1, 1).K(X).eval()
+    K_noise = K + noise * np.eye(n)
+    obs = np.array([-0.1, 0.5, 1.1])
+
+    # Posterior mean
+    L_noise = np.linalg.cholesky(K_noise)
+    alpha = np.linalg.solve(L_noise.T, np.linalg.solve(L_noise, obs))
+    mu_post = np.dot(K.T, alpha)
+
+    # Posterior standard deviation
+    v = np.linalg.solve(L_noise, K)
+    std_post = (K - np.dot(v.T, v)).diagonal() ** 0.5
 
     with pm.Model() as model:
-        x = pm.MvNormal('x', mu=np.zeros(n), cov=K, shape=n)
-        x_obs = pm.MvNormal('x_obs', observed=mu, mu=x,
+        x = pm.Flat('x', shape=n)
+        x_obs = pm.MvNormal('x_obs', observed=obs, mu=x,
                             cov=noise * np.eye(n), shape=n)
 
-    return model.test_point, model, (K, mu, noise)
+    return model.test_point, model, (K, mu_post, std_post, noise)
 
 
 def non_normal(n=2):

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -189,16 +189,16 @@ class TestStepMethods(object):  # yield test doesn't work subclassing unittest.T
             yield self.check_stat, check, trace, step.__class__.__name__
 
     def test_step_elliptical_slice(self):
-        start, model, (K, mu, noise) = mv_prior_simple()
+        start, model, (K, mu, std, noise) = mv_prior_simple()
         unc = noise ** 0.5
         check = (('x', np.mean, mu, unc / 10.),
-                 ('x', np.std, unc, unc / 10.))
+                 ('x', np.std, std, unc / 10.))
         with model:
             steps = (
                 EllipticalSlice(prior_cov=K),
             )
         for step in steps:
-            trace = sample(8000, step=step, start=start, model=model, random_seed=1)
+            trace = sample(5000, step=step, start=start, model=model, random_seed=1)
             yield self.check_stat, check, trace, step.__class__.__name__
 
 


### PR DESCRIPTION
The elliptical slice sampler tests should really be testing against the posterior mean and standard deviation and were only working because I set the noise too low to expose the error. This increases the noise to a more reasonable level and fixes the tests.