### PR TITLE
[WIP] Add support for cholesky parametrizations for cov/corr matrices

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -6,7 +6,7 @@ from .distributions import *
 from .external import *
 from .glm import *
 from . import gp
-from .math import logsumexp, logit, invlogit
+from .math import logsumexp, logit, invlogit, expand_packed_triangular
 from .model import *
 from .stats import *
 from .sampling import *

--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -58,6 +58,7 @@ from .multivariate import Dirichlet
 from .multivariate import Multinomial
 from .multivariate import Wishart
 from .multivariate import WishartBartlett
+from .multivariate import LKJCholeskyCov
 from .multivariate import LKJCorr
 
 from .timeseries import AR1
@@ -118,6 +119,7 @@ __all__ = ['Uniform',
            'Multinomial',
            'Wishart',
            'WishartBartlett',
+           'LKJCholeskyCov',
            'LKJCorr',
            'AR1',
            'GaussianRandomWalk',

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -713,7 +713,7 @@ class LKJCholeskyCov(Continuous):
         logp_sd = self.sd_dist.logp(sd_vals).sum()
         corr_diag = x[diag_idxs] / sd_vals
 
-        logp_lkj = (2 * eta - 3 + n - tt.arange(n)) * np.log(corr_diag)
+        logp_lkj = (2 * eta - 3 + n - tt.arange(n)) * tt.log(corr_diag)
         logp_lkj = tt.sum(logp_lkj)
 
         # Compute the log det jacobian of the second transformation

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -266,3 +266,19 @@ class Circular(Transform):
         return 0
 
 circular = Circular()
+
+
+class CholeskyCovPacked(Transform):
+    name = "cholesky_cov_packed"
+
+    def __init__(self, n):
+        self.diag_idxs = np.arange(1, n + 1).cumsum() - 1
+
+    def backward(self, x):
+        return tt.advanced_set_subtensor1(x, tt.exp(x[self.diag_idxs]), self.diag_idxs)
+
+    def forward(self, y):
+        return tt.advanced_set_subtensor1(y, tt.log(y[self.diag_idxs]), self.diag_idxs)
+
+    def jacobian_det(self, y):
+        return tt.sum(y[self.diag_idxs])

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -117,10 +117,8 @@ def expand_packed_triangular(n, packed, lower=False, diagonal_only=False):
     elif lower:
         out = tt.zeros((n, n), dtype=theano.config.floatX)
         idxs = np.tril_indices(n)
-        return tt.advanced_set_subtensor(out, packed, idxs)
+        return tt.set_subtensor(out[idxs], packed)
     elif not lower:
         out = tt.zeros((n, n), dtype=theano.config.floatX)
         idxs = np.triu_indices(n)
-        return tt.advanced_set_subtensor(out, packed, idxs)
-    else:
-        assert False
+        return tt.set_subtensor(out[idxs], packed)

--- a/pymc3/tests/sampler_fixtures.py
+++ b/pymc3/tests/sampler_fixtures.py
@@ -97,7 +97,7 @@ class StudentTFixture(KnownMean, KnownCDF):
 
 class LKJCholeskyCovFixture(KnownCDF):
     cdfs = {
-        'log_stds': [stats.norm(loc=x, scale=x / 10).cdf
+        'log_stds': [stats.norm(loc=x, scale=x / 10.).cdf
                      for x in [1, 2, 3, 4, 5]],
         # The entries of the correlation matrix should follow
         # beta(eta - 1 + d/2, eta - 1 + d/2) on (-1, 1).
@@ -112,7 +112,7 @@ class LKJCholeskyCovFixture(KnownCDF):
     def make_model(cls):
         with pm.Model() as model:
             sd_mu = np.array([1, 2, 3, 4, 5])
-            sd_dist = pm.Lognormal.dist(mu=sd_mu, sd=sd_mu / 10, shape=5)
+            sd_dist = pm.Lognormal.dist(mu=sd_mu, sd=sd_mu / 10., shape=5)
             chol_packed = pm.LKJCholeskyCov('chol_packed', 5, 3, sd_dist)
             chol = pm.expand_packed_triangular(5, chol_packed, lower=True)
             cov = tt.dot(chol, chol.T)

--- a/pymc3/tests/test_posteriors.py
+++ b/pymc3/tests/test_posteriors.py
@@ -90,3 +90,11 @@ class NUTSNormalLong(sf.NutsFixture, sf.NormalFixture):
     min_n_eff = 300000
     rtol = 0.01
     atol = 0.001
+
+
+class NUTSLKJCholeskyCov(sf.NutsFixture, sf.LKJCholeskyCovFixture):
+    n_samples = 2000
+    tune = 1000
+    burn = 1000
+    chains = 2
+    min_n_eff = 200


### PR DESCRIPTION
This is a first stab at a parameterization for cholesky decomposed cov/corr matrices.
#1850 is related, as it implements support for using these matrices in MvNormal.

Usage would be something like this:

```python
data = np.random.randn(100, 5)
mu = np.zeros(5)

with pm.Model() as model:
    sd_dist = pm.HalfCauchy.dist(beta=2.5, shape=5)
    cov_packed = pm.LKJCholeskyCov('cov', 2, sd_dist=sd_dist)

    cov = tt.zeros((5, 5))
    idxs = np.tril_indices(5)
    cov = tt.set_subtensor(cov[idxs], cov_packed)
    cov = cov.dot(cov.T)
    pm.MvNormal('y', mu=mu, cov=cov, observed=data)
```

or with a couple of changes to MvNormal
```python
data = np.random.randn(100, 5)
mu = np.zeros(5)

with pm.Model() as model:
    sd_dist = pm.HalfCauchy.dist(beta=2.5, shape=5)
    packed_chol = pm.LKJCholeskyCov('cov', 2, sd_dist=sd_dist)
    pm.MvNormal('y', mu=mu, packed_chol=packed_chol, observed=data)
```

Note, that `LKJCholeskyCov` takes a distribution for the standard deviations (sqrt of the diagonal entries of the cov) as argument. The unconstrained variables are the entries of the cholesky decomposition of the cov matrix (and their log for the diagonal entries).

There are a few other parametrizations for the same model and I'm not sure which is better in what circumstances. The default choice in the stan manual uses a different one, where the unconstrained parameters are closely related to the entries of the cholesky decomposition of the correlation matrix instead of the covariance matrix. There is a section in the stan manual describing those: "Transformations of Constrained Variables". I went for this one first, mainly because it is easy to implement and should be pretty fast computationally.

Tests and documentation are obviously still missing...