### PR TITLE
Fix sampler stats error in NUTS

### DIFF
--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -466,19 +466,20 @@ class NutsReport(object):
         """Print warnings for obviously problematic chains."""
         self._chain_id = strace.chain
 
-        tuning = strace.get_sampler_stats('tune')
-        if tuning.ndim == 2:
-            tuning = np.any(tuning, axis=-1)
+        if strace.supports_sampler_stats:
+            tuning = strace.get_sampler_stats('tune')
+            if tuning.ndim == 2:
+                tuning = np.any(tuning, axis=-1)
 
-        accept = strace.get_sampler_stats('mean_tree_accept')
-        if accept.ndim == 2:
-            accept = np.mean(accept, axis=-1)
+            accept = strace.get_sampler_stats('mean_tree_accept')
+            if accept.ndim == 2:
+                accept = np.mean(accept, axis=-1)
 
-        depth = strace.get_sampler_stats('depth')
-        if depth.ndim == 2:
-            depth = np.max(depth, axis=-1)
+            depth = strace.get_sampler_stats('depth')
+            if depth.ndim == 2:
+                depth = np.max(depth, axis=-1)
 
-        self._check_len(tuning)
-        self._check_depth(depth[~tuning])
-        self._check_accept(accept[~tuning])
-        self._check_divergence()
+            self._check_len(tuning)
+            self._check_depth(depth[~tuning])
+            self._check_accept(accept[~tuning])
+            self._check_divergence()

--- a/pymc3/tests/test_text_backend.py
+++ b/pymc3/tests/test_text_backend.py
@@ -1,7 +1,21 @@
+import pymc3 as pm
 from pymc3.tests import backend_fixtures as bf
 from pymc3.backends import ndarray, text
 import pytest
 import theano
+
+
+class TestTextSampling(object):
+    name = 'text-db'
+
+    def test_supports_sampler_stats(self):
+        with pm.Model():
+            pm.Normal("mu", mu=0, sd=1, shape=2)
+            db = text.Text(self.name)
+            pm.sample(20, tune=10, init=None, trace=db)
+
+    def teardown_method(self):
+        bf.remove_file_or_directory(self.name)
 
 
 class TestText0dSampling(bf.SamplingTestCase):


### PR DESCRIPTION
Addresses a bug brought up in discourse (https://discourse.pymc.io/t/using-text-backend-raises-sampler-stats-error/165).  I spent some time trying to get sampler stats working for the text backend, but it was more difficult than anticipated.  

This PR includes a test that recreates the problem, and a code change that fixes it.