### PR TITLE
Fixed text_size argument in plot_posterior

### DIFF
--- a/pymc3/plots/artists.py
+++ b/pymc3/plots/artists.py
@@ -64,12 +64,12 @@ def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
         ax.axvline(ref_val, ymin=0.02, ymax=.75, color='g',
                    linewidth=4, alpha=0.65)
         ax.text(trace_values.mean(), plot_height * 0.6, ref_in_posterior,
-                size=14, horizontalalignment='center')
+                size=text_size, horizontalalignment='center')
 
     def display_rope(rope):
         ax.plot(rope, (plot_height * 0.02, plot_height * 0.02),
                 linewidth=20, color='r', alpha=0.75)
-        text_props = dict(size=16, horizontalalignment='center', color='r')
+        text_props = dict(size=text_size, horizontalalignment='center', color='r')
         ax.text(rope[0], plot_height * 0.14, rope[0], **text_props)
         ax.text(rope[1], plot_height * 0.14, rope[1], **text_props)
 
@@ -102,13 +102,13 @@ def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
                                 plot_height * 0.02), linewidth=4, color='k')
         ax.text(hpd_intervals[0], plot_height * 0.07,
                 hpd_intervals[0].round(round_to),
-                size=16, horizontalalignment='right')
+                size=text_size, horizontalalignment='right')
         ax.text(hpd_intervals[1], plot_height * 0.07,
                 hpd_intervals[1].round(round_to),
-                size=16, horizontalalignment='left')
+                size=text_size, horizontalalignment='left')
         ax.text((hpd_intervals[0] + hpd_intervals[1]) / 2, plot_height * 0.2,
                 format_as_percent(1 - alpha_level) + ' HPD',
-                size=16, horizontalalignment='center')
+                size=text_size, horizontalalignment='center')
 
     def format_axes():
         ax.yaxis.set_ticklabels([])
@@ -119,7 +119,7 @@ def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
         ax.yaxis.set_ticks_position('none')
         ax.xaxis.set_ticks_position('bottom')
         ax.tick_params(axis='x', direction='out', width=1, length=3,
-                       color='0.5')
+                       color='0.5', labelsize=text_size)
         ax.spines['bottom'].set_color('0.5')
 
     def set_key_if_doesnt_exist(d, key, value):

--- a/pymc3/plots/posteriorplot.py
+++ b/pymc3/plots/posteriorplot.py
@@ -22,7 +22,7 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
     figsize : figure size tuple
         If None, size is (12, num of variables * 2) inch
     text_size : int
-        Text size of the point_estimates and HPD (Default:16)
+        Text size of the point_estimates, axis ticks, and HPD (Default:16)
     alpha_level : float
         Defines range for High Posterior Density
     round_to : int


### PR DESCRIPTION
The `text_size` argument in `plot_posterior` is not currently propagated to all of the text annotations on the plot. This PR allows all text to be controlled with this argument.