### PR TITLE
[WIP] Added MatrixNormal

### DIFF
--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -57,6 +57,7 @@ from .mixture import Mixture
 from .mixture import NormalMixture
 
 from .multivariate import MvNormal
+from .multivariate import MatrixNormal
 from .multivariate import MvStudentT
 from .multivariate import Dirichlet
 from .multivariate import Multinomial
@@ -123,6 +124,7 @@ __all__ = ['Uniform',
            'NoDistribution',
            'TensorType',
            'MvNormal',
+           'MatrixNormal',
            'MvStudentT',
            'Dirichlet',
            'Multinomial',

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -1180,7 +1180,7 @@ class MatrixNormal(Continuous):
     """
 
     def __init__(self, mu=0, rowcov=None, rowchol=None, rowtau=None,
-                 colcov=None, colchol=None, coltau=None, *args, shape=None,
+                 colcov=None, colchol=None, coltau=None, shape=None, *args,
                  **kwargs):
 
         self._setup_matrices(colcov, colchol, coltau, rowcov, rowchol, rowtau)

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -1182,20 +1182,14 @@ class MatrixNormal(Continuous):
     def __init__(self, mu=0, rowcov=None, rowchol=None, rowtau=None,
                  colcov=None, colchol=None, coltau=None, shape=None, *args,
                  **kwargs):
-
         self._setup_matrices(colcov, colchol, coltau, rowcov, rowchol, rowtau)
-
         if shape is None:
             raise TypeError('shape is a required argument')
         assert len(shape) == 2, "shape must have length 2: mxn"
         self.shape = shape
-
         super(MatrixNormal, self).__init__(shape=shape, *args, **kwargs)
-
         self.mu = tt.as_tensor_variable(mu)
-
         self.mean = self.median = self.mode = self.mu
-
         self.solve_lower = tt.slinalg.solve_lower_triangular
         self.solve_upper = tt.slinalg.solve_upper_triangular
 
@@ -1269,7 +1263,6 @@ class MatrixNormal(Continuous):
                                 point=point
                                 )
         standard_normal = np.random.standard_normal(size)
-
         return mu + np.matmul(rowchol, np.matmul(standard_normal, colchol.T))
 
     def _trquaddist(self, value):
@@ -1291,7 +1284,6 @@ class MatrixNormal(Continuous):
         rowdiag = tt.nlinalg.diag(rowchol_cov)
         half_collogdet = tt.sum(tt.log(coldiag))  # logdet(M) = 2*Tr(log(L))
         half_rowlogdet = tt.sum(tt.log(rowdiag))  # Using Cholesky: M = L L^T
-
         return trquaddist, half_collogdet, half_rowlogdet
 
     def logp(self, value):

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -25,7 +25,7 @@ from .dist_math import bound, logpow, factln, Cholesky
 
 __all__ = ['MvNormal', 'MvStudentT', 'Dirichlet',
            'Multinomial', 'Wishart', 'WishartBartlett',
-           'LKJCorr', 'LKJCholeskyCov']
+           'LKJCorr', 'LKJCholeskyCov', 'MatrixNormal']
 
 
 class _QuadFormBase(Continuous):
@@ -1091,3 +1091,183 @@ class LKJCorr(Continuous):
                      eta > 0,
                      broadcast_conditions=False
         )
+
+
+class MatrixNormal(Continuous):
+    R"""
+    Matrix-valued normal log-likelihood.
+
+    ===============  =====================================
+    Support          :math:`x \in \mathbb{R}^{q \times p}`
+    Mean             :math:`\mu`
+    Right Variance   :math:`T_R^{-1}`
+    Left Variance    :math:`T_L^{-1}`
+    ===============  =====================================
+
+    Parameters
+    ----------
+    mu : array
+        Vector of means.
+    rcov : array
+        Right (or row) pxp covariance matrix. Defines variance within rows.
+        Exactly one of rcov or rchol is needed.
+    rchol : array
+        Cholesky decomposition of pxp covariance matrix. Defines variance
+        within rows. Exactly one of rcov or rchol is needed.
+    lcov : array
+        Left (or column) qxq covariance matrix. Defines variance within
+        columns. Exactly one of lcov or lchol is needed.
+    lchol : array
+        Cholesky decomposition of qxq covariance matrix. Defines variance
+        within columns. Exactly one of lcov or lchol is needed.
+
+    Examples
+    --------
+    ?
+    """
+
+    def __init__(self, mu=0, rcov=None, rchol=None, rtau=None,
+                 lcov=None, lchol=None, ltau=None, *args, **kwargs):
+
+        self.setup_matrices(rcov, rchol, rtau, lcov, lchol, ltau)
+
+        shape = kwargs.pop('shape', None)
+        assert len(shape) == 2, "only 2d tuple inputs work right now: qxp"
+        self.shape = shape
+
+        super(MatrixNormal, self).__init__(shape=shape, *args, **kwargs)
+
+        self.mu = tt.as_tensor_variable(mu)
+
+        self.mean = self.median = self.mode = self.mu
+
+        # self.solve_lower = tt.slinalg.Solve(A_structure="lower_triangular")
+        # self.solve_upper = tt.slinalg.Solve(A_structure="upper_triangular")
+        self.solve_lower = tt.slinalg.solve_lower_triangular
+        self.solve_upper = tt.slinalg.solve_upper_triangular
+
+    def setup_matrices(self, rcov, rchol, rtau, lcov, lchol, ltau):
+        # Step methods and advi do not catch LinAlgErrors at the
+        # moment. We work around that by using a cholesky op
+        # that returns a nan as first entry instead of raising
+        # an error.
+        cholesky = Cholesky(nofail=True, lower=True)
+
+        # Right (or row) matrices
+        if len([i for i in [rtau, rcov, rchol] if i is not None]) != 1:
+            raise ValueError('Incompatible parameterization. '
+                             'Specify exactly one of rtau, rcov, '
+                             'or rchol.')
+        if rcov is not None:
+            self.p = rcov.shape[0]  # How many points along vector
+            self._rcov_type = 'cov'
+            rcov = tt.as_tensor_variable(rcov)
+            if rcov.ndim != 2:
+                raise ValueError('rcov must be two dimensional.')
+            self.rchol_cov = cholesky(rcov)
+            self.rcov = rcov
+            # self._n = self.rcov.shape[-1]
+        elif rtau is not None:
+            raise ValueError('rtau not supported at this time')
+            self.p = rtau.shape[0]
+            self._rcov_type = 'tau'
+            rtau = tt.as_tensor_variable(rtau)
+            if rtau.ndim != 2:
+                raise ValueError('rtau must be two dimensional.')
+            self.rchol_tau = cholesky(rtau)
+            self.rtau = rtau
+            # self._n = self.rtau.shape[-1]
+        else:
+            self.p = rchol.shape[0]
+            self._rcov_type = 'chol'
+            if rchol.ndim != 2:
+                raise ValueError('rchol must be two dimensional.')
+            self.rchol_cov = tt.as_tensor_variable(rchol)
+            # self._n = self.rchol_cov.shape[-1]
+
+        # Left (or column) matrices
+        if len([i for i in [ltau, lcov, lchol] if i is not None]) != 1:
+            raise ValueError('Incompatible parameterization. '
+                             'Specify exactly one of ltau, lcov, '
+                             'or lchol.')
+        if lcov is not None:
+            self.q = lcov.shape[0]
+            self._lcov_type = 'cov'
+            lcov = tt.as_tensor_variable(lcov)
+            if lcov.ndim != 2:
+                raise ValueError('lcov must be two dimensional.')
+            self.lchol_cov = cholesky(lcov)
+            self.lcov = lcov
+            # self._n = self.lcov.shape[-1]
+        elif ltau is not None:
+            raise ValueError('ltau not supported at this time')
+            self.q = ltau.shape[0]
+            self._lcov_type = 'tau'
+            ltau = tt.as_tensor_variable(ltau)
+            if ltau.ndim != 2:
+                raise ValueError('ltau must be two dimensional.')
+            self.lchol_tau = cholesky(ltau)
+            self.ltau = ltau
+            # self._n = self.ltau.shape[-1]
+        else:
+            self.q = lchol.shape[0]
+            self._lcov_type = 'chol'
+            if lchol.ndim != 2:
+                raise ValueError('lchol must be two dimensional.')
+            self.lchol_cov = tt.as_tensor_variable(lchol)
+            # self._n = self.lchol_cov.shape[-1]
+
+    def random(self, point=None, size=None):
+        if size is None:
+            size = list(self.shape)
+
+        mu, rchol, lchol = draw_values(
+                                [self.mu, self.rchol_cov, self.lchol_cov],
+                                point=point
+                                )
+        standard_normal = np.random.standard_normal(size)
+
+        return mu + lchol @ standard_normal @ rchol.T
+
+    def _trquaddist(self, value):
+        """Compute Tr[rcov^-1 @ (x - mu).T @ lcov^-1 @ (x - mu)] and
+        the logdet of rcov and lcov."""
+        mu = self.mu
+
+        delta = value - mu
+
+        lchol_cov = self.lchol_cov
+        rchol_cov = self.rchol_cov
+
+        rdiag = tt.nlinalg.diag(rchol_cov)
+        ldiag = tt.nlinalg.diag(lchol_cov)
+        # Check if the covariance matrix is positive definite.
+        rok = tt.all(rdiag > 0)
+        lok = tt.all(ldiag > 0)
+        ok = rok and lok
+
+        # If not, replace the diagonal. We return -inf later, but
+        # need to prevent solve_lower from throwing an exception.
+        rchol_cov = tt.switch(rok, rchol_cov, 1)
+        lchol_cov = tt.switch(lok, lchol_cov, 1)
+
+        # Find exponent piece by piece
+        right_quaddist = self.solve_lower(lchol_cov, delta)
+        quaddist = tt.nlinalg.matrix_dot(right_quaddist.T, right_quaddist)
+        quaddist = self.solve_lower(rchol_cov, quaddist)
+        quaddist = self.solve_upper(rchol_cov.T, quaddist)
+        trquaddist = tt.nlinalg.trace(quaddist)
+
+        half_rlogdet = tt.sum(tt.log(rdiag))  # logdet(M) = 2*Tr(log(L))
+        half_llogdet = tt.sum(tt.log(ldiag))  # Using Cholesky: M = L L^T
+
+        return trquaddist, half_rlogdet, half_llogdet, ok
+
+    def logp(self, value):
+        trquaddist, half_rlogdet, half_llogdet, ok = self._trquaddist(value)
+        q = self.q
+        p = self.p
+        norm = - 0.5 * q * p * pm.floatX(np.log(2 * np.pi))
+        return bound(
+                norm - 0.5 * trquaddist - q * half_rlogdet - p * half_llogdet,
+                ok)

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -706,24 +706,24 @@ class TestMatchesScipy(SeededTest):
 
     @pytest.mark.parametrize('n', [1, 2, 3])
     def test_matrixnormal(self, n):
-        self.pymc3_matches_scipy(MatrixNormal, RealMatrix(5, n),
-                                 {'mu': Vector(R, n), 'rowcov': PdMatrix(n),
+        self.pymc3_matches_scipy(MatrixNormal, RealMatrix(n, n),
+                                 {'mu': RealMatrix(n, n), 'rowcov': PdMatrix(n),
                                   'colcov': PdMatrix(n)},
                                  matrix_normal_logpdf_cov)
-        self.pymc3_matches_scipy(MatrixNormal, Vector(R, n),
-                                 {'mu': Vector(R, n), 'rowcov': PdMatrix(n),
+        self.pymc3_matches_scipy(MatrixNormal, RealMatrix(2, n),
+                                 {'mu': RealMatrix(2, n), 'rowcov': PdMatrix(2),
                                   'colcov': PdMatrix(n)},
                                  matrix_normal_logpdf_cov)
-        self.pymc3_matches_scipy(MatrixNormal, RealMatrix(5, n),
-                                 {'mu': Vector(R, n),
-                                  'rowchol': PdMatrixChol(n),
+        self.pymc3_matches_scipy(MatrixNormal, RealMatrix(3, n),
+                                 {'mu': RealMatrix(3, n),
+                                  'rowchol': PdMatrixChol(3),
                                   'colchol': PdMatrixChol(n)},
                                  matrix_normal_logpdf_chol,
                                  decimal=select_by_precision(float64=6, float32=-1))
-        self.pymc3_matches_scipy(MatrixNormal, Vector(R, n),
-                                 {'mu': Vector(R, n),
+        self.pymc3_matches_scipy(MatrixNormal, RealMatrix(n, 3),
+                                 {'mu': RealMatrix(n, 3),
                                   'rowchol': PdMatrixChol(n),
-                                  'colchol': PdMatrixChol(n)},
+                                  'colchol': PdMatrixChol(3)},
                                  matrix_normal_logpdf_chol,
                                  decimal=select_by_precision(float64=6, float32=0))
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -7,7 +7,7 @@ from ..vartypes import continuous_types
 from ..model import Model, Point, Potential, Deterministic
 from ..blocking import DictToVarBijection, DictToArrayBijection, ArrayOrdering
 from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Dirichlet,
-                             MvStudentT, MvNormal, ZeroInflatedPoisson,
+                             MvStudentT, MvNormal, MatrixNormal, ZeroInflatedPoisson,
                              ZeroInflatedNegativeBinomial, Constant, Poisson, Bernoulli, Beta,
                              BetaBinomial, HalfStudentT, StudentT, Weibull, Pareto,
                              InverseGamma, Gamma, Cauchy, HalfCauchy, Lognormal, Laplace,


### PR DESCRIPTION
This PR adds the functionality discussed [here](https://discourse.pymc.io/t/multiple-uncertain-function-observations-of-the-same-gaussian-process/400/15). This is marked as WIP because
* the `shape` kwarg is currently required, must specify the shape of the qxp matrix
* it does not support multiple draws from the distribution, i.e., `len(shape) > 2`
* there is no example in the docstring
* it has not been extensively tested
* there may be better/quicker ways to implement it
* etc.

I used the following as guides:
* [Wikipedia](https://en.wikipedia.org/wiki/Matrix_normal_distribution)
* [This article](http://ftp.stat.duke.edu/WorkingPapers/08-01.pdf)

Any help getting this up to your standards would be appreciated! Thanks.