### PR TITLE
Convert eps value to floatX fixes test failures of  #2515

### DIFF
--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -250,7 +250,7 @@ class StickBreaking(Transform):
 
     name = "stickbreaking"
 
-    def __init__(self, eps=np.finfo(theano.config.floatX).eps):
+    def __init__(self, eps=floatX(np.finfo(theano.config.floatX).eps)):
         self.eps = eps
 
     def forward(self, x_):
@@ -263,7 +263,7 @@ class StickBreaking(Transform):
         k = tt.arange(Km1)[(slice(None), ) + (None, ) * (x.ndim - 1)]
         eq_share = logit(1. / (Km1 + 1 - k).astype(str(x_.dtype)))
         y = logit(z) - eq_share
-        return y.T
+        return floatX(y.T)
 
     def forward_val(self, x, point=None):
         return self.forward(x)
@@ -278,7 +278,7 @@ class StickBreaking(Transform):
         yu = tt.concatenate([tt.ones(y[:1].shape), 1 - z])
         S = tt.extra_ops.cumprod(yu, 0)
         x = S * yl
-        return x.T
+        return floatX(x.T)
 
     def jacobian_det(self, y_):
         y = y_.T

--- a/pymc3/tests/test_transforms.py
+++ b/pymc3/tests/test_transforms.py
@@ -7,7 +7,10 @@ from .test_distributions import Simplex, Rplusbig, Rminusbig, Unit, R, Vector, M
 from .checks import close_to, close_to_logical
 from ..theanof import jacobian
 
-tol = 1e-7
+
+# some transforms (stick breaking) require additon of small slack in order to be numerically
+# stable. The minimal addable slack for float32 is higher thus we need to be less strict
+tol = 1e-7 if theano.config.floatX == 'flaot64' else 1e-6
 
 
 def check_transform_identity(transform, domain, constructor=tt.dscalar, test=0):


### PR DESCRIPTION
Tests failed on python 2.7 because eps of stick_breaking transform was not converted to correct float format.
Sorry for the inconvenience...
Problems with previous pull request are fixed here.