### PR TITLE
Traceplot used to fail with discrete variables

### DIFF
--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -91,7 +91,7 @@ def traceplot(trace, varnames=None, transform=lambda x: x, figsize=None,
             d = make_2d(d)
             if d.dtype.kind == 'i':
                 hist_objs = histplot_op(ax[i, 0], d, alpha=alpha)
-                colors = [h[-1][0].get_color() for h in hist_objs]
+                colors = [h[-1][0].get_facecolor() for h in hist_objs]
             else:
                 artists = kdeplot_op(ax[i, 0], d, prior, prior_alpha, prior_style)[0]
                 colors = [a[0].get_color() for a in artists]

--- a/pymc3/tests/test_plots.py
+++ b/pymc3/tests/test_plots.py
@@ -5,7 +5,7 @@ import numpy as np
 import pymc3 as pm
 from .checks import close_to
 
-from .models import multidimensional_model
+from .models import multidimensional_model, simple_categorical
 from ..plots import traceplot, forestplot, autocorrplot, plot_posterior, make_2d
 from ..step_methods import Slice, Metropolis
 from ..sampling import sample
@@ -26,6 +26,18 @@ def test_plots():
         forestplot(trace)
         plot_posterior(trace)
         autocorrplot(trace)
+
+
+def test_plots_categorical():
+    # Test single trace
+    start, model, _ = simple_categorical()
+    with asmod.build_model() as model:
+        start = model.test_point
+        h = find_hessian(start)
+        step = Metropolis(model.vars, h)
+        trace = sample(3000, step=step, start=start)
+
+        traceplot(trace)
 
 
 def test_plots_multidimensional():


### PR DESCRIPTION
I forgot to push the latest local version before https://github.com/pymc-devs/pymc3/pull/1767 was merged. Now it gets facecolor for histograms properly instead of `.get_color`.