### PR TITLE
Fix typo

### DIFF
--- a/docs/source/notebooks/getting_started.ipynb
+++ b/docs/source/notebooks/getting_started.ipynb
@@ -109,7 +109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here is what the simulated data look like. We use the `pylab` module from the plotting library matplotlib. "
+    "Here is what the simulated data look like. We use the `plt` module from the plotting library matplotlib. "
    ]
   },
   {
@@ -1456,21 +1456,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/getting_started.ipynb
+++ b/docs/source/notebooks/getting_started.ipynb
@@ -109,7 +109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here is what the simulated data look like. We use the `plt` module from the plotting library matplotlib. "
+    "Here is what the simulated data look like. We use the `pyplot` module from the plotting library matplotlib. "
    ]
   },
   {


### PR DESCRIPTION
Replaces `pylab` with `plt` in the `getting_started` notebook, as reported in #2069 .