### PR TITLE
Use helper function to check for transformed variables

### DIFF
--- a/pymc3/backends/tracetab.py
+++ b/pymc3/backends/tracetab.py
@@ -4,7 +4,7 @@
 import numpy as np
 import pandas as pd
 
-from .model import is_transformed_name
+from ..util import get_default_varnames
 
 __all__ = ['trace_to_dataframe']
 
@@ -28,18 +28,16 @@ def trace_to_dataframe(trace, chains=None, varnames=None, hide_transformed_vars=
     var_shapes = trace._straces[0].var_shapes
 
     if varnames is None:
-        varnames = var_shapes.keys()
+        varnames = get_default_varnames(var_shapes.keys(),
+                                        include_transformed=not hide_transformed_vars)
 
-    flat_names = {v: create_flat_names(v, shape) for v, shape in var_shapes.items()
-                  if not (hide_transformed_vars and is_transformed_name(v))}
+    flat_names = {v: create_flat_names(v, var_shapes[v]) for v in varnames}
 
     var_dfs = []
     for v in var_shapes:
-        if v in varnames:
-            if not hide_transformed_vars or not is_transformed_name(v):
-                vals = trace.get_values(v, combine=True, chains=chains)
-                flat_vals = vals.reshape(vals.shape[0], -1)
-                var_dfs.append(pd.DataFrame(flat_vals, columns=flat_names[v]))
+        vals = trace.get_values(v, combine=True, chains=chains)
+        flat_vals = vals.reshape(vals.shape[0], -1)
+        var_dfs.append(pd.DataFrame(flat_vals, columns=flat_names[v]))
     return pd.concat(var_dfs, axis=1)
 
 

--- a/pymc3/backends/tracetab.py
+++ b/pymc3/backends/tracetab.py
@@ -4,6 +4,8 @@
 import numpy as np
 import pandas as pd
 
+from .model import is_transformed_name
+
 __all__ = ['trace_to_dataframe']
 
 
@@ -28,14 +30,13 @@ def trace_to_dataframe(trace, chains=None, varnames=None, hide_transformed_vars=
     if varnames is None:
         varnames = var_shapes.keys()
 
-    flat_names = {v: create_flat_names(v, shape)
-                    for v, shape in var_shapes.items()
-                    if not (hide_transformed_vars and v.endswith('_'))}
+    flat_names = {v: create_flat_names(v, shape) for v, shape in var_shapes.items()
+                  if not (hide_transformed_vars and is_transformed_name(v))}
 
     var_dfs = []
     for v in var_shapes:
         if v in varnames:
-            if not hide_transformed_vars or not v.endswith('_'):
+            if not hide_transformed_vars or not is_transformed_name(v):
                 vals = trace.get_values(v, combine=True, chains=chains)
                 flat_vals = vals.reshape(vals.shape[0], -1)
                 var_dfs.append(pd.DataFrame(flat_vals, columns=flat_names[v]))

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -14,6 +14,7 @@ from .memoize import memoize
 from .theanof import gradient, hessian, inputvars, generator
 from .vartypes import typefilter, discrete_types, continuous_types, isgenerator
 from .blocking import DictToArrayBijection, ArrayOrdering
+from .util import get_transformed_name
 
 __all__ = [
     'Model', 'Factor', 'compilef', 'fn', 'fastfn', 'modelcontext',
@@ -21,55 +22,6 @@ __all__ = [
 ]
 
 FlatView = collections.namedtuple('FlatView', 'input, replacements, view')
-
-
-def get_transformed_name(name, transform):
-    """
-    Consistent way of transforming names
-
-    Parameters
-    ----------
-    name : str
-        Name to transform
-    transform : object
-        Should be a subclass of `transforms.Transform`
-
-    Returns:
-    A string to use for the transformed variable
-    """
-    return "{}_{}__".format(name, transform.name)
-
-
-def is_transformed_name(name):
-    """
-    Quickly check if a name was transformed with `get_transormed_name`
-
-    Parameters
-    ----------
-    name : str
-        Name to check
-
-    Returns:
-    Boolean, whether the string could have been produced by `get_transormed_name`
-    """
-    return name.endswith('__') and name.count('_') >= 3
-
-
-def get_untransformed_name(name):
-    """
-    Undo transformation in `get_transformed_name`. Throws ValueError if name wasn't transformed
-
-    Parameters
-    ----------
-    name : str
-        Name to untransform
-
-    Returns:
-    String with untransformed version of the name.
-    """
-    if not is_transformed_name(name):
-        raise ValueError(u'{} does not appear to be a transformed name'.format(name))
-    return '_'.join(name.split('_')[:-3])
 
 
 class InstanceMethod(object):

--- a/pymc3/plots/autocorrplot.py
+++ b/pymc3/plots/autocorrplot.py
@@ -44,7 +44,7 @@ def autocorrplot(trace, varnames=None, max_lag=100, burn=0, plot_transformed=Fal
             yield varname
 
     if varnames is None:
-        varnames = get_default_varnames(trace, plot_transformed)
+        varnames = get_default_varnames(trace.varnames, plot_transformed)
 
     varnames = list(itertools.chain.from_iterable(map(_handle_array_varnames, varnames)))
 

--- a/pymc3/plots/forestplot.py
+++ b/pymc3/plots/forestplot.py
@@ -40,7 +40,7 @@ def _make_rhat_plot(trace, ax, title, labels, varnames, include_transformed):
 
     """
     if varnames is None:
-        varnames = get_default_varnames(trace, include_transformed)
+        varnames = get_default_varnames(trace.varnames, include_transformed)
 
     R = gelman_rubin(trace)
     R = {v: R[v] for v in varnames}
@@ -182,7 +182,7 @@ def forestplot(trace_obj, varnames=None, transform=identity_transform, alpha=0.0
     nchains = trace_obj.nchains
 
     if varnames is None:
-        varnames = get_default_varnames(trace_obj, plot_transformed)
+        varnames = get_default_varnames(trace_obj.varnames, plot_transformed)
 
     plot_rhat = (rhat and nchains > 1)
     # Empty list for y-axis labels

--- a/pymc3/plots/posteriorplot.py
+++ b/pymc3/plots/posteriorplot.py
@@ -84,7 +84,7 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
                           alpha_level=alpha_level, ref_val=ref_val, rope=rope, **kwargs)
     else:
         if varnames is None:
-            varnames = get_default_varnames(trace, plot_transformed)
+            varnames = get_default_varnames(trace.varnames, plot_transformed)
 
         trace_dict = get_trace_dict(trace, varnames)
 

--- a/pymc3/plots/traceplot.py
+++ b/pymc3/plots/traceplot.py
@@ -71,7 +71,7 @@ def traceplot(trace, varnames=None, transform=identity_transform, figsize=None, 
     trace = trace[skip_first:]
 
     if varnames is None:
-        varnames = get_default_varnames(trace, plot_transformed)
+        varnames = get_default_varnames(trace.varnames, plot_transformed)
 
     if figsize is None:
         figsize = (12, len(varnames) * 2)

--- a/pymc3/plots/utils.py
+++ b/pymc3/plots/utils.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.signal import gaussian, convolve
 # plotting utilities can all be in this namespace
-from ..util import get_default_varnames  # noqa
+from ..util import get_default_varnames  # pylint: disable=unused-import
 
 
 def identity_transform(x):

--- a/pymc3/plots/utils.py
+++ b/pymc3/plots/utils.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.signal import gaussian, convolve
+from .model import is_transformed_name
 
 
 def identity_transform(x):
@@ -13,7 +14,7 @@ def get_default_varnames(trace, include_transformed):
     if include_transformed:
         return [name for name in trace.varnames]
     else:
-        return [name for name in trace.varnames if not name.endswith('_')]
+        return [name for name in trace.varnames if not is_transformed_name(name)]
 
 
 def get_axis(ax, default_rows, default_columns, **default_kwargs):

--- a/pymc3/plots/utils.py
+++ b/pymc3/plots/utils.py
@@ -1,20 +1,13 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.signal import gaussian, convolve
-from .model import is_transformed_name
+# plotting utilities can all be in this namespace
+from ..util import get_default_varnames  # noqa
 
 
 def identity_transform(x):
     """f(x) = x"""
     return x
-
-
-def get_default_varnames(trace, include_transformed):
-    """Helper to extract default varnames from a trace."""
-    if include_transformed:
-        return [name for name in trace.varnames]
-    else:
-        return [name for name in trace.varnames if not is_transformed_name(name)]
 
 
 def get_axis(ax, default_rows, default_columns, **default_kwargs):

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -7,11 +7,12 @@ import numpy as np
 import pymc3 as pm
 from .backends.base import merge_traces, BaseTrace, MultiTrace
 from .backends.ndarray import NDArray
-from .model import modelcontext, Point, is_transformed_name, get_untransformed_name
+from .model import modelcontext, Point
 from .step_methods import (NUTS, HamiltonianMC, Metropolis, BinaryMetropolis,
                            BinaryGibbsMetropolis, CategoricalGibbsMetropolis,
                            Slice, CompoundStep)
 from .plots.traceplot import traceplot
+from .util import is_transformed_name, get_untransformed_name
 from tqdm import tqdm
 
 import sys

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -6,7 +6,7 @@ import itertools
 import sys
 import warnings
 from collections import namedtuple
-from .model import modelcontext
+from .model import modelcontext, is_transformed_name
 
 from scipy.misc import logsumexp
 from scipy.stats.distributions import pareto
@@ -98,7 +98,7 @@ def autocov(x, lag=1):
 
 def dic(trace, model=None):
     """Calculate the deviance information criterion of the samples in trace from model
-    Read more theory here - in a paper by some of the leading authorities on Model Selection - 
+    Read more theory here - in a paper by some of the leading authorities on Model Selection -
     dx.doi.org/10.1111/1467-9868.00353
 
     Parameters
@@ -271,7 +271,7 @@ def loo(trace, model=None, pointwise=False):
 def bpic(trace, model=None):
     """
     Calculates Bayesian predictive information criterion n of the samples in trace from model
-    Read more theory here - in a paper by some of the leading authorities on Model Selection - 
+    Read more theory here - in a paper by some of the leading authorities on Model Selection -
     dx.doi.org/10.1111/1467-9868.00353
 
     Parameters
@@ -637,7 +637,7 @@ def df_summary(trace, varnames=None, stat_funcs=None, extend=False, include_tran
         if include_transformed:
             varnames = [name for name in trace.varnames]
         else:
-            varnames = [name for name in trace.varnames if not name.endswith('_')]
+            varnames = [name for name in trace.varnames if not is_transformed_name(name)]
 
     if batches is None:
         batches = min([100, len(trace)])
@@ -704,7 +704,7 @@ def summary(trace, varnames=None, transform=lambda x: x, alpha=0.05, start=0,
         if include_transformed:
             varnames = [name for name in trace.varnames]
         else:
-            varnames = [name for name in trace.varnames if not name.endswith('_')]
+            varnames = [name for name in trace.varnames if not is_transformed_name(name)]
 
     if batches is None:
         batches = min([100, len(trace)])

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -6,7 +6,8 @@ import itertools
 import sys
 import warnings
 from collections import namedtuple
-from .model import modelcontext, is_transformed_name
+from .model import modelcontext
+from .util import get_default_varnames
 
 from scipy.misc import logsumexp
 from scipy.stats.distributions import pareto
@@ -634,10 +635,7 @@ def df_summary(trace, varnames=None, stat_funcs=None, extend=False, include_tran
         mu__1  0.067513 -0.159097 -0.045637  0.062912
     """
     if varnames is None:
-        if include_transformed:
-            varnames = [name for name in trace.varnames]
-        else:
-            varnames = [name for name in trace.varnames if not is_transformed_name(name)]
+        varnames = get_default_varnames(trace.varnames, include_transformed=include_transformed)
 
     if batches is None:
         batches = min([100, len(trace)])
@@ -701,10 +699,7 @@ def summary(trace, varnames=None, transform=lambda x: x, alpha=0.05, start=0,
       File to write results to. If not given, print to stdout.
     """
     if varnames is None:
-        if include_transformed:
-            varnames = [name for name in trace.varnames]
-        else:
-            varnames = [name for name in trace.varnames if not is_transformed_name(name)]
+        varnames = get_default_varnames(trace.varnames, include_transformed=include_transformed)
 
     if batches is None:
         batches = min([100, len(trace)])

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -3,12 +3,10 @@ import scipy.stats as stats
 import numpy as np
 import pymc3 as pm
 from pymc3.distributions import HalfCauchy, Normal
-from pymc3.distributions.transforms import Transform
 from pymc3 import Potential, Deterministic
 from pymc3.theanof import generator
 from .helpers import select_by_precision
 import pytest
-
 
 
 def gen1():
@@ -194,28 +192,3 @@ class TestScaling(object):
             g1 = grad1(1)
             g2 = grad2(1)
             np.testing.assert_almost_equal(g1, g2)
-
-
-class TestTransformName(object):
-    cases = [
-        ('var', 'var_test__'),
-        ('var_test_', 'var_test__test__')
-    ]
-    transform_name = 'test'
-
-    def test_get_transformed_name(self):
-        test_transform = Transform()
-        test_transform.name = self.transform_name
-        for name, transformed in self.cases:
-            assert pm.model.get_transformed_name(name, test_transform) == transformed
-
-    def test_is_transformed_name(self):
-        for name, transformed in self.cases:
-            assert pm.model.is_transformed_name(transformed)
-            assert not pm.model.is_transformed_name(name)
-
-    def test_get_untransformed_name(self):
-        for name, transformed in self.cases:
-            assert pm.model.get_untransformed_name(transformed) == name
-            with pytest.raises(ValueError):
-                pm.model.get_untransformed_name(name)

--- a/pymc3/tests/test_util.py
+++ b/pymc3/tests/test_util.py
@@ -1,0 +1,29 @@
+import pytest
+
+from pymc3.distributions.transforms import Transform
+import pymc3 as pm
+
+
+class TestTransformName(object):
+    cases = [
+        ('var', 'var_test__'),
+        ('var_test_', 'var_test__test__')
+    ]
+    transform_name = 'test'
+
+    def test_get_transformed_name(self):
+        test_transform = Transform()
+        test_transform.name = self.transform_name
+        for name, transformed in self.cases:
+            assert pm.util.get_transformed_name(name, test_transform) == transformed
+
+    def test_is_transformed_name(self):
+        for name, transformed in self.cases:
+            assert pm.util.is_transformed_name(transformed)
+            assert not pm.util.is_transformed_name(name)
+
+    def test_get_untransformed_name(self):
+        for name, transformed in self.cases:
+            assert pm.util.get_untransformed_name(transformed) == name
+            with pytest.raises(ValueError):
+                pm.util.get_untransformed_name(name)

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -1,0 +1,66 @@
+def get_transformed_name(name, transform):
+    """
+    Consistent way of transforming names
+
+    Parameters
+    ----------
+    name : str
+        Name to transform
+    transform : object
+        Should be a subclass of `transforms.Transform`
+
+    Returns:
+    A string to use for the transformed variable
+    """
+    return "{}_{}__".format(name, transform.name)
+
+
+def is_transformed_name(name):
+    """
+    Quickly check if a name was transformed with `get_transormed_name`
+
+    Parameters
+    ----------
+    name : str
+        Name to check
+
+    Returns:
+    Boolean, whether the string could have been produced by `get_transormed_name`
+    """
+    return name.endswith('__') and name.count('_') >= 3
+
+
+def get_untransformed_name(name):
+    """
+    Undo transformation in `get_transformed_name`. Throws ValueError if name wasn't transformed
+
+    Parameters
+    ----------
+    name : str
+        Name to untransform
+
+    Returns:
+    String with untransformed version of the name.
+    """
+    if not is_transformed_name(name):
+        raise ValueError(u'{} does not appear to be a transformed name'.format(name))
+    return '_'.join(name.split('_')[:-3])
+
+
+def get_default_varnames(var_iterator, include_transformed):
+    """Helper to extract default varnames from a trace.
+
+    Parameters
+    ----------
+    varname_iterator : iterator
+        Elements will be cast to string to check whether it is transformed, and optionally filtered
+    include_transformed : boolean
+        Should transformed variable names be included in return value
+
+    Returns:
+    List of variables, possibly filtered
+    """
+    if include_transformed:
+        return list(var_iterator)
+    else:
+        return [var for var in var_iterator if not is_transformed_name(str(var))]

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -412,7 +412,7 @@ def sample_vp(
     # Random variables which will be sampled
     if hide_transformed:
         vars_sampled = [v_ for v_ in model.unobserved_RVs
-                        if not str(v_).endswith('_')]
+                        if not pm.model.is_transformed_name(str(v_))]
     else:
         vars_sampled = [v_ for v_ in model.unobserved_RVs]
 

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -410,11 +410,8 @@ def sample_vp(
     f = theano.function([], samples)
 
     # Random variables which will be sampled
-    if hide_transformed:
-        vars_sampled = [v_ for v_ in model.unobserved_RVs
-                        if not pm.model.is_transformed_name(str(v_))]
-    else:
-        vars_sampled = [v_ for v_ in model.unobserved_RVs]
+    vars_sampled = pm.util.get_default_varnames(model.unobserved_RVs,
+                                                include_transformed=not hide_transformed)
 
     varnames = [str(var) for var in model.unobserved_RVs]
     trace = pm.sampling.NDArray(model=model, vars=vars_sampled)

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -1,33 +1,33 @@
 """
-Variational inference is a great approach for doing really complex, 
-often intractable Bayesian inference in approximate form. Common methods 
-(e.g. ADVI) lack from complexity so that approximate posterior does not 
-reveal the true nature of underlying problem. In some applications it can 
-yield unreliable decisions. 
+Variational inference is a great approach for doing really complex,
+often intractable Bayesian inference in approximate form. Common methods
+(e.g. ADVI) lack from complexity so that approximate posterior does not
+reveal the true nature of underlying problem. In some applications it can
+yield unreliable decisions.
 
-Recently on NIPS 2017 [OPVI](https://arxiv.org/abs/1610.09033) framework 
-was presented. It generalizes variational inverence so that the problem is 
-build with blocks. The first and essential block is Model itself. Second is 
-Approximation, in some cases :math:`log Q(D)` is not really needed. Necessity 
-depends on the third and forth part of that black box, Operator and 
-Test Function respectively. 
+Recently on NIPS 2017 [OPVI](https://arxiv.org/abs/1610.09033) framework
+was presented. It generalizes variational inverence so that the problem is
+build with blocks. The first and essential block is Model itself. Second is
+Approximation, in some cases :math:`log Q(D)` is not really needed. Necessity
+depends on the third and forth part of that black box, Operator and
+Test Function respectively.
 
-Operator is like an approach we use, it constructs loss from given Model, 
-Approximation and Test Function. The last one is not needed if we minimize 
-KL Divergence from Q to posterior. As a drawback we need to compute :math:`loq Q(D)`. 
-Sometimes approximation family is intractable and :math:`loq Q(D)` is not available, 
+Operator is like an approach we use, it constructs loss from given Model,
+Approximation and Test Function. The last one is not needed if we minimize
+KL Divergence from Q to posterior. As a drawback we need to compute :math:`loq Q(D)`.
+Sometimes approximation family is intractable and :math:`loq Q(D)` is not available,
 here comes LS(Langevin Stein) Operator with a set of test functions.
 
-Test Function has more unintuitive meaning. It is usually used with LS operator 
-and represents all we want from our approximate distribution. For any given vector 
-based function of :math:`z` LS operator yields zero mean function under posterior. 
-:math:`loq Q(D)` is no more needed. That opens a door to rich approximation 
+Test Function has more unintuitive meaning. It is usually used with LS operator
+and represents all we want from our approximate distribution. For any given vector
+based function of :math:`z` LS operator yields zero mean function under posterior.
+:math:`loq Q(D)` is no more needed. That opens a door to rich approximation
 families as neural networks.
 
 References
 ----------
--   Rajesh Ranganath, Jaan Altosaar, Dustin Tran, David M. Blei 
-    Operator Variational Inference 
+-   Rajesh Ranganath, Jaan Altosaar, Dustin Tran, David M. Blei
+    Operator Variational Inference
     https://arxiv.org/abs/1610.09033 (2016)
 """
 
@@ -39,7 +39,7 @@ import theano.tensor as tt
 import pymc3 as pm
 from .updates import adam
 from ..distributions.dist_math import rho2sd, log_normal
-from ..model import modelcontext, ArrayOrdering, DictToArrayBijection
+from ..model import modelcontext, ArrayOrdering, DictToArrayBijection, is_transformed_name
 from ..theanof import tt_rng, memoize, change_flags, GradScale
 
 
@@ -487,19 +487,19 @@ class Approximation(object):
             It is needed only if used with operator
             that requires :math:`logq` of an approximation
             Returns Scalar
-            
+
     You can also override the following methods:
         - :code:`._setup(**kwargs)`
             Do some specific stuff having :code:`kwargs` before calling :code:`.create_shared_params`
-            
+
         - :code:`.check_model(model, **kwargs)`
             Do some specific check for model having :code:`kwargs`
 
     Notes
     -----
-    :code:`kwargs` mentioned above are supplied as additional arguments 
+    :code:`kwargs` mentioned above are supplied as additional arguments
     for :code:`Approximation.__init__`
-    
+
     There are some defaults class attributes for approximation classes that can be
     optionally overriden.
         - :code:`initial_dist_name`
@@ -508,8 +508,8 @@ class Approximation(object):
 
         - :code:`initial_dist_map`
             float where initial distribution has maximum density
-        
-        
+
+
     References
     ----------
     -   Geoffrey Roeder, Yuhuai Wu, David Duvenaud, 2016
@@ -868,7 +868,7 @@ class Approximation(object):
         """
         if hide_transformed:
             vars_sampled = [v_ for v_ in self.model.unobserved_RVs
-                            if not str(v_).endswith('_')]
+                            if not is_transformed_name(str(v_))]
         else:
             vars_sampled = [v_ for v_ in self.model.unobserved_RVs]
         posterior = self.random_fn(draws)


### PR DESCRIPTION
This is a followup to a few places that were manually checking whether variables ended in '_' to decide if they were transformed.  Now they use the helper function `is_transformed_name` from #2089.  
