### PR TITLE
fix #2392

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -12,7 +12,7 @@ from .step_methods import (NUTS, HamiltonianMC, Metropolis, BinaryMetropolis,
                            BinaryGibbsMetropolis, CategoricalGibbsMetropolis,
                            Slice, CompoundStep)
 from .plots.traceplot import traceplot
-from .util import is_transformed_name, get_untransformed_name
+from .util import is_transformed_name, get_untransformed_name, update_start_vals
 from tqdm import tqdm
 
 import sys
@@ -365,9 +365,9 @@ def _iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
     strace = _choose_backend(trace, chain, model=model)
 
     if len(strace) > 0:
-        _update_start_vals(start, strace.point(-1), model)
+        update_start_vals(start, strace.point(-1), model)
     else:
-        _update_start_vals(start, model.test_point, model)
+        update_start_vals(start, model.test_point, model)
 
     try:
         step = CompoundStep(step)
@@ -473,21 +473,6 @@ def stop_tuning(step):
         step.methods = [stop_tuning(s) for s in step.methods]
 
     return step
-
-def _update_start_vals(a, b, model):
-    """Update a with b, without overwriting existing keys. Values specified for
-    transformed variables on the original scale are also transformed and inserted.
-    """
-    if model is not None:
-        for free_RV in model.free_RVs:
-            tname = free_RV.name
-            for name in a:
-                if is_transformed_name(tname) and get_untransformed_name(tname) == name:
-                    transform_func = [d.transformation for d in model.deterministics if d.name == name]
-                    if transform_func:
-                        b[tname] = transform_func[0].forward_val(a[name], point=b).eval()
-
-    a.update({k: v for k, v in b.items() if k not in a})
 
 
 def sample_ppc(trace, samples=None, model=None, vars=None, size=None,

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -12,7 +12,7 @@ from .step_methods import (NUTS, HamiltonianMC, Metropolis, BinaryMetropolis,
                            BinaryGibbsMetropolis, CategoricalGibbsMetropolis,
                            Slice, CompoundStep)
 from .plots.traceplot import traceplot
-from .util import is_transformed_name, get_untransformed_name, update_start_vals
+from .util import update_start_vals
 from tqdm import tqdm
 
 import sys

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -14,6 +14,7 @@ import theano
 from .models import simple_init
 from .helpers import SeededTest
 from scipy import stats
+from .util import update_start_vals
 
 import pytest
 
@@ -127,19 +128,19 @@ class TestSoftUpdate(SeededTest):
     def test_soft_update_all_present(self):
         start = {'a': 1, 'b': 2}
         test_point = {'a': 3, 'b': 4}
-        pm.sampling._update_start_vals(start, test_point, model=None)
+        update_start_vals(start, test_point, model=None)
         assert start == {'a': 1, 'b': 2}
 
     def test_soft_update_one_missing(self):
         start = {'a': 1, }
         test_point = {'a': 3, 'b': 4}
-        pm.sampling._update_start_vals(start, test_point, model=None)
+        update_start_vals(start, test_point, model=None)
         assert start == {'a': 1, 'b': 4}
 
     def test_soft_update_empty(self):
         start = {}
         test_point = {'a': 3, 'b': 4}
-        pm.sampling._update_start_vals(start, test_point, model=None)
+        update_start_vals(start, test_point, model=None)
         assert start == test_point
 
     def test_soft_update_transformed(self):
@@ -147,7 +148,7 @@ class TestSoftUpdate(SeededTest):
             pm.Exponential('a', 1)
         start = {'a': 2.}
         test_point = {'a_log__': 0}
-        pm.sampling._update_start_vals(start, test_point, model)
+        update_start_vals(start, test_point, model)
         assert_almost_equal(np.exp(start['a_log__']), start['a'])
 
     def test_soft_update_parent(self):
@@ -162,7 +163,7 @@ class TestSoftUpdate(SeededTest):
         test_point = {'lower_interval__': -0.3746934494414109,
                       'upper_interval__': 0.693147180559945,
                       'interv_interval__': 0.4519851237430569}
-        pm.sampling._update_start_vals(start, model.test_point, model)
+        update_start_vals(start, model.test_point, model)
         assert_almost_equal(start['lower_interval__'], 
                             test_point['lower_interval__'])
         assert_almost_equal(start['upper_interval__'], 

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -1,6 +1,5 @@
 from itertools import combinations
 import numpy as np
-from numpy.testing import assert_almost_equal
 
 try:
     import unittest.mock as mock  # py3

--- a/pymc3/tests/test_util.py
+++ b/pymc3/tests/test_util.py
@@ -1,6 +1,7 @@
 import pytest
 
 import pymc3 as pm
+from .helpers import SeededTest
 from pymc3.distributions.transforms import Transform
 
 
@@ -27,7 +28,6 @@ class TestTransformName(object):
             assert pm.util.get_untransformed_name(transformed) == name
             with pytest.raises(ValueError):
                 pm.util.get_untransformed_name(name)
-
 
 
 

--- a/pymc3/tests/test_util.py
+++ b/pymc3/tests/test_util.py
@@ -27,3 +27,58 @@ class TestTransformName(object):
             assert pm.util.get_untransformed_name(transformed) == name
             with pytest.raises(ValueError):
                 pm.util.get_untransformed_name(name)
+
+
+
+
+class TestUpdateStartVals(SeededTest):
+    def setup_method(self):
+        super(TestUpdateStartVals, self).setup_method()
+    
+    def test_soft_update_all_present(self):
+        start = {'a': 1, 'b': 2}
+        test_point = {'a': 3, 'b': 4}
+        pm.util.update_start_vals(start, test_point, model=None)
+        assert start == {'a': 1, 'b': 2}
+    
+    def test_soft_update_one_missing(self):
+        start = {'a': 1, }
+        test_point = {'a': 3, 'b': 4}
+        pm.util.update_start_vals(start, test_point, model=None)
+        assert start == {'a': 1, 'b': 4}
+    
+    def test_soft_update_empty(self):
+        start = {}
+        test_point = {'a': 3, 'b': 4}
+        pm.util.update_start_vals(start, test_point, model=None)
+        assert start == test_point
+    
+    def test_soft_update_transformed(self):
+        with pm.Model() as model:
+            pm.Exponential('a', 1)
+        start = {'a': 2.}
+        test_point = {'a_log__': 0}
+        pm.util.update_start_vals(start, test_point, model)
+        assert_almost_equal(np.exp(start['a_log__']), start['a'])
+    
+    def test_soft_update_parent(self):
+        with pm.Model() as model:
+            a = pm.Uniform('a', lower=0., upper=1.)
+            b = pm.Uniform('b', lower=2., upper=3.)
+            pm.Uniform('lower', lower=a, upper=3.)
+            pm.Uniform('upper', lower=0., upper=b)
+            pm.Uniform('interv', lower=a, upper=b)
+        
+        start = {'a': .3, 'b': 2.1, 'lower': 1.4, 'upper': 1.4, 'interv':1.4}
+        test_point = {'lower_interval__': -0.3746934494414109,
+            'upper_interval__': 0.693147180559945,
+                'interv_interval__': 0.4519851237430569}
+        pm.util.update_start_vals(start, model.test_point, model)
+        assert_almost_equal(start['lower_interval__'],
+                            test_point['lower_interval__'])
+        assert_almost_equal(start['upper_interval__'],
+                            test_point['upper_interval__'])
+        assert_almost_equal(start['interv_interval__'],
+                            test_point['interv_interval__'])
+
+

--- a/pymc3/tests/test_util.py
+++ b/pymc3/tests/test_util.py
@@ -1,6 +1,7 @@
 import pytest
 
 import pymc3 as pm
+from numpy.testing import assert_almost_equal
 from .helpers import SeededTest
 from pymc3.distributions.transforms import Transform
 

--- a/pymc3/tests/test_util.py
+++ b/pymc3/tests/test_util.py
@@ -1,6 +1,7 @@
 import pytest
 
 import pymc3 as pm
+import numpy as np
 from numpy.testing import assert_almost_equal
 from .helpers import SeededTest
 from pymc3.distributions.transforms import Transform

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -48,6 +48,8 @@ def find_MAP(start=None, vars=None, fmin=None,
     model = modelcontext(model)
     if start is None:
         start = model.test_point
+    else:
+        pm.sampling._update_start_vals(start, model.test_point, model)
 
     if not set(start.keys()).issubset(model.named_vars.keys()):
         extra_keys = ', '.join(set(start.keys()) - set(model.named_vars.keys()))

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -12,6 +12,7 @@ from ..vartypes import discrete_types, typefilter
 from ..model import modelcontext, Point
 from ..theanof import inputvars
 from ..blocking import DictToArrayBijection, ArrayOrdering
+from ..util import update_start_vals
 
 from inspect import getargspec
 
@@ -49,7 +50,7 @@ def find_MAP(start=None, vars=None, fmin=None,
     if start is None:
         start = model.test_point
     else:
-        pm.sampling._update_start_vals(start, model.test_point, model)
+        update_start_vals(start, model.test_point, model)
 
     if not set(start.keys()).issubset(model.named_vars.keys()):
         extra_keys = ', '.join(set(start.keys()) - set(model.named_vars.keys()))

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -114,3 +114,4 @@ def update_start_vals(a, b, model):
                             a[name], point=b).eval()
 
     a.update({k: v for k, v in b.items() if k not in a})
+

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -1,5 +1,6 @@
 from numpy import asscalar
 
+
 def get_transformed_name(name, transform):
     """
     Consistent way of transforming names
@@ -51,7 +52,8 @@ def get_untransformed_name(name):
         String with untransformed version of the name.
     """
     if not is_transformed_name(name):
-        raise ValueError(u'{} does not appear to be a transformed name'.format(name))
+        raise ValueError(
+            u'{} does not appear to be a transformed name'.format(name))
     return '_'.join(name.split('_')[:-3])
 
 
@@ -84,8 +86,9 @@ def get_variable_name(variable):
     if name is None:
         if hasattr(variable, 'get_parents'):
             try:
-                names = [get_variable_name(item) for item in variable.get_parents()[0].inputs]
-                return 'f(%s)' % ','.join([n for n in names if isinstance(n, str)]) 
+                names = [get_variable_name(item)
+                         for item in variable.get_parents()[0].inputs]
+                return 'f(%s)' % ','.join([n for n in names if isinstance(n, str)])
             except IndexError:
                 pass
         value = variable.eval()
@@ -94,17 +97,20 @@ def get_variable_name(variable):
         return 'array'
     return name
 
+
 def update_start_vals(a, b, model):
     """Update a with b, without overwriting existing keys. Values specified for
-        transformed variables on the original scale are also transformed and inserted.
-        """
+    transformed variables on the original scale are also transformed and inserted.
+    """
     if model is not None:
         for free_RV in model.free_RVs:
             tname = free_RV.name
             for name in a:
                 if is_transformed_name(tname) and get_untransformed_name(tname) == name:
-                    transform_func = [d.transformation for d in model.deterministics if d.name == name]
+                    transform_func = [
+                        d.transformation for d in model.deterministics if d.name == name]
                     if transform_func:
-                        b[tname] = transform_func[0].forward_val(a[name], point=b).eval()
+                        b[tname] = transform_func[0].forward_val(
+                            a[name], point=b).eval()
 
     a.update({k: v for k, v in b.items() if k not in a})

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -93,3 +93,18 @@ def get_variable_name(variable):
             return asscalar(value)
         return 'array'
     return name
+
+def update_start_vals(a, b, model):
+    """Update a with b, without overwriting existing keys. Values specified for
+        transformed variables on the original scale are also transformed and inserted.
+        """
+    if model is not None:
+        for free_RV in model.free_RVs:
+            tname = free_RV.name
+            for name in a:
+                if is_transformed_name(tname) and get_untransformed_name(tname) == name:
+                    transform_func = [d.transformation for d in model.deterministics if d.name == name]
+                    if transform_func:
+                        b[tname] = transform_func[0].forward_val(a[name], point=b).eval()
+
+    a.update({k: v for k, v in b.items() if k not in a})

--- a/pymc3/variational/approximations.py
+++ b/pymc3/variational/approximations.py
@@ -5,6 +5,7 @@ from theano import tensor as tt
 import pymc3 as pm
 from pymc3.distributions.dist_math import rho2sd, log_normal
 from pymc3.variational.opvi import Approximation, node_property
+from pymc3.util import update_start_vals
 
 
 __all__ = [
@@ -82,7 +83,7 @@ class MeanField(Approximation):
             start = self.model.test_point
         else:
             start_ = self.model.test_point.copy()
-            pm.sampling._update_start_vals(start_, start, self.model)
+            update_start_vals(start_, start, self.model)
             start = start_
         start = self.gbij.map(start)
         return {'mu': theano.shared(
@@ -165,7 +166,7 @@ class FullRank(Approximation):
             start = self.model.test_point
         else:
             start_ = self.model.test_point.copy()
-            pm.sampling._update_start_vals(start_, start, self.model)
+            update_start_vals(start_, start, self.model)
             start = start_
         start = pm.floatX(self.gbij.map(start))
         n = self.global_size
@@ -417,7 +418,7 @@ class Empirical(Approximation):
             start = hist.model.test_point
         else:
             start_ = hist.model.test_point.copy()
-            pm.sampling._update_start_vals(start_, start, hist.model)
+            update_start_vals(start_, start, hist.model)
             start = start_
         start = pm.floatX(hist.gbij.map(start))
         # Initialize particles


### PR DESCRIPTION
find_MAP bug if model contains transform RV but the start value is provided as non-transform.
Using the soft update function from pymc3.sampling