### PR TITLE
Add requirements file for API autodocs on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,12 +2,12 @@
 formats:
   - epub
 
-# pip requirements file for building sphinx docs (e.g. nbsphinx)
-requirements_file: docs/requirements-docs.txt
-
-# can also specify a conda env file if pip isn't enough, for example:
+# Conda requirements file
 # conda:
-#   file: environment.yml
+#   file: docs/environment.yml
+
+# pip requirements file for building sphinx docs (e.g. nbsphinx)
+requirements_file: docs/requirements.txt
 
 # Use python 3 for building
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ formats:
 #   file: docs/environment.yml
 
 # pip requirements file for building sphinx docs (e.g. nbsphinx)
-requirements_file: docs/requirements.txt
+requirements_file: requirements-dev.txt
 
 # Use python 3 for building
 python:

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,3 +1,0 @@
-nbsphinx
-ipykernel
-numpy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,12 @@
+nbsphinx
+tqdm
+numpy
+theano
+pandas
+ipykernel
+matplotlib
+patsy
+joblib
+six
+h5py
+enum34


### PR DESCRIPTION
Following up on #2314 

API docs now build on rtd. Here's my local version: http://pymc3-testing.readthedocs.io/en/rtd-docs/index.html