### PR TITLE
[WIP] Add precision modes and floatX wrapping in test_distributions.

### DIFF
--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -15,7 +15,6 @@ from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Di
                              Bound, Uniform, Triangular, Binomial, SkewNormal, DiscreteWeibull)
 from ..distributions import continuous, multivariate
 from pymc3.theanof import floatX
-import theano
 from nose_parameterized import parameterized
 from numpy import array, inf, log, exp
 from numpy.testing import assert_almost_equal, assert_allclose
@@ -26,10 +25,13 @@ from scipy import integrate
 import scipy.stats.distributions as sp
 import scipy.stats
 
+# Keep track of floating point mode for determining equality decimal cutoffs.
+DTYPE = floatX(1.0).dtype.name
+
 
 def select_by_precision(float64, float32):
     """Helper function to choose reasonable decimal cutoffs for different floatX modes."""
-    decimal = float64 if theano.config.floatX == "float64" else float32
+    decimal = float64 if DTYPE == "float64" else float32
     return decimal
 
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -27,7 +27,7 @@ import scipy.stats.distributions as sp
 import scipy.stats
 
 
-def select_decimal(float64, float32):
+def select_by_precision(float64, float32):
     """Helper function to choose reasonable decimal cutoffs for different floatX modes."""
     decimal = float64 if theano.config.floatX == "float64" else float32
     return decimal
@@ -314,7 +314,7 @@ class TestMatchesScipy(SeededTest):
         logp = model.fastlogp
         for pt in product(domains, n_samples=100):
             pt = Point(pt, model=model)
-            assert_almost_equal(logp(pt), logp_reference(pt), decimal=select_decimal(float64=6, float32=2), err_msg=str(pt))
+            assert_almost_equal(logp(pt), logp_reference(pt), decimal=select_by_precision(float64=6, float32=2), err_msg=str(pt))
 
     def check_int_to_1(self, model, value, domain, paramdomains):
         pdf = model.fastfn(exp(model.logpt))
@@ -350,7 +350,7 @@ class TestMatchesScipy(SeededTest):
         for pt in product(domains, n_samples=100):
             pt = Point(pt, model=model)
             pt = bij.map(pt)
-            assert_almost_equal(dlogp(pt), ndlogp(pt), decimal=select_decimal(float64=6, float32=4), err_msg=str(pt))
+            assert_almost_equal(dlogp(pt), ndlogp(pt), decimal=select_by_precision(float64=6, float32=4), err_msg=str(pt))
 
     def checkd(self, distfam, valuedomain, vardomains, checks=None, extra_args={}):
         if checks is None:
@@ -423,7 +423,7 @@ class TestMatchesScipy(SeededTest):
         with Model() as model:
             Wald('wald', mu=mu, lam=lam, phi=phi, alpha=alpha, transform=None)
         pt = {'wald': value}
-        assert_almost_equal(model.fastlogp(pt), logp, decimal=select_decimal(float64=6, float32=1), err_msg=str(pt))
+        assert_almost_equal(model.fastlogp(pt), logp, decimal=select_by_precision(float64=6, float32=1), err_msg=str(pt))
 
     def test_beta(self):
         self.pymc3_matches_scipy(Beta, Unit, {'alpha': Rplus, 'beta': Rplus},
@@ -567,7 +567,7 @@ class TestMatchesScipy(SeededTest):
             LKJCorr('lkj', n=n, p=p, transform=None)
 
         pt = {'lkj': x}
-        assert_almost_equal(model.fastlogp(pt), lp, decimal=select_decimal(float64=6, float32=4), err_msg=str(pt))
+        assert_almost_equal(model.fastlogp(pt), lp, decimal=select_by_precision(float64=6, float32=4), err_msg=str(pt))
 
     @parameterized.expand([(2,), (3,)])
     def test_dirichlet(self, n):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -15,6 +15,7 @@ from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Di
                              Bound, Uniform, Triangular, Binomial, SkewNormal, DiscreteWeibull)
 from ..distributions import continuous, multivariate
 from pymc3.theanof import floatX
+import theano
 from nose_parameterized import parameterized
 from numpy import array, inf, log, exp
 from numpy.testing import assert_almost_equal, assert_allclose
