### PR TITLE
Do not require a password for container notebook server

### DIFF
--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -9,4 +9,5 @@ docker run -d \
     -p $PORT:8888 \
     -v $SRC_DIR:/home/jovyan/pymc3 \
     -v $NOTEBOOK_DIR:/home/jovyan/work/ \
-    --name pymc3 pymc3
+    --name pymc3 pymc3 \
+    start-notebook.sh --NotebookApp.token=''


### PR DESCRIPTION
A recent Jupyter update enabled password protection on notebooks by default.  Since we are running this container locally, that's unnecessary and inconvenient.

![screen shot 2017-04-08 at 9 04 10 am](https://cloud.githubusercontent.com/assets/3465592/24829187/485c8298-1c3b-11e7-9c10-f69f017d3904.png)
