### PR TITLE
Tidy plots

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -486,7 +486,7 @@ def init_nuts(init='ADVI', njobs=1, n_init=500000, model=None,
         if njobs == 1:
             start = start[0]
     else:
-        raise NotImplemented('Initializer {} is not supported.'.format(init))
+        raise NotImplementedError('Initializer {} is not supported.'.format(init))
 
     step = pm.NUTS(scaling=cov, is_cov=True, **kwargs)
 


### PR DESCRIPTION
This is a start towards making the plot module more manageable.  Most of the changes here are for `forestplot`, factoring out common code into helper functions and converting some matplotlib calls to be object oriented instead of context based (`ax.set_foo` instead of `plt.foo`).

The only functional change here is a keyword argument, swapping `xrange`, a python 2.x builtin, for `xlim`, which is the matplotlib property that it is setting.  

All tests pass, and I confirmed that the rugby example plots don't change.

Two future changes:
1.   Put plotting utilities into a directory so the file is smaller and utility functions are isolated.
2.  `main` keyword argument in forestplot, which is documented as a string, but has special meaning if it is `None` or `False`, which leads to some awkward code (`if name is not False`)