### PR TITLE
Split up requirements, update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Please verify that your issue is not being currently addressed by other issues o
 
 While issue reporting is valuable, we strongly encourage users who are inclined to do so to submit patches for new or existing issues via pull requests. This is particularly the case for simple fixes, such as typos or tweaks to documentation, which do not require a heavy investment of time and attention.
 
-Contributors are also encouraged to contribute new code to enhance PyMC's functionality, also via pull requests. Please consult the [PyMC3 documentation](https://pymc-devs.github.io/pymc3/) to ensure that any new contribution does not strongly overlap with existing functionality.
+Contributors are also encouraged to contribute new code to enhance PyMC3's functionality, also via pull requests. Please consult the [PyMC3 documentation](https://pymc-devs.github.io/pymc3/) to ensure that any new contribution does not strongly overlap with existing functionality.
 
 The preferred workflow for contributing to PyMC3 is to fork the [GitHUb repository](https://github.com/pymc-devs/pymc3/), clone it to your local machine, and develop on a feature branch.
 
@@ -27,11 +27,12 @@ The preferred workflow for contributing to PyMC3 is to fork the [GitHUb reposito
 
 1. Fork the [project repository](https://github.com/pymc-devs/pymc3/) by clicking on the 'Fork' button near the top right of the main repository page. This creates a copy of the code under your GitHub user account.
 
-2. Clone your fork of the PyMC3 repo from your GitHub account to your local disk:
+2. Clone your fork of the PyMC3 repo from your GitHub account to your local disk, and add the base repository as a remote:
 
    ```bash
    $ git clone git@github.com:<your GitHub handle>/pymc3.git
-   $ cd pymc3-learn
+   $ cd pymc3
+   $ git remote add upstream git@github.com:pymc-devs/pymc3.git
    ```
 
 3. Create a ``feature`` branch to hold your development changes:
@@ -42,20 +43,36 @@ The preferred workflow for contributing to PyMC3 is to fork the [GitHUb reposito
 
    Always use a ``feature`` branch. It's good practice to never routinely work on the ``master`` branch of any repository.
 
-4. Develop the feature on your feature branch. Add changed files using ``git add`` and then ``git commit`` files:
+4. Project requirements are in ``requirements.txt``, and libraries used for development are in ``requirements-dev.txt``.  To set up a development environment, you may (probably in a [virtual environment](http://python-guide-pt-br.readthedocs.io/en/latest/dev/virtualenvs/)) run:
+
+   ```bash
+   $ pip install -r requirements.txt
+   $ pip install -r requirements-dev.txt
+   ```
+
+Alternatively, there is a script to create a docker environment for development.  See: [Developing in Docker](#Developing-in-Docker).
+
+5. Develop the feature on your feature branch. Add changed files using ``git add`` and then ``git commit`` files:
 
    ```bash
    $ git add modified_files
    $ git commit
    ```
 
-   to record your changes in Git locally, then push the changes to your GitHub account with:
+   to record your changes locally.
+   After committing, it is a good idea to sync with the base repository in case there have been any changes:
+   ```bash
+   $ git fetch upstream
+   $ git rebase upstream/master
+   ```
+
+   Then push the changes to your GitHub account with:
 
    ```bash
    $ git push -u origin my-feature
    ```
 
-5. Go to the GitHub web page of your fork of the PyMC3 repo. Click the 'Pull request' button to send your changes to the project's maintainers fo review. This will send an email to the committers.
+6. Go to the GitHub web page of your fork of the PyMC3 repo. Click the 'Pull request' button to send your changes to the project's maintainers for review. This will send an email to the committers.
 
 ## Pull request checklist
 
@@ -96,8 +113,8 @@ tools:
 * No PEP8 warnings, check with:
 
   ```bash
-  $ pip install pep8
-  $ pep8 path/to/module.py
+  $ pip install pycodestyle
+  $ pycodestyle path/to/module.py
   ```
 
 * AutoPEP8 can help you fix some of the easy redundant errors:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,7 @@
+numpy>=1.11.0
+scipy>=0.12.0
+h5py>=2.7.0
+numdifftools>=0.9.20
 CommonMark>=0.5.4
 recommonmark>=0.4.0
 sphinx>=1.5.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+CommonMark>=0.5.4
+recommonmark>=0.4.0
+sphinx>=1.5.5
+nbsphinx>=0.2.13
+pytest>=3.0.7
+pytest-cov>=2.5.1
+mock>=2.0.0; python_version < '3.4'
+pyflakes>=1.5.0
+pycodestyle>=2.3.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pytest-cov>=2.5.1
 mock>=2.0.0; python_version < '3.4'
 pyflakes>=1.5.0
 pycodestyle>=2.3.1
+nose-parameterized==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-numpy>=1.11.0
-scipy>=0.12.0
 matplotlib>=1.5.0
 theano>=0.9.0
 pandas>=0.18.0
@@ -7,6 +5,4 @@ patsy>=0.4.0
 joblib>=0.9
 tqdm>=4.8.4
 six>=1.10.0
-h5py>=2.7.0
-numdifftools>=0.9.20
 enum34>=1.1.6; python_version < '3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,7 @@ pandas>=0.18.0
 patsy>=0.4.0
 joblib>=0.9
 tqdm>=4.8.4
-CommonMark==0.5.4
-recommonmark
-sphinx
-nbsphinx
-numdifftools
-six
-h5py
+six>=1.10.0
+h5py>=2.7.0
+numdifftools>=0.9.20
+enum34>=1.1.6; python_version < '3.4'

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -35,8 +35,8 @@ then
 fi
 
 pip install jupyter
-conda install --yes pyqt matplotlib --channel conda-forge
-conda install --yes pyzmq numpy scipy pytest pytest-cov pandas Cython patsy statsmodels joblib coverage mkl-service
+conda install --yes matplotlib --channel conda-forge
+conda install --yes numpy scipy pytest pytest-cov pandas patsy joblib mkl-service
 if [ ${PYTHON_VERSION} == "2.7" ]; then
     conda install --yes mock enum34;
 fi
@@ -44,9 +44,8 @@ fi
 pip install --upgrade pip
 pip install --no-deps numdifftools
 pip install git+https://github.com/Theano/Theano.git
-pip install tqdm h5py parameterized
+pip install tqdm h5py
 
-if [ -z ${NO_SETUP} ]
-then
+if [ -z ${NO_SETUP} ]; then
     python setup.py build_ext --inplace
 fi

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -44,7 +44,7 @@ fi
 pip install --upgrade pip
 pip install --no-deps numdifftools
 pip install git+https://github.com/Theano/Theano.git
-pip install tqdm h5py
+pip install tqdm h5py nose-parameterized==0.6.0
 
 if [ -z ${NO_SETUP} ]; then
     python setup.py build_ext --inplace


### PR DESCRIPTION
Addresses #2199 .  Might take a few tries on travis.

A few changes:
- Using a neat trick to install by version in requirements.txt: http://stackoverflow.com/questions/19559247/requirements-txt-depending-on-python-version/33451105#33451105, though this will apparently break on `pip < 6.0`.  

- `setup.py` still reads requirements from `requirements.txt` (and plays nicely with the above trick), and useful packages for development can be installed with `requirements-dev.txt`.

- Also slimmed down `create_testenv.sh` (for example, `pytest-cov` installs `coverage`), though it'd be nice to figure out a way for that to read from requirements{-dev}.txt, too.  I like using conda to create that environment, but don't know enough about how to get conda to play nicely with `setup.py`...

Also, there are at least two libraries that are still included but could be considered optional or removed (really, if we wanted to be super careful, probably *just* theano suffices, since it requires numpy and scipy):

- `numdifftools` is used for one test, and one function that is used nowhere else (`tuning.scaling.approx_hessian`), and was last touched 4 years ago when @twiecki made `numdifftools` optional.

- `h5py` is only used for the backend

Finally!  We might want to benchmark speedups from `mkl-service` and advertise them -- the `create_testenv.sh` script installs it, but if we find real performance benefits from it, it might make sense to add to the requirements, or mention somewhere that this exists.