### PR TITLE
Removed unused class definitions

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -158,14 +158,6 @@ class DensityDist(Distribution):
         self.logp = logp
 
 
-class MultivariateContinuous(Continuous):
-    pass
-
-
-class MultivariateDiscrete(Discrete):
-    pass
-
-
 def draw_values(params, point=None):
     """
     Draw (fix) parameter values. Handles a number of cases:


### PR DESCRIPTION
`distributions` included two empty classes `MultivariateContinuous` and `MultivariateDiscrete` that were unused elsewhere. This removes them.