### PR TITLE
Update sample argument ordering

### DIFF
--- a/pymc3/examples/lightspeed_example.py
+++ b/pymc3/examples/lightspeed_example.py
@@ -36,7 +36,7 @@ def run(n=5000):
     with model_1:
         xstart = pm.find_MAP()
         xstep = pm.Slice()
-        trace = pm.sample(5000, xstep, xstart,
+        trace = pm.sample(5000, xstep, start=xstart,
                           random_seed=123, progressbar=True)
 
         pm.summary(trace)


### PR DESCRIPTION
Parameter order of sample has changed, specify start=.. instead of using argument position. The second parameter of sample is now init, not start.