### PR TITLE
fix memory allocation problem for generators

### DIFF
--- a/pymc3/data.py
+++ b/pymc3/data.py
@@ -54,7 +54,7 @@ class DataGenerator(object):
     def __init__(self, generator):
         if not isgenerator(generator):
             raise TypeError('Object should be generator like')
-        self.test_value = next(generator)
+        self.test_value = copy(next(generator))
         # make pickling potentially possible
         self._yielded_test_value = False
         self.gen = generator
@@ -68,7 +68,7 @@ class DataGenerator(object):
             self._yielded_test_value = True
             return self.test_value
         else:
-            return next(self.gen)
+            return copy(next(self.gen))
 
     # python2 generator
     next = __next__


### PR DESCRIPTION
Sometimes generator has memory allocation problems and causes unexpected behaviour. This PR fixes the problem.