@@ -25,13 +26,10 @@ from scipy import integrate
 import scipy.stats.distributions as sp
 import scipy.stats
 
-# Keep track of floating point mode for determining equality decimal cutoffs.
-DTYPE = floatX(1.0).dtype.name
-
 
 def select_by_precision(float64, float32):
     """Helper function to choose reasonable decimal cutoffs for different floatX modes."""
-    decimal = float64 if DTYPE == "float64" else float32
+    decimal = float64 if theano.config.floatX == "float64" else float32
     return decimal
 
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -18,7 +18,7 @@ from pymc3.theanof import floatX
 import theano
 from nose_parameterized import parameterized
 from numpy import array, inf, log, exp
-from numpy.testing import assert_almost_equal, assert_allclose
+from numpy.testing import assert_almost_equal
 import numpy.random as nr
 import numpy as np
 
@@ -27,7 +27,7 @@ import scipy.stats.distributions as sp
 import scipy.stats
 
 
-def select_by_precision(float64, float32):
+def select_decimal(float64, float32):
     """Helper function to choose reasonable decimal cutoffs for different floatX modes."""
     decimal = float64 if theano.config.floatX == "float64" else float32
     return decimal
@@ -314,7 +314,7 @@ class TestMatchesScipy(SeededTest):
         logp = model.fastlogp
         for pt in product(domains, n_samples=100):
             pt = Point(pt, model=model)
-            assert_allclose(logp(pt), logp_reference(pt), rtol=select_by_precision(float64=1E-6, float32=1E-4), err_msg=str(pt))
+            assert_almost_equal(logp(pt), logp_reference(pt), decimal=select_decimal(float64=6, float32=2), err_msg=str(pt))
 
     def check_int_to_1(self, model, value, domain, paramdomains):
         pdf = model.fastfn(exp(model.logpt))
@@ -350,7 +350,7 @@ class TestMatchesScipy(SeededTest):
         for pt in product(domains, n_samples=100):
             pt = Point(pt, model=model)
             pt = bij.map(pt)
-            assert_allclose(dlogp(pt), ndlogp(pt), rtol=select_by_precision(float64=1E-6, float32=1E-5), err_msg=str(pt))
+            assert_almost_equal(dlogp(pt), ndlogp(pt), decimal=select_decimal(float64=6, float32=4), err_msg=str(pt))
 
     def checkd(self, distfam, valuedomain, vardomains, checks=None, extra_args={}):
         if checks is None:
@@ -423,7 +423,7 @@ class TestMatchesScipy(SeededTest):
         with Model() as model:
             Wald('wald', mu=mu, lam=lam, phi=phi, alpha=alpha, transform=None)
         pt = {'wald': value}
