### PR TITLE
Raise TypeError on non-data values of observed

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -3,7 +3,7 @@ import theano.tensor as tt
 from theano import function
 import theano
 from ..memoize import memoize
-from ..model import Model, get_named_nodes
+from ..model import Model, get_named_nodes, FreeRV, ObservedRV
 from ..vartypes import string_types
 from .dist_math import bound
 
@@ -30,11 +30,13 @@ class Distribution(object):
 
         if isinstance(name, string_types):
             data = kwargs.pop('observed', None)
+            if isinstance(data, ObservedRV) or isinstance(data, FreeRV):
+                raise TypeError("observed needs to be data but got: {}".format(type(data)))
             total_size = kwargs.pop('total_size', None)
             dist = cls.dist(*args, **kwargs)
             return model.Var(name, dist, data, total_size)
         else:
-            raise TypeError("Name needs to be a string but got: %s" % name)
+            raise TypeError("Name needs to be a string but got: {}".format(name))
 
     def __getnewargs__(self):
         return _Unpickling,

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -136,6 +136,12 @@ class TestNested(unittest.TestCase):
             with pm.Model() as sub:
                 self.assertTrue(model is sub.root)
 
+class TestObserved(unittest.TestCase):
+    def test_observed_rv_fail(self):
+        with self.assertRaises(TypeError):
+            with pm.Model() as model:
+                x = Normal('x')
+                Normal('n', observed=x)
 
 class TestScaling(unittest.TestCase):
     def test_density_scaling(self):


### PR DESCRIPTION
I was shown an example of a model which passed a random variable as the `observed` argument in a likelihood. Though the model did not output sensible results, it did not fail. This change guards against non-data values for `observed` so that this mis-specification never occurs.