### PR TITLE
Precompute Cholesky decomposition in elliptical slice sampler

### DIFF
--- a/pymc3/step_methods/elliptical_slice.py
+++ b/pymc3/step_methods/elliptical_slice.py
@@ -10,6 +10,30 @@ from ..distributions import draw_values
 __all__ = ['EllipticalSlice']
 
 
+def get_chol(cov, chol):
+    """Get Cholesky decomposition of the prior covariance.
+
+    Ensure that exactly one of the prior covariance or Cholesky
+    decomposition is passed. If the prior covariance was passed, then
+    return its Cholesky decomposition.
+
+    Parameters
+    ----------
+    cov : array, optional
+        Covariance matrix of the multivariate Gaussian prior.
+    chol : array, optional
+        Cholesky decomposition of the covariance matrix of the
+        multivariate Gaussian prior.
+    """
+
+    if len([i for i in [cov, chol] if i is not None]) != 1:
+        raise ValueError('Must pass exactly one of cov or chol')
+
+    if cov is not None:
+        chol = tt.slinalg.cholesky(cov)
+    return chol
+
+
 class EllipticalSlice(ArrayStep):
     """Multivariate elliptical slice sampler step.
 
@@ -26,8 +50,11 @@ class EllipticalSlice(ArrayStep):
     ----------
     vars : list
         List of variables for sampler.
-    prior_cov : array
+    prior_cov : array, optional
         Covariance matrix of the multivariate Gaussian prior.
+    prior_chol : array, optional
+        Cholesky decomposition of the covariance matrix of the
+        multivariate Gaussian prior.
     model : PyMC Model
         Optional model for sampling step. Defaults to None (taken from
         context).
@@ -42,10 +69,11 @@ class EllipticalSlice(ArrayStep):
 
     default_blocked = True
 
-    def __init__(self, vars=None, prior_cov=None, model=None, **kwargs):
+    def __init__(self, vars=None, prior_cov=None, prior_chol=None, model=None,
+                 **kwargs):
         self.model = modelcontext(model)
-        self.prior_cov = tt.as_tensor_variable(prior_cov)
-        self.prior_mean = tt.zeros_like(self.prior_cov[0])
+        chol = get_chol(prior_cov, prior_chol)
+        self.prior_chol = tt.as_tensor_variable(chol)
 
         if vars is None:
             vars = self.model.cont_vars
@@ -57,8 +85,11 @@ class EllipticalSlice(ArrayStep):
         """q0 : current state
         logp : log probability function
         """
-        mean, cov = draw_values([self.prior_mean, self.prior_cov])
-        nu = nr.multivariate_normal(mean=mean, cov=cov)
+
+        # Draw from the normal prior by multiplying the Cholesky decomposition
+        # of the covariance with draws from a standard normal
+        chol = draw_values([self.prior_chol])
+        nu = np.dot(chol, nr.randn(chol.shape[0]))
         y = logp(q0) - nr.standard_exponential()
 
         # Draw initial proposal and propose a candidate point

--- a/pymc3/tests/models.py
+++ b/pymc3/tests/models.py
@@ -104,6 +104,7 @@ def mv_prior_simple():
     X = np.linspace(0, 1, n)[:, None]
 
     K = pm.gp.cov.ExpQuad(1, 1)(X).eval()
+    L = np.linalg.cholesky(K)
     K_noise = K + noise * np.eye(n)
     obs = np.array([-0.1, 0.5, 1.1])
 
@@ -121,7 +122,7 @@ def mv_prior_simple():
         x_obs = pm.MvNormal('x_obs', observed=obs, mu=x,
                             cov=noise * np.eye(n), shape=n)
 
-    return model.test_point, model, (K, mu_post, std_post, noise)
+    return model.test_point, model, (K, L, mu_post, std_post, noise)
 
 
 def non_normal(n=2):

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -189,13 +189,14 @@ class TestStepMethods(object):  # yield test doesn't work subclassing unittest.T
             yield self.check_stat, check, trace, step.__class__.__name__
 
     def test_step_elliptical_slice(self):
-        start, model, (K, mu, std, noise) = mv_prior_simple()
+        start, model, (K, L, mu, std, noise) = mv_prior_simple()
         unc = noise ** 0.5
         check = (('x', np.mean, mu, unc / 10.),
                  ('x', np.std, std, unc / 10.))
         with model:
             steps = (
                 EllipticalSlice(prior_cov=K),
+                EllipticalSlice(prior_chol=L),
             )
         for step in steps:
             trace = sample(5000, step=step, start=start, model=model, random_seed=1)


### PR DESCRIPTION
Instead of calling `np.random.multivariate_normal`, precompute the Cholesky decomposition and multiply it with independent standard normal draws, which is basically what NumPy does anyway behind the scenes. This also lets users specify the prior distribution with the Cholesky decomposition of the covariance instead of the covariance itself. I haven't done much benchmarking, but this speeds up the Gaussian process slice sampling notebook by 7-8x (50 -> 350+ samples/second).