### PR TITLE
Methods to only compute diagonal of covariance functions

### DIFF
--- a/pymc3/gp/cov.py
+++ b/pymc3/gp/cov.py
@@ -99,18 +99,18 @@ class Combination(Covariance):
                 self.factor_list.append(factor)
 
     def merge_factors(self, X, Z=None, diag=False):
-        factors = []
+        factor_list = []
         for factor in self.factor_list:
             if isinstance(factor, Covariance):
-                factors.append(factor(X, Z, diag))
+                factor_list.append(factor(X, Z, diag))
             elif hasattr(factor, "ndim"):
                 if diag:
-                    factors.append(tt.diag(factor))
+                    factor_list.append(tt.diag(factor))
                 else:
-                    factors.append(factor)
+                    factor_list.append(factor)
             else:
-                factors.append(factor)
-        return factors
+                factor_list.append(factor)
+        return factor_list
 
 
 class Add(Combination):

--- a/pymc3/gp/cov.py
+++ b/pymc3/gp/cov.py
@@ -1,6 +1,7 @@
 import theano.tensor as tt
 import numpy as np
 from functools import reduce
+from theano import Variable
 
 __all__ = ['ExpQuad',
            'RatQuad',
@@ -35,7 +36,7 @@ class Covariance(object):
             if len(active_dims) != input_dim:
                 raise ValueError("Length of active_dims must match input_dim")
 
-    def __call__(self, X, Z):
+    def __call__(self, X, Z=None, diag=False):
         R"""
         Evaluate the kernel/covariance function.
 
@@ -43,8 +44,12 @@ class Covariance(object):
         ----------
         X : The training inputs to the kernel.
         Z : The optional prediction set of inputs the kernel.  If Z is None, Z = X.
+        daig: Return only the diagonal of the covariance function.  Default is False.
         """
-        raise NotImplementedError
+        if diag:
+            return self.diag(X)
+        else:
+            return self.full(X, Z)
 
     def _slice(self, X, Z):
         X = X[:, self.active_dims]
@@ -93,17 +98,29 @@ class Combination(Covariance):
             else:
                 self.factor_list.append(factor)
 
+    def merge_factors(self, X, Z=None, diag=False):
+        factors = []
+        for factor in self.factor_list:
+            if isinstance(factor, Covariance):
+                factors.append(factor(X, Z, diag))
+            elif hasattr(factor, "ndim"):
+                if diag:
+                    factors.append(tt.diag(factor))
+                else:
+                    factors.append(factor)
+            else:
+                factors.append(factor)
+        return factors
+
 
 class Add(Combination):
-    def __call__(self, X, Z=None):
-        return reduce((lambda x, y: x + y),
-                      [k(X, Z) if isinstance(k, Covariance) else k for k in self.factor_list])
+    def __call__(self, X, Z=None, diag=False):
+        return reduce((lambda x, y: x + y), self.merge_factors(X, Z, diag))
 
 
 class Prod(Combination):
-    def __call__(self, X, Z=None):
-        return reduce((lambda x, y: x * y),
-                      [k(X, Z) if isinstance(k, Covariance) else k for k in self.factor_list])
+    def __call__(self, X, Z=None, diag=False):
+        return reduce((lambda x, y: x * y), self.merge_factors(X, Z, diag))
 
 
 class Stationary(Covariance):
@@ -139,6 +156,12 @@ class Stationary(Covariance):
         r2 = self.square_dist(X, Z)
         return tt.sqrt(r2 + 1e-12)
 
+    def diag(self, X):
+        return tt.ones(tt.stack([X.shape[0], ]))
+
+    def full(self, X, Z=None):
+        raise NotImplementedError
+
 
 class ExpQuad(Stationary):
     R"""
@@ -150,7 +173,7 @@ class ExpQuad(Stationary):
        k(x, x') = \mathrm{exp}\left[ -\frac{(x - x')^2}{2 \ell^2} \right]
     """
 
-    def __call__(self, X, Z=None):
+    def full(self, X, Z=None):
         X, Z = self._slice(X, Z)
         return tt.exp( -0.5 * self.square_dist(X, Z))
 
@@ -169,7 +192,7 @@ class RatQuad(Stationary):
         self.lengthscales = lengthscales
         self.alpha = alpha
 
-    def __call__(self, X, Z=None):
+    def full(self, X, Z=None):
         X, Z = self._slice(X, Z)
         return tt.power((1.0 + 0.5 * self.square_dist(X, Z) * (1.0 / self.alpha)), -1.0 * self.alpha)
 
@@ -183,7 +206,7 @@ class Matern52(Stationary):
        k(x, x') = \left(1 + \frac{\sqrt{5(x - x')^2}}{\ell} + \frac{5(x-x')^2}{3\ell^2}\right) \mathrm{exp}\left[ - \frac{\sqrt{5(x - x')^2}}{\ell} \right]
     """
 
-    def __call__(self, X, Z=None):
+    def full(self, X, Z=None):
         X, Z = self._slice(X, Z)
         r = self.euclidean_dist(X, Z)
         return (1.0 + np.sqrt(5.0) * r + 5.0 / 3.0 * tt.square(r)) * tt.exp(-1.0 * np.sqrt(5.0) * r)
@@ -198,7 +221,7 @@ class Matern32(Stationary):
        k(x, x') = \left(1 + \frac{\sqrt{3(x - x')^2}}{\ell}\right)\mathrm{exp}\left[ - \frac{\sqrt{3(x - x')^2}}{\ell} \right]
     """
 
