### PR TITLE
small fixes to GP docs

### DIFF
--- a/docs/source/api/gp.rst
+++ b/docs/source/api/gp.rst
@@ -2,6 +2,18 @@
 Gaussian Processes
 ******************
 
+
+GP
+--
+
+.. currentmodule:: pymc3.gp.gp
+.. automodule:: pymc3.gp.gp
+   :members:
+
+
+Covariance Functions / Kernels
+------------------------------
+
 .. currentmodule:: pymc3.gp.cov
 .. autosummary::
 

--- a/pymc3/gp/cov.py
+++ b/pymc3/gp/cov.py
@@ -15,7 +15,7 @@ __all__ = ['ExpQuad',
 
 class Covariance(object):
     R"""
-    Base class for all covariance functions.
+    Base class for all kernels/covariance functions.
 
     Parameters
     ----------
@@ -37,7 +37,7 @@ class Covariance(object):
 
     def __call__(self, X, Z):
         R"""
-        Evaluate the covariance function.
+        Evaluate the kernel/covariance function.
 
         Parameters
         ----------
@@ -108,7 +108,7 @@ class Prod(Combination):
 
 class Stationary(Covariance):
     R"""
-    Base class for stationary covariance functions.
+    Base class for stationary kernels/covariance functions.
 
     Parameters
     ----------
@@ -142,8 +142,8 @@ class Stationary(Covariance):
 
 class ExpQuad(Stationary):
     R"""
-    The exponentiated quadratic kernel.  Also refered to as the squared
-    exponential, or radial basis function kernel.
+    The Exponentiated Quadratic kernel.  Also refered to as the Squared
+    Exponential, or Radial Basis Function kernel.
 
     .. math::
 
@@ -157,7 +157,7 @@ class ExpQuad(Stationary):
 
 class RatQuad(Stationary):
     R"""
-    The rational quadratic kernel.
+    The Rational Quadratic kernel.
 
     .. math::
 
@@ -220,7 +220,7 @@ class Exponential(Stationary):
 
 class Cosine(Stationary):
     R"""
-    The cosine kernel.
+    The Cosine kernel.
 
     .. math::
        k(x, x') = \mathrm{cos}\left( \frac{||x - x'||}{ \ell^2} \right)
@@ -233,7 +233,7 @@ class Cosine(Stationary):
 
 class Linear(Covariance):
     R"""
-    The linear kernel.
+    The Linear kernel.
 
     .. math::
        k(x, x') = (x - c)(x' - c)
@@ -255,7 +255,7 @@ class Linear(Covariance):
 
 class Polynomial(Linear):
     R"""
-    The polynomial covariance function.
+    The Polynomial kernel.
 
     .. math::
        k(x, x') = [(x - c)(x' - c) + \mathrm{offset}]^{d}
@@ -273,11 +273,11 @@ class Polynomial(Linear):
 
 class WarpedInput(Covariance):
     R"""
-    Warp the inputs of any covariance function using an arbitrary function
+    Warp the inputs of any kernel using an arbitrary function
     defined using Theano.
 
     .. math::
-       k_{\mathrm{warped}}(x, x') = k(w(x), w(x'))
+       k(x, x') = k(w(x), w(x'))
 
     Parameters
     ----------
@@ -308,18 +308,19 @@ class WarpedInput(Covariance):
 
 class Gibbs(Covariance):
     R"""
-    Use an arbitrary lengthscale function defined using Theano.  Operates on a single input dimension.
+    The Gibbs kernel.  Use an arbitrary lengthscale function defined
+    using Theano.  Only tested in one dimension.
 
     .. math::
-       k_{\mathrm{gibbs}}(x, x') = \sqrt{\frac{2\ell(x)\ell(x')}{\ell^2(x) + \ell^2(x')}}
-                                   \mathrm{exp}\left[ -\frac{(x - x')^2}{\ell(x)^2 + \ell^2(x')} \right]
+       k(x, x') = \sqrt{\frac{2\ell(x)\ell(x')}{\ell^2(x) + \ell^2(x')}}
+                  \mathrm{exp}\left[ -\frac{(x - x')^2}{\ell^2(x) + \ell^2(x')} \right]
 
     Parameters
     ----------
     lengthscale_func : callable
         Theano function of X and additional optional arguments.
     args : optional, tuple or list of scalars or PyMC3 variables
-        Additional inputs (besides X or Z) to warp_func.
+        Additional inputs (besides X or Z) to lengthscale_func.
     """
     def __init__(self, input_dim, lengthscale_func, args=None, active_dims=None):
         Covariance.__init__(self, input_dim, active_dims)


### PR DESCRIPTION
- small fixes to cov.py docstrings
- adds `gp.GP` and `gp.sample_gp` to API documentation

Should be consistent with calling things either kernels or covariance functions... I'm not sure what everyone decided what they liked best (see discussion in #1674).  