### PR TITLE
improved sampler auto-assignment

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -94,7 +94,7 @@ def assign_step_methods(model, step=None, methods=STEP_METHODS):
 
 
 
-def instantiate_steppers(model, steps, selected_steps:dict, step_kwargs=None):
+def instantiate_steppers(model, steps, selected_steps, step_kwargs=None):
     """Instantiates steppers assigned to the model variables.
 
     This function is intended to be called automatically from `sample()`, but

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -134,7 +134,8 @@ def assign_step_methods(model, step=None, methods=STEP_METHODS,
                     has_gradient = False
             # select the best method
             selected = max(methods, key=lambda method,
-                           var=var: method._competence(var, has_gradient))
+                           var=var, has_gradient=has_gradient:
+                           method._competence(var, has_gradient))
             pm._log.info('Assigned {0} to {1}'.format(selected.__name__, var))
             selected_steps[selected].append(var)
 

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -5,7 +5,6 @@ from ..blocking import ArrayOrdering, DictToArrayBijection
 import numpy as np
 from numpy.random import uniform
 from enum import IntEnum, unique
-import inspect
 
 __all__ = [
     'ArrayStep', 'ArrayStepShared', 'metrop_select', 'Competence']
@@ -89,9 +88,9 @@ class BlockedStep(object):
         have_grad = np.atleast_1d(have_grad)
         competences = []
         for var,has_grad in zip(vars, have_grad):
-            if "has_grad" in inspect.signature(cls.competence).parameters:
+            try:
                 competences.append(cls.competence(var, has_grad))
-            else:
+            except TypeError:
                 competences.append(cls.competence(var))
         return competences
 

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -5,6 +5,7 @@ from ..blocking import ArrayOrdering, DictToArrayBijection
 import numpy as np
 from numpy.random import uniform
 from enum import IntEnum, unique
+import inspect
 
 __all__ = [
     'ArrayStep', 'ArrayStepShared', 'metrop_select', 'Competence']
@@ -79,12 +80,20 @@ class BlockedStep(object):
         return self.__newargs
 
     @staticmethod
-    def competence(var):
+    def competence(var, has_grad):
         return Competence.INCOMPATIBLE
 
     @classmethod
-    def _competence(cls, vars):
-        return [cls.competence(var) for var in np.atleast_1d(vars)]
+    def _competence(cls, vars, have_grad):
+        vars = np.atleast_1d(vars)
+        have_grad = np.atleast_1d(have_grad)
+        competences = []
+        for var,has_grad in zip(vars, have_grad):
+            if "has_grad" in inspect.signature(cls.competence).parameters:
+                competences.append(cls.competence(var, has_grad))
+            else:
+                competences.append(cls.competence(var))
+        return competences
 
 
 class ArrayStep(BlockedStep):

--- a/pymc3/step_methods/elliptical_slice.py
+++ b/pymc3/step_methods/elliptical_slice.py
@@ -110,7 +110,7 @@ class EllipticalSlice(ArrayStep):
         return q_new
 
     @staticmethod
-    def competence(var):
+    def competence(var, has_grad):
         # Because it requires a specific type of prior, this step method
         # should only be assigned explicitly.
         return Competence.INCOMPATIBLE

--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -44,7 +44,7 @@ class ElemwiseCategorical(ArrayStep):
         return categorical(p, self.var.dshape)
 
     @staticmethod
-    def competence(var):
+    def competence(var, has_grad):
         if isinstance(var.distribution, Categorical):
             return Competence.COMPATIBLE
         return Competence.INCOMPATIBLE

--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -78,8 +78,8 @@ class HamiltonianMC(BaseHMC):
         return metrop_select(energy_change, state.q, start.q)[0]
 
     @staticmethod
-    def competence(var):
+    def competence(var, has_grad):
         """Check how appropriate this class is for sampling a random variable."""
-        if var.dtype in discrete_types:
+        if var.dtype in discrete_types or not has_grad:
             return Competence.INCOMPATIBLE
         return Competence.COMPATIBLE

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -231,9 +231,9 @@ class NUTS(BaseHMC):
         return q, [stats]
 
     @staticmethod
-    def competence(var):
+    def competence(var, has_grad):
         """Check how appropriate this class is for sampling a random variable."""
-        if var.dtype in continuous_types:
+        if var.dtype in continuous_types and has_grad:
             return Competence.IDEAL
         return Competence.INCOMPATIBLE
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -167,7 +167,7 @@ class Metropolis(ArrayStepShared):
         return q_new, [stats]
 
     @staticmethod
-    def competence(var):
+    def competence(var, has_grad):
         if var.dtype in pm.discrete_types:
             return Competence.COMPATIBLE
         return Competence.INCOMPATIBLE

--- a/pymc3/step_methods/sgmcmc.py
+++ b/pymc3/step_methods/sgmcmc.py
@@ -40,7 +40,7 @@ def elemwise_dlogL(vars, model, flat_view):
     Returns Jacobian of the log likelihood for each training datum wrt vars
     as a matrix of size N x D
     """
