### PR TITLE
fix #2135

### DIFF
--- a/pymc3/glm/utils.py
+++ b/pymc3/glm/utils.py
@@ -1,6 +1,5 @@
 import six
 import pandas as pd
-from pandas.core.common import PandasError
 import numpy as np
 import theano.tensor as tt
 
@@ -58,7 +57,7 @@ def any_to_tensor_and_labels(x, labels=None):
         # some types fail there
         # another approach is to construct
         # variable by hand
-        except (PandasError, TypeError):
+        except (ValueError, TypeError):
             res = []
             labels = []
             for k, v in x.items():

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -41,7 +41,7 @@ from .updates import adam
 from ..distributions.dist_math import rho2sd, log_normal
 from ..model import modelcontext, ArrayOrdering, DictToArrayBijection
 from ..util import get_default_varnames
-from ..theanof import tt_rng, memoize, change_flags, GradScale
+from ..theanof import tt_rng, memoize, change_flags, GradScale, identity
 
 
 __all__ = [
@@ -289,7 +289,7 @@ class Operator(object):
     RETURNS_LOSS = True
     SUPPORT_AEVB = True
     OBJECTIVE = ObjectiveFunction
-    T = pm.theanof.identity
+    T = identity
 
     def __init__(self, approx):
         if not self.SUPPORT_AEVB and approx.local_vars:


### PR DESCRIPTION
* import error of pm.theanof.identity
Fixed `AttributeError: module 'pymc3' has no attribute 'theanof'`
* api change in Pandas 0.20.0. see https://github.com/pandas-dev/pandas/blob/master/doc/source/whatsnew/v0.20.0.txt
``DataFrame`` and ``Panel`` constructors with invalid input will now raise ``ValueError`` rather than ``pandas.core.common.PandasError``, if called with scalar inputs and not axes; The exception ``PandasError`` is removed as well. (:issue:`15541`)
