### PR TITLE
Fix pickleing of NoDistribution

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -132,10 +132,12 @@ class NoDistribution(Distribution):
         self.parent_dist = parent_dist
 
     def __getattr__(self, name):
-        try:
-            self.__dict__[name]
-        except KeyError:
-            return getattr(self.parent_dist, name)
+        # Do not use __getstate__ and __setstate__ from parent_dist
+        # to avoid infinite recursion during unpickling
+        if name.startswith('__'):
+            raise AttributeError(
+                "'NoDistribution' has no attribute '%s'" % name)
+        return getattr(self.parent_dist, name)
 
     def logp(self, x):
         return 0


### PR DESCRIPTION
Without this patch this leads to infinite recursion during `pickle.loads`. @willferreira reported this in #1247 (thank you!).

```python
import numpy as np
import pymc3 as pm
import pickle
data_with_missing = np.ma.masked_equal([1, -999], value=-999)

with pm.Model() as model:
    n = pm.Normal('n', mu=0, sd=1, observed=data_with_missing)
    pickled = pickle.dumps(n.missing_values.distribution)
    pickle.loads(pickled)
```

I'm not entirely sure what the exact problem is, and how this fixes it, but it does seem to work.

Also, `__getattr__` doesn't need to check `self.__dict__`, it only gets called if name is not found the usual way (`__getattribute__` is the crazy one that gets all of those). And if it did, we couldn't actually use `self.__dict__` either ;-)