### PR TITLE
metrop_accept returns whether the sample was accepted

### DIFF
--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -159,7 +159,8 @@ def metrop_select(mr, q, q0):
     """Perform rejection/acceptance step for Metropolis class samplers.
 
     Returns the new sample q if a uniform random number is less than the
-    metropolis acceptance rate (`mr`), and the old sample otherwise.
+    metropolis acceptance rate (`mr`), and the old sample otherwise, along
+    with a boolean indicating whether the sample was accepted.
 
     Parameters
     ----------
@@ -173,6 +174,6 @@ def metrop_select(mr, q, q0):
     """
     # Compare acceptance ratio to uniform random number
     if np.isfinite(mr) and np.log(uniform()) < mr:
-        return q
+        return q, True
     else:
-        return q0
+        return q0, False

--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -64,7 +64,7 @@ class HamiltonianMC(BaseHMC):
         initial_energy = self.compute_energy(q, p)
         q, p, current_energy = self.leapfrog(q, p, e, n_steps)
         energy_change = initial_energy - current_energy
-        return metrop_select(energy_change, q, q0)
+        return metrop_select(energy_change, q, q0)[0]
 
     @staticmethod
     def competence(var):

--- a/pymc3/step_methods/smc.py
+++ b/pymc3/step_methods/smc.py
@@ -31,7 +31,7 @@ import numpy.random as nr
 from .arraystep import metrop_select
 from ..backends import smc_text as atext
 
-__all__ = ('SMC', 'ATMIP_sample')
+__all__ = ['SMC', 'ATMIP_sample']
 
 EXPERIMENTAL_WARNING = "Warning: SMC is an experimental step method, and not yet"\
     " recommended for use in PyMC3!"
@@ -242,10 +242,10 @@ class SMC(atext.ArrayStepSharedLLK):
 
                 if np.isfinite(varlogp):
                     logp = self.logp_forw(q)
-                    q_new = metrop_select(
+                    q_new, accepted = metrop_select(
                         self.beta * (logp[self._llk_index] - l0[self._llk_index]), q, q0)
 
-                    if q_new is q:
+                    if accepted:
                         self.accepted += 1
                         l_new = logp
                         self.chain_previous_lpoint[self.chain_index] = l_new
@@ -257,10 +257,10 @@ class SMC(atext.ArrayStepSharedLLK):
 
             else:
                 logp = self.logp_forw(q)
-                q_new = metrop_select(
+                q_new, accepted = metrop_select(
                     self.beta * (logp[self._llk_index] - l0[self._llk_index]), q, q0)
 
-                if q_new is q:
+                if accepted:
                     self.accepted += 1
                     l_new = logp
                     self.chain_previous_lpoint[self.chain_index] = l_new


### PR DESCRIPTION
With the metropolis acceptance step, we were always (except in `HamiltonianMC`) checking whether a proposal had been accepted just after returning.  This makes `metrop_accept` return a tuple instead, and I think makes the code a little more readable.