### PR TITLE
[WIP] Allow `size` argument sampling from `Normal` distribution

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -284,6 +284,7 @@ class Normal(Continuous):
         assert_negative_support(tau, 'tau', 'Normal')
 
         super(Normal, self).__init__(**kwargs)
+        self.shape = np.broadcast(mu, sd).shape
 
     def random(self, point=None, size=None, repeat=None):
         mu, tau, _ = draw_values([self.mu, self.tau, self.sd],


### PR DESCRIPTION
This came up in #2614, and is a super partial fix that I wanted opinions on before implementing everywhere.  Consider the following two code samples:

```
x = pm.Normal.dist(mu=np.array([1, 2]), sd=np.array([.2, .3]))
x.random(size=5)
```
This returns a `(5,2)` array with this change, as (arguably!) desired.  On master, it throws an exception (which is the bug in #2614)

```
with pm.Model():
    pm.Normal('X', mu=np.array([1, 2]), sd=np.array([.2, .3]), shape=9)
    trace = pm.sample()
```
This returns a `(500, 2)` array with this change, ignoring the `shape=9` argument, which I think is bad.  On master, it throws an exception, which I think is good.  My understanding is that `shape` is intended to be a hint as to the shape of `mu`/`sd`?  It shouldn't be hard to throw an exception with this change (just change the line to `self.shape = self.shape or np.broadcast(...).shape`).

I can add this change pretty easily to all the distributions, but wanted input before proceeding!