### PR TITLE
Fix for mean functions

### DIFF
--- a/pymc3/gp/mean.py
+++ b/pymc3/gp/mean.py
@@ -3,10 +3,9 @@ import theano.tensor as tt
 __all__ = ['Zero', 'Constant']
 
 class Mean(object):
-    """
+    R"""
     Base class for mean functions
     """
-    
     def __call__(self, X):
         R"""
         Evaluate the mean function.
@@ -22,49 +21,52 @@ class Mean(object):
 
     def __mul__(self, other):
         return Prod(self, other)
-        
+
 class Zero(Mean):
-    def __call__(self, X):
-        return tt.zeros(X.shape, dtype='float32')
-        
-class Constant(Mean):
+    R"""
+    Zero mean function for Gaussian process.
+
     """
+    def __call__(self, X):
+        return tt.zeros(tt.stack([X.shape[0], ]), dtype='float32')
+
+class Constant(Mean):
+    R"""
     Constant mean function for Gaussian process.
-    
+
     Parameters
     ----------
     c : variable, array or integer
         Constant mean value
     """
-
     def __init__(self, c=0):
         Mean.__init__(self)
         self.c = c
 
     def __call__(self, X):
-        return tt.ones(X.shape) * self.c
+        return tt.ones(tt.stack([X.shape[0], ])) * self.c
+
 
 class Linear(Mean):
-    
+    R"""
+    Linear mean function for Gaussian process.
+
+    Parameters
+    ----------
+    coeffs : variables
+        Linear coefficients
+    intercept : variable, array or integer
+        Intercept for linear function (Defaults to zero)
+    """
     def __init__(self, coeffs, intercept=0):
-        """
-        Linear mean function for Gaussian process.
-        
-        Parameters
-        ----------
-        coeffs : variables
-            Linear coefficients
-        intercept : variable, array or integer
-            Intercept for linear function (Defaults to zero)
-        """
         Mean.__init__(self)
         self.b = intercept
         self.A = coeffs
-        
+
     def __call__(self, X):
         return tt.dot(X, self.A) + self.b
 
-        
+
 class Add(Mean):
     def __init__(self, first_mean, second_mean):
         Mean.__init__(self)
@@ -83,4 +85,4 @@ class Prod(Mean):
 
     def __call__(self, X):
         return tt.mul(self.m1(X), self.m2(X))
-        
+

--- a/pymc3/gp/mean.py
+++ b/pymc3/gp/mean.py
@@ -64,7 +64,7 @@ class Linear(Mean):
         self.A = coeffs
 
     def __call__(self, X):
