### PR TITLE
Remove unused argument from CpuLeapfrogIntegrator

### DIFF
--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -65,5 +65,4 @@ class BaseHMC(arraystep.GradientSharedStep):
         else:
             self.potential = quad_potential(scaling, is_cov)
 
-        self.integrator = integration.CpuLeapfrogIntegrator(
-            size, self.potential, self._logp_dlogp_func)
+        self.integrator = integration.CpuLeapfrogIntegrator(self.potential, self._logp_dlogp_func)

--- a/pymc3/step_methods/hmc/integration.py
+++ b/pymc3/step_methods/hmc/integration.py
@@ -8,11 +8,8 @@ State = namedtuple("State", 'q, p, v, q_grad, energy')
 
 
 class CpuLeapfrogIntegrator(object):
-    """Optimized leapfrog integration using numpy."""
-
-    def __init__(self, ndim, potential, logp_dlogp_func):
+    def __init__(self, potential, logp_dlogp_func):
         """Leapfrog integrator using CPU."""
-        self._ndim = ndim
         self._potential = potential
         self._logp_dlogp_func = logp_dlogp_func
         self._dtype = self._logp_dlogp_func.dtype


### PR DESCRIPTION
It looks like this is not used anywhere -- I'm fine leaving it around if there are plans for it though!