### PR TITLE
bug fixed #2430

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -505,7 +505,13 @@ class Multinomial(Discrete):
     def _random(self, n, p, size=None):
         if size == p.shape:
             size = None
-        return np.random.multinomial(n, p, size=size)
+
+        if p.ndim > 1 and p.shape[0] > 1:
+            randnum = np.asarray([np.random.multinomial(n, pp, size=size) for pp in p])
+        else:
+            randnum = np.random.multinomial(n, p, size=size)
+
+        return randnum
 
     def random(self, point=None, size=None):
         n, p = draw_values([self.n, self.p], point=point)

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -506,10 +506,13 @@ class Multinomial(Discrete):
         if size == p.shape:
             size = None
 
-        if p.ndim > 1 and p.shape[0] > 1:
+        if p.ndim == 1:
+            randnum = np.random.multinomial(n, p.squeeze(), size=size)
+        elif p.ndim == 2:
             randnum = np.asarray([np.random.multinomial(n, pp, size=size) for pp in p])
         else:
-            randnum = np.random.multinomial(n, p, size=size)
+            raise ValueError('Outcome probabilities must be 1- or 2-dimensional '
+                             '(supplied `p` has {} dimensions)'.format(p.ndim))
 
         return randnum
 


### PR DESCRIPTION
Multinomial random fix for p.shape[0] > 1

[Edit 2]:
There are still some cases that the random of `pm.Multinomial` doesn't work:
```python
import pymc3 as pm
import numpy as np
p1 = np.asarray([.25,.25,.25,.25])
p2 = np.asarray([[.25,.25,.25,.25], [.25,.25,.25,.25]])
with pm.Model() as model:
    test1=pm.Multinomial('test1', n=1, p=p1, shape=(4))
    test2=pm.Multinomial('test2', n=1, p=p1, shape=(1, 4))
    test3=pm.Multinomial('test3', n=1, p=p1, shape=(10, 4))
    test4=pm.Multinomial('test4', n=1, p=p1, shape=(10, 1, 4))
    test5=pm.Multinomial('test5', n=1, p=p2, shape=(2, 4))
    test6=pm.Multinomial('test6', n=1, p=p2, shape=(1, 2, 4))
    test7=pm.Multinomial('test7', n=1, p=p2, shape=(10, 2, 4))

test1.random()
test2.random() # fixed in this PR
test3.random() # broken
test4.random() # fixed in this PR
test5.random() # broken
test6.random() # fixed in this PR
test7.random() # fixed in this PR
```