-        assert_allclose(model.fastlogp(pt), logp, rtol=select_by_precision(float64=1E-6, float32=1E-4), err_msg=str(pt))
+        assert_almost_equal(model.fastlogp(pt), logp, decimal=select_decimal(float64=6, float32=1), err_msg=str(pt))
 
     def test_beta(self):
         self.pymc3_matches_scipy(Beta, Unit, {'alpha': Rplus, 'beta': Rplus},
@@ -567,7 +567,7 @@ class TestMatchesScipy(SeededTest):
             LKJCorr('lkj', n=n, p=p, transform=None)
 
         pt = {'lkj': x}
-        assert_allclose(model.fastlogp(pt), lp, rtol=select_by_precision(float64=1E-6, float32=1E-5), err_msg=str(pt))
+        assert_almost_equal(model.fastlogp(pt), lp, decimal=select_decimal(float64=6, float32=4), err_msg=str(pt))
 
     @parameterized.expand([(2,), (3,)])
     def test_dirichlet(self, n):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -18,7 +18,7 @@ from pymc3.theanof import floatX
 import theano
 from nose_parameterized import parameterized
 from numpy import array, inf, log, exp
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_allclose
 import numpy.random as nr
 import numpy as np
 
@@ -27,7 +27,7 @@ import scipy.stats.distributions as sp
 import scipy.stats
 
 
-def select_decimal(float64, float32):
+def select_by_precision(float64, float32):
     """Helper function to choose reasonable decimal cutoffs for different floatX modes."""
     decimal = float64 if theano.config.floatX == "float64" else float32
     return decimal
@@ -314,7 +314,7 @@ class TestMatchesScipy(SeededTest):
         logp = model.fastlogp
         for pt in product(domains, n_samples=100):
             pt = Point(pt, model=model)
-            assert_almost_equal(logp(pt), logp_reference(pt), decimal=select_decimal(float64=6, float32=2), err_msg=str(pt))
+            assert_allclose(logp(pt), logp_reference(pt), rtol=select_by_precision(float64=1E-6, float32=1E-4), err_msg=str(pt))
 
     def check_int_to_1(self, model, value, domain, paramdomains):
         pdf = model.fastfn(exp(model.logpt))
@@ -350,7 +350,7 @@ class TestMatchesScipy(SeededTest):
         for pt in product(domains, n_samples=100):
             pt = Point(pt, model=model)
             pt = bij.map(pt)
-            assert_almost_equal(dlogp(pt), ndlogp(pt), decimal=select_decimal(float64=6, float32=4), err_msg=str(pt))
+            assert_allclose(dlogp(pt), ndlogp(pt), rtol=select_by_precision(float64=1E-6, float32=1E-5), err_msg=str(pt))
 
     def checkd(self, distfam, valuedomain, vardomains, checks=None, extra_args={}):
         if checks is None:
@@ -423,7 +423,7 @@ class TestMatchesScipy(SeededTest):
         with Model() as model:
             Wald('wald', mu=mu, lam=lam, phi=phi, alpha=alpha, transform=None)
         pt = {'wald': value}
-        assert_almost_equal(model.fastlogp(pt), logp, decimal=select_decimal(float64=6, float32=1), err_msg=str(pt))
+        assert_allclose(model.fastlogp(pt), logp, rtol=select_by_precision(float64=1E-6, float32=1E-4), err_msg=str(pt))
 
     def test_beta(self):
         self.pymc3_matches_scipy(Beta, Unit, {'alpha': Rplus, 'beta': Rplus},
@@ -567,7 +567,7 @@ class TestMatchesScipy(SeededTest):
             LKJCorr('lkj', n=n, p=p, transform=None)
 
         pt = {'lkj': x}
-        assert_almost_equal(model.fastlogp(pt), lp, decimal=select_decimal(float64=6, float32=4), err_msg=str(pt))
+        assert_allclose(model.fastlogp(pt), lp, rtol=select_by_precision(float64=1E-6, float32=1E-5), err_msg=str(pt))
 
     @parameterized.expand([(2,), (3,)])
     def test_dirichlet(self, n):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -15,6 +15,7 @@ from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Di
                              Bound, Uniform, Triangular, Binomial, SkewNormal, DiscreteWeibull)
 from ..distributions import continuous, multivariate
 from pymc3.theanof import floatX
+import theano
 from nose_parameterized import parameterized
 from numpy import array, inf, log, exp
 from numpy.testing import assert_almost_equal
@@ -25,13 +26,10 @@ from scipy import integrate
 import scipy.stats.distributions as sp
 import scipy.stats
 
-# Keep track of floating point mode for determining equality decimal cutoffs.
-DTYPE = floatX(1.0).dtype.name
-
 
 def select_decimal(float64, float32):
     """Helper function to choose reasonable decimal cutoffs for different floatX modes."""
-    decimal = float64 if DTYPE == "float64" else float32
+    decimal = float64 if theano.config.floatX == "float64" else float32
     return decimal
 
 


### PR DESCRIPTION
Before patches, cuda + float32 gives `FAILED (errors=43, failures=8)`.

After patches, cuda + float32 gives `FAILED (errors=44, failures=1)`.  CPU + float64 still gives 100% success after patch.

I'm not going to figure out the theano inf / testval stuff in a finite amount of time, so I think the best we can do is fix the other test failures one batch at a time.

I tried to be conservative in the precision reductions on the tests.  I don't think anything was unreasonable: 64 to 32 bit could easily kill 7 digits of precision IIRC, while I nixed at most 5 decimals.