### PR TITLE
Make install scripts idempotent

### DIFF
--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -15,12 +15,23 @@ do
     shift
 done
 
+command -v conda >/dev/null 2>&1 || {
+  echo "Requires conda but it is not installed.  Run install_miniconda.sh." >&2;
+  exit 1;
+}
+
+ENVNAME="testenv"
 PYTHON_VERSION=${PYTHON_VERSION:-3.6} # if no python specified, use 3.6
 
 if [ -z ${GLOBAL} ]
 then
-    conda create -n testenv --yes pip python=${PYTHON_VERSION}
-    source activate testenv
+    if conda env list | grep -q ${ENVNAME}
+    then
+      echo "Environment ${ENVNAME} already exists, keeping up to date"
+    else
+      conda create -n ${ENVNAME} --yes pip python=${PYTHON_VERSION}
+      source activate ${ENVNAME}
+    fi
 fi
 
 pip install jupyter

--- a/scripts/install_miniconda.sh
+++ b/scripts/install_miniconda.sh
@@ -9,32 +9,39 @@ if conda --version > /dev/null 2>&1; then
 
 PYTHON_VERSION=${PYTHON_VERSION:-3.6} # if no python specified, use 3.6
 
-if [ "$(uname)" == "Darwin" ]; then
-  URL_OS="MacOSX"
-elif [ "$(expr substr "$(uname -s)" 1 5)" == "Linux" ]; then
-  URL_OS="Linux"
-elif [ "$(expr substr "$(uname -s)" 1 10)" == "MINGW32_NT" ]; then
-  URL_OS="Windows"
-fi
-
-echo "Downloading miniconda for $URL_OS"
-DOWNLOAD_PATH="miniconda.sh"
-
 if [ ${PYTHON_VERSION} == "2.7" ]; then
-  wget http://repo.continuum.io/miniconda/Miniconda-latest-$URL_OS-x86_64.sh -O ${DOWNLOAD_PATH};
   INSTALL_FOLDER="$HOME/miniconda2"
 else
-  wget http://repo.continuum.io/miniconda/Miniconda3-latest-$URL_OS-x86_64.sh -O ${DOWNLOAD_PATH};
   INSTALL_FOLDER="$HOME/miniconda3"
 fi
 
 
-echo "Installing miniconda for python-$PYTHON_VERSION to $INSTALL_FOLDER"
-# install miniconda to home folder
-bash ${DOWNLOAD_PATH} -b -p $INSTALL_FOLDER
+if [ ! -d $INSTALL_FOLDER ]; then
+  if [ "$(uname)" == "Darwin" ]; then
+    URL_OS="MacOSX"
+  elif [ "$(expr substr "$(uname -s)" 1 5)" == "Linux" ]; then
+    URL_OS="Linux"
+  elif [ "$(expr substr "$(uname -s)" 1 10)" == "MINGW32_NT" ]; then
+    URL_OS="Windows"
+  fi
 
-# tidy up
-rm ${DOWNLOAD_PATH}
+  echo "Downloading miniconda for $URL_OS"
+  DOWNLOAD_PATH="miniconda.sh"
+  if [ ${PYTHON_VERSION} == "2.7" ]; then
+    wget http://repo.continuum.io/miniconda/Miniconda-latest-$URL_OS-x86_64.sh -O ${DOWNLOAD_PATH};
+  else
+    wget http://repo.continuum.io/miniconda/Miniconda3-latest-$URL_OS-x86_64.sh -O ${DOWNLOAD_PATH};
+  fi
+
+  echo "Installing miniconda for python-$PYTHON_VERSION to $INSTALL_FOLDER"
+  # install miniconda to home folder
+  bash ${DOWNLOAD_PATH} -b -p $INSTALL_FOLDER
+
+  # tidy up
+  rm ${DOWNLOAD_PATH}
+else
+  echo "Miniconda already installed at ${INSTALL_FOLDER}.  Updating, adding to path and exiting"
+fi
 
 export PATH="$INSTALL_FOLDER/bin:$PATH"
 echo "Adding $INSTALL_FOLDER to PATH.  Consider adding it in your .rc file as well."


### PR DESCRIPTION
This makes it so running these scripts twice will just update the install (so "idempotent" is a strong word).  In the past there would be errors.

If anyone is good with bash, this is a super hacky way of checking whether the conda environment already exists (printing info about environments, and grepping for the desired name).  

I intend to use this for the benchmark script -- these two files could be run daily before running the benchmark to stay on the latest theano version.