### PR TITLE
improve error messages and round results

### DIFF
--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -426,9 +426,8 @@ def compare(traces, models, ic='WAIC', method='stacking', b_samples=1000,
             'The number of observed RVs should be the same across all models')
 
     if method not in ['stacking', 'BB-pseudo-BMA', 'pseudo-BMA']:
-        raise NotImplementedError(
-            'The method {}, to compute weights,'
-            'is not supported.'.format(method))
+        raise ValueError('The method {}, to compute weights,'
+                         'is not supported.'.format(method))
 
     warns = np.zeros(len(models))
 
@@ -539,7 +538,7 @@ def _ic_matrix(ics):
     for i in range(K):
         ic = ics[i][1][3]
         if len(ic) != N:
-            raise ValueError('The number of data points should be the same '
+            raise ValueError('The number of observations should be the same '
                              'across all models')
         else:
             ic_i[:, i] = ic

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -451,7 +451,7 @@ def compare(traces, models, ic='WAIC', method='stacking', b_samples=1000,
         Km = K - 1
 
         def w_fuller(w):
-            return np.concatenate((w, 1. - np.sum(w, keepdims=True)))
+            return np.concatenate((w, [max(1. - np.sum(w), 0.)]))
 
         def log_score(w):
             w_full = w_fuller(w)
@@ -480,7 +480,7 @@ def compare(traces, models, ic='WAIC', method='stacking', b_samples=1000,
                      bounds=bounds,
                      constraints=constraints)
 
-        weights = w_fuller(np.round(w['x'], round_to))
+        weights = w_fuller(w['x'])
         ses = [res[1] for _, res in ics]
 
     elif method == 'BB-pseudo-BMA':


### PR DESCRIPTION
* Add error messages for models with different number of data points (following the discussion in #2503)
* Results are rounded in the DataFrame, the user can control the number of decimals used, default is 2
* Sometimes the optimization used when computing the stacking weights leads to very small negative numbers (that in fact should be zero), now there is and _extra round_ in order to avoid reporting negative weights.