### PR TITLE
Allow alpha to be passed to KDE in plot_posterior

### DIFF
--- a/pymc3/plots/artists.py
+++ b/pymc3/plots/artists.py
@@ -122,11 +122,7 @@ def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
             d[key] = value
 
     if kde_plot:
-        if 'alpha' in kwargs:
-            alpha = kwargs.pop('alpha')
-        else:
-            alpha = 0.35
-        kdeplot(trace_values, alpha=alpha, ax=ax, **kwargs)
+        kdeplot(trace_values, alpha=kwargs.pop('alpha', 0.35), ax=ax, **kwargs)
 
     else:
         set_key_if_doesnt_exist(kwargs, 'bins', 30)

--- a/pymc3/plots/artists.py
+++ b/pymc3/plots/artists.py
@@ -122,7 +122,11 @@ def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
             d[key] = value
 
     if kde_plot:
-        kdeplot(trace_values, alpha=0.35, ax=ax, **kwargs)
+        if 'alpha' in kwargs:
+            alpha = kwargs.pop('alpha')
+        else:
+            alpha = 0.35
+        kdeplot(trace_values, alpha=alpha, ax=ax, **kwargs)
 
     else:
         set_key_if_doesnt_exist(kwargs, 'bins', 30)


### PR DESCRIPTION
Small fix: added option for passing alpha to kde in plot_posterior via kwargs