### PR TITLE
tqdm progress bar display for ipython notebooks

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -34,3 +34,21 @@ if not logging.root.handlers:
     _log.setLevel(logging.INFO)
     handler = logging.StreamHandler()
     _log.addHandler(handler)
+
+def tqdm(*args, **kwargs):
+    try:
+        from tqdm import tqdm_notebook
+        return tqdm_notebook(*args, **kwargs)
+    except:
+        from tqdm import tqdm
+        return tqdm(*args, **kwargs)
+
+def trange(*args, **kwargs):
+    try:
+        from tqdm import tnrange
+        return tnrange(*args, **kwargs)
+    except:
+        from tqdm import trange
+        return trange(*args, **kwargs)
+
+

--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -1,10 +1,10 @@
 import numpy as np
 from scipy import stats
-from tqdm import tqdm
 
 from theano.tensor.nlinalg import matrix_inverse
 import theano.tensor as tt
 
+import pymc3 as pm
 from .mean import Zero, Mean
 from .cov import Covariance
 from ..distributions import MvNormal, Continuous, draw_values, generate_samples
@@ -15,7 +15,7 @@ __all__ = ['GP', 'sample_gp']
 
 class GP(Continuous):
     """Gausian process
-    
+
     Parameters
     ----------
     mean_func : Mean
@@ -23,39 +23,39 @@ class GP(Continuous):
     cov_func : Covariance
         Covariance function of Gaussian process
     X : array
-        Grid of points to evaluate Gaussian process over. Only required if the 
+        Grid of points to evaluate Gaussian process over. Only required if the
         GP is not an observed variable.
     sigma : scalar or array
         Observation standard deviation (defaults to zero)
     """
     def __init__(self, mean_func=None, cov_func=None, X=None, sigma=0, *args, **kwargs):
-        
+
         if mean_func is None:
             self.M = Zero()
         else:
             if not isinstance(mean_func, Mean):
                 raise ValueError('mean_func must be a subclass of Mean')
             self.M = mean_func
-            
+
         if cov_func is None:
             raise ValueError('A covariance function must be specified for GPP')
         if not isinstance(cov_func, Covariance):
             raise ValueError('cov_func must be a subclass of Covariance')
         self.K = cov_func
-        
+
         self.sigma = sigma
-        
+
         if X is not None:
             self.X = X
             self.mean = self.mode = self.M(X)
             kwargs.setdefault("shape", X.squeeze().shape)
-            
+
         super(GP, self).__init__(*args, **kwargs)
-                
+
     def random(self, point=None, size=None, **kwargs):
         X = self.X
         mu, cov = draw_values([self.M(X).squeeze(), self.K(X) + np.eye(X.shape[0])*self.sigma**2], point=point)
-        
+
         def _random(mean, cov, size=None):
             return stats.multivariate_normal.rvs(
                 mean, cov, None if size == mean.shape else size)
@@ -74,7 +74,7 @@ class GP(Continuous):
         Sigma = self.K(X) + tt.eye(X.shape[0])*self.sigma**2
 
         return MvNormal.dist(mu, Sigma).logp(Y)
-        
+
 
 def sample_gp(trace, gp, X_values, samples=None, obs_noise=True, model=None, random_seed=None, progressbar=True):
     """Generate samples from a posterior Gaussian process.
@@ -92,38 +92,38 @@ def sample_gp(trace, gp, X_values, samples=None, obs_noise=True, model=None, ran
         length of `trace`
     obs_noise : bool
         Flag for including observation noise in sample. Defaults to True.
-    model : Model 
+    model : Model
         Model used to generate `trace`. Optional if in `with` context manager.
     random_seed : integer > 0
         Random number seed for sampling.
     progressbar : bool
         Flag for showing progress bar.
-    
+
     Returns
     -------
     Array of samples from posterior GP evaluated at Z.
     """
     model = modelcontext(model)
-    
+
     if samples is None:
         samples = len(trace)
-    
+
     if random_seed:
         np.random.seed(random_seed)
-    
+
     if progressbar:
-        indices = tqdm(np.random.randint(0, len(trace), samples), total=samples)
+        indices = pm.tqdm(np.random.randint(0, len(trace), samples), total=samples)
     else:
         indices = np.random.randint(0, len(trace), samples)
 
-    K = gp.distribution.K 
-        
+    K = gp.distribution.K
+
     data = [v for v in model.observed_RVs if v.name==gp.name][0].data
 
     X = data['X']
     Y = data['Y']
     Z = X_values
-    
+
     S_xz = K(X, Z)
     S_zz = K(Z)
     if obs_noise:
@@ -137,7 +137,7 @@ def sample_gp(trace, gp, X_values, samples=None, obs_noise=True, model=None, ran
     S_post = S_zz - tt.dot(tt.dot(S_xz.T, S_inv), S_xz)
 
     gp_post = MvNormal.dist(m_post, S_post, shape=Z.shape[0])
-    
+
     samples = [gp_post.random(point=trace[idx]) for idx in indices]
-    
+
     return np.array(samples)

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -11,7 +11,6 @@ from .model import modelcontext, Point
 from .step_methods import (NUTS, HamiltonianMC, Metropolis, BinaryMetropolis,
                            BinaryGibbsMetropolis, CategoricalGibbsMetropolis,
                            Slice, CompoundStep)
-from tqdm import tqdm
 
 import warnings
 
@@ -191,7 +190,7 @@ def _sample(draws, step=None, start=None, trace=None, chain=0, tune=None,
     sampling = _iter_sample(draws, step, start, trace, chain,
                             tune, model, random_seed)
     if progressbar:
-        sampling = tqdm(sampling, total=draws)
+        sampling = pm.tqdm(sampling, total=draws)
     try:
         strace = None
         for strace in sampling:
@@ -405,7 +404,7 @@ def sample_ppc(trace, samples=None, model=None, vars=None, size=None, random_see
     seed(random_seed)
 
     if progressbar:
-        indices = tqdm(randint(0, len(trace), samples), total=samples)
+        indices = pm.tqdm(randint(0, len(trace), samples), total=samples)
     else:
         indices = randint(0, len(trace), samples)
 

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -13,8 +13,6 @@ import pymc3 as pm
 from pymc3.backends.base import MultiTrace
 from ..theanof import floatX
 
-from tqdm import trange
-
 __all__ = ['advi', 'sample_vp']
 
 ADVIFit = namedtuple('ADVIFit', 'means, stds, elbo_vals')
@@ -150,7 +148,7 @@ def advi(vars=None, start=None, model=None, n=5000, accurate_elbo=False,
     # Optimization loop
     elbos = np.empty(n)
     divergence_flag = False
-    progress = trange(n)
+    progress = pm.trange(n)
     try:
         uw_i, elbo_current = f()
         if np.isnan(elbo_current):
@@ -405,7 +403,7 @@ def sample_vp(
     trace = pm.sampling.NDArray(model=model, vars=vars_sampled)
     trace.setup(draws=draws, chain=0)
 
-    range_ = trange(draws) if progressbar else range(draws)
+    range_ = pm.trange(draws) if progressbar else range(draws)
 
     for _ in range_:
         # 'point' is like {'var1': np.array(0.1), 'var2': np.array(0.2), ...}

--- a/pymc3/variational/advi_minibatch.py
+++ b/pymc3/variational/advi_minibatch.py
@@ -5,7 +5,6 @@ import theano
 import theano.tensor as tt
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 from theano.configparser import change_flags
-import tqdm
 
 import pymc3 as pm
 from pymc3.theanof import reshape_t, inputvars, floatX
@@ -520,7 +519,7 @@ def advi_minibatch(vars=None, start=None, model=None, n=5000, n_mcsamples=1,
 
     # Optimization loop
     elbos = np.empty(n)
-    progress = tqdm.trange(n)
+    progress = pm.trange(n)
     for i in progress:
         e = f(*next(minibatches))
         if np.isnan(e):

--- a/pymc3/variational/inference.py
+++ b/pymc3/variational/inference.py
@@ -3,7 +3,6 @@ from __future__ import division
 import logging
 
 import numpy as np
-import tqdm
 
 import pymc3 as pm
 from pymc3.variational.approximations import MeanField, FullRank
@@ -56,7 +55,7 @@ class Inference(object):
             score=score, fn_kwargs=fn_kwargs,
             **kwargs
         )
-        progress = tqdm.trange(n)
+        progress = pm.trange(n)
         try:
             for _ in progress:
                 step_func()
@@ -92,7 +91,7 @@ class Inference(object):
         i = 0
         scores = np.empty(n)
         scores[:] = np.nan
-        progress = tqdm.trange(n)
+        progress = pm.trange(n)
         if score:
             try:
                 for i in progress:

--- a/pymc3/variational/svgd.py
+++ b/pymc3/variational/svgd.py
@@ -7,7 +7,6 @@ import numpy as np
 import theano
 from theano.ifelse import ifelse
 import theano.tensor as tt
-from tqdm import tqdm
 from .updates import adagrad
 
 import pymc3 as pm
@@ -100,7 +99,7 @@ def svgd(vars=None, n=5000, n_particles=100, jitter=.01,
                                 updates=svgd_updates)
     # Run svgd optimization
     if progressbar:
-        progress = tqdm(np.arange(n))
+        progress = pm.tqdm(np.arange(n))
     else:
         progress = np.arange(n)
 


### PR DESCRIPTION
When pymc3 is run in terminal the standard tqdm progress bar is displayed, as before.  When pymc3 is run in an ipython notebook, [the progress bar widget is used](https://raw.githubusercontent.com/tqdm/tqdm/master/images/tqdm-jupyter-1.gif).

This feature was included in #1813.  I'm separating it out since it's really not related.