### PR TITLE
Edited TypeError message for Distribution

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -24,7 +24,7 @@ class Distribution(object):
             model = Model.get_context()
         except TypeError:
             raise TypeError("No model on context stack, which is needed to "
-                            "instantiate distributions. Add variable inside"
+                            "instantiate distributions. Add variable inside "
                             "a 'with model:' block")
 
         if isinstance(name, string_types):

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -24,8 +24,8 @@ class Distribution(object):
             model = Model.get_context()
         except TypeError:
             raise TypeError("No model on context stack, which is needed to "
-                            "use the Normal('x', 0,1) syntax. "
-                            "Add a 'with model:' block")
+                            "instantiate distributions. Add variable inside"
+                            "a 'with model:' block")
 
         if isinstance(name, string_types):
             data = kwargs.pop('observed', None)


### PR DESCRIPTION
Improved message returned with `TypeError` when defining a variable outside of a `Model` context. Existing message uses a standard normal distribution in the message which may be confusing when raised with other distributions. This message is more generic.