### PR TITLE
initial workaround to fix #2510 (Interpolated.dist().logp)

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2004,11 +2004,4 @@ class Interpolated(Continuous):
                                 size=size)
 
     def logp(self, value):
-        # TODO: this implementation is suboptimal
-        #       the SplineWrapper should get proper broadcasting behavior
-        value = tt.as_tensor_variable(value)
-        if hasattr(value, "__iter__"):
-            iv = tt.stack([self.interp_op(v) for v in value])
-        else:
-            iv = self.interp_op(value)
-        return tt.log(iv / self.Z)
+        return tt.log(self.interp_op(value) / self.Z)

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2004,4 +2004,11 @@ class Interpolated(Continuous):
                                 size=size)
 
     def logp(self, value):
-        return tt.log(self.interp_op(value) / self.Z)
+        # TODO: this implementation is suboptimal
+        #       the SplineWrapper should get proper broadcasting behavior
+        value = tt.as_tensor_variable(value)
+        if hasattr(value, "__iter__"):
+            iv = tt.stack([self.interp_op(v) for v in value])
+        else:
+            iv = self.interp_op(value)
+        return tt.log(iv / self.Z)

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -317,11 +317,13 @@ class SplineWrapper(theano.Op):
     """
 
     __props__ = ('spline',)
-    itypes = [tt.dscalar]
-    otypes = [tt.dscalar]
 
     def __init__(self, spline):
         self.spline = spline
+
+    def make_node(self, x):
+        x = tt.as_tensor_variable(x)
+        return tt.Apply(self, [x], [x.type()])
 
     @property
     def grad_op(self):


### PR DESCRIPTION
logp fails if value is not a TensorVariable. Also the SplitWrapper (self.interp_op) does not do broadcasting. This workaround is probably not the fastest though.

A better solution would be to implement `make_node` on the `SplineWrapper` `Op` and make sure that 1.) it uses `tt.as_tensor_variable` on its inputs and 2.) has a proper broadcasting behavior. 