### PR TITLE
Use pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,18 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
   - if [ ${MATPLOTLIB} = "1.2" ]; then mkdir $HOME/.matplotlib; fi
   - if [ ${MATPLOTLIB} = "1.2" ]; then cp ${SRCDIR}/tools/matplotlibrc $HOME/.matplotlib/matplotlibrc; fi
-  #- mkdir -p $HOME/.config/matplotlib; echo "backend: agg" > $HOME/.config/matplotlib/matplotlibrc
 
 install:
   - . ./scripts/create_testenv.sh
-  - pip install coveralls pylint
+  - pip install coveralls pylint nose_parameterized
 
 env:
-  - PYTHON_VERSION=2.7 TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 -e test_examples -e test_distributions"
-  - PYTHON_VERSION=2.7 RUN_PYLINT="true" TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 pymc3.tests.test_distributions pymc3.tests.test_examples"
-  - PYTHON_VERSION=2.7 TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 pymc3.tests.test_distributions_random"
-  - PYTHON_VERSION=3.6 TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 -e test_examples -e test_distributions"
-  - PYTHON_VERSION=3.6 TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 pymc3.tests.test_distributions pymc3.tests.test_examples"
-  - PYTHON_VERSION=3.6 TESTCMD=" -vv --with-timer --with-coverage --cover-package=pymc3 pymc3.tests.test_distributions_random"
+  - PYTHON_VERSION=2.7 TESTCMD="--durations=10 --ignore=pymc3/tests/test_examples.py --cov-append --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py"
+  - PYTHON_VERSION=2.7 RUN_PYLINT="true" TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py"
+  - PYTHON_VERSION=2.7 TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_variational_inference.py"
+  - PYTHON_VERSION=3.6 TESTCMD="--durations=10 --cov-append --ignore=pymc3/tests/test_examples.py --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py"
+  - PYTHON_VERSION=3.6 TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py"
+  - PYTHON_VERSION=3.6 TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_variational_inference.py"
 script:
   - . ./scripts/test.sh $TESTCMD
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,11 +77,11 @@ We recommended that your contribution complies with the following guidelines bef
 You can also check for common programming errors with the following
 tools:
 
-* Code with good unittest **coverage** (at least 80%), check with:
+* Code with good test **coverage** (at least 80%), check with:
 
   ```bash
-  $ pip install nose coverage
-  $ nosetests --with-coverage path/to/tests_for_package
+  $ pip install pytest pytest-cov coverage
+  $ pytest --cov=pymc3 pymc3/tests/tests_for_package.py
   ```
 
 * No `pyflakes` warnings, check with:
