### PR TITLE
Turn off theano round warning

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -1,6 +1,10 @@
 # pylint: disable=wildcard-import
 __version__ = "3.0"
 
+# Turn off nagging Theano warnings
+import os
+os.environ["THEANO_FLAGS"] = "warn.round=False"
+
 from .blocking import *
 from .distributions import *
 from .external import *

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -1,10 +1,6 @@
 # pylint: disable=wildcard-import
 __version__ = "3.0"
 
-# Turn off nagging Theano warnings
-import os
-os.environ["THEANO_FLAGS"] = "warn.round=False"
-
 from .blocking import *
 from .distributions import *
 from .external import *

--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -1,3 +1,7 @@
+# Turn off nagging Theano warnings
+import os
+os.environ["THEANO_FLAGS"] = "warn.round=False"
+
 from . import timeseries
 from . import transforms
 

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -129,7 +129,7 @@ class MvNormal(Continuous):
             result -= tt.log(det(tau))
         else:
             result -= logdet(tau)
-        result += (tt.dot(tau, delta) * delta).sum(axis=delta.ndim - 1)
+        result += (tt.dot(delta, tau) * delta).sum(axis=delta.ndim - 1)
         return -1 / 2. * result
 
 

--- a/pymc3/examples/lightspeed_example.py
+++ b/pymc3/examples/lightspeed_example.py
@@ -36,7 +36,7 @@ def run(n=5000):
     with model_1:
         xstart = pm.find_MAP()
         xstep = pm.Slice()
-        trace = pm.sample(5000, xstep, xstart,
+        trace = pm.sample(5000, xstep, start=xstart,
                           random_seed=123, progressbar=True)
 
         pm.summary(trace)

--- a/pymc3/gp/cov.py
+++ b/pymc3/gp/cov.py
@@ -32,7 +32,8 @@ class Covariance(object):
             self.active_dims = np.arange(input_dim)
         else:
             self.active_dims = np.array(active_dims)
-            assert len(active_dims) == input_dim, "One boolean value per dimension required"
+            if len(active_dims) != input_dim:
+                raise ValueError("Length of active_dims must match input_dim")
 
     def __call__(self, X, Z):
         R"""
@@ -44,7 +45,6 @@ class Covariance(object):
         Z : The optional prediction set of inputs the kernel.  If Z is None, Z = X.
         """
         raise NotImplementedError
-
 
     def _slice(self, X, Z):
         X = X[:, self.active_dims]
@@ -289,8 +289,10 @@ class WarpedInput(Covariance):
 
     def __init__(self, input_dim, cov_func, warp_func, args=None, active_dims=None):
         Covariance.__init__(self, input_dim, active_dims)
-        assert callable(warp_func), "Must be a callable"
-        assert isinstance(cov_func, Covariance), "Must be one of the covariance functions"
+        if not callable(warp_func):
+            raise TypeError("warp_func must be callable")
+        if not isinstance(cov_func, Covariance):
+            raise TypeError("Must be or inherit from the Covariance class")
         self.w = handle_args(warp_func, args)
         self.args = args
         self.cov_func = cov_func
@@ -326,7 +328,8 @@ class Gibbs(Covariance):
         else:
             if input_dim != 1:
                 raise NotImplementedError("Higher dimensional inputs are untested")
-        assert callable(lengthscale_func), "Must be a callable"
+        if not callable(lengthscale_func):
+            raise TypeError("lengthscale_func must be callable")
         self.ell = handle_args(lengthscale_func, args)
         self.args = args
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -2,8 +2,10 @@ import threading
 import six
 
 import numpy as np
+import scipy.sparse as sps
 import theano
 import theano.tensor as tt
+import theano.sparse as sparse
 from theano.tensor.var import TensorVariable
 
 import pymc3 as pm
@@ -787,6 +789,8 @@ def pandas_to_array(data):
         return data
     elif isinstance(data, theano.gof.graph.Variable):
         return data
+    elif sps.issparse(data):
+        return data
     elif isgenerator(data):
         return generator(data)
     else:
@@ -810,6 +814,10 @@ def as_tensor(data, name, model, distribution):
             constant[data.mask.nonzero()], missing_values)
         dataTensor.missing_values = missing_values
         return dataTensor
