### PR TITLE
More work on SMC

### DIFF
--- a/pymc3/backends/smc_text.py
+++ b/pymc3/backends/smc_text.py
@@ -291,7 +291,7 @@ class Text(BaseSMCTrace):
         return pt
 
 
-def get_highest_sampled_stage(homedir, return_final=False):
+def get_highest_sampled_stage(homedir):
     """Return stage number of stage that has been sampled before the final stage.
 
     Paramaeters
@@ -306,14 +306,8 @@ def get_highest_sampled_stage(homedir, return_final=False):
     stages = glob(os.path.join(homedir, 'stage_*'))
     stagenumbers = []
     for s in stages:
-        stage_ending = os.path.splitext(s)[0].rsplit('_', 1)[1]
-        try:
-            stagenumbers.append(int(stage_ending))
-        except ValueError:
-            pm._log.debug('string - Thats the final stage!')
-            if return_final:
-                return stage_ending
-
+        stage_ending = os.path.basename(s).split('_')[-1]
+        stagenumbers.append(int(stage_ending))
     return max(stagenumbers)
 
 
@@ -441,12 +435,12 @@ def load_atmip_params(project_dir, stage_number, mode):
     ----------
     project_dir : str
         absolute path to directory of BEAT project
-    stage number : string
-        of stage number or 'final' for last stage
+    stage number : int
+        of stage number or -1 for last stage
     mode : str
         problem mode that has been solved ('geometry', 'static', 'kinematic')
     """
-    stage_path = os.path.join(project_dir, mode, 'stage_%s' % stage_number, 'atmip.params')
+    stage_path = os.path.join(project_dir, mode, 'stage_%i' % stage_number, 'atmip.params')
     step = load_objects(stage_path)
     return step
 

--- a/pymc3/tests/test_smc.py
+++ b/pymc3/tests/test_smc.py
@@ -67,7 +67,6 @@ class TestSMC(SeededTest):
             step=step,
             n_jobs=n_jobs,
             progressbar=True,
-            stage='0',
             homepath=self.test_folder,
             model=ATMIP_test,
             rm_flag=True)

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -160,7 +160,7 @@ class TestStepMethods(object):  # yield test doesn't work subclassing object
             if step_method.__name__ == 'SMC':
                 Deterministic('like', - 0.5 * tt.log(2 * np.pi) - 0.5 * x.T.dot(x))
                 trace = smc.ATMIP_sample(n_steps=n_steps, step=step_method(random_seed=1),
-                                         n_jobs=1, progressbar=False, stage='0',
+                                         n_jobs=1, progressbar=False,
                                          homepath=self.temp_dir)
             else:
                 trace = sample(n_steps, step=step_method(), random_seed=1)


### PR DESCRIPTION
This is two incremental changes:
-- the `paripool` function is simplified
-- the `stage` argument used to be possibly an int, string, or `None`.  Now it is consistently an int.