@@ -111,7 +111,7 @@ We have provided a Dockerfile which helps for isolating build problems, and loca
 Install [Docker](https://www.docker.com/) for your operating system, clone this repo, then
 run `./scripts/start_container.sh`. This should start a local docker container called `pymc3`,
 as well as a [`jupyter`](http://jupyter.org/) notebook server running on port 8888. You will have to open
-a browser at `localhost:8888`. The repo will be running the code from your local copy of `pymc3`, 
+a browser at `localhost:8888`. The repo will be running the code from your local copy of `pymc3`,
 so it is good for development.  You may also use it to run the test suite, with
 
 ```bash

--- a/pymc3/tests/helpers.py
+++ b/pymc3/tests/helpers.py
@@ -1,26 +1,25 @@
-import unittest
 from logging.handlers import BufferingHandler
 import numpy.random as nr
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 from ..theanof import set_tt_rng, tt_rng
 
 
-class SeededTest(unittest.TestCase):
+class SeededTest(object):
     random_seed = 20160911
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         nr.seed(cls.random_seed)
 
-    def setUp(self):
+    def setup_method(self):
         nr.seed(self.random_seed)
         self.old_tt_rng = tt_rng()
         set_tt_rng(MRG_RandomStreams(self.random_seed))
 
-    def tearDown(self):
+    def teardown_method(self):
         set_tt_rng(self.old_tt_rng)
 
-class TestHandler(BufferingHandler):
+class LoggingHandler(BufferingHandler):
     def __init__(self, matcher):
         # BufferingHandler takes a "capacity" argument
         # so as to know when to flush. As we're overriding

--- a/pymc3/tests/test_diagnostics.py
+++ b/pymc3/tests/test_diagnostics.py
@@ -9,6 +9,7 @@ from ..tuning import find_MAP
 from ..sampling import sample
 from ..diagnostics import effective_n, geweke, gelman_rubin
 from .test_examples import build_disaster_model
+import pytest
 
 
 class TestGelmanRubin(SeededTest):
@@ -29,15 +30,15 @@ class TestGelmanRubin(SeededTest):
         """Confirm Gelman-Rubin statistic is close to 1 for a reasonable number of samples."""
         n_samples = 1000
         rhat = gelman_rubin(self.get_ptrace(n_samples))
-        self.assertTrue(all(1 / self.good_ratio < r <
-                            self.good_ratio for r in rhat.values()))
+        assert all(1 / self.good_ratio < r <
+                            self.good_ratio for r in rhat.values())
 
     def test_bad(self):
         """Confirm Gelman-Rubin statistic is far from 1 for a small number of samples."""
         n_samples = 10
         rhat = gelman_rubin(self.get_ptrace(n_samples))
-        self.assertFalse(all(1 / self.good_ratio < r <
-                             self.good_ratio for r in rhat.values()))
+        assert not all(1 / self.good_ratio < r <
+                             self.good_ratio for r in rhat.values())
 
     def test_right_shape_python_float(self, shape=None, test_shape=None):
         """Check Gelman-Rubin statistic shape is correct w/ python float"""
@@ -62,10 +63,10 @@ class TestGelmanRubin(SeededTest):
             test_shape = shape
 
         if shape is None or shape == ():
-            self.assertTrue(isinstance(rhat, float))
+            assert isinstance(rhat, float)
         else:
-            self.assertTrue(isinstance(rhat, np.ndarray))
-            self.assertEqual(rhat.shape, test_shape)
+            assert isinstance(rhat, np.ndarray)
+            assert rhat.shape == test_shape
 
     def test_right_shape_scalar_tuple(self):
         """Check Gelman-Rubin statistic shape is correct w/ scalar as shape=()"""
@@ -108,7 +109,7 @@ class TestDiagnostics(SeededTest):
                           last=last, intervals=n_intervals)
 
         # These z-scores should be larger, since there are not many samples.
-        self.assertGreater(max(abs(z_switch[:, 1])), 1)
+        assert max(abs(z_switch[:, 1])) > 1
 
     def test_geweke_positive(self):
         """Confirm Geweke diagnostic is smaller than 1 for a reasonable number of samples."""
@@ -116,11 +117,11 @@ class TestDiagnostics(SeededTest):
         n_intervals = 20
         switchpoint = self.get_switchpoint(n_samples)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             # first and last must be between 0 and 1
             geweke(switchpoint, first=-0.3, last=1.1, intervals=n_intervals)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             # first and last must add to < 1
             geweke(switchpoint, first=0.3, last=0.7, intervals=n_intervals)
 
@@ -134,13 +135,13 @@ class TestDiagnostics(SeededTest):
         z_scores = z_switch[:, 1]
 
         # Ensure `intervals` argument is honored
-        self.assertEqual(z_switch.shape[0], n_intervals)
+        assert z_switch.shape[0] == n_intervals
 
         # Start index should not be in the last <last>% of samples
         assert_array_less(start, (1 - last) * n_samples)
 
         # These z-scores should be small, since there are more samples.
-        self.assertLess(max(abs(z_scores)), 1)
+        assert max(abs(z_scores)) < 1
 
     def test_effective_n(self):
         """Check effective sample size is equal to number of samples when initializing with MAP"""
@@ -183,10 +184,10 @@ class TestDiagnostics(SeededTest):
             test_shape = shape
 
         if shape is None or shape == ():
-            self.assertTrue(isinstance(n_effective, float))
+            assert isinstance(n_effective, float)
         else:
-            self.assertTrue(isinstance(n_effective, np.ndarray))
-            self.assertEqual(n_effective.shape, test_shape)
+            assert isinstance(n_effective, np.ndarray)
+            assert n_effective.shape == test_shape
 
     def test_effective_n_right_shape_scalar_tuple(self):
         """Check effective sample size shape is correct w/ scalar as shape=()"""

--- a/pymc3/tests/test_distribution_defaults.py
+++ b/pymc3/tests/test_distribution_defaults.py
@@ -4,7 +4,7 @@ from ..model import Model
 from ..distributions import DiscreteUniform, Continuous
 
 import numpy as np
-from nose.tools import raises
+import pytest
 
 
 class DistTest(Continuous):
@@ -18,15 +18,13 @@ class DistTest(Continuous):
         return 0
 
 
-@raises(AttributeError)
 def test_default_nan_fail():
-    with Model():
+    with Model(), pytest.raises(AttributeError):
         DistTest('x', np.nan, 2, defaults=['a'])
 
 
-@raises(AttributeError)
 def test_default_empty_fail():
-    with Model():
+    with Model(), pytest.raises(AttributeError):
         DistTest('x', 1, 2, defaults=[])
 
 

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -28,7 +28,7 @@ def get_city_data():
     return data.merge(unique, 'inner', on='fips')
 
 
-class ARM5_4(SeededTest):
+class TestARM5_4(SeededTest):
     def build_model(self):
         wells = pm.get_data_file('pymc3.examples', 'data/wells.dat')
         data = pd.read_csv(wells, delimiter=u' ', index_col=u'id', dtype={u'switch': np.int8})
@@ -233,8 +233,8 @@ class TestLatentOccupancy(SeededTest):
     Created by Chris Fonnesbeck on 2008-07-28.
     Copyright (c) 2008 University of Otago. All rights reserved.
     """
-    def setUp(self):
-        super(TestLatentOccupancy, self).setUp()
+    def setup_method(self):
+        super(TestLatentOccupancy, self).setup_method()
         # Sample size
         n = 100
         # True mean count, given occupancy

--- a/pymc3/tests/test_glm.py
+++ b/pymc3/tests/test_glm.py
@@ -14,8 +14,8 @@ def generate_data(intercept, slope, size=700):
 
 class TestGLM(SeededTest):
     @classmethod
-    def setUpClass(cls):
-        super(TestGLM, cls).setUpClass()
+    def setup_class(cls):
+        super(TestGLM, cls).setup_class()
         cls.intercept = 1
         cls.slope = 3
         cls.sd = .05
@@ -37,9 +37,9 @@ class TestGLM(SeededTest):
             step = Slice(model.vars)
             trace = sample(500, step=step, start=start, progressbar=False, random_seed=self.random_seed)
 
-            self.assertAlmostEqual(np.mean(trace['Intercept']), self.intercept, 1)
-            self.assertAlmostEqual(np.mean(trace['x']), self.slope, 1)
-            self.assertAlmostEqual(np.mean(trace['sigma']), self.sd, 1)
+            assert round(abs(np.mean(trace['Intercept'])-self.intercept), 1) == 0
+            assert round(abs(np.mean(trace['x'])-self.slope), 1) == 0
+            assert round(abs(np.mean(trace['sigma'])-self.sd), 1) == 0
 
     def test_glm(self):
         with Model() as model:
@@ -47,9 +47,9 @@ class TestGLM(SeededTest):
             step = Slice(model.vars)
             trace = sample(500, step, progressbar=False, random_seed=self.random_seed)
 
-            self.assertAlmostEqual(np.mean(trace['Intercept']), self.intercept, 1)
-            self.assertAlmostEqual(np.mean(trace['x']), self.slope, 1)
-            self.assertAlmostEqual(np.mean(trace['sd']), self.sd, 1)
+            assert round(abs(np.mean(trace['Intercept'])-self.intercept), 1) == 0
+            assert round(abs(np.mean(trace['x'])-self.slope), 1) == 0
+            assert round(abs(np.mean(trace['sd'])-self.sd), 1) == 0
 
     def test_glm_link_func(self):
         with Model() as model:
@@ -58,8 +58,8 @@ class TestGLM(SeededTest):
             step = Slice(model.vars)
             trace = sample(1000, step, progressbar=False, random_seed=self.random_seed)
 
-            self.assertAlmostEqual(np.mean(trace['Intercept']), self.intercept, 1)
-            self.assertAlmostEqual(np.mean(trace['x']), self.slope, 1)
+            assert round(abs(np.mean(trace['Intercept'])-self.intercept), 1) == 0
+            assert round(abs(np.mean(trace['x'])-self.slope), 1) == 0
 
     def test_more_than_one_glm_is_ok(self):
         with Model():

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -1,39 +1,40 @@
 #  pylint:disable=unused-variable
 from .helpers import SeededTest
-import unittest
 from pymc3 import Model, gp, sample, Uniform
 import theano
 import theano.tensor as tt
 import numpy as np
+import numpy.testing as npt
+import pytest
 
-class TestZero(unittest.TestCase):
+class TestZero(object):
     def test_value(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
             zero_mean = gp.mean.Zero()
         M = theano.function([], zero_mean(X))()
-        self.assertTrue(np.all(M==0))
-        self.assertSequenceEqual(M.shape, (10,1))
+        assert np.all(M==0)
+        assert M.shape == (10,1)
 
-class TestConstant(unittest.TestCase):
+class TestConstant(object):
     def test_value(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
             const_mean = gp.mean.Constant(6)
         M = theano.function([], const_mean(X))()
-        self.assertTrue(np.all(M==6))
-        self.assertSequenceEqual(M.shape, (10,1))
+        assert np.all(M==6)
+        assert M.shape == (10,1)
 
-class TestLinearMean(unittest.TestCase):
+class TestLinearMean(object):
     def test_value(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
             linear_mean = gp.mean.Linear(2, 0.5)
         M = theano.function([], linear_mean(X))()
-        self.assertAlmostEqual(M[1,0], 0.7222, 3)
+        npt.assert_allclose(M[1, 0], 0.7222, atol=1e-3)
 
 
-class TestCovAdd(unittest.TestCase):
+class TestCovAdd(object):
     def test_symadd_cov(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -41,7 +42,7 @@ class TestCovAdd(unittest.TestCase):
             cov2 = gp.cov.ExpQuad(1, 0.1)
             cov = cov1 + cov2
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 2*0.53940, 3)
+        npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
 
     def test_rightadd_scalar(self):
         X = np.linspace(0,1,10)[:,None]
@@ -49,7 +50,7 @@ class TestCovAdd(unittest.TestCase):
             a = 1
             cov = gp.cov.ExpQuad(1, 0.1) + a
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 1 + 0.53940, 3)
+        npt.assert_allclose(K[0, 1], 1.53940, atol=1e-3)
 
     def test_leftadd_scalar(self):
         X = np.linspace(0,1,10)[:,None]
@@ -57,7 +58,7 @@ class TestCovAdd(unittest.TestCase):
             a = 1
             cov = a + gp.cov.ExpQuad(1, 0.1)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 1 + 0.53940, 3)
+        npt.assert_allclose(K[0, 1], 1.53940, atol=1e-3)
 
     def test_rightadd_matrix(self):
         X = np.linspace(0,1,10)[:,None]
@@ -65,7 +66,7 @@ class TestCovAdd(unittest.TestCase):
         with Model() as model:
             cov = gp.cov.ExpQuad(1, 0.1) + M
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 2 + 0.53940, 3)
+        npt.assert_allclose(K[0, 1], 2.53940, atol=1e-3)
 
     def test_leftprod_matrix(self):
         X = np.linspace(0,1,3)[:,None]
@@ -75,10 +76,10 @@ class TestCovAdd(unittest.TestCase):
             cov_true = gp.cov.ExpQuad(1, 0.1) + M
         K = theano.function([], cov(X))()
         K_true = theano.function([], cov_true(X))()
-        self.assertTrue(np.allclose(K, K_true))
+        assert np.allclose(K, K_true)
 
 
-class TestCovProd(unittest.TestCase):
+class TestCovProd(object):
     def test_symprod_cov(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
@@ -86,7 +87,7 @@ class TestCovProd(unittest.TestCase):
             cov2 = gp.cov.ExpQuad(1, 0.1)
             cov = cov1 * cov2
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.53940 * 0.53940, 3)
+        npt.assert_allclose(K[0, 1], 0.53940 * 0.53940, atol=1e-3)
 
     def test_rightprod_scalar(self):
         X = np.linspace(0,1,10)[:,None]
@@ -94,7 +95,7 @@ class TestCovProd(unittest.TestCase):
             a = 2
             cov = gp.cov.ExpQuad(1, 0.1) * a
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 2 * 0.53940, 3)
+        npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
 
     def test_leftprod_scalar(self):
         X = np.linspace(0,1,10)[:,None]
@@ -102,7 +103,7 @@ class TestCovProd(unittest.TestCase):
             a = 2
             cov = a * gp.cov.ExpQuad(1, 0.1)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 2 * 0.53940, 3)
+        npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
 
     def test_rightprod_matrix(self):
         X = np.linspace(0,1,10)[:,None]
@@ -110,7 +111,7 @@ class TestCovProd(unittest.TestCase):
         with Model() as model:
             cov = gp.cov.ExpQuad(1, 0.1) * M
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 2 * 0.53940, 3)
+        npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
 
     def test_leftprod_matrix(self):
         X = np.linspace(0,1,3)[:,None]
@@ -120,7 +121,7 @@ class TestCovProd(unittest.TestCase):
             cov_true = gp.cov.ExpQuad(1, 0.1) * M
         K = theano.function([], cov(X))()
         K_true = theano.function([], cov_true(X))()
-        self.assertTrue(np.allclose(K, K_true))
+        assert np.allclose(K, K_true)
 
     def test_multiops(self):
         X = np.linspace(0,1,3)[:,None]
@@ -130,157 +131,157 @@ class TestCovProd(unittest.TestCase):
             cov2 = gp.cov.ExpQuad(1, 0.1) * M * gp.cov.ExpQuad(1, 0.1) * M + gp.cov.ExpQuad(1, 0.1) + 3
         K1 = theano.function([], cov1(X))()
         K2 = theano.function([], cov2(X))()
-        self.assertTrue(np.allclose(K1, K2))
+        assert np.allclose(K1, K2)
 
 
-class TestCovSliceDim(unittest.TestCase):
+class TestCovSliceDim(object):
     def test_slice1(self):
         X = np.linspace(0,1,30).reshape(10,3)
         with Model() as model:
             cov = gp.cov.ExpQuad(3, 0.1, active_dims=[0,0,1])
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.20084298, 3)
+        npt.assert_allclose(K[0, 1], 0.20084298, atol=1e-3)
 
     def test_slice2(self):
         X = np.linspace(0,1,30).reshape(10,3)
         with Model() as model:
             cov = gp.cov.ExpQuad(3, [0.1, 0.1], active_dims=[False, True, True])
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.34295549, 3)
+        npt.assert_allclose(K[0, 1], 0.34295549, atol=1e-3)
 
     def test_slice3(self):
         X = np.linspace(0,1,30).reshape(10,3)
         with Model() as model:
             cov = gp.cov.ExpQuad(3, np.array([0.1, 0.1]), active_dims=[False, True, True])
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.34295549, 3)
+        npt.assert_allclose(K[0, 1], 0.34295549, atol=1e-3)
 
     def test_diffslice(self):
         X = np.linspace(0,1,30).reshape(10,3)
         with Model() as model:
             cov = gp.cov.ExpQuad(3, 0.1, [1, 0, 0]) + gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.683572, 3)
+        npt.assert_allclose(K[0, 1], 0.683572, atol=1e-3)
 
     def test_raises(self):
         lengthscales = 2.0
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             gp.cov.ExpQuad(1, lengthscales, [True, False])
             gp.cov.ExpQuad(2, lengthscales, [True])
 
 
-class TestStability(unittest.TestCase):
+class TestStability(object):
     def test_stable(self):
         X = np.random.uniform(low=320., high=400., size=[2000,2])
         with Model() as model:
             cov = gp.cov.ExpQuad(2, 0.1)
         dists = theano.function([], cov.square_dist(X, X))()
-        self.assertFalse(np.any(dists < 0))
+        assert not np.any(dists < 0)
 
 
-class TestExpQuad(unittest.TestCase):
+class TestExpQuad(object):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
             cov = gp.cov.ExpQuad(1, 0.1)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.53940, 3)
+        npt.assert_allclose(K[0, 1], 0.53940, atol=1e-3)
         K = theano.function([], cov(X,X))()
-        self.assertAlmostEqual(K[0,1], 0.53940, 3)
+        npt.assert_allclose(K[0, 1], 0.53940, atol=1e-3)
 
     def test_2d(self):
         X = np.linspace(0,1,10).reshape(5,2)
         with Model() as model:
             cov = gp.cov.ExpQuad(2, 0.5)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.820754, 3)
+        npt.assert_allclose(K[0, 1], 0.820754, atol=1e-3)
 
     def test_2dard(self):
         X = np.linspace(0,1,10).reshape(5,2)
         with Model() as model:
             cov = gp.cov.ExpQuad(2, np.array([1, 2]))
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.969607, 3)
+        npt.assert_allclose(K[0, 1], 0.969607, atol=1e-3)
 
 
-class TestRatQuad(unittest.TestCase):
+class TestRatQuad(object):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
             cov = gp.cov.RatQuad(1, 0.1, 0.5)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.66896, 3)
+        npt.assert_allclose(K[0, 1], 0.66896, atol=1e-3)
         K = theano.function([], cov(X,X))()
-        self.assertAlmostEqual(K[0,1], 0.66896, 3)
+        npt.assert_allclose(K[0, 1], 0.66896, atol=1e-3)
 
 
-class TestExponential(unittest.TestCase):
+class TestExponential(object):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
             cov = gp.cov.Exponential(1, 0.1)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.57375, 3)
+        npt.assert_allclose(K[0, 1], 0.57375, atol=1e-3)
         K = theano.function([], cov(X,X))()
-        self.assertAlmostEqual(K[0,1], 0.57375, 3)
+        npt.assert_allclose(K[0, 1], 0.57375, atol=1e-3)
 
 
-class TestMatern52(unittest.TestCase):
+class TestMatern52(object):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
             cov = gp.cov.Matern52(1, 0.1)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.46202, 3)
+        npt.assert_allclose(K[0, 1], 0.46202, atol=1e-3)
         K = theano.function([], cov(X,X))()
-        self.assertAlmostEqual(K[0,1], 0.46202, 3)
+        npt.assert_allclose(K[0, 1], 0.46202, atol=1e-3)
 
 
-class TestMatern32(unittest.TestCase):
+class TestMatern32(object):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
             cov = gp.cov.Matern32(1, 0.1)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.42682, 3)
+        npt.assert_allclose(K[0, 1], 0.42682, atol=1e-3)
         K = theano.function([], cov(X,X))()
-        self.assertAlmostEqual(K[0,1], 0.42682, 3)
+        npt.assert_allclose(K[0, 1], 0.42682, atol=1e-3)
 
 
-class TestCosine(unittest.TestCase):
+class TestCosine(object):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
             cov = gp.cov.Cosine(1, 0.1)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], -0.93969, 3)
+        npt.assert_allclose(K[0, 1], -0.93969, atol=1e-3)
         K = theano.function([], cov(X,X))()
-        self.assertAlmostEqual(K[0,1], -0.93969, 3)
+        npt.assert_allclose(K[0, 1], -0.93969, atol=1e-3)
 
 
-class TestLinear(unittest.TestCase):
+class TestLinear(object):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
             cov = gp.cov.Linear(1, 0.5)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.19444, 3)
+        npt.assert_allclose(K[0, 1], 0.19444, atol=1e-3)
         K = theano.function([], cov(X,X))()
-        self.assertAlmostEqual(K[0,1], 0.19444, 3)
+        npt.assert_allclose(K[0, 1], 0.19444, atol=1e-3)
 
 
-class TestPolynomial(unittest.TestCase):
+class TestPolynomial(object):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         with Model() as model:
             cov = gp.cov.Polynomial(1, 0.5, 2, 0)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.03780, 4)
+        npt.assert_allclose(K[0, 1], 0.03780, atol=1e-3)
         K = theano.function([], cov(X,X))()
-        self.assertAlmostEqual(K[0,1], 0.03780, 4)
+        npt.assert_allclose(K[0, 1], 0.03780, atol=1e-3)
 
 
-class TestWarpedInput(unittest.TestCase):
+class TestWarpedInput(object):
     def test_1d(self):
         X = np.linspace(0,1,10)[:,None]
         def warp_func(x, a, b, c):
@@ -289,19 +290,19 @@ class TestWarpedInput(unittest.TestCase):
             cov_m52 = gp.cov.Matern52(1, 0.2)
             cov = gp.cov.WarpedInput(1, warp_func=warp_func, args=(1,10,1), cov_func=cov_m52)
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[0,1], 0.79593, 4)
+        npt.assert_allclose(K[0, 1], 0.79593, atol=1e-3)
         K = theano.function([], cov(X,X))()
-        self.assertAlmostEqual(K[0,1], 0.79593, 4)
+        npt.assert_allclose(K[0, 1], 0.79593, atol=1e-3)
 
     def test_raises(self):
         cov_m52 = gp.cov.Matern52(1, 0.2)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             gp.cov.WarpedInput(1, cov_m52, "str is not callable")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             gp.cov.WarpedInput(1, "str is not Covariance object", lambda x: x)
 
 
-class TestGibbs(unittest.TestCase):
+class TestGibbs(object):
     def test_1d(self):
         X = np.linspace(0, 2, 10)[:,None]
         def tanh_func(x, x1, x2, w, x0):
@@ -309,20 +310,20 @@ class TestGibbs(unittest.TestCase):
         with Model() as model:
             cov = gp.cov.Gibbs(1, tanh_func, args=(0.05, 0.6, 0.4, 1.0))
         K = theano.function([], cov(X))()
-        self.assertAlmostEqual(K[2,3], 0.136683, 4)
+        npt.assert_allclose(K[2, 3], 0.136683, atol=1e-4)
         K = theano.function([], cov(X,X))()
-        self.assertAlmostEqual(K[2,3], 0.136683, 4)
+        npt.assert_allclose(K[2, 3], 0.136683, atol=1e-4)
 
     def test_raises(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             gp.cov.Gibbs(1, "str is not callable")
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             gp.cov.Gibbs(2, lambda x: x)
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             gp.cov.Gibbs(3, lambda x: x, active_dims=[True, True, False])
 
 
-class TestHandleArgs(unittest.TestCase):
+class TestHandleArgs(object):
     def test_handleargs(self):
         def func_noargs(x):
             return x
@@ -336,9 +337,9 @@ class TestHandleArgs(unittest.TestCase):
         func_noargs2 = gp.cov.handle_args(func_noargs, None)
         func_onearg2 = gp.cov.handle_args(func_onearg, a)
         func_twoarg2 = gp.cov.handle_args(func_twoarg, args=(a, b))
-        self.assertEqual(func_noargs(x),       func_noargs2(x, args=None))
-        self.assertEqual(func_onearg(x, a),    func_onearg2(x, args=a))
-        self.assertEqual(func_twoarg(x, a, b), func_twoarg2(x, args=(a, b)))
+        assert func_noargs(x) == func_noargs2(x, args=None)
+        assert func_onearg(x, a) == func_onearg2(x, args=a)
+        assert func_twoarg(x, a, b) == func_twoarg2(x, args=(a, b))
 
 
 class TestGP(SeededTest):
@@ -347,9 +348,9 @@ class TestGP(SeededTest):
         Y = np.random.randn(10,1)
         with Model() as model:
             # make a Gaussian model
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 random_test = gp.GP('random_test', cov_func=gp.mean.Zero(), observed={'X':X, 'Y':Y})
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 random_test = gp.GP('random_test', mean_func=gp.cov.Matern32(1, 1),
                                         cov_func=gp.cov.Matern32(1, 1), observed={'X':X, 'Y':Y})
 

--- a/pymc3/tests/test_math.py
+++ b/pymc3/tests/test_math.py
@@ -11,8 +11,8 @@ def test_probit():
 
 
 class TestLogDet(SeededTest):
-    def setUp(self):
-        super(TestLogDet, self).setUp()
+    def setup_method(self):
+        super(TestLogDet, self).setup_method()
         utt.seed_rng()
         self.op_class = LogDet
         self.op = logdet

--- a/pymc3/tests/test_mixture.py
+++ b/pymc3/tests/test_mixture.py
@@ -22,8 +22,8 @@ def generate_poisson_mixture_data(w, mu, size=1000):
 
 class TestMixture(SeededTest):
     @classmethod
-    def setUpClass(cls):
-        super(TestMixture, cls).setUpClass()
+    def setup_class(cls):
+        super(TestMixture, cls).setup_class()
 
         cls.norm_w = np.array([0.75, 0.25])
         cls.norm_mu = np.array([0., 5.])

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -1,4 +1,3 @@
-import unittest
 from theano import theano, tensor as tt
 import scipy.stats as stats
 import numpy as np
@@ -6,6 +5,7 @@ import pymc3 as pm
 from pymc3.distributions import HalfCauchy, Normal
 from pymc3 import Potential, Deterministic
 from pymc3.theanof import generator
+import pytest
 
 
 
@@ -45,21 +45,21 @@ class DocstringModel(pm.Model):
         Potential('p1', tt.constant(1))
 
 
-class TestBaseModel(unittest.TestCase):
+class TestBaseModel(object):
     def test_setattr_properly_works(self):
         with pm.Model() as model:
             pm.Normal('v1')
-            self.assertEqual(len(model.vars), 1)
+            assert len(model.vars) == 1
             with pm.Model('sub') as submodel:
                 submodel.Var('v1', pm.Normal.dist())
-                self.assertTrue(hasattr(submodel, 'v1'))
-                self.assertEqual(len(submodel.vars), 1)
-            self.assertEqual(len(model.vars), 2)
+                assert hasattr(submodel, 'v1')
+                assert len(submodel.vars) == 1
+            assert len(model.vars) == 2
             with submodel:
                 submodel.Var('v2', pm.Normal.dist())
-                self.assertTrue(hasattr(submodel, 'v2'))
-                self.assertEqual(len(submodel.vars), 2)
-            self.assertEqual(len(model.vars), 3)
+                assert hasattr(submodel, 'v2')
+                assert len(submodel.vars) == 2
+            assert len(model.vars) == 3
 
     def test_context_passes_vars_to_parent_model(self):
         with pm.Model() as model:
@@ -72,78 +72,75 @@ class TestBaseModel(unittest.TestCase):
                 usermodel2.Var('v3', pm.Normal.dist())
                 pm.Normal('v4')
                 # this variable is created in parent model too
-        self.assertIn('another_v2', model.named_vars)
-        self.assertIn('another_v3', model.named_vars)
-        self.assertIn('another_v3', usermodel2.named_vars)
-        self.assertIn('another_v4', model.named_vars)
-        self.assertIn('another_v4', usermodel2.named_vars)
-        self.assertTrue(hasattr(usermodel2, 'v3'))
-        self.assertTrue(hasattr(usermodel2, 'v2'))
-        self.assertTrue(hasattr(usermodel2, 'v4'))
+        assert 'another_v2' in model.named_vars
+        assert 'another_v3' in model.named_vars
+        assert 'another_v3' in usermodel2.named_vars
+        assert 'another_v4' in model.named_vars
+        assert 'another_v4' in usermodel2.named_vars
+        assert hasattr(usermodel2, 'v3')
+        assert hasattr(usermodel2, 'v2')
+        assert hasattr(usermodel2, 'v4')
         # When you create a class based model you should follow some rules
         with model:
             m = NewModel('one_more')
-        self.assertTrue(m.d is model['one_more_d'])
-        self.assertTrue(m['d'] is model['one_more_d'])
-        self.assertTrue(m['one_more_d'] is model['one_more_d'])
+        assert m.d is model['one_more_d']
+        assert m['d'] is model['one_more_d']
+        assert m['one_more_d'] is model['one_more_d']
 
 
-class TestNested(unittest.TestCase):
+class TestNested(object):
     def test_nest_context_works(self):
         with pm.Model() as m:
             new = NewModel()
             with new:
-                self.assertTrue(
-                    pm.modelcontext(None) is new
-                )
-            self.assertTrue(
-                pm.modelcontext(None) is m
-            )
-        self.assertIn('v1', m.named_vars)
-        self.assertIn('v2', m.named_vars)
+                assert pm.modelcontext(None) is new
+            assert pm.modelcontext(None) is m
+        assert 'v1' in m.named_vars
+        assert 'v2' in m.named_vars
 
     def test_named_context(self):
         with pm.Model() as m:
             NewModel(name='new')
-        self.assertIn('new_v1', m.named_vars)
-        self.assertIn('new_v2', m.named_vars)
+        assert 'new_v1' in m.named_vars
+        assert 'new_v2' in m.named_vars
 
     def test_docstring_example1(self):
         usage1 = DocstringModel()
-        self.assertIn('v1', usage1.named_vars)
-        self.assertIn('v2', usage1.named_vars)
-        self.assertIn('v3', usage1.named_vars)
-        self.assertIn('v3_sq', usage1.named_vars)
-        self.assertTrue(len(usage1.potentials), 1)
+        assert 'v1' in usage1.named_vars
+        assert 'v2' in usage1.named_vars
+        assert 'v3' in usage1.named_vars
+        assert 'v3_sq' in usage1.named_vars
+        assert len(usage1.potentials), 1
 
     def test_docstring_example2(self):
         with pm.Model() as model:
             DocstringModel(name='prefix')
-        self.assertIn('prefix_v1', model.named_vars)
-        self.assertIn('prefix_v2', model.named_vars)
-        self.assertIn('prefix_v3', model.named_vars)
-        self.assertIn('prefix_v3_sq', model.named_vars)
-        self.assertTrue(len(model.potentials), 1)
+        assert 'prefix_v1' in model.named_vars
+        assert 'prefix_v2' in model.named_vars
+        assert 'prefix_v3' in model.named_vars
+        assert 'prefix_v3_sq' in model.named_vars
+        assert len(model.potentials), 1
 
     def test_duplicates_detection(self):
         with pm.Model():
             DocstringModel(name='prefix')
-            self.assertRaises(ValueError, DocstringModel, name='prefix')
+            with pytest.raises(ValueError):
+                DocstringModel(name='prefix')
 
     def test_model_root(self):
         with pm.Model() as model:
-            self.assertTrue(model is model.root)
+            assert model is model.root
             with pm.Model() as sub:
-                self.assertTrue(model is sub.root)
+                assert model is sub.root
 
-class TestObserved(unittest.TestCase):
+class TestObserved(object):
     def test_observed_rv_fail(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             with pm.Model() as model:
                 x = Normal('x')
                 Normal('n', observed=x)
 
-class TestScaling(unittest.TestCase):
+class TestScaling(object):
     def test_density_scaling(self):
         with pm.Model() as model1:
             Normal('n', observed=[[1]], total_size=1)
@@ -152,7 +149,7 @@ class TestScaling(unittest.TestCase):
         with pm.Model() as model2:
             Normal('n', observed=[[1]], total_size=2)
             p2 = theano.function([], model2.logpt)
-        self.assertEqual(p1() * 2, p2())
+        assert p1() * 2 == p2()
 
     def test_density_scaling_with_genarator(self):
         # We have different size generators

--- a/pymc3/tests/test_model_helpers.py
+++ b/pymc3/tests/test_model_helpers.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 import numpy.ma as ma
 import numpy.testing as npt
@@ -12,7 +10,7 @@ import theano.tensor as tt
 import theano.sparse as sparse
 
 
-class HelperFuncTests(unittest.TestCase):
+class TestHelperFunc(object):
     def test_pandas_to_array(self):
         """
         Ensure that pandas_to_array returns the dense array, masked array,
@@ -48,14 +46,14 @@ class HelperFuncTests(unittest.TestCase):
         # without missing values
         for input_value in [dense_input, pandas_input]:
             func_output = func(input_value)
-            self.assertIsInstance(func_output, np.ndarray)
-            self.assertEqual(func_output.shape, input_value.shape)
+            assert isinstance(func_output, np.ndarray)
+            assert func_output.shape == input_value.shape
             npt.assert_allclose(func_output, dense_input)
 
         # Check function behavior with sparse matrix inputs
         sparse_output = func(sparse_input)
-        self.assertTrue(sps.issparse(sparse_output))
-        self.assertEqual(sparse_output.shape, sparse_input.shape)
+        assert sps.issparse(sparse_output)
+        assert sparse_output.shape == sparse_input.shape
         npt.assert_allclose(sparse_output.toarray(),
                             sparse_input.toarray())
 
@@ -63,22 +61,22 @@ class HelperFuncTests(unittest.TestCase):
         # objects with missing data
         for input_value in [masked_array_input, missing_pandas_input]:
             func_output = func(input_value)
-            self.assertIsInstance(func_output, ma.core.MaskedArray)
-            self.assertEqual(func_output.shape, input_value.shape)
+            assert isinstance(func_output, ma.core.MaskedArray)
+            assert func_output.shape == input_value.shape
             npt.assert_allclose(func_output, masked_array_input)
 
         # Check function behavior with Theano graph variable
         theano_output = func(theano_graph_input)
-        self.assertIsInstance(theano_output, theano.gof.graph.Variable)
-        self.assertEqual(theano_output.name, input_name)
+        assert isinstance(theano_output, theano.gof.graph.Variable)
+        assert theano_output.name == input_name
 
         # Check function behavior with generator data
         generator_output = func(square_generator)
         # Make sure the returned object has .set_gen and .set_default methods
-        self.assertTrue(hasattr(generator_output, "set_gen"))
-        self.assertTrue(hasattr(generator_output, "set_default"))
+        assert hasattr(generator_output, "set_gen")
+        assert hasattr(generator_output, "set_default")
         # Make sure the returned object is a Theano TensorVariable
-        self.assertIsInstance(generator_output, tt.TensorVariable)
+        assert isinstance(generator_output, tt.TensorVariable)
 
         return None
 
@@ -122,20 +120,20 @@ class HelperFuncTests(unittest.TestCase):
 
         # Ensure that the missing values are appropriately set to None
         for func_output in [dense_output, sparse_output]:
-            self.assertIsNone(func_output.missing_values)
+            assert func_output.missing_values is None
 
         # Ensure that the Theano variable names are correctly set.
         # Note that the output for masked inputs do not have their names set
         # to the passed value.
         for func_output in [dense_output, sparse_output]:
-            self.assertEqual(func_output.name, input_name)
+            assert func_output.name == input_name
 
         # Ensure the that returned functions are all of the correct type
-        self.assertIsInstance(dense_output, tt.TensorConstant)
-        self.assertTrue(sparse.basic._is_sparse_variable(sparse_output))
+        assert isinstance(dense_output, tt.TensorConstant)
+        assert sparse.basic._is_sparse_variable(sparse_output)
 
         # Masked output is something weird. Just ensure it has missing values
         # self.assertIsInstance(masked_output, tt.TensorConstant)
-        self.assertIsNotNone(masked_output.missing_values)
+        assert masked_output.missing_values is not None
 
         return None

--- a/pymc3/tests/test_modelcontext.py
+++ b/pymc3/tests/test_modelcontext.py
@@ -1,10 +1,8 @@
 import threading
-import unittest
-
 from pymc3 import Model, Normal
 
 
-class TestModelContext(unittest.TestCase):
+class TestModelContext(object):
     def test_thread_safety(self):
         """ Regression test for issue #1552: Thread safety of model context manager
 
@@ -40,9 +38,7 @@ class TestModelContext(unittest.TestCase):
         # - B enters it's model context after A, but before a is declared -> a goes into B
         # - A leaves it's model context before B attempts to declare b. A's context manager
         #   takes B from the stack, such that b ends up in model A
-        self.assertEqual(
-            (
+        assert (
                 list(modelA.named_vars),
                 list(modelB.named_vars),
-            ), (['a'],['b'])
-        )
+            ) == (['a'],['b'])

--- a/pymc3/tests/test_models_linear.py
+++ b/pymc3/tests/test_models_linear.py
@@ -2,6 +2,7 @@ import numpy as np
 from .helpers import SeededTest
 from pymc3 import Model, Uniform, Normal, find_MAP, Slice, sample
 from pymc3.glm import LinearComponent, GLM
+import pytest
 
 
 # Generate data
@@ -13,8 +14,8 @@ def generate_data(intercept, slope, size=700):
 
 class TestGLM(SeededTest):
     @classmethod
-    def setUpClass(cls):
-        super(TestGLM, cls).setUpClass()
+    def setup_class(cls):
+        super(TestGLM, cls).setup_class()
         cls.intercept = 1
         cls.slope = 3
         cls.sd = .05
@@ -46,10 +47,10 @@ class TestGLM(SeededTest):
             step = Slice(model.vars)
             trace = sample(500, step=step, start=start, progressbar=False, random_seed=self.random_seed)
 
-            self.assertAlmostEqual(np.mean(trace['lm_Intercept']), self.intercept, 1)
-            self.assertAlmostEqual(np.mean(trace['lm_x0']), self.slope, 1)
-            self.assertAlmostEqual(np.mean(trace['sigma']), self.sd, 1)
-        self.assertSetEqual(vars_to_create, set(model.named_vars.keys()))
+            assert round(abs(np.mean(trace['lm_Intercept'])-self.intercept), 1) == 0
+            assert round(abs(np.mean(trace['lm_x0'])-self.slope), 1) == 0
+            assert round(abs(np.mean(trace['sigma'])-self.sd), 1) == 0
+        assert vars_to_create == set(model.named_vars.keys())
 
     def test_linear_component_from_formula(self):
         with Model() as model:
@@ -60,9 +61,9 @@ class TestGLM(SeededTest):
             step = Slice(model.vars)
             trace = sample(500, step=step, start=start, progressbar=False, random_seed=self.random_seed)
 
-            self.assertAlmostEqual(np.mean(trace['Intercept']), self.intercept, 1)
-            self.assertAlmostEqual(np.mean(trace['x']), self.slope, 1)
-            self.assertAlmostEqual(np.mean(trace['sigma']), self.sd, 1)
+            assert round(abs(np.mean(trace['Intercept'])-self.intercept), 1) == 0
+            assert round(abs(np.mean(trace['x'])-self.slope), 1) == 0
+            assert round(abs(np.mean(trace['sigma'])-self.sd), 1) == 0
 
     def test_glm(self):
         with Model() as model:
@@ -80,10 +81,10 @@ class TestGLM(SeededTest):
             start = find_MAP()
             step = Slice(model.vars)
             trace = sample(500, step=step, start=start, progressbar=False, random_seed=self.random_seed)
-            self.assertAlmostEqual(np.mean(trace['glm_Intercept']), self.intercept, 1)
-            self.assertAlmostEqual(np.mean(trace['glm_x0']), self.slope, 1)
-            self.assertAlmostEqual(np.mean(trace['glm_sd']), self.sd, 1)
-            self.assertSetEqual(vars_to_create, set(model.named_vars.keys()))
+            assert round(abs(np.mean(trace['glm_Intercept'])-self.intercept), 1) == 0
+            assert round(abs(np.mean(trace['glm_x0'])-self.slope), 1) == 0
+            assert round(abs(np.mean(trace['glm_sd'])-self.sd), 1) == 0
+            assert vars_to_create == set(model.named_vars.keys())
 
     def test_glm_from_formula(self):
         with Model() as model:
@@ -93,16 +94,14 @@ class TestGLM(SeededTest):
             step = Slice(model.vars)
             trace = sample(500, step=step, start=start, progressbar=False, random_seed=self.random_seed)
 
-            self.assertAlmostEqual(np.mean(trace['%s_Intercept' % NAME]), self.intercept, 1)
-            self.assertAlmostEqual(np.mean(trace['%s_x' % NAME]), self.slope, 1)
-            self.assertAlmostEqual(np.mean(trace['%s_sd' % NAME]), self.sd, 1)
+            assert round(abs(np.mean(trace['%s_Intercept' % NAME])-self.intercept), 1) == 0
+            assert round(abs(np.mean(trace['%s_x' % NAME])-self.slope), 1) == 0
+            assert round(abs(np.mean(trace['%s_sd' % NAME])-self.sd), 1) == 0
 
     def test_strange_types(self):
         with Model():
-            self.assertRaises(
-                ValueError,
-                GLM,
-                1,
+            with pytest.raises(
+                ValueError):
+                GLM(1,
                 self.data_linear['y'],
-                name='lm'
-            )
+                name='lm')

--- a/pymc3/tests/test_models_utils.py
+++ b/pymc3/tests/test_models_utils.py
@@ -1,24 +1,22 @@
-import unittest
 import numpy as np
 import pandas as pd
 import theano.tensor as tt
 from pymc3.glm import utils
+import pytest
 
 
-class TestUtils(unittest.TestCase):
-    def setUp(self):
+class TestUtils(object):
+    def setup_method(self):
         self.data = pd.DataFrame(dict(a=[1, 2, 3], b=[4, 5, 6]))
 
     def assertMatrixLabels(self, m, l, mt=None, lt=None):
-        self.assertTrue(
-            np.all(
+        assert np.all(
                 np.equal(
                     m.eval(),
                     mt if mt is not None else self.data.as_matrix()
                 )
             )
-        )
-        self.assertEqual(l, list(lt or self.data.columns))
+        assert l == list(lt or self.data.columns)
 
     def test_numpy_init(self):
         m, l = utils.any_to_tensor_and_labels(self.data.as_matrix())
@@ -65,15 +63,11 @@ class TestUtils(unittest.TestCase):
 
     def test_user_mistakes(self):
         # no labels for tensor variable
-        self.assertRaises(
-            ValueError,
-            utils.any_to_tensor_and_labels,
-            tt.as_tensor_variable(self.data.as_matrix().tolist())
-        )
+        with pytest.raises(
+            ValueError):
+            utils.any_to_tensor_and_labels(tt.as_tensor_variable(self.data.as_matrix().tolist()))
         # len of labels is bad
-        self.assertRaises(
-            ValueError,
-            utils.any_to_tensor_and_labels,
-            self.data.as_matrix().tolist(),
-            labels=['x']
-        )
+        with pytest.raises(
+            ValueError):
+            utils.any_to_tensor_and_labels(self.data.as_matrix().tolist(),
+            labels=['x'])

--- a/pymc3/tests/test_ndarray_backend.py
+++ b/pymc3/tests/test_ndarray_backend.py
@@ -1,8 +1,8 @@
-import unittest
 import numpy as np
 import numpy.testing as npt
 from pymc3.tests import backend_fixtures as bf
 from pymc3.backends import base, ndarray
+import pytest
 
 
 STATS1 = [{
@@ -107,28 +107,28 @@ class TestMultiTrace(bf.ModelBackendSetupTestCase):
     backend = ndarray.NDArray
     shape = ()
 
-    def setUp(self):
-        super(TestMultiTrace, self).setUp()
+    def setup_method(self):
+        super(TestMultiTrace, self).setup_method()
         self.strace0 = self.strace
 
-        super(TestMultiTrace, self).setUp()
+        super(TestMultiTrace, self).setup_method()
         self.strace1 = self.strace
 
     def test_multitrace_nonunique(self):
-        self.assertRaises(ValueError,
-                          base.MultiTrace, [self.strace0, self.strace1])
+        with pytest.raises(ValueError):
+            base.MultiTrace([self.strace0, self.strace1])
 
     def test_merge_traces_nonunique(self):
         mtrace0 = base.MultiTrace([self.strace0])
         mtrace1 = base.MultiTrace([self.strace1])
 
-        self.assertRaises(ValueError,
-                          base.merge_traces, [mtrace0, mtrace1])
+        with pytest.raises(ValueError):
+            base.merge_traces([mtrace0, mtrace1])
 
 
-class TestSqueezeCat(unittest.TestCase):
+class TestSqueezeCat(object):
 
-    def setUp(self):
+    def setup_method(self):
         self.x = np.arange(10)
         self.y = np.arange(10, 20)
 

--- a/pymc3/tests/test_pickling.py
+++ b/pymc3/tests/test_pickling.py
@@ -1,11 +1,10 @@
-import unittest
 import pickle
 import traceback
 from .models import simple_model
 
 
-class TestPickling(unittest.TestCase):
-    def setUp(self):
+class TestPickling(object):
+    def setup_method(self):
         _, self.model, _ = simple_model()
 
     def test_model_roundtrip(self):

--- a/pymc3/tests/test_posteriors.py
+++ b/pymc3/tests/test_posteriors.py
@@ -1,9 +1,8 @@
-from nose.plugins.attrib import attr
-
+import pytest
 from . import sampler_fixtures as sf
 
 
-class NUTSUniform(sf.NutsFixture, sf.UniformFixture):
+class TestNUTSUniform(sf.NutsFixture, sf.UniformFixture):
     n_samples = 10000
     tune = 1000
     burn = 1000
@@ -13,7 +12,7 @@ class NUTSUniform(sf.NutsFixture, sf.UniformFixture):
     atol = 0.05
 
 
-class MetropolisUniform(sf.MetropolisFixture, sf.UniformFixture):
+class TestMetropolisUniform(sf.MetropolisFixture, sf.UniformFixture):
     n_samples = 50000
     tune = 10000
     burn = 10000
@@ -23,7 +22,7 @@ class MetropolisUniform(sf.MetropolisFixture, sf.UniformFixture):
     atol = 0.05
 
 
-class SliceUniform(sf.SliceFixture, sf.UniformFixture):
+class TestSliceUniform(sf.SliceFixture, sf.UniformFixture):
     n_samples = 10000
     tune = 1000
     burn = 1000
@@ -33,25 +32,23 @@ class SliceUniform(sf.SliceFixture, sf.UniformFixture):
     atol = 0.05
 
 
-@attr('extra')
-class NUTSUniform2(NUTSUniform):
+class TestNUTSUniform2(TestNUTSUniform):
     step_args = {'target_accept': 0.95, 'integrator': 'two-stage'}
 
 
-class NUTSUniform3(NUTSUniform):
+class TestNUTSUniform3(TestNUTSUniform):
     step_args = {'target_accept': 0.80, 'integrator': 'two-stage'}
 
 
-@attr('extra')
-class NUTSUniform4(NUTSUniform):
+class TestNUTSUniform4(TestNUTSUniform):
     step_args = {'target_accept': 0.95, 'integrator': 'three-stage'}
 
 
-class NUTSUniform5(NUTSUniform):
+class TestNUTSUniform5(TestNUTSUniform):
     step_args = {'target_accept': 0.80, 'integrator': 'three-stage'}
 
 
-class NUTSNormal(sf.NutsFixture, sf.NormalFixture):
+class TestNUTSNormal(sf.NutsFixture, sf.NormalFixture):
     n_samples = 10000
     tune = 1000
     burn = 1000
@@ -61,7 +58,7 @@ class NUTSNormal(sf.NutsFixture, sf.NormalFixture):
     atol = 0.05
 
 
-class NUTSBetaBinomial(sf.NutsFixture, sf.BetaBinomialFixture):
+class TestNUTSBetaBinomial(sf.NutsFixture, sf.BetaBinomialFixture):
     n_samples = 2000
     ks_thin = 5
     tune = 1000
@@ -70,8 +67,7 @@ class NUTSBetaBinomial(sf.NutsFixture, sf.BetaBinomialFixture):
     min_n_eff = 400
 
 
-@attr('extra')
-class NUTSStudentT(sf.NutsFixture, sf.StudentTFixture):
+class TestNUTSStudentT(sf.NutsFixture, sf.StudentTFixture):
     n_samples = 100000
     tune = 1000
     burn = 1000
@@ -81,8 +77,8 @@ class NUTSStudentT(sf.NutsFixture, sf.StudentTFixture):
     atol = 0.05
 
 
-@attr('extra')
-class NUTSNormalLong(sf.NutsFixture, sf.NormalFixture):
+@pytest.mark.skip('Takes too long to run')
+class TestNUTSNormalLong(sf.NutsFixture, sf.NormalFixture):
     n_samples = 500000
     tune = 5000
     burn = 5000
@@ -92,7 +88,7 @@ class NUTSNormalLong(sf.NutsFixture, sf.NormalFixture):
     atol = 0.001
 
 
-class NUTSLKJCholeskyCov(sf.NutsFixture, sf.LKJCholeskyCovFixture):
+class TestNUTSLKJCholeskyCov(sf.NutsFixture, sf.LKJCholeskyCovFixture):
     n_samples = 2000
     tune = 1000
     burn = 1000

--- a/pymc3/tests/test_profile.py
+++ b/pymc3/tests/test_profile.py
@@ -1,17 +1,16 @@
-import unittest
 from .models import simple_model
 
 
-class TestProfile(unittest.TestCase):
-    def setUp(self):
+class TestProfile(object):
+    def setup_method(self):
         _, self.model, _ = simple_model()
 
     def test_profile_model(self):
-        self.assertGreater(self.model.profile(self.model.logpt).fct_call_time, 0)
+        assert self.model.profile(self.model.logpt).fct_call_time > 0
 
     def test_profile_variable(self):
-        self.assertGreater(self.model.profile(self.model.vars[0].logpt).fct_call_time, 0)
+        assert self.model.profile(self.model.vars[0].logpt).fct_call_time > 0
 
     def test_profile_count(self):
         count = 1005
-        self.assertEqual(self.model.profile(self.model.logpt, n=count).fct_callcount, count)
+        assert self.model.profile(self.model.logpt, n=count).fct_callcount == count

--- a/pymc3/tests/test_quadpotential.py
+++ b/pymc3/tests/test_quadpotential.py
@@ -1,4 +1,3 @@
-import functools
 import numpy as np
 import scipy.sparse
 import theano.tensor as tt
@@ -6,30 +5,19 @@ import theano
 
 from pymc3.step_methods.hmc import quadpotential
 import pymc3
-
-from nose.tools import raises
-from nose.plugins.skip import SkipTest
+import pytest
 
 
-def require_sparse(f):
-    @functools.wraps(f)
-    def inner():
-        if not quadpotential.chol_available:
-            raise SkipTest("Test requires sksparse.cholmod")
-        f()
-    return inner
-
-
-@raises(quadpotential.PositiveDefiniteError)
 def test_elemwise_posdef():
     scaling = np.array([0, 2, 3])
-    quadpotential.quad_potential(scaling, True, True)
+    with pytest.raises(quadpotential.PositiveDefiniteError):
+        quadpotential.quad_potential(scaling, True, True)
 
 
-@raises(quadpotential.PositiveDefiniteError)
 def test_elemwise_posdef2():
     scaling = np.array([0, 2, 3])
-    quadpotential.quad_potential(scaling, True, False)
+    with pytest.raises(quadpotential.PositiveDefiniteError):
+        quadpotential.quad_potential(scaling, True, False)
 
 
 def test_elemwise_velocity():

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -4,7 +4,6 @@ try:
     import unittest.mock as mock  # py3
 except ImportError:
     import mock
-import unittest
 
 import pymc3 as pm
 import theano.tensor as tt
@@ -14,6 +13,7 @@ from .helpers import SeededTest
 
 # Test if multiprocessing is available
 import multiprocessing
+import pytest
 try:
     multiprocessing.Pool(2)
 except:
@@ -21,8 +21,8 @@ except:
 
 
 class TestSample(SeededTest):
-    def setUp(self):
-        super(TestSample, self).setUp()
+    def setup_method(self):
+        super(TestSample, self).setup_method()
         self.model, self.start, self.step, _ = simple_init()
 
     def test_sample_does_not_set_seed(self):
@@ -32,7 +32,7 @@ class TestSample(SeededTest):
             with self.model:
                 pm.sample(1)
                 random_numbers.append(np.random.random())
-        self.assertEqual(random_numbers[0], random_numbers[1])
+        assert random_numbers[0] == random_numbers[1]
 
     def test_parallel_sample_does_not_reuse_seed(self):
         njobs = 4
@@ -46,13 +46,13 @@ class TestSample(SeededTest):
             for first, second in combinations(range(njobs), 2):
                 first_chain = trace.get_values('x', chains=first)
                 second_chain = trace.get_values('x', chains=second)
-                self.assertFalse((first_chain == second_chain).all())
+                assert not (first_chain == second_chain).all()
             draws.append(trace.get_values('x'))
             random_numbers.append(np.random.random())
 
         # Make sure future random processes aren't effected by this
-        self.assertEqual(*random_numbers)
-        self.assertTrue((draws[0] == draws[1]).all())
+        assert random_numbers[0] == random_numbers[1]
+        assert (draws[0] == draws[1]).all()
 
     def test_sample(self):
         test_njobs = [1]
@@ -73,14 +73,14 @@ class TestSample(SeededTest):
         with self.model:
             samps = pm.sampling.iter_sample(5, self.step, self.start, random_seed=self.random_seed)
             for i, trace in enumerate(samps):
-                self.assertEqual(i, len(trace) - 1, "Trace does not have correct length.")
+                assert i == len(trace) - 1, "Trace does not have correct length."
 
     def test_parallel_start(self):
         with self.model:
             tr = pm.sample(5, njobs=2, start=[{'x': [10, 10]}, {'x': [-10, -10]}],
                            random_seed=self.random_seed)
-        self.assertGreater(tr.get_values('x', chains=0)[0][0], 0)
-        self.assertLess(tr.get_values('x', chains=1)[0][0], 0)
+        assert tr.get_values('x', chains=0)[0][0] > 0
+        assert tr.get_values('x', chains=1)[0][0] < 0
 
 
 class SoftUpdate(SeededTest):
@@ -88,19 +88,19 @@ class SoftUpdate(SeededTest):
         start = {'a': 1, 'b': 2}
         test_point = {'a': 3, 'b': 4}
         pm.sampling._soft_update(start, test_point)
-        self.assertDictEqual(start, {'a': 1, 'b': 2})
+        assert start == {'a': 1, 'b': 2}
 
     def test_soft_update_one_missing(self):
         start = {'a': 1, }
         test_point = {'a': 3, 'b': 4}
         pm.sampling._soft_update(start, test_point)
-        self.assertDictEqual(start, {'a': 1, 'b': 4})
+        assert start == {'a': 1, 'b': 4}
 
     def test_soft_update_empty(self):
         start = {}
         test_point = {'a': 3, 'b': 4}
         pm.sampling._soft_update(start, test_point)
-        self.assertDictEqual(start, test_point)
+        assert start == test_point
 
 
 class TestNamedSampling(SeededTest):
@@ -142,11 +142,11 @@ class TestNamedSampling(SeededTest):
 
 
 
-class TestChooseBackend(unittest.TestCase):
+class TestChooseBackend(object):
     def test_choose_backend_none(self):
         with mock.patch('pymc3.sampling.NDArray') as nd:
             pm.sampling._choose_backend(None, 'chain')
-        self.assertTrue(nd.called)
+        assert nd.called
 
     def test_choose_backend_list_of_variables(self):
         with mock.patch('pymc3.sampling.NDArray') as nd:
@@ -154,13 +154,12 @@ class TestChooseBackend(unittest.TestCase):
         nd.assert_called_with(vars=['var1', 'var2'])
 
     def test_choose_backend_invalid(self):
-        self.assertRaises(ValueError,
-                          pm.sampling._choose_backend,
-                          'invalid', 'chain')
+        with pytest.raises(ValueError):
+            pm.sampling._choose_backend('invalid', 'chain')
 
     def test_choose_backend_shortcut(self):
         backend = mock.Mock()
         shortcuts = {'test_backend': {'backend': backend,
                                       'name': None}}
         pm.sampling._choose_backend('test_backend', 'chain', shortcuts=shortcuts)
-        self.assertTrue(backend.called)
+        assert backend.called

--- a/pymc3/tests/test_stats.py
+++ b/pymc3/tests/test_stats.py
@@ -14,8 +14,8 @@ from scipy import stats as st
 
 class TestStats(SeededTest):
     @classmethod
-    def setUpClass(cls):
-        super(TestStats, cls).setUpClass()
+    def setup_class(cls):
+        super(TestStats, cls).setup_class()
         cls.normal_sample = normal(0, 1, 200000)
 
     def test_autocorr(self):

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 
 from .checks import close_to
 from .models import simple_categorical, mv_simple, mv_simple_discrete, simple_2model, mv_prior_simple
@@ -15,9 +14,10 @@ from numpy.testing import assert_array_almost_equal
 import numpy as np
 import numpy.testing as npt
 from tqdm import tqdm
+import pytest
 
 
-class TestStepMethods(object):  # yield test doesn't work subclassing unittest.TestCase
+class TestStepMethods(object):  # yield test doesn't work subclassing object
     master_samples = {
         Slice: np.array([
             -8.13087389e-01, -3.08921856e-01, -6.79377098e-01, 6.50812585e-01, -7.63577596e-01,
@@ -208,7 +208,7 @@ class TestStepMethods(object):  # yield test doesn't work subclassing unittest.T
             yield self.check_stat, check, trace, step.__class__.__name__
 
 
-class TestMetropolisProposal(unittest.TestCase):
+class TestMetropolisProposal(object):
     def test_proposal_choice(self):
         _, model, _ = mv_simple()
         with model:
@@ -219,7 +219,7 @@ class TestMetropolisProposal(unittest.TestCase):
             sampler = Metropolis(S=s)
             assert isinstance(sampler.proposal_dist, MultivariateNormalProposal)
             s[0, 0] = -s[0, 0]
-            with self.assertRaises(np.linalg.LinAlgError):
+            with pytest.raises(np.linalg.LinAlgError):
                 sampler = Metropolis(S=s)
 
     def test_mv_proposal(self):
@@ -231,7 +231,7 @@ class TestMetropolisProposal(unittest.TestCase):
         npt.assert_allclose(np.cov(samples.T), cov, rtol=0.2)
 
 
-class TestCompoundStep(unittest.TestCase):
+class TestCompoundStep(object):
     samplers = (Metropolis, Slice, HamiltonianMC, NUTS)
 
     def test_non_blocked(self):
@@ -239,46 +239,46 @@ class TestCompoundStep(unittest.TestCase):
         _, model = simple_2model()
         with model:
             for sampler in self.samplers:
-                self.assertIsInstance(sampler(blocked=False), CompoundStep)
+                assert isinstance(sampler(blocked=False), CompoundStep)
 
     def test_blocked(self):
         _, model = simple_2model()
         with model:
             for sampler in self.samplers:
                 sampler_instance = sampler(blocked=True)
-                self.assertNotIsInstance(sampler_instance, CompoundStep)
-                self.assertIsInstance(sampler_instance, sampler)
+                assert not isinstance(sampler_instance, CompoundStep)
+                assert isinstance(sampler_instance, sampler)
 
 
-class TestAssignStepMethods(unittest.TestCase):
+class TestAssignStepMethods(object):
     def test_bernoulli(self):
         """Test bernoulli distribution is assigned binary gibbs metropolis method"""
         with Model() as model:
             Bernoulli('x', 0.5)
             steps = assign_step_methods(model, [])
-        self.assertIsInstance(steps, BinaryGibbsMetropolis)
+        assert isinstance(steps, BinaryGibbsMetropolis)
 
     def test_normal(self):
         """Test normal distribution is assigned NUTS method"""
         with Model() as model:
             Normal('x', 0, 1)
             steps = assign_step_methods(model, [])
-        self.assertIsInstance(steps, NUTS)
+        assert isinstance(steps, NUTS)
 
     def test_categorical(self):
         """Test categorical distribution is assigned categorical gibbs metropolis method"""
         with Model() as model:
             Categorical('x', np.array([0.25, 0.75]))
             steps = assign_step_methods(model, [])
-        self.assertIsInstance(steps, BinaryGibbsMetropolis)
+        assert isinstance(steps, BinaryGibbsMetropolis)
         with Model() as model:
             Categorical('y', np.array([0.25, 0.70, 0.05]))
             steps = assign_step_methods(model, [])
-        self.assertIsInstance(steps, CategoricalGibbsMetropolis)
+        assert isinstance(steps, CategoricalGibbsMetropolis)
 
     def test_binomial(self):
         """Test binomial distribution is assigned metropolis method."""
         with Model() as model:
             Binomial('x', 10, 0.5)
             steps = assign_step_methods(model, [])
-        self.assertIsInstance(steps, Metropolis)
+        assert isinstance(steps, Metropolis)

--- a/pymc3/tests/test_text_backend.py
+++ b/pymc3/tests/test_text_backend.py
@@ -52,8 +52,8 @@ class TestTextDumpFunction(bf.BackendEqualityTestCase):
     shape = (2, 3)
 
     @classmethod
-    def setUpClass(cls):
-        super(TestTextDumpFunction, cls).setUpClass()
+    def setup_class(cls):
+        super(TestTextDumpFunction, cls).setup_class()
         text.dump(cls.name1, cls.mtrace1)
         with cls.model:
             cls.mtrace1 = text.load(cls.name1)

--- a/pymc3/tests/test_tracetab.py
+++ b/pymc3/tests/test_tracetab.py
@@ -13,7 +13,7 @@ class TestTraceToDf(bf.ModelBackendSampledTestCase):
     def test_trace_to_dataframe(self):
         mtrace = self.mtrace
         df = ttab.trace_to_dataframe(mtrace)
-        self.assertEqual(len(mtrace) * mtrace.nchains, df.shape[0])
+        assert len(mtrace) * mtrace.nchains == df.shape[0]
 
         checked = False
         for varname in self.test_point.keys():
@@ -26,12 +26,12 @@ class TestTraceToDf(bf.ModelBackendSampledTestCase):
             npt.assert_equal(vararr[:, 1, 0], df[varname + '__1_0'].values)
             npt.assert_equal(vararr[:, 1, 2], df[varname + '__1_2'].values)
             checked = True
-        self.assertTrue(checked)
+        assert checked
 
     def test_trace_to_dataframe_chain_arg(self):
         mtrace = self.mtrace
         df = ttab.trace_to_dataframe(mtrace, chains=0)
-        self.assertEqual(len(mtrace), df.shape[0])
+        assert len(mtrace) == df.shape[0]
 
         checked = False
         for varname in self.test_point.keys():
@@ -44,7 +44,7 @@ class TestTraceToDf(bf.ModelBackendSampledTestCase):
             npt.assert_equal(vararr[:, 1, 0], df[varname + '__1_0'].values)
             npt.assert_equal(vararr[:, 1, 2], df[varname + '__1_2'].values)
             checked = True
-        self.assertTrue(checked)
+        assert checked
 
 
 def test_create_flat_names_0d():

--- a/pymc3/tests/test_types.py
+++ b/pymc3/tests/test_types.py
@@ -1,6 +1,5 @@
 from copy import copy
 
-import unittest
 import theano
 
 from pymc3.sampling import sample
@@ -11,14 +10,14 @@ from pymc3.distributions import Normal
 import numpy as np
 
 
-class TestType(unittest.TestCase):
+class TestType(object):
     samplers = (Metropolis, Slice, HamiltonianMC, NUTS)
 
-    def setUp(self):
+    def setup_method(self):
         # save theano config object
         self.theano_config = copy(theano.config)
 
-    def tearDown(self):
+    def teardown_method(self):
         # restore theano config
         theano.config = self.theano_config
 

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -1,5 +1,4 @@
 import pickle
-import unittest
 import numpy as np
 from theano import theano, tensor as tt
 import pymc3 as pm
@@ -14,6 +13,7 @@ from pymc3.variational.approximations import MeanField
 
 from pymc3.tests import models
 from pymc3.tests.helpers import SeededTest
+import pytest
 
 
 class TestELBO(SeededTest):
@@ -58,7 +58,7 @@ class TestApproximates:
                 app = self.inference().approx
                 posterior = app.random(10)
                 x_sampled = app.view(posterior, 'x').eval()
-            self.assertEqual(x_sampled.shape, (10,) + model['x'].dshape)
+            assert x_sampled.shape == (10,) + model['x'].dshape
 
         def test_vars_view_dynamic_size(self):
             _, model, _ = models.multidimensional_model()
@@ -68,9 +68,9 @@ class TestApproximates:
                 i.tag.test_value = 1
                 posterior = app.random(i)
             x_sampled = app.view(posterior, 'x').eval({i: 10})
-            self.assertEqual(x_sampled.shape, (10,) + model['x'].dshape)
+            assert x_sampled.shape == (10,) + model['x'].dshape
             x_sampled = app.view(posterior, 'x').eval({i: 1})
-            self.assertEqual(x_sampled.shape, (1,) + model['x'].dshape)
+            assert x_sampled.shape == (1,) + model['x'].dshape
 
         def test_vars_view_dynamic_size_numpy(self):
             _, model, _ = models.multidimensional_model()
@@ -79,11 +79,11 @@ class TestApproximates:
                 i = tt.iscalar('i')
                 i.tag.test_value = 1
             x_sampled = app.view(app.random_fn(10), 'x')
-            self.assertEqual(x_sampled.shape, (10,) + model['x'].dshape)
+            assert x_sampled.shape == (10,) + model['x'].dshape
             x_sampled = app.view(app.random_fn(1), 'x')
-            self.assertEqual(x_sampled.shape, (1,) + model['x'].dshape)
+            assert x_sampled.shape == (1,) + model['x'].dshape
             x_sampled = app.view(app.random_fn(), 'x')
-            self.assertEqual(x_sampled.shape, () + model['x'].dshape)
+            assert x_sampled.shape == () + model['x'].dshape
 
         def test_sample_vp(self):
             n_samples = 100
@@ -93,11 +93,11 @@ class TestApproximates:
                 pm.Binomial('xs', n=1, p=p, observed=xs)
                 app = self.inference().approx
                 trace = app.sample_vp(draws=1, hide_transformed=True)
-                self.assertListEqual(trace.varnames, ['p'])
-                self.assertEqual(len(trace), 1)
+                assert trace.varnames == ['p']
+                assert len(trace) == 1
                 trace = app.sample_vp(draws=10, hide_transformed=False)
-                self.assertListEqual(sorted(trace.varnames), ['p', 'p_logodds_'])
-                self.assertEqual(len(trace), 10)
+                assert sorted(trace.varnames) == ['p', 'p_logodds_']
+                assert len(trace) == 10
 
         def test_sample_node(self):
             n_samples = 100
@@ -125,13 +125,13 @@ class TestApproximates:
                 Normal('x', mu=mu_, sd=sd, observed=data)
                 pm.Deterministic('mu_sq', mu_**2)
                 inf = self.inference()
-                self.assertEqual(len(inf.hist), 0)
+                assert len(inf.hist) == 0
                 inf.fit(10)
-                self.assertEqual(len(inf.hist), 10)
-                self.assertFalse(np.isnan(inf.hist).any())
+                assert len(inf.hist) == 10
+                assert not np.isnan(inf.hist).any()
                 approx = inf.fit(self.NITER)
-                self.assertEqual(len(inf.hist), self.NITER + 10)
-                self.assertFalse(np.isnan(inf.hist).any())
+                assert len(inf.hist) == self.NITER + 10
+                assert not np.isnan(inf.hist).any()
                 trace = approx.sample_vp(10000)
             np.testing.assert_allclose(np.mean(trace['mu']), mu_post, rtol=0.1)
             np.testing.assert_allclose(np.std(trace['mu']), np.sqrt(1. / d), rtol=0.2)
@@ -243,8 +243,10 @@ class TestMeanField(TestApproximates.Base):
         with models.multidimensional_model()[1]:
             meth = ADVI()
             fit(10, method=meth)
-            self.assertRaises(KeyError, fit, 10, method='undefined')
-            self.assertRaises(TypeError, fit, 10, method=1)
+            with pytest.raises(KeyError):
+                fit(10, method='undefined')
+            with pytest.raises(TypeError):
+                fit(10, method=1)
 
 
 class TestFullRank(TestApproximates.Base):
@@ -264,7 +266,8 @@ class TestFullRank(TestApproximates.Base):
 
     def test_combined(self):
         with models.multidimensional_model()[1]:
-            self.assertRaises(ValueError, fit, 10, method='advi->fullrank_advi', frac=1)
+            with pytest.raises(ValueError):
+                fit(10, method='advi->fullrank_advi', frac=1)
             fit(10, method='advi->fullrank_advi', frac=.5)
 
     def test_approximate(self):
@@ -317,4 +320,4 @@ class TestHistogram(SeededTest):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    object.main()

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -36,17 +36,15 @@ fi
 
 pip install jupyter
 conda install --yes pyqt matplotlib --channel conda-forge
-conda install --yes pyzmq numpy scipy nose pandas Cython patsy statsmodels joblib coverage mkl-service
+conda install --yes pyzmq numpy scipy pytest pytest-cov pandas Cython patsy statsmodels joblib coverage mkl-service
 if [ ${PYTHON_VERSION} == "2.7" ]; then
     conda install --yes mock enum34;
 fi
 
 pip install --upgrade pip
 pip install tqdm
-pip install nose_parameterized
 pip install --no-deps numdifftools
 pip install git+https://github.com/Theano/Theano.git
-pip install git+https://github.com/mahmoudimus/nose-timer.git
 pip install h5py
 
 if [ -z ${NO_SETUP} ]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-THEANO_FLAGS='gcc.cxxflags="-march=core2"' nosetests "$@"
+THEANO_FLAGS='gcc.cxxflags="-march=core2"' pytest -v --cov=pymc3 "$@"
 
 if [[ "$RUN_PYLINT" == "true" ]]; then
     . ./scripts/lint.sh

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[nosetests]
-attr=!extra
+[tool:pytest]
+testpaths = pymc3/tests

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open(REQUIREMENTS_FILE) as f:
 if sys.version_info < (3, 4):
     install_reqs.append('enum34')
 
-test_reqs = ['nose']
+test_reqs = ['pytest', 'pytest-cov']
 if sys.version_info[0] == 2:  # py3 has mock in stdlib
     test_reqs.append('mock')
 


### PR DESCRIPTION
Here's a start at moving from `nose` to `pytest`.  Major work was done using [unittest2pytest](https://pypi.python.org/pypi/unittest2pytest/), since pytest can't parameterize tests that subclass `unittest.TestCase`.  I'm running tests by default on travis with flags `x`, meaning "fail after first failure", and `v`, which prints the name of each test.  I may also add timing information.

This shouldn't get merged until we 

- [x] confirm that the coverage is the same,
- [x] update the `CONTRIBUTING` file to mention best practices for pytest.

