### PR TITLE
Fixed step method argument storage hack for unpickling in parallel processes

### DIFF
--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -37,6 +37,7 @@ class BlockedStep(object):
             kwargs['blocked'] = blocked
 
         model = modelcontext(kwargs.get('model'))
+        kwargs.update({'model':model})
 
         # vars can either be first arg or a kwarg
         if 'vars' not in kwargs and len(args) >= 1:

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -37,7 +37,7 @@ class BlockedStep(object):
             kwargs['blocked'] = blocked
 
         model = modelcontext(kwargs.get('model'))
-        kwargs['model'] = model
+        kwargs.update({'model':model})
 
         # vars can either be first arg or a kwarg
         if 'vars' not in kwargs and len(args) >= 1:

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -37,7 +37,7 @@ class BlockedStep(object):
             kwargs['blocked'] = blocked
 
         model = modelcontext(kwargs.get('model'))
-        kwargs.update({'model':model})
+        kwargs['model'] = model
 
         # vars can either be first arg or a kwarg
         if 'vars' not in kwargs and len(args) >= 1:


### PR DESCRIPTION
There was a hack originally put in place to store arguments necessary to reconstruct the step_method object when forking parallel processes. However, it did not store the model. When reconstructing the object, it would attempt to find a model in context. This fails in a forked process on Windows, presumably because the interpreter does not have access to the Model class present at the main execution level (which is available to spawned processes on Linux). As a result, attempting to sample with njobs > 1 throws an exception on Windows.

This proposed change explicitly sets the 'model' entry in the stored arguments for the step_method.

This is in response to this issue: https://github.com/pymc-devs/pymc3/issues/2383