### PR TITLE
Raise exception if covariance matrix is passed to Normal

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -213,8 +213,8 @@ class Normal(Continuous):
         self.variance = 1. / self.tau
         
         if self.sd.ndim > self.mu.ndim:
-            raise ValueError('sd or tau should not have larger dimension than mu.'
-                            + ' Covariance matrices should only be used with MvNormal.')
+            warnings.warn('The dimension of sd or tau is larger than mu.'
+                        + ' Covariance matrices should only be used with MvNormal.')
 
         assert_negative_support(sd, 'sd', 'Normal')
         assert_negative_support(tau, 'tau', 'Normal')

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -205,11 +205,16 @@ class Normal(Continuous):
 
     def __init__(self, mu=0, sd=None, tau=None, **kwargs):
         tau, sd = get_tau_sd(tau=tau, sd=sd)
+        
         self.sd = tt.as_tensor_variable(sd)
         self.tau = tt.as_tensor_variable(tau)
 
         self.mean = self.median = self.mode = self.mu = mu = tt.as_tensor_variable(mu)
         self.variance = 1. / self.tau
+        
+        if self.sd.ndim > self.mu.ndim:
+            raise ValueError('sd or tau should not have larger dimension than mu.'
+                            + ' Covariance matrices should only be used with MvNormal.')
 
         assert_negative_support(sd, 'sd', 'Normal')
         assert_negative_support(tau, 'tau', 'Normal')


### PR DESCRIPTION
Currently, if a covariance matrix is passed to `Normal` (instead of `MvNormal`) it is accepted without error. This can result in unanticipated results if the user expects `Normal` to properly account for the covariances. This PR checks that the dimension of `sd` (or `tau`) is not larger than the dimension of `mu`, raising an exception if it does and suggesting the use of `MvNormal`.