### PR TITLE
Accept step method args in pm.sample

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -21,23 +21,23 @@ sys.setrecursionlimit(10000)
 
 __all__ = ['sample', 'iter_sample', 'sample_ppc', 'init_nuts']
 
+STEP_METHODS = (NUTS, HamiltonianMC, Metropolis, BinaryMetropolis,
+                BinaryGibbsMetropolis, Slice, CategoricalGibbsMetropolis)
 
-def assign_step_methods(model, step=None, methods=(NUTS, HamiltonianMC, Metropolis,
-                                                   BinaryMetropolis, BinaryGibbsMetropolis,
-                                                   Slice, CategoricalGibbsMetropolis)):
-    '''
-    Assign model variables to appropriate step methods. Passing a specified
-    model will auto-assign its constituent stochastic variables to step methods
-    based on the characteristics of the variables. This function is intended to
-    be called automatically from `sample()`, but may be called manually. Each
-    step method passed should have a `competence()` method that returns an
-    ordinal competence value corresponding to the variable passed to it. This
-    value quantifies the appropriateness of the step method for sampling the
-    variable.
+def assign_step_methods(model, step=None, methods=STEP_METHODS,
+                        step_kwargs=None):
+    """Assign model variables to appropriate step methods.
+
+    Passing a specified model will auto-assign its constituent stochastic
+    variables to step methods based on the characteristics of the variables.
+    This function is intended to be called automatically from `sample()`, but
+    may be called manually. Each step method passed should have a
+    `competence()` method that returns an ordinal competence value
+    corresponding to the variable passed to it. This value quantifies the
+    appropriateness of the step method for sampling the variable.
 
     Parameters
     ----------
-
     model : Model object
         A fully-specified model object
     step : step function or vector of step functions
@@ -46,12 +46,17 @@ def assign_step_methods(model, step=None, methods=(NUTS, HamiltonianMC, Metropol
     methods : vector of step method classes
         The set of step methods from which the function may choose. Defaults
         to the main step methods provided by PyMC3.
+    step_kwargs : dict
+        Parameters for the samplers. Keys are the lower case names of
+        the step method, values a dict of arguments.
 
     Returns
     -------
-    List of step methods associated with the model's variables.
-    '''
-
+    methods : list
+        List of step methods associated with the model's variables.
+    """
+    if step_kwargs is None:
+        step_kwargs = {}
     steps = []
     assigned_vars = set()
     if step is not None:
@@ -76,7 +81,18 @@ def assign_step_methods(model, step=None, methods=(NUTS, HamiltonianMC, Metropol
             selected_steps[selected].append(var)
 
     # Instantiate all selected step methods
-    steps += [step(vars=selected_steps[step]) for step in selected_steps if selected_steps[step]]
+    used_keys = set()
+    for step_class, vars in selected_steps.items():
+        if not vars:
+            continue
+        args = step_kwargs.get(step_class.name, {})
+        used_keys.add(step_class.name)
+        step = step_class(vars=vars, **args)
+        steps.append(step)
+
+    unused_args = set(step_kwargs).difference(used_keys)
+    if unused_args:
+        raise ValueError('Unused step method arguments: %s' % unused_args)
 
     if len(steps) == 1:
         steps = steps[0]
@@ -85,8 +101,9 @@ def assign_step_methods(model, step=None, methods=(NUTS, HamiltonianMC, Metropol
 
 
 def sample(draws, step=None, init='ADVI', n_init=200000, start=None,
-           trace=None, chain=0, njobs=1, tune=None, progressbar=True,
-           model=None, random_seed=-1, live_plot=False, **kwargs):
+           trace=None, chain=0, njobs=1, tune=None, step_kwargs=None,
+           progressbar=True, model=None, random_seed=-1, live_plot=False,
+           **kwargs):
     """Draw samples from the posterior using the given step methods.
 
     Multiple step methods are supported via compound step methods.
