### PR TITLE
Remove default covariance from MvNormal

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -35,8 +35,8 @@ def get_tau_cov(mu, tau=None, cov=None):
     Parameters
     ----------
     mu : array-like
-    tau : array-like, optional
-    cov : array-like, optional
+    tau : array-like, not required if cov is passed
+    cov : array-like, not required of tau is passed
 
     Results
     -------
@@ -48,8 +48,8 @@ def get_tau_cov(mu, tau=None, cov=None):
     """
     if tau is None:
         if cov is None:
-            cov = np.eye(len(mu))
-            tau = np.eye(len(mu))
+            raise ValueError('Incompatible parameterization. Either use tau'
+                             'or cov to specify distribution.')
         else:
             tau = tt.nlinalg.matrix_inverse(cov)
 
@@ -81,10 +81,10 @@ class MvNormal(Continuous):
     ----------
     mu : array
         Vector of means.
-    cov : array, optional
-        Covariance matrix.
-    tau : array, optional
-        Precision matrix.
+    cov : array
+        Covariance matrix. Not required if tau is passed.
+    tau : array
+        Precision matrix. Not required if tau is passed.
 
     Flags
     ----------

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -530,6 +530,11 @@ class TestMatchesScipy(SeededTest):
     def test_mvnormal(self, n):
         self.pymc3_matches_scipy(MvNormal, Vector(R, n),
                                  {'mu': Vector(R, n), 'tau': PdMatrix(n)}, normal_logpdf)
+                                 
+    def test_mvnormal_init_fail(self):
+        with Model():
+            with self.assertRaises(ValueError):
+                x = MvNormal('x', np.zeros(3), shape=3)
 
     @parameterized.expand([(1,), (2,)])
     def test_mvt(self, n):
@@ -655,8 +660,8 @@ class TestMatchesScipy(SeededTest):
         tau, cov = multivariate.get_tau_cov(mu, cov=cov)
         assert_almost_equal(tau.eval(), np.linalg.inv(cov))
 
-        tau, cov = multivariate.get_tau_cov(mu)
-        assert_almost_equal(cov, np.eye(3))
+        with self.assertRaises(ValueError):
+            tau, cov = multivariate.get_tau_cov(mu)
 
     @parameterized.expand([
         (0.5, -50.000, 0.500, 0.500, -99.8068528),


### PR DESCRIPTION
I did not realize that an identity matrix is assumed in MvNormal if a matrix is not passed. In general, we should avoid having defaults for important parameters in distributions. It should definitely not say in the documentation that these are "optional" parameters -- new users will get burned by this.

This PR removes this default, and raises a ValueError if cov or tau is not passed.

Closes #1845