-    # select one observed random variable 
+    # select one observed random variable
     obs_var = model.observed_RVs[0]
     # tensor of shape (batch_size,)
     logL = obs_var.logp_elemwiset.sum(axis=tuple(range(1, obs_var.logp_elemwiset.ndim)))
@@ -57,12 +57,12 @@ def elemwise_dlogL(vars, model, flat_view):
 class BaseStochasticGradient(ArrayStepShared):
     R"""
     BaseStochasticGradient Object
-    
+
     For working with BaseStochasticGradient Object
-    we need to supply the probabilistic model 
+    we need to supply the probabilistic model
     (:code:`model`) with the data supplied to observed
     variables of type `GeneratorOp`
-    
+
     Parameters
     -------
     vars : list
@@ -74,7 +74,7 @@ class BaseStochasticGradient(ArrayStepShared):
     step_size : float
         Step size for the parameter update
     step_size_decay : int
-        Step size decay rate. Every `step_size_decay` iteration the step size reduce 
+        Step size decay rate. Every `step_size_decay` iteration the step size reduce
         to the half of the previous step size
     model : PyMC Model
         Optional model for sampling step. Defaults to None (taken from context)
@@ -108,9 +108,9 @@ class BaseStochasticGradient(ArrayStepShared):
                  minibatch_tensors=None,
                  **kwargs):
         warnings.warn(EXPERIMENTAL_WARNING)
-        
+
         model = modelcontext(model)
-        
+
         if vars is None:
             vars = model.vars
 
@@ -136,7 +136,7 @@ class BaseStochasticGradient(ArrayStepShared):
         self.step_size_decay = step_size_decay
         shared = make_shared_replacements(vars, model)
         self.q_size = int(sum(v.dsize for v in self.vars))
-        
+
         flat_view = model.flatten(vars)
         self.inarray = [flat_view.input]
         self.updates = OrderedDict()
@@ -146,7 +146,7 @@ class BaseStochasticGradient(ArrayStepShared):
         if minibatch_tensors != None:
             _check_minibatches(minibatch_tensors, minibatches)
             self.minibatches = minibatches
-            
+
             # Replace input shared variables with tensors
             def is_shared(t):
                 return isinstance(t, theano.compile.sharedvalue.SharedVariable)
@@ -165,7 +165,7 @@ class BaseStochasticGradient(ArrayStepShared):
         """Initializes the parameters for the stochastic gradient minibatch
         algorithm"""
         raise NotImplementedError
-    
+
     def mk_training_fn(self):
         raise NotImplementedError
 
@@ -175,7 +175,7 @@ class BaseStochasticGradient(ArrayStepShared):
 
     def astep(self, q0):
         """Perform a single update in the stochastic gradient method.
-        
+
         Returns new shared values and values sampled
         The size and ordering of q0 and q must be the same
         Parameters
