### PR TITLE
convert default to right dtype

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -48,7 +48,7 @@ class Distribution(object):
         dist.__init__(*args, **kwargs)
         return dist
 
-    def __init__(self, shape, dtype, testval=None, defaults=[], transform=None):
+    def __init__(self, shape, dtype, testval=None, defaults=(), transform=None):
         self.shape = np.atleast_1d(shape)
         if False in (np.floor(self.shape) == self.shape):
             raise TypeError("Expected int elements in shape")
@@ -59,7 +59,7 @@ class Distribution(object):
         self.transform = transform
 
     def default(self):
-        return self.get_test_val(self.testval, self.defaults)
+        return np.asarray(self.get_test_val(self.testval, self.defaults), self.dtype)
 
     def get_test_val(self, val, defaults):
         if val is None:
@@ -92,7 +92,7 @@ def TensorType(dtype, shape):
 
 class NoDistribution(Distribution):
 
-    def __init__(self, shape, dtype, testval=None, defaults=[], transform=None, parent_dist=None, *args, **kwargs):
+    def __init__(self, shape, dtype, testval=None, defaults=(), transform=None, parent_dist=None, *args, **kwargs):
         super(NoDistribution, self).__init__(shape=shape, dtype=dtype,
                                              testval=testval, defaults=defaults,
                                              *args, **kwargs)
@@ -111,7 +111,7 @@ class NoDistribution(Distribution):
 class Discrete(Distribution):
     """Base class for discrete distributions"""
 
-    def __init__(self, shape=(), dtype=None, defaults=['mode'],
+    def __init__(self, shape=(), dtype=None, defaults=('mode', ),
                  *args, **kwargs):
         if dtype is None:
             if theano.config.floatX == 'float32':
@@ -127,7 +127,7 @@ class Discrete(Distribution):
 class Continuous(Distribution):
     """Base class for continuous distributions"""
 
-    def __init__(self, shape=(), dtype=None, defaults=['median', 'mean', 'mode'], *args, **kwargs):
+    def __init__(self, shape=(), dtype=None, defaults=('median', 'mean', 'mode'), *args, **kwargs):
         if dtype is None:
             dtype = theano.config.floatX
         super(Continuous, self).__init__(

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import division
 
 import itertools
 
@@ -51,7 +52,10 @@ LKJ_CASES = get_lkj_cases()
 class Domain(object):
 
     def __init__(self, vals, dtype=None, edges=None, shape=None):
-        avals = array(vals)
+        avals = array(vals, dtype=dtype)
+        if dtype is None and not str(avals.dtype).startswith('int'):
+            avals = avals.astype(theano.config.floatX)
+        vals = [array(v, dtype=avals.dtype) for v in vals]
 
         if edges is None:
             edges = array(vals[0]), array(vals[-1])

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1,5 +1,4 @@
 from __future__ import division
-from __future__ import division
 
 import itertools
 
@@ -50,7 +49,6 @@ LKJ_CASES = get_lkj_cases()
 
 
 class Domain(object):
-
     def __init__(self, vals, dtype=None, edges=None, shape=None):
         avals = array(vals, dtype=dtype)
         if dtype is None and not str(avals.dtype).startswith('int'):
@@ -287,7 +285,6 @@ def mvt_logpdf(value, nu, Sigma, mu=0):
 
 
 class Simplex(object):
-
     def __init__(self, n):
         self.vals = list(simplex_values(n))
         self.shape = (n,)
@@ -326,6 +323,7 @@ PdMatrixChol2 = Domain([np.eye(2), [[0.1, 0], [10, 1]]], edges=(None, None))
 PdMatrixChol3 = Domain([np.eye(3), [[0.1, 0, 0], [10, 100, 0], [0, 1, 10]]],
                        edges=(None, None))
 
+
 def PdMatrixChol(n):
     if n == 1:
         return PdMatrixChol1
@@ -340,7 +338,8 @@ def PdMatrixChol(n):
 PdMatrixCholUpper1 = Domain([np.eye(1), [[0.001]]], edges=(None, None))
 PdMatrixCholUpper2 = Domain([np.eye(2), [[0.1, 10], [0, 1]]], edges=(None, None))
 PdMatrixCholUpper3 = Domain([np.eye(3), [[0.1, 10, 0], [0, 100, 1], [0, 0, 10]]],
-                       edges=(None, None))
+                            edges=(None, None))
+
 
 def PdMatrixCholUpper(n):
     if n == 1:
@@ -553,6 +552,7 @@ class TestMatchesScipy(SeededTest):
     def test_skew_normal(self):
         self.pymc3_matches_scipy(SkewNormal, R, {'mu': R, 'sd': Rplusbig, 'alpha': R},
                                  lambda value, alpha, mu, sd: sp.skewnorm.logpdf(value, alpha, mu, sd))
+
     def test_binomial(self):
         self.pymc3_matches_scipy(Binomial, Nat, {'n': NatSmall, 'p': Unit},
                                  lambda value, n, p: sp.binom.logpmf(value, n, p))
@@ -805,7 +805,6 @@ class TestMatchesScipy(SeededTest):
                 xmax = mu + 5 * sd
 
                 class TestedInterpolated (Interpolated):
-
                     def __init__(self, **kwargs):
                         x_points = np.linspace(xmin, xmax, 100000)
                         pdf_points = sp.norm.pdf(x_points, loc=mu, scale=sd)


### PR DESCRIPTION
Having closer look here, I foud that my today's problems were caused by [this](https://github.com/pymc-devs/pymc3/blob/master/pymc3/distributions/distribution.py#L62) line. This method is not aware of distribution dtype. Then [here](https://github.com/pymc-devs/pymc3/blob/master/pymc3/model.py#L815) the returned unchecked value is muptiplied by numpy array. Not sure why it happened so but I got a random variable of float32 dtype with float64 test value. Next `compute_test_value` fails unexpectedly with non informative message. That forces to use float64 every time. It's so annoying, spent a day investigating that bug.