### PR TITLE
Fixed error introduced by 6f58dbf

### DIFF
--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -42,7 +42,7 @@ class BaseHMC(ArrayStepShared):
         vars = inputvars(vars)
 
         if scaling is None and potential is None:
-            scaling = floatX(np.ones(model.dict_to_array(model.test_point).size))
+            scaling = {k: floatX(np.ones(v.shape)) for k, v in model.test_point.items()}
 
         if isinstance(scaling, dict):
             scaling = guess_scaling(Point(scaling, model=model), model=model, vars=vars)

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -5,6 +5,7 @@ from pymc3.tuning import guess_scaling
 from pymc3.model import modelcontext, Point
 from .quadpotential import quad_potential
 from pymc3.theanof import inputvars, make_shared_replacements, floatX
+from pymc3.blocking import DictToArrayBijection, ArrayOrdering
 import numpy as np
 
 
@@ -42,7 +43,9 @@ class BaseHMC(ArrayStepShared):
         vars = inputvars(vars)
 
         if scaling is None and potential is None:
-            scaling = {k: floatX(np.ones(v.shape)) for k, v in model.test_point.items()}
+            varnames = [var.name for var in vars]
+            size = sum(v.size for k, v in model.test_point.items() if k in varnames)
+            scaling = floatX(np.ones(size))
 
         if isinstance(scaling, dict):
             scaling = guess_scaling(Point(scaling, model=model), model=model, vars=vars)

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -5,7 +5,6 @@ from pymc3.tuning import guess_scaling
 from pymc3.model import modelcontext, Point
 from .quadpotential import quad_potential
 from pymc3.theanof import inputvars, make_shared_replacements, floatX
-from pymc3.blocking import DictToArrayBijection, ArrayOrdering
 import numpy as np
 
 


### PR DESCRIPTION
In which the 'scaling' variable is initialized as an array of ones instead of a dict that matches variables with arrays of ones with the shape of the variable. This resulted in the 'scaling' variable have the shape of entire model. So, if a user set the step method manually for a variable, the shape of the '

This commit preserves the intentions of the 6f58dbf commit by initializing 'scaling' to a dict of arrays of ones with type floatX. As a result, the function "guess_scaling" will be able to create a scaling array with the correct shape.