### PR TITLE
suppress error raise in #2258

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -599,7 +599,7 @@ def init_nuts(init='ADVI', njobs=1, n_init=500000, model=None,
             n=n_init, method='advi', model=model,
             callbacks=cb,
             progressbar=progressbar,
-            obj_optimizer=pm.adagrad_window,
+            obj_optimizer=pm.adagrad_window
         )  # type: pm.MeanField
         start = approx.sample(draws=njobs, include_transformed=True)
         stds = approx.gbij.rmap(approx.std.eval())


### PR DESCRIPTION
This is a temporary solution!!! 
Related/same issue including: #2076, #2109
Behavior:  
1, The user supplied start value is taken as priority (same as before the fix)
2, if there is transformed RV conditioned on another free_RV, the start value will be ignore (due to error in #2258)
3, No more error using default init in situation 2:
```python
with pm.Model() as model:
    a1 = pm.Uniform('a1', lower=0., upper=1.)
    b1 = pm.Uniform('b1', lower=0., upper=1. - a1)
    pm.sample()
```