### PR TITLE
change the default of include_transformed...

### DIFF
--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -878,7 +878,7 @@ class Approximation(object):
             return dict([(n_, s_) for n_, s_ in zip(self.global_names+self.local_names, _samples)])
         return inner
 
-    def sample(self, draws=500, include_transformed=False):
+    def sample(self, draws=500, include_transformed=True):
         """Draw samples from variational posterior.
 
         Parameters


### PR DESCRIPTION
to `True`. Users confusion in `sample_ppc` or `sample_gp` could be avoided (e.g., Users are reporting error: https://github.com/pymc-devs/pymc3/issues/2368 and https://discourse.pymc.io/t/bayesian-neural-net-with-beta-distribution/136)