### PR TITLE
Fix test_step.py on CUDA platform

### DIFF
--- a/pymc3/tests/helpers.py
+++ b/pymc3/tests/helpers.py
@@ -1,7 +1,10 @@
 from logging.handlers import BufferingHandler
 import numpy.random as nr
+import numpy as np
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 from ..theanof import set_tt_rng, tt_rng
+from pymc3.theanof import floatX
+import theano
 
 
 class SeededTest(object):
@@ -77,3 +80,13 @@ class Matcher(object):
         else:
             result = dv.find(v) >= 0
         return result
+
+
+def select_by_precision(float64, float32):
+    """Helper function to choose reasonable decimal cutoffs for different floatX modes."""
+    decimal = float64 if theano.config.floatX == "float64" else float32
+    return decimal
+
+
+def fxarray(x):
+    return floatX(np.array(x))

--- a/pymc3/tests/models.py
+++ b/pymc3/tests/models.py
@@ -4,7 +4,7 @@ import pymc3 as pm
 from itertools import product
 import theano.tensor as tt
 from theano.compile.ops import as_op
-
+from .helpers import fxarray
 
 def simple_model():
     mu = -2.1
@@ -16,8 +16,8 @@ def simple_model():
 
 
 def simple_categorical():
-    p = np.array([0.1, 0.2, 0.3, 0.4])
-    v = np.array([0.0, 1.0, 2.0, 3.0])
+    p = fxarray([0.1, 0.2, 0.3, 0.4])
+    v = fxarray([0.0, 1.0, 2.0, 3.0])
     with Model() as model:
         Categorical('x', p, shape=3, testval=[1, 2, 3])
 
@@ -43,7 +43,7 @@ def simple_arbitrary_det():
     with Model() as model:
         a = Normal('a')
         b = arbitrary_det(a)
-        Normal('obs', mu=b.astype('float64'), observed=np.array([1, 3, 5]))
+        Normal('obs', mu=b.astype('float64'), observed=fxarray([1, 3, 5]))
 
     return model.test_point, model
 
@@ -66,15 +66,15 @@ def simple_2model():
 
 
 def mv_simple():
