### PR TITLE
Fix model comparison for multidim observed vars

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -915,7 +915,7 @@ def as_tensor(data, name, model, distribution):
 
     if hasattr(data, 'mask'):
         from .distributions import NoDistribution
-        testval = distribution.default()
+        testval = np.broadcast_to(distribution.default(), data.shape)[data.mask]
         fakedist = NoDistribution.dist(shape=data.mask.sum(), dtype=dtype,
                                        testval=testval, parent_dist=distribution)
         missing_values = FreeRV(name=name + '_missing', distribution=fakedist,

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -915,7 +915,7 @@ def as_tensor(data, name, model, distribution):
 
     if hasattr(data, 'mask'):
         from .distributions import NoDistribution
-        testval = distribution.testval or data.mean().astype(dtype)
+        testval = distribution.default()
         fakedist = NoDistribution.dist(shape=data.mask.sum(), dtype=dtype,
                                        testval=testval, parent_dist=distribution)
         missing_values = FreeRV(name=name + '_missing', distribution=fakedist,
@@ -959,13 +959,14 @@ class ObservedRV(Factor, TensorVariable):
             data = pandas_to_array(data)
             type = TensorType(distribution.dtype, data.shape)
 
+        self.observations = data
+
         super(ObservedRV, self).__init__(type, owner, index, name)
 
         if distribution is not None:
             data = as_tensor(data, name, model, distribution)
 
             self.missing_values = data.missing_values
-
             self.logp_elemwiset = distribution.logp(data)
             self.total_size = total_size
             self.model = model

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -1,5 +1,8 @@
 import pytest
 from theano import theano, tensor as tt
+import numpy as np
+import pandas as pd
+import numpy.testing as npt
 
 import pymc3 as pm
 from pymc3.distributions import HalfCauchy, Normal, transforms
@@ -166,3 +169,13 @@ def test_duplicate_vars():
             pm.Binomial('a', 10, .5)
             pm.Normal('a', transform=transforms.log)
     err.match('already exists')
+
+
+def test_empty_observed():
+    data = pd.DataFrame(np.ones((2, 3)) / 3)
+    data.values[:] = np.nan
+    with pm.Model():
+        a = pm.Normal('a', observed=data)
+        npt.assert_allclose(a.tag.test_value, np.zeros((2, 3)))
+        b = pm.Beta('b', alpha=1, beta=1, observed=data)
+        npt.assert_allclose(b.tag.test_value, np.ones((2, 3)) / 2)

--- a/pymc3/tests/test_model_helpers.py
+++ b/pymc3/tests/test_model_helpers.py
@@ -97,7 +97,7 @@ class TestHelperFunc(object):
         # Create a fake model and fake distribution to be used for the test
         fake_model = pm.Model()
         with fake_model:
-            fake_distribution = pm.Normal('fake_dist', mu=0, sd=1)
+            fake_distribution = pm.Normal.dist(mu=0, sd=1)
             # Create the testval attribute simply for the sake of model testing
             fake_distribution.testval = None
 


### PR DESCRIPTION
This should fix #2311.
Along the way I also fixed an issue in ObservedRV: The default value was sometimes computed as `data.mean()`, which doesn't even have the right dtype for discrete values and was broken if all values are missing. I am using `distribution.default()` now.