-        return tt.dot(X, self.A) + self.b
+        return (tt.dot(X, self.A) + self.b).squeeze()
 
 
 class Add(Mean):

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -7,36 +7,81 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-class TestZero(object):
+
+class TestZeroMean(object):
     def test_value(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             zero_mean = gp.mean.Zero()
         M = theano.function([], zero_mean(X))()
         assert np.all(M==0)
-        assert M.shape == (10,1)
+        assert M.shape == (10, )
 
-class TestConstant(object):
+
+class TestConstantMean(object):
     def test_value(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             const_mean = gp.mean.Constant(6)
         M = theano.function([], const_mean(X))()
         assert np.all(M==6)
-        assert M.shape == (10,1)
+        assert M.shape == (10, )
+
 
 class TestLinearMean(object):
     def test_value(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             linear_mean = gp.mean.Linear(2, 0.5)
         M = theano.function([], linear_mean(X))()
         npt.assert_allclose(M[1, 0], 0.7222, atol=1e-3)
 
 
+class TestAddProdMean(object):
+    def test_add(self):
+        X = np.linspace(0, 1, 10)[:, None]
+        with Model() as model:
+            mean1 = gp.mean.Linear(coeffs=2, intercept=0.5)
+            mean2 = gp.mean.Constant(2)
+            mean = mean1 + mean2 + mean2
+        M = theano.function([], mean(X))()
+        npt.assert_allclose(M[1], 0.7222 + 2 + 2, atol=1e-3)
+
+    def test_prod(self):
+        X = np.linspace(0, 1, 10)[:, None]
+        with Model() as model:
+            mean1 = gp.mean.Linear(coeffs=2, intercept=0.5)
+            mean2 = gp.mean.Constant(2)
+            mean = mean1 * mean2 * mean2
+        M = theano.function([], mean(X))()
+        npt.assert_allclose(M[1], 0.7222 * 2 * 2, atol=1e-3)
+
+    def test_add_multid(self):
+        X = np.linspace(0, 1, 30).reshape(10, 3)
+        A = np.array([1, 2, 3])
+        b = 10
+        with Model() as model:
+            mean1 = gp.mean.Linear(coeffs=A, intercept=b)
+            mean2 = gp.mean.Constant(2)
+            mean = mean1 + mean2 + mean2
+        M = theano.function([], mean(X))()
+        npt.assert_allclose(M[1], 10.8965 + 2 + 2, atol=1e-3)
+
+    def test_prod_multid(self):
+        X = np.linspace(0, 1, 30).reshape(10, 3)
+        A = np.array([1, 2, 3])
+        b = 10
+        with Model() as model:
+            mean1 = gp.mean.Linear(coeffs=A, intercept=b)
+            mean2 = gp.mean.Constant(2)
+            mean = mean1 * mean2 * mean2
+        M = theano.function([], mean(X))()
+        npt.assert_allclose(M[1], 10.8965 * 2 * 2, atol=1e-3)
+
+
 class TestCovAdd(object):
     def test_symadd_cov(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             cov1 = gp.cov.ExpQuad(1, 0.1)
             cov2 = gp.cov.ExpQuad(1, 0.1)
@@ -45,7 +90,7 @@ class TestCovAdd(object):
         npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
 
     def test_rightadd_scalar(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             a = 1
             cov = gp.cov.ExpQuad(1, 0.1) + a
@@ -53,7 +98,7 @@ class TestCovAdd(object):
         npt.assert_allclose(K[0, 1], 1.53940, atol=1e-3)
 
     def test_leftadd_scalar(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             a = 1
             cov = a + gp.cov.ExpQuad(1, 0.1)
@@ -61,16 +106,16 @@ class TestCovAdd(object):
         npt.assert_allclose(K[0, 1], 1.53940, atol=1e-3)
 
     def test_rightadd_matrix(self):
-        X = np.linspace(0,1,10)[:,None]
-        M = 2 * np.ones((10,10))
+        X = np.linspace(0, 1, 10)[:, None]
+        M = 2 * np.ones((10, 10))
         with Model() as model:
             cov = gp.cov.ExpQuad(1, 0.1) + M
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2.53940, atol=1e-3)
 
     def test_leftprod_matrix(self):
-        X = np.linspace(0,1,3)[:,None]
-        M = np.array([[1,2,3],[2,1,2],[3,2,1]])
+        X = np.linspace(0, 1, 3)[:, None]
+        M = np.array([[1, 2, 3], [2, 1, 2], [3, 2, 1]])
         with Model() as model:
             cov = M + gp.cov.ExpQuad(1, 0.1)
             cov_true = gp.cov.ExpQuad(1, 0.1) + M
@@ -81,7 +126,7 @@ class TestCovAdd(object):
 
 class TestCovProd(object):
     def test_symprod_cov(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             cov1 = gp.cov.ExpQuad(1, 0.1)
             cov2 = gp.cov.ExpQuad(1, 0.1)
@@ -90,7 +135,7 @@ class TestCovProd(object):
         npt.assert_allclose(K[0, 1], 0.53940 * 0.53940, atol=1e-3)
 
     def test_rightprod_scalar(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             a = 2
             cov = gp.cov.ExpQuad(1, 0.1) * a
@@ -98,7 +143,7 @@ class TestCovProd(object):
         npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
 
     def test_leftprod_scalar(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             a = 2
             cov = a * gp.cov.ExpQuad(1, 0.1)
@@ -106,16 +151,16 @@ class TestCovProd(object):
         npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
 
     def test_rightprod_matrix(self):
-        X = np.linspace(0,1,10)[:,None]
-        M = 2 * np.ones((10,10))
+        X = np.linspace(0, 1, 10)[:, None]
+        M = 2 * np.ones((10, 10))
         with Model() as model:
             cov = gp.cov.ExpQuad(1, 0.1) * M
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
 
     def test_leftprod_matrix(self):
-        X = np.linspace(0,1,3)[:,None]
-        M = np.array([[1,2,3],[2,1,2],[3,2,1]])
+        X = np.linspace(0, 1, 3)[:, None]
+        M = np.array([[1, 2, 3], [2, 1, 2], [3, 2, 1]])
         with Model() as model:
             cov = M * gp.cov.ExpQuad(1, 0.1)
             cov_true = gp.cov.ExpQuad(1, 0.1) * M
@@ -124,8 +169,8 @@ class TestCovProd(object):
         assert np.allclose(K, K_true)
 
     def test_multiops(self):
-        X = np.linspace(0,1,3)[:,None]
-        M = np.array([[1,2,3],[2,1,2],[3,2,1]])
+        X = np.linspace(0, 1, 3)[:, None]
+        M = np.array([[1, 2, 3], [2, 1, 2], [3, 2, 1]])
         with Model() as model:
             cov1 = 3 + gp.cov.ExpQuad(1, 0.1) + M * gp.cov.ExpQuad(1, 0.1) * M * gp.cov.ExpQuad(1, 0.1)
             cov2 = gp.cov.ExpQuad(1, 0.1) * M * gp.cov.ExpQuad(1, 0.1) * M + gp.cov.ExpQuad(1, 0.1) + 3
@@ -136,28 +181,28 @@ class TestCovProd(object):
 
 class TestCovSliceDim(object):
     def test_slice1(self):
-        X = np.linspace(0,1,30).reshape(10,3)
+        X = np.linspace(0, 1, 30).reshape(10, 3)
         with Model() as model:
-            cov = gp.cov.ExpQuad(3, 0.1, active_dims=[0,0,1])
+            cov = gp.cov.ExpQuad(3, 0.1, active_dims=[0, 0, 1])
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.20084298, atol=1e-3)
 
     def test_slice2(self):
-        X = np.linspace(0,1,30).reshape(10,3)
+        X = np.linspace(0, 1, 30).reshape(10, 3)
         with Model() as model:
             cov = gp.cov.ExpQuad(3, [0.1, 0.1], active_dims=[False, True, True])
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.34295549, atol=1e-3)
 
     def test_slice3(self):
-        X = np.linspace(0,1,30).reshape(10,3)
+        X = np.linspace(0, 1, 30).reshape(10, 3)
         with Model() as model:
             cov = gp.cov.ExpQuad(3, np.array([0.1, 0.1]), active_dims=[False, True, True])
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.34295549, atol=1e-3)
 
     def test_diffslice(self):
-        X = np.linspace(0,1,30).reshape(10,3)
+        X = np.linspace(0, 1, 30).reshape(10, 3)
         with Model() as model:
             cov = gp.cov.ExpQuad(3, 0.1, [1, 0, 0]) + gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
         K = theano.function([], cov(X))()
@@ -172,7 +217,7 @@ class TestCovSliceDim(object):
 
 class TestStability(object):
     def test_stable(self):
-        X = np.random.uniform(low=320., high=400., size=[2000,2])
+        X = np.random.uniform(low=320., high=400., size=[2000, 2])
         with Model() as model:
             cov = gp.cov.ExpQuad(2, 0.1)
         dists = theano.function([], cov.square_dist(X, X))()
@@ -181,23 +226,23 @@ class TestStability(object):
 
 class TestExpQuad(object):
     def test_1d(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             cov = gp.cov.ExpQuad(1, 0.1)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.53940, atol=1e-3)
-        K = theano.function([], cov(X,X))()
+        K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.53940, atol=1e-3)
 
     def test_2d(self):
-        X = np.linspace(0,1,10).reshape(5,2)
+        X = np.linspace(0, 1, 10).reshape(5, 2)
         with Model() as model:
             cov = gp.cov.ExpQuad(2, 0.5)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.820754, atol=1e-3)
 
     def test_2dard(self):
-        X = np.linspace(0,1,10).reshape(5,2)
+        X = np.linspace(0, 1, 10).reshape(5, 2)
         with Model() as model:
             cov = gp.cov.ExpQuad(2, np.array([1, 2]))
         K = theano.function([], cov(X))()
@@ -206,92 +251,92 @@ class TestExpQuad(object):
 
 class TestRatQuad(object):
     def test_1d(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             cov = gp.cov.RatQuad(1, 0.1, 0.5)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.66896, atol=1e-3)
-        K = theano.function([], cov(X,X))()
+        K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.66896, atol=1e-3)
 
 
 class TestExponential(object):
     def test_1d(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             cov = gp.cov.Exponential(1, 0.1)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.57375, atol=1e-3)
-        K = theano.function([], cov(X,X))()
+        K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.57375, atol=1e-3)
 
 
 class TestMatern52(object):
     def test_1d(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             cov = gp.cov.Matern52(1, 0.1)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.46202, atol=1e-3)
-        K = theano.function([], cov(X,X))()
+        K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.46202, atol=1e-3)
 
 
 class TestMatern32(object):
     def test_1d(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             cov = gp.cov.Matern32(1, 0.1)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.42682, atol=1e-3)
