### PR TITLE
Display optimization progress for find_MAP

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -11,7 +11,7 @@ from .model import modelcontext, Point
 from .step_methods import (NUTS, HamiltonianMC, Metropolis, BinaryMetropolis,
                            BinaryGibbsMetropolis, CategoricalGibbsMetropolis,
                            Slice, CompoundStep)
-from tqdm import tqdm
+from tqdm import tqdm, tqdm_notebook
 
 import sys
 sys.setrecursionlimit(10000)
@@ -187,7 +187,11 @@ def _sample(draws, step=None, start=None, trace=None, chain=0, tune=None,
     sampling = _iter_sample(draws, step, start, trace, chain,
                             tune, model, random_seed)
     if progressbar:
-        sampling = tqdm(sampling, total=draws)
+        try:
+            # try notebook formatting
+            sampling = tqdm_notebook(sampling, total=draws, dynamic_ncols=True)
+        except:
+            sampling = tqdm(sampling, total=draws, dynamic_ncols=True)
     try:
         strace = None
         for strace in sampling:
@@ -401,7 +405,11 @@ def sample_ppc(trace, samples=None, model=None, vars=None, size=None, random_see
     seed(random_seed)
 
     if progressbar:
-        indices = tqdm(randint(0, len(trace), samples), total=samples)
+        try:
+            # try notebook formatting
+            indices = tqdm_notebook(randint(0, len(trace), samples), total=samples, dynamic_ncols=True)
+        except:
+            indices = tqdm(randint(0, len(trace), samples), total=samples, dynamic_ncols=True)
     else:
         indices = randint(0, len(trace), samples)
 

--- a/pymc3/tests/test_starting.py
+++ b/pymc3/tests/test_starting.py
@@ -80,3 +80,22 @@ def test_find_MAP():
 
     close_to(map_est2['mu'], 0, tol)
     close_to(map_est2['sigma'], 1, tol)
+
+
+def test_find_MAP_noverbosity():
+    # test with verbosity turned off (it is on by default)
+    #   should not error
+    with Model():
+        mu = Normal('mu', 0, 1, testval=100)
+        map_est1 = starting.find_MAP(fmin=starting.optimize.fmin_bfgs,   disp=False)
+        map_est2 = starting.find_MAP(fmin=starting.optimize.fmin_powell, disp=False)
+
+    # providing a callback should override disp (since it is a callback)
+    #   should not error
+    with Model():
+        mu = Normal('mu', 0, 1, testval=100)
+        # test with verbosity turned off (it is on by default)
+        map_est1 = starting.find_MAP(fmin=starting.optimize.fmin_bfgs,   disp=True, callback = lambda x: 1.0)
+        map_est2 = starting.find_MAP(fmin=starting.optimize.fmin_powell, disp=True, callback = lambda x: 1.0)
+
+

--- a/pymc3/tests/test_starting.py
+++ b/pymc3/tests/test_starting.py
@@ -82,20 +82,20 @@ def test_find_MAP():
     close_to(map_est2['sigma'], 1, tol)
 
 
-def test_find_MAP_noverbosity():
+def test_find_MAP_nomonitor():
     # test with verbosity turned off (it is on by default)
     #   should not error
     with Model():
         mu = Normal('mu', 0, 1, testval=100)
-        map_est1 = starting.find_MAP(fmin=starting.optimize.fmin_bfgs,   disp=False)
+        map_est1 = starting.find_MAP(fmin=starting.optimize.fmin_bfgs, disp=False)
         map_est2 = starting.find_MAP(fmin=starting.optimize.fmin_powell, disp=False)
 
-    # providing a callback should override disp (since it is a callback)
+    # providing a callback should override disp (since monitor works via callback to sp.optimize)
     #   should not error
     with Model():
         mu = Normal('mu', 0, 1, testval=100)
         # test with verbosity turned off (it is on by default)
-        map_est1 = starting.find_MAP(fmin=starting.optimize.fmin_bfgs,   disp=True, callback = lambda x: 1.0)
+        map_est1 = starting.find_MAP(fmin=starting.optimize.fmin_bfgs, disp=True, callback = lambda x: 1.0)
         map_est2 = starting.find_MAP(fmin=starting.optimize.fmin_powell, disp=True, callback = lambda x: 1.0)
 
 

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -204,9 +204,11 @@ class Monitor(object):
             self.paramtable = {}
 
     def __call__(self, x):
+        self.iters += 1
         if not self.disp:
             return
-        self.iters += 1
+        if self.iters == 1 and not self.using_notebook:
+            pm._log.info("iter    runtime    lpost    ||grad||    ")
         if time.time() - self.t0 > 1:
             self.update_progtable(x)
             self.update_paramtable(x)
@@ -241,8 +243,8 @@ class Monitor(object):
             self.paramtable[parameter] = {"size": val.size, "valstr": valstr}
 
     def display_terminal(self):
-        pm._log.info("iter    runtime    lpost    ||grad||    ")
-        disp_str = "{:8.3f}{:s}{:9.3f}{12.3f} \r".format(self.iters, self.t_elapsed, self.logpost, self.dlogpost)
+        disp_str = "{}  {:s}  {:9.3f}  {:12.3f}".format(self.iters, self.t_elapsed, self.logpost, self.dlogpost)
+        pm._log.info(disp_str)
 
     def display_notebook(self):
         ## Progress table

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -190,8 +190,10 @@ class Monitor(object):
                 self.hor_align = FlexBox(children = [l_col, r_col], width='100%', orientation='vertical')
                 display(self.hor_align)
                 self.using_notebook = True
+                self.update_interval = 1
             except:
                 self.using_notebook = False
+                self.update_interval = 2
 
             self.bij = bij
             self.logp = logp
@@ -208,8 +210,8 @@ class Monitor(object):
         if not self.disp:
             return
         if self.iters == 1 and not self.using_notebook:
-            pm._log.info("iter    runtime    lpost    ||grad||    ")
-        if time.time() - self.t0 > 1:
+            print("iter         runtime   lpost      ||grad||    ")
+        if time.time() - self.t0 > self.update_interval:
             self.update_progtable(x)
             self.update_paramtable(x)
             if self.using_notebook:
@@ -222,7 +224,7 @@ class Monitor(object):
         s = time.time() - self.t_initial
         hours, remainder = divmod(int(s), 3600)
         minutes, seconds = divmod(remainder, 60)
-        self.t_elapsed = "{}h {}m {}s".format(hours, minutes, seconds)
+        self.t_elapsed = "{:2d}h{:2d}m{:2d}s".format(hours, minutes, seconds)
         self.logpost = np.float(self.logp(x))
         self.dlogpost = np.linalg.norm(self.dlogp(x))
 
@@ -243,8 +245,8 @@ class Monitor(object):
             self.paramtable[parameter] = {"size": val.size, "valstr": valstr}
 
     def display_terminal(self):
-        disp_str = "{}  {:s}  {:9.3f}  {:12.3f}".format(self.iters, self.t_elapsed, self.logpost, self.dlogpost)
-        pm._log.info(disp_str)
+        disp_str = "{:<5d}       {:<s}  {:<9.3f}  {:<12.3f}".format(self.iters, self.t_elapsed, self.logpost, self.dlogpost)
+        print(disp_str + "\r")
 
     def display_notebook(self):
         ## Progress table

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -225,7 +225,7 @@ class Monitor(object):
         hours, remainder = divmod(int(s), 3600)
         minutes, seconds = divmod(remainder, 60)
         self.t_elapsed = "{:2d}h{:2d}m{:2d}s".format(hours, minutes, seconds)
-        self.logpost = np.float(self.logp(x))
+        self.logpost = -1.0*np.float(self.logp(x))
         self.dlogpost = np.linalg.norm(self.dlogp(x))
 
     def _update_paramtable(self, x):

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -279,7 +279,6 @@ class Monitor(object):
              </tr>""".format(self.dlogpost)
         html += "</table>"
         self.prog_table.value = html
-
         ## Parameter table
         html = r"""<style type="text/css">
           .tg .tg-bgft{font-weight:normal;font-family:"Lucida Console", Monaco, monospace !important;background-color:#0E688A;color:#ffffff;}
@@ -306,22 +305,3 @@ class Monitor(object):
             """.format(parameter, values["size"], values["valstr"])
         html += "</table>"
         self.param_table.value = html
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -12,8 +12,8 @@ from theano.sandbox.rng_mrg import MRG_RandomStreams
 import pymc3 as pm
 from pymc3.backends.base import MultiTrace
 from ..theanof import floatX
-
 from tqdm import trange
+import tqdm
 
 __all__ = ['advi', 'sample_vp']
 
@@ -148,10 +148,15 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
     elbos = np.empty(n)
     divergence_flag = False
     try:
-        progress = trange(n)
         uw_i, elbo_current = f()
         if np.isnan(elbo_current):
             raise FloatingPointError('NaN occurred in ADVI optimization.')
+        # set up progress bar
+        try:
+            progress = tqdm.tqdm_notebook(range(n))
+        except:
+            progress = tqdm.trange(n)
+
         for i in progress:
             uw_i, e = f()
             if np.isnan(e):
@@ -186,7 +191,7 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
                         divergence_flag = True
                     else:
                         divergence_flag = False
-                        
+
     except KeyboardInterrupt:
         elbos = elbos[:i]
         if n < 10:
@@ -202,10 +207,10 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
         else:
             avg_elbo = elbos[-n // 10:].mean()
             pm._log.info('Finished [100%]: Average ELBO = {:,.5g}'.format(avg_elbo))
-    
+
     if divergence_flag:
         pm._log.info('Evidence of divergence detected, inspect ELBO.')
-        
+
     # Estimated parameters
     l = int(uw_i.size / 2)
     u = bij.rmap(uw_i[:l])
@@ -400,7 +405,14 @@ def sample_vp(
     trace = pm.sampling.NDArray(model=model, vars=vars_sampled)
     trace.setup(draws=draws, chain=0)
 
-    range_ = trange(draws) if progressbar else range(draws)
+    if progressbar:
+        # set up progress bar
+        try:
+            range_ = tqdm.tqdm_notebook(range(draws))
+        except:
+            range_ = tqdm.trange(draws)
+    else:
+        range_ = range(draws)
 
     for _ in range_:
         # 'point' is like {'var1': np.array(0.1), 'var2': np.array(0.2), ...}

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -12,7 +12,6 @@ from theano.sandbox.rng_mrg import MRG_RandomStreams
 import pymc3 as pm
 from pymc3.backends.base import MultiTrace
 from ..theanof import floatX
-from tqdm import trange
 import tqdm
 
 __all__ = ['advi', 'sample_vp']

--- a/pymc3/variational/advi_minibatch.py
+++ b/pymc3/variational/advi_minibatch.py
@@ -518,9 +518,14 @@ def advi_minibatch(vars=None, start=None, model=None, n=5000, n_mcsamples=1,
     updates = OrderedDict(optimizer(loss=-1 * elbo, param=params))
     f = theano.function(tensors, elbo, updates=updates, mode=mode)
 
+    # set up progress bar
+    try:
+        progress = tqdm.tqdm_notebook(range(n))
+    except:
+        progress = tqdm.trange(n)
+
     # Optimization loop
     elbos = np.empty(n)
-    progress = tqdm.trange(n)
     for i in progress:
         e = f(*next(minibatches))
         if np.isnan(e):


### PR DESCRIPTION
If `disp=True` in call to `find_MAP`, then optimization progress is printed out.
- If ipython notebook is being used, an updating table showing parameter progress is displayed.  Colors are taken from PyMC3 logo.
- If ipython notebook is not being used, more basic info (number of iterations, log posterior value, ||grad||, runtime) is displayed every 2 seconds.

Also in this PR is a small change to appearances of tqdm.  If the user is developing in a notebook, the better looking tqdm notebook iteration bar is displayed.

Let me know if there are any changes, cosmetic or otherwise, you would like or would prefer.

![terminal version](https://cloud.githubusercontent.com/assets/6325473/23252345/25a99afc-f976-11e6-84f4-cbd8685adae7.png)

![notebook version](https://cloud.githubusercontent.com/assets/6325473/23252352/2cf69134-f976-11e6-8375-4138f00f5177.png)

