### PR TITLE
Spelling fixes in Empirical notebook

### DIFF
--- a/docs/source/notebooks/empirical-approx-overview.ipynb
+++ b/docs/source/notebooks/empirical-approx-overview.ipynb
@@ -14,7 +14,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -244,9 +246,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It has exactly the same number of samples that you had in trace before. In our particular case it is 50k. Then another thing to notice is thet if you have multitrace with **more than one chain** you'll get much **more samples** stored at once. We flatten all the trace for creating `Empirical`.\n",
+    "It has exactly the same number of samples that you had in trace before. In our particular case it is 50k.  Another thing to notice is thet if you have multitrace with **more than one chain** you'll get much **more samples** stored at once. We flatten all the trace for creating `Empirical`.\n",
     "\n",
-    "This *histogram* is about *how* we store samples. Structure is pretty simple: `(n_samples, n_dim)` The order of these variables is stored internally in the class and in most cases will not be needed for end user"
+    "This *histogram* is about *how* we store samples. The structure is pretty simple: `(n_samples, n_dim)` The order of these variables is stored internally in the class and in most cases will not be needed for end user"
    ]
   },
   {
@@ -273,7 +275,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sampling from posterior is done uniformly with replacements. Calling `approx.sample(1000)` you'll get again the trace but the order is not determined. There is not way now to reconstruct the underlying trace again with `approx.sample`."
+    "Sampling from posterior is done uniformly with replacements. Call `approx.sample(1000)` and you'll get again the trace but the order is not determined. There is no way now to reconstruct the underlying trace again with `approx.sample`."
    ]
   },
   {
@@ -369,7 +371,9 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "with model:\n",
@@ -452,7 +456,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Previously we had `trace_cov` function"
+    "Previously we had a `trace_cov` function"
    ]
   },
   {
@@ -527,7 +531,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Estimations are very close and differ due to precision error. We can get mean in the same way"
+    "Estimations are very close and differ due to precision error. We can get the mean in the same way"
    ]
   },
   {
@@ -550,8 +554,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "IPython (Python 3)",
+   "language": "",
    "name": "python3"
   },
   "language_info": {
@@ -564,7 +568,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I just noticed a misspelling in the filename of the new Empirical notebook, so I went ahead and made some spelling and grammar fixes.