### PR TITLE
Fix support of LKJCorr

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -20,7 +20,6 @@ from ..model import Deterministic
 from .continuous import ChiSquared, Normal
 from .special import gammaln, multigammaln
 from .dist_math import bound, logpow, factln
-from . import transforms
 
 __all__ = ['MvNormal', 'MvStudentT', 'Dirichlet',
            'Multinomial', 'Wishart', 'WishartBartlett', 'LKJCorr']

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -20,6 +20,7 @@ from ..model import Deterministic
 from .continuous import ChiSquared, Normal
 from .special import gammaln, multigammaln
 from .dist_math import bound, logpow, factln
+from . import transforms
 
 __all__ = ['MvNormal', 'MvStudentT', 'Dirichlet',
            'Multinomial', 'Wishart', 'WishartBartlett', 'LKJCorr']
@@ -583,12 +584,17 @@ class LKJCorr(Continuous):
         100(9), pp.1989-2001.
     """
 
-    def __init__(self, n, p, *args, **kwargs):
+    def __init__(self, n, p, transform='interval', *args, **kwargs):
         self.n = n
         self.p = p
         n_elem = int(p * (p - 1) / 2)
         self.mean = np.zeros(n_elem, dtype=theano.config.floatX)
-        super(LKJCorr, self).__init__(shape=n_elem, *args, **kwargs)
+
+        if transform == 'interval':
+            transform = transforms.interval(-1, 1)
+
+        super(LKJCorr, self).__init__(shape=n_elem, transform=transform,
+                                      *args, **kwargs)
 
         self.tri_index = np.zeros([p, p], dtype='int32')
         self.tri_index[np.triu_indices(p, k=1)] = np.arange(n_elem)

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -530,7 +530,7 @@ class TestMatchesScipy(SeededTest):
     def test_mvnormal(self, n):
         self.pymc3_matches_scipy(MvNormal, Vector(R, n),
                                  {'mu': Vector(R, n), 'tau': PdMatrix(n)}, normal_logpdf)
-                                 
+
     def test_mvnormal_init_fail(self):
         with Model():
             with self.assertRaises(ValueError):
@@ -556,7 +556,8 @@ class TestMatchesScipy(SeededTest):
     @parameterized.expand(gen_lkj_cases)
     def test_lkj(self, x, n, p, lp):
         with Model() as model:
-            LKJCorr('lkj', n=n, p=p)
+            LKJCorr('lkj', n=n, p=p, transform=None)
+
         pt = {'lkj': x}
         assert_almost_equal(model.fastlogp(pt), lp, decimal=6, err_msg=str(pt))
 


### PR DESCRIPTION
LKJCorr did not use an interval transformation to fix the support of the entries of the corr matrix to [-1, 1]. Because of this advi did not work at all and nuts reported diverging transitions in almost every sample:
```python
with pm.Model() as model:
    corr = pm.LKJCorr('corr', n=1, p=2)
    trace = pm.sample(2000, tune=1000, init=None)
   trace['diverging'].mean()
```
gives 0.998.

This should fix #1852.