### PR TITLE
Add gelman_rubin and effective_n to df_summary (#2532)

### DIFF
--- a/pymc3/diagnostics.py
+++ b/pymc3/diagnostics.py
@@ -3,6 +3,7 @@
 import numpy as np
 from .stats import statfunc
 from .util import get_default_varnames
+from .backends.base import MultiTrace
 
 __all__ = ['geweke', 'gelman_rubin', 'effective_n']
 
@@ -108,7 +109,7 @@ def gelman_rubin(mtrace, varnames=None, include_transformed=False):
 
     Parameters
     ----------
-    mtrace : MultiTrace
+    mtrace : MultiTrace or trace object
       A MultiTrace object containing parallel traces (minimum 2)
       of one or more stochastic parameters.
     varnames : list
@@ -119,7 +120,7 @@ def gelman_rubin(mtrace, varnames=None, include_transformed=False):
 
     Returns
     -------
-    Rhat : dict
+    Rhat : dict of floats (MultiTrace) or float (trace object)
       Returns dictionary of the potential scale reduction
       factors, :math:`\hat{R}`
 
@@ -141,19 +142,7 @@ def gelman_rubin(mtrace, varnames=None, include_transformed=False):
     Brooks and Gelman (1998)
     Gelman and Rubin (1992)"""
 
-    if mtrace.nchains < 2:
-        raise ValueError(
-            'Gelman-Rubin diagnostic requires multiple chains '
-            'of the same length.')
-
-    if varnames is None:
-        varnames = get_default_varnames(mtrace.varnames, include_transformed=include_transformed)
-
-    Rhat = {}
-    for var in varnames:
-        x = np.array(mtrace.get_values(var, combine=False))
-        num_samples = x.shape[1]
-
+    def rscore(x, num_samples):
         # Calculate between-chain variance
         B = num_samples * np.var(np.mean(x, axis=1), axis=0, ddof=1)
 
@@ -163,7 +152,26 @@ def gelman_rubin(mtrace, varnames=None, include_transformed=False):
         # Estimate of marginal posterior variance
         Vhat = W * (num_samples - 1) / num_samples + B / num_samples
 
-        Rhat[var] = np.sqrt(Vhat / W)
+        return np.sqrt(Vhat / W)
+
+    if not isinstance(mtrace, MultiTrace):
+        # Return rscore for passed arrays
+        return rscore(np.array(mtrace), mtrace.shape[1])
+
+    if mtrace.nchains < 2:
+        raise ValueError(
+            'Gelman-Rubin diagnostic requires multiple chains '
+            'of the same length.')
+
+    if varnames is None:
+        varnames = get_default_varnames(mtrace.varnames, include_transformed=include_transformed)
+
+    Rhat = {}
+
+    for var in varnames:
+        x = np.array(mtrace.get_values(var, combine=False))
+        num_samples = x.shape[1]
+        Rhat[var] = rscore(x, num_samples)
 
     return Rhat
 
@@ -173,7 +181,7 @@ def effective_n(mtrace, varnames=None, include_transformed=False):
 
     Parameters
     ----------
-    mtrace : MultiTrace
+    mtrace : MultiTrace or trace object
       A MultiTrace object containing parallel traces (minimum 2)
       of one or more stochastic parameters.
     varnames : list
@@ -184,7 +192,7 @@ def effective_n(mtrace, varnames=None, include_transformed=False):
 
     Returns
     -------
-    n_eff : float
+    n_eff : dictionary of floats (MultiTrace) or float (trace object)
         Return the effective sample size, :math:`\hat{n}_{eff}`
 
     Notes
@@ -201,17 +209,8 @@ def effective_n(mtrace, varnames=None, include_transformed=False):
     ----------
     Gelman et al. (2014)"""
 
-    if mtrace.nchains < 2:
-        raise ValueError(
-            'Calculation of effective sample size requires multiple chains '
-            'of the same length.')
-
-    if varnames is None:
-        varnames = get_default_varnames(mtrace.varnames, include_transformed=include_transformed)
-
     def get_vhat(x):
-        # number of chains is last dim (-1)
-        # chain samples are second to last dim (-2)
+        # Chain samples are second to last dim (-2)
         num_samples = x.shape[-2]
 
         # Calculate between-chain variance
@@ -220,19 +219,23 @@ def effective_n(mtrace, varnames=None, include_transformed=False):
         # Calculate within-chain variance
         W = np.mean(np.var(x, axis=-2, ddof=1), axis=-1)
 
-        # Estimate of marginal posterior variance
+        # Estimate marginal posterior variance
         Vhat = W * (num_samples - 1) / num_samples + B / num_samples
 
         return Vhat
 
     def get_neff(x, Vhat):
+        # Number of chains is last dim (-1)
         num_chains = x.shape[-1]
+
+        # Chain samples are second to last dim (-2)
         num_samples = x.shape[-2]
 
         negative_autocorr = False
-        t = 1
 
         rho = np.ones(num_samples)
+        t = 1
+
         # Iterate until the sum of consecutive estimates of autocorrelation is
         # negative
         while not negative_autocorr and (t < num_samples):
@@ -250,37 +253,50 @@ def effective_n(mtrace, varnames=None, include_transformed=False):
         return min(num_chains * num_samples,
                    int(num_chains * num_samples / (1. + 2 * rho[1:t-1].sum())))
 
-    n_eff = {}
-    for var in varnames:
-        x = np.array(mtrace.get_values(var, combine=False))
+    def generate_neff(trace_values):
+        x = np.array(trace_values)
+        shape = x.shape
 
-        # make sure to handle scalars correctly - add extra dim if needed
-        if len(x.shape) == 2:
-            is_scalar = True
-            x = np.atleast_3d(mtrace.get_values(var, combine=False))
-        else:
-            is_scalar = False
+        # Make sure to handle scalars correctly, adding extra dimensions if
+        # needed. We could use np.squeeze here, but we don't want to squeeze
+        # out dummy dimensions that a user inputs.
+        if len(shape) == 2:
+            x = np.atleast_3d(trace_values)
 
-        # now we are going to transpose all dims - makes the loop below
+        # Transpose all dimensions, which makes the loop below
         # easier by moving the axes of the variable to the front instead
-        # of the chain and sample axes
+        # of the chain and sample axes.
         x = x.transpose()
 
         Vhat = get_vhat(x)
 
-        # get an array the same shape as the var
+        # Get an array the same shape as the var
         _n_eff = np.zeros(x.shape[:-2])
 
-        # iterate over tuples of indices of the shape of var
+        # Iterate over tuples of indices of the shape of var
         for tup in np.ndindex(*list(x.shape[:-2])):
             _n_eff[tup] = get_neff(x[tup], Vhat[tup])
 
-        # we could be using np.squeeze here, but we don't want to squeeze
-        # out dummy dimensions that a user inputs
-        if is_scalar:
-            n_eff[var] = _n_eff[0]
-        else:
-            # make sure to transpose the dims back
-            n_eff[var] = np.transpose(_n_eff)
+        if len(shape) == 2:
+            return _n_eff[0]
+
+        return np.transpose(_n_eff)
+
+    if not isinstance(mtrace, MultiTrace):
+        # Return neff for non-multitrace array
+        return generate_neff(mtrace)
+
+    if mtrace.nchains < 2:
+        raise ValueError(
+            'Calculation of effective sample size requires multiple chains '
+            'of the same length.')
+
+    if varnames is None:
+        varnames = get_default_varnames(mtrace.varnames,include_transformed=include_transformed)
+
+    n_eff = {}
+
+    for var in varnames:
+        n_eff[var] = generate_neff(mtrace.get_values(var, combine=False))
 
     return n_eff

--- a/pymc3/tests/test_stats.py
+++ b/pymc3/tests/test_stats.py
@@ -422,13 +422,15 @@ class TestDfSummary(bf.ModelBackendSampledTestCase):
     def test_column_names(self):
         ds = summary(self.mtrace, batches=3)
         npt.assert_equal(np.array(['mean', 'sd', 'mc_error',
-                                   'hpd_2.5', 'hpd_97.5']),
+                                   'hpd_2.5', 'hpd_97.5',
+                                   'n_eff', 'Rhat']),
                          ds.columns)
 
     def test_column_names_decimal_hpd(self):
         ds = summary(self.mtrace, batches=3, alpha=0.001)
         npt.assert_equal(np.array(['mean', 'sd', 'mc_error',
-                                   'hpd_0.05', 'hpd_99.95']),
+                                   'hpd_0.05', 'hpd_99.95',
+                                   'n_eff', 'Rhat']),
                          ds.columns)
 
     def test_column_names_custom_function(self):
