### PR TITLE
Switch relative paths to absolute paths in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from os.path import realpath, dirname, join
 from setuptools import setup, find_packages
 import sys
 
@@ -28,7 +29,10 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Topic :: Scientific/Engineering :: Mathematics',
                'Operating System :: OS Independent']
 
-with open('requirements.txt') as f:
+PROJECT_ROOT = dirname(realpath(__file__))
+REQUIREMENTS_FILE = join(PROJECT_ROOT, 'requirements.txt')
+
+with open(REQUIREMENTS_FILE) as f:
     install_reqs = f.read().splitlines()
 
 if sys.version_info < (3, 4):
@@ -49,7 +53,7 @@ if __name__ == "__main__":
           url=URL,
           long_description=LONG_DESCRIPTION,
           packages=find_packages(),
-          package_data={'docs':['*'], 'pymc3.examples':['data/*']},
+          package_data={'docs': ['*'], 'pymc3.examples': ['data/*']},
           classifiers=classifiers,
           install_requires=install_reqs,
           tests_require=test_reqs,


### PR DESCRIPTION
This change enables setup.py to be called from directories other than the project root by resolving the static relative path 'requirements.txt' to an absolute path before opening the file.

Though a less common use-case, it prevents a file not found error occurring any time setup.py is called from outside the project root directory, which is currently what happens.

For example, this works after the PR and threw an error before:
```bash
git clone https://github.com/pymc-devs/pymc3 $HOME/pymc3
cd /tmp/
python $HOME/pymc3/setup.py install
```

Also, I put in two whitespaces on another line in accordance with PEP8 E231.
