### PR TITLE
Ensure auto-transformed variables use specified starting values

### DIFF
--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -7,7 +7,7 @@ from ..math import logit, invlogit
 import numpy as np
 
 __all__ = ['transform', 'stick_breaking', 'logodds', 'interval',
-           'log', 'sum_to_1', 't_stick_breaking']
+          'lowerbound', 'upperbound', 'log', 'sum_to_1', 't_stick_breaking']
 
 
 class Transform(object):

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -6,7 +6,7 @@ from . import distribution
 from ..math import logit, invlogit
 import numpy as np
 
-__all__ = ['transform', 'stick_breaking', 'logodds',
+__all__ = ['transform', 'stick_breaking', 'logodds', 'interval',
            'log', 'sum_to_1', 't_stick_breaking']
 
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -989,19 +989,14 @@ class TransformedRV(TensorVariable):
         if type is None:
             type = distribution.type
         super(TransformedRV, self).__init__(type, owner, index, name)
+        
+        self.transformation = transform
 
         if distribution is not None:
             self.model = model
 
             transformed_name = "{}_{}_".format(name, transform.name)
-            bound_dict = {'a':None, 'b':None}
-            for key in bound_dict:
-                try:
-                    bound_dict[key] = transform.__dict__[key].eval()
-                except KeyError:
-                    pass
-            if bound_dict['a'] is not None or bound_dict['b'] is not None:
-                transformed_name += '({},{})_'.format(bound_dict['a'], bound_dict['b'])                  
+
             self.transformed = model.Var(
                 transformed_name, transform.apply(distribution), total_size=total_size)
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -994,6 +994,14 @@ class TransformedRV(TensorVariable):
             self.model = model
 
             transformed_name = "{}_{}_".format(name, transform.name)
+            bound_dict = {'a':None, 'b':None}
+            for key in bound_dict:
+                try:
+                    bound_dict[key] = transform.__dict__[key].eval()
+                except KeyError:
+                    pass
+            if bound_dict['a'] is not None or bound_dict['b'] is not None:
+                transformed_name += '({},{})_'.format(bound_dict['a'], bound_dict['b'])                  
             self.transformed = model.Var(
                 transformed_name, transform.apply(distribution), total_size=total_size)
 

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -348,9 +348,9 @@ def _iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
     strace = _choose_backend(trace, chain, model=model)
 
     if len(strace) > 0:
-        _soft_update(start, strace.point(-1), model)
+        _update_start_vals(start, strace.point(-1), model)
     else:
-        _soft_update(start, model.test_point, model)
+        _update_start_vals(start, model.test_point, model)
 
     try:
         step = CompoundStep(step)
@@ -457,7 +457,7 @@ def stop_tuning(step):
 
     return step
 
-def _soft_update(a, b, model):
+def _update_start_vals(a, b, model):
     """Update a with b, without overwriting existing keys. Values specified for
     transformed variables on the original scale are also transformed and inserted.
     """

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -476,7 +476,7 @@ def _transformed_init(a, b):
         for tname in b:
             if tname.startswith(name) and tname!=name:
                 transform = tname.split(name)[-1][1:-1]
-                transform_func = distributions.__dict__[transform]
+                transform_func = distributions.transforms.__dict__[transform]
                 b[tname] = transform_func.forward(a[name]).eval()
                 
     return b

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -461,6 +461,15 @@ def stop_tuning(step):
 def _transformed_init(a, b):
     """Transforms original starting values for transformed variables specified by 
     the user (dict a) and inserts them into the init dict (dict b).
+    
+    Examples
+    --------
+    .. code:: ipython
+
+        >>> a = {'alpha': 5.0}
+        >>> b = {'alpha_log_': 0}
+        >>> _transformed_init(a, b)
+        {'alpha_log_': array(1.6094379425048828, dtype=float32)}
     """
 
     for name in a:

--- a/pymc3/tests/test_diagnostics.py
+++ b/pymc3/tests/test_diagnostics.py
@@ -21,7 +21,7 @@ class TestGelmanRubin(SeededTest):
             # Run sampler
             step1 = Slice([model.early_mean_log_, model.late_mean_log_])
             step2 = Metropolis([model.switchpoint])
-            start = {'early_mean': 7., 'late_mean': 1., 'switchpoint': 100}
+            start = {'early_mean': 7., 'late_mean': 5., 'switchpoint': 10}
             ptrace = sample(n_samples, step=[step1, step2], start=start, njobs=2, 
                     progressbar=False, random_seed=[20090425, 19700903])
         return ptrace

--- a/pymc3/tests/test_diagnostics.py
+++ b/pymc3/tests/test_diagnostics.py
@@ -21,7 +21,7 @@ class TestGelmanRubin(SeededTest):
             # Run sampler
             step1 = Slice([model.early_mean_log_, model.late_mean_log_])
             step2 = Metropolis([model.switchpoint])
-            start = {'early_mean': 3., 'late_mean': 1., 'switchpoint': 100}
+            start = {'early_mean': 7., 'late_mean': 1., 'switchpoint': 100}
             ptrace = sample(n_samples, step=[step1, step2], start=start, njobs=2, 
                     progressbar=False, random_seed=[20090425, 19700903])
         return ptrace
@@ -35,7 +35,7 @@ class TestGelmanRubin(SeededTest):
 
     def test_bad(self):
         """Confirm Gelman-Rubin statistic is far from 1 for a small number of samples."""
-        n_samples = 10
+        n_samples = 5
         rhat = gelman_rubin(self.get_ptrace(n_samples))
         assert not all(1 / self.good_ratio < r <
                              self.good_ratio for r in rhat.values())
@@ -43,7 +43,7 @@ class TestGelmanRubin(SeededTest):
     def test_right_shape_python_float(self, shape=None, test_shape=None):
         """Check Gelman-Rubin statistic shape is correct w/ python float"""
         n_jobs = 3
-        n_samples = 10
+        n_samples = 5
 
         with Model():
             if shape is not None:

--- a/pymc3/tests/test_diagnostics.py
+++ b/pymc3/tests/test_diagnostics.py
@@ -21,7 +21,7 @@ class TestGelmanRubin(SeededTest):
             # Run sampler
             step1 = Slice([model.early_mean_log_, model.late_mean_log_])
             step2 = Metropolis([model.switchpoint])
-            start = {'early_mean': 7., 'late_mean': 1., 'switchpoint': 100}
+            start = {'early_mean': 3., 'late_mean': 1., 'switchpoint': 100}
             ptrace = sample(n_samples, step=[step1, step2], start=start, njobs=2, 
                     progressbar=False, random_seed=[20090425, 19700903])
         return ptrace

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -1,5 +1,7 @@
 from itertools import combinations
 import numpy as np
+from numpy.testing import assert_almost_equal
+
 try:
     import unittest.mock as mock  # py3
 except ImportError:
@@ -117,6 +119,12 @@ class SoftUpdate(SeededTest):
         test_point = {'a': 3, 'b': 4}
         pm.sampling._soft_update(start, test_point)
         assert start == test_point
+        
+    def test_soft_update_transformed(self):
+        start = {'a': 2}
+        test_point = {'a_log_': 0}
+        pm.sampling._soft_update(start, test_point)
+        assert assert_almost_equal(start['a_log_'], np.log(start['a']))
 
 
 class TestNamedSampling(SeededTest):


### PR DESCRIPTION
Currently starting values specified for variables that are auto-transformed are ignored by `sample`. This adds a function `_transformed_init` which ensures these values are properly transformed and included in the `start` dict.

Closes #2042 