### PR TITLE
Partial GPU fix for test_hmc

### DIFF
--- a/pymc3/tests/test_math.py
+++ b/pymc3/tests/test_math.py
@@ -3,6 +3,7 @@ import theano
 from theano.tests import unittest_tools as utt
 from pymc3.math import LogDet, logdet, probit, invprobit
 from .helpers import SeededTest
+import pytest
 
 
 def test_probit():
@@ -30,6 +31,7 @@ class TestLogDet(SeededTest):
         # Test gradient:
         utt.verify_grad(self.op, [input_mat])
 
+    @pytest.mark.skipif(theano.config.device in ["cuda", "gpu"], reason="No logDet implementation on GPU.")
     def test_basic(self):
         # Calls validate with different params
         test_case_1 = np.random.randn(3, 3) / np.sqrt(3)


### PR DESCRIPTION
This fixes test_leapfrog_reversible and applies the same patches to test_leapfrog_reversible_single.  However, test_leapfrog_reversible_single is still busted.  

I accidentally included my previous PR (test_math) in this one, but that shouldn't matter once the other is merged.
