### PR TITLE
Do not allow observed Bound RVs

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -474,6 +474,11 @@ class Bound(object):
         self.upper = upper
 
     def __call__(self, *args, **kwargs):
+        if 'observed' in kwargs:
+            raise ValueError('Observed Bound distributions are not allowed. '
+                             'If you want to model truncated data '
+                             'you can use a pm.Potential in combination '
+                             'with the cumulative probability function.')
         first, args = args[0], args[1:]
 
         return Bounded(first, self.distribution, self.lower, self.upper,


### PR DESCRIPTION
Temporary fix for #1843 until #1864 is finished.
The error message is a bit vague about how to model truncated distributions, but it's the best I could come up with that's still short enough to qualify as an error message.