### PR TITLE
WIP: Update LKJ notebook to not refer to Wishart

### DIFF
--- a/docs/source/notebooks/LKJ.ipynb
+++ b/docs/source/notebooks/LKJ.ipynb
@@ -13,9 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Outside of the [beta](https://en.wikipedia.org/wiki/Beta_distribution)-[binomial](https://en.wikipedia.org/wiki/Binomial_distribution) model, the multivariate normal model is likely the most studied Bayesian model in history.  Unfortunately, as this [issue](https://github.com/pymc-devs/pymc3/issues/538) shows, `pymc3` cannot (yet) sample from the standard conjugate [normal-Wishart](https://en.wikipedia.org/wiki/Normal-Wishart_distribution) model.  Fortunately, `pymc3` *does* support sampling from the [LKJ distribution](http://www.sciencedirect.com/science/article/pii/S0047259X09000876).  This post will show how to fit a simple multivariate normal model using `pymc3` with an normal-LKJ prior.\n",
-    "\n",
-    "The normal-Wishart prior is conjugate for the multivariate normal model, so we can find the posterior distribution in closed form.  Even with this closed form solution, sampling from a multivariate normal model in `pymc3` is important as a building block for more complex models.\n",
+    "Outside of the [beta](https://en.wikipedia.org/wiki/Beta_distribution)-[binomial](https://en.wikipedia.org/wiki/Binomial_distribution) model, the multivariate normal model is likely the most studied Bayesian model in history. `PyMC3` supports sampling from the [LKJ distribution](http://www.sciencedirect.com/science/article/pii/S0047259X09000876). The LKJ distribution represents the distribution on correlation matrices and is conjugate to the multivariate normal distribution. This post will show how to fit a simple multivariate normal model using `pymc3` with a normal-LKJ prior.\n",
     "\n",
     "First, we generate some two-dimensional sample data."
    ]

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -542,7 +542,7 @@ class Wishart(Continuous):
     Note
     ----
     This distribution is unusable in a PyMC3 model. You should instead
-    use WishartBartlett or LKJCholeskyCov, LKJCorr.
+    use LKJCholeskyCov or LKJCorr.
     """
 
     def __init__(self, nu, V, *args, **kwargs):
@@ -550,9 +550,9 @@ class Wishart(Continuous):
         warnings.warn('The Wishart distribution can currently not be used '
                       'for MCMC sampling. The probability of sampling a '
                       'symmetric matrix is basically zero. Instead, please '
-                      'use WishartBartlett or better yet, LKJCholeskyCov/LKJCorr.'
-                      'For more information on the issues surrounding the '
-                      'Wishart see here: https://github.com/pymc-devs/pymc3/issues/538.',
+                      'use LKJCholeskyCov or LKJCorr. For more information '
+                      'on the issues surrounding the Wishart see here: '
+                      'https://github.com/pymc-devs/pymc3/issues/538.',
                       UserWarning)
         self.nu = nu
         self.p = p = V.shape[0]
@@ -624,6 +624,9 @@ def WishartBartlett(name, S, nu, is_cholesky=False, return_cholesky=False, testv
     This is not a standard Distribution class but follows a similar
     interface. Besides the Wishart distribution, it will add RVs
     c and z to your model which make up the matrix.
+
+    This distribution is usually a bad idea to use as a prior for multivariate
+    normal. You should instead use LKJCholeskyCov or LKJCorr.
     """
 
     L = S if is_cholesky else scipy.linalg.cholesky(S)


### PR DESCRIPTION
As the Wishart is highly discouraged now, including the Wishart-Bartlett form, we should change the documentation to not refer to it, and even perhaps talk more about the LKJ distribution.