### PR TITLE
Add config for read the docs (RTD) build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+# Build ePub (pdf is currently failing)
+formats:
+  - epub
+
+# pip requirements file for building sphinx docs (e.g. nbsphinx)
+requirements_file: docs/requirements-docs.txt
+
+# can also specify a conda env file if pip isn't enough, for example:
+# conda:
+#   file: environment.yml
+
+# Use python 3 for building
+python:
+  version: 3.5

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,3 @@
+nbsphinx
+ipykernel
+numpy


### PR DESCRIPTION
Solves #2132 

- Added RTD requirements file for nbsphinx builds
- Added RTD config file

In order to build the docs a maintainer must:
1. Create an account on readthedocs.org
2. Link pymc3 repo
3. select: advanced settings -> versions -> choose versions to show

To have previous (3.0) versions show up on RTD, we'll have to branch off from the previous `3.0-final` tag and add these config changes there.