+    elif sps.issparse(data):
+        data = sparse.basic.as_sparse(data, name=name)
+        data.missing_values = None
+        return data
     else:
         data = tt.as_tensor_variable(data, name=name)
         data.missing_values = None

--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -779,12 +779,12 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
         if ax is None:
             ax, fig = create_axes_grid(figsize, trace_dict)
 
-        for a, v in zip(ax, trace_dict):
+        for a, v in zip(np.atleast_1d(ax), trace_dict):
             tr_values = transform(trace_dict[v])
             plot_posterior_op(tr_values, ax=a)
             a.set_title(v)
 
-        fig.tight_layout()
+        plt.tight_layout()
     return ax
 
 

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -6,7 +6,7 @@ import theano
 import theano.tensor as tt
 import numpy as np
 
-class ZeroTest(unittest.TestCase):
+class TestZero(unittest.TestCase):
     def test_value(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -15,7 +15,7 @@ class ZeroTest(unittest.TestCase):
         self.assertTrue(np.all(M==0))
         self.assertSequenceEqual(M.shape, (10,1))
 
-class ConstantTest(unittest.TestCase):
+class TestConstant(unittest.TestCase):
     def test_value(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -24,7 +24,7 @@ class ConstantTest(unittest.TestCase):
         self.assertTrue(np.all(M==6))
         self.assertSequenceEqual(M.shape, (10,1))
 
-class LinearMeanTest(unittest.TestCase):
+class TestLinearMean(unittest.TestCase):
     def test_value(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -33,7 +33,7 @@ class LinearMeanTest(unittest.TestCase):
         self.assertAlmostEqual(M[1,0], 0.7222, 3)
 
 
-class CovAddTest(unittest.TestCase):
+class TestCovAdd(unittest.TestCase):
     def test_symadd_cov(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -78,7 +78,7 @@ class CovAddTest(unittest.TestCase):
         self.assertTrue(np.allclose(K, K_true))
 
 
-class CovProdTest(unittest.TestCase):
+class TestCovProd(unittest.TestCase):
     def test_symprod_cov(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -133,7 +133,7 @@ class CovProdTest(unittest.TestCase):
         self.assertTrue(np.allclose(K1, K2))
 
 
-class CovSliceDimTest(unittest.TestCase):
+class TestCovSliceDim(unittest.TestCase):
     def test_slice1(self):
         X = np.linspace(0,1,30).reshape(10,3)
         with Model() as model:
@@ -164,10 +164,12 @@ class CovSliceDimTest(unittest.TestCase):
 
     def test_raises(self):
         lengthscales = 2.0
-        self.assertRaises(AssertionError, gp.cov.ExpQuad, 1, lengthscales, [True, False])
+        with self.assertRaises(ValueError):
+            gp.cov.ExpQuad(1, lengthscales, [True, False])
+            gp.cov.ExpQuad(2, lengthscales, [True])
 
 
-class ExpQuadTest(unittest.TestCase):
+class TestExpQuad(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -192,7 +194,7 @@ class ExpQuadTest(unittest.TestCase):
         self.assertAlmostEqual(K[0,1], 0.969607, 3)
 
 
-class RatQuadTest(unittest.TestCase):
+class TestRatQuad(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -203,7 +205,7 @@ class RatQuadTest(unittest.TestCase):
         self.assertAlmostEqual(K[0,1], 0.66896, 3)
 
 
-class ExponentialTest(unittest.TestCase):
+class TestExponential(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -214,7 +216,7 @@ class ExponentialTest(unittest.TestCase):
         self.assertAlmostEqual(K[0,1], 0.57375, 3)
 
 
-class Matern52Test(unittest.TestCase):
+class TestMatern52(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -225,7 +227,7 @@ class Matern52Test(unittest.TestCase):
         self.assertAlmostEqual(K[0,1], 0.46202, 3)
 
 
-class Matern32Test(unittest.TestCase):
+class TestMatern32(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -236,7 +238,7 @@ class Matern32Test(unittest.TestCase):
         self.assertAlmostEqual(K[0,1], 0.42682, 3)
 
 
-class CosineTest(unittest.TestCase):
+class TestCosine(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -247,7 +249,7 @@ class CosineTest(unittest.TestCase):
         self.assertAlmostEqual(K[0,1], -0.93969, 3)
 
 
-class LinearTest(unittest.TestCase):
+class TestLinear(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -258,7 +260,7 @@ class LinearTest(unittest.TestCase):
         self.assertAlmostEqual(K[0,1], 0.19444, 3)
 
 
-class PolynomialTest(unittest.TestCase):
+class TestPolynomial(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -269,7 +271,7 @@ class PolynomialTest(unittest.TestCase):
         self.assertAlmostEqual(K[0,1], 0.03780, 4)
 
 
-class WarpedInputTest(unittest.TestCase):
+class TestWarpedInput(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         def warp_func(x, a, b, c):
@@ -284,11 +286,13 @@ class WarpedInputTest(unittest.TestCase):
 
     def test_raises(self):
         cov_m52 = gp.cov.Matern52(1, 0.2)
-        self.assertRaises(AssertionError, gp.cov.WarpedInput, 1, cov_m52, "not callable")
-        self.assertRaises(AssertionError, gp.cov.WarpedInput, 1, "not a Covariance object", lambda x: x)
+        with self.assertRaises(TypeError):
+            gp.cov.WarpedInput(1, cov_m52, "str is not callable")
+        with self.assertRaises(TypeError):
+            gp.cov.WarpedInput(1, "str is not Covariance object", lambda x: x)
 
 
-class GibbsTest(unittest.TestCase):
+class TestGibbs(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0, 2, 10)[:,None]
         def tanh_func(x, x1, x2, w, x0):
@@ -301,11 +305,15 @@ class GibbsTest(unittest.TestCase):
         self.assertAlmostEqual(K[2,3], 0.136683, 4)
 
     def test_raises(self):
-        self.assertRaises(AssertionError, gp.cov.Gibbs, 1, 555)
-        self.assertRaises(NotImplementedError, gp.cov.Gibbs, 2, lambda x: x)
-        self.assertRaises(NotImplementedError, gp.cov.Gibbs, 3, lambda x: x, active_dims=[True, True, False])
+        with self.assertRaises(TypeError):
+            gp.cov.Gibbs(1, "str is not callable")
+        with self.assertRaises(NotImplementedError):
+            gp.cov.Gibbs(2, lambda x: x)
+        with self.assertRaises(NotImplementedError):
+            gp.cov.Gibbs(3, lambda x: x, active_dims=[True, True, False])
 
-class HandleArgsTest(unittest.TestCase):
+
+class TestHandleArgs(unittest.TestCase):
     def test_handleargs(self):
         def func_noargs(x):
             return x
@@ -324,7 +332,7 @@ class HandleArgsTest(unittest.TestCase):
         self.assertEqual(func_twoarg(x, a, b), func_twoarg2(x, args=(a, b)))
 
 
-class GPTest(SeededTest):
+class TestGP(SeededTest):
     def test_func_args(self):
         X = np.linspace(0,1,10)[:,None]
         Y = np.random.randn(10,1)

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -32,12 +32,149 @@ class LinearMeanTest(unittest.TestCase):
         M = theano.function([], linear_mean(X))()
         self.assertAlmostEqual(M[1,0], 0.7222, 3)
 
+
+class CovAddTest(unittest.TestCase):
+    def test_symadd_cov(self):
+        X = np.linspace(0,1,10)[:,None]
+        with Model() as model:
+            cov1 = gp.cov.ExpQuad(1, 0.1)
+            cov2 = gp.cov.ExpQuad(1, 0.1)
+            cov = cov1 + cov2
+        K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 2*0.53940, 3)
+
+    def test_rightadd_scalar(self):
+        X = np.linspace(0,1,10)[:,None]
+        with Model() as model:
+            a = 1
+            cov = gp.cov.ExpQuad(1, 0.1) + a
+        K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 1 + 0.53940, 3)
+
+    def test_leftadd_scalar(self):
+        X = np.linspace(0,1,10)[:,None]
+        with Model() as model:
+            a = 1
+            cov = a + gp.cov.ExpQuad(1, 0.1)
+        K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 1 + 0.53940, 3)
+
+    def test_rightadd_matrix(self):
+        X = np.linspace(0,1,10)[:,None]
+        M = 2 * np.ones((10,10))
+        with Model() as model:
+            cov = gp.cov.ExpQuad(1, 0.1) + M
+        K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 2 + 0.53940, 3)
+
+    def test_leftprod_matrix(self):
+        X = np.linspace(0,1,3)[:,None]
+        M = np.array([[1,2,3],[2,1,2],[3,2,1]])
+        with Model() as model:
+            cov = M + gp.cov.ExpQuad(1, 0.1)
+            cov_true = gp.cov.ExpQuad(1, 0.1) + M
+        K = theano.function([], cov(X))()
+        K_true = theano.function([], cov_true(X))()
+        self.assertTrue(np.allclose(K, K_true))
+
+
+class CovProdTest(unittest.TestCase):
+    def test_symprod_cov(self):
+        X = np.linspace(0,1,10)[:,None]
+        with Model() as model:
+            cov1 = gp.cov.ExpQuad(1, 0.1)
+            cov2 = gp.cov.ExpQuad(1, 0.1)
+            cov = cov1 * cov2
+        K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 0.53940 * 0.53940, 3)
+
+    def test_rightprod_scalar(self):
+        X = np.linspace(0,1,10)[:,None]
+        with Model() as model:
+            a = 2
+            cov = gp.cov.ExpQuad(1, 0.1) * a
+        K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 2 * 0.53940, 3)
+
+    def test_leftprod_scalar(self):
+        X = np.linspace(0,1,10)[:,None]
+        with Model() as model:
+            a = 2
+            cov = a * gp.cov.ExpQuad(1, 0.1)
+        K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 2 * 0.53940, 3)
+
+    def test_rightprod_matrix(self):
+        X = np.linspace(0,1,10)[:,None]
+        M = 2 * np.ones((10,10))
+        with Model() as model:
+            cov = gp.cov.ExpQuad(1, 0.1) * M
+        K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 2 * 0.53940, 3)
+
+    def test_leftprod_matrix(self):
+        X = np.linspace(0,1,3)[:,None]
+        M = np.array([[1,2,3],[2,1,2],[3,2,1]])
+        with Model() as model:
+            cov = M * gp.cov.ExpQuad(1, 0.1)
+            cov_true = gp.cov.ExpQuad(1, 0.1) * M
+        K = theano.function([], cov(X))()
+        K_true = theano.function([], cov_true(X))()
+        self.assertTrue(np.allclose(K, K_true))
+
+    def test_multiops(self):
+        X = np.linspace(0,1,3)[:,None]
+        M = np.array([[1,2,3],[2,1,2],[3,2,1]])
+        with Model() as model:
+            cov1 = 3 + gp.cov.ExpQuad(1, 0.1) + M * gp.cov.ExpQuad(1, 0.1) * M * gp.cov.ExpQuad(1, 0.1)
+            cov2 = gp.cov.ExpQuad(1, 0.1) * M * gp.cov.ExpQuad(1, 0.1) * M + gp.cov.ExpQuad(1, 0.1) + 3
+        K1 = theano.function([], cov1(X))()
+        K2 = theano.function([], cov2(X))()
+        self.assertTrue(np.allclose(K1, K2))
+
+
+class CovSliceDimTest(unittest.TestCase):
+    def test_slice1(self):
+        X = np.linspace(0,1,30).reshape(10,3)
+        with Model() as model:
+            cov = gp.cov.ExpQuad(3, 0.1, active_dims=[0,0,1])
+        K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 0.20084298, 3)
+
+    def test_slice2(self):
+        X = np.linspace(0,1,30).reshape(10,3)
+        with Model() as model:
+            cov = gp.cov.ExpQuad(3, [0.1, 0.1], active_dims=[False, True, True])
+        K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 0.34295549, 3)
+
+    def test_slice3(self):
+        X = np.linspace(0,1,30).reshape(10,3)
+        with Model() as model:
+            cov = gp.cov.ExpQuad(3, np.array([0.1, 0.1]), active_dims=[False, True, True])
+        K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 0.34295549, 3)
+
+    def test_diffslice(self):
+        X = np.linspace(0,1,30).reshape(10,3)
+        with Model() as model:
+            cov = gp.cov.ExpQuad(3, 0.1, [1, 0, 0]) + gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
+        K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 0.683572, 3)
+
+    def test_raises(self):
+        lengthscales = 2.0
+        self.assertRaises(AssertionError, gp.cov.ExpQuad, 1, lengthscales, [True, False])
+
+
 class ExpQuadTest(unittest.TestCase):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
             cov = gp.cov.ExpQuad(1, 0.1)
         K = theano.function([], cov(X))()
+        self.assertAlmostEqual(K[0,1], 0.53940, 3)
+        K = theano.function([], cov(X,X))()
         self.assertAlmostEqual(K[0,1], 0.53940, 3)
 
     def test_2d(self):
@@ -62,20 +199,8 @@ class RatQuadTest(unittest.TestCase):
             cov = gp.cov.RatQuad(1, 0.1, 0.5)
         K = theano.function([], cov(X))()
         self.assertAlmostEqual(K[0,1], 0.66896, 3)
-
-    def test_2d(self):
-        X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
-            cov = gp.cov.RatQuad(2, 0.5, 0.5)
-        K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.84664, 3)
-
-    def test_2dard(self):
-        X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
-            cov = gp.cov.RatQuad(2, np.array([1, 2]), 0.5)
-        K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.97049, 3)
+        K = theano.function([], cov(X,X))()
+        self.assertAlmostEqual(K[0,1], 0.66896, 3)
 
 
 class ExponentialTest(unittest.TestCase):
