### PR TITLE
Added message about init only working with auto-assigned step methods

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -101,7 +101,7 @@ def sample(draws, step=None, init='ADVI', n_init=200000, start=None,
         specified, or are partially specified, they will be assigned
         automatically (defaults to None).
     init : str {'ADVI', 'ADVI_MAP', 'MAP', 'NUTS', None}
-        Initialization method to use.
+        Initialization method to use. Only works for auto-assigned step methods.
         * ADVI : Run ADVI to estimate starting points and diagonal covariance
         matrix. If njobs > 1 it will sample starting points from the estimated
         posterior, otherwise it will use the estimated posterior mean.


### PR DESCRIPTION
There is ongoing confusion about the use of the `init` argument in `sample`. This adds text to the docstring that clarifies its use.

Really, we should move `init` and `n_init` back in the order of `sample` arguments, since they are only relevant for auto-assigned model runs.