### PR TITLE
Discrete dists need int16 when run in float32 mode.

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -111,9 +111,15 @@ class NoDistribution(Distribution):
 class Discrete(Distribution):
     """Base class for discrete distributions"""
 
-    def __init__(self, shape=(), dtype='int64', defaults=['mode'], *args, **kwargs):
-        if dtype != 'int64':
-            raise TypeError('Discrete classes expect dtype to be int64.')
+    def __init__(self, shape=(), dtype=None, defaults=['mode'],
+                 *args, **kwargs):
+        if dtype is None:
+            if theano.config.floatX == 'float32':
+                dtype = 'int16'
+            else:
+                dtype = 'int32'
+        if dtype != 'int16' and dtype != 'int32':
+            raise TypeError('Discrete classes expect dtype to be int16 or int 32.')
         super(Discrete, self).__init__(
             shape, dtype, defaults=defaults, *args, **kwargs)
 

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -119,7 +119,7 @@ class Discrete(Distribution):
             else:
                 dtype = 'int32'
         if dtype != 'int16' and dtype != 'int32':
-            raise TypeError('Discrete classes expect dtype to be int16 or int 32.')
+            raise TypeError('Discrete classes expect dtype to be int16 or int32.')
         super(Discrete, self).__init__(
             shape, dtype, defaults=defaults, *args, **kwargs)
 

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -117,9 +117,9 @@ class Discrete(Distribution):
             if theano.config.floatX == 'float32':
                 dtype = 'int16'
             else:
-                dtype = 'int32'
-        if dtype != 'int16' and dtype != 'int32':
-            raise TypeError('Discrete classes expect dtype to be int16 or int32.')
+                dtype = 'int64'
+        if dtype != 'int16' and dtype != 'int64':
+            raise TypeError('Discrete classes expect dtype to be int16 or int64.')
         super(Discrete, self).__init__(
             shape, dtype, defaults=defaults, *args, **kwargs)
 


### PR DESCRIPTION
Should fix https://github.com/pymc-devs/pymc3/issues/2115