### PR TITLE
Simplify obj_optimizer to optimizer

### DIFF
--- a/pymc3/data.py
+++ b/pymc3/data.py
@@ -119,7 +119,7 @@ class DataSampler(object):
     ...                          observed=minibatches,
     ...                          total_size=data.shape[0])
     ...     adam = partial(pm.adam, learning_rate=.8) # easy problem
-    ...     approx = pm.fit(10000, method='advi', obj_optimizer=adam)
+    ...     approx = pm.fit(10000, method='advi', optimizer=adam)
     >>> new = pickle.loads(pickle.dumps(approx))
     >>> new #doctest: +ELLIPSIS
     <pymc3.variational.approximations.MeanField object at 0x...>

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -58,7 +58,7 @@ def _test_aevb(self):
     rho = theano.shared(np.zeros_like(x.init_value))
     with model:
         inference = self.inference(local_rv={x: (mu, rho)})
-        approx = inference.fit(3, obj_n_mc=2, obj_optimizer=self.optimizer)
+        approx = inference.fit(3, obj_n_mc=2, optimizer=self.optimizer)
         approx.sample_vp(10)
         approx.apply_replacements(
             y,
@@ -145,7 +145,7 @@ class TestApproximates:
                 Normal('x', mu=mu_, sd=sd, observed=data)
                 inf = self.inference()
                 inf.fit(10)
-                approx = inf.fit(self.NITER, obj_optimizer=self.optimizer)
+                approx = inf.fit(self.NITER, optimizer=self.optimizer)
                 trace = approx.sample_vp(10000)
             np.testing.assert_allclose(np.mean(trace['mu']), mu_post, rtol=0.1)
             np.testing.assert_allclose(np.std(trace['mu']), np.sqrt(1. / d), rtol=0.4)
@@ -172,7 +172,7 @@ class TestApproximates:
                 mu_ = Normal('mu', mu=mu0, sd=sd0, testval=0)
                 Normal('x', mu=mu_, sd=sd, observed=minibatches, total_size=n)
                 inf = self.inference()
-                approx = inf.fit(self.NITER * 3, obj_optimizer=self.optimizer)
+                approx = inf.fit(self.NITER * 3, optimizer=self.optimizer)
                 trace = approx.sample_vp(10000)
             np.testing.assert_allclose(np.mean(trace['mu']), mu_post, rtol=0.1)
             np.testing.assert_allclose(np.std(trace['mu']), np.sqrt(1. / d), rtol=0.4)
@@ -203,7 +203,7 @@ class TestApproximates:
                 mu_ = Normal('mu', mu=mu0, sd=sd0, testval=0)
                 Normal('x', mu=mu_, sd=sd, observed=data_t, total_size=n)
                 inf = self.inference()
-                approx = inf.fit(self.NITER * 3, callbacks=[cb], obj_n_mc=10, obj_optimizer=self.optimizer)
+                approx = inf.fit(self.NITER * 3, callbacks=[cb], obj_n_mc=10, optimizer=self.optimizer)
                 trace = approx.sample_vp(10000)
             np.testing.assert_allclose(np.mean(trace['mu']), mu_post, rtol=0.4)
             np.testing.assert_allclose(np.std(trace['mu']), np.sqrt(1. / d), rtol=0.4)
@@ -246,7 +246,7 @@ class TestMeanField(TestApproximates.Base):
             inf.fit(10)
             assert len(inf.hist) == 10
             assert not np.isnan(inf.hist).any()
-            inf.fit(self.NITER, obj_optimizer=self.optimizer)
+            inf.fit(self.NITER, optimizer=self.optimizer)
             assert len(inf.hist) == self.NITER + 10
             assert not np.isnan(inf.hist).any()
 

--- a/pymc3/variational/operators.py
+++ b/pymc3/variational/operators.py
@@ -24,13 +24,13 @@ class KL(Operator):
 
 
 class KSDObjective(ObjectiveFunction):
-    def add_obj_updates(self, updates, obj_n_mc=None, obj_optimizer=adam,
+    def add_obj_updates(self, updates, obj_n_mc=None, optimizer=adam,
                         more_obj_params=None, more_replacements=None):
         if obj_n_mc is not None:
             _warn_not_used('obj_n_mc', self.op)
         d_obj_padams = self(None)
         d_obj_padams = theano.clone(d_obj_padams, more_replacements, strict=False)
-        updates.update(obj_optimizer([d_obj_padams], self.obj_params))
+        updates.update(optimizer([d_obj_padams], self.obj_params))
 
     def __call__(self, z):
         return self.op.apply(self.tf)

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -61,7 +61,7 @@ class ObjectiveFunction(object):
         """
         return self.op.approx.random(size)
 
-    def updates(self, obj_n_mc=None, tf_n_mc=None, obj_optimizer=adam, test_optimizer=adam,
+    def updates(self, obj_n_mc=None, tf_n_mc=None, optimizer=adam, test_optimizer=adam,
                 more_obj_params=None, more_tf_params=None, more_updates=None, more_replacements=None):
         """
         Calculates gradients for objective function, test function and then
@@ -73,7 +73,7 @@ class ObjectiveFunction(object):
             Number of monte carlo samples used for approximation of objective gradients
         tf_n_mc : int
             Number of monte carlo samples used for approximation of test function gradients
-        obj_optimizer : function (loss, params) -> updates
+        optimizer : function (loss, params) -> updates
             Optimizer that is used for objective params
         test_optimizer : function (loss, params) -> updates
             Optimizer that is used for test function params
@@ -119,7 +119,7 @@ class ObjectiveFunction(object):
         self.add_obj_updates(
             resulting_updates,
             obj_n_mc=obj_n_mc,
-            obj_optimizer=obj_optimizer,
+            optimizer=optimizer,
             more_obj_params=more_obj_params,
             more_replacements=more_replacements
         )
@@ -132,17 +132,17 @@ class ObjectiveFunction(object):
         tf_target = theano.clone(tf_target, more_replacements, strict=False)
         updates.update(test_optimizer(tf_target, self.test_params + more_tf_params))
 
-    def add_obj_updates(self, updates, obj_n_mc=None, obj_optimizer=adam, more_obj_params=None, more_replacements=None):
+    def add_obj_updates(self, updates, obj_n_mc=None, optimizer=adam, more_obj_params=None, more_replacements=None):
         obj_z = self.random(obj_n_mc)
         obj_target = self(obj_z)
         obj_target = theano.clone(obj_target, more_replacements, strict=False)
-        updates.update(obj_optimizer(obj_target, self.obj_params + more_obj_params))
+        updates.update(optimizer(obj_target, self.obj_params + more_obj_params))
         if self.op.RETURNS_LOSS:
             updates.loss = obj_target
 
     @memoize
     def step_function(self, obj_n_mc=None, tf_n_mc=None,
-                      obj_optimizer=adam, test_optimizer=adam,
+                      optimizer=adam, test_optimizer=adam,
                       more_obj_params=None, more_tf_params=None,
                       more_updates=None, more_replacements=None, score=False,
                       fn_kwargs=None):
@@ -160,7 +160,7 @@ class ObjectiveFunction(object):
             Number of monte carlo samples used for approximation of objective gradients
         tf_n_mc : int
             Number of monte carlo samples used for approximation of test function gradients
-        obj_optimizer : function (loss, params) -> updates
+        optimizer : function (loss, params) -> updates
             Optimizer that is used for objective params
         test_optimizer : function (loss, params) -> updates
             Optimizer that is used for test function params
@@ -186,7 +186,7 @@ class ObjectiveFunction(object):
         if score and not self.op.RETURNS_LOSS:
             raise NotImplementedError('%s does not have loss' % self.op)
         updates = self.updates(obj_n_mc=obj_n_mc, tf_n_mc=tf_n_mc,
-                               obj_optimizer=obj_optimizer,
+                               optimizer=optimizer,
                                test_optimizer=test_optimizer,
                                more_obj_params=more_obj_params,
                                more_tf_params=more_tf_params,


### PR DESCRIPTION
Since there is only one optimizer to specify, I'm replacing the `obj_optimizer` keyword with just `optimizer`, which is simpler and easier to remember.