@@ -85,20 +210,8 @@ class ExponentialTest(unittest.TestCase):
             cov = gp.cov.Exponential(1, 0.1)
         K = theano.function([], cov(X))()
         self.assertAlmostEqual(K[0,1], 0.57375, 3)
-
-    def test_2d(self):
-        X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
-            cov = gp.cov.Exponential(2, 0.5)
-        K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.73032, 3)
-
-    def test_2dard(self):
-        X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
-            cov = gp.cov.Exponential(2, np.array([1, 2]))
-        K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.88318, 3)
+        K = theano.function([], cov(X,X))()
+        self.assertAlmostEqual(K[0,1], 0.57375, 3)
 
 
 class Matern52Test(unittest.TestCase):
@@ -108,20 +221,8 @@ class Matern52Test(unittest.TestCase):
             cov = gp.cov.Matern52(1, 0.1)
         K = theano.function([], cov(X))()
         self.assertAlmostEqual(K[0,1], 0.46202, 3)
-
-    def test_2d(self):
-        X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
-            cov = gp.cov.Matern52(2, 0.5)
-        K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.75143, 3)
-
-    def test_2dard(self):
-        X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
-            cov = gp.cov.Matern52(2, np.array([1, 2]))
-        K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.95153, 3)
+        K = theano.function([], cov(X,X))()
+        self.assertAlmostEqual(K[0,1], 0.46202, 3)
 
 
 class Matern32Test(unittest.TestCase):
