### PR TITLE
Fix advi init for large models

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -14,6 +14,7 @@ from theano.tensor.nlinalg import det, matrix_inverse, trace
 import pymc3 as pm
 
 from pymc3.math import tround
+from pymc3.theanof import floatX
 from . import transforms
 from .distribution import Continuous, Discrete, draw_values, generate_samples
 from ..model import Deterministic
@@ -810,7 +811,7 @@ class LKJCholeskyCov(Continuous):
         self.sd_dist = sd_dist
         self.diag_idxs = transform.diag_idxs
 
-        self.mode = np.zeros(shape)
+        self.mode = floatX(np.zeros(shape))
         self.mode[self.diag_idxs] = 1
 
     def logp(self, x):

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -583,8 +583,8 @@ def init_nuts(init='ADVI', njobs=1, n_init=500000, model=None,
             progressbar=progressbar
         )  # type: pm.MeanField
         start = approx.sample(draws=njobs)
-        stds = approx.gbij.rmap(np.diag(approx.cov.eval()))
-        cov = model.dict_to_array(stds)
+        stds = approx.gbij.rmap(approx.std.eval())
+        cov = model.dict_to_array(stds) ** 2
         if njobs == 1:
             start = start[0]
     elif init == 'advi_map':

--- a/pymc3/variational/approximations.py
+++ b/pymc3/variational/approximations.py
@@ -62,6 +62,10 @@ class MeanField(Approximation):
     def cov(self):
         return tt.diag(rho2sd(self.rho)**2)
 
+    @property
+    def std(self):
+        return rho2sd(self.rho)
+
     def create_shared_params(self, **kwargs):
         start = kwargs.get('start')
         if start is None:


### PR DESCRIPTION
Righ now initializing nuts with advi creates a n x n matrix. This fails with a memory error for large models:
```python
with pm.Model() as model:
    pm.Normal('a', mu=0, sd=1, shape=100000)
    pm.sample(1, n_init=10)
```
I also forgot at floatx conversion in LKJCholeskyCov.