### PR TITLE
Update create testenv

### DIFF
--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -35,8 +35,16 @@ then
 fi
 
 pip install --upgrade pip
+
+#  Install editable using the setup.py
 pip install -e .
-pip install pytest pytest-cov nose-parameterized==0.6.0 pylint
+
+# Install extra testing stuff
+if [ ${PYTHON_VERSION} == "2.7" ]; then
+    pip install mock
+fi
+
+pip install pytest pytest-cov nose-parameterized pylint
 
 if [ -z ${NO_SETUP} ]; then
     python setup.py build_ext --inplace

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -34,17 +34,9 @@ then
     fi
 fi
 
-pip install jupyter
-conda install --yes matplotlib --channel conda-forge
-conda install --yes numpy scipy pytest pytest-cov pandas patsy joblib mkl-service
-if [ ${PYTHON_VERSION} == "2.7" ]; then
-    conda install --yes mock enum34;
-fi
-
 pip install --upgrade pip
-pip install --no-deps numdifftools
-pip install git+https://github.com/Theano/Theano.git
-pip install tqdm h5py nose-parameterized==0.6.0
+pip install -e .
+pip install pytest pytest-cov nose-parameterized==0.6.0 pylint
 
 if [ -z ${NO_SETUP} ]; then
     python setup.py build_ext --inplace

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -46,6 +46,9 @@ fi
 
 pip install pytest pytest-cov nose-parameterized pylint
 
+# Install untested, non-required code (linter fails without them)
+pip install ipython ipywidgets numdifftools
+
 if [ -z ${NO_SETUP} ]; then
     python setup.py build_ext --inplace
 fi

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -33,6 +33,7 @@ then
       source activate ${ENVNAME}
     fi
 fi
+conda install --yes numpy scipy mkl-service
 
 pip install --upgrade pip
 


### PR DESCRIPTION
This would have caught #2227, and should catch `pip install pymc3` issues in the future.  I'm not sure what the effects of installing everything with `pip` instead of `conda` are, but we'll see.  I've marked it `WIP` since there might be a merge conflict adding `h5py` to `requirements.txt`, as in #2228.