### PR TITLE
Renamed seed arguments to random_seed

### DIFF
--- a/pymc3/data.py
+++ b/pymc3/data.py
@@ -101,7 +101,7 @@ class DataSampler(object):
     ----------
     data : array like
     batchsize : sample size over zero axis
-    seed : int for numpy random generator
+    random_seed : int for numpy random generator
     dtype : str representing dtype
 
     Usage
@@ -128,7 +128,7 @@ class DataSampler(object):
     >>> new.sample_vp(draws=1000)['sd'].mean()
     1.2178044136104513
     """
-    def __init__(self, data, batchsize=50, seed=42, dtype='floatX'):
+    def __init__(self, data, batchsize=50, random_seed=42, dtype='floatX'):
         self.dtype = theano.config.floatX if dtype == 'floatX' else dtype
         self.rng = np.random.RandomState(seed)
         self.data = data

--- a/pymc3/data.py
+++ b/pymc3/data.py
@@ -130,7 +130,7 @@ class DataSampler(object):
     """
     def __init__(self, data, batchsize=50, random_seed=42, dtype='floatX'):
         self.dtype = theano.config.floatX if dtype == 'floatX' else dtype
-        self.rng = np.random.RandomState(seed)
+        self.rng = np.random.RandomState(random_seed)
         self.data = data
         self.n = batchsize
 

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -568,7 +568,7 @@ def init_nuts(init='ADVI', njobs=1, n_init=500000, model=None,
 
     if init == 'advi':
         approx = pm.fit(
-            seed=random_seed,
+            random_seed=random_seed,
             n=n_init, method='advi', model=model,
             callbacks=[pm.callbacks.CheckParametersConvergence(tolerance=1e-2)],
             progressbar=progressbar
@@ -582,7 +582,7 @@ def init_nuts(init='ADVI', njobs=1, n_init=500000, model=None,
         start = pm.find_MAP()
         approx = pm.MeanField(model=model, start=start)
         pm.fit(
-            seed=random_seed,
+            random_seed=random_seed,
             n=n_init, method=pm.ADVI.from_mean_field(approx),
             callbacks=[pm.callbacks.CheckParametersConvergence(tolerance=1e-2)],
             progressbar=progressbar

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -390,7 +390,7 @@ def tt_rng(random_seed=None):
         `theano.sandbox.rng_mrg.MRG_RandomStreams`
         instance passed to the most recent call of `set_tt_rng`
     """
-    if seed is None:
+    if random_seed is None:
         return _tt_rng
     else:
         ret = MRG_RandomStreams(random_seed)

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -374,7 +374,7 @@ _tt_rng = MRG_RandomStreams()
 launch_rng(_tt_rng)
 
 
-def tt_rng(seed=None):
+def tt_rng(random_seed=None):
     """
     Get the package-level random number generator or new with specified seed.
 
@@ -393,7 +393,7 @@ def tt_rng(seed=None):
     if seed is None:
         return _tt_rng
     else:
-        ret = MRG_RandomStreams(seed)
+        ret = MRG_RandomStreams(random_seed)
         launch_rng(ret)
         return ret
 

--- a/pymc3/variational/approximations.py
+++ b/pymc3/variational/approximations.py
@@ -118,7 +118,7 @@ class FullRank(Approximation):
         Yuhuai Wu, David Duvenaud, 2016) for details   
     scale_cost_to_minibatch : bool, default False
         Scale cost to minibatch instead of full dataset
-    seed : None or int
+    random_seed : None or int
         leave None to use package global RandomStream or other
         valid value to create instance specific one
 
@@ -130,12 +130,12 @@ class FullRank(Approximation):
     """
     def __init__(self, local_rv=None, model=None, cost_part_grad_scale=1,
                  scale_cost_to_minibatch=False,
-                 gpu_compat=False, seed=None, **kwargs):
+                 gpu_compat=False, random_seed=None, **kwargs):
         super(FullRank, self).__init__(
             local_rv=local_rv, model=model,
             cost_part_grad_scale=cost_part_grad_scale,
             scale_cost_to_minibatch=scale_cost_to_minibatch,
-            seed=seed, **kwargs
+            random_seed=random_seed, **kwargs
         )
         self.gpu_compat = gpu_compat
 
@@ -256,7 +256,7 @@ class Empirical(Approximation):
     scale_cost_to_minibatch : bool, default False
         Scale cost to minibatch instead of full dataset
     model : PyMC3 model
-    seed : None or int
+    random_seed : None or int
         leave None to use package global RandomStream or other
         valid value to create instance specific one
 
@@ -269,10 +269,10 @@ class Empirical(Approximation):
     """
     def __init__(self, trace, local_rv=None,
                  scale_cost_to_minibatch=False,
-                 model=None, seed=None, **kwargs):
+                 model=None, random_seed=None, **kwargs):
         super(Empirical, self).__init__(
             local_rv=local_rv, scale_cost_to_minibatch=scale_cost_to_minibatch,
-            model=model, trace=trace, seed=seed, **kwargs)
+            model=model, trace=trace, random_seed=random_seed, **kwargs)
 
     def check_model(self, model, **kwargs):
         trace = kwargs.get('trace')

--- a/pymc3/variational/approximations.py
+++ b/pymc3/variational/approximations.py
@@ -351,7 +351,7 @@ class Empirical(Approximation):
 
     @classmethod
     def from_noise(cls, size, jitter=.01, local_rv=None,
-                   start=None, model=None, seed=None, **kwargs):
+                   start=None, model=None, random_seed=None, **kwargs):
         """Initialize Histogram with random noise
 
         Parameters
@@ -365,7 +365,7 @@ class Empirical(Approximation):
         start : initial point
         model : pm.Model
             PyMC3 Model
-        seed : None or int
+        random_seed : None or int
             leave None to use package global RandomStream or other
             valid value to create instance specific one
         kwargs : other kwargs passed to init
@@ -374,7 +374,7 @@ class Empirical(Approximation):
         -------    
         Empirical
         """
