### PR TITLE
Remove domain name from docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,7 @@ which focuses on advanced Markov chain Monte Carlo and variational fitting
 algorithms. Its flexibility and extensibility make it applicable to a
 large suite of problems.
 
-Check out the `getting started
-guide <http://pymc-devs.github.io/pymc3/notebooks/getting_started.html>`__!
+Check out the :ref:`getting started guide<notebooks/getting_started.ipynb>`!
 
 Features
 ========
@@ -38,10 +37,9 @@ Getting started
 If you already know about Bayesian statistics:
 ----------------------------------------------
 
--  `API quickstart guide <http://pymc-devs.github.io/pymc3/notebooks/api_quickstart.html>`__
--  The `PyMC3 tutorial <http://pymc-devs.github.io/pymc3/notebooks/getting_started.html>`__
--  `PyMC3 examples <http://pymc-devs.github.io/pymc3/examples.html>`__
-   and the `API reference <http://pymc-devs.github.io/pymc3/api.html>`__
+-  :ref:`API quickstart guide<notebooks/api_quickstart.ipynb>`
+-  The :ref:`PyMC3 tutorial<notebooks/getting_started.ipynb>`
+-  :ref:`PyMC3 examples<examples>` and the :ref:`API reference<api>`
 
 Learn Bayesian statistics with a book together with PyMC3:
 ----------------------------------------------------------