-    def __call__(self, X, Z=None):
+    def full(self, X, Z=None):
         X, Z = self._slice(X, Z)
         r = self.euclidean_dist(X, Z)
         return (1.0 + np.sqrt(3.0) * r) * tt.exp(-np.sqrt(3.0) * r)
@@ -213,7 +236,7 @@ class Exponential(Stationary):
        k(x, x') = \mathrm{exp}\left[ -\frac{||x - x'||}{2\ell^2} \right]
     """
 
-    def __call__(self, X, Z=None):
+    def full(self, X, Z=None):
         X, Z = self._slice(X, Z)
         return tt.exp(-0.5 * self.euclidean_dist(X, Z))
 
@@ -226,7 +249,7 @@ class Cosine(Stationary):
        k(x, x') = \mathrm{cos}\left( \frac{||x - x'||}{ \ell^2} \right)
     """
 
-    def __call__(self, X, Z=None):
+    def full(self, X, Z=None):
         X, Z = self._slice(X, Z)
         return tt.cos(np.pi * self.euclidean_dist(X, Z))
 
@@ -243,15 +266,22 @@ class Linear(Covariance):
         Covariance.__init__(self, input_dim, active_dims)
         self.c = c
 
-    def __call__(self, X, Z=None):
+    def _common(self, X, Z=None):
         X, Z = self._slice(X, Z)
         Xc = tt.sub(X, self.c)
+        return X, Xc, Z
+
+    def full(self, X, Z=None):
+        X, Xc, Z = self._common(X, Z)
         if Z is None:
             return tt.dot(Xc, tt.transpose(Xc))
         else:
             Zc = tt.sub(Z, self.c)
             return tt.dot(Xc, tt.transpose(Zc))
 
+    def diag(self, X):
+        X, Xc, _ = self._common(X, None)
+        return tt.sum(tt.square(Xc), 1)
 
 class Polynomial(Linear):
     R"""
@@ -266,10 +296,13 @@ class Polynomial(Linear):
         self.d = d
         self.offset = offset
 
-    def __call__(self, X, Z=None):
-        linear = super(Polynomial, self).__call__(X, Z)
+    def full(self, X, Z=None):
+        linear = super(Polynomial, self).full(X, Z)
         return tt.power(linear + self.offset, self.d)
 
+    def diag(self, X):
+        linear = super(Polynomial, self).diag(X)
+        return tt.power(linear + self.offset, self.d)
 
 class WarpedInput(Covariance):
     R"""
@@ -298,12 +331,16 @@ class WarpedInput(Covariance):
         self.args = args
         self.cov_func = cov_func
 
-    def __call__(self, X, Z=None):
+    def full(self, X, Z=None):
         X, Z = self._slice(X, Z)
         if Z is None:
             return self.cov_func(self.w(X, self.args), Z)
         else:
             return self.cov_func(self.w(X, self.args), self.w(Z, self.args))
+
+    def diag(self, X):
+        X, _ = self._slice(X, None)
+        return self.cov_func(self.w(X, self.args), diag=True)
 
 
 class Gibbs(Covariance):
