### PR TITLE
Change docstring to correctly specify the support for Categorical 

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -482,7 +482,7 @@ class Categorical(Discrete):
     .. math:: f(x \mid p) = p_x
 
     ========  ===================================
-    Support   :math:`x \in \{1, 2, \ldots, |p|\}`
+    Support   :math:`x \in \{0, 1, \ldots, |p|-1\}`
     ========  ===================================
 
     Parameters


### PR DESCRIPTION
The docstring for Categorical specifies the support as 1,2,...|p|, however this is incorrect and the actual support is 0,1,...,|p|-1. Note that
```python
import pymc3 as pm
data = [1,2,3,4,5,6]
with pm.Model() as die_model:
    p = pm.Dirichlet('p', np.ones(6))
    d = pm.Categorical('d', p=p, observed=data)
```
Gives the error "index 6 is out of bounds for size 6", whereas
```python
data = [0,1,2,3,4,5]
with pm.Model() as die_model:
    p = pm.Dirichlet('p', np.ones(6))
    d = pm.Categorical('d', p=p, observed=data)
```
works as intended.

