### PR TITLE
Forestplot axis fix, add transform argument to summary

### DIFF
--- a/pymc3/plots/forestplot.py
+++ b/pymc3/plots/forestplot.py
@@ -257,7 +257,7 @@ def forestplot(trace_obj, varnames=None, transform=identity_transform, alpha=0.0
     gs.update(left=left_margin, right=0.95, top=0.9, bottom=0.05)
 
     # Define range of y-axis
-    interval_plot.set_ylim(-var-0.5, -0.5)
+    interval_plot.set_ylim(-var - 0.5, -0.5)
 
     datarange = plotrange[1] - plotrange[0]
     interval_plot.set_xlim(plotrange[0] - 0.05 * datarange, plotrange[1] + 0.05 * datarange)

--- a/pymc3/plots/forestplot.py
+++ b/pymc3/plots/forestplot.py
@@ -257,7 +257,7 @@ def forestplot(trace_obj, varnames=None, transform=identity_transform, alpha=0.0
     gs.update(left=left_margin, right=0.95, top=0.9, bottom=0.05)
 
     # Define range of y-axis
-    interval_plot.set_ylim(-var + 0.5, -0.5)
+    interval_plot.set_ylim(-var-0.5, -0.5)
 
     datarange = plotrange[1] - plotrange[0]
     interval_plot.set_xlim(plotrange[0] - 0.05 * datarange, plotrange[1] + 0.05 * datarange)

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -633,7 +633,7 @@ def _hpd_df(x, alpha):
 
 
 def summary(trace, varnames=None, transform=lambda x: x, alpha=0.05, start=0,
-             batches=None, roundto=3, include_transformed=False, to_file=None):
+            batches=None, roundto=3, include_transformed=False, to_file=None):
     R"""
     Generate a pretty-printed summary of the node.
 

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -632,8 +632,8 @@ def _hpd_df(x, alpha):
     return pd.DataFrame(hpd(x, alpha), columns=cnames)
 
 
-def summary(trace, varnames=None, alpha=0.05, start=0, batches=None, roundto=3,
-            include_transformed=False, to_file=None):
+def summary(trace, varnames=None, transform=lambda x: x, alpha=0.05, start=0,
+             batches=None, roundto=3, include_transformed=False, to_file=None):
     R"""
     Generate a pretty-printed summary of the node.
 
@@ -644,6 +644,8 @@ def summary(trace, varnames=None, alpha=0.05, start=0, batches=None, roundto=3,
     varnames : list of strings
       List of variables to summarize. Defaults to None, which results
       in all variables summarized.
+    transform : callable
+      Function to transform data (defaults to identity)
     alpha : float
       The alpha level for generating posterior intervals. Defaults to
       0.05.
@@ -682,7 +684,7 @@ def summary(trace, varnames=None, alpha=0.05, start=0, batches=None, roundto=3,
 
     for var in varnames:
         # Extract sampled values
-        sample = trace.get_values(var, burn=start, combine=True)
+        sample = transform(trace.get_values(var, burn=start, combine=True))
 
         fh.write('\n%s:\n\n' % var)
 


### PR DESCRIPTION
The `forestplot` function was overplotting the last element on the x-axis; this PR fixes that. 

I also added a `transform` argument to `summary`, as is available in the posterior plotting functions.