### PR TITLE
find_MAP monitor for notebooks

### DIFF
--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -7,6 +7,7 @@ from scipy import optimize
 import numpy as np
 from numpy import isfinite, nan_to_num, logical_not
 import pymc3 as pm
+import time
 from ..vartypes import discrete_types, typefilter
 from ..model import modelcontext, Point
 from ..theanof import inputvars
@@ -16,9 +17,8 @@ from inspect import getargspec
 
 __all__ = ['find_MAP']
 
-
 def find_MAP(start=None, vars=None, fmin=None,
-             return_raw=False,model=None, *args, **kwargs):
+             return_raw=False, model=None, live_disp=False, callback=None, *args, **kwargs):
     """
     Sets state to the local maximum a posteriori point given a model.
     Current default of fmin_Hessian does not deal well with optimizing close
@@ -52,7 +52,6 @@ def find_MAP(start=None, vars=None, fmin=None,
     if vars is None:
         vars = model.cont_vars
     vars = inputvars(vars)
-
     disc_vars = list(typefilter(vars, discrete_types))
 
     try:
@@ -90,22 +89,29 @@ def find_MAP(start=None, vars=None, fmin=None,
         def grad_logp_o(point):
             return nan_to_num(-dlogp(point))
 
-        r = fmin(logp_o, bij.map(
-            start), fprime=grad_logp_o, *args, **kwargs)
+        if live_disp:
+            callback = Monitor(bij, logp_o, model, grad_logp_o)
+
+        r = fmin(logp_o, bij.map(start), fprime=grad_logp_o, callback=callback, *args, **kwargs)
         compute_gradient = True
     else:
-        compute_gradient = False
+        if live_disp:
+            callback = Monitor(bij, logp_o, dlogp=None)
 
         # Check to see if minimization function uses a starting value
         if 'x0' in getargspec(fmin).args:
-            r = fmin(logp_o, bij.map(start), *args, **kwargs)
+            r = fmin(logp_o, bij.map(start), callback=callback, *args, **kwargs)
         else:
-            r = fmin(logp_o, *args, **kwargs)
+            r = fmin(logp_o, callback=callback, *args, **kwargs)
+        compute_gradient = False
 
     if isinstance(r, tuple):
         mx0 = r[0]
     else:
         mx0 = r
+
+    if live_disp:
+        callback(mx0)
 
     mx = bij.rmap(mx0)
 
@@ -158,7 +164,6 @@ def find_MAP(start=None, vars=None, fmin=None,
     else:
         return mx
 
-
 def allfinite(x):
     return np.all(isfinite(x))
 
@@ -171,3 +176,126 @@ def allinmodel(vars, model):
     notin = [v for v in vars if v not in model.vars]
     if notin:
         raise ValueError("Some variables not in the model: " + str(notin))
+
+
+
+class Monitor(object):
+    def __init__(self, bij, logp, model, dlogp=None):
+        try:
+            from IPython.display import display
+            from ipywidgets import HTML, VBox, HBox, FlexBox
+            self.prog_table  = HTML(width='100%')
+            self.param_table = HTML(width='100%')
+            r_col = VBox(children=[self.param_table], padding=3, width='100%')
+            l_col = HBox(children=[self.prog_table],  padding=3, width='25%')
+            self.hor_align = FlexBox(children = [l_col, r_col], width='100%', orientation='vertical')
+            display(self.hor_align)
+            self.using_notebook = True
+            self.update_interval = 1
+        except:
+            self.using_notebook = False
+            self.update_interval = 2
+
+        self.iters = 0
+        self.bij = bij
+        self.model = model
+        self.fn = model.fastfn(model.unobserved_RVs)
+        self.logp = logp
+        self.dlogp = dlogp
+        self.t_initial = time.time()
+        self.t0 = self.t_initial
+        self.paramtable = {}
+
+    def __call__(self, x):
+        self.iters += 1
+        if time.time() - self.t0 > self.update_interval:
+            self._update_progtable(x)
+            self._update_paramtable(x)
+            if self.using_notebook:
+                self._display_notebook()
+                self.t0 = time.time()
+
+    def _update_progtable(self, x):
+        s = time.time() - self.t_initial
+        hours, remainder = divmod(int(s), 3600)
+        minutes, seconds = divmod(remainder, 60)
+        self.t_elapsed = "{:2d}h{:2d}m{:2d}s".format(hours, minutes, seconds)
+        self.logpost = -1.0*np.float(self.logp(x))
+        self.dlogpost = np.linalg.norm(self.dlogp(x))
+
+    def _update_paramtable(self, x):
+        var_state = self.fn(self.bij.rmap(x))
+        for var, val in zip(self.model.unobserved_RVs, var_state):
+            if not var.name.endswith("_"):
+                valstr = format_values(val)
+                self.paramtable[var.name] = {"size": val.size, "valstr": valstr}
+
+    def _display_notebook(self):
+        ## Progress table
+        html = r"""<style type="text/css">
+        table { border-collapse:collapse }
+        .tg {border-collapse:collapse;border-spacing:0;border:none;}
+        .tg td{font-family:Arial, sans-serif;font-size:14px;padding:3px 3px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;}
+        .tg th{Impact, Charcoal, sans-serif;font-size:13px;font-weight:bold;padding:3px 3px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal; background-color:#0E688A;color:#ffffff;}
+        .tg .tg-vkoh{font-weight:normal;font-family:"Lucida Console", Monaco, monospace !important; background-color:#ffffff;color:#000000}
+        .tg .tg-suao{font-weight:bold;font-family:"Lucida Console", Monaco, monospace !important;background-color:#0E688A;color:#ffffff;}
+        """
+        html += r"""
+        </style>
+        <table class="tg" style="undefined;">
+           <col width="400px" />
+           <tr>
+             <th class= "tg-vkoh">Time Elapsed: {:s}</th>
+           </tr>
+           <tr>
+             <th class= "tg-vkoh">Iteration: {:d}</th>
+           </tr>
+           <tr>
+             <th class= "tg-vkoh">Log Posterior: {:.3f}</th>
+           </tr>
+        """.format(self.t_elapsed, self.iters, self.logpost)
+        if self.dlogp is not None:
+           html += r"""
+             <tr>
+               <th class= "tg-vkoh">||grad||: {:.3f}</th>
+             </tr>""".format(self.dlogpost)
+        html += "</table>"
+        self.prog_table.value = html
+        ## Parameter table
+        html = r"""<style type="text/css">
+          .tg .tg-bgft{font-weight:normal;font-family:"Lucida Console", Monaco, monospace !important;background-color:#0E688A;color:#ffffff;}
+          .tg td{font-family:Arial, sans-serif;font-size:12px;padding:3px 3px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;border-color:#504A4E;color:#333;background-color:#fff;word-wrap: break-word;}
+          .tg th{Impact, Charcoal, sans-serif;font-size:13px;font-weight:bold;padding:3px 3px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;border-color:#504A4E;background-color:#0E688A;color:#ffffff;}
+          </style>
+          <table class="tg" style="undefined;">
+             <col width="130px" />
+             <col width="50px" />
+             <col width="600px" />
+             <tr>
+               <th class="tg">Parameter</th>
+               <th class="tg">Size</th>
+               <th class="tg">Current Value</th>
+             </tr>
+           """
+        for var, values in self.paramtable.items():
+            html += r"""
+              <tr>
+                <td class="tg-bgft">{:s}</td>
+                <td class="tg-vkoh">{:d}</td>
+                <td class="tg-vkoh">{:s}</td>
+              </tr>
+            """.format(var, values["size"], values["valstr"])
+        html += "</table>"
+        self.param_table.value = html
+
+
+def format_values(val):
+    fmt = "{:8.3f}"
+    if val.size == 1:
+        return fmt.format(np.float(val))
+    elif val.size < 9:
+        return ", ".join([fmt.format(v) for v in val])
+    else:
+        start = ", ".join([fmt.format(v) for v in val[:4]])
+        end   = ", ".join([fmt.format(v) for v in val[-4:]])
+        return start + ", ... , " + end

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -310,4 +310,4 @@ def format_values(val):
     else:
         start = "[" + ", ".join([fmt.format(v) for v in val[:4]])
         end   = ", ".join([fmt.format(v) for v in val[-4:]]) +"]"
-        return start + ",   ...   ,  " + end
+        return start + ",   ...   , " + end

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -95,13 +95,13 @@ def find_MAP(start=None, vars=None, fmin=None,
         def grad_logp_o(point):
             return nan_to_num(-dlogp(point))
 
-        if live_disp and callback is not None:
+        if live_disp and callback is None:
             callback = Monitor(bij, logp_o, model, grad_logp_o)
 
         r = fmin(logp_o, bij.map(start), fprime=grad_logp_o, callback=callback, *args, **kwargs)
         compute_gradient = True
     else:
-        if live_disp and callback is not None:
+        if live_disp and callback is None:
             callback = Monitor(bij, logp_o, dlogp=None)
 
         # Check to see if minimization function uses a starting value


### PR DESCRIPTION
This PR is the find_MAP monitor for notebooks, without the changes to tqdm (#1951).  It contains the changes from #1813, with some fixes.   Variables that were transformed are now displayed in their original, untransformed, space.

![optmonitor](https://cloud.githubusercontent.com/assets/6325473/24574206/cf53992e-1643-11e7-959b-9e1da4fb3351.png)
