### PR TITLE
Fix NUTS.check_trace for several samplers

### DIFF
--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -215,19 +215,19 @@ class NUTS(BaseHMC):
 
         diverging = strace.get_sampler_stats('diverging')
         if diverging.ndim == 2:
-            diverging = np.any(diverging, axis=0)
+            diverging = np.any(diverging, axis=-1)
 
         tuning = strace.get_sampler_stats('tune')
         if tuning.ndim == 2:
-            tuning = np.any(tuning, axis=0)
+            tuning = np.any(tuning, axis=-1)
 
         accept = strace.get_sampler_stats('mean_tree_accept')
         if accept.ndim == 2:
-            accept = np.mean(accept, axis=0)
+            accept = np.mean(accept, axis=-1)
 
         depth = strace.get_sampler_stats('depth')
         if depth.ndim == 2:
-            depth = np.max(depth, axis=0)
+            depth = np.max(depth, axis=-1)
 
         n_samples = n - (~tuning).sum()
 


### PR DESCRIPTION
fixes #2143.
Sorry, I didn't really test the case of multiple samplers.
There might still be unnecessary warnings if two different NUTS samplers were used with different `taget_accept` or `max_treedepth` parameters. The `check_trace` function sees the stats of both, but can't tell which of the stats belong to itself. But I think that should be rare, and I can't see anything that we could do about it right now.