### PR TITLE
Support sparse matrices in observed keyword argument

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -2,8 +2,10 @@ import threading
 import six
 
 import numpy as np
+import scipy.sparse as sps
 import theano
 import theano.tensor as tt
+import theano.sparse as sparse
 from theano.tensor.var import TensorVariable
 
 import pymc3 as pm
@@ -787,6 +789,8 @@ def pandas_to_array(data):
         return data
     elif isinstance(data, theano.gof.graph.Variable):
         return data
+    elif sps.issparse(data):
+        return data
     elif isgenerator(data):
         return generator(data)
     else:
@@ -810,6 +814,10 @@ def as_tensor(data, name, model, distribution):
             constant[data.mask.nonzero()], missing_values)
         dataTensor.missing_values = missing_values
         return dataTensor
+    elif sps.issparse(data):
+        data = sparse.basic.as_sparse(data, name=name)
+        data.missing_values = None
+        return data
     else:
         data = tt.as_tensor_variable(data, name=name)
         data.missing_values = None

--- a/pymc3/tests/test_model_helpers.py
+++ b/pymc3/tests/test_model_helpers.py
@@ -130,8 +130,6 @@ class HelperFuncTests(unittest.TestCase):
         for func_output in [dense_output, sparse_output]:
             self.assertEqual(func_output.name, input_name)
 
-        print type(dense_output)
-
         # Ensure the that returned functions are all of the correct type
         self.assertIsInstance(dense_output, tt.TensorConstant)
         self.assertTrue(sparse.basic._is_sparse_variable(sparse_output))

--- a/pymc3/tests/test_model_helpers.py
+++ b/pymc3/tests/test_model_helpers.py
@@ -1,0 +1,87 @@
+import unittest
+
+import numpy as np
+import numpy.ma as ma
+import numpy.testing as npt
+import pandas as pd
+import pymc3 as pm
+import scipy.sparse as sps
+
+import theano
+import theano.tensor as tt
+import theano.sparse as sparse
+
+
+class HelperFuncTests(unittest.TestCase):
+    def test_pandas_to_array(self):
+        """
+        Ensure that pandas_to_array returns the dense array, masked array,
+        graph variable, TensorVariable, or sparse matrix as appropriate.
+        """
+        # Create the various inputs to the function
+        sparse_input = sps.csr_matrix(np.eye(3))
+        dense_input = np.arange(9).reshape((3, 3))
+
+        input_name = 'input_variable'
+        theano_graph_input = tt.as_tensor(dense_input, name=input_name)
+
+        pandas_input = pd.DataFrame(dense_input)
+
+        # All the even numbers are replaced with NaN
+        missing_pandas_input = pd.DataFrame(np.array([[np.nan, 1, np.nan],
+                                                      [3, np.nan, 5],
+                                                      [np.nan, 7, np.nan]]))
+        masked_array_input = ma.array(dense_input,
+                                      mask=(np.mod(dense_input, 2) == 0))
+
+        # Create a generator object. Apparently the generator object needs to
+        # yield numpy arrays.
+        square_generator = (np.array([i**2], dtype=int) for i in range(100))
+
+        # Alias the function to be tested
+        func = pm.model.pandas_to_array
+
+        #####
+        # Perform the various tests
+        #####
+        # Check function behavior with dense arrays and pandas dataframes
+        # without missing values
+        for input_value in [dense_input, pandas_input]:
+            func_output = func(input_value)
+            self.assertIsInstance(func_output, np.ndarray)
+            self.assertEqual(func_output.shape, input_value.shape)
+            npt.assert_allclose(func_output, dense_input)
+
+        # Check function behavior with sparse matrix inputs
+        sparse_output = func(sparse_input)
+        self.assertTrue(sps.issparse(sparse_output))
+        self.assertEqual(sparse_output.shape, sparse_input.shape)
+        npt.assert_allclose(sparse_output.toarray(),
+                            sparse_input.toarray())
+
+        # Check function behavior when using masked array inputs and pandas
+        # objects with missing data
+        for input_value in [masked_array_input, missing_pandas_input]:
+            func_output = func(input_value)
+            self.assertIsInstance(func_output, ma.core.MaskedArray)
+            self.assertEqual(func_output.shape, input_value.shape)
+            npt.assert_allclose(func_output, masked_array_input)
+
+        # Check function behavior with Theano graph variable
+        theano_output = func(theano_graph_input)
+        self.assertIsInstance(theano_output, theano.gof.graph.Variable)
+        self.assertEqual(theano_output.name, input_name)
+
+        # Check function behavior with generator data
+        generator_output = func(square_generator)
+        # Make sure the returned object has .set_gen and .set_default methods
+        self.assertTrue(hasattr(generator_output, "set_gen"))
+        self.assertTrue(hasattr(generator_output, "set_default"))
+        # Make sure the returned object is a Theano TensorVariable
+        self.assertIsInstance(generator_output, tt.TensorVariable)
+
+        return None
+
+
+
+


### PR DESCRIPTION
This pull request is in response to [Issue #1835 ](https://github.com/pymc-devs/pymc3/issues/1835)

It should allow sparse matrices to be correctly handled as data for one's distribution when they are passed through the observed keyword argument. PyMC3 will no longer try to convert sparse matrices to numpy arrays when using `pandas_to_array()` and they will be correctly transformed into Theano objects when using `as_tensor()`.