@@ -332,7 +369,7 @@ class Gibbs(Covariance):
                 raise NotImplementedError("Higher dimensional inputs are untested")
         if not callable(lengthscale_func):
             raise TypeError("lengthscale_func must be callable")
-        self.ell = handle_args(lengthscale_func, args)
+        self.lfunc = handle_args(lengthscale_func, args)
         self.args = args
 
     def square_dist(self, X, Z):
@@ -348,19 +385,22 @@ class Gibbs(Covariance):
                   (tt.reshape(Xs, (-1, 1)) + tt.reshape(Zs, (1, -1)))
         return tt.clip(sqd, 0.0, np.inf)
 
-    def __call__(self, X, Z=None):
+    def full(self, X, Z=None):
         X, Z = self._slice(X, Z)
-        rx = self.ell(X, self.args)
+        rx = self.lfunc(X, self.args)
         rx2 = tt.reshape(tt.square(rx), (-1, 1))
         if Z is None:
             r2 = self.square_dist(X,X)
-            rz = self.ell(X, self.args)
+            rz = self.lfunc(X, self.args)
         else:
             r2 = self.square_dist(X,Z)
-            rz = self.ell(Z, self.args)
+            rz = self.lfunc(Z, self.args)
         rz2 = tt.reshape(tt.square(rz), (1, -1))
         return tt.sqrt((2.0 * tt.dot(rx, tt.transpose(rz))) / (rx2 + rz2)) *\
                tt.exp(-1.0 * r2 / (rx2 + rz2))
+
+    def diag(self, X):
+        return tt.ones(tt.stack([X.shape[0], ]))
 
 
 def handle_args(func, args):

--- a/pymc3/gp/cov.py
+++ b/pymc3/gp/cov.py
@@ -44,7 +44,7 @@ class Covariance(object):
         ----------
         X : The training inputs to the kernel.
         Z : The optional prediction set of inputs the kernel.  If Z is None, Z = X.