-        K = theano.function([], cov(X,X))()
+        K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.42682, atol=1e-3)
 
 
 class TestCosine(object):
     def test_1d(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             cov = gp.cov.Cosine(1, 0.1)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], -0.93969, atol=1e-3)
-        K = theano.function([], cov(X,X))()
+        K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], -0.93969, atol=1e-3)
 
 
 class TestLinear(object):
     def test_1d(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             cov = gp.cov.Linear(1, 0.5)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.19444, atol=1e-3)
-        K = theano.function([], cov(X,X))()
+        K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.19444, atol=1e-3)
 
 
 class TestPolynomial(object):
     def test_1d(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         with Model() as model:
             cov = gp.cov.Polynomial(1, 0.5, 2, 0)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.03780, atol=1e-3)
-        K = theano.function([], cov(X,X))()
+        K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.03780, atol=1e-3)
 
 
 class TestWarpedInput(object):
     def test_1d(self):
-        X = np.linspace(0,1,10)[:,None]
+        X = np.linspace(0, 1, 10)[:, None]
         def warp_func(x, a, b, c):
             return x + (a * tt.tanh(b * (x - c)))
         with Model() as model:
             cov_m52 = gp.cov.Matern52(1, 0.2)
-            cov = gp.cov.WarpedInput(1, warp_func=warp_func, args=(1,10,1), cov_func=cov_m52)
+            cov = gp.cov.WarpedInput(1, warp_func=warp_func, args=(1, 10, 1), cov_func=cov_m52)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.79593, atol=1e-3)
-        K = theano.function([], cov(X,X))()
+        K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.79593, atol=1e-3)
 
     def test_raises(self):