@@ -445,7 +447,8 @@ class TestDfSummary(bf.ModelBackendSampledTestCase):
         ds = summary(self.mtrace, batches=3,
                         stat_funcs=[customf], extend=True)
         npt.assert_equal(np.array(['mean', 'sd', 'mc_error',
-                                   'hpd_2.5', 'hpd_97.5', 'my_mean']),
+                                   'hpd_2.5', 'hpd_97.5',
+                                   'n_eff', 'Rhat', 'my_mean']),
                          ds.columns)
 
     def test_value_alignment(self):


### PR DESCRIPTION
Hi there,

I'm submitting this [WIP] PR to ensure what I'm building is consistent with the spirit of `stats.py` and `diagnostics.py`. 

The approach I'm taking to add`effective_n` and `gelman_rubin` to `df_summary` in `stats.py` is to add them to the list of `funcs` that are iterated over by `df_summary`. However, this will require functions that take specific var values, as opposed to accepting a trace, as is the case in the `diagnostics.py` implementation. 

My question is whether it makes more sense to have these new "atomic" functions (the ones that process var values directly) in `stats.py` where they can then be used by `df_summary` and then imported by `diagonistics.py` to be rolled up into a wrapper function that iterates over `varnames`, or whether the functions in `diagnostics.py` should be split out into an atomic portion (that can be imported into `stats.py`) and a wrapper that takes traces. My hunch is to have the atomic functions in `stats.py`, yet would love feedback. 