-    mu = np.array([-.1, .5, 1.1])
-    p = np.array([
+    mu = fxarray([-.1, .5, 1.1])
+    p = fxarray([
         [2., 0, 0],
         [.05, .1, 0],
         [1., -0.05, 5.5]])
     tau = np.dot(p, p.T)
     with pm.Model() as model:
         pm.MvNormal('x', tt.constant(mu), tau=tt.constant(tau),
-                    shape=3, testval=np.array([.1, 1., .8]))
+                    shape=3, testval=fxarray([.1, 1., .8]))
     H = tau
     C = np.linalg.inv(H)
     return model.test_point, model, (mu, C)
@@ -83,7 +83,7 @@ def mv_simple():
 def mv_simple_discrete():
     d = 2
     n = 5
-    p = np.array([.15, .85])
+    p = fxarray([.15, .85])
     with pm.Model() as model:
         pm.Multinomial('x', n, tt.constant(p), shape=d, testval=np.array([1, 4]))
         mu = n * p
@@ -106,7 +106,7 @@ def mv_prior_simple():
     K = pm.gp.cov.ExpQuad(1, 1)(X).eval()
     L = np.linalg.cholesky(K)
     K_noise = K + noise * np.eye(n)
-    obs = np.array([-0.1, 0.5, 1.1])
+    obs = fxarray([-0.1, 0.5, 1.1])
 
     # Posterior mean
     L_noise = np.linalg.cholesky(K_noise)

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 import itertools
-from .helpers import SeededTest, fxarray, select_by_precision
+from .helpers import SeededTest, select_by_precision
 from ..vartypes import continuous_types
 from ..model import Model, Point, Potential
 from ..blocking import DictToVarBijection, DictToArrayBijection, ArrayOrdering
@@ -31,13 +31,13 @@ def get_lkj_cases():
     Log probabilities calculated using the formulas in:
     http://www.sciencedirect.com/science/article/pii/S0047259X09000876
     """
-    tri = fxarray([0.7, 0.0, -0.7])
+    tri = np.array([0.7, 0.0, -0.7])
     return [
         (tri, 1, 3, 1.5963125911388549),
         (tri, 3, 3, -7.7963493376312742),
         (tri, 0, 3, -np.inf),
-        (fxarray([1.1, 0.0, -0.7]), 1, 3, -np.inf),
-        (fxarray([0.7, 0.0, -1.1]), 1, 3, -np.inf)
+        (np.array([1.1, 0.0, -0.7]), 1, 3, -np.inf),
+        (np.array([0.7, 0.0, -1.1]), 1, 3, -np.inf)
     ]
 
 
@@ -587,7 +587,7 @@ class TestMatchesScipy(SeededTest):
 
     def test_multinomial_vec(self):
         vals = np.array([[2,4,4], [3,3,4]])
-        p = fxarray([0.2, 0.3, 0.5])
+        p = np.array([0.2, 0.3, 0.5])
         n = 10
 
         with Model() as model_single:
@@ -602,7 +602,7 @@ class TestMatchesScipy(SeededTest):
 
     def test_multinomial_vec_1d_n(self):
         vals = np.array([[2,4,4], [4,3,4]])
-        p = fxarray([0.2, 0.3, 0.5])
+        p = np.array([0.2, 0.3, 0.5])
         ns = np.array([10, 11])
 
         with Model() as model:
@@ -614,7 +614,7 @@ class TestMatchesScipy(SeededTest):
 
     def test_multinomial_vec_1d_n_2d_p(self):
         vals = np.array([[2,4,4], [4,3,4]])
-        ps = fxarray([[0.2, 0.3, 0.5],
+        ps = np.array([[0.2, 0.3, 0.5],
                        [0.9, 0.09, 0.01]])
         ns = np.array([10, 11])
 
@@ -627,7 +627,7 @@ class TestMatchesScipy(SeededTest):
 
     def test_multinomial_vec_2d_p(self):
         vals = np.array([[2,4,4], [3,3,4]])
-        ps = fxarray([[0.2, 0.3, 0.5],
+        ps = np.array([[0.2, 0.3, 0.5],
                        [0.3, 0.3, 0.4]])
         n = 10
 
@@ -640,7 +640,7 @@ class TestMatchesScipy(SeededTest):
 
     def test_categorical_bounds(self):
         with Model():
-            x = Categorical('x', p=fxarray([0.2, 0.3, 0.5]))
+            x = Categorical('x', p=np.array([0.2, 0.3, 0.5]))
             assert np.isinf(x.logp({'x': -1}))
             assert np.isinf(x.logp({'x': 3}))
 
@@ -661,7 +661,7 @@ class TestMatchesScipy(SeededTest):
             self.check_dlogp(model, value, R, {})
 
     def test_get_tau_sd(self):
-        sd = fxarray([2])
+        sd = np.array([2])
         assert_almost_equal(continuous.get_tau_sd(sd=sd), [1. / sd**2, sd])
 
     @pytest.mark.parametrize('value,mu,sigma,nu,logp', [

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 import itertools
-from .helpers import SeededTest
+from .helpers import SeededTest, fxarray, select_by_precision
 from ..vartypes import continuous_types
 from ..model import Model, Point, Potential
 from ..blocking import DictToVarBijection, DictToArrayBijection, ArrayOrdering
@@ -15,7 +15,6 @@ from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Di
                              Bound, Uniform, Triangular, Binomial, SkewNormal, DiscreteWeibull)
 from ..distributions import continuous, multivariate
 from pymc3.theanof import floatX
-import theano
 from numpy import array, inf, log, exp
 from numpy.testing import assert_almost_equal
 import numpy.random as nr
@@ -27,24 +26,18 @@ import scipy.stats.distributions as sp
 import scipy.stats
 
 
-def select_by_precision(float64, float32):
-    """Helper function to choose reasonable decimal cutoffs for different floatX modes."""
-    decimal = float64 if theano.config.floatX == "float64" else float32
-    return decimal
-
-
 def get_lkj_cases():
     """
     Log probabilities calculated using the formulas in:
     http://www.sciencedirect.com/science/article/pii/S0047259X09000876
     """
-    tri = np.array([0.7, 0.0, -0.7])
+    tri = fxarray([0.7, 0.0, -0.7])
     return [
         (tri, 1, 3, 1.5963125911388549),
         (tri, 3, 3, -7.7963493376312742),
         (tri, 0, 3, -np.inf),
-        (np.array([1.1, 0.0, -0.7]), 1, 3, -np.inf),
-        (np.array([0.7, 0.0, -1.1]), 1, 3, -np.inf)
+        (fxarray([1.1, 0.0, -0.7]), 1, 3, -np.inf),
+        (fxarray([0.7, 0.0, -1.1]), 1, 3, -np.inf)
     ]
 
 
@@ -586,7 +579,7 @@ class TestMatchesScipy(SeededTest):
 
     def test_multinomial_vec(self):
         vals = np.array([[2,4,4], [3,3,4]])
-        p = np.array([0.2, 0.3, 0.5])
+        p = fxarray([0.2, 0.3, 0.5])
         n = 10
 
         with Model() as model_single:
@@ -601,7 +594,7 @@ class TestMatchesScipy(SeededTest):
 
     def test_multinomial_vec_1d_n(self):
         vals = np.array([[2,4,4], [4,3,4]])
-        p = np.array([0.2, 0.3, 0.5])
+        p = fxarray([0.2, 0.3, 0.5])
         ns = np.array([10, 11])
 
         with Model() as model:
@@ -613,7 +606,7 @@ class TestMatchesScipy(SeededTest):
 
     def test_multinomial_vec_1d_n_2d_p(self):
         vals = np.array([[2,4,4], [4,3,4]])
-        ps = np.array([[0.2, 0.3, 0.5],
+        ps = fxarray([[0.2, 0.3, 0.5],
                        [0.9, 0.09, 0.01]])
         ns = np.array([10, 11])
 
@@ -626,7 +619,7 @@ class TestMatchesScipy(SeededTest):
 
     def test_multinomial_vec_2d_p(self):
         vals = np.array([[2,4,4], [3,3,4]])
-        ps = np.array([[0.2, 0.3, 0.5],
+        ps = fxarray([[0.2, 0.3, 0.5],
                        [0.3, 0.3, 0.4]])
         n = 10
 
@@ -639,7 +632,7 @@ class TestMatchesScipy(SeededTest):
 
     def test_categorical_bounds(self):
         with Model():
-            x = Categorical('x', p=np.array([0.2, 0.3, 0.5]))
+            x = Categorical('x', p=fxarray([0.2, 0.3, 0.5]))
             assert np.isinf(x.logp({'x': -1}))
             assert np.isinf(x.logp({'x': 3}))
 
@@ -660,7 +653,7 @@ class TestMatchesScipy(SeededTest):
             self.check_dlogp(model, value, R, {})
 
     def test_get_tau_sd(self):
-        sd = np.array([2])
+        sd = fxarray([2])
         assert_almost_equal(continuous.get_tau_sd(sd=sd), [1. / sd**2, sd])
 
     def test_get_tau_cov(self):

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -139,7 +139,7 @@ class TestStepMethods(object):  # yield test doesn't work subclassing object
             trace = sample(n_steps, step=step_method(), random_seed=1)
 
         if not benchmarking:
-            assert_array_almost_equal(trace.get_values('x'), self.master_samples[step_method], decimal=select_by_precision(float64=6, float32=5))
+            assert_array_almost_equal(trace.get_values('x'), self.master_samples[step_method], decimal=select_by_precision(float64=6, float32=4))
 
     def check_stat(self, check, trace, name):
         for (var, stat, value, bound) in check:


### PR DESCRIPTION
1.  Refactored helper functions in #1948  into helpers.py
2.  Added floatX wrappers and precision adjustments to fix 32 bit tests
3.  Skipped 3 tests on float32 due to linear algebra failures.

```
#Before changes:
master
cuda float32
pytest -v pymc3/tests/test_step.py
=================================================================================== 8 pytest-warnings, 2 error in 57.23 seconds ====================================================================================

cuda evenmoregpu
pytest -v pymc3/tests/test_step.py
============================================================================ 22 passed, 2 skipped, 16 pytest-warnings in 226.87 seconds ============================================================================
```
