### PR TITLE
Silenced Theano round warning

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -4,10 +4,9 @@ import theano
 import theano.tensor as tt
 from scipy import stats
 
-tround = lambda *args, **kwargs: tt.round(*args, **kwargs, mode='half_to_even')
-
 from .dist_math import bound, factln, binomln, betaln, logpow
 from .distribution import Discrete, draw_values, generate_samples, reshape_sampled
+from pymc3.math import tround
 
 __all__ = ['Binomial',  'BetaBinomial',  'Bernoulli',  'DiscreteWeibull',
            'Poisson', 'NegativeBinomial', 'ConstantDist', 'Constant',

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -4,7 +4,7 @@ import theano
 import theano.tensor as tt
 from scipy import stats
 
-round = lambda *args, **kwargs: tt.round(*args, **kwargs, mode='half_to_even')
+tround = lambda *args, **kwargs: tt.round(*args, **kwargs, mode='half_to_even')
 
 from .dist_math import bound, factln, binomln, betaln, logpow
 from .distribution import Discrete, draw_values, generate_samples, reshape_sampled
@@ -43,7 +43,7 @@ class Binomial(Discrete):
         super(Binomial, self).__init__(*args, **kwargs)
         self.n = n = tt.as_tensor_variable(n)
         self.p = p = tt.as_tensor_variable(p)
-        self.mode = tt.cast(round(n * p), self.dtype)
+        self.mode = tt.cast(tround(n * p), self.dtype)
 
     def random(self, point=None, size=None, repeat=None):
         n, p = draw_values([self.n, self.p], point=point)
@@ -95,7 +95,7 @@ class BetaBinomial(Discrete):
         self.alpha = alpha = tt.as_tensor_variable(alpha)
         self.beta = beta = tt.as_tensor_variable(beta)
         self.n = n = tt.as_tensor_variable(n)
-        self.mode = tt.cast(tt.round(alpha / (alpha + beta)), 'int8')
+        self.mode = tt.cast(tround(alpha / (alpha + beta)), 'int8')
 
     def _random(self, alpha, beta, n, size=None):
         size = size or 1
@@ -149,7 +149,7 @@ class Bernoulli(Discrete):
     def __init__(self, p, *args, **kwargs):
         super(Bernoulli, self).__init__(*args, **kwargs)
         self.p = p = tt.as_tensor_variable(p)
-        self.mode = tt.cast(tt.round(p), 'int8')
+        self.mode = tt.cast(tround(p), 'int8')
 
     def random(self, point=None, size=None, repeat=None):
         p = draw_values([self.p], point=point)

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -4,6 +4,8 @@ import theano
 import theano.tensor as tt
 from scipy import stats
 
+round = lambda *args, **kwargs: tt.round(*args, **kwargs, mode='half_to_even')
+
 from .dist_math import bound, factln, binomln, betaln, logpow
 from .distribution import Discrete, draw_values, generate_samples, reshape_sampled
 
@@ -41,7 +43,7 @@ class Binomial(Discrete):
         super(Binomial, self).__init__(*args, **kwargs)
         self.n = n = tt.as_tensor_variable(n)
         self.p = p = tt.as_tensor_variable(p)
-        self.mode = tt.cast(tt.round(n * p), self.dtype)
+        self.mode = tt.cast(round(n * p), self.dtype)
 
     def random(self, point=None, size=None, repeat=None):
         n, p = draw_values([self.n, self.p], point=point)

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -7,6 +7,8 @@ import scipy
 import theano
 import theano.tensor as tt
 
+tround = lambda *args, **kwargs: tt.round(*args, **kwargs, mode='half_to_even')
+
 from scipy import stats
 
 from theano.tensor.nlinalg import det, matrix_inverse, trace
@@ -314,7 +316,7 @@ class Multinomial(Discrete):
             self.p = tt.as_tensor_variable(p)
 
         self.mean = self.n * self.p
-        self.mode = tt.cast(tt.round(self.mean), 'int32')
+        self.mode = tt.cast(tround(self.mean), 'int32')
 
     def _random(self, n, p, size=None):
         if size == p.shape:

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -7,15 +7,13 @@ import scipy
 import theano
 import theano.tensor as tt
 
-tround = lambda *args, **kwargs: tt.round(*args, **kwargs, mode='half_to_even')
-
 from scipy import stats
 
 from theano.tensor.nlinalg import det, matrix_inverse, trace
 
 import pymc3 as pm
 
-from pymc3.math import logdet
+from pymc3.math import logdet, tround
 from . import transforms
 from .distribution import Continuous, Discrete, draw_values, generate_samples
 from ..model import Deterministic

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -19,7 +19,7 @@ def tround(*args, **kwargs):
     Temporary function to silence round warning in Theano. Please remove
     when the warning disappears.
     """
-    rerurn tt.round(*args, **kwargs, mode='half_to_even')
+    return tt.round(*args, **kwargs, mode='half_to_even')
 
 
 def logsumexp(x, axis=None):

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -14,6 +14,13 @@ from theano.gof import Op, Apply
 import numpy as np
 # pylint: enable=unused-import
 
+def tround(*args, **kwargs): 
+    """
+    Temporary function to silence round warning in Theano. Please remove
+    when the warning disappears.
+    """
+    rerurn tt.round(*args, **kwargs, mode='half_to_even')
+
 
 def logsumexp(x, axis=None):
     # Adapted from https://github.com/Theano/Theano/issues/1563

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -19,7 +19,8 @@ def tround(*args, **kwargs):
     Temporary function to silence round warning in Theano. Please remove
     when the warning disappears.
     """
-    return tt.round(*args, **kwargs, mode='half_to_even')
+    kwargs['mode'] = 'half_to_even'
+    return tt.round(*args, **kwargs)
 
 
 def logsumexp(x, axis=None):


### PR DESCRIPTION
Having been unable to use flag-setting to kill this warning, here I am simply passing the default argument that causes the warning explicitly. Seems to do the trick.