Also, two quick questions that I imagine will be obvious to others: 

1. When I get `RuntimeWarning: Degrees of freedom <= 0 for slice`, does that relate to the shape of the test input generated by ndarray.py? 

2. Since in `effective_n` in diagnostics.py it appears `get_vhat(x)` returns a scaler (`Vhat = get_vhat(x)`), how can it be indexed (i.e. ` _n_eff[tup] = get_neff(x[tup], Vhat[tup])`)?. I'm including `get_vhat(x)` and a portion of `effective_n` from diagnostics.py for context:

```
def get_vhat(x):
    # number of chains is last dim (-1)
    # chain samples are second to last dim (-2)
    num_samples = x.shape[-2]

    # Calculate between-chain variance
    B = num_samples * np.var(np.mean(x, axis=-2), axis=-1, ddof=1)

    # Calculate within-chain variance
    W = np.mean(np.var(x, axis=-2, ddof=1), axis=-1)

    # Estimate of marginal posterior variance
    Vhat = W * (num_samples - 1) / num_samples + B / num_samples

    return Vhat
```
```
for var in varnames:
    x = np.array(mtrace.get_values(var, combine=False))

    # make sure to handle scalars correctly - add extra dim if needed
    if len(x.shape) == 2:
        is_scalar = True
        x = np.atleast_3d(mtrace.get_values(var, combine=False))
    else:
        is_scalar = False

    # now we are going to transpose all dims - makes the loop below
    # easier by moving the axes of the variable to the front instead
    # of the chain and sample axes
    x = x.transpose()

    Vhat = get_vhat(x)

    # get an array the same shape as the var
    _n_eff = np.zeros(x.shape[:-2])

    # iterate over tuples of indices of the shape of var
    for tup in np.ndindex(*list(x.shape[:-2])):
        _n_eff[tup] = get_neff(x[tup], Vhat[tup])
``` 