-        hist = cls(None, local_rv=local_rv, model=model, seed=seed, **kwargs)
+        hist = cls(None, local_rv=local_rv, model=model, random_seed=random_seed, **kwargs)
         if start is None:
             start = hist.model.test_point
         else:

--- a/pymc3/variational/inference.py
+++ b/pymc3/variational/inference.py
@@ -306,7 +306,7 @@ class ADVI(Inference):
         Yuhuai Wu, David Duvenaud, 2016) for details
     scale_cost_to_minibatch : bool, default False
         Scale cost to minibatch instead of full dataset
-    seed : None or int
+    random_seed : None or int
         leave None to use package global RandomStream or other
         valid value to create instance specific one    
     start : Point
@@ -328,13 +328,13 @@ class ADVI(Inference):
     def __init__(self, local_rv=None, model=None,
                  cost_part_grad_scale=1,
                  scale_cost_to_minibatch=False,
-                 seed=None, start=None):
+                 random_seed=None, start=None):
         super(ADVI, self).__init__(
             KL, MeanField, None,
             local_rv=local_rv, model=model,
             cost_part_grad_scale=cost_part_grad_scale,
             scale_cost_to_minibatch=scale_cost_to_minibatch,
-            seed=seed, start=start)
+            random_seed=random_seed, start=start)
 
     @classmethod
     def from_mean_field(cls, mean_field):
@@ -380,7 +380,7 @@ class FullRankADVI(Inference):
         Yuhuai Wu, David Duvenaud, 2016) for details
     scale_cost_to_minibatch : bool, default False
         Scale cost to minibatch instead of full dataset
-    seed : None or int
+    random_seed : None or int
         leave None to use package global RandomStream or other
         valid value to create instance specific one
     start : Point
@@ -402,13 +402,13 @@ class FullRankADVI(Inference):
     def __init__(self, local_rv=None, model=None,
                  cost_part_grad_scale=1,
                  scale_cost_to_minibatch=False,
-                 gpu_compat=False, seed=None, start=None):
+                 gpu_compat=False, random_seed=None, start=None):
         super(FullRankADVI, self).__init__(
             KL, FullRank, None,
             local_rv=local_rv, model=model,
             cost_part_grad_scale=cost_part_grad_scale,
             scale_cost_to_minibatch=scale_cost_to_minibatch,
-            gpu_compat=gpu_compat, seed=seed, start=start)
+            gpu_compat=gpu_compat, random_seed=random_seed, start=start)
 
     @classmethod
     def from_full_rank(cls, full_rank):
@@ -514,7 +514,7 @@ class SVGD(Inference):
         initial point for inference
     histogram : Empirical
         initialize SVGD with given Empirical approximation instead of default initial particles
-    seed : None or int
+    random_seed : None or int
         leave None to use package global RandomStream or other
         valid value to create instance specific one
     start : Point
