### PR TITLE
Switch MAP solver to one that supports float32 in test_linear

### DIFF
--- a/pymc3/tests/test_distributions_timeseries.py
+++ b/pymc3/tests/test_distributions_timeseries.py
@@ -38,7 +38,7 @@ def test_linear():
         Normal('zh', mu=xh, sd=5e-3, observed=z)
     # invert
     with model:
-        start = find_MAP(vars=[xh], fmin=fmin_bfgs)  # So l_bfgs_b requires float64 dtypes and won't work for floatX
+        start = find_MAP(vars=[xh], fmin=fmin_bfgs)  # So fmin_l_bfgs_b requires float64 dtypes and won't work for floatX; use fmin_bfgs instead
         warmup = sample(200, NUTS(scaling=start))
         trace = sample(1000, NUTS(scaling=warmup[-1], gamma=0.25), start=warmup[-1])
     ppc = sample_ppc(trace, model=model)


### PR DESCRIPTION
In getting test_linear to work on the GPU, I noticed that it called `find_MAP()` with the fortran `l_bfgs_b()` scipy solver.  However, this solver seems to hard-code float64 variables, so I switched to the python BFGS solver in scipy, which is written in numpy and seems to handle different float precision modes.  

The old error is here: https://gist.github.com/kyleabeauchamp/477f16f910b63a5aaa23bbe6d2f1fbf9