--- a/docs/source/notebooks/GLM-linear.ipynb
+++ b/docs/source/notebooks/GLM-linear.ipynb
@@ -399,7 +399,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   },
   "latex_envs": {
    "bibliofile": "biblio.bib",

--- a/docs/source/notebooks/GLM-robust-with-outlier-detection.ipynb
+++ b/docs/source/notebooks/GLM-robust-with-outlier-detection.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "**A minimal reproducable example of Robust Regression with Outlier Detection using Hogg 2010 Signal vs Noise method.**\n",
     "\n",
-    "+ This is a complementary approach to the Student-T robust regression as illustrated in Thomas Wiecki's notebook in the [PyMC3 documentation](http://pymc-devs.github.io/pymc3/GLM-robust/), that approach is also compared here.\n",
+    "+ This is a complementary approach to the Student-T robust regression as illustrated in [Thomas Wiecki's notebook]((GLM-robust.ipynb), that approach is also compared here.\n",
     "+ This model returns a robust estimate of linear coefficients and an indication of which datapoints (if any) are outliers.\n",
     "+ The likelihood evaluation is essentially a copy of eqn 17 in \"Data analysis recipes: Fitting a model to data\" - [Hogg 2010](http://arxiv.org/abs/1008.4686).\n",
     "+ The model is adapted specifically from Jake Vanderplas' [implementation](http://www.astroml.org/book_figures/chapter8/fig_outlier_rejection.html) (3rd model tested).\n",
@@ -336,7 +336,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "I've added this brief section in order to directly compare the Student-T based method exampled in Thomas Wiecki's notebook in the [PyMC3 documentation](http://pymc-devs.github.io/pymc3/GLM-robust/)\n",
+    "I've added this brief section in order to directly compare the Student-T based method exampled in [Thomas Wiecki's notebook](GLM-robust.ipynb).\n",
     "\n",
     "Instead of using a Normal distribution for the likelihood, we use a Student-T, which has fatter tails. In theory this allows outliers to have a smaller mean square error in the likelihood, and thus have less influence on the regression estimation. This method does not produce inlier / outlier flags but is simpler and faster to run than the Signal Vs Noise model below, so a comparison seems worthwhile.\n",
     "\n",
@@ -872,7 +872,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/GLM-rolling-regression.ipynb
+++ b/docs/source/notebooks/GLM-rolling-regression.ipynb
@@ -127,7 +127,9 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "finite_idx = (np.isfinite(prices.GLD.values)) & (np.isfinite(prices.GFI.values))\n",
@@ -241,7 +243,7 @@
    "source": [
     "## Rolling regression\n",
     "\n",
-    "Next, we will build an improved model that will allow for changes in the regression coefficients over time. Specifically, we will assume that intercept and slope follow a random-walk through time. That idea is similar to the [stochastic volatility model](http://pymc-devs.github.io/pymc3/stochastic_volatility/).\n",
+    "Next, we will build an improved model that will allow for changes in the regression coefficients over time. Specifically, we will assume that intercept and slope follow a random-walk through time. That idea is similar to the [stochastic volatility model](stochastic_volatility.ipynb).\n",
     "\n",
     "$$ \\alpha_t \\sim \\mathcal{N}(\\alpha_{t-1}, \\sigma_\\alpha^2) $$\n",
     "$$ \\beta_t \\sim \\mathcal{N}(\\beta_{t-1}, \\sigma_\\beta^2) $$"
@@ -279,7 +281,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import theano.tensor as tt\n",
@@ -310,7 +314,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "with model_randomwalk:\n",
@@ -490,7 +496,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/LKJ.ipynb
+++ b/docs/source/notebooks/LKJ.ipynb
@@ -151,7 +151,7 @@
     "\n",
     "The LKJ distribution provides a prior on the correlation matrix, $\\mathbf{C} = \\textrm{Corr}(x_i, x_j)$, which, combined with priors on the standard deviations of each component, [induces](http://www3.stat.sinica.edu.tw/statistica/oldpdf/A10n416.pdf) a prior on the covariance matrix, $\\Sigma$.  Since inverting $\\Sigma$ is numerically unstable and inefficient, it is computationally advantageous to use the [Cholesky decompositon](https://en.wikipedia.org/wiki/Cholesky_decomposition) of $\\Sigma$, $\\Sigma = \\mathbf{L} \\mathbf{L}^{\\top}$, where $\\mathbf{L}$ is a lower-triangular matrix.  This decompositon allows computation of the term $(\\mathbf{x} - \\mu)^{\\top} \\Sigma^{-1} (\\mathbf{x} - \\mu)$ using back-substitution, which is more numerically stable and efficient than direct matrix inversion.\n",
     "\n",
-    "PyMC3 supports LKJ priors for the Cholesky decomposition of the covariance matrix via the [`LKJCholeskyCov`](http://pymc-devs.github.io/pymc3/api/distributions/multivariate.html#pymc3.distributions.multivariate.LKJCholeskyCov) distribution.  This distribution has parameters `n` and `sd_dist`, which are the dimension of the observations, $\\mathbf{x}$, and the PyMC3 distribution of the component standard deviations, repsectively.  It also has a hyperparamter `eta`, which controls the amount of correlation between components of $\\mathbf{x}$.  The LKJ distribution has the density $f(\\mathbf{C}\\ |\\ \\eta) \\propto |\\mathbf{C}|^{\\eta - 1}$, so $\\eta = 1$ leads to a uniform distribution on correlation matrices, while the magnitude of correlations between components decreases as $\\eta \\to \\infty$.\n",
+    "PyMC3 supports LKJ priors for the Cholesky decomposition of the covariance matrix via the [LKJCholeskyCov](../api/distributions/multivariate.rst) distribution.  This distribution has parameters `n` and `sd_dist`, which are the dimension of the observations, $\\mathbf{x}$, and the PyMC3 distribution of the component standard deviations, repsectively.  It also has a hyperparamter `eta`, which controls the amount of correlation between components of $\\mathbf{x}$.  The LKJ distribution has the density $f(\\mathbf{C}\\ |\\ \\eta) \\propto |\\mathbf{C}|^{\\eta - 1}$, so $\\eta = 1$ leads to a uniform distribution on correlation matrices, while the magnitude of correlations between components decreases as $\\eta \\to \\infty$.\n",
     "\n",
     "In this example, we model the standard deviations with $\\textrm{HalfCauchy}(2.5)$ priors, and the correlation matrix as $\\mathbf{C} \\sim \\textrm{LKJ}(\\eta = 2)$."
    ]
@@ -202,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use [`expand_packed_triangular`](http://pymc-devs.github.io/pymc3/api/math.html#pymc3.math.expand_packed_triangular) to transform this vector into the lower triangular matrix $\\mathbf{L}$, which appears in the Cholesky decomposition $\\Sigma = \\mathbf{L} \\mathbf{L}^{\\top}$."
+    "We use [expand_packed_triangular](../api/math.rst) to transform this vector into the lower triangular matrix $\\mathbf{L}$, which appears in the Cholesky decomposition $\\Sigma = \\mathbf{L} \\mathbf{L}^{\\top}$."
    ]
   },
   {
@@ -472,7 +472,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   },
   "latex_envs": {
    "bibliofile": "biblio.bib",

--- a/docs/source/notebooks/api_quickstart.ipynb
+++ b/docs/source/notebooks/api_quickstart.ipynb
@@ -329,11 +329,11 @@
    "source": [
     "In the PyMC3 module, the structure for probability distributions looks like this:\n",
     "\n",
-    "[pymc3.distributions](http://pymc-devs.github.io/pymc3/api/distributions.html)<br>\n",
-    " |- [continuous](http://pymc-devs.github.io/pymc3/api/distributions/continuous.html)<br>\n",
-    " |- [discrete](http://pymc-devs.github.io/pymc3/api/distributions/discrete.html)<br>\n",
-    " |- [timeseries](http://pymc-devs.github.io/pymc3/api/distributions/timeseries.html)<br>\n",
-    " |- [mixture](http://pymc-devs.github.io/pymc3/api/distributions/mixture.html)<br>"
+    "[pymc3.distributions](../api/distributions.rst)\n",
+    "- [continuous](../api/distributions/continuous.rst)\n",
+    "- [discrete](../api/distributions/discrete.rst)\n",
+    "- [timeseries](../api/distributions/timeseries.rst)\n",
+    "- [mixture](../api/distributions/mixture.rst)\n"
    ]
   },
   {
@@ -1168,7 +1168,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more information on sampler stats and the energy plot, see [here](http://pymc-devs.github.io/pymc3/notebooks/sampler-stats.html). For more information on identifying sampling problems and what to do about them, see [here](http://pymc-devs.github.io/pymc3/notebooks/Diagnosing_biased_Inference_with_Divergences.html)."
+    "For more information on sampler stats and the energy plot, see [here](sampler-stats.ipynb). For more information on identifying sampling problems and what to do about them, see [here](Diagnosing_biased_Inference_with_Divergences.ipynb)."
    ]
   },
   {
@@ -1596,7 +1596,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0b4"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/bayesian_neural_network_advi.ipynb
+++ b/docs/source/notebooks/bayesian_neural_network_advi.ipynb
@@ -17,10 +17,10 @@
    "source": [
     "## Current trends in Machine Learning\n",
     "\n",
-    "There are currently three big trends in machine learning: **Probabilistic Programming**, **Deep Learning** and \"**Big Data**\". Inside of PP, a lot of innovation is in making things scale using **Variational Inference**. In this blog post, I will show how to use **Variational Inference** in [PyMC3](http://pymc-devs.github.io/pymc3/) to fit a simple Bayesian Neural Network. I will also discuss how bridging Probabilistic Programming and Deep Learning can open up very interesting avenues to explore in future research.\n",
+    "There are currently three big trends in machine learning: **Probabilistic Programming**, **Deep Learning** and \"**Big Data**\". Inside of PP, a lot of innovation is in making things scale using **Variational Inference**. In this blog post, I will show how to use **Variational Inference** in PyMC3 to fit a simple Bayesian Neural Network. I will also discuss how bridging Probabilistic Programming and Deep Learning can open up very interesting avenues to explore in future research.\n",
     "\n",
     "### Probabilistic Programming at scale\n",
-    "**Probabilistic Programming** allows very flexible creation of custom probabilistic models and is mainly concerned with **insight** and learning from your data. The approach is inherently **Bayesian** so we can specify **priors** to inform and constrain our models and get uncertainty estimation in form of a **posterior** distribution. Using [MCMC sampling algorithms](http://twiecki.github.io/blog/2015/11/10/mcmc-sampling/) we can draw samples from this posterior to very flexibly estimate these models. [PyMC3](http://pymc-devs.github.io/pymc3/) and [Stan](http://mc-stan.org/) are the current state-of-the-art tools to consruct and estimate these models. One major drawback of sampling, however, is that it's often very slow, especially for high-dimensional models. That's why more recently, **variational inference** algorithms have been developed that are almost as flexible as MCMC but much faster. Instead of drawing samples from the posterior, these algorithms instead fit a distribution (e.g. normal) to the posterior turning a sampling problem into and optimization problem. [ADVI](http://arxiv.org/abs/1506.03431) -- Automatic Differentation Variational Inference -- is implemented in [PyMC3](http://pymc-devs.github.io/pymc3/) and [Stan](http://mc-stan.org/), as well as a new package called [Edward](https://github.com/blei-lab/edward/) which is mainly concerned with Variational Inference. \n",
+    "**Probabilistic Programming** allows very flexible creation of custom probabilistic models and is mainly concerned with **insight** and learning from your data. The approach is inherently **Bayesian** so we can specify **priors** to inform and constrain our models and get uncertainty estimation in form of a **posterior** distribution. Using [MCMC sampling algorithms](http://twiecki.github.io/blog/2015/11/10/mcmc-sampling/) we can draw samples from this posterior to very flexibly estimate these models. PyMC3 and [Stan](http://mc-stan.org/) are the current state-of-the-art tools to consruct and estimate these models. One major drawback of sampling, however, is that it's often very slow, especially for high-dimensional models. That's why more recently, **variational inference** algorithms have been developed that are almost as flexible as MCMC but much faster. Instead of drawing samples from the posterior, these algorithms instead fit a distribution (e.g. normal) to the posterior turning a sampling problem into and optimization problem. [ADVI](http://arxiv.org/abs/1506.03431) -- Automatic Differentation Variational Inference -- is implemented in PyMC3 and [Stan](http://mc-stan.org/), as well as a new package called [Edward](https://github.com/blei-lab/edward/) which is mainly concerned with Variational Inference. \n",
     "\n",
     "Unfortunately, when it comes to traditional ML problems like classification or (non-linear) regression, Probabilistic Programming often plays second fiddle (in terms of accuracy and scalability) to more algorithmic approaches like [ensemble learning](https://en.wikipedia.org/wiki/Ensemble_learning) (e.g. [random forests](https://en.wikipedia.org/wiki/Random_forest) or [gradient boosted regression trees](https://en.wikipedia.org/wiki/Boosting_(machine_learning)).\n",
     "\n",
@@ -139,7 +139,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def construct_nn(ann_input, ann_output):\n",
@@ -205,9 +207,9 @@
    "source": [
     "### Variational Inference: Scaling model complexity\n",
     "\n",
-    "We could now just run a MCMC sampler like [`NUTS`](http://pymc-devs.github.io/pymc3/api.html#nuts) which works pretty well in this case but as I already mentioned, this will become very slow as we scale our model up to deeper architectures with more layers.\n",
+    "We could now just run a MCMC sampler like [NUTS](../api/inference.rst) which works pretty well in this case, but as I already mentioned, this will become very slow as we scale our model up to deeper architectures with more layers.\n",
     "\n",
-    "Instead, we will use the brand-new [ADVI](http://pymc-devs.github.io/pymc3/api.html#advi) variational inference algorithm which was recently added to `PyMC3`, and updated to use the operator variational inference (OPVI) framework. This is much faster and will scale better. Note, that this is a mean-field approximation so we ignore correlations in the posterior."
+    "Instead, we will use the brand-new [ADVI](../api/inference.rst) variational inference algorithm which was recently added to `PyMC3`, and updated to use the operator variational inference (OPVI) framework. This is much faster and will scale better. Note, that this is a mean-field approximation so we ignore correlations in the posterior."
    ]
   },
   {
@@ -300,7 +302,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "trace = approx.sample(draws=5000)"
@@ -343,7 +347,7 @@
    "source": [
     "Now that we trained our model, lets predict on the hold-out set using a posterior predictive check (PPC). \n",
     "\n",
-    "1. We can use [`sample_ppc()`](http://pymc-devs.github.io/pymc3/api.html#pymc3.sampling.sample_ppc) to generate new data (in this case class predictions) from the posterior (sampled from the variational estimation).\n",
+    "1. We can use [`sample_ppc()`](../api/inference.rst) to generate new data (in this case class predictions) from the posterior (sampled from the variational estimation).\n",
     "2. It is better to get the node directly and build theano graph using our approximation (`approx.sample_node`) , we get a lot of speed up"
    ]
   },
@@ -712,7 +716,7 @@
    "source": [
     "## Summary\n",
     "\n",
-    "Hopefully this blog post demonstrated a very powerful new inference algorithm available in [PyMC3](http://pymc-devs.github.io/pymc3/): [ADVI](http://pymc-devs.github.io/pymc3/api.html#advi). I also think bridging the gap between Probabilistic Programming and Deep Learning can open up many new avenues for innovation in this space, as discussed above. Specifically, a hierarchical neural network sounds pretty bad-ass. These are really exciting times.\n",
+    "Hopefully this blog post demonstrated a very powerful new inference algorithm available in PyMC3: [ADVI](http://pymc-devs.github.io/pymc3/api.html#advi). I also think bridging the gap between Probabilistic Programming and Deep Learning can open up many new avenues for innovation in this space, as discussed above. Specifically, a hierarchical neural network sounds pretty bad-ass. These are really exciting times.\n",
     "\n",
     "## Next steps\n",
     "\n",
@@ -731,6 +735,15 @@
     "\n",
     "[Taku Yoshioka](https://github.com/taku-y) did a lot of work on ADVI in PyMC3, including the mini-batch implementation as well as the sampling from the variational posterior. I'd also like to the thank the Stan guys (specifically Alp Kucukelbir and Daniel Lee) for deriving ADVI and teaching us about it. Thanks also to Chris Fonnesbeck, Andrew Campbell, Taku Yoshioka, and Peadar Coyle for useful comments on an earlier draft."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -750,7 +763,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.1"
   },
   "latex_envs": {
    "bibliofile": "biblio.bib",

--- a/docs/source/notebooks/bayesian_neural_network_with_sgfs.ipynb
+++ b/docs/source/notebooks/bayesian_neural_network_with_sgfs.ipynb
@@ -139,7 +139,7 @@
    "source": [
     "## Model specification\n",
     "\n",
-    "A neural network is quite simple. The basic unit is a [perceptron](https://en.wikipedia.org/wiki/Perceptron) which is nothing more than [logistic regression](http://pymc-devs.github.io/pymc3/notebooks/posterior_predictive.html#Prediction). We use many of these in parallel and then stack them up to get hidden layers. Here we will use 2 hidden layers with 5 neurons each which is sufficient for such a simple problem."
+    "A neural network is quite simple. The basic unit is a [perceptron](https://en.wikipedia.org/wiki/Perceptron) which is nothing more than [logistic regression](posterior_predictive.ipynb#Prediction). We use many of these in parallel and then stack them up to get hidden layers. Here we will use 2 hidden layers with 5 neurons each which is sufficient for such a simple problem."
    ]
   },
   {
@@ -500,7 +500,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   },
   "latex_envs": {
    "bibliofile": "biblio.bib",

--- a/docs/source/notebooks/dependent_density_regression.ipynb
+++ b/docs/source/notebooks/dependent_density_regression.ipynb
@@ -7,7 +7,7 @@
     "# Dependent density regression\n",
     "Author: [Austin Rochford](https://github.com/AustinRochford/)\n",
     "\n",
-    "In another [example](http://pymc-devs.github.io/pymc3/notebooks/dp_mix.html), we showed how to use Dirichlet processes to perform Bayesian nonparametric density estimation.  This example expands on the previous one, illustrating dependent density regression.\n",
+    "In another [example](dp_mix.ipynb), we showed how to use Dirichlet processes to perform Bayesian nonparametric density estimation.  This example expands on the previous one, illustrating dependent density regression.\n",
     "\n",
     "Just as Dirichlet process mixtures can be thought of as infinite mixture models that select the number of active components as part of inference, dependent density regression can be thought of as infinite [mixtures of experts](https://en.wikipedia.org/wiki/Committee_machine) that select the active experts as part of inference.  Their flexibility and modularity make them powerful tools for performing nonparametric Bayesian Data analysis."
    ]
@@ -15,7 +15,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -25,7 +27,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from matplotlib import animation as ani, pyplot as plt\n",
@@ -39,7 +43,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "plt.rc('animation', writer='avconv')\n",
@@ -49,7 +55,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "SEED = 972915 # from random.org; for reproducibility\n",
@@ -231,7 +239,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig, (scatter_ax, hist_ax) = plt.subplots(ncols=2, figsize=(16, 6))\n",
@@ -952,7 +962,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def norm_cdf(z):\n",
@@ -968,6 +980,7 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -1014,7 +1027,9 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "with model:\n",
@@ -1033,7 +1048,9 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "with model:\n",

--- a/docs/source/notebooks/dp_mix.ipynb
+++ b/docs/source/notebooks/dp_mix.ipynb
@@ -55,7 +55,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline"
@@ -64,7 +66,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from __future__ import division"
@@ -73,7 +77,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from matplotlib import pyplot as plt\n",
@@ -88,7 +94,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "blue, *_ = sns.color_palette()"
@@ -97,7 +105,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "SEED = 5132290 # from random.org\n",
@@ -108,7 +118,9 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "N = 20\n",
@@ -128,7 +140,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "beta = sp.stats.beta.rvs(1, alpha, size=(N, K))\n",
@@ -263,7 +277,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "N = 5\n",
@@ -277,7 +293,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "beta = sp.stats.beta.rvs(1, alpha, size=(N, K))\n",
@@ -357,7 +375,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sampling from these stochastic processes is fun, but these ideas become truly useful when we fit them to data.  The discreteness of samples and the stick-breaking representation of the Dirichlet process lend themselves nicely to Markov chain Monte Carlo simulation of posterior distributions.  We will perform this sampling using [`pymc3`](https://pymc-devs.github.io/pymc3/).\n",
+    "Sampling from these stochastic processes is fun, but these ideas become truly useful when we fit them to data.  The discreteness of samples and the stick-breaking representation of the Dirichlet process lend themselves nicely to Markov chain Monte Carlo simulation of posterior distributions.  We will perform this sampling using `PyMC3`.\n",
     "\n",
     "Our first example uses a Dirichlet process mixture to estimate the density of waiting times between eruptions of the [Old Faithful](https://en.wikipedia.org/wiki/Old_Faithful) geyser in [Yellowstone National Park](https://en.wikipedia.org/wiki/Yellowstone_National_Park)."
    ]
@@ -365,7 +383,9 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "old_faithful_df = get_rdataset('faithful', cache=True).data[['waiting']]"
@@ -381,7 +401,9 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "old_faithful_df['std_waiting'] = (old_faithful_df.waiting - old_faithful_df.waiting.mean()) / old_faithful_df.waiting.std()"
@@ -530,7 +552,9 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "N = old_faithful_df.shape[0]\n",
@@ -541,7 +565,9 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def stick_breaking(beta):\n",
@@ -553,7 +579,9 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "with pm.Model() as model:\n",
@@ -679,7 +707,9 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "post_pdf_contribs = sp.stats.norm.pdf(np.atleast_3d(x_plot),\n",
@@ -784,7 +814,9 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "sunspot_df = get_rdataset('sunspot.year', cache=True).data"
@@ -895,7 +927,9 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "K = 50\n",
@@ -906,6 +940,7 @@
    "cell_type": "code",
    "execution_count": 30,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -1015,7 +1050,9 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "x_plot = np.arange(250)"
@@ -1024,7 +1061,9 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "post_pmf_contribs = sp.stats.poisson.pmf(np.atleast_3d(x_plot),\n",

--- a/docs/source/notebooks/empirical-approx-overview.ipynb
+++ b/docs/source/notebooks/empirical-approx-overview.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "For most models we use sampling MCMC algorithms like Metropolis or NUTS. In pymc3 we got used to store traces of MC samples and then do analysis using them. As new VI interface was implememted it needed a lot of approximation types. \n",
     "\n",
-    "One of them was so-called *Empirical*. This type of approximation stores particles for SVGD sampler. But there is no difference between independent SVGD particles and MCMC trace. So the idea was pretty simple to understand and realize: make *Empirical* be a bridge between MCMC sampling output and full-fledged VI utils like `apply_replacements` or `sample_node`. For the interface description, see [variational_api_quickstart](http://pymc-devs.github.io/pymc3/notebooks/variational_api_quickstart.html). Here I will just focus on Emprical and give an overview of specific things for *Empirical* approximation"
+    "One of them was so-called *Empirical*. This type of approximation stores particles for SVGD sampler. But there is no difference between independent SVGD particles and MCMC trace. So the idea was pretty simple to understand and realize: make *Empirical* be a bridge between MCMC sampling output and full-fledged VI utils like `apply_replacements` or `sample_node`. For the interface description, see [variational_api_quickstart](variational_api_quickstart.ipynb). Here I will just focus on Emprical and give an overview of specific things for *Empirical* approximation"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "metadata": {},
    "source": [
     "## Multimodal density\n",
-    "Let's recall the problem from [variational_api_quickstart](http://pymc-devs.github.io/pymc3/notebooks/variational_api_quickstart.html) where we first got a NUTS trace"
+    "Let's recall the problem from [variational_api_quickstart](variational_api_quickstart.ipynb) where we first got a NUTS trace"
    ]
   },
   {
@@ -537,7 +537,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0b4"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/marginalized_gaussian_mixture_model.ipynb
+++ b/docs/source/notebooks/marginalized_gaussian_mixture_model.ipynb
@@ -73,9 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "component = np.random.choice(MU.size, size=N, p=W)\n",
@@ -85,9 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -135,7 +131,7 @@
     "\\end{align*}\n",
     "$$\n",
     "\n",
-    "An implementation of this parameterization in PyMC3 is available [here](http://pymc-devs.github.io/pymc3/notebooks/gaussian_mixture_model.html).  A drawback of this parameterization is that is posterior relies on sampling the discrete latent variable $z$.  This reliance can cause slow mixing and ineffective exploration of the tails of the distribution.\n",
+    "An implementation of this parameterization in PyMC3 is available [here](gaussian_mixture_model.ipynb).  A drawback of this parameterization is that is posterior relies on sampling the discrete latent variable $z$.  This reliance can cause slow mixing and ineffective exploration of the tails of the distribution.\n",
     "\n",
     "An alternative, equivalent parameterization that addresses these problems is to marginalize over $z$.  The marginalized model is\n",
     "\n",
@@ -166,9 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with pm.Model() as model:\n",
@@ -183,9 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -214,9 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -244,9 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -281,9 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -309,7 +295,6 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [
@@ -363,9 +348,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/docs/source/notebooks/survival_analysis.ipynb
+++ b/docs/source/notebooks/survival_analysis.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Author: Austin Rochford\n",
     "\n",
-    "[Survival analysis](https://en.wikipedia.org/wiki/Survival_analysis) studies the distribution of the time to an event.  Its applications span many fields across medicine, biology, engineering, and social science.  This tutorial shows how to fit and analyze a Bayesian survival model in Python using [PyMC3](https://pymc-devs.github.io/pymc3).\n",
+    "[Survival analysis](https://en.wikipedia.org/wiki/Survival_analysis) studies the distribution of the time to an event.  Its applications span many fields across medicine, biology, engineering, and social science.  This tutorial shows how to fit and analyze a Bayesian survival model in Python using PyMC3.\n",
     "\n",
     "We illustrate these concepts by analyzing a [mastectomy data set](https://vincentarelbundock.github.io/Rdatasets/doc/HSAUR/mastectomy.html) from `R`'s [HSAUR](https://cran.r-project.org/web/packages/HSAUR/index.html) package."
    ]
@@ -16,7 +16,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline"
@@ -25,7 +27,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from matplotlib import pyplot as plt\n",
@@ -47,7 +51,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "df = datasets.get_rdataset('mastectomy', 'HSAUR', cache=True).data\n",
@@ -305,7 +311,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "interval_length = 3\n",
@@ -373,7 +381,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "last_period = np.floor((df.time - 0.01) / interval_length).astype(int)\n",
@@ -392,7 +402,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "exposure = np.greater_equal.outer(df.time, interval_bounds[:-1]) * interval_length\n",
@@ -411,7 +423,9 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "SEED = 5078864 # from random.org"
@@ -421,6 +435,7 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -447,7 +462,9 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "n_samples = 1000\n",
@@ -558,7 +575,9 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "base_hazard = trace['lambda0']\n",
@@ -568,7 +587,9 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def cum_hazard(hazard):\n",
@@ -581,7 +602,9 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def plot_with_hpd(x, hazard, f, ax, color=None, label=None, alpha=0.05):\n",
@@ -661,7 +684,9 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "with pm.Model() as time_varying_model:\n",
@@ -787,7 +812,9 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tv_base_hazard = time_varying_trace['lambda0']\n",


### PR DESCRIPTION
We had hardcoded in "pymc-devs.github.io/pymc3/" in a number of places in the docs.  I think this removes all of them, and when sphinx builds the docs, it will perhaps use relative links instead.  Will test this on my own fork, and remove WIP tag when it is ready.