### PR TITLE
inclusiver upper bound on DiscreteUniform fixes #2592

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -447,7 +447,8 @@ class DiscreteUniform(Discrete):
     def _random(self, lower, upper, size=None):
         # This way seems to be the only to deal with lower and upper
         # as array-like.
-        samples = stats.uniform.rvs(lower, upper - lower - np.finfo(float).eps,
+        samples = stats.uniform.rvs(lower,
+                                    upper + 1 - lower - np.finfo(float).eps,
                                     size=size)
         return np.floor(samples).astype('int32')
 

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -447,10 +447,8 @@ class DiscreteUniform(Discrete):
     def _random(self, lower, upper, size=None):
         # This way seems to be the only to deal with lower and upper
         # as array-like.
-        samples = stats.uniform.rvs(lower,
-                                    upper + 1 - lower - np.finfo(float).eps,
-                                    size=size)
-        return np.floor(samples).astype('int32')
+        samples = stats.randint.rvs(lower, upper + 1, size=size)
+        return samples
 
     def random(self, point=None, size=None, repeat=None):
         lower, upper = draw_values([self.lower, self.upper], point=point)

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -506,7 +506,7 @@ class TestScalarParameterSamples(SeededTest):
 
     def test_discrete_uniform(self):
         def ref_rand(size, lower, upper):
-            return st.randint.rvs(lower, upper, size=size)
+            return st.randint.rvs(lower, upper + 1, size=size)
         pymc3_random_discrete(pm.DiscreteUniform, {'lower': -NatSmall, 'upper': NatSmall},
                               ref_rand=ref_rand)
 


### PR DESCRIPTION
draw random samples with inclusive upper bound (just like the theano sampling does)
see #2592 for details