### PR TITLE
Update to parameterized for travis and local testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 
 install:
   - . ./scripts/create_testenv.sh
-  - pip install coveralls pylint nose_parameterized
+  - pip install coveralls pylint
 
 env:
   - PYTHON_VERSION=2.7 TESTCMD="--durations=10 --ignore=pymc3/tests/test_examples.py --cov-append --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py"

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -42,10 +42,9 @@ if [ ${PYTHON_VERSION} == "2.7" ]; then
 fi
 
 pip install --upgrade pip
-pip install tqdm
 pip install --no-deps numdifftools
 pip install git+https://github.com/Theano/Theano.git
-pip install h5py
+pip install tqdm h5py parameterized
 
 if [ -z ${NO_SETUP} ]
 then


### PR DESCRIPTION
#1947 We import `theano.tests` in `test_math.py`, which requires this library.