### PR TITLE
Fix DiscreteUniform default test_point

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -440,7 +440,7 @@ class DiscreteUniform(Discrete):
         self.lower = tt.floor(lower).astype('int32')
         self.upper = tt.floor(upper).astype('int32')
         self.mode = tt.maximum(
-            tt.floor((upper - lower) / 2.).astype('int32'), self.lower)
+            tt.floor((upper + lower) / 2.).astype('int32'), self.lower)
 
     def _random(self, lower, upper, size=None):
         # This way seems to be the only to deal with lower and upper

--- a/pymc3/tests/test_distribution_defaults.py
+++ b/pymc3/tests/test_distribution_defaults.py
@@ -63,3 +63,9 @@ def test_default_discrete_uniform():
     with Model():
         x = DiscreteUniform('x', lower=1, upper=2)
         assert x.init_value == 1
+
+def test_discrete_uniform_negative():
+    model = Model()
+    with model:
+        x = DiscreteUniform('x', lower=-10, upper=0)
+    assert model.test_point['x'] == -5


### PR DESCRIPTION
Fix for #2185.
@ColCarroll where do you think a test for this should go? [test_distributions](https://github.com/pymc-devs/pymc3/blob/master/pymc3/tests/test_distributions.py) or [test_distribution_defaults](https://github.com/pymc-devs/pymc3/blob/master/pymc3/tests/test_distribution_defaults.py) ?