@@ -131,20 +232,19 @@ class Matern32Test(unittest.TestCase):
             cov = gp.cov.Matern32(1, 0.1)
         K = theano.function([], cov(X))()
         self.assertAlmostEqual(K[0,1], 0.42682, 3)
+        K = theano.function([], cov(X,X))()
+        self.assertAlmostEqual(K[0,1], 0.42682, 3)
 
-    def test_2d(self):
-        X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
-            cov = gp.cov.Matern32(2, 0.5)
-        K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.70318, 3)
 
-    def test_2dard(self):
-        X = np.linspace(0,1,10).reshape(5,2)
+class CosineTest(unittest.TestCase):
+    def test_1d(self):
+        X = np.linspace(0,1,10)[:,None]
         with Model() as model:
-            cov = gp.cov.Matern32(2, np.array([1, 2]))
+            cov = gp.cov.Cosine(1, 0.1)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.930135, 3)
+        self.assertAlmostEqual(K[0,1], -0.93969, 3)
+        K = theano.function([], cov(X,X))()
+        self.assertAlmostEqual(K[0,1], -0.93969, 3)
 
 
 class LinearTest(unittest.TestCase):
@@ -154,20 +254,8 @@ class LinearTest(unittest.TestCase):
             cov = gp.cov.Linear(1, 0.5)
         K = theano.function([], cov(X))()
         self.assertAlmostEqual(K[0,1], 0.19444, 3)
