### PR TITLE
Plot posterior reliable mode calculation for continuous variables and ignore kde_plot=True for discretes ones

### DIFF
--- a/pymc3/plots/artists.py
+++ b/pymc3/plots/artists.py
@@ -82,7 +82,12 @@ def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
         if point_estimate == 'mean':
             point_value = trace_values.mean()
         elif point_estimate == 'mode':
-            point_value = mode(trace_values.round(round_to))[0][0]
+            if isinstance(trace_values[0], float):
+                density, l, u = fast_kde(trace_values)
+                x = np.linspace(l, u, len(density))
+                point_value = x[np.argmax(density)]
+            else:
+                point_value = mode(trace_values.round(round_to))[0][0]
         elif point_estimate == 'median':
             point_value = np.median(trace_values)
         point_text = '{point_estimate}={point_value:.{round_to}f}'.format(point_estimate=point_estimate,
@@ -121,7 +126,7 @@ def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
         if key not in d:
             d[key] = value
 
-    if kde_plot:
+    if kde_plot and isinstance(trace_values[0], float):
         kdeplot(trace_values, alpha=kwargs.pop('alpha', 0.35), ax=ax, **kwargs)
 
     else:

--- a/pymc3/plots/posteriorplot.py
+++ b/pymc3/plots/posteriorplot.py
@@ -34,7 +34,7 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
     ref_val: bool
         display the percentage below and above ref_val
     kde_plot: bool
-        if True plot a KDE instead of a histogram. For discrete variable this
+        if True plot a KDE instead of a histogram. For discrete variables this
         argument is ignored.
     plot_transformed : bool
         Flag for plotting automatically transformed variables in addition to

--- a/pymc3/plots/posteriorplot.py
+++ b/pymc3/plots/posteriorplot.py
@@ -34,7 +34,8 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
     ref_val: bool
         display the percentage below and above ref_val
     kde_plot: bool
-        if True plot a KDE instead of a histogram
+        if True plot a KDE instead of a histogram. For discrete variable this
+        argument is ignored.
     plot_transformed : bool
         Flag for plotting automatically transformed variables in addition to
         original variables (defaults to False).


### PR DESCRIPTION
* scipy.mode is a not a reliable way to compute the mode for continuous variables, I change it for a method based on kde computation.

* `kde_plot=True` is now ignored for discrete variables, allowing to have kde plots (for continuous variables) with histogram (for discrete variables) in the same posterior_plot.
