### PR TITLE
Better error message for empty models

### DIFF
--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -49,6 +49,9 @@ class BlockedStep(object):
         # get the actual inputs from the vars
         vars = inputvars(vars)
 
+        if len(vars) == 0:
+            raise ValueError('No free random variables to sample.')
+
         if not blocked and len(vars) > 1:
             # In this case we create a separate sampler for each var
             # and append them to a CompoundStep

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -212,6 +212,9 @@ def join_nonshared_inputs(xs, vars, shared, make_shared=False):
     tensors : list of same tensors but with inarray as input
     inarray : vector of inputs
     """
+    if not vars:
+        raise ValueError('Empty list of variables.')
+
     joined = tt.concatenate([var.ravel() for var in vars])
 
     if not make_shared:

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -111,6 +111,9 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
         vars = model.vars
     vars = pm.inputvars(vars)
 
+    if len(vars) == 0:
+        raise ValueError('No free random variables to fit.')
+
     if not pm.model.all_continuous(vars):
         raise ValueError('Model can not include discrete RVs for ADVI.')
 


### PR DESCRIPTION
Empty models lead to strange error messages at the moment:

```python
with pm.Model() as model:
    a = pm.Normal('a', mu=1, sd=5, observed=5)
    step = pm.NUTS()
```
```pytb
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
<ipython-input-2-05ff1e11f93c> in <module>()
      1 with pm.Model() as model:
      2     a = pm.Normal('a', mu=1, sd=5, observed=5)
----> 3     step = pm.NUTS()
      4     trace = pm.sample(1000)

/home/adr/git/pymc3/pymc3/step_methods/hmc/nuts.py in __init__(self, vars, Emax, target_accept, gamma, k, t0, adapt_step_size, max_treedepth, **kwargs)
    111         The step size adaptation stops when `self.tune` is set to False.
    112         """
--> 113         super(NUTS, self).__init__(vars, use_single_leapfrog=True, **kwargs)
    114 
    115         self.Emax = Emax

/home/adr/git/pymc3/pymc3/step_methods/hmc/base_hmc.py in __init__(self, vars, scaling, step_scale, is_cov, model, blocked, use_single_leapfrog, potential, integrator, **theano_kwargs)
     50             raise ValueError("Can not specify both potential and scaling.")
     51 
---> 52         self.step_size = step_scale / (model.ndim ** 0.25)
     53         if potential is not None:
     54             self.potential = potential

ZeroDivisionError: float division by zero
```