@@ -304,14 +349,14 @@ class TestWarpedInput(object):
 
 class TestGibbs(object):
     def test_1d(self):
-        X = np.linspace(0, 2, 10)[:,None]
+        X = np.linspace(0, 2, 10)[:, None]
         def tanh_func(x, x1, x2, w, x0):
             return (x1 + x2) / 2.0 - (x1 - x2) / 2.0 * tt.tanh((x - x0) / w)
         with Model() as model:
             cov = gp.cov.Gibbs(1, tanh_func, args=(0.05, 0.6, 0.4, 1.0))
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[2, 3], 0.136683, atol=1e-4)
-        K = theano.function([], cov(X,X))()
+        K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[2, 3], 0.136683, atol=1e-4)
 
     def test_raises(self):
@@ -344,8 +389,8 @@ class TestHandleArgs(object):
 
 class TestGP(SeededTest):
     def test_func_args(self):
-        X = np.linspace(0,1,10)[:,None]
-        Y = np.random.randn(10,1)
+        X = np.linspace(0, 1, 10)[:, None]
+        Y = np.random.randn(10, 1)
         with Model() as model:
             # make a Gaussian model
             with pytest.raises(ValueError):
@@ -355,8 +400,8 @@ class TestGP(SeededTest):
                                         cov_func=gp.cov.Matern32(1, 1), observed={'X':X, 'Y':Y})
 
     def test_sample(self):
-        X = np.linspace(0,1,10)[:,None]
-        Y = np.random.randn(10,1)
+        X = np.linspace(0, 1, 10)[:, None]
+        Y = np.random.randn(10, 1)
         with Model() as model:
             M = gp.mean.Zero()
             l = Uniform('l', 0, 5)

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -34,7 +34,8 @@ class TestLinearMean(object):
         with Model() as model:
             linear_mean = gp.mean.Linear(2, 0.5)
         M = theano.function([], linear_mean(X))()
-        npt.assert_allclose(M[1, 0], 0.7222, atol=1e-3)
+        npt.assert_allclose(M[1], 0.7222, atol=1e-3)
+        assert M.shape == (10, )
 
 
 class TestAddProdMean(object):


### PR DESCRIPTION
This PR cleans up PR #2111, where things got messy (sorry about that, I closed it).  It fixes the bug reported in issue #2078.  

- `Zero` and `Constant` used to return the same shape as the input, `X.shape` (Linear was OK)
- All mean functions now return with shape `X.shape[0]`.
- fix spacing after commas in tests
- tidy up docstrings
- add tests for adding and multiplying mean functions

