### PR TITLE
Set theano config in model context

### DIFF
--- a/pymc3/tests/conftest.py
+++ b/pymc3/tests/conftest.py
@@ -1,0 +1,11 @@
+import theano
+
+config = theano.configparser.change_flags(compute_test_value='raise')
+
+
+def pytest_sessionstart(session):
+    config.__enter__()
+
+
+def pytest_sessionfinish(session, exitstatus):
+    config.__exit__()

--- a/pymc3/tests/conftest.py
+++ b/pymc3/tests/conftest.py
@@ -1,11 +1,9 @@
 import theano
-
-config = theano.configparser.change_flags(compute_test_value='raise')
-
-
-def pytest_sessionstart(session):
-    config.__enter__()
+import pytest
 
 
-def pytest_sessionfinish(session, exitstatus):
-    config.__exit__()
+@pytest.fixture(scope="session", autouse=True)
+def theano_config():
+    config = theano.configparser.change_flags(compute_test_value='raise')
+    with config:
+        yield

--- a/pymc3/tests/test_special_functions.py
+++ b/pymc3/tests/test_special_functions.py
@@ -21,9 +21,9 @@ def test_functions():
     psi = function([x], ps.psi(x))
     function([x, p], ps.multigammaln(x, p))
     for x in xvals:
-        yield check_vals, gammaln, ss.gammaln, x
+        check_vals(gammaln, ss.gammaln, x)
     for x in xvals[1:]:
-        yield check_vals, psi, ss.psi, x
+        check_vals(psi, ss.psi, x)
 
 """
 scipy.special.multigammaln gives bad values if you pass a non scalar to a
@@ -52,7 +52,7 @@ def t_multigamma():
 
     for p in [0, 1, 2, 3, 4, 100]:
         for x in xvals:
-            yield check_vals, multigammaln, ssmultigammaln, x, p
+            check_vals(multigammaln, ssmultigammaln, x, p)
 
 
 def check_vals(fn1, fn2, *args):

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -136,7 +136,7 @@ class TestStepMethods(object):  # yield test doesn't work subclassing object
 
     def test_sample_exact(self):
         for step_method in self.master_samples:
-            yield self.check_trace, step_method
+            self.check_trace(step_method)
 
     def check_trace(self, step_method):
         """Tests whether the trace for step methods is exactly the same as on master.
@@ -196,7 +196,7 @@ class TestStepMethods(object):  # yield test doesn't work subclassing object
             )
         for step in steps:
             trace = sample(8000, step=step, start=start, model=model, random_seed=1)
-            yield self.check_stat, check, trace, step.__class__.__name__
+            self.check_stat(check, trace, step.__class__.__name__)
 
     def test_step_discrete(self):
         if theano.config.floatX == "float32":
@@ -211,7 +211,7 @@ class TestStepMethods(object):  # yield test doesn't work subclassing object
             )
         for step in steps:
             trace = sample(20000, step=step, start=start, model=model, random_seed=1)
-            yield self.check_stat, check, trace, step.__class__.__name__
+            self.check_stat(check, trace, step.__class__.__name__)
 
     def test_step_categorical(self):
         start, model, (mu, C) = simple_categorical()
@@ -225,7 +225,7 @@ class TestStepMethods(object):  # yield test doesn't work subclassing object
             )
         for step in steps:
             trace = sample(8000, step=step, start=start, model=model, random_seed=1)
-            yield self.check_stat, check, trace, step.__class__.__name__
+            self.check_stat(check, trace, step.__class__.__name__)
 
     def test_step_elliptical_slice(self):
         start, model, (K, L, mu, std, noise) = mv_prior_simple()
@@ -239,7 +239,7 @@ class TestStepMethods(object):  # yield test doesn't work subclassing object
             )
         for step in steps:
             trace = sample(5000, step=step, start=start, model=model, random_seed=1)
-            yield self.check_stat, check, trace, step.__class__.__name__
+            self.check_stat(check, trace, step.__class__.__name__)
 
 
 class TestMetropolisProposal(object):

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -427,3 +427,31 @@ class GradScale(theano.compile.ViewOp):
 
 def floatX_array(x):
     return floatX(np.array(x))
+
+
+def set_theano_conf(values):
+    """Change the theano configuration and return old values.
+
+    This is similar to `theano.configparser.change_flags`, but it
+    returns the original values in a pickleable form.
+    """
+    variables = {}
+    unknown = set(values.keys())
+    for variable in theano.configparser._config_var_list:
+        if variable.fullname in values:
+            variables[variable.fullname] = variable
+            unknown.remove(variable.fullname)
+    if len(unknown) > 0:
+        raise ValueError("Unknown theano config settings: %s" % unknown)
+
+    old = {}
+    for name, variable in variables.items():
+        old_value = variable.__get__(True, None)
+        try:
+            variable.__set__(None, values[name])
+        except Exception:
+            for key, old_value in old.items():
+                variables[key].__set__(None, old_value)
+            raise
+        old[name] = old_value
+    return old


### PR DESCRIPTION
This should fix #566. I'm not sure this is the best way to do this, it might be better to include the theano context in `Context`, but this gets a bit complicated because we need to pass arguments though metaclasses and multiple inheritance.
I removed `sum_div_dimshuffle_bug`. Couldn't even find a reference to this in the theano config. I guess this was removed at some point?
I set `compute_test_value` to 'ignore' in some functions about the hessian, because I had some trouble with those (see Theano/Theano#5907).