### PR TITLE
kdeplot: alow separated kwarg for line and shade

### DIFF
--- a/pymc3/plots/energyplot.py
+++ b/pymc3/plots/energyplot.py
@@ -1,13 +1,12 @@
 import matplotlib.pyplot as plt
 import numpy as np
-
 from .kdeplot import kdeplot
 
 
 def energyplot(trace, kind='kde', figsize=None, ax=None, legend=True, lw=0,
-               alpha=0.35, frame=True, **kwargs):
-    """Plot energy transition distribution and marginal energy distribution in order
-    to diagnose poor exploration by HMC algorithms.
+               shade=0.35, frame=True, kwargs_shade={}, **kwargs):
+    """Plot energy transition distribution and marginal energy distribution in
+    order to diagnose poor exploration by HMC algorithms.
 
     Parameters
     ----------
@@ -23,11 +22,13 @@ def energyplot(trace, kind='kde', figsize=None, ax=None, legend=True, lw=0,
         Flag for plotting legend (defaults to True)
     lw : int
         Line width
-    alpha : float
-        Alpha value for plot line. Defaults to 0.35.
+    shade : float
+        Alpha blending value for the shaded area under the curve, between 0
+        (no shade) and 1 (opaque). Defaults to 0.35
     frame : bool
         Flag for plotting frame around figure.
-
+    kwargs_shade : dicts, optional
+        Additional keywords passed to `fill_between` (to control the shade)
     Returns
     -------
 
@@ -50,8 +51,8 @@ def energyplot(trace, kind='kde', figsize=None, ax=None, legend=True, lw=0,
 
     if kind == 'kde':
         for label, value in series:
-            kdeplot(value, label=label, alpha=alpha, shade=True, ax=ax,
-                    **kwargs)
+            kdeplot(value, label=label, shade=shade, ax=ax,
+                    kwargs_shade=kwargs_shade, **kwargs)
 
     elif kind == 'hist':
         for label, value in series:

--- a/pymc3/plots/energyplot.py
+++ b/pymc3/plots/energyplot.py
@@ -3,7 +3,7 @@ import numpy as np
 from .kdeplot import kdeplot
 
 
-def energyplot(trace, kind='kde', figsize=None, ax=None, legend=True, lw=0,
+def energyplot(trace, kind='kde', figsize=None, ax=None, legend=True,
                shade=0.35, frame=True, kwargs_shade={}, **kwargs):
     """Plot energy transition distribution and marginal energy distribution in
     order to diagnose poor exploration by HMC algorithms.
@@ -20,8 +20,6 @@ def energyplot(trace, kind='kde', figsize=None, ax=None, legend=True, lw=0,
         Matplotlib axes.
     legend : bool
         Flag for plotting legend (defaults to True)
-    lw : int
-        Line width
     shade : float
         Alpha blending value for the shaded area under the curve, between 0
         (no shade) and 1 (opaque). Defaults to 0.35
@@ -56,7 +54,7 @@ def energyplot(trace, kind='kde', figsize=None, ax=None, legend=True, lw=0,
 
     elif kind == 'hist':
         for label, value in series:
-            ax.hist(value, lw=lw, alpha=alpha, label=label, **kwargs)
+            ax.hist(value, alpha=shade, label=label, **kwargs)
 
     else:
         raise ValueError('Plot type {} not recognized.'.format(kind))

--- a/pymc3/plots/kdeplot.py
+++ b/pymc3/plots/kdeplot.py
@@ -3,15 +3,34 @@ import numpy as np
 from scipy.signal import gaussian, convolve
 
 
-def kdeplot(trace_values, label=None, alpha=0.35, shade=False, ax=None,
-            **kwargs):
+def kdeplot(values, label=None, shade=0, ax=None, kwargs_shade={}, **kwargs):
+    """
+    1D KDE plot taking into account boundary conditions
+
+    Parameters
+    ----------
+    values : array-like
+        Values to plot
+    label : string
+        Text to include as part of the legend
+    shade : float
+        Alpha blending value for the shaded area under the curve, between 0
+        (no shade) and 1 (opaque). Defaults to 0
+    ax : matplotlib axes
+    kwargs_shade : dicts, optional
+        Additional keywords passed to `fill_between` (to control the shade)
+    Returns
+    ----------
+    ax : matplotlib axes
+
+    """
     if ax is None:
         _, ax = plt.subplots()
-    density, l, u = fast_kde(trace_values)
+    density, l, u = fast_kde(values)
     x = np.linspace(l, u, len(density))
     ax.plot(x, density, label=label, **kwargs)
     if shade:
-        ax.fill_between(x, density, alpha=alpha, **kwargs)
+        ax.fill_between(x, density, alpha=shade, **kwargs_shade)
     return ax
 
 
@@ -34,6 +53,7 @@ def fast_kde(x):
     xmax: maximum value of x
 
     """
+    x = np.array(x, dtype=float)
     x = x[~np.isnan(x)]
     x = x[~np.isinf(x)]
     n = len(x)

--- a/pymc3/plots/kdeplot.py
+++ b/pymc3/plots/kdeplot.py
@@ -18,7 +18,8 @@ def kdeplot(values, label=None, shade=0, ax=None, kwargs_shade={}, **kwargs):
         (no shade) and 1 (opaque). Defaults to 0
     ax : matplotlib axes
     kwargs_shade : dicts, optional
-        Additional keywords passed to `fill_between` (to control the shade)
+        Additional keywords passed to `matplotlib.axes.Axes.fill_between`
+        (to control the shade)
     Returns
     ----------
     ax : matplotlib axes

--- a/pymc3/tests/test_plots.py
+++ b/pymc3/tests/test_plots.py
@@ -6,7 +6,7 @@ import pymc3 as pm
 from .checks import close_to
 
 from .models import multidimensional_model, simple_categorical
-from ..plots import traceplot, forestplot, autocorrplot, plot_posterior
+from ..plots import traceplot, forestplot, autocorrplot, plot_posterior, energyplot
 from ..plots.utils import make_2d
 from ..step_methods import Slice, Metropolis
 from ..sampling import sample
@@ -29,6 +29,14 @@ def test_plots():
         forestplot(trace)
         plot_posterior(trace)
         autocorrplot(trace)
+        energyplot(trace)
+
+
+def test_energyplot():
+    with asmod.build_model() as model:
+        trace = sample()
+
+        energyplot(trace)
 
 
 def test_plots_categorical():

--- a/pymc3/tests/test_plots.py
+++ b/pymc3/tests/test_plots.py
@@ -25,18 +25,20 @@ def test_plots():
         step = Metropolis(model.vars, h)
         trace = sample(3000, tune=0, step=step, start=start)
 
-        traceplot(trace)
-        forestplot(trace)
-        plot_posterior(trace)
-        autocorrplot(trace)
-        energyplot(trace)
+    traceplot(trace)
+    forestplot(trace)
+    plot_posterior(trace)
+    autocorrplot(trace)
+    energyplot(trace)
 
 
 def test_energyplot():
     with asmod.build_model() as model:
         trace = sample()
 
-        energyplot(trace)
+    energyplot(trace)
+    energyplot(trace, shade=0.5, alpha=0)
+    energyplot(trace, kind='hist')
 
 
 def test_plots_categorical():


### PR DESCRIPTION
* replace `alpha` argument by `shade` and set default to 0 to avoid having two arguments to control the shade, `shade = 0` evaluates to `False`
* add kwargs_shade argument to avoid "argument clash", for example we can now use `alpha` for the line and `shade` for the area below the curve.
* add docstring to `kdeplot`
* allow `fast_kde``(and hence `kdeplot`) to accept a array-like objects
* add energyplot to the tests
