### PR TITLE
Add wrong-import-order to pylintrc.  accidentally a lot of other fixes.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -58,6 +58,7 @@ enable=import-error,
        bad-open-mode,
        redundant-unittest-assert,
        boolean-datetime,
+       wrong-import-order
        # unused-variable
 
 

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -1,6 +1,8 @@
 # pylint: disable=wildcard-import
 __version__ = "3.1"
 
+import logging
+
 from .blocking import *
 from .distributions import *
 from .external import *
@@ -29,7 +31,6 @@ from .tests import test
 
 from .data import *
 
-import logging
 _log = logging.getLogger('pymc3')
 if not logging.root.handlers:
     _log.setLevel(logging.INFO)

--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -3,10 +3,13 @@
 See the docstring for pymc3.backends for more information (including
 creating custom backends).
 """
-import numpy as np
-from ..model import modelcontext
 import warnings
+
+import numpy as np
 import theano.tensor as tt
+
+from ..model import modelcontext
+
 
 class BackendError(Exception):
     pass
@@ -71,7 +74,6 @@ class BaseTrace(object):
                                      "different types." % key)
 
         self.sampler_vars = sampler_vars
-
 
     def setup(self, draws, chain, sampler_vars=None):
         """Perform chain-specific setup.
@@ -162,8 +164,7 @@ class BaseTrace(object):
         if sampler_idx is not None:
             return self._get_sampler_stats(varname, sampler_idx, burn, thin)
 
-        sampler_idxs = [i for i, s in enumerate(self.sampler_vars)
-                       if varname in s]
+        sampler_idxs = [i for i, s in enumerate(self.sampler_vars) if varname in s]
         if not sampler_idxs:
             raise KeyError("Unknown sampler stat %s" % varname)
 
@@ -173,7 +174,6 @@ class BaseTrace(object):
             return vals[..., 0]
         else:
             return vals
-
 
     def _get_sampler_stats(self, varname, sampler_idx, burn, thin):
         """Get sampler statistics."""
@@ -283,9 +283,9 @@ class MultiTrace(object):
         var = str(var)
         if var in self.varnames:
             if var in self.stat_names:
-                warnings.warn("Attribute access on a trace object is ambigous. "
-                "Sampler statistic and model variable share a name. Use "
-                "trace.get_values or trace.get_sampler_stats.")
+                warnings.warn("Attribute access on a trace object is ambiguous. "
+                              "Sampler statistic and model variable share a name. Use "
+                              "trace.get_values or trace.get_sampler_stats.")
             return self.get_values(var, burn=burn, thin=thin)
         if var in self.stat_names:
             return self.get_sampler_stats(var, burn=burn, thin=thin)
@@ -303,9 +303,9 @@ class MultiTrace(object):
         name = str(name)
         if name in self.varnames:
             if name in self.stat_names:
-                warnings.warn("Attribute access on a trace object is ambigous. "
-                "Sampler statistic and model variable share a name. Use "
-                "trace.get_values or trace.get_sampler_stats.")
+                warnings.warn("Attribute access on a trace object is ambiguous. "
+                              "Sampler statistic and model variable share a name. Use "
+                              "trace.get_values or trace.get_sampler_stats.")
             return self.get_values(name)
         if name in self.stat_names:
             return self.get_sampler_stats(name)

--- a/pymc3/backends/hdf5.py
+++ b/pymc3/backends/hdf5.py
@@ -1,6 +1,9 @@
-from ..backends import base, ndarray
-import h5py
 from contextlib import contextmanager
+
+import h5py
+
+from ..backends import base, ndarray
+
 
 @contextmanager
 def activator(instance):
@@ -99,15 +102,15 @@ class HDF5(base.BaseTrace):
     @property
     def sampler_vars(self):
         with self.activate_file:
-            l = []
+            s_vars = []
             for i, sampler in sorted(self.stats.items(), key=lambda x: int(x[0])):
                 d = {}
                 for varname, ds in sampler.items():
                     d[varname] = ds.dtype
-                l.append(d)
-        if not l:
+                s_vars.append(d)
+        if not s_vars:
             return None
-        return l
+        return s_vars
 
     @sampler_vars.setter
     def sampler_vars(self, values):
@@ -152,7 +155,6 @@ class HDF5(base.BaseTrace):
             self._set_sampler_vars(sampler_vars)
             self._is_base_setup = True
             self._resize(self.draws)
-
 
     def close(self):
         with self.activate_file:

--- a/pymc3/backends/sqlite.py
+++ b/pymc3/backends/sqlite.py
@@ -16,8 +16,9 @@ For example, a variable with the shape (2, 2) would be stored as
 The key is autoincremented each time a new row is added to the table.
 The chain column denotes the chain index and starts at 0.
 """
-import numpy as np
 import sqlite3
+
+import numpy as np
 
 from ..backends import base, ndarray
 from . import tracetab as ttab

--- a/pymc3/blocking.py
+++ b/pymc3/blocking.py
@@ -3,9 +3,10 @@ pymc3.blocking
 
 Classes for working with subsets of parameters.
 """
-import copy
-import numpy as np
 import collections
+import copy
+
+import numpy as np
 
 __all__ = ['ArrayOrdering', 'DictToArrayBijection', 'DictToVarBijection']
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -6,23 +6,20 @@ nodes in PyMC.
 
 """
 from __future__ import division
+import warnings
 
 import numpy as np
 import theano.tensor as tt
 from scipy import stats
 from scipy.interpolate import InterpolatedUnivariateSpline
-import warnings
 
 from pymc3.theanof import floatX
-from . import transforms
 from pymc3.util import get_variable_name
-
-from .dist_math import (
-    bound, logpow, gammaln, betaln, std_cdf, i0,
-    i1, alltrue_elemwise, SplineWrapper
-)
-from .distribution import Continuous, draw_values, generate_samples
+from . import transforms
 from .bound import Bound
+from .dist_math import (bound, logpow, gammaln, betaln, std_cdf, i0, i1, alltrue_elemwise,
+                        SplineWrapper)
+from .distribution import Continuous, draw_values, generate_samples
 
 __all__ = ['Uniform', 'Flat', 'HalfFlat', 'Normal', 'Beta', 'Exponential',
            'Laplace', 'StudentT', 'Cauchy', 'HalfCauchy', 'Gamma', 'Weibull',
@@ -46,14 +43,14 @@ class UnitContinuous(Continuous):
         super(UnitContinuous, self).__init__(
             transform=transform, *args, **kwargs)
 
+
 def assert_negative_support(var, label, distname, value=-1e-6):
     # Checks for evidence of positive support for a variable
     if var is None:
         return
     try:
         # Transformed distribution
-        support = np.isfinite(var.transformed.distribution.dist
-                                .logp(value).tag.test_value)
+        support = np.isfinite(var.transformed.distribution.dist.logp(value).tag.test_value)
     except AttributeError:
         try:
             # Untransformed distribution
@@ -161,9 +158,8 @@ class Uniform(Continuous):
             dist = self
         lower = dist.lower
         upper = dist.upper
-        return r'${} \sim \text{{Uniform}}(\mathit{{lower}}={}, \mathit{{upper}}={})$'.format(name,
-                                                                get_variable_name(lower),
-                                                                get_variable_name(upper))
+        return r'${} \sim \text{{Uniform}}(\mathit{{lower}}={}, \mathit{{upper}}={})$'.format(
+            name, get_variable_name(lower), get_variable_name(upper))
 
 
 class Flat(Continuous):
@@ -274,9 +270,8 @@ class Normal(Continuous):
             dist = self
         sd = dist.sd
         mu = dist.mu
-        return r'${} \sim \text{{Normal}}(\mathit{{mu}}={}, \mathit{{sd}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(sd))
+        return r'${} \sim \text{{Normal}}(\mathit{{mu}}={}, \mathit{{sd}}={})$'.format(
+            name, get_variable_name(mu), get_variable_name(sd))
 
 
 class HalfNormal(PositiveContinuous):
@@ -333,8 +328,8 @@ class HalfNormal(PositiveContinuous):
         if dist is None:
             dist = self
         sd = dist.sd
-        return r'${} \sim \text{{HalfNormal}}(\mathit{{sd}}={})$'.format(name,
-                                                                get_variable_name(sd))
+        return r'${} \sim \text{{HalfNormal}}(\mathit{{sd}}={})$'.format(
+            name, get_variable_name(sd))
 
 
 class Wald(PositiveContinuous):
@@ -463,10 +458,8 @@ class Wald(PositiveContinuous):
         lam = dist.lam
         mu = dist.mu
         alpha = dist.alpha
-        return r'${} \sim \text{{Wald}}(\mathit{{mu}}={}, \mathit{{lam}}={}, \mathit{{alpha}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(lam),
-                                                                get_variable_name(alpha))
+        return r'${} \sim \text{{Wald}}(\mathit{{mu}}={}, \mathit{{lam}}={}, \mathit{{alpha}}={})$'.format(
+            name, get_variable_name(mu), get_variable_name(lam), get_variable_name(alpha))
 
 
 class Beta(UnitContinuous):
@@ -561,9 +554,8 @@ class Beta(UnitContinuous):
             dist = self
         alpha = dist.alpha
         beta = dist.beta
-        return r'${} \sim \text{{Beta}}(\mathit{{alpha}}={}, \mathit{{alpha}}={})$'.format(name,
-                                                                get_variable_name(alpha),
-                                                                get_variable_name(beta))
+        return r'${} \sim \text{{Beta}}(\mathit{{alpha}}={}, \mathit{{alpha}}={})$'.format(
+            name, get_variable_name(alpha), get_variable_name(beta))
 
 
 class Exponential(PositiveContinuous):
@@ -611,8 +603,9 @@ class Exponential(PositiveContinuous):
         if dist is None:
             dist = self
         lam = dist.lam
-        return r'${} \sim \text{{Exponential}}(\mathit{{lam}}={})$'.format(name,
-                                                                get_variable_name(lam))
+        return r'${} \sim \text{{Exponential}}(\mathit{{lam}}={})$'.format(
+            name, get_variable_name(lam))
+
 
 class Laplace(Continuous):
     R"""