@@ -196,7 +196,7 @@ class BaseStochasticGradient(ArrayStepShared):
 class SGFS(BaseStochasticGradient):
     R"""
     StochasticGradientFisherScoring
-    
+
     Parameters
     -----
     vars : list
@@ -214,7 +214,7 @@ class SGFS(BaseStochasticGradient):
         """
         Parameters
         ----------
-        vars : list 
+        vars : list
             Theano variables, default continuous vars
         B : np.array
             Symmetric positive Semi-definite Matrix
@@ -229,7 +229,7 @@ class SGFS(BaseStochasticGradient):
         self.t = theano.shared(1, name='t')
         # 2. Set gamma
         self.gamma = (self.batch_size + self.total_size) / (self.total_size)
-        
+
         self.training_fn = self.mk_training_fn()
 
     def mk_training_fn(self):
@@ -259,7 +259,7 @@ class SGFS(BaseStochasticGradient):
         I_t = (1. - 1. / t) * avg_I + (1. / t) * V
 
         if B is None:
-            # if B is not specified 
+            # if B is not specified
             # B \propto I_t as given in
             # http://www.ics.uci.edu/~welling/publications/papers/SGFS_v10_final.pdf
             # after iterating over the data few times to get a good approximation of I_N
@@ -294,7 +294,7 @@ class SGFS(BaseStochasticGradient):
         return f
 
     @staticmethod
-    def competence(var):
-        if var.dtype in continuous_types:
+    def competence(var, has_grad):
+        if var.dtype in continuous_types and has_grad:
             return Competence.COMPATIBLE
         return Competence.INCOMPATIBLE

--- a/pymc3/step_methods/slicer.py
+++ b/pymc3/step_methods/slicer.py
@@ -79,7 +79,7 @@ class Slice(ArrayStep):
         return q
 
     @staticmethod
-    def competence(var):
+    def competence(var, has_grad):
         if var.dtype in continuous_types:
             if not var.shape:
                 return Competence.PREFERRED

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -377,7 +377,10 @@ class TestAssignStepMethods(object):
             x = Normal('x', 0, 1)
 
             # a custom Theano Op that does not have a grad:
-            @theano.as_op([tt.dscalar], [tt.dscalar])
+            is_64 = theano.config.floatX == "float64"
+            itypes = [tt.dscalar] if is_64 else [tt.fscalar]
+            otypes = [tt.dscalar] if is_64 else [tt.fscalar]
+            @theano.as_op(itypes, otypes)
             def kill_grad(x):
                 return x
 

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -381,7 +381,8 @@ class TestAssignStepMethods(object):
             def kill_grad(x):
                 return x
 
-            Normal("y", mu=kill_grad(x), sd=1, observed=np.random.normal(size=(100,)))
+            data = np.random.normal(size=(100,))
+            Normal("y", mu=kill_grad(x), sd=1, observed=data.astype(theano.config.floatX))
 
             steps = assign_step_methods(model, [])
         assert isinstance(steps, Slice)

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -371,6 +371,21 @@ class TestAssignStepMethods(object):
             steps = assign_step_methods(model, [])
         assert isinstance(steps, Metropolis)
 
+    def test_normal_nograd_op(self):
+        """Test normal distribution without an implemented gradient is assigned slice method"""
+        with Model() as model:
+            x = Normal('x', 0, 1)
+
+            # a custom Theano Op that does not have a grad:
+            @theano.as_op([tt.dscalar], [tt.dscalar])
+            def kill_grad(x):
+                return x
+
+            Normal("y", mu=kill_grad(x), sd=1, observed=np.random.normal(size=(100,)))
+
+            steps = assign_step_methods(model, [])
+        assert isinstance(steps, Slice)
+
 
 @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
 class TestNutsCheckTrace(object):


### PR DESCRIPTION
This PR relates to #2625 