@@ -528,19 +528,19 @@ class SVGD(Inference):
     """
     def __init__(self, n_particles=100, jitter=.01, model=None, kernel=test_functions.rbf,
                  scale_cost_to_minibatch=False, start=None, histogram=None,
-                 seed=None, local_rv=None):
+                 random_seed=None, local_rv=None):
         if histogram is None:
             histogram = Empirical.from_noise(
                 n_particles, jitter=jitter,
                 scale_cost_to_minibatch=scale_cost_to_minibatch,
-                start=start, model=model, local_rv=local_rv, seed=seed)
+                start=start, model=model, local_rv=local_rv, random_seed=random_seed)
         super(SVGD, self).__init__(
             KSD, histogram,
             kernel,
-            model=model, seed=seed)
+            model=model, random_seed=random_seed)
 
 
-def fit(n=10000, local_rv=None, method='advi', model=None, seed=None, start=None, **kwargs):
+def fit(n=10000, local_rv=None, method='advi', model=None, random_seed=None, start=None, **kwargs):
     """
     Handy shortcut for using inference methods in functional way
 
@@ -558,7 +558,7 @@ def fit(n=10000, local_rv=None, method='advi', model=None, seed=None, start=None
     kwargs : kwargs for Inference.fit
     frac : float
         if method is 'advi->fullrank_advi' represents advi fraction when training
-    seed : None or int
+    random_seed : None or int
         leave None to use package global RandomStream or other
         valid value to create instance specific one
     start : Point
@@ -580,7 +580,7 @@ def fit(n=10000, local_rv=None, method='advi', model=None, seed=None, start=None
             raise ValueError('frac should be in (0, 1)')
         n1 = int(n * frac)
         n2 = n-n1
-        inference = ADVI(local_rv=local_rv, model=model, seed=seed, start=start)
+        inference = ADVI(local_rv=local_rv, model=model, random_seed=random_seed, start=start)
         logger.info('fitting advi ...')
         inference.fit(n1, **kwargs)
         inference = FullRankADVI.from_advi(inference)
@@ -590,7 +590,7 @@ def fit(n=10000, local_rv=None, method='advi', model=None, seed=None, start=None
     elif isinstance(method, str):
         try:
             inference = _select[method.lower()](
-                local_rv=local_rv, model=model, seed=seed,
+                local_rv=local_rv, model=model, random_seed=random_seed,
                 start=start
             )
         except KeyError:

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -459,7 +459,7 @@ class Approximation(object):
         Yuhuai Wu, David Duvenaud, 2016) for details     
     scale_cost_to_minibatch : bool, default False
         Scale cost to minibatch instead of full dataset
-    seed : None or int
+    random_seed : None or int
         leave None to use package global RandomStream or other
         valid value to create instance specific one
 
@@ -516,13 +516,13 @@ class Approximation(object):
     def __init__(self, local_rv=None, model=None,
                  cost_part_grad_scale=1,
                  scale_cost_to_minibatch=False,
-                 seed=None, **kwargs):
+                 random_seed=None, **kwargs):
         model = modelcontext(model)
         self.scale_cost_to_minibatch = theano.shared(np.int8(0))
         if scale_cost_to_minibatch:
             self.scale_cost_to_minibatch.set_value(1)
         self.cost_part_grad_scale = pm.floatX(cost_part_grad_scale)
-        self._seed = seed
+        self._seed = random_seed
         self._rng = tt_rng(seed)
         self.model = model
         self.check_model(model, **kwargs)
@@ -547,7 +547,7 @@ class Approximation(object):
         self._setup(**kwargs)
         self.shared_params = self.create_shared_params(**kwargs)
 
-    def seed(self, seed=None):
+    def seed(self, random_seed=None):
         """
         Reinitialize RandomStream used by this approximation
 
@@ -555,7 +555,7 @@ class Approximation(object):
         ----------
         seed : int
         """
-        self._seed = seed
+        self._seed = random_seed
         self._rng.seed(seed)
 
     @property

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -523,7 +523,7 @@ class Approximation(object):
             self.scale_cost_to_minibatch.set_value(1)
         self.cost_part_grad_scale = pm.floatX(cost_part_grad_scale)
         self._seed = random_seed
-        self._rng = tt_rng(seed)
+        self._rng = tt_rng(random_seed)
         self.model = model
         self.check_model(model, **kwargs)
         if local_rv is None:


### PR DESCRIPTION
The new API for variational inference uses `seed=` as the argument for supplying a random seed, while the rest of the fitting methods use `random_seed=`. This PR standardizes on `random_seed=`.