@@ -134,6 +151,20 @@ def sample(draws, step=None, init='ADVI', n_init=200000, start=None,
         in the system - 2.
     tune : int
         Number of iterations to tune, if applicable (defaults to None)
+    step_kwargs: dict
+        Options for step methods. Keys are the lower case names of
+        the step method, values are dicts of keyword arguments.
+        You can find a full list of arguments in the docstring of
+        the step methods.
+
+        Common arguments for the step method `"nuts"` are
+
+        * target_accept: float in [0, 1]. The step size is tuned such
+          that we approximate this acceptance rate. Higher values like 0.9
+          or 0.95 often work better for problematic posteriors.
+        * max_treedepth: The maximum depth of the trajectory tree.
+        * step_scale: float, default 0.25
+          The initial guess for the step size scaled down by `1/n**(1/4)`.
     progressbar : bool
         Whether or not to display a progress bar in the command line. The
         bar shows the percentage of completion, the sampling speed in
@@ -178,15 +209,21 @@ def sample(draws, step=None, init='ADVI', n_init=200000, start=None,
     if step is None and init is not None and pm.model.all_continuous(model.vars):
         # By default, use NUTS sampler
         pm._log.info('Auto-assigning NUTS sampler...')
+        args = step_kwargs if step_kwargs is not None else {}
+        args = args.get('nuts', {})
         start_, step = init_nuts(init=init, njobs=njobs, n_init=n_init,
                                  model=model, random_seed=random_seed,
-                                 progressbar=progressbar)
+                                 progressbar=progressbar, **args)
         if start is None:
             start = start_
     else:
         if step is not None and init is not None:
-            warnings.warn('Instantiated step methods cannot be automatically initialized. init argument ignored.')
-        step = assign_step_methods(model, step)
+            warnings.warn('Instantiated step methods cannot be automatically '
+                          'initialized. init argument ignored.')
+        if init is not None and not pm.model.all_continuous(model.vars):
+            warnings.warn('Automatic initialization is not supported '
+                          'for discrete variables. Ignoring init argument.')
+        step = assign_step_methods(model, step, step_kwargs=step_kwargs)
 
     if njobs is None:
         import multiprocessing as mp
@@ -219,7 +256,7 @@ def _sample(draws, step=None, start=None, trace=None, chain=0, tune=None,
             progressbar=True, model=None, random_seed=-1, live_plot=False,
             **kwargs):
     live_plot_args = {'skip_first': 0, 'refresh_every': 100}
-    live_plot_args = {arg: kwargs[arg] if arg in kwargs else live_plot_args[arg] for arg in live_plot_args}
+    live_plot_args.update(kwargs)
     skip_first = live_plot_args['skip_first']
     refresh_every = live_plot_args['refresh_every']
 

--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -22,6 +22,7 @@ def unif(step_size, elow=.85, ehigh=1.15):
 
 
 class HamiltonianMC(BaseHMC):
+    name = 'hmc'
     default_blocked = True
 
     def __init__(self, vars=None, path_length=2., step_rand=unif, **kwargs):

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -66,6 +66,8 @@ class NUTS(BaseHMC):
     .. [1] Hoffman, Matthew D., & Gelman, Andrew. (2011). The No-U-Turn Sampler:
        Adaptively Setting Path Lengths in Hamiltonian Monte Carlo.
     """
+    name = 'nuts'
+
     default_blocked = True
     generates_stats = True
     stats_dtypes = [{
@@ -107,13 +109,13 @@ class NUTS(BaseHMC):
         adapt_step_size : bool, default=True
             Whether step size adaptation should be enabled. If this is
             disabled, `k`, `t0`, `gamma` and `target_accept` are ignored.
+        max_treedepth : int, default=10
+            The maximum tree depth. Trajectories are stoped when this
+            depth is reached.
         integrator : str, default "leapfrog"
             The integrator to use for the trajectories. One of "leapfrog",
             "two-stage" or "three-stage". The second two can increase
             sampling speed for some high dimensional problems.
-        step_scale : float, default=0.25
-            Initial size of steps to take, automatically scaled down
-            by 1/n**(1/4).
         scaling : array_like, ndim = {1,2}
             The inverse mass, or precision matrix. One dimensional arrays are
             interpreted as diagonal matrices. If `is_cov` is set to True,

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -78,6 +78,8 @@ class Metropolis(ArrayStepShared):
     mode :  string or `Mode` instance.
         compilation mode passed to Theano functions
     """
+    name = 'metropolis'
+
     default_blocked = False
     generates_stats = True
     stats_dtypes = [{
@@ -225,6 +227,8 @@ class BinaryMetropolis(ArrayStep):
         Optional model for sampling step. Defaults to None (taken from context).
 
     """
+    name = 'binary_metropolis'
+
     generates_stats = True
     stats_dtypes = [{
         'accept': np.float64,
@@ -287,6 +291,7 @@ class BinaryMetropolis(ArrayStep):
 
 class BinaryGibbsMetropolis(ArrayStep):
     """A Metropolis-within-Gibbs step method optimized for binary variables"""
+    name = 'binary_gibbs_metropolis'
 
     def __init__(self, vars, order='random', model=None):
 
@@ -348,6 +353,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
        which was introduced by Liu in his 1996 technical report
        "Metropolized Gibbs Sampler: An Improvement".
     """
+    name = 'caregorical_gibbs_metropolis'
 
     def __init__(self, vars, proposal='uniform', order='random', model=None):
 

--- a/pymc3/step_methods/slicer.py
+++ b/pymc3/step_methods/slicer.py
@@ -27,6 +27,7 @@ class Slice(ArrayStep):
         Optional model for sampling step. Defaults to None (taken from context).
 
     """
+    name = 'slice'
     default_blocked = False
 
     def __init__(self, vars=None, w=1., tune=True, model=None, **kwargs):

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -69,6 +69,16 @@ class TestSample(SeededTest):
                           random_seed=self.random_seed)
 
 
+    def test_sample_nuts_args(self):
+        with self.model:
+            with pytest.raises(TypeError) as excinfo:
+                pm.sample(50, init=None, step_kwargs={'nuts': {'foo': 1}})
+            assert "'foo'" in str(excinfo.value)
+
+            with pytest.raises(ValueError) as excinfo:
+                pm.sample(50, init=None, step_kwargs={'foo': {}})
+            assert 'foo' in str(excinfo.value)
+
     def test_iter_sample(self):
         with self.model:
             samps = pm.sampling.iter_sample(5, self.step, self.start, random_seed=self.random_seed)

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -69,7 +69,7 @@ class TestSample(SeededTest):
                           random_seed=self.random_seed)
 
 
-    def test_sample_nuts_args(self):
+    def test_sample_args(self):
         with self.model:
             with pytest.raises(TypeError) as excinfo:
                 pm.sample(50, init=None, step_kwargs={'nuts': {'foo': 1}})
@@ -78,6 +78,12 @@ class TestSample(SeededTest):
             with pytest.raises(ValueError) as excinfo:
                 pm.sample(50, init=None, step_kwargs={'foo': {}})
             assert 'foo' in str(excinfo.value)
+
+            pm.sample(10, init=None, nuts_kwargs={'target_accept': 0.9})
+
+            with pytest.raises(ValueError) as excinfo:
+                pm.sample(5, init=None, step_kwargs={}, nuts_kwargs={})
+            assert 'Specify only one' in str(excinfo.value)
 
     def test_iter_sample(self):
         with self.model:


### PR DESCRIPTION
Add an option to pass kwargs for step methods though `pm.sample`.

Instead of (or in addition to) a general `step_kwargs` argument we could add a `nuts_kwargs`. That would avoid nested dicts: `pm.sample(..., step_kwargs={'nuts': {'target_accept': 0.95}})`.