### PR TITLE
Print warnings for some bad traces

### DIFF
--- a/pymc3/step_methods/compound.py
+++ b/pymc3/step_methods/compound.py
@@ -30,3 +30,8 @@ class CompoundStep(object):
             for method in self.methods:
                 point = method.step(point)
             return point
+
+    def check_trace(self, trace):
+        for method in self.methods:
+            if hasattr(self, 'check_trace'):
+                method.check_trace(trace)

--- a/pymc3/step_methods/compound.py
+++ b/pymc3/step_methods/compound.py
@@ -33,5 +33,5 @@ class CompoundStep(object):
 
     def check_trace(self, trace):
         for method in self.methods:
-            if hasattr(self, 'check_trace'):
+            if hasattr(method, 'check_trace'):
                 method.check_trace(trace)


### PR DESCRIPTION
Right now we don't report anything if a trace if obviously nonsense. This PR prints warnings if a trace does not meet some minimum requirements.
The test about the target acceptance probability is a bit hairy, I don't know any obvious choices for the threshold. The one I implemented works out to printing a warning if:
- If the target accept is 0.99, fail if mean accept is not between 0.96 and 0.9997.
- If target_accept = 0.8, fail if mean accept is not between 0.72, 0.87.
I'm open for better ideas...