### PR TITLE
Automatically start browser from start_container

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,13 +110,10 @@ tools:
 We have provided a Dockerfile which helps for isolating build problems, and local development.
 Install [Docker](https://www.docker.com/) for your operating system, clone this repo, then
 run `./scripts/start_container.sh`. This should start a local docker container called `pymc3`,
-as well as a [`jupyter`](http://jupyter.org/) notebook server running on port 8888. You will have to open
-a browser at `localhost:8888`. The repo will be running the code from your local copy of `pymc3`,
+as well as a [`jupyter`](http://jupyter.org/) notebook server running on port 8888. The
+notebook should be opened in your browser automatically (you can disable this by passing
+`--no-browser`). The repo will be running the code from your local copy of `pymc3`,
 so it is good for development.  To find the token necessary to access the notebooks, run
-
-```bash
-$ docker exec -it pymc3 jupyter notebook list
-```
 
 You may also use it to run the test suite, with
 
@@ -128,6 +125,13 @@ $  . ./scripts/test.sh # takes a while!
 
 This should be quite close to how the tests run on TravisCI.
 
+If the container was started without opening the browser, you
+need the a token to work with the notebook. This token can be
+access with
+
+```
+docker exec -it pymc3 jupyter notebook list
+```
 
 ## Style guide
 

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -3,10 +3,16 @@
 PORT=${PORT:-8888}
 SRC_DIR=${SRC_DIR:-`pwd`}
 NOTEBOOK_DIR=${NOTEBOOK_DIR:-$SRC_DIR/notebooks}
+TOKEN=$(openssl rand -hex 24)
 
 docker build -t pymc3 $SRC_DIR/scripts
 docker run -d \
     -p $PORT:8888 \
     -v $SRC_DIR:/home/jovyan/pymc3 \
     -v $NOTEBOOK_DIR:/home/jovyan/work/ \
-    --name pymc3 pymc3
+    --name pymc3 pymc3 \
+    start-notebook.sh --NotebookApp.token=${TOKEN}
+
+if [[ $* != *--no-browser* ]]; then
+  python -m webbrowser "http://localhost:${PORT}/?token=${TOKEN}"
+fi


### PR DESCRIPTION
Replacement for #2008 and #2012
@AustinRochford Turns out jupyter does have some protection against csrf attacks, even without this token. It generates an independent token for that. The patch about the password wasn't as bad as I thought yesterday, sorry if I scared you there. 😇
I still think we shouldn't disable it, but I can't see anything wrong with generating our own. I don't have docker installed, but I think this should work. Could someone tests this?
Not sure if opening the browser should be the default (I'm not sure how people use this script in the first place), what do you think @ColCarroll @twiecki.