### PR TITLE
Use multiple chains by default

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -6,7 +6,7 @@ import numpy as np
 import theano.gradient as tg
 
 import pymc3 as pm
-from .backends.base import merge_traces, BaseTrace, MultiTrace
+from .backends.base import BaseTrace, MultiTrace
 from .backends.ndarray import NDArray
 from .model import modelcontext, Point
 from .step_methods import (NUTS, HamiltonianMC, SGFS, Metropolis, BinaryMetropolis,
@@ -328,25 +328,27 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None,
     if model.ndim == 0:
         raise ValueError('The model does not contain any free variables.')
 
-
     if step is None and init is not None and pm.model.all_continuous(model.vars):
         try:
             # By default, try to use NUTS
             pm._log.info('Auto-assigning NUTS sampler...')
             args = step_kwargs if step_kwargs is not None else {}
             args = args.get('nuts', {})
-            start_, step = init_nuts(init=init, njobs=njobs, n_init=n_init,
+            start_, step = init_nuts(init=init, chains=chains, n_init=n_init,
                                      model=model, random_seed=random_seed,
                                      progressbar=progressbar, **args)
             if start is None:
                 start = start_
         except (AttributeError, NotImplementedError, tg.NullTypeGradError):
             # gradient computation failed
-            pm._log.info("Initializing NUTS failed. "\
+            pm._log.info("Initializing NUTS failed. "
                          "Falling back to elementwise auto-assignment.")
             step = assign_step_methods(model, step, step_kwargs=step_kwargs)
     else:
         step = assign_step_methods(model, step, step_kwargs=step_kwargs)
+
+    if start is None:
+        start = [None] * chains
 
     sample_args = {
         'draws': draws,
@@ -587,7 +589,7 @@ def _mp_sample(**kwargs):
     jobs = (delayed(_sample)(*args, **kwargs)
             for args in zip(chain_nums, pbars, rseed, start))
     traces = Parallel(n_jobs=njobs)(jobs)
-    return merge_traces(traces)
+    return MultiTrace(traces)
 
 
 def stop_tuning(step):
@@ -770,8 +772,8 @@ def sample_ppc_w(traces, samples=None, models=None, size=None, weights=None,
     return {k: np.asarray(v) for k, v in ppc.items()}
 
 
-def init_nuts(init='auto', njobs=1, n_init=500000, model=None,
-              random_seed=-1, progressbar=True, **kwargs):
+def init_nuts(init='auto', chains=1, n_init=500000, model=None,
+              random_seed=None, progressbar=True, **kwargs):
     """Set up the mass matrix initialization for NUTS.
 
     NUTS convergence and sampling speed is extremely dependent on the
@@ -805,8 +807,8 @@ def init_nuts(init='auto', njobs=1, n_init=500000, model=None,
         * map : Use the MAP as starting point. This is discouraged.
         * nuts : Run NUTS and estimate posterior mean and mass matrix from
           the trace.
-    njobs : int
-        Number of parallel jobs to start.
+    chains : int
+        Number of jobs to start.
     n_init : int
         Number of iterations of initializer
         If 'ADVI', number of iterations, if 'nuts', number of draws.
@@ -843,7 +845,9 @@ def init_nuts(init='auto', njobs=1, n_init=500000, model=None,
 
     pm._log.info('Initializing NUTS using {}...'.format(init))
 
-    random_seed = int(np.atleast_1d(random_seed)[0])
+    if random_seed is not None:
+        random_seed = int(np.atleast_1d(random_seed)[0])
+        np.random.seed(random_seed)
 
     cb = [
         pm.callbacks.CheckParametersConvergence(
@@ -853,14 +857,14 @@ def init_nuts(init='auto', njobs=1, n_init=500000, model=None,
     ]
 
     if init == 'adapt_diag':
-        start = [model.test_point] * njobs
+        start = [model.test_point] * chains
         mean = np.mean([model.dict_to_array(vals) for vals in start], axis=0)
         var = np.ones_like(mean)
         potential = quadpotential.QuadPotentialDiagAdapt(
             model.ndim, mean, var, 10)
     elif init == 'jitter+adapt_diag':
         start = []
-        for _ in range(njobs):
+        for _ in range(chains):
             mean = {var: val.copy() for var, val in model.test_point.items()}
             for val in mean.values():
                 val[...] += 2 * np.random.rand(*val.shape) - 1
@@ -877,7 +881,7 @@ def init_nuts(init='auto', njobs=1, n_init=500000, model=None,
             progressbar=progressbar,
             obj_optimizer=pm.adagrad_window,
         )  # type: pm.MeanField
-        start = approx.sample(draws=njobs)
+        start = approx.sample(draws=chains)
         start = list(start)
         stds = approx.bij.rmap(approx.std.eval())
         cov = model.dict_to_array(stds) ** 2
@@ -894,7 +898,7 @@ def init_nuts(init='auto', njobs=1, n_init=500000, model=None,
             progressbar=progressbar,
             obj_optimizer=pm.adagrad_window,
         )  # type: pm.MeanField
-        start = approx.sample(draws=njobs)
+        start = approx.sample(draws=chains)
         start = list(start)
         stds = approx.bij.rmap(approx.std.eval())
         cov = model.dict_to_array(stds) ** 2
@@ -911,7 +915,7 @@ def init_nuts(init='auto', njobs=1, n_init=500000, model=None,
             progressbar=progressbar,
             obj_optimizer=pm.adagrad_window
         )  # type: pm.MeanField
-        start = approx.sample(draws=njobs)
+        start = approx.sample(draws=chains)
         start = list(start)
         stds = approx.bij.rmap(approx.std.eval())
         cov = model.dict_to_array(stds) ** 2
@@ -926,7 +930,7 @@ def init_nuts(init='auto', njobs=1, n_init=500000, model=None,
             progressbar=progressbar,
             obj_optimizer=pm.adagrad_window
         )
-        start = approx.sample(draws=njobs)
+        start = approx.sample(draws=chains)
         start = list(start)
         stds = approx.bij.rmap(approx.std.eval())
         cov = model.dict_to_array(stds) ** 2
@@ -934,14 +938,14 @@ def init_nuts(init='auto', njobs=1, n_init=500000, model=None,
     elif init == 'map':
         start = pm.find_MAP(include_transformed=True)
         cov = pm.find_hessian(point=start)
-        start = [start] * njobs
+        start = [start] * chains
         potential = quadpotential.QuadPotentialFull(cov)
     elif init == 'nuts':
         init_trace = pm.sample(draws=n_init, step=pm.NUTS(),
                                tune=n_init // 2,
                                random_seed=random_seed)
         cov = np.atleast_1d(pm.trace_cov(init_trace))
-        start = list(np.random.choice(init_trace, njobs))
+        start = list(np.random.choice(init_trace, chains))
         potential = quadpotential.QuadPotentialFull(cov)
     else:
         raise NotImplementedError('Initializer {} is not supported.'.format(init))

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -300,7 +300,7 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None,
     model = modelcontext(model)
 
     if njobs is None:
-        njobs = _cpu_count()
+        njobs = min(4, _cpu_count())
     if chains is None:
         chains = max(2, njobs)
     if isinstance(start, dict):

--- a/pymc3/tests/test_distributions_timeseries.py
+++ b/pymc3/tests/test_distributions_timeseries.py
@@ -64,7 +64,7 @@ def test_linear():
         Normal('zh', mu=xh, sd=sig2, observed=z)
     # invert
     with model:
-        trace = sample(init='advi+adapt_diag')
+        trace = sample(init='advi+adapt_diag', chains=1)
 
     ppc = sample_ppc(trace, model=model)
     # test

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -166,7 +166,7 @@ class TestDisasterModel(SeededTest):
             start = {'early_mean': 2., 'late_mean': 3.}
             # Use slice sampler for means (other varibles auto-selected)
             step = pm.Slice([model.early_mean_log__, model.late_mean_log__])
-            tr = pm.sample(500, tune=50, start=start, step=step)
+            tr = pm.sample(500, tune=50, start=start, step=step, chains=1)
             pm.summary(tr)
 
     def test_disaster_model_missing(self):
@@ -176,7 +176,7 @@ class TestDisasterModel(SeededTest):
             start = {'early_mean': 2., 'late_mean': 3.}
             # Use slice sampler for means (other varibles auto-selected)
             step = pm.Slice([model.early_mean_log__, model.late_mean_log__])
-            tr = pm.sample(500, tune=50, start=start, step=step)
+            tr = pm.sample(500, tune=50, start=start, step=step, chains=1)
             pm.summary(tr)
 
 
@@ -256,10 +256,14 @@ class TestLatentOccupancy(SeededTest):
     def test_run(self):
         model = self.build_model()
         with model:
-            start = {'psi': 0.5, 'z': (self.y > 0).astype('int16'), 'theta': 5}
+            start = {
+                'psi': np.array(0.5, dtype='f'),
+                'z': (self.y > 0).astype('int16'),
+                'theta': np.array(5, dtype='f'),
+            }
             step_one = pm.Metropolis([model.theta_interval__, model.psi_logodds__])
             step_two = pm.BinaryMetropolis([model.z])
-            pm.sample(50, step=[step_one, step_two], start=start)
+            pm.sample(50, step=[step_one, step_two], start=start, chains=1)
 
 
 @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32 due to starting inf at starting logP")

--- a/pymc3/tests/test_hmc.py
+++ b/pymc3/tests/test_hmc.py
@@ -34,7 +34,7 @@ def test_nuts_tuning():
     with model:
         pymc3.Normal("mu", mu=0, sd=1)
         step = pymc3.NUTS()
-        trace = pymc3.sample(10, step=step, tune=5, progressbar=False)
+        trace = pymc3.sample(10, step=step, tune=5, progressbar=False, chains=1)
 
     assert not step.tune
     assert np.all(trace['step_size'][5:] == trace['step_size'][5])

--- a/pymc3/tests/test_mixture.py
+++ b/pymc3/tests/test_mixture.py
@@ -44,7 +44,8 @@ class TestMixture(SeededTest):
                     [Normal.dist(mu[0], tau=tau[0]), Normal.dist(mu[1], tau=tau[1])],
                     observed=self.norm_x)
             step = Metropolis()
-            trace = sample(5000, step, random_seed=self.random_seed, progressbar=False)
+            trace = sample(5000, step, random_seed=self.random_seed,
+                           progressbar=False, chains=1)
 
         assert_allclose(np.sort(trace['w'].mean(axis=0)),
                         np.sort(self.norm_w),
@@ -60,7 +61,8 @@ class TestMixture(SeededTest):
             tau = Gamma('tau', 1., 1., shape=self.norm_w.size)
             NormalMixture('x_obs', w, mu, tau=tau, observed=self.norm_x)
             step = Metropolis()
-            trace = sample(5000, step, random_seed=self.random_seed, progressbar=False)
+            trace = sample(5000, step, random_seed=self.random_seed,
+                           progressbar=False, chains=1)
 
         assert_allclose(np.sort(trace['w'].mean(axis=0)),
                         np.sort(self.norm_w),
@@ -75,7 +77,8 @@ class TestMixture(SeededTest):
             mu = Gamma('mu', 1., 1., shape=self.pois_w.size)
             Mixture('x_obs', w, Poisson.dist(mu), observed=self.pois_x)
             step = Metropolis()
-            trace = sample(5000, step, random_seed=self.random_seed, progressbar=False)
+            trace = sample(5000, step, random_seed=self.random_seed,
+                           progressbar=False, chains=1)
 
         assert_allclose(np.sort(trace['w'].mean(axis=0)),
                         np.sort(self.pois_w),
@@ -92,7 +95,8 @@ class TestMixture(SeededTest):
                     [Poisson.dist(mu[0]), Poisson.dist(mu[1])],
                     observed=self.pois_x)
             step = Metropolis()
-            trace = sample(5000, step, random_seed=self.random_seed, progressbar=False)
+            trace = sample(5000, step, random_seed=self.random_seed,
+                           progressbar=False, chains=1)
 
         assert_allclose(np.sort(trace['w'].mean(axis=0)),
                         np.sort(self.pois_w),

--- a/pymc3/tests/test_plots.py
+++ b/pymc3/tests/test_plots.py
@@ -23,7 +23,7 @@ def test_plots():
         start = model.test_point
         h = find_hessian(start)
         step = Metropolis(model.vars, h)
-        trace = sample(3000, tune=0, step=step, start=start)
+        trace = sample(3000, tune=0, step=step, start=start, njobs=1)
 
     traceplot(trace)
     forestplot(trace)
@@ -34,7 +34,7 @@ def test_plots():
 
 def test_energyplot():
     with asmod.build_model():
-        trace = sample()
+        trace = sample(njobs=1)
 
     energyplot(trace)
     energyplot(trace, shade=0.5, alpha=0)
@@ -48,7 +48,7 @@ def test_plots_categorical():
         start = model.test_point
         h = find_hessian(start)
         step = Metropolis(model.vars, h)
-        trace = sample(3000, tune=0, step=step, start=start)
+        trace = sample(3000, tune=0, step=step, start=start, njobs=1)
 
         traceplot(trace)
 
@@ -93,14 +93,26 @@ def test_make_2d():
 
 
 def test_plots_transformed():
-    with pm.Model() as model:
+    with pm.Model():
         pm.Uniform('x', 0, 1)
         step = pm.Metropolis()
-        trace = pm.sample(100, tune=0, step=step)
+        trace = pm.sample(100, tune=0, step=step, chains=1)
 
     assert traceplot(trace).shape == (1, 2)
     assert traceplot(trace, plot_transformed=True).shape == (2, 2)
     assert autocorrplot(trace).shape == (1, 1)
     assert autocorrplot(trace, plot_transformed=True).shape == (2, 1)
+    assert plot_posterior(trace).numCols == 1
+    assert plot_posterior(trace, plot_transformed=True).shape == (2, )
+
+    with pm.Model():
+        pm.Uniform('x', 0, 1)
+        step = pm.Metropolis()
+        trace = pm.sample(100, tune=0, step=step, chains=2)
+
+    assert traceplot(trace).shape == (1, 2)
+    assert traceplot(trace, plot_transformed=True).shape == (2, 2)
+    assert autocorrplot(trace).shape == (1, 2)
+    assert autocorrplot(trace, plot_transformed=True).shape == (2, 2)
     assert plot_posterior(trace).numCols == 1
     assert plot_posterior(trace, plot_transformed=True).shape == (2, )

--- a/pymc3/tests/test_quadpotential.py
+++ b/pymc3/tests/test_quadpotential.py
@@ -135,5 +135,5 @@ def test_user_potential():
     pot = Potential(floatX([1]))
     with model:
         step = pymc3.NUTS(potential=pot)
-        pymc3.sample(10, init=None, step=step)
+        pymc3.sample(10, init=None, step=step, chains=1)
     assert called

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -28,7 +28,7 @@ class TestSample(SeededTest):
         for _ in range(2):
             np.random.seed(1)
             with self.model:
-                pm.sample(1, tune=0)
+                pm.sample(1, tune=0, chains=1)
                 random_numbers.append(np.random.random())
         assert random_numbers[0] == random_numbers[1]
 
@@ -125,7 +125,8 @@ class TestSample(SeededTest):
     @pytest.mark.parametrize(
         'start', [
             {'x': np.array([1, 1])},
-            [{'x': [10, 10]}, {'x': [-10, -10]}]
+            {'x': [10, 10]},
+            {'x': [-10, -10]},
         ]
     )
     def test_sample_start_good_shape(self, start):
@@ -262,8 +263,12 @@ def test_exec_nuts_init(method):
         pm.HalfNormal('b', sd=1)
     with model:
         start, _ = pm.init_nuts(init=method, n_init=10)
-        assert isinstance(start, dict)
-        start, _ = pm.init_nuts(init=method, n_init=10, njobs=2)
+        assert isinstance(start, list)
+        assert len(start) == 1
+        assert isinstance(start[0], dict)
+        assert 'a' in start[0] and 'b_log__' in start[0]
+        start, _ = pm.init_nuts(init=method, n_init=10, chains=2)
         assert isinstance(start, list)
         assert len(start) == 2
         assert isinstance(start[0], dict)
+        assert 'a' in start[0] and 'b_log__' in start[0]

--- a/pymc3/tests/test_stats.py
+++ b/pymc3/tests/test_stats.py
@@ -17,7 +17,7 @@ from scipy import stats as st
 def test_log_post_trace():
     with pm.Model() as model:
         pm.Normal('y')
-        trace = pm.sample(10, tune=10)
+        trace = pm.sample(10, tune=10, chains=1)
 
     logp = pmstats._log_post_trace(trace, model)
     assert logp.shape == (len(trace), 0)
@@ -25,7 +25,7 @@ def test_log_post_trace():
     with pm.Model() as model:
         pm.Normal('a')
         pm.Normal('y', observed=np.zeros((2, 3)))
-        trace = pm.sample(10, tune=10)
+        trace = pm.sample(10, tune=10, chains=1)
 
     logp = pmstats._log_post_trace(trace, model)
     assert logp.shape == (len(trace), 6)
@@ -40,7 +40,7 @@ def test_log_post_trace():
         data = data.copy()
         data.values[:] = np.nan
         pm.Normal('y3', observed=data)
-        trace = pm.sample(10, tune=10)
+        trace = pm.sample(10, tune=10, chains=1)
 
     logp = pmstats._log_post_trace(trace, model)
     assert logp.shape == (len(trace), 17)
@@ -118,7 +118,7 @@ class TestStats(SeededTest):
             pm.Binomial('x', 5, p, observed=x_obs)
 
             step = pm.Metropolis()
-            trace = pm.sample(100, step)
+            trace = pm.sample(100, step, chains=1)
             calculated = pm.dic(trace)
 
         mean_deviance = -2 * st.binom.logpmf(
@@ -139,7 +139,7 @@ class TestStats(SeededTest):
             pm.Binomial('x', 5, p, observed=x_obs)
 
             step = pm.Metropolis()
-            trace = pm.sample(100, step)
+            trace = pm.sample(100, step, chains=1)
             calculated = pm.bpic(trace)
 
         mean_deviance = -2 * st.binom.logpmf(

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -209,11 +209,11 @@ class TestStepMethods(object):  # yield test doesn't work subclassing object
                 step = step_method(scaling=model.test_point)
                 trace = sample(0, tune=n_steps,
                                discard_tuned_samples=False,
-                               step=step, random_seed=1)
+                               step=step, random_seed=1, chains=1)
             else:
                 trace = sample(0, tune=n_steps,
                                discard_tuned_samples=False,
-                               step=step_method(), random_seed=1)
+                               step=step_method(), random_seed=1, chains=1)
         assert_array_almost_equal(
             trace.get_values('x'),
             self.master_samples[step_method],
@@ -243,7 +243,7 @@ class TestStepMethods(object):  # yield test doesn't work subclassing object
                     HamiltonianMC(scaling=C, is_cov=True, blocked=False)]),
             )
         for step in steps:
-            trace = sample(0, tune=8000,
+            trace = sample(0, tune=8000, chains=1,
                            discard_tuned_samples=False, step=step,
                            start=start, model=model, random_seed=1)
             self.check_stat(check, trace, step.__class__.__name__)
@@ -260,7 +260,8 @@ class TestStepMethods(object):  # yield test doesn't work subclassing object
                 Metropolis(S=C, proposal_dist=MultivariateNormalProposal),
             )
         for step in steps:
-            trace = sample(20000, tune=0, step=step, start=start, model=model, random_seed=1)
+            trace = sample(20000, tune=0, step=step, start=start, model=model,
+                           random_seed=1, chains=1)
             self.check_stat(check, trace, step.__class__.__name__)
 
     def test_step_categorical(self):
@@ -288,7 +289,8 @@ class TestStepMethods(object):  # yield test doesn't work subclassing object
                 EllipticalSlice(prior_chol=L),
             )
         for step in steps:
-            trace = sample(5000, tune=0, step=step, start=start, model=model, random_seed=1)
+            trace = sample(5000, tune=0, step=step, start=start, model=model,
+                           random_seed=1, chains=1)
             self.check_stat(check, trace, step.__class__.__name__)
 
 
@@ -397,9 +399,11 @@ class TestNutsCheckTrace(object):
         with Model():
             prob = Beta('prob', alpha=5., beta=3.)
             Binomial('outcome', n=1, p=prob)
+            # Catching warnings through multiprocessing doesn't work,
+            # so we have to use single threaded sampling.
             with pytest.warns(None) as warns:
                 sample(3, tune=2, discard_tuned_samples=False,
-                       n_init=None)
+                       n_init=None, chains=1)
             messages = [warn.message.args[0] for warn in warns]
             assert any("contains only 3" in msg for msg in messages)
             assert all('boolean index did not' not in msg for msg in messages)
@@ -417,8 +421,10 @@ class TestNutsCheckTrace(object):
             a = tt.switch(a > 0, np.inf, a)
             b = tt.slinalg.solve(floatX(np.eye(2)), a)
             Normal('c', mu=b, shape=2)
+            # Catching warnings through multiprocessing doesn't work,
+            # so we have to use single threaded sampling.
             with pytest.warns(None) as warns:
-                trace = sample(20, init=None, tune=5)
+                trace = sample(20, init=None, tune=5, chains=1)
             warns = [str(warn.message) for warn in warns]
             assert np.any(trace['diverging'])
             assert any('diverging samples after tuning' in warn

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -809,10 +809,10 @@ def test_sample_replacements(binomial_model_inference):
 def test_empirical_from_trace(another_simple_model):
     with another_simple_model:
         step = pm.Metropolis()
-        trace = pm.sample(100, step=step)
+        trace = pm.sample(100, step=step, chains=1)
         emp = Empirical(trace)
         assert emp.histogram.shape[0].eval() == 100
-        trace = pm.sample(100, step=step, njobs=4)
+        trace = pm.sample(100, step=step, chains=4)
         emp = Empirical(trace)
         assert emp.histogram.shape[0].eval() == 400
 


### PR DESCRIPTION
See #2611 for discussion.
This also adds a kwarg `chains` to `pm.sample`, that allows users to change the number of chains independent from the number of jobs, so that we can run the chains sequentially if we like.

**Update**
`njobs` in now the number of processes in the worker pool for running traces. So we run at most `njobs` chains in parallel.

`chains` is the total number of chains we want to sample.

We only use multiprocessing if both `njobs` *and* `chains` is greater than 1.

The defaults are:
```
if njobs is None:
    njobs = min(4, _cpu_count())
if chains is None:
    chains = max(2, njobs)
```

### How does this change current code?

```
pm.sample(njobs=n)
```
will return `n` chains as it used to **except** for `n=1`. Here, it will still return two chains, that run sequentially.

```
pm.sample()
```
This used to run only one chain, but now it runs two (whether or not they run in parallel depends on the number of cores in the system). This means that in most cases this will now pickle the model, which might break some user code. (It did break a couple of tests that used a lambda function or similar.)

To get the old behaviour of only running one chains, users have to set `chains` to one explicitly:
```
pm.sample(chains=1)
```