## Changes
+ [x] `assign_step_methods` was split into two functions: `assign_step_methods` and `instantiate_steppers`
+ [x] `assign_step_methods` validates that the grad for continuous variables is available
+ [x] the API of `BlockedStep.competence` was changed to include a `has_grad` argument
+ [x] implementations of `competence` classmethods by the sampler were updated to consider the `has_grad` argument

## Example
This is a linear regression. The first implementation uses a custom, non-differentiable theano Op and should be sampled with a mix of step methods.  The second implementation is all differentiable and uses NUTS for all variables.

```python
import numpy
import pymc3
import theano
import theano.tensor as tt

real_a = 0.6
real_b = 2.4
x = numpy.linspace(0, 10, 5)
real_data = real_a * x + real_b
real_data = numpy.random.normal(loc=real_data, scale=0.3)


class UndifferentiableLinregOp(theano.Op):
    """This is a theano Op that becomes a node in the computation graph.
    It is not differentiable, because the output is computed in Python.
    """
    __props__ = ("x",)

    def __init__(self, x):
        self.x = x
        return super().__init__()

    def __hash__(self):
        subhashes = (
            hash(type(self)),
            hash(self.x.tostring())     # because numpy.ndarray is not hashable
        )
        return hash(subhashes)

    def make_node(self, inputs:list):
        a = tt.as_tensor_variable(inputs[0])
        b = tt.as_tensor_variable(inputs[1])
        apply_node = theano.Apply(self,
                            [a,b],              # symbolic inputs
                            [tt.dmatrix()])     # symbolic outputs
        return apply_node

    def perform(self, node, inputs, output_storage):
        a, b = inputs
        y = a * self.x + b
        output_storage[0][0] = numpy.array([y])
        return

    # when this is implemented according to theano's recommendation
    # http://deeplearning.net/software/theano/sandbox/how_to_make_ops.html#grad ->
    #   "If the op is not differentiable wrt one of its inputs, the gradient
    #    for that input should be None; if the op is not differentiable with
    #    respect to any of its inputs, it should return something equivalent
    #    to [None] * len(inputs). If grad is not implemented for any op in a
    #    graph, then the symbolic gradient engine will complain (with an attribute exception)."
    # then theano.gradient.NullTypeGradError or NotImplementedError is raised
    # but not caught by pymc3
    def grad(self, inputs, outputs):
        # theano.gradient.grad_undefined or theano.gradient.grad_not_implemented
        # are both acceptable
        return [theano.gradient.grad_undefined(self, k, inp,
                        'No gradient defined through UndifferentiableLinregOp.')
                for k, inp in enumerate(inputs)]

    def infer_shape(self, node, input_shapes):
        return [(1,len(self.x))]

with pymc3.Model() as pmodel:
    a = pymc3.Beta("a", alpha=2, beta=5)
    b = pymc3.Normal("b", mu=2, sd=1)

    # make a prediction (y = (a * x + 0) + b)
    incline = UndifferentiableLinregOp(x)([a, 0])   # no gradient available
    shifted = incline + b                           # gradient available
    y_obs = pymc3.Normal("y", mu=shifted, sd=0.3, observed=real_data)

    multitrace = pymc3.sample()
    # expected:
    # a -> Metropolis/Slice
    # b -> NUTS
    # previous actual behavior:
    # AttributeError: 'UndifferentiableLinregOp' object has no attribute 'grad'
    # OR (when grad is implemented according to theano specification)
    # theano.gradient.NullTypeGradError


with pymc3.Model() as pmodel:
    a = pymc3.Beta("a", alpha=2, beta=5)
    b = pymc3.Normal("b", mu=2, sd=1)

    # make a prediction (y = (a * x + 0) + b)
    incline = a * x         # gradient available
    shifted = incline + b   # gradient available
    y_obs = pymc3.Normal("y", mu=shifted, sd=0.3, observed=real_data)

    multitrace = pymc3.sample()
    # expected:
    # a, b -> NUTS
```

## Tests
+ [x] a test for sampler-assignment with a `@theano.as_op` that kills the gradient