-
-    def test_2d(self):
-        X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
-            cov = gp.cov.Linear(2, 0.2)
-        K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], -0.01629, 3)
-
-    def test_2dard(self):
-        X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
-            cov = gp.cov.Linear(2, np.array([0.2, -0.1]))
-        K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.08703, 3)
+        K = theano.function([], cov(X,X))()
+        self.assertAlmostEqual(K[0,1], 0.19444, 3)
 
 
 class PolynomialTest(unittest.TestCase):
@@ -177,20 +265,8 @@ class PolynomialTest(unittest.TestCase):
             cov = gp.cov.Polynomial(1, 0.5, 2, 0)
         K = theano.function([], cov(X))()
         self.assertAlmostEqual(K[0,1], 0.03780, 4)
-
-    def test_2d(self):
-        X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
-            cov = gp.cov.Polynomial(2, 0.2, 2, 0)
-        K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.00026, 4)
-
-    def test_2dard(self):
-        X = np.linspace(0,1,10).reshape(5,2)
-        with Model() as model:
-            cov = gp.cov.Polynomial(2, np.array([0.2, -0.1]), 2, 0)
-        K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.00757, 4)
+        K = theano.function([], cov(X,X))()
+        self.assertAlmostEqual(K[0,1], 0.03780, 4)
 
 
 class WarpedInputTest(unittest.TestCase):
