### PR TITLE
Speedup dist tests

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -632,11 +632,13 @@ class ZeroInflatedPoisson(Discrete):
         psi = self.psi
         theta = self.theta
 
-        logp_val = tt.switch(tt.gt(value, 0),
-                     tt.log(psi) + self.pois.logp(value),
-                     logaddexp(tt.log1p(-psi), tt.log(psi) - theta))
+        logp_val = tt.switch(
+            tt.gt(value, 0),
+            tt.log(psi) + self.pois.logp(value),
+            logaddexp(tt.log1p(-psi), tt.log(psi) - theta))
 
-        return bound(logp_val,
+        return bound(
+            logp_val,
             0 <= value,
             0 <= psi, psi <= 1,
             0 <= theta)
@@ -700,11 +702,13 @@ class ZeroInflatedBinomial(Discrete):
         p = self.p
         n = self.n
 
-        logp_val = tt.switch(tt.gt(value, 0),
-                 tt.log(psi) + self.bin.logp(value),
-                 logaddexp(tt.log1p(-psi), tt.log(psi) + n * tt.log1p(-p)))
+        logp_val = tt.switch(
+            tt.gt(value, 0),
+            tt.log(psi) + self.bin.logp(value),
+            logaddexp(tt.log1p(-psi), tt.log(psi) + n * tt.log1p(-p)))
 
-        return bound(logp_val,
+        return bound(
+            logp_val,
             0 <= value, value <= n,
             0 <= psi, psi <= 1,
             0 <= p, p <= 1)
@@ -715,10 +719,14 @@ class ZeroInflatedBinomial(Discrete):
         n = dist.n
         p = dist.p
         psi = dist.psi
-        return r'${} \sim \text{{ZeroInflatedBinomial}}(\mathit{{n}}={}, \mathit{{p}}={}, \mathit{{psi}}={})$'.format(name,
-                                                get_variable_name(n),
-                                                get_variable_name(p),
-                                                get_variable_name(psi))
+
+        name_n = get_variable_name(n)
+        name_p = get_variable_name(p)
+        name_psi = get_variable_name(psi)
+        return (r'${} \sim \text{{ZeroInflatedBinomial}}'
+                r'(\mathit{{n}}={}, \mathit{{p}}={}, '
+                r'\mathit{{psi}}={})$'
+                .format(name, name_n, name_p, name_psi))
 
 
 class ZeroInflatedNegativeBinomial(Discrete):
@@ -731,10 +739,18 @@ class ZeroInflatedNegativeBinomial(Discrete):
 
     .. math::
 
-       f(x \mid \psi, \mu, \alpha) = \left\{ \begin{array}{l}
-            (1-\psi) + \psi \left (\frac{\alpha}{\alpha+\mu} \right) ^\alpha, \text{if } x = 0 \\
-            \psi \frac{\Gamma(x+\alpha)}{x! \Gamma(\alpha)} \left (\frac{\alpha}{\mu+\alpha} \right)^\alpha \left( \frac{\mu}{\mu+\alpha} \right)^x, \text{if } x=1,2,3,\ldots
-            \end{array} \right.
+       f(x \mid \psi, \mu, \alpha) = \left\{
+         \begin{array}{l}
+           (1-\psi) + \psi \left (
+             \frac{\alpha}{\alpha+\mu}
+           \right) ^\alpha, \text{if } x = 0 \\
+           \psi \frac{\Gamma(x+\alpha)}{x! \Gamma(\alpha)} \left (
+             \frac{\alpha}{\mu+\alpha}
+           \right)^\alpha \left(
+             \frac{\mu}{\mu+\alpha}
+           \right)^x, \text{if } x=1,2,3,\ldots
+         \end{array}
+       \right.
 
     ========  ==========================
     Support   :math:`x \in \mathbb{N}_0`
@@ -776,14 +792,21 @@ class ZeroInflatedNegativeBinomial(Discrete):
         mu = self.mu
         psi = self.psi
 
-        logp_val = tt.switch(tt.gt(value, 0),
-                     tt.log(psi) + self.nb.logp(value),
-                     logaddexp(tt.log1p(-psi), tt.log(psi) + alpha * (tt.log(alpha) - tt.log(alpha + mu))))
+        logp_other = tt.log(psi) + self.nb.logp(value)
+        logp_0 = logaddexp(
+            tt.log1p(-psi),
+            tt.log(psi) + alpha * (tt.log(alpha) - tt.log(alpha + mu)))
 
-        return bound(logp_val,
-                    0 <= value,
-                    0 <= psi, psi <= 1,
-                    mu > 0, alpha > 0)
+        logp_val = tt.switch(
+            tt.gt(value, 0),
+            logp_other,
+            logp_0)
+
+        return bound(
+            logp_val,
+            0 <= value,
+            0 <= psi, psi <= 1,
+            mu > 0, alpha > 0)
 
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:
@@ -791,7 +814,11 @@ class ZeroInflatedNegativeBinomial(Discrete):
         mu = dist.mu
         alpha = dist.alpha
         psi = dist.psi
-        return r'${} \sim \text{{ZeroInflatedNegativeBinomial}}(\mathit{{mu}}={}, \mathit{{alpha}}={}, \mathit{{psi}}={})$'.format(name,
-                                                get_variable_name(mu),
-                                                get_variable_name(alpha),
-                                                get_variable_name(psi))
+
+        name_mu = get_variable_name(mu)
+        name_alpha = get_variable_name(alpha)
+        name_psi = get_variable_name(psi)
+        return (r'${} \sim \text{{ZeroInflatedNegativeBinomial}}'
+                r'(\mathit{{mu}}={}, \mathit{{alpha}}={}, '
+                r'\mathit{{psi}}={})$'
+                .format(name, name_mu, name_alpha, name_psi))

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -152,6 +152,9 @@ class Factor(object):
     """Common functionality for objects with a log probability density
     associated with them.
     """
+    def __init__(self, *args, **kwargs):
+        super(Factor, self).__init__(*args, **kwargs)
+
     @property
     def logp(self):
         """Compiled log probability density function"""

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -378,7 +378,7 @@ class TestMatchesScipy(SeededTest):
 
     def check_int_to_1(self, model, value, domain, paramdomains):
         pdf = model.fastfn(exp(model.logpt))
-        for pt in product(paramdomains, n_samples=100):
+        for pt in product(paramdomains, n_samples=10):
             pt = Point(pt, value=value.tag.test_value, model=model)
             bij = DictToVarBijection(value, (), pt)
             pdfx = bij.mapf(pdf)


### PR DESCRIPTION
This decreases the number of `int_to_1` tests for each distribution from 100 to 10. Those tests take a reasonable share of the total test time, and I think 100 samples are a bit excessive.
Also, some whitespace stuff, and a missing call to `super().__init__`.