### PR TITLE
Add logp_nojac and logp_sum

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -91,6 +91,28 @@ class Distribution(object):
         """Magic method name for IPython to use for LaTeX formatting."""
         return None
 
+    def logp_nojac(self, *args, **kwargs):
+        """Return the logp, but do not include a jacobian term for transforms.
+
+        If we use different parametrizations for the same distribution, we
+        need to add the determinant of the jacobian of the transformation
+        to make sure the densities still describe the same distribution.
+        However, MAP estimates are not invariant with respect to the
+        parametrization, we need to exclude the jacobian terms in this case.
+
+        This function should be overwritten in base classes for transformed
+        distributions.
+        """
+        return self.logp(*args, **kwargs)
+
+    def logp_sum(self, *args, **kwargs):
+        """Return the sum of the logp values for the given observations.
+
+        Subclasses can use this to improve the speed of logp evaluations
+        if only the sum of the logp values is needed.
+        """
+        return tt.sum(self.logp(*args, **kwargs))
+
     __latex__ = _repr_latex_
 
 

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -80,6 +80,9 @@ class TransformedDistribution(distribution.Distribution):
         return (self.dist.logp(self.transform_used.backward(x)) +
                 self.transform_used.jacobian_det(x))
 
+    def logp_nojac(self, x):
+        return self.dist.logp(self.transform_used.backward(x))
+
 transform = Transform
 
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -662,7 +662,10 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor)):
             logp_factors = tt.sum(factors)
             logp_potentials = tt.sum([tt.sum(pot) for pot in self.potentials])
             logp = logp_factors + logp_potentials
-            logp.name = '__logp'
+            if self.name:
+                logp.name = '__logp_%s' % self.name
+            else:
+                logp.name = '__logp'
             return logp
 
     @property
@@ -671,7 +674,10 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor)):
         with self:
             factors = [var.logp_nojact for var in self.basic_RVs] + self.potentials
             logp = tt.sum([tt.sum(factor) for factor in factors])
-            logp.name = '__logp_nojac'
+            if self.name:
+                logp.name = '__logp_nojac_%s' % self.name
+            else:
+                logp.name = '__logp_nojac'
             return logp
 
     @property

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -170,6 +170,18 @@ class Factor(object):
         return self.model.fn(hessian(self.logpt, vars))
 
     @property
+    def logp_nojac(self):
+        return self.model.fn(self.logp_nojact)
+
+    def dlogp_nojac(self, vars=None):
+        """Compiled log density gradient function, without jacobian terms."""
+        return self.model.fn(gradient(self.logp_nojact, vars))
+
+    def d2logp_nojac(self, vars=None):
+        """Compiled log density hessian function, without jacobian terms."""
+        return self.model.fn(hessian(self.logp_nojact, vars))
+
+    @property
     def fastlogp(self):
         """Compiled log probability density function"""
         return self.model.fastfn(self.logpt)
@@ -183,12 +195,35 @@ class Factor(object):
         return self.model.fastfn(hessian(self.logpt, vars))
 
     @property
+    def fastlogp_nojac(self):
+        return self.model.fastfn(self.logp_nojact)
+
+    def fastdlogp_nojac(self, vars=None):
+        """Compiled log density gradient function, without jacobian terms."""
+        return self.model.fastfn(gradient(self.logp_nojact, vars))
+
+    def fastd2logp_nojac(self, vars=None):
+        """Compiled log density hessian function, without jacobian terms."""
+        return self.model.fastfn(hessian(self.logp_nojact, vars))
+
+    @property
     def logpt(self):
         """Theano scalar of log-probability of the model"""
         if getattr(self, 'total_size', None) is not None:
-            logp = tt.sum(self.logp_elemwiset) * self.scaling
+            logp = self.logp_sum_unscaledt * self.scaling
         else:
-            logp = tt.sum(self.logp_elemwiset)
+            logp = self.logp_sum_unscaledt
+        if self.name is not None:
+            logp.name = '__logp_%s' % self.name
+        return logp
+
+    @property
+    def logp_nojact(self):
+        """Theano scalar of log-probability, excluding jacobian terms."""
+        if getattr(self, 'total_size', None) is not None:
+            logp = tt.sum(self.logp_nojac_unscaledt) * self.scaling
+        else:
+            logp = tt.sum(self.logp_nojac_unscaledt)
         if self.name is not None:
             logp.name = '__logp_%s' % self.name
         return logp
@@ -623,9 +658,20 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor)):
     def logpt(self):
         """Theano scalar of log-probability of the model"""
         with self:
-            factors = [var.logpt for var in self.basic_RVs] + self.potentials
-            logp = tt.add(*map(tt.sum, factors))
+            factors = [var.logpt for var in self.basic_RVs]
+            logp_factors = tt.sum(factors)
+            logp_potentials = tt.sum([tt.sum(pot) for pot in self.potentials])
+            logp = logp_factors + logp_potentials
             logp.name = '__logp'
+            return logp
+
+    @property
+    def logp_nojact(self):
+        """Theano scalar of log-probability of the model"""
+        with self:
+            factors = [var.logp_nojact for var in self.basic_RVs] + self.potentials
+            logp = tt.sum([tt.sum(factor) for factor in factors])
+            logp.name = '__logp_nojac'
             return logp
 
     @property
@@ -634,7 +680,7 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor)):
            (excluding deterministic)."""
         with self:
             factors = [var.logpt for var in self.vars]
-            return tt.add(*map(tt.sum, factors))
+            return tt.sum(factors)
 
     @property
     def vars(self):
@@ -1066,6 +1112,10 @@ class FreeRV(Factor, TensorVariable):
             self.tag.test_value = np.ones(
                 distribution.shape, distribution.dtype) * distribution.default()
             self.logp_elemwiset = distribution.logp(self)
+            # The logp might need scaling in minibatches.
+            # This is done in `Factor`.
+            self.logp_sum_unscaledt = distribution.logp_sum(self)
+            self.logp_nojac_unscaledt = distribution.logp_nojac(self)
             self.total_size = total_size
             self.model = model
             self.scaling = _get_scaling(total_size, self.shape, self.ndim)
@@ -1169,6 +1219,10 @@ class ObservedRV(Factor, TensorVariable):
 
             self.missing_values = data.missing_values
             self.logp_elemwiset = distribution.logp(data)
+            # The logp might need scaling in minibatches.
+            # This is done in `Factor`.
+            self.logp_sum_unscaledt = distribution.logp_sum(data)
+            self.logp_nojac_unscaledt = distribution.logp_nojac(data)
             self.total_size = total_size
             self.model = model
             self.distribution = distribution
@@ -1220,6 +1274,10 @@ class MultiObservedRV(Factor):
         self.missing_values = [datum.missing_values for datum in self.data.values()
                                if datum.missing_values is not None]
         self.logp_elemwiset = distribution.logp(**self.data)
+        # The logp might need scaling in minibatches.
+        # This is done in `Factor`.
+        self.logp_sum_unscaledt = distribution.logp_sum(**self.data)
+        self.logp_nojac_unscaledt = distribution.logp_nojac(**self.data)
         self.total_size = total_size
         self.model = model
         self.distribution = distribution

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -18,8 +18,10 @@ from inspect import getargspec
 
 __all__ = ['find_MAP']
 
+
 def find_MAP(start=None, vars=None, fmin=None,
-             return_raw=False, model=None, live_disp=False, callback=None, *args, **kwargs):
+             return_raw=False, model=None, live_disp=False, callback=None,
+             *args, **kwargs):
     """
     Sets state to the local maximum a posteriori point given a model.
     Current default of fmin_Hessian does not deal well with optimizing close
@@ -69,7 +71,7 @@ def find_MAP(start=None, vars=None, fmin=None,
     except AttributeError:
         gradient_avail = False
 
-    if disc_vars or not gradient_avail :
+    if disc_vars or not gradient_avail:
         pm._log.warning("Warning: gradient not available." +
                         "(E.g. vars contains discrete variables). MAP " +
                         "estimates may not be accurate for the default " +
@@ -88,13 +90,13 @@ def find_MAP(start=None, vars=None, fmin=None,
     start = Point(start, model=model)
     bij = DictToArrayBijection(ArrayOrdering(vars), start)
 
-    logp = bij.mapf(model.fastlogp)
+    logp = bij.mapf(model.fastlogp_nojac)
     def logp_o(point):
         return nan_to_high(-logp(point))
 
     # Check to see if minimization function actually uses the gradient
     if 'fprime' in getargspec(fmin).args:
-        dlogp = bij.mapf(model.fastdlogp(vars))
+        dlogp = bij.mapf(model.fastdlogp_nojac(vars))
         def grad_logp_o(point):
             return nan_to_num(-dlogp(point))
 


### PR DESCRIPTION
This is WIP for fixing #2482.
It adds `Distribution.logp_nojac`, which returns the logp, but doesn't include the jacobian terms for transformed distributions. `find_MAP` now also uses this instead of the normal `logp` function.

It also adds `Distribution.logp_sum`, which isn't used at the moment, but can be used to speed up some logp functions, for cases where we only need the sum of the logp values and not the individual values (nuts!). I experimented with that for `Normal` and `MvNormal` at it seems this can provide a moderate speedup in some cases.

I think this should probably wait until #2468 is merged, and then rebased. @kyleabeauchamp wrote some tests for this, but they require #2468, which we can also add after that is merged.