### PR TITLE
Run lint before tests, so travis fails faster

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,8 +2,9 @@
 
 set -e
 
-THEANO_FLAGS="floatX=${FLOATX},gcc.cxxflags='-march=core2'" pytest -v --cov=pymc3 "$@"
-
 if [[ "$RUN_PYLINT" == "true" ]]; then
     . ./scripts/lint.sh
 fi
+
+THEANO_FLAGS="floatX=${FLOATX},gcc.cxxflags='-march=core2'" pytest -v --cov=pymc3 "$@"
+


### PR DESCRIPTION
Should just allow a faster failure on lint errors on travis.