### PR TITLE
Adds a check in `sample` for `start` kwarg shapes

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -227,6 +227,9 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None,
     """
     model = modelcontext(model)
 
+    if start is not None:
+        _check_start_shape(model, start)
+
     draws += tune
 
     if nuts_kwargs is not None:
@@ -278,6 +281,20 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None,
     discard = tune if discard_tuned_samples else 0
 
     return sample_func(**sample_args)[discard:]
+
+
+def _check_start_shape(model, start):
+    e = ''
+    for var in model.vars:
+        if var.name in start.keys():
+            var_shape = var.shape.tag.test_value
+            start_shape = start[var.name].shape
+            if not np.array_equal(var_shape, start_shape):
+                e += "\nExpected shape {} for var '{}', got: {}".format(
+                    tuple(var_shape), var.name, start_shape
+                )
+    if e != '':
+        raise ValueError("Bad shape for start argument:{}".format(e))
 
 
 def _sample(draws, step=None, start=None, trace=None, chain=0, tune=None,

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -289,6 +289,7 @@ def _check_start_shape(model, start):
         # to deal with iterable start argument
         for start_iter in start:
             _check_start_shape(model, start_iter)
+        return
     elif not isinstance(start, dict):
         raise TypeError("start argument must be a dict "
                         "or an array-like of dicts")

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -290,7 +290,7 @@ def _check_start_shape(model, start):
         for start_iter in start:
             _check_start_shape(model, start_iter)
     elif not isinstance(start, dict):
-        raise TypeError("start argument must be a dict"
+        raise TypeError("start argument must be a dict "
                         "or an array-like of dicts")
     for var in model.vars:
         if var.name in start.keys():

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+from collections import defaultdict, Sequence
 
 from joblib import Parallel, delayed
 from numpy.random import randint, seed
@@ -285,15 +285,15 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None,
 
 def _check_start_shape(model, start):
     e = ''
+    if isinstance(start, (Sequence, np.ndarray)):
+        # to deal with iterable start argument
+        for start_iter in start:
+            _check_start_shape(model, start_iter)
+    elif not isinstance(start, dict):
+        raise TypeError("start argument must be a dict"
+                        "or an array-like of dicts")
     for var in model.vars:
-        if np.shape(start):
-            # to deal with iterable start argument
-            for start_iter in start:
-                _check_start_shape(model, start_iter)
-        elif not isinstance(start, dict):
-            raise TypeError("start argument must be a dict"
-                            "or an array-like of dicts")
-        elif var.name in start.keys():
+        if var.name in start.keys():
             var_shape = var.shape.tag.test_value
             start_var_shape = np.shape(start[var.name])
             if start_var_shape:

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -110,6 +110,27 @@ class TestSample(SeededTest):
             trace = pm.sample(draws=100, tune=50, njobs=4)
             assert len(trace) == 100
 
+    @pytest.mark.parametrize(
+        'start, error', [
+            ([1, 2], TypeError),
+            ({'x': 1}, ValueError),
+            ({'x': [1, 2, 3]}, ValueError),
+            ({'x': np.array([[1, 1], [1, 1]])}, ValueError)
+        ]
+    )
+    def test_sample_start_bad_shape(self, start, error):
+        with pytest.raises(error):
+            pm.sampling._check_start_shape(self.model, start)
+
+    @pytest.mark.parametrize(
+        'start', [
+            {'x': np.array([1, 1])},
+            [{'x': [10, 10]}, {'x': [-10, -10]}]
+        ]
+    )
+    def test_sample_start_good_shape(self, start):
+        pm.sampling._check_start_shape(self.model, start)
+
 
 def test_empty_model():
     with pm.Model():


### PR DESCRIPTION
Addresses #2323 

This PR is designed to check the the shapes of arguments specified in the `start` kwargs are valid given the model `vars`. I ran the tests locally and they all passed. 
Main things missing at this point are:
- potential update to `sample` docstring
- unit tests

Something I realised while writing this was that a list of dicts is a valid argument for `start` (as it is used in test_parallel_start.py), but this is not documented in the docstring and I would need some pointers as to what the accepted types are (if there are any beyond dict and list of dict) to update the docstring properly.

If whoever looks at this is generally happy with the approach, I can also add some unit tests (I was thinking in test_sampling.py)