@@ -203,6 +279,14 @@ class WarpedInputTest(unittest.TestCase):
             cov = gp.cov.WarpedInput(1, warp_func=warp_func, args=(1,10,1), cov_func=cov_m52)
         K = theano.function([], cov(X))()
         self.assertAlmostEqual(K[0,1], 0.79593, 4)
+        K = theano.function([], cov(X,X))()
+        self.assertAlmostEqual(K[0,1], 0.79593, 4)
+
+    def test_raises(self):
+        cov_m52 = gp.cov.Matern52(1, 0.2)
+        self.assertRaises(AssertionError, gp.cov.WarpedInput, 1, cov_m52, "not callable")
+        self.assertRaises(AssertionError, gp.cov.WarpedInput, 1, "not a Covariance object", lambda x: x)
+
 
 class GibbsTest(unittest.TestCase):
     def test_1d(self):
@@ -213,6 +297,32 @@ class GibbsTest(unittest.TestCase):
             cov = gp.cov.Gibbs(1, tanh_func, args=(0.05, 0.6, 0.4, 1.0))
         K = theano.function([], cov(X))()
         self.assertAlmostEqual(K[2,3], 0.136683, 4)
+        K = theano.function([], cov(X,X))()
+        self.assertAlmostEqual(K[2,3], 0.136683, 4)
+
+    def test_raises(self):
+        self.assertRaises(AssertionError, gp.cov.Gibbs, 1, 555)
+        self.assertRaises(NotImplementedError, gp.cov.Gibbs, 2, lambda x: x)
+        self.assertRaises(NotImplementedError, gp.cov.Gibbs, 3, lambda x: x, active_dims=[True, True, False])
+
+class HandleArgsTest(unittest.TestCase):
+    def test_handleargs(self):
+        def func_noargs(x):
+            return x
+        def func_onearg(x, a):
+            return x + a
+        def func_twoarg(x, a, b):
+            return x + a + b
+        x = 100
+        a = 2
+        b = 3
+        func_noargs2 = gp.cov.handle_args(func_noargs, None)
+        func_onearg2 = gp.cov.handle_args(func_onearg, a)
+        func_twoarg2 = gp.cov.handle_args(func_twoarg, args=(a, b))
+        self.assertEqual(func_noargs(x),       func_noargs2(x, args=None))
+        self.assertEqual(func_onearg(x, a),    func_onearg2(x, args=a))
+        self.assertEqual(func_twoarg(x, a, b), func_twoarg2(x, args=(a, b)))
+
 
 class GPTest(SeededTest):
     def test_func_args(self):
@@ -234,8 +344,6 @@ class GPTest(SeededTest):
             l = Uniform('l', 0, 5)
             K = gp.cov.Matern32(1, l)
             sigma = Uniform('sigma', 0, 10)
-
             # make a Gaussian model
             random_test = gp.GP('random_test', mean_func=M, cov_func=K, sigma=sigma, observed={'X':X, 'Y':Y})
-
             tr = sample(500, init=None, progressbar=False, random_seed=self.random_seed)

--- a/pymc3/tests/test_model_helpers.py
+++ b/pymc3/tests/test_model_helpers.py
@@ -130,8 +130,6 @@ class HelperFuncTests(unittest.TestCase):
         for func_output in [dense_output, sparse_output]:
             self.assertEqual(func_output.name, input_name)
 
-        print type(dense_output)
-
         # Ensure the that returned functions are all of the correct type
         self.assertIsInstance(dense_output, tt.TensorConstant)
         self.assertTrue(sparse.basic._is_sparse_variable(sparse_output))

--- a/pymc3/tests/test_model_helpers.py
+++ b/pymc3/tests/test_model_helpers.py
@@ -1,0 +1,87 @@
+import unittest
+
+import numpy as np
+import numpy.ma as ma
+import numpy.testing as npt
+import pandas as pd
+import pymc3 as pm
+import scipy.sparse as sps
+
+import theano
+import theano.tensor as tt
+import theano.sparse as sparse
+
+
+class HelperFuncTests(unittest.TestCase):
+    def test_pandas_to_array(self):
+        """
+        Ensure that pandas_to_array returns the dense array, masked array,
+        graph variable, TensorVariable, or sparse matrix as appropriate.
+        """
+        # Create the various inputs to the function
+        sparse_input = sps.csr_matrix(np.eye(3))
+        dense_input = np.arange(9).reshape((3, 3))
+
+        input_name = 'input_variable'
+        theano_graph_input = tt.as_tensor(dense_input, name=input_name)
+
+        pandas_input = pd.DataFrame(dense_input)
+
+        # All the even numbers are replaced with NaN
+        missing_pandas_input = pd.DataFrame(np.array([[np.nan, 1, np.nan],
+                                                      [3, np.nan, 5],
+                                                      [np.nan, 7, np.nan]]))
+        masked_array_input = ma.array(dense_input,
+                                      mask=(np.mod(dense_input, 2) == 0))
+
+        # Create a generator object. Apparently the generator object needs to
+        # yield numpy arrays.
+        square_generator = (np.array([i**2], dtype=int) for i in range(100))
+
+        # Alias the function to be tested
+        func = pm.model.pandas_to_array
+
+        #####
+        # Perform the various tests
+        #####
+        # Check function behavior with dense arrays and pandas dataframes
+        # without missing values
+        for input_value in [dense_input, pandas_input]:
+            func_output = func(input_value)
+            self.assertIsInstance(func_output, np.ndarray)
+            self.assertEqual(func_output.shape, input_value.shape)
+            npt.assert_allclose(func_output, dense_input)
+
+        # Check function behavior with sparse matrix inputs
+        sparse_output = func(sparse_input)
+        self.assertTrue(sps.issparse(sparse_output))
+        self.assertEqual(sparse_output.shape, sparse_input.shape)
+        npt.assert_allclose(sparse_output.toarray(),
+                            sparse_input.toarray())
+
+        # Check function behavior when using masked array inputs and pandas
+        # objects with missing data
+        for input_value in [masked_array_input, missing_pandas_input]:
+            func_output = func(input_value)
+            self.assertIsInstance(func_output, ma.core.MaskedArray)
+            self.assertEqual(func_output.shape, input_value.shape)
+            npt.assert_allclose(func_output, masked_array_input)
+
+        # Check function behavior with Theano graph variable
+        theano_output = func(theano_graph_input)
+        self.assertIsInstance(theano_output, theano.gof.graph.Variable)
+        self.assertEqual(theano_output.name, input_name)
+
+        # Check function behavior with generator data
+        generator_output = func(square_generator)
+        # Make sure the returned object has .set_gen and .set_default methods
+        self.assertTrue(hasattr(generator_output, "set_gen"))
+        self.assertTrue(hasattr(generator_output, "set_default"))
+        # Make sure the returned object is a Theano TensorVariable
+        self.assertIsInstance(generator_output, tt.TensorVariable)
+
+        return None
+
+
+
+


### PR DESCRIPTION
Recent versions of Theano report a warning regarding the use of `tt.round` that users don't need to see.

```
UserWarning: theano.tensor.round() changed its default from `half_away_from_zero` to `half_to_even` to have the same default as NumPy. Use the Theano flag `warn.round=False` to disable this warning.
  "theano.tensor.round() changed its default from"
```

This occurs pretty frequently (every time a discrete variable is used, apparently), so this PR silences it. I anticipate the need to do this from time to time as Theano evolves.