### PR TITLE
Fixed figsize and round bug in posteriorplot

### DIFF
--- a/pymc3/plots/artists.py
+++ b/pymc3/plots/artists.py
@@ -65,8 +65,8 @@ def kde2plot_op(ax, x, y, grid=200, **kwargs):
     ax.imshow(np.rot90(Z), extent=extent, **kwargs)
 
 
-def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
-                      alpha_level, ref_val, rope, **kwargs):
+def plot_posterior_op(trace_values, figsize, ax, kde_plot, point_estimate, round_to,
+                      alpha_level, ref_val, rope, text_size=16, **kwargs):
     """Artist to draw posterior."""
     def format_as_percent(x, round_to=0):
         return '{0:.{1:d}f}%'.format(100 * x, round_to)
@@ -95,28 +95,24 @@ def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
             return
         if point_estimate not in ('mode', 'mean', 'median'):
             raise ValueError(
-                "Point Estimate should be in ('mode','mean','median', None)")
+                "Point Estimate should be in ('mode','mean','median')")
         if point_estimate == 'mean':
             point_value = trace_values.mean()
-            point_text = '{}={}'.format(
-                point_estimate, point_value.round(round_to))
         elif point_estimate == 'mode':
             point_value = mode(trace_values.round(round_to))[0][0]
-            point_text = '{}={}'.format(
-                point_estimate, point_value.round(round_to))
         elif point_estimate == 'median':
             point_value = np.median(trace_values)
-            point_text = '{}={}'.format(
-                point_estimate, point_value.round(round_to))
+        point_text = '{point_estimate}={point_value:.{round_to}g}'.format(point_estimate=point_estimate,
+                                                                          point_value=point_value, round_to=round_to)
 
         ax.text(point_value, plot_height * 0.8, point_text,
-                size=16, horizontalalignment='center')
+                size=text_size, horizontalalignment='center')
 
     def display_hpd():
         hpd_intervals = hpd(trace_values, alpha=alpha_level)
         ax.plot(hpd_intervals, (plot_height * 0.02,
                                 plot_height * 0.02), linewidth=4, color='k')
-        text_props = dict(size=16, horizontalalignment='center')
+        text_props = dict(size=text_size, horizontalalignment='center')
         ax.text(hpd_intervals[0], plot_height * 0.07,
                 hpd_intervals[0].round(round_to), **text_props)
         ax.text(hpd_intervals[1], plot_height * 0.07,
@@ -143,7 +139,7 @@ def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
     if kde_plot:
         density, l, u = fast_kde(trace_values)
         x = np.linspace(l, u, len(density))
-        ax.plot(x, density, **kwargs)
+        ax.plot(x, density, figsize=figsize, **kwargs)
     else:
         set_key_if_doesnt_exist(kwargs, 'bins', 30)
         set_key_if_doesnt_exist(kwargs, 'edgecolor', 'w')

--- a/pymc3/plots/artists.py
+++ b/pymc3/plots/artists.py
@@ -102,7 +102,7 @@ def plot_posterior_op(trace_values, figsize, ax, kde_plot, point_estimate, round
             point_value = mode(trace_values.round(round_to))[0][0]
         elif point_estimate == 'median':
             point_value = np.median(trace_values)
-        point_text = '{point_estimate}={point_value:.{round_to}g}'.format(point_estimate=point_estimate,
+        point_text = '{point_estimate}={point_value:.{round_to}f}'.format(point_estimate=point_estimate,
                                                                           point_value=point_value, round_to=round_to)
 
         ax.text(point_value, plot_height * 0.8, point_text,

--- a/pymc3/plots/posteriorplot.py
+++ b/pymc3/plots/posteriorplot.py
@@ -6,7 +6,7 @@ from .artists import plot_posterior_op
 from .utils import identity_transform, get_default_varnames
 
 
-def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=None,
+def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=None, text_size=16,
                    alpha_level=0.05, round_to=3, point_estimate='mean', rope=None,
                    ref_val=None, kde_plot=False, plot_transformed=False, ax=None, **kwargs):
     """Plot Posterior densities in style of John K. Kruschke book.
@@ -21,6 +21,8 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
         Function to transform data (defaults to identity)
     figsize : figure size tuple
         If None, size is (12, num of variables * 2) inch
+    text_size : int
+        Text size of the point_estimates and HPD (Default:16)
     alpha_level : float
         Defines range for High Posterior Density
     round_to : int
@@ -43,7 +45,6 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
         value of the argument kde_plot
         Some defaults are added, if not specified
         color='#87ceeb' will match the style in the book
-
 
     Returns
     -------
@@ -79,9 +80,9 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
             figsize = (6, 2)
         if ax is None:
             fig, ax = plt.subplots()
-        plot_posterior_op(transform(trace), ax=ax, kde_plot=kde_plot,
+        plot_posterior_op(transform(trace), figsize=figsize, ax=ax, kde_plot=kde_plot,
                           point_estimate=point_estimate, round_to=round_to,
-                          alpha_level=alpha_level, ref_val=ref_val, rope=rope, **kwargs)
+                          alpha_level=alpha_level, ref_val=ref_val, rope=rope, text_size=text_size, **kwargs)
     else:
         if varnames is None:
             varnames = get_default_varnames(trace.varnames, plot_transformed)
@@ -93,13 +94,14 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
 
         for a, v in zip(np.atleast_1d(ax), trace_dict):
             tr_values = transform(trace_dict[v])
-            plot_posterior_op(tr_values, ax=a, kde_plot=kde_plot,
+            plot_posterior_op(tr_values, figsize=figsize, ax=a, kde_plot=kde_plot,
                               point_estimate=point_estimate, round_to=round_to,
-                              alpha_level=alpha_level, ref_val=ref_val, rope=rope, **kwargs)
+                              alpha_level=alpha_level, ref_val=ref_val, rope=rope, text_size=text_size, **kwargs)
             a.set_title(v)
 
         plt.tight_layout()
     return ax
+
 
 def plot_posterior_predictive_glm(trace, eval=None, lm=None, samples=30, **kwargs):
     """Plot posterior predictive of a linear model.


### PR DESCRIPTION
What I did:
- fixed a figsize bug that did not passed the parameter to plot_posterior_op
- fixed a round error in plot_posterior_op
- passed another parameter (text_size) to control the text size of the numbers in the plot