### PR TITLE
Don't include `-np.inf` in calculating average ELBO

### DIFF
--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -160,7 +160,7 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
             if n < 10:
                 progress.set_description('ELBO = {:,.5g}'.format(elbos[i]))
             elif i % (n // 10) == 0 and i > 0:
-                avg_elbo = elbos[i - n // 10:i].mean()
+                avg_elbo = infmean(elbos[i - n // 10:i])
                 progress.set_description('Average ELBO = {:,.5g}'.format(avg_elbo))
 
             if i % eval_elbo == 0:
@@ -193,14 +193,14 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
             pm._log.info('Interrupted at {:,d} [{:.0f}%]: ELBO = {:,.5g}'.format(
                 i, 100 * i // n, elbos[i]))
         else:
-            avg_elbo = elbos[i - n // 10:i].mean()
+            avg_elbo = infmean(elbos[i - n // 10:i])
             pm._log.info('Interrupted at {:,d} [{:.0f}%]: Average ELBO = {:,.5g}'.format(
                 i, 100 * i // n, avg_elbo))
     else:
         if n < 10:
             pm._log.info('Finished [100%]: ELBO = {:,.5g}'.format(elbos[-1]))
         else:
-            avg_elbo = elbos[-n // 10:].mean()
+            avg_elbo = infmean(elbos[-n // 10:])
             pm._log.info('Finished [100%]: Average ELBO = {:,.5g}'.format(avg_elbo))
     finally:
         progress.close()
@@ -410,3 +410,8 @@ def sample_vp(
         trace.record(point)
 
     return MultiTrace([trace])
+
+
+def infmean(input_array):
+    """Return the median of the finite values of the array"""
+    return np.mean(np.asarray(input_array)[np.isfinite(input_array)])

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -413,5 +413,5 @@ def sample_vp(
 
 
 def infmean(input_array):
-    """Return the median of the finite values of the array"""
+    """Return the mean of the finite values of the array"""
     return np.mean(np.asarray(input_array)[np.isfinite(input_array)])

--- a/pymc3/variational/advi_minibatch.py
+++ b/pymc3/variational/advi_minibatch.py
@@ -9,7 +9,7 @@ import tqdm
 
 import pymc3 as pm
 from pymc3.theanof import reshape_t, inputvars, floatX
-from .advi import ADVIFit, adagrad_optimizer, gen_random_state
+from .advi import ADVIFit, adagrad_optimizer, gen_random_state, infmean
 
 __all__ = ['advi_minibatch']
 
@@ -529,7 +529,7 @@ def advi_minibatch(vars=None, start=None, model=None, n=5000, n_mcsamples=1,
         if n < 10:
             progress.set_description('ELBO = {:,.2f}'.format(elbos[i]))
         elif i % (n // 10) == 0 and i > 0:
-            avg_elbo = elbos[i - n // 10:i].mean()
+            avg_elbo = infmean(elbos[i - n // 10:i])
             progress.set_description('Average ELBO = {:,.2f}'.format(avg_elbo))
 
     pm._log.info('Finished minibatch ADVI: ELBO = {:,.2f}'.format(elbos[-1]))


### PR DESCRIPTION
This PR addresses a minor issue in which likelihoods which can return a 0 probability (-inf log-probability) often report a negative infinity average ELBO for the entire simulation. 

For instance,

```python
with pm.Model() as model:

    a = pm.Normal('a', mu=0, sd=1.)
    obs = pm.Uniform('obs', lower=a, upper=10, observed=0)
    trace = pm.sample(5000, random_seed=123, progressbar=True)
```

Here, I just report the mean after removing the -np.inf values so convergence can be monitored.