### PR TITLE
Close trace before validating traces

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -242,8 +242,6 @@ def _sample(draws, step=None, start=None, trace=None, chain=0, tune=None,
     finally:
         if progressbar:
             sampling.close()
-    if strace is not None:
-        strace.close()
     result = [] if strace is None else [strace]
     return MultiTrace(result)
 
@@ -324,6 +322,7 @@ def _iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
         strace.setup(draws, chain, step.stats_dtypes)
     else:
         strace.setup(draws, chain)
+
     try:
         for i in range(draws):
             if i == tune:
@@ -339,10 +338,15 @@ def _iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
                 strace.record(point)
             yield strace
     except KeyboardInterrupt:
+        strace.close()
         if hasattr(step, 'check_trace'):
             step.check_trace(strace)
         raise
+    except BaseException:
+        strace.close()
+        raise
     else:
+        strace.close()
         if hasattr(step, 'check_trace'):
             step.check_trace(strace)
 

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -231,13 +231,14 @@ class NUTS(BaseHMC):
 
         if n < 1000:
             warnings.warn('Chain %s contains only %s samples.' % (chain, n))
-        if np.all(diverging):
-            warnings.warn('Chain %s contains only diverging samples. '
-                          'The model is probably misspecified.' % chain)
         if np.all(tuning):
             warnings.warn('Step size tuning was enabled throughout the whole '
                           'trace. You might want to specify the number of '
                           'tuning steps.')
+        if np.all(diverging):
+            warnings.warn('Chain %s contains only diverging samples. '
+                          'The model is probably misspecified.' % chain)
+            return
         if np.any(diverging[~tuning]):
             warnings.warn("Chain %s contains diverging samples after tuning. "
                           "If increasing `target_accept` doesn't help, "


### PR DESCRIPTION
Fix a bug in #2002.
The trace was closed *after* the sanity check. In traces that were aborted with SIGINT that lead to false warnings, as values from missing samples are still present in the trace as zeros.