### PR TITLE
add link to numfocus site

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,3 +183,4 @@ Sponsors
 .. |Quantopian| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/master/docs/quantopianlogo.jpg
    :target: https://quantopian.com
 .. |NumFOCUS_badge| image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
+   :target: http://www.numfocus.org/


### PR DESCRIPTION
#2363 added a numfocus badge, but no link to numfocus webpage.