### PR TITLE
use normalized loss in VI

### DIFF
--- a/pymc3/variational/operators.py
+++ b/pymc3/variational/operators.py
@@ -14,4 +14,4 @@ class KL(Operator):
     """
     def apply(self, f):
         z = self.input
-        return self.logq(z) - self.logp(z)
+        return self.logq_norm(z) - self.logp_norm(z)

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -410,7 +410,7 @@ class Approximation(object):
 
     @property
     def normalizing_constant(self):
-        return tt.max([v.scaling for v in self.model.free_RVs])
+        return self.to_flat_input(tt.max([v.scaling for v in self.model.basic_RVs]))
 
     def _setup(self):
         pass

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -43,8 +43,19 @@ class Operator(object):
         p = theano.clone(p, {self.input: z})
         return p
 
+    def logp_norm(self, z):
+        t = self.approx.normalizing_constant
+        factors = [tt.sum(var.logpt)/t for var in self.model.basic_RVs + self.model.potentials]
+        logpt = tt.add(*factors)
+        p = self.approx.to_flat_input(logpt)
+        p = theano.clone(p, {self.input: z})
+        return p
+
     def logq(self, z):
         return self.approx.logq(z)
+
+    def logq_norm(self, z):
+        return self.approx.logq_norm(z)
 
     def apply(self, f):   # pragma: no cover
         """
@@ -396,6 +407,10 @@ class Approximation(object):
         self.grad_scale_op = GradScale(cost_part_grad_scale)
         self._setup()
         self.shared_params = self.create_shared_params()
+
+    @property
+    def normalizing_constant(self):
+        return tt.max([v.scaling for v in self.model.free_RVs])
 
     def _setup(self):
         pass
@@ -768,6 +783,9 @@ class Approximation(object):
         Total logq for approximation
         """
         return self.log_q_W_global(z) + self.log_q_W_local(z)
+
+    def logq_norm(self, z):
+        return self.logq(z) / self.normalizing_constant
 
     def view(self, space, name, reshape=True):
         """


### PR DESCRIPTION
Loss in VI with mini batches is upscaled to full dataset. This can cause overflow problems. In order to avoid them I downscale each factor of logp so that I get loss for minibatch only