-        daig: Return only the diagonal of the covariance function.  Default is False.
+        diag: Return only the diagonal of the covariance function.  Default is False.
         """
         if diag:
             return self.diag(X)

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -89,6 +89,9 @@ class TestCovAdd(object):
             cov = cov1 + cov2
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_rightadd_scalar(self):
         X = np.linspace(0, 1, 10)[:, None]
@@ -97,6 +100,9 @@ class TestCovAdd(object):
             cov = gp.cov.ExpQuad(1, 0.1) + a
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 1.53940, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_leftadd_scalar(self):
         X = np.linspace(0, 1, 10)[:, None]
@@ -105,6 +111,9 @@ class TestCovAdd(object):
             cov = a + gp.cov.ExpQuad(1, 0.1)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 1.53940, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_rightadd_matrix(self):
         X = np.linspace(0, 1, 10)[:, None]
@@ -113,6 +122,9 @@ class TestCovAdd(object):
             cov = gp.cov.ExpQuad(1, 0.1) + M
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2.53940, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_leftprod_matrix(self):
         X = np.linspace(0, 1, 3)[:, None]
@@ -134,6 +146,9 @@ class TestCovProd(object):
             cov = cov1 * cov2
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.53940 * 0.53940, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_rightprod_scalar(self):
         X = np.linspace(0, 1, 10)[:, None]
@@ -142,6 +157,9 @@ class TestCovProd(object):
             cov = gp.cov.ExpQuad(1, 0.1) * a
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_leftprod_scalar(self):
         X = np.linspace(0, 1, 10)[:, None]
@@ -150,6 +168,9 @@ class TestCovProd(object):
             cov = a * gp.cov.ExpQuad(1, 0.1)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_rightprod_matrix(self):
         X = np.linspace(0, 1, 10)[:, None]
@@ -158,6 +179,9 @@ class TestCovProd(object):
             cov = gp.cov.ExpQuad(1, 0.1) * M
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_leftprod_matrix(self):
         X = np.linspace(0, 1, 3)[:, None]
@@ -178,6 +202,11 @@ class TestCovProd(object):
         K1 = theano.function([], cov1(X))()
         K2 = theano.function([], cov2(X))()
         assert np.allclose(K1, K2)
+        # check diagonal
+        K1d = theano.function([], cov1(X, diag=True))()
+        K2d = theano.function([], cov2(X, diag=True))()
+        npt.assert_allclose(np.diag(K1), K2d, atol=1e-5)
+        npt.assert_allclose(np.diag(K2), K1d, atol=1e-5)
 
 
 class TestCovSliceDim(object):
@@ -187,6 +216,9 @@ class TestCovSliceDim(object):
             cov = gp.cov.ExpQuad(3, 0.1, active_dims=[0, 0, 1])
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.20084298, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_slice2(self):
         X = np.linspace(0, 1, 30).reshape(10, 3)
@@ -194,6 +226,9 @@ class TestCovSliceDim(object):
             cov = gp.cov.ExpQuad(3, [0.1, 0.1], active_dims=[False, True, True])
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.34295549, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_slice3(self):
         X = np.linspace(0, 1, 30).reshape(10, 3)
@@ -201,6 +236,9 @@ class TestCovSliceDim(object):
             cov = gp.cov.ExpQuad(3, np.array([0.1, 0.1]), active_dims=[False, True, True])
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.34295549, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_diffslice(self):
         X = np.linspace(0, 1, 30).reshape(10, 3)
@@ -208,6 +246,9 @@ class TestCovSliceDim(object):
             cov = gp.cov.ExpQuad(3, 0.1, [1, 0, 0]) + gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.683572, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_raises(self):
         lengthscales = 2.0
@@ -234,6 +275,9 @@ class TestExpQuad(object):
         npt.assert_allclose(K[0, 1], 0.53940, atol=1e-3)
         K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.53940, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_2d(self):
         X = np.linspace(0, 1, 10).reshape(5, 2)
@@ -241,6 +285,9 @@ class TestExpQuad(object):
             cov = gp.cov.ExpQuad(2, 0.5)
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.820754, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_2dard(self):
         X = np.linspace(0, 1, 10).reshape(5, 2)
@@ -248,6 +295,9 @@ class TestExpQuad(object):
             cov = gp.cov.ExpQuad(2, np.array([1, 2]))
         K = theano.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.969607, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
 class TestRatQuad(object):
@@ -259,6 +309,9 @@ class TestRatQuad(object):
         npt.assert_allclose(K[0, 1], 0.66896, atol=1e-3)
         K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.66896, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
 class TestExponential(object):
@@ -270,6 +323,9 @@ class TestExponential(object):
         npt.assert_allclose(K[0, 1], 0.57375, atol=1e-3)
         K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.57375, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
 class TestMatern52(object):
@@ -281,6 +337,9 @@ class TestMatern52(object):
         npt.assert_allclose(K[0, 1], 0.46202, atol=1e-3)
         K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.46202, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
 class TestMatern32(object):
@@ -292,6 +351,9 @@ class TestMatern32(object):
         npt.assert_allclose(K[0, 1], 0.42682, atol=1e-3)
         K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.42682, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
 class TestCosine(object):
@@ -303,6 +365,9 @@ class TestCosine(object):
         npt.assert_allclose(K[0, 1], -0.93969, atol=1e-3)
         K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], -0.93969, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
 class TestLinear(object):
@@ -314,6 +379,9 @@ class TestLinear(object):
         npt.assert_allclose(K[0, 1], 0.19444, atol=1e-3)
         K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.19444, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
 class TestPolynomial(object):
@@ -325,6 +393,9 @@ class TestPolynomial(object):
         npt.assert_allclose(K[0, 1], 0.03780, atol=1e-3)
         K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.03780, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
 class TestWarpedInput(object):
@@ -339,6 +410,9 @@ class TestWarpedInput(object):
         npt.assert_allclose(K[0, 1], 0.79593, atol=1e-3)
         K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.79593, atol=1e-3)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_raises(self):
         cov_m52 = gp.cov.Matern52(1, 0.2)
@@ -359,6 +433,9 @@ class TestGibbs(object):
         npt.assert_allclose(K[2, 3], 0.136683, atol=1e-4)
         K = theano.function([], cov(X, X))()
         npt.assert_allclose(K[2, 3], 0.136683, atol=1e-4)
+        # check diagonal
+        Kd = theano.function([], cov(X, diag=True))()
+        npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_raises(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
- `__call__` of covariance functions have new arg in signature: `cov(X, Z, diag=True)`
  - `diag=True` computes and returns only the diagonal
  - default is `False`
- adds tests

this should help speed up some of the sparse approximations