### PR TITLE
Histogram: use only free RVs from trace

### DIFF
--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -286,17 +286,20 @@ class TestHistogram(SeededTest):
         np.testing.assert_allclose(trace0['x'].mean(0), trace1['x'].mean(0), atol=0.02)
         np.testing.assert_allclose(trace0['x'].var(0), trace1['x'].var(0), atol=0.02)
 
-    def test_random(self):
-        with models.multidimensional_model()[1]:
-            full_rank = FullRankADVI()
-            approx = full_rank.approx
-            trace0 = approx.sample_vp(10000)
-            histogram = Histogram(trace0)
+    def test_random_with_transformed(self):
+        p = .2
+        trials = (np.random.uniform(size=10) < p).astype('int8')
+        with pm.Model():
+            p = pm.Uniform('p')
+            pm.Bernoulli('trials', p, observed=trials)
+            trace = pm.sample(1000, step=pm.Metropolis())
+            histogram = Histogram(trace)
             histogram.randidx(None).eval()
             histogram.randidx(1).eval()
             histogram.random_fn(no_rand=True)
             histogram.random_fn(no_rand=False)
             histogram.histogram_logp.eval()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -276,7 +276,7 @@ class TestHistogram(SeededTest):
         with model:
             inference = ADVI(local_rv={x: (mu, rho)})
             approx = inference.approx
-            trace0 = approx.sample_vp(1000)
+            trace0 = approx.sample_vp(10000)
             histogram = Histogram(trace0, local_rv={x: (mu, rho)})
             trace1 = histogram.sample_vp(10000)
             histogram.random(no_rand=True)

--- a/pymc3/variational/approximations.py
+++ b/pymc3/variational/approximations.py
@@ -248,13 +248,10 @@ class Histogram(Approximation):
         self._histogram_logp = None
         super(Histogram, self).__init__(local_rv=local_rv, model=model)
 
-    @staticmethod
-    def check_model(model):
-        return True
-
-    def get_global_vars(self):
-        return [var for var in self.model.unobserved_RVs
-                if var.name in self.trace.varnames]
+    def check_model(self, model):
+        if not all([var.name in self.trace.varnames
+                    for var in model.free_RVs]):
+            raise ValueError('trace has not all FreeRV')
 
     def _setup(self):
         self._histogram_order = ArrayOrdering(self.global_vars)

--- a/pymc3/variational/approximations.py
+++ b/pymc3/variational/approximations.py
@@ -5,7 +5,7 @@ from theano import tensor as tt
 from pymc3 import ArrayOrdering, DictToArrayBijection
 from pymc3.distributions.dist_math import rho2sd, log_normal, log_normal_mv
 from pymc3.variational.opvi import Approximation
-from pymc3.theanof import tt_rng
+from pymc3.theanof import tt_rng, memoize
 
 
 __all__ = [
@@ -245,7 +245,6 @@ class Histogram(Approximation):
     """
     def __init__(self, trace, local_rv=None, model=None):
         self.trace = trace
-        self._histogram_logp = None
         super(Histogram, self).__init__(local_rv=local_rv, model=model)
 
     def check_model(self, model):
@@ -300,20 +299,20 @@ class Histogram(Approximation):
         return self.shared_params
 
     @property
+    @memoize
     def histogram_logp(self):
         """
         Symbolic logp for every point in trace
         """
-        if self._histogram_logp is None:
-            node = self.to_flat_input(self.model.logpt)
+        node = self.to_flat_input(self.model.logpt)
 
-            def mapping(z):
-                return theano.clone(node, {self.input: z})
-            x = self.histogram
-            self._histogram_logp, _ = theano.scan(
-                mapping, x, n_steps=x.shape[0]
-            )
-        return self._histogram_logp
+        def mapping(z):
+            return theano.clone(node, {self.input: z})
+        x = self.histogram
+        _histogram_logp, _ = theano.scan(
+            mapping, x, n_steps=x.shape[0]
+        )
+        return _histogram_logp
 
     @property
     def mean(self):

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -423,8 +423,7 @@ class Approximation(object):
     _view = property(lambda self: self.flat_view.view)
     input = property(lambda self: self.flat_view.input)
 
-    @staticmethod
-    def check_model(model):
+    def check_model(self, model):
         """
         Checks that model is valid for variational inference
         """


### PR DESCRIPTION
While experimenting I found that TransformedRVs are quite different from regular ones and Histogram fails on them. This PR fixes the problem

P.S. according to conventions I switched to memoize usage in one property