### PR TITLE
Change sampling defaults

### DIFF
--- a/pymc3/tests/test_diagnostics.py
+++ b/pymc3/tests/test_diagnostics.py
@@ -22,7 +22,7 @@ class TestGelmanRubin(SeededTest):
             step1 = Slice([model.early_mean_log__, model.late_mean_log__])
             step2 = Metropolis([model.switchpoint])
             start = {'early_mean': 7., 'late_mean': 5., 'switchpoint': 10}
-            ptrace = sample(n_samples, step=[step1, step2], start=start, njobs=2,
+            ptrace = sample(n_samples, tune=0, step=[step1, step2], start=start, njobs=2,
                     progressbar=False, random_seed=[20090425, 19700903])
         return ptrace
 
@@ -54,7 +54,7 @@ class TestGelmanRubin(SeededTest):
             # start sampling at the MAP
             start = find_MAP()
             step = NUTS(scaling=start)
-            ptrace = sample(n_samples, step=step, start=start,
+            ptrace = sample(n_samples, tune=0, step=step, start=start,
                             njobs=n_jobs, random_seed=42)
 
         rhat = gelman_rubin(ptrace)['x']
@@ -93,7 +93,7 @@ class TestDiagnostics(SeededTest):
             # Run sampler
             step1 = Slice([model.early_mean_log__, model.late_mean_log__])
             step2 = Metropolis([model.switchpoint])
-            trace = sample(n_samples, step=[step1, step2], progressbar=False, random_seed=1)
+            trace = sample(0, tune=n_samples, step=[step1, step2], progressbar=False, random_seed=1, discard_tuned_samples=False)
         return trace['switchpoint']
 
     def test_geweke_negative(self):
@@ -154,8 +154,9 @@ class TestDiagnostics(SeededTest):
             # start sampling at the MAP
             start = find_MAP()
             step = NUTS(scaling=start)
-            ptrace = sample(n_samples, step=step, start=start,
-                            njobs=n_jobs, random_seed=42)
+            ptrace = sample(0, tune=n_samples, step=step, start=start,
+                            njobs=n_jobs, discard_tuned_samples=False,
+                            random_seed=42)
 
         n_effective = effective_n(ptrace)['x']
         assert_allclose(n_effective, n_jobs * n_samples, 2)
@@ -175,8 +176,9 @@ class TestDiagnostics(SeededTest):
             # start sampling at the MAP
             start = find_MAP()
             step = NUTS(scaling=start)
-            ptrace = sample(n_samples, step=step, start=start,
-                            njobs=n_jobs, random_seed=42)
+            ptrace = sample(0, tune=n_samples, step=step, start=start,
+                            njobs=n_jobs, discard_tuned_samples=False,
+                            random_seed=42)
 
         n_effective = effective_n(ptrace)['x']
 

--- a/pymc3/tests/test_distributions_timeseries.py
+++ b/pymc3/tests/test_distributions_timeseries.py
@@ -3,13 +3,10 @@ from __future__ import division
 from ..model import Model
 from ..distributions.continuous import Flat, Normal
 from ..distributions.timeseries import EulerMaruyama
-from ..tuning.starting import find_MAP
 from ..sampling import sample, sample_ppc
-from ..step_methods import NUTS
 from ..theanof import floatX
 
 import numpy as np
-from scipy.optimize import fmin_bfgs
 
 
 def _gen_sde_path(sde, pars, dt, n, x0):
@@ -38,9 +35,8 @@ def test_linear():
         Normal('zh', mu=xh, sd=5e-3, observed=z)
     # invert
     with model:
-        start = find_MAP(vars=[xh], fmin=fmin_bfgs)  # So fmin_l_bfgs_b requires float64 dtypes and won't work for floatX; use fmin_bfgs instead
-        warmup = sample(200, NUTS(scaling=start))
-        trace = sample(1000, NUTS(scaling=warmup[-1], gamma=0.25), start=warmup[-1])
+        trace = sample()
+
     ppc = sample_ppc(trace, model=model)
     # test
     p95 = [2.5, 97.5]

--- a/pymc3/tests/test_glm.py
+++ b/pymc3/tests/test_glm.py
@@ -35,7 +35,8 @@ class TestGLM(SeededTest):
             Normal('y_obs', mu=lm.y_est, sd=sigma, observed=self.y_linear)
             start = find_MAP(vars=[sigma])
             step = Slice(model.vars)
-            trace = sample(500, step=step, start=start, progressbar=False, random_seed=self.random_seed)
+            trace = sample(500, tune=0, step=step, start=start,
+                           progressbar=False, random_seed=self.random_seed)
 
             assert round(abs(np.mean(trace['Intercept'])-self.intercept), 1) == 0
             assert round(abs(np.mean(trace['x'])-self.slope), 1) == 0
@@ -45,7 +46,8 @@ class TestGLM(SeededTest):
         with Model() as model:
             GLM.from_formula('y ~ x', self.data_linear)
             step = Slice(model.vars)
-            trace = sample(500, step, progressbar=False, random_seed=self.random_seed)
+            trace = sample(500, step=step, tune=0, progressbar=False,
+                           random_seed=self.random_seed)
 
             assert round(abs(np.mean(trace['Intercept'])-self.intercept), 1) == 0
             assert round(abs(np.mean(trace['x'])-self.slope), 1) == 0
@@ -56,7 +58,8 @@ class TestGLM(SeededTest):
             GLM.from_formula('y ~ x', self.data_logistic,
                     family=families.Binomial(link=families.logit))
             step = Slice(model.vars)
-            trace = sample(1000, step, progressbar=False, random_seed=self.random_seed)
+            trace = sample(1000, step=step, tune=0, progressbar=False,
+                           random_seed=self.random_seed)
 
             assert round(abs(np.mean(trace['Intercept'])-self.intercept), 1) == 0
             assert round(abs(np.mean(trace['x'])-self.slope), 1) == 0

--- a/pymc3/tests/test_models_linear.py
+++ b/pymc3/tests/test_models_linear.py
@@ -45,7 +45,8 @@ class TestGLM(SeededTest):
             Normal('y_obs', mu=lm.y_est, sd=sigma, observed=self.y_linear)  # yields y_obs
             start = find_MAP(vars=[sigma])
             step = Slice(model.vars)
-            trace = sample(500, step=step, start=start, progressbar=False, random_seed=self.random_seed)
+            trace = sample(500, tune=0, step=step, start=start,
+                           progressbar=False, random_seed=self.random_seed)
 
             assert round(abs(np.mean(trace['lm_Intercept'])-self.intercept), 1) == 0
             assert round(abs(np.mean(trace['lm_x0'])-self.slope), 1) == 0
@@ -59,7 +60,9 @@ class TestGLM(SeededTest):
             Normal('y_obs', mu=lm.y_est, sd=sigma, observed=self.y_linear)
             start = find_MAP(vars=[sigma])
             step = Slice(model.vars)
-            trace = sample(500, step=step, start=start, progressbar=False, random_seed=self.random_seed)
+            trace = sample(500, tune=0, step=step, start=start,
+                           progressbar=False,
+                           random_seed=self.random_seed)
 
             assert round(abs(np.mean(trace['Intercept'])-self.intercept), 1) == 0
             assert round(abs(np.mean(trace['x'])-self.slope), 1) == 0
@@ -80,7 +83,8 @@ class TestGLM(SeededTest):
             )
             start = find_MAP()
             step = Slice(model.vars)
-            trace = sample(500, step=step, start=start, progressbar=False, random_seed=self.random_seed)
+            trace = sample(500, tune=0, step=step, start=start,
+                           progressbar=False, random_seed=self.random_seed)
             assert round(abs(np.mean(trace['glm_Intercept'])-self.intercept), 1) == 0
             assert round(abs(np.mean(trace['glm_x0'])-self.slope), 1) == 0
             assert round(abs(np.mean(trace['glm_sd'])-self.sd), 1) == 0
@@ -92,7 +96,8 @@ class TestGLM(SeededTest):
             GLM.from_formula('y ~ x', self.data_linear, name=NAME)
             start = find_MAP()
             step = Slice(model.vars)
-            trace = sample(500, step=step, start=start, progressbar=False, random_seed=self.random_seed)
+            trace = sample(500, tune=0, step=step, start=start,
+                           progressbar=False, random_seed=self.random_seed)
 
             assert round(abs(np.mean(trace['%s_Intercept' % NAME])-self.intercept), 1) == 0
             assert round(abs(np.mean(trace['%s_x' % NAME])-self.slope), 1) == 0

--- a/pymc3/tests/test_plots.py
+++ b/pymc3/tests/test_plots.py
@@ -21,7 +21,7 @@ def test_plots():
         start = model.test_point
         h = find_hessian(start)
         step = Metropolis(model.vars, h)
-        trace = sample(3000, step=step, start=start)
+        trace = sample(3000, tune=0, step=step, start=start)
 
         traceplot(trace)
         forestplot(trace)
@@ -36,7 +36,7 @@ def test_plots_categorical():
         start = model.test_point
         h = find_hessian(start)
         step = Metropolis(model.vars, h)
-        trace = sample(3000, step=step, start=start)
+        trace = sample(3000, tune=0, step=step, start=start)
 
         traceplot(trace)
 
@@ -47,7 +47,7 @@ def test_plots_multidimensional():
     with model:
         h = np.diag(find_hessian(start))
         step = Metropolis(model.vars, h)
-        trace = sample(3000, step=step, start=start)
+        trace = sample(3000, tune=0, step=step, start=start)
 
         traceplot(trace)
         plot_posterior(trace)
@@ -60,7 +60,7 @@ def test_multichain_plots():
         step1 = Slice([model.early_mean_log__, model.late_mean_log__])
         step2 = Metropolis([model.switchpoint])
         start = {'early_mean': 2., 'late_mean': 3., 'switchpoint': 50}
-        ptrace = sample(1000, step=[step1, step2], start=start, njobs=2)
+        ptrace = sample(1000, tune=0, step=[step1, step2], start=start, njobs=2)
 
     forestplot(ptrace, varnames=['early_mean', 'late_mean'])
     autocorrplot(ptrace, varnames=['switchpoint'])
@@ -84,7 +84,7 @@ def test_plots_transformed():
     with pm.Model() as model:
         pm.Uniform('x', 0, 1)
         step = pm.Metropolis()
-        trace = pm.sample(100, step=step)
+        trace = pm.sample(100, tune=0, step=step)
 
     assert traceplot(trace).shape == (1, 2)
     assert traceplot(trace, plot_transformed=True).shape == (2, 2)

--- a/pymc3/tests/test_posteriors.py
+++ b/pymc3/tests/test_posteriors.py
@@ -15,7 +15,7 @@ class TestNUTSUniform(sf.NutsFixture, sf.UniformFixture):
 class TestMetropolisUniform(sf.MetropolisFixture, sf.UniformFixture):
     n_samples = 50000
     tune = 10000
-    burn = 10000
+    burn = 0
     chains = 4
     min_n_eff = 10000
     rtol = 0.1
@@ -25,7 +25,7 @@ class TestMetropolisUniform(sf.MetropolisFixture, sf.UniformFixture):
 class TestSliceUniform(sf.SliceFixture, sf.UniformFixture):
     n_samples = 10000
     tune = 1000
-    burn = 1000
+    burn = 0
     chains = 4
     min_n_eff = 5000
     rtol = 0.1
@@ -51,7 +51,7 @@ class TestNUTSUniform5(TestNUTSUniform):
 class TestNUTSNormal(sf.NutsFixture, sf.NormalFixture):
     n_samples = 10000
     tune = 1000
-    burn = 1000
+    burn = 0
     chains = 2
     min_n_eff = 10000
     rtol = 0.1
@@ -62,7 +62,7 @@ class TestNUTSBetaBinomial(sf.NutsFixture, sf.BetaBinomialFixture):
     n_samples = 2000
     ks_thin = 5
     tune = 1000
-    burn = 1000
+    burn = 0
     chains = 2
     min_n_eff = 400
 
@@ -70,7 +70,7 @@ class TestNUTSBetaBinomial(sf.NutsFixture, sf.BetaBinomialFixture):
 class TestNUTSStudentT(sf.NutsFixture, sf.StudentTFixture):
     n_samples = 100000
     tune = 1000
-    burn = 1000
+    burn = 0
     chains = 2
     min_n_eff = 5000
     rtol = 0.1
@@ -81,7 +81,7 @@ class TestNUTSStudentT(sf.NutsFixture, sf.StudentTFixture):
 class TestNUTSNormalLong(sf.NutsFixture, sf.NormalFixture):
     n_samples = 500000
     tune = 5000
-    burn = 5000
+    burn = 0
     chains = 2
     min_n_eff = 300000
     rtol = 0.01
@@ -91,6 +91,6 @@ class TestNUTSNormalLong(sf.NutsFixture, sf.NormalFixture):
 class TestNUTSLKJCholeskyCov(sf.NutsFixture, sf.LKJCholeskyCovFixture):
     n_samples = 2000
     tune = 1000
-    burn = 1000
+    burn = 0
     chains = 2
     min_n_eff = 200

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -1,5 +1,6 @@
 import shutil
 import tempfile
+import warnings
 
 from .checks import close_to
 from .models import simple_categorical, mv_simple, mv_simple_discrete, simple_2model, mv_prior_simple
@@ -9,6 +10,7 @@ from pymc3.step_methods import (NUTS, BinaryGibbsMetropolis, CategoricalGibbsMet
                                 Metropolis, Slice, CompoundStep, NormalProposal,
                                 MultivariateNormalProposal, HamiltonianMC,
                                 EllipticalSlice, smc)
+from pymc3.distributions import Binomial, Normal, Bernoulli, Categorical, Beta
 
 from numpy.testing import assert_array_almost_equal
 import numpy as np
@@ -330,7 +332,8 @@ class TestNutsCheckTrace(object):
             prob = Beta('prob', alpha=5, beta=3)
             Binomial('outcome', n=1, p=prob)
             with warnings.catch_warnings(record=True) as warns:
-                sample(0, draws=5, discard_tuned_samples=False, n_init=None, tune=2)
+                sample(3, tune=2, discard_tuned_samples=False,
+                       n_init=None)
             messages = [warn.message.args[0] for warn in warns]
             assert any("contains only 5" in msg for msg in messages)
             assert all('boolean index did not' not in msg for msg in messages)


### PR DESCRIPTION
As we are making pymc3 more user-friendly I think one behavior we can encourage is to use tune. The bahavior is as follows:
`pm.sample()` draws 500 samples with tune=True and then 500 samples with tune=False. Only the non-tuned samples are returned. If you pass `pm.sample(1000)` 1500 samples in total will be sampled but only the last 1000 returned. I think this way we have the easiest backwards compatibility.