### PR TITLE
Revert "small fix for multivariate mixture models"

### DIFF
--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -61,9 +61,7 @@ class Mixture(Distribution):
 
         try:
             comp_modes = self._comp_modes()
-            # for logp the different modes are like different observations, i.e. rows, hence use comp_modes.T
-            # logPs is a vector, hence self.logp(..).T == self.logp(..)
-            comp_mode_logps = self.logp(comp_modes.T)
+            comp_mode_logps = self.logp(comp_modes)
             self.mode = comp_modes[tt.argmax(w * comp_mode_logps, axis=-1)]
 
             if 'mode' not in defaults:


### PR DESCRIPTION
Reverts pymc-devs/pymc3#1810

@schlichtanders unfortunately, this change breaks mixtures for one-dimensional observations when the mixture weights vary across observation points (see the dependent density example).  I'm inclined to revert this to get it working again for one-dimensional distributions and we can more carefully consider how to support multi-dimensional distributions.