### PR TITLE
Sensible default value for eps in stick_breaking transform

### DIFF
--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -1,3 +1,4 @@
+import theano
 import theano.tensor as tt
 
 from ..model import FreeRV
@@ -249,7 +250,7 @@ class StickBreaking(Transform):
 
     name = "stickbreaking"
 
-    def __init__(self, eps=0.0):
+    def __init__(self, eps=np.finfo(theano.config.floatX).eps):
         self.eps = eps
 
     def forward(self, x_):


### PR DESCRIPTION
If the stick_breaking transform is not initialized with a sensible default value ADVI generates NaNs during optimization due to numerical instability. This is especially the case for Dirichlet distributions.
