### PR TITLE
Typo in _repr_latex_ for Flat distribution

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -203,7 +203,7 @@ class Flat(Continuous):
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:
             dist = self
-        return r'${} \sim \text{{Flat}()$'
+        return r'${} \sim \text{Flat}()$'
 
 
 class HalfFlat(PositiveContinuous):


### PR DESCRIPTION
Extra open bracket was breaking it.