@@ -663,9 +656,8 @@ class Laplace(Continuous):
             dist = self
         b = dist.b
         mu = dist.mu
-        return r'${} \sim \text{{Laplace}}(\mathit{{mu}}={}, \mathit{{b}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(b))
+        return r'${} \sim \text{{Laplace}}(\mathit{{mu}}={}, \mathit{{b}}={})$'.format(
+            name, get_variable_name(mu), get_variable_name(b))
 
 
 class Lognormal(PositiveContinuous):
@@ -736,9 +728,8 @@ class Lognormal(PositiveContinuous):
             dist = self
         tau = dist.tau
         mu = dist.mu
-        return r'${} \sim \text{{Lognormal}}(\mathit{{mu}}={}, \mathit{{tau}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(tau))
+        return r'${} \sim \text{{Lognormal}}(\mathit{{mu}}={}, \mathit{{tau}}={})$'.format(
+            name, get_variable_name(mu), get_variable_name(tau))
 
 
 class StudentT(Continuous):
@@ -810,10 +801,8 @@ class StudentT(Continuous):
         nu = dist.nu
         mu = dist.mu
         lam = dist.lam
-        return r'${} \sim \text{{StudentT}}(\mathit{{nu}}={}, \mathit{{mu}}={}, \mathit{{lam}}={})$'.format(name,
-                                                                get_variable_name(nu),
-                                                                get_variable_name(mu),
-                                                                get_variable_name(lam))
+        return r'${} \sim \text{{StudentT}}(\mathit{{nu}}={}, \mathit{{mu}}={}, \mathit{{lam}}={})$'.format(
+            name, get_variable_name(nu), get_variable_name(mu), get_variable_name(lam))
 
 
 class Pareto(PositiveContinuous):
@@ -858,7 +847,6 @@ class Pareto(PositiveContinuous):
         assert_negative_support(alpha, 'alpha', 'Pareto')
         assert_negative_support(m, 'm', 'Pareto')
 
-
     def _random(self, alpha, m, size=None):
         u = np.random.uniform(size=size)
         return m * (1. - u)**(-1. / alpha)
@@ -882,9 +870,8 @@ class Pareto(PositiveContinuous):
             dist = self
         alpha = dist.alpha
         m = dist.m
-        return r'${} \sim \text{{Pareto}}(\mathit{{alpha}}={}, \mathit{{m}}={})$'.format(name,
-                                                                get_variable_name(alpha),
-                                                                get_variable_name(m))
+        return r'${} \sim \text{{Pareto}}(\mathit{{alpha}}={}, \mathit{{m}}={})$'.format(
+            name, get_variable_name(alpha), get_variable_name(m))
 
 
 class Cauchy(Continuous):
@@ -943,9 +930,8 @@ class Cauchy(Continuous):
             dist = self
         alpha = dist.alpha
         beta = dist.beta
-        return r'${} \sim \text{{Cauchy}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(alpha),
-                                                                get_variable_name(beta))
+        return r'${} \sim \text{{Cauchy}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(
+            name, get_variable_name(alpha), get_variable_name(beta))
 
 
 class HalfCauchy(PositiveContinuous):
@@ -997,8 +983,9 @@ class HalfCauchy(PositiveContinuous):
         if dist is None:
             dist = self
         beta = dist.beta
-        return r'${} \sim \text{{HalfCauchy}}(\mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(beta))
+        return r'${} \sim \text{{HalfCauchy}}(\mathit{{beta}}={})$'.format(
+            name, get_variable_name(beta))
+
 
 class Gamma(PositiveContinuous):
     R"""
@@ -1087,9 +1074,8 @@ class Gamma(PositiveContinuous):
             dist = self
         beta = dist.beta
         alpha = dist.alpha
-        return r'${} \sim \text{{Gamma}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(alpha),
-                                                                get_variable_name(beta))
+        return r'${} \sim \text{{Gamma}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(
+            name, get_variable_name(alpha), get_variable_name(beta))
 
 
 class InverseGamma(PositiveContinuous):
@@ -1157,9 +1143,8 @@ class InverseGamma(PositiveContinuous):
             dist = self
         beta = dist.beta
         alpha = dist.alpha
-        return r'${} \sim \text{{InverseGamma}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(alpha),
-                                                                get_variable_name(beta))
+        return r'${} \sim \text{{InverseGamma}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(
+            name, get_variable_name(alpha), get_variable_name(beta))
 
 
 class ChiSquared(Gamma):
@@ -1191,8 +1176,7 @@ class ChiSquared(Gamma):
         if dist is None:
             dist = self
         nu = dist.nu
-        return r'${} \sim \Chi^2(\mathit{{nu}}={})$'.format(name,
-                                                                get_variable_name(nu))
+        return r'${} \sim \Chi^2(\mathit{{nu}}={})$'.format(name, get_variable_name(nu))
 
 
 class Weibull(PositiveContinuous):
@@ -1255,15 +1239,15 @@ class Weibull(PositiveContinuous):
             dist = self
         beta = dist.beta
         alpha = dist.alpha
-        return r'${} \sim \text{{Weibull}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(alpha),
-                                                                get_variable_name(beta))
+        return r'${} \sim \text{{Weibull}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(
+            name, get_variable_name(alpha), get_variable_name(beta))
 
 
 def StudentTpos(*args, **kwargs):
     warnings.warn("StudentTpos has been deprecated. In future, use HalfStudentT instead.",
-                DeprecationWarning)
+                  DeprecationWarning)
     return HalfStudentT(*args, **kwargs)
+
 
 HalfStudentT = Bound(StudentT, lower=0)
 
@@ -1355,10 +1339,8 @@ class ExGaussian(Continuous):
         sigma = dist.sigma
         mu = dist.mu
         nu = dist.nu
-        return r'${} \sim \text{{ExGaussian}}(\mathit{{mu}}={}, \mathit{{sigma}}={}, \mathit{{nu}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(sigma),
-                                                                get_variable_name(nu))
+        return r'${} \sim \text{{ExGaussian}}(\mathit{{mu}}={}, \mathit{{sigma}}={}, \mathit{{nu}}={})$'.format(
+            name, get_variable_name(mu), get_variable_name(sigma), get_variable_name(nu))
 
 
 class VonMises(Continuous):
@@ -1413,10 +1395,8 @@ class VonMises(Continuous):
             dist = self
         kappa = dist.kappa
         mu = dist.mu
-        return r'${} \sim \text{{VonMises}}(\mathit{{mu}}={}, \mathit{{kappa}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(kappa))
-
+        return r'${} \sim \text{{VonMises}}(\mathit{{mu}}={}, \mathit{{kappa}}={})$'.format(
+            name, get_variable_name(mu), get_variable_name(kappa))
 
 
 class SkewNormal(Continuous):
@@ -1456,8 +1436,8 @@ class SkewNormal(Continuous):
     When alpha=0 we recover the Normal distribution and mu becomes the mean,
     tau the precision and sd the standard deviation. In the limit of alpha
     approaching plus/minus infinite we get a half-normal distribution.
-
     """
+
     def __init__(self, mu=0.0, sd=None, tau=None, alpha=1,  *args, **kwargs):
         super(SkewNormal, self).__init__(*args, **kwargs)
         tau, sd = get_tau_sd(tau=tau, sd=sd)
@@ -1487,10 +1467,8 @@ class SkewNormal(Continuous):
         mu = self.mu
         alpha = self.alpha
         return bound(
-            tt.log(1 +
-            tt.erf(((value - mu) * tt.sqrt(tau) * alpha) / tt.sqrt(2)))
-            + (-tau * (value - mu)**2
-            + tt.log(tau / np.pi / 2.)) / 2.,
+            tt.log(1 + tt.erf(((value - mu) * tt.sqrt(tau) * alpha) / tt.sqrt(2)))
+            + (-tau * (value - mu)**2 + tt.log(tau / np.pi / 2.)) / 2.,
             tau > 0, sd > 0)
 
     def _repr_latex_(self, name=None, dist=None):
@@ -1499,10 +1477,8 @@ class SkewNormal(Continuous):
         sd = dist.sd
         mu = dist.mu
         alpha = dist.alpha
-        return r'${} \sim \text{{Skew-Normal}}(\mathit{{mu}}={}, \mathit{{sd}}={}, \mathit{{alpha}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(sd),
-                                                                get_variable_name(alpha))
+        return r'${} \sim \text{{Skew-Normal}}(\mathit{{mu}}={}, \mathit{{sd}}={}, \mathit{{alpha}}={})$'.format(
+            name, get_variable_name(mu), get_variable_name(sd), get_variable_name(alpha))
 
 
 class Triangular(Continuous):
@@ -1524,7 +1500,7 @@ class Triangular(Continuous):
                  *args, **kwargs):
         super(Triangular, self).__init__(*args, **kwargs)
 
-        self.median = self.mean = self.c = c  = tt.as_tensor_variable(c)
+        self.median = self.mean = self.c = c = tt.as_tensor_variable(c)
         self.lower = lower = tt.as_tensor_variable(lower)
         self.upper = upper = tt.as_tensor_variable(upper)
 
@@ -1542,7 +1518,8 @@ class Triangular(Continuous):
                          tt.log(2 * (value - lower) / ((upper - lower) * (c - lower))),
                          tt.switch(tt.eq(value, c), tt.log(2 / (upper - lower)),
                          tt.switch(alltrue_elemwise([c < value, value <= upper]),
-                         tt.log(2 * (upper - value) / ((upper - lower) * (upper - c))),np.inf)))
+                                   tt.log(2 * (upper - value) / ((upper - lower) * (upper - c))),
+                                   np.inf)))
 
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:
@@ -1550,10 +1527,8 @@ class Triangular(Continuous):
         lower = dist.lower
         upper = dist.upper
         c = dist.c
-        return r'${} \sim \text{{Triangular}}(\mathit{{c}}={}, \mathit{{lower}}={}, \mathit{{upper}}={})$'.format(name,
-                                                                get_variable_name(c),
-                                                                get_variable_name(lower),
-                                                                get_variable_name(upper))
+        return r'${} \sim \text{{Triangular}}(\mathit{{c}}={}, \mathit{{lower}}={}, \mathit{{upper}}={})$'.format(
+            name, get_variable_name(c), get_variable_name(lower), get_variable_name(upper))
 
 
 class Gumbel(Continuous):
@@ -1604,9 +1579,8 @@ class Gumbel(Continuous):
             dist = self
         beta = dist.beta
         mu = dist.mu
-        return r'${} \sim \text{{Gumbel}}(\mathit{{mu}}={}, \mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(beta))
+        return r'${} \sim \text{{Gumbel}}(\mathit{{mu}}={}, \mathit{{beta}}={})$'.format(
+            name, get_variable_name(mu), get_variable_name(beta))
 
 
 class Interpolated(Continuous):

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -1,13 +1,14 @@
 from functools import partial
+
 import numpy as np
+from scipy import stats
 import theano
 import theano.tensor as tt
-from scipy import stats
 
+from pymc3.math import tround
 from pymc3.util import get_variable_name
 from .dist_math import bound, factln, binomln, betaln, logpow
 from .distribution import Discrete, draw_values, generate_samples, reshape_sampled
-from pymc3.math import tround
 from ..math import logaddexp
 
 __all__ = ['Binomial',  'BetaBinomial',  'Bernoulli',  'DiscreteWeibull',

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -10,8 +10,8 @@ import scipy.linalg
 import theano.tensor as tt
 import theano
 
-from .special import gammaln
 from pymc3.theanof import floatX
+from .special import gammaln
 
 f = floatX
 c = - .5 * np.log(2. * np.pi)
@@ -91,7 +91,7 @@ def i0(x):
     return tt.switch(tt.lt(x, 5), 1. + x**2 / 4. + x**4 / 64. + x**6 / 2304. + x**8 / 147456.
                      + x**10 / 14745600. + x**12 / 2123366400.,
                      np.e**x / (2. * np.pi * x)**0.5 * (1. + 1. / (8. * x) + 9. / (128. * x**2) + 225. / (3072 * x**3)
-                                                       + 11025. / (98304. * x**4)))
+                                                        + 11025. / (98304. * x**4)))
 
 
 def i1(x):

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -1,22 +1,17 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import warnings
+
 import numpy as np
 import scipy
+from scipy import stats, linalg
 import theano
 import theano.tensor as tt
-
-from scipy import stats, linalg
-
 from theano.tensor.nlinalg import det, matrix_inverse, trace
 
 import pymc3 as pm
-
 from pymc3.math import tround
 from pymc3.theanof import floatX
-from . import transforms
 from pymc3.util import get_variable_name
+from . import transforms
 from .distribution import Continuous, Discrete, draw_values, generate_samples
 from ..model import Deterministic
 from .continuous import ChiSquared, Normal
@@ -445,8 +440,7 @@ class Dirichlet(Continuous):
         if dist is None:
             dist = self
         a = dist.a
-        return r'${} \sim \text{{Dirichlet}}(\mathit{{a}}={})$'.format(name,
-                                                get_variable_name(a))
+        return r'${} \sim \text{{Dirichlet}}(\mathit{{a}}={})$'.format(name, get_variable_name(a))
 
 
 class Multinomial(Discrete):
@@ -533,9 +527,8 @@ class Multinomial(Discrete):
             dist = self
         n = dist.n
         p = dist.p
-        return r'${} \sim \text{{Multinomial}}(\mathit{{n}}={}, \mathit{{p}}={})$'.format(name,
-                                                get_variable_name(n),
-                                                get_variable_name(p))
+        return r'${} \sim \text{{Multinomial}}(\mathit{{n}}={}, \mathit{{p}}={})$'.format(
+            name, get_variable_name(n), get_variable_name(p))
 
 
 def posdef(AA):
@@ -583,6 +576,7 @@ class PosDefMatrix(theano.Op):
 
     def __str__(self):
         return "MatrixIsPositiveDefinite"
+
 
 matrix_pos_def = PosDefMatrix()
 
@@ -656,17 +650,16 @@ class Wishart(Continuous):
                      matrix_pos_def(X),
                      tt.eq(X, X.T),
                      nu > (p - 1),
-                     broadcast_conditions=False
-        )
+                     broadcast_conditions=False)
 
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:
             dist = self
         nu = dist.nu
         V = dist.V
-        return r'${} \sim \text{{Wishart}}(\mathit{{nu}}={}, \mathit{{V}}={})$'.format(name,
-                                                get_variable_name(nu),
-                                                get_variable_name(V))
+        return r'${} \sim \text{{Wishart}}(\mathit{{nu}}={}, \mathit{{V}}={})$'.format(
+            name, get_variable_name(nu), get_variable_name(V))
+
 
 def WishartBartlett(name, S, nu, is_cholesky=False, return_cholesky=False, testval=None):
     R"""
@@ -878,6 +871,7 @@ class LKJCholeskyCov(Continuous):
        determinant, URL (version: 2012-04-14):
        http://math.stackexchange.com/q/130026
     """
+
     def __init__(self, eta, n, sd_dist, *args, **kwargs):
         self.n = n
         self.eta = eta
@@ -1021,5 +1015,4 @@ class LKJCorr(Continuous):
                      tt.all(X <= 1), tt.all(X >= -1),
                      matrix_pos_def(X),
                      eta > 0,
-                     broadcast_conditions=False
-        )
+                     broadcast_conditions=False)

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -1,3 +1,4 @@
+import numpy as np
 import theano.tensor as tt
 
 from ..model import FreeRV
@@ -5,7 +6,6 @@ from ..theanof import gradient, floatX
 from . import distribution
 from ..math import logit, invlogit
 from .distribution import draw_values
-import numpy as np
 
 __all__ = ['transform', 'stick_breaking', 'logodds', 'interval',
            'lowerbound', 'upperbound', 'log', 'sum_to_1', 't_stick_breaking']
@@ -80,6 +80,7 @@ class TransformedDistribution(distribution.Distribution):
         return (self.dist.logp(self.transform_used.backward(x)) +
                 self.transform_used.jacobian_det(x))
 
+
 transform = Transform
 
 
@@ -98,6 +99,7 @@ class Log(ElemwiseTransform):
     def jacobian_det(self, x):
         return x
 
+
 log = Log()
 
 
@@ -115,6 +117,7 @@ class LogOdds(ElemwiseTransform):
 
     def forward_val(self, x, point=None):
         return self.forward(x)
+
 
 logodds = LogOdds()
 
@@ -141,13 +144,13 @@ class Interval(ElemwiseTransform):
         # 2017-06-19
         # the `self.a-0.` below is important for the testval to propagates
         # For an explanation see pull/2328#issuecomment-309303811
-        a, b = draw_values([self.a-0., self.b-0.],
-                            point=point)
+        a, b = draw_values([self.a-0., self.b-0.], point=point)
         return floatX(tt.log(x - a) - tt.log(b - x))
 
     def jacobian_det(self, x):
         s = tt.nnet.softplus(-x)
         return tt.log(self.b - self.a) - 2 * s - x
+
 
 interval = Interval
 
@@ -180,6 +183,7 @@ class LowerBound(ElemwiseTransform):
     def jacobian_det(self, x):
         return x
 
+
 lowerbound = LowerBound
 
 
@@ -211,6 +215,7 @@ class UpperBound(ElemwiseTransform):
     def jacobian_det(self, x):
         return x
 
+
 upperbound = UpperBound
 
 
@@ -230,6 +235,7 @@ class SumTo1(Transform):
 
     def jacobian_det(self, x):
         return 0
+
 
 sum_to_1 = SumTo1()
 
@@ -286,9 +292,11 @@ class StickBreaking(Transform):
         S = tt.extra_ops.cumprod(yu, 0)
         return tt.sum(tt.log(S[:-1]) - tt.log1p(tt.exp(yl)) - tt.log1p(tt.exp(-yl)), 0).T
 
+
 stick_breaking = StickBreaking()
 
-t_stick_breaking = lambda eps: StickBreaking(eps)
+
+t_stick_breaking = StickBreaking
 
 
 class Circular(Transform):
@@ -307,6 +315,7 @@ class Circular(Transform):
 
     def jacobian_det(self, x):
         return 0
+
 
 circular = Circular()
 

--- a/pymc3/gp/cov.py
+++ b/pymc3/gp/cov.py
@@ -1,6 +1,7 @@
-import theano.tensor as tt
-import numpy as np
 from functools import reduce
+
+import numpy as np
+import theano.tensor as tt
 
 __all__ = ['ExpQuad',
            'RatQuad',
@@ -13,6 +14,7 @@ __all__ = ['ExpQuad',
            'WarpedInput',
            'Gibbs']
 
+
 class Covariance(object):
     R"""
     Base class for all kernels/covariance functions.
@@ -22,8 +24,8 @@ class Covariance(object):
     input_dim : integer
         The number of input dimensions, or columns of X (or Z) the kernel will operate on.
     active_dims : A list of booleans whose length equals input_dim.
-	The booleans indicate whether or not the covariance function operates
-        over that dimension or column of X.
+                  The booleans indicate whether or not the covariance function operates
+                  over that dimension or column of X.
     """
 
     def __init__(self, input_dim, active_dims=None):
@@ -72,11 +74,11 @@ class Covariance(object):
         """
         Required to allow radd/rmul by numpy arrays.
         """
-        r,c = result.shape
-        A = np.zeros((r,c))
+        r, c = result.shape
+        A = np.zeros((r, c))
         for i in range(r):
             for j in range(c):
-                A[i,j] = result[i,j].factor_list[1]
+                A[i, j] = result[i, j].factor_list[1]
         if isinstance(result[0][0], Add):
             return result[0][0].factor_list[0] + A
         elif isinstance(result[0][0], Prod):
@@ -145,8 +147,8 @@ class Stationary(Covariance):
         else:
             Z = tt.mul(Z, 1.0 / self.lengthscales)
             Zs = tt.sum(tt.square(Z), 1)
-            sqd = -2.0 * tt.dot(X, tt.transpose(Z)) +\
-                  (tt.reshape(Xs, (-1, 1)) + tt.reshape(Zs, (1, -1)))
+            sqd = -2.0 * tt.dot(X, tt.transpose(Z)) + (
+                tt.reshape(Xs, (-1, 1)) + tt.reshape(Zs, (1, -1)))
         return tt.clip(sqd, 0.0, np.inf)
 
     def euclidean_dist(self, X, Z):
@@ -172,7 +174,7 @@ class ExpQuad(Stationary):
 
     def full(self, X, Z=None):
         X, Z = self._slice(X, Z)
-        return tt.exp( -0.5 * self.square_dist(X, Z))
+        return tt.exp(-0.5 * self.square_dist(X, Z))
 
 
 class RatQuad(Stationary):
@@ -279,6 +281,7 @@ class Linear(Covariance):
         X, Xc, _ = self._common(X, None)
         return tt.sum(tt.square(Xc), 1)
 
+
 class Polynomial(Linear):
     R"""
     The Polynomial kernel.
@@ -299,6 +302,7 @@ class Polynomial(Linear):
     def diag(self, X):
         linear = super(Polynomial, self).diag(X)
         return tt.power(linear + self.offset, self.d)
+
 
 class WarpedInput(Covariance):
     R"""
@@ -355,6 +359,7 @@ class Gibbs(Covariance):
     args : optional, tuple or list of scalars or PyMC3 variables
         Additional inputs (besides X or Z) to lengthscale_func.
     """
+
     def __init__(self, input_dim, lengthscale_func, args=None, active_dims=None):
         super(Gibbs, self).__init__(input_dim, active_dims)
         if active_dims is not None:
@@ -377,8 +382,8 @@ class Gibbs(Covariance):
         else:
             Z = tt.as_tensor_variable(Z)
             Zs = tt.sum(tt.square(Z), 1)
-            sqd = -2.0 * tt.dot(X, tt.transpose(Z)) +\
-                  (tt.reshape(Xs, (-1, 1)) + tt.reshape(Zs, (1, -1)))
+            sqd = -2.0 * tt.dot(X, tt.transpose(Z)) + (
+                tt.reshape(Xs, (-1, 1)) + tt.reshape(Zs, (1, -1)))
         return tt.clip(sqd, 0.0, np.inf)
 
     def full(self, X, Z=None):
@@ -386,14 +391,14 @@ class Gibbs(Covariance):
         rx = self.lfunc(X, self.args)
         rx2 = tt.reshape(tt.square(rx), (-1, 1))
         if Z is None:
-            r2 = self.square_dist(X,X)
+            r2 = self.square_dist(X, X)
             rz = self.lfunc(X, self.args)
         else:
-            r2 = self.square_dist(X,Z)
+            r2 = self.square_dist(X, Z)
             rz = self.lfunc(Z, self.args)
         rz2 = tt.reshape(tt.square(rz), (1, -1))
-        return tt.sqrt((2.0 * tt.dot(rx, tt.transpose(rz))) / (rx2 + rz2)) *\
-               tt.exp(-1.0 * r2 / (rx2 + rz2))
+        return tt.sqrt((2.0 * tt.dot(rx, tt.transpose(rz))) / (rx2 + rz2)) * tt.exp(
+            -1.0 * r2 / (rx2 + rz2))
 
     def diag(self, X):
         return tt.ones(tt.stack([X.shape[0], ]))

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1,10 +1,14 @@
 from collections import defaultdict
+import sys
 
 from joblib import Parallel, delayed
-from numpy.random import randint, seed
 import numpy as np
+from numpy.random import randint, seed
+from tqdm import tqdm
 
 import pymc3 as pm
+from pymc3.distributions import distribution
+from pymc3.step_methods.hmc import quadpotential
 from .backends.base import merge_traces, BaseTrace, MultiTrace
 from .backends.ndarray import NDArray
 from .model import modelcontext, Point
@@ -13,11 +17,7 @@ from .step_methods import (NUTS, HamiltonianMC, SGFS, Metropolis, BinaryMetropol
                            Slice, CompoundStep)
 from .plots.traceplot import traceplot
 from .util import update_start_vals
-from pymc3.step_methods.hmc import quadpotential
-from pymc3.distributions import distribution
-from tqdm import tqdm
 
-import sys
 sys.setrecursionlimit(10000)
 
 __all__ = ['sample', 'iter_sample', 'sample_ppc', 'sample_ppc_w', 'init_nuts']

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -10,7 +10,6 @@ import pandas as pd
 from scipy.misc import logsumexp
 from scipy.stats.distributions import pareto
 
-from pymc3 import _log
 from pymc3.theanof import floatX
 from .model import modelcontext
 from .util import get_default_varnames
@@ -558,14 +557,8 @@ def quantiles(x, qlist=(2.5, 25, 50, 75, 97.5), transform=lambda x: x):
         # Sort univariate node
         sx = np.sort(x)
 
-    try:
-        # Generate specified quantiles
-        quants = [sx[int(len(sx) * q / 100.0)] for q in qlist]
-
-        return dict(zip(qlist, quants))
-
-    except IndexError:
-        _log.warning("Too few elements for quantile calculation")
+    # Generate specified quantiles
+    return {q: sx[int(len(sx) * q / 100.0)] for q in qlist}
 
 
 def df_summary(trace, varnames=None, transform=lambda x: x, stat_funcs=None,

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -1,18 +1,19 @@
 """Statistical utility functions for PyMC"""
 
-import numpy as np
-import pandas as pd
+from collections import namedtuple
 import itertools
 import sys
 import warnings
-from collections import namedtuple
-from .model import modelcontext
-from .util import get_default_varnames
-from pymc3.theanof import floatX
 
+import numpy as np
+import pandas as pd
 from scipy.misc import logsumexp
 from scipy.stats.distributions import pareto
 
+from pymc3 import _log
+from pymc3.theanof import floatX
+from .model import modelcontext
+from .util import get_default_varnames
 from .backends import tracetab as ttab
 
 __all__ = ['autocorr', 'autocov', 'dic', 'bpic', 'waic', 'loo', 'hpd', 'quantiles',
@@ -508,11 +509,8 @@ def mc_error(x, batches=5):
     `float` representing the error
     """
     if x.ndim > 1:
-
         dims = np.shape(x)
-        #ttrace = np.transpose(np.reshape(trace, (dims[0], sum(dims[1:]))))
         trace = np.transpose([t.ravel() for t in x])
-
         return np.reshape([mc_error(t, batches) for t in trace], dims[1:])
 
     else:
@@ -570,7 +568,7 @@ def quantiles(x, qlist=(2.5, 25, 50, 75, 97.5), transform=lambda x: x):
         _log.warning("Too few elements for quantile calculation")
 
 
-def df_summary(trace, varnames=None, transform=lambda x: x, stat_funcs=None, 
+def df_summary(trace, varnames=None, transform=lambda x: x, stat_funcs=None,
                extend=False, include_transformed=False,
                alpha=0.05, start=0, batches=None):
     R"""Create a data frame with summary statistics.

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -1,10 +1,11 @@
+from enum import IntEnum, unique
+import numpy as np
+from numpy.random import uniform
+
 from .compound import CompoundStep
 from ..model import modelcontext
 from ..theanof import inputvars
 from ..blocking import ArrayOrdering, DictToArrayBijection
-import numpy as np
-from numpy.random import uniform
-from enum import IntEnum, unique
 
 __all__ = [
     'ArrayStep', 'ArrayStepShared', 'metrop_select', 'Competence']

--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -1,16 +1,17 @@
-'''
+"""
 Created on May 12, 2012
 
 @author: john
-'''
-from .arraystep import ArrayStep, Competence
-from ..distributions.discrete import Categorical
-from numpy import array, max, exp, cumsum, nested_iters, empty, searchsorted, ones, arange
-from numpy.random import uniform
+"""
 from warnings import warn
 
+from numpy import array, max, exp, cumsum, nested_iters, empty, searchsorted, ones, arange
+from numpy.random import uniform
 from theano.gof.graph import inputs
 from theano.tensor import add
+
+from .arraystep import ArrayStep, Competence
+from ..distributions.discrete import Categorical
 from ..model import modelcontext
 __all__ = ['ElemwiseCategorical']
 
@@ -27,7 +28,7 @@ class ElemwiseCategorical(ArrayStep):
 
     def __init__(self, vars, values=None, model=None):
         warn('ElemwiseCategorical is deprecated, switch to CategoricalGibbsMetropolis.',
-             DeprecationWarning, stacklevel = 2)
+             DeprecationWarning, stacklevel=2)
         model = modelcontext(model)
         self.var = vars[0]
         self.sh = ones(self.var.dshape, self.var.dtype)

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -1,11 +1,11 @@
-from ..arraystep import ArrayStepShared
-from .trajectory import get_theano_hamiltonian_functions
+import numpy as np
 
+from pymc3.theanof import inputvars, make_shared_replacements, floatX
 from pymc3.tuning import guess_scaling
 from pymc3.model import modelcontext, Point
+from ..arraystep import ArrayStepShared
+from .trajectory import get_theano_hamiltonian_functions
 from .quadpotential import quad_potential, QuadPotentialDiagAdapt
-from pymc3.theanof import inputvars, make_shared_replacements, floatX
-import numpy as np
 
 
 class BaseHMC(ArrayStepShared):

--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -3,11 +3,12 @@ Created on Mar 7, 2011
 
 @author: johnsalvatier
 '''
-from ..arraystep import metrop_select, Competence
-from .base_hmc import BaseHMC
+import numpy as np
+
 from pymc3.vartypes import discrete_types
 from pymc3.theanof import floatX
-import numpy as np
+from ..arraystep import metrop_select, Competence
+from .base_hmc import BaseHMC
 
 
 __all__ = ['HamiltonianMC']

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -1,16 +1,17 @@
 from collections import namedtuple
 import warnings
 
-from ..arraystep import Competence
-from pymc3.exceptions import SamplingError
-from .base_hmc import BaseHMC
-from pymc3.theanof import floatX
-from pymc3.vartypes import continuous_types
-
 import numpy as np
 import numpy.random as nr
 from scipy import stats, linalg
 import six
+
+from pymc3.theanof import floatX
+from pymc3.vartypes import continuous_types
+from pymc3.exceptions import SamplingError
+from ..arraystep import Competence
+from .base_hmc import BaseHMC
+
 
 __all__ = ['NUTS']
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -1,12 +1,12 @@
 import numpy as np
 import numpy.random as nr
-import theano
 import scipy.linalg
+import theano
 
-from ..distributions import draw_values
-from .arraystep import ArrayStepShared, ArrayStep, metrop_select, Competence
 import pymc3 as pm
 from pymc3.theanof import floatX
+from ..distributions import draw_values
+from .arraystep import ArrayStepShared, ArrayStep, metrop_select, Competence
 
 __all__ = ['Metropolis', 'BinaryMetropolis', 'BinaryGibbsMetropolis',
            'CategoricalGibbsMetropolis', 'NormalProposal', 'CauchyProposal',

--- a/pymc3/step_methods/sgmcmc.py
+++ b/pymc3/step_methods/sgmcmc.py
@@ -1,13 +1,15 @@
 from collections import OrderedDict
 import warnings
 
-from .arraystep import Competence, ArrayStepShared
-from ..vartypes import continuous_types
-from ..model import modelcontext, inputvars
-import theano.tensor as tt
-from ..theanof import tt_rng, make_shared_replacements
-import theano
 import numpy as np
+import theano
+import theano.tensor as tt
+
+from .arraystep import Competence, ArrayStepShared
+from ..model import modelcontext, inputvars
+from ..theanof import tt_rng, make_shared_replacements
+from ..vartypes import continuous_types
+
 
 __all__ = ['SGFS']
 
@@ -40,7 +42,7 @@ def elemwise_dlogL(vars, model, flat_view):
     Returns Jacobian of the log likelihood for each training datum wrt vars
     as a matrix of size N x D
     """
-    # select one observed random variable 
+    # select one observed random variable
     obs_var = model.observed_RVs[0]
     # tensor of shape (batch_size,)
     logL = obs_var.logp_elemwiset.sum(axis=tuple(range(1, obs_var.logp_elemwiset.ndim)))
@@ -57,12 +59,12 @@ def elemwise_dlogL(vars, model, flat_view):
 class BaseStochasticGradient(ArrayStepShared):
     R"""
     BaseStochasticGradient Object
-    
+
     For working with BaseStochasticGradient Object
-    we need to supply the probabilistic model 
+    we need to supply the probabilistic model
     (:code:`model`) with the data supplied to observed
     variables of type `GeneratorOp`
-    
+
     Parameters
     -------
     vars : list
@@ -104,9 +106,9 @@ class BaseStochasticGradient(ArrayStepShared):
                  minibatch_tensors=None,
                  **kwargs):
         warnings.warn(EXPERIMENTAL_WARNING)
-        
+
         model = modelcontext(model)
-        
+
         if vars is None:
             vars = model.vars
 
@@ -131,7 +133,7 @@ class BaseStochasticGradient(ArrayStepShared):
         self.step_size = step_size
         shared = make_shared_replacements(vars, model)
         self.q_size = int(sum(v.dsize for v in self.vars))
-        
+
         flat_view = model.flatten(vars)
         self.inarray = [flat_view.input]
         self.updates = OrderedDict()
@@ -141,7 +143,7 @@ class BaseStochasticGradient(ArrayStepShared):
         if minibatch_tensors != None:
             _check_minibatches(minibatch_tensors, minibatches)
             self.minibatches = minibatches
-            
+
             # Replace input shared variables with tensors
             def is_shared(t):
                 return isinstance(t, theano.compile.sharedvalue.SharedVariable)
@@ -160,7 +162,7 @@ class BaseStochasticGradient(ArrayStepShared):
         """Initializes the parameters for the stochastic gradient minibatch
         algorithm"""
         raise NotImplementedError
-    
+
     def mk_training_fn(self):
         raise NotImplementedError
 
@@ -170,7 +172,7 @@ class BaseStochasticGradient(ArrayStepShared):
 
     def astep(self, q0):
         """Perform a single update in the stochastic gradient method.
-        
+
         Returns new shared values and values sampled
         The size and ordering of q0 and q must be the same
         Parameters
@@ -191,7 +193,7 @@ class BaseStochasticGradient(ArrayStepShared):
 class SGFS(BaseStochasticGradient):
     R"""
     StochasticGradientFisherScoring
-    
+
     Parameters
     -----
     vars : list
@@ -209,7 +211,7 @@ class SGFS(BaseStochasticGradient):
         """
         Parameters
         ----------
-        vars : list 
+        vars : list
             Theano variables, default continuous vars
         B : np.array
             Symmetric positive Semi-definite Matrix
@@ -224,7 +226,7 @@ class SGFS(BaseStochasticGradient):
         self.t = theano.shared(1, name='t')
         # 2. Set gamma
         self.gamma = (self.batch_size + self.total_size) / (self.total_size)
-        
+
         self.training_fn = self.mk_training_fn()
 
     def mk_training_fn(self):
@@ -254,7 +256,7 @@ class SGFS(BaseStochasticGradient):
         I_t = (1. - 1. / t) * avg_I + (1. / t) * V
 
         if B is None:
-            # if B is not specified 
+            # if B is not specified
             # B \propto I_t as given in
             # http://www.ics.uci.edu/~welling/publications/papers/SGFS_v10_final.pdf
             # after iterating over the data few times to get a good approximation of I_N

--- a/pymc3/step_methods/smc.py
+++ b/pymc3/step_methods/smc.py
@@ -12,19 +12,18 @@ Renamed to SMC and further improvements March 2017
 
 @author: Hannes Vasyura-Bathke
 """
-import numpy as np
-import pymc3 as pm
-from tqdm import tqdm
-
-import theano
 import copy
 import warnings
 
+import numpy as np
+import numpy.random as nr
+import theano
+from tqdm import tqdm
+
+import pymc3 as pm
 from ..model import modelcontext
 from ..vartypes import discrete_types
 from ..theanof import inputvars, make_shared_replacements, join_nonshared_inputs
-import numpy.random as nr
-
 from .metropolis import MultivariateNormalProposal
 from .arraystep import metrop_select
 from ..backends import smc_text as atext
@@ -411,7 +410,8 @@ class SMC(atext.ArrayStepSharedLLK):
 
 
 def sample_smc(n_steps, n_chains=100, step=None, start=None, homepath=None, stage=0, n_jobs=1,
-                 tune_interval=10, tune=None, progressbar=False, model=None, random_seed=-1, rm_flag=True):
+               tune_interval=10, tune=None, progressbar=False, model=None, random_seed=-1,
+               rm_flag=True):
     """Sequential Monte Carlo sampling
 
     Samples the solution space with n_chains of Metropolis chains, where each
@@ -505,7 +505,7 @@ def sample_smc(n_steps, n_chains=100, step=None, start=None, homepath=None, stag
                         'as defined in `step`.' % step.likelihood_name)
 
     step.n_steps = int(n_steps)
-    
+
     stage_handler = atext.TextStage(homepath)
 
     if progressbar and n_jobs > 1:

--- a/pymc3/tests/backend_fixtures.py
+++ b/pymc3/tests/backend_fixtures.py
@@ -1,13 +1,14 @@
-import numpy as np
-import numpy.testing as npt
+import collections
 import os
 import shutil
-import collections
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+import theano
 
 from pymc3.tests import models
 from pymc3.backends import base
-import pytest
-import theano
 
 
 class ModelBackendSetupTestCase(object):

--- a/pymc3/tests/helpers.py
+++ b/pymc3/tests/helpers.py
@@ -1,8 +1,10 @@
 from logging.handlers import BufferingHandler
+
 import numpy.random as nr
-from theano.sandbox.rng_mrg import MRG_RandomStreams
-from ..theanof import set_tt_rng, tt_rng
 import theano
+from theano.sandbox.rng_mrg import MRG_RandomStreams
+
+from ..theanof import set_tt_rng, tt_rng
 
 
 class SeededTest(object):

--- a/pymc3/tests/models.py
+++ b/pymc3/tests/models.py
@@ -1,10 +1,12 @@
-from pymc3 import Model, Normal, Categorical, Metropolis
-import numpy as np
-import pymc3 as pm
 from itertools import product
-import theano.tensor as tt
+
+import numpy as np
 import theano
 from theano.compile.ops import as_op
+import theano.tensor as tt
+
+import pymc3 as pm
+from pymc3 import Model, Normal, Categorical, Metropolis
 from pymc3.theanof import floatX_array
 
 

--- a/pymc3/tests/test_diagnostics.py
+++ b/pymc3/tests/test_diagnostics.py
@@ -1,5 +1,7 @@
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_less
+import pytest
+import theano
 
 from .helpers import SeededTest
 from ..model import Model
@@ -9,8 +11,6 @@ from ..tuning import find_MAP
 from ..sampling import sample
 from ..diagnostics import effective_n, geweke, gelman_rubin
 from .test_examples import build_disaster_model
-import pytest
-import theano
 
 
 @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
@@ -25,22 +25,20 @@ class TestGelmanRubin(SeededTest):
             step2 = Metropolis([model.switchpoint])
             start = {'early_mean': 7., 'late_mean': 5., 'switchpoint': 10}
             ptrace = sample(n_samples, tune=0, step=[step1, step2], start=start, njobs=2,
-                    progressbar=False, random_seed=[20090425, 19700903])
+                            progressbar=False, random_seed=[20090425, 19700903])
         return ptrace
 
     def test_good(self):
         """Confirm Gelman-Rubin statistic is close to 1 for a reasonable number of samples."""
         n_samples = 1000
         rhat = gelman_rubin(self.get_ptrace(n_samples))
-        assert all(1 / self.good_ratio < r <
-                            self.good_ratio for r in rhat.values())
+        assert all(1 / self.good_ratio < r < self.good_ratio for r in rhat.values())
 
     def test_bad(self):
         """Confirm Gelman-Rubin statistic is far from 1 for a small number of samples."""
         n_samples = 5
         rhat = gelman_rubin(self.get_ptrace(n_samples))
-        assert not all(1 / self.good_ratio < r <
-                             self.good_ratio for r in rhat.values())
+        assert not all(1 / self.good_ratio < r < self.good_ratio for r in rhat.values())
 
     def test_right_shape_python_float(self, shape=None, test_shape=None):
         """Check Gelman-Rubin statistic shape is correct w/ python float"""

--- a/pymc3/tests/test_distribution_defaults.py
+++ b/pymc3/tests/test_distribution_defaults.py
@@ -1,10 +1,10 @@
 from __future__ import division
 
-from ..model import Model
-from ..distributions import DiscreteUniform, Continuous
-
 import numpy as np
 import pytest
+
+from ..model import Model
+from ..distributions import DiscreteUniform, Continuous
 
 
 class DistTest(Continuous):
@@ -63,6 +63,7 @@ def test_default_discrete_uniform():
     with Model():
         x = DiscreteUniform('x', lower=1, upper=2)
         assert x.init_value == 1
+
 
 def test_discrete_uniform_negative():
     model = Model()

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -598,7 +598,8 @@ class TestMatchesScipy(SeededTest):
 
     def test_bound_poisson(self):
         NonZeroPoisson = Bound(Poisson, lower=1.)
-        self.pymc3_matches_scipy(NonZeroPoisson, PosNat, {'mu': Rplus}, sp.poisson.logpmf)
+        self.pymc3_matches_scipy(NonZeroPoisson, PosNat, {'mu': Rplus},
+                                 lambda value, mu: sp.poisson.logpmf(value, mu))
 
         with Model():
             x = NonZeroPoisson('x', mu=4)

--- a/pymc3/tests/test_distributions_timeseries.py
+++ b/pymc3/tests/test_distributions_timeseries.py
@@ -1,12 +1,12 @@
 from __future__ import division
 
+import numpy as np
+
 from ..model import Model
 from ..distributions.continuous import Flat, Normal
 from ..distributions.timeseries import EulerMaruyama
 from ..sampling import sample, sample_ppc
 from ..theanof import floatX
-
-import numpy as np
 
 
 def _gen_sde_path(sde, pars, dt, n, x0):
@@ -25,7 +25,9 @@ def test_linear():
     sig2 = 5e-3
     N = 300
     dt = 1e-1
-    sde = lambda x, lam: (lam * x, sig2)
+
+    def sde(x, lam):
+        return lam * x, sig2
     x = floatX(_gen_sde_path(sde, (lam,), dt, N, 5.0))
     z = x + np.random.randn(x.size) * 5e-3
     # build model

--- a/pymc3/tests/test_glm.py
+++ b/pymc3/tests/test_glm.py
@@ -1,9 +1,10 @@
 import numpy as np
+import pandas as pd
 
-from .helpers import SeededTest
 from pymc3 import Model, Uniform, Normal, find_MAP, Slice, sample
 from pymc3 import families, GLM, LinearComponent
-import pandas as pd
+from .helpers import SeededTest
+
 
 # Generate data
 def generate_data(intercept, slope, size=700):
@@ -56,7 +57,7 @@ class TestGLM(SeededTest):
     def test_glm_link_func(self):
         with Model() as model:
             GLM.from_formula('y ~ x', self.data_logistic,
-                    family=families.Binomial(link=families.logit))
+                             family=families.Binomial(link=families.logit))
             step = Slice(model.vars)
             trace = sample(1000, step=step, tune=0, progressbar=False,
                            random_seed=self.random_seed)
@@ -67,11 +68,11 @@ class TestGLM(SeededTest):
     def test_more_than_one_glm_is_ok(self):
         with Model():
             GLM.from_formula('y ~ x', self.data_logistic,
-                    family=families.Binomial(link=families.logit),
-                    name='glm1')
+                             family=families.Binomial(link=families.logit),
+                             name='glm1')
             GLM.from_formula('y ~ x', self.data_logistic,
-                    family=families.Binomial(link=families.logit),
-                    name='glm2')
+                             family=families.Binomial(link=families.logit),
+                             name='glm2')
 
     def test_from_xy(self):
         with Model():

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -1,11 +1,13 @@
 #  pylint:disable=unused-variable
-from .helpers import SeededTest
-from pymc3 import Model, gp, sample, Uniform
-import theano
-import theano.tensor as tt
 import numpy as np
 import numpy.testing as npt
 import pytest
+import theano
+import theano.tensor as tt
+
+from pymc3 import Model, gp, sample, Uniform
+from .helpers import SeededTest
+
 
 class TestZeroMean(object):
     def test_value(self):
@@ -13,7 +15,7 @@ class TestZeroMean(object):
         with Model() as model:
             zero_mean = gp.mean.Zero()
         M = theano.function([], zero_mean(X))()
-        assert np.all(M==0)
+        assert np.all(M == 0)
         assert M.shape == (10, )
 
 
@@ -23,7 +25,7 @@ class TestConstantMean(object):
         with Model() as model:
             const_mean = gp.mean.Constant(6)
         M = theano.function([], const_mean(X))()
-        assert np.all(M==6)
+        assert np.all(M == 6)
         assert M.shape == (10, )
 
 
@@ -400,6 +402,7 @@ class TestPolynomial(object):
 class TestWarpedInput(object):
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
+
         def warp_func(x, a, b, c):
             return x + (a * tt.tanh(b * (x - c)))
         with Model() as model:
@@ -424,6 +427,7 @@ class TestWarpedInput(object):
 class TestGibbs(object):
     def test_1d(self):
         X = np.linspace(0, 2, 10)[:, None]
+
         def tanh_func(x, x1, x2, w, x0):
             return (x1 + x2) / 2.0 - (x1 - x2) / 2.0 * tt.tanh((x - x0) / w)
         with Model() as model:
@@ -449,8 +453,10 @@ class TestHandleArgs(object):
     def test_handleargs(self):
         def func_noargs(x):
             return x
+
         def func_onearg(x, a):
             return x + a
+
         def func_twoarg(x, a, b):
             return x + a + b
         x = 100
@@ -471,21 +477,24 @@ class TestGP(SeededTest):
         with Model() as model:
             # make a Gaussian model
             with pytest.raises(ValueError):
-                random_test = gp.GP('random_test', cov_func=gp.mean.Zero(), observed={'X':X, 'Y':Y})
+                random_test = gp.GP('random_test',
+                                    cov_func=gp.mean.Zero(),
+                                    observed={'X': X, 'Y': Y})
             with pytest.raises(ValueError):
                 random_test = gp.GP('random_test', mean_func=gp.cov.Matern32(1, 1),
-                                        cov_func=gp.cov.Matern32(1, 1), observed={'X':X, 'Y':Y})
+                                    cov_func=gp.cov.Matern32(1, 1), observed={'X': X, 'Y': Y})
 
     def test_sample(self):
         X = np.linspace(0, 1, 10)[:, None]
         Y = np.random.randn(10)
         with Model() as model:
             M = gp.mean.Zero()
-            l = Uniform('l', 0, 5)
-            K = gp.cov.Matern32(1, l)
+            length = Uniform('length', 0, 5)
+            K = gp.cov.Matern32(1, length)
             sigma = Uniform('sigma', 0, 10)
             # make a Gaussian model
-            random_test = gp.GP('random_test', mean_func=M, cov_func=K, sigma=sigma, observed={'X':X, 'Y':Y})
+            random_test = gp.GP('random_test', mean_func=M, cov_func=K, sigma=sigma,
+                                observed={'X': X, 'Y': Y})
             tr = sample(20, init=None, progressbar=False, random_seed=self.random_seed)
 
         # test prediction

--- a/pymc3/tests/test_hdf5_backend.py
+++ b/pymc3/tests/test_hdf5_backend.py
@@ -1,8 +1,9 @@
+import os
+import tempfile
+
 import numpy as np
 from pymc3.tests import backend_fixtures as bf
 from pymc3.backends import ndarray, hdf5
-import os
-import tempfile
 
 STATS1 = [{
     'a': np.float64,
@@ -17,6 +18,7 @@ STATS2 = [{
 }]
 
 DBNAME = os.path.join(tempfile.gettempdir(), 'test.h5')
+
 
 class TestHDF50dSampling(bf.SamplingTestCase):
     backend = hdf5.HDF5

--- a/pymc3/tests/test_hmc.py
+++ b/pymc3/tests/test_hmc.py
@@ -1,14 +1,14 @@
 import numpy as np
-
-from pymc3.blocking import DictToArrayBijection
-from . import models
-from pymc3.step_methods.hmc.base_hmc import BaseHMC
-import pymc3
-from pymc3.theanof import floatX
-from .checks import close_to
-from .helpers import select_by_precision
 import pytest
 import theano
+
+import pymc3
+from pymc3.blocking import DictToArrayBijection
+from pymc3.step_methods.hmc.base_hmc import BaseHMC
+from pymc3.theanof import floatX
+from . import models
+from .checks import close_to
+from .helpers import select_by_precision
 
 
 def test_leapfrog_reversible():
@@ -27,6 +27,7 @@ def test_leapfrog_reversible():
             q, p, _ = step.leapfrog(q, -p, floatX(np.array(epsilon)), np.array(n_steps, dtype='int32'))
             close_to(q, q0, precision, str((n_steps, epsilon)))
             close_to(-p, p0, precision, str((n_steps, epsilon)))
+
 
 @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
 def test_leapfrog_reversible_single():

--- a/pymc3/tests/test_math.py
+++ b/pymc3/tests/test_math.py
@@ -1,12 +1,12 @@
 import numpy as np
+import pytest
 import theano
 import theano.tensor as tt
 from theano.tests import unittest_tools as utt
-from pymc3.math import (
-    LogDet, logdet, probit, invprobit, expand_packed_triangular)
-from .helpers import SeededTest
-import pytest
+
+from pymc3.math import LogDet, logdet, probit, invprobit, expand_packed_triangular
 from pymc3.theanof import floatX
+from .helpers import SeededTest
 
 
 def test_probit():

--- a/pymc3/tests/test_mixture.py
+++ b/pymc3/tests/test_mixture.py
@@ -1,9 +1,9 @@
 import numpy as np
 from numpy.testing import assert_allclose
 
-from .helpers import SeededTest
 from pymc3 import Dirichlet, Gamma, Metropolis, Mixture, Model, Normal, NormalMixture, Poisson, sample
 from pymc3.theanof import floatX
+from .helpers import SeededTest
 
 
 # Generate data

--- a/pymc3/tests/test_models_linear.py
+++ b/pymc3/tests/test_models_linear.py
@@ -1,8 +1,9 @@
 import numpy as np
-from .helpers import SeededTest
+import pytest
+
 from pymc3 import Model, Uniform, Normal, find_MAP, Slice, sample
 from pymc3.glm import LinearComponent, GLM
-import pytest
+from .helpers import SeededTest
 
 
 # Generate data
@@ -107,8 +108,5 @@ class TestGLM(SeededTest):
 
     def test_strange_types(self):
         with Model():
-            with pytest.raises(
-                ValueError):
-                GLM(1,
-                self.data_linear['y'],
-                name='lm')
+            with pytest.raises(ValueError):
+                GLM(1, self.data_linear['y'], name='lm')

--- a/pymc3/tests/test_plots.py
+++ b/pymc3/tests/test_plots.py
@@ -2,9 +2,12 @@ import matplotlib
 matplotlib.use('Agg', warn=False)  # noqa
 
 import numpy as np
-import pymc3 as pm
-from .checks import close_to
+import pytest
+import theano
 
+import pymc3 as pm
+from pymc3.examples import arbitrary_stochastic as asmod
+from .checks import close_to
 from .models import multidimensional_model, simple_categorical
 from ..plots import traceplot, forestplot, autocorrplot, plot_posterior
 from ..plots.utils import make_2d
@@ -12,9 +15,6 @@ from ..step_methods import Slice, Metropolis
 from ..sampling import sample
 from ..tuning.scaling import find_hessian
 from .test_examples import build_disaster_model
-from pymc3.examples import arbitrary_stochastic as asmod
-import theano
-import pytest
 
 
 def test_plots():

--- a/pymc3/tests/test_posteriors.py
+++ b/pymc3/tests/test_posteriors.py
@@ -1,6 +1,8 @@
 import pytest
-from . import sampler_fixtures as sf
 import theano
+
+from . import sampler_fixtures as sf
+
 
 @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
 class TestNUTSUniform(sf.NutsFixture, sf.UniformFixture):

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -1,20 +1,20 @@
 from itertools import combinations
-import numpy as np
 
 try:
     import unittest.mock as mock  # py3
 except ImportError:
     import mock
 
-import pymc3 as pm
+import numpy as np
+import pytest
+from scipy import stats
 import theano.tensor as tt
 from theano import shared
 import theano
+
+import pymc3 as pm
 from .models import simple_init
 from .helpers import SeededTest
-from scipy import stats
-
-import pytest
 
 
 @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")

--- a/pymc3/tests/test_shared.py
+++ b/pymc3/tests/test_shared.py
@@ -1,7 +1,8 @@
-import pymc3 as pm
-from .helpers import SeededTest
 import numpy as np
 import theano
+
+import pymc3 as pm
+from .helpers import SeededTest
 
 
 class TestShared(SeededTest):

--- a/pymc3/tests/test_smc.py
+++ b/pymc3/tests/test_smc.py
@@ -1,13 +1,14 @@
-import pymc3 as pm
-import numpy as np
-from pymc3.step_methods import smc
-from pymc3.backends.smc_text import TextStage
-import pytest
 from tempfile import mkdtemp
 import shutil
+
+import numpy as np
+import pytest
 import theano.tensor as tt
 import theano
 
+import pymc3 as pm
+from pymc3.step_methods import smc
+from pymc3.backends.smc_text import TextStage
 from .helpers import SeededTest
 
 

--- a/pymc3/tests/test_sqlite_backend.py
+++ b/pymc3/tests/test_sqlite_backend.py
@@ -1,9 +1,11 @@
 import os
-from pymc3.tests import backend_fixtures as bf
-from pymc3.backends import ndarray, sqlite
 import tempfile
+
 import pytest
 import theano
+
+from pymc3.tests import backend_fixtures as bf
+from pymc3.backends import ndarray, sqlite
 
 DBNAME = os.path.join(tempfile.gettempdir(), 'test.db')
 

--- a/pymc3/tests/test_starting.py
+++ b/pymc3/tests/test_starting.py
@@ -1,7 +1,8 @@
-from .checks import close_to
 import numpy as np
+
 from pymc3.tuning import starting
 from pymc3 import Model, Uniform, Normal, Beta, Binomial, find_MAP, Point
+from .checks import close_to
 from .models import simple_model, non_normal, exponential_beta, simple_arbitrary_det
 from .helpers import select_by_precision
 

--- a/pymc3/tests/test_stats.py
+++ b/pymc3/tests/test_stats.py
@@ -1,17 +1,18 @@
-from .models import Model, Normal, Metropolis
 import numpy as np
+from numpy.random import random, normal
 import numpy.testing as npt
+from numpy.testing import assert_equal, assert_almost_equal, assert_array_almost_equal
 import pandas as pd
+from scipy import stats as st
+
 import pymc3 as pm
+import pymc3.stats as pmstats
 from .helpers import SeededTest
+from .models import Model, Normal, Metropolis
 from ..tests import backend_fixtures as bf
 from ..backends import ndarray
 from ..stats import df_summary, autocorr, hpd, mc_error, quantiles, make_indices
 from ..theanof import floatX_array
-import pymc3.stats as pmstats
-from numpy.random import random, normal
-from numpy.testing import assert_equal, assert_almost_equal, assert_array_almost_equal
-from scipy import stats as st
 
 
 def test_log_post_trace():

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -2,8 +2,13 @@ import shutil
 import tempfile
 import warnings
 
-from .checks import close_to
-from .models import simple_categorical, mv_simple, mv_simple_discrete, simple_2model, mv_prior_simple
+from numpy.testing import assert_array_almost_equal
+import numpy as np
+import numpy.testing as npt
+import pytest
+import theano
+import theano.tensor as tt
+
 from pymc3.sampling import assign_step_methods, sample
 from pymc3.model import Model
 from pymc3.step_methods import (NUTS, BinaryGibbsMetropolis, CategoricalGibbsMetropolis,
@@ -12,16 +17,11 @@ from pymc3.step_methods import (NUTS, BinaryGibbsMetropolis, CategoricalGibbsMet
                                 EllipticalSlice, smc)
 from pymc3.theanof import floatX
 from pymc3 import SamplingError
-from pymc3.distributions import (
-    Binomial, Normal, Bernoulli, Categorical, Beta, HalfNormal)
-
-from numpy.testing import assert_array_almost_equal
-import numpy as np
-import numpy.testing as npt
-import pytest
-import theano
-import theano.tensor as tt
+from pymc3.distributions import Binomial, Normal, Bernoulli, Categorical, Beta, HalfNormal
+from .checks import close_to
 from .helpers import select_by_precision
+from .models import (simple_categorical, mv_simple, mv_simple_discrete,
+                     simple_2model, mv_prior_simple)
 
 
 class TestStepMethods(object):  # yield test doesn't work subclassing object

--- a/pymc3/tests/test_util.py
+++ b/pymc3/tests/test_util.py
@@ -1,10 +1,10 @@
+import numpy as np
+from numpy.testing import assert_almost_equal
 import pytest
 
 import pymc3 as pm
-import numpy as np
-from numpy.testing import assert_almost_equal
-from .helpers import SeededTest
 from pymc3.distributions.transforms import Transform
+from .helpers import SeededTest
 
 
 class TestTransformName(object):
@@ -36,25 +36,25 @@ class TestTransformName(object):
 class TestUpdateStartVals(SeededTest):
     def setup_method(self):
         super(TestUpdateStartVals, self).setup_method()
-    
+
     def test_soft_update_all_present(self):
         start = {'a': 1, 'b': 2}
         test_point = {'a': 3, 'b': 4}
         pm.util.update_start_vals(start, test_point, model=None)
         assert start == {'a': 1, 'b': 2}
-    
+
     def test_soft_update_one_missing(self):
         start = {'a': 1, }
         test_point = {'a': 3, 'b': 4}
         pm.util.update_start_vals(start, test_point, model=None)
         assert start == {'a': 1, 'b': 4}
-    
+
     def test_soft_update_empty(self):
         start = {}
         test_point = {'a': 3, 'b': 4}
         pm.util.update_start_vals(start, test_point, model=None)
         assert start == test_point
-    
+
     def test_soft_update_transformed(self):
         with pm.Model() as model:
             pm.Exponential('a', 1)
@@ -62,7 +62,7 @@ class TestUpdateStartVals(SeededTest):
         test_point = {'a_log__': 0}
         pm.util.update_start_vals(start, test_point, model)
         assert_almost_equal(np.exp(start['a_log__']), start['a'])
-    
+
     def test_soft_update_parent(self):
         with pm.Model() as model:
             a = pm.Uniform('a', lower=0., upper=1.)
@@ -70,7 +70,7 @@ class TestUpdateStartVals(SeededTest):
             pm.Uniform('lower', lower=a, upper=3.)
             pm.Uniform('upper', lower=0., upper=b)
             pm.Uniform('interv', lower=a, upper=b)
-        
+
         start = {'a': .3, 'b': 2.1, 'lower': 1.4, 'upper': 1.4, 'interv':1.4}
         test_point = {'lower_interval__': -0.3746934494414109,
             'upper_interval__': 0.693147180559945,
@@ -82,5 +82,3 @@ class TestUpdateStartVals(SeededTest):
                             test_point['upper_interval__'])
         assert_almost_equal(start['interv_interval__'],
                             test_point['interv_interval__'])
-
-

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -1,18 +1,15 @@
-import pytest
 import pickle
 import operator
+
 import numpy as np
+import pytest
 from theano import theano, tensor as tt
 from theano.configparser import change_flags
+
 import pymc3 as pm
 from pymc3 import Model, Normal
-from pymc3.variational import (
-    ADVI, FullRankADVI, SVGD, NFVI,
-    Empirical, ASVGD,
-    MeanField, FullRank,
-    fit, flows
-)
-
+from pymc3.variational import (ADVI, FullRankADVI, SVGD, NFVI, Empirical, ASVGD, MeanField,
+                               FullRank, fit, flows)
 from pymc3.variational.operators import KL
 from pymc3.tests import models
 

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -3,20 +3,23 @@ Created on Mar 12, 2011
 
 @author: johnsalvatier
 '''
+from inspect import getargspec
+import time
+
 from scipy import optimize
 import numpy as np
 from numpy import isfinite, nan_to_num, logical_not
+
 import pymc3 as pm
-import time
 from ..vartypes import discrete_types, typefilter
 from ..model import modelcontext, Point
 from ..theanof import inputvars
 from ..blocking import DictToArrayBijection, ArrayOrdering
 from ..util import update_start_vals
 
-from inspect import getargspec
 
 __all__ = ['find_MAP']
+
 
 def find_MAP(start=None, vars=None, fmin=None,
              return_raw=False, model=None, live_disp=False, callback=None, *args, **kwargs):

--- a/pymc3/variational/advi.py
+++ b/pymc3/variational/advi.py
@@ -1,4 +1,3 @@
-
 '''
 (c) 2016, John Salvatier & Taku Yoshioka
 '''
@@ -9,11 +8,11 @@ import theano
 import theano.tensor as tt
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 
+from tqdm import trange
+
 import pymc3 as pm
 from pymc3.backends.base import MultiTrace
 from ..theanof import floatX
-
-from tqdm import trange
 
 __all__ = ['advi', 'sample_vp']
 

--- a/pymc3/variational/test_functions.py
+++ b/pymc3/variational/test_functions.py
@@ -1,6 +1,8 @@
 from theano import tensor as tt
-from .opvi import TestFunction
+
 from pymc3.theanof import floatX
+
+from .opvi import TestFunction
 
 __all__ = [
     'rbf'
@@ -8,7 +10,7 @@ __all__ = [
 
 
 class Kernel(TestFunction):
-    """
+    r"""
     Dummy base class for kernel SVGD in case we implement more
 
     .. math::


### PR DESCRIPTION
Added a new check to `.pylintrc`, in response to a comment on #2405.  Went through a lot of files and also corrected a bunch of linter errors which makes this a bigger change than is probably good.  
All changes should be cosmetic (except one undefined `_log`), and are, in roughly descending order of frequency:

- Import order
- line continuation indent
- spacing between functions
- getting rid of variables named `l` or `I`
- turning lambdas into honest functions
