### PR TITLE
Binomial GLM returns incorrect results with bool outcome variable #2548

### DIFF
--- a/pymc3/glm/linear.py
+++ b/pymc3/glm/linear.py
@@ -5,6 +5,7 @@ from . import families
 from ..model import Model, Deterministic
 from .utils import any_to_tensor_and_labels
 
+
 __all__ = [
     'LinearComponent',
     'GLM'
@@ -79,12 +80,14 @@ class LinearComponent(Model):
         self.y_est = x.dot(self.coeffs)
 
     @classmethod
-    def from_formula(cls, formula, data, priors=None, vars=None, name='', model=None):
+    def from_formula(cls, formula, data, priors=None, vars=None,
+                     name='', model=None):
         import patsy
         y, x = patsy.dmatrices(formula, data)
         labels = x.design_info.column_names
-        return cls(np.asarray(x), np.asarray(y)[:, 0], intercept=False, labels=labels,
-                   priors=priors, vars=vars, name=name, model=model)
+        return cls(np.asarray(x), np.asarray(y)[:, -1], intercept=False,
+                   labels=labels, priors=priors, vars=vars, name=name,
+                   model=model)
 
 
 class GLM(LinearComponent):
@@ -132,7 +135,9 @@ class GLM(LinearComponent):
         import patsy
         y, x = patsy.dmatrices(formula, data)
         labels = x.design_info.column_names
-        return cls(np.asarray(x), np.asarray(y)[:, 0], intercept=False, labels=labels,
-                   priors=priors, vars=vars, family=family, name=name, model=model)
+        return cls(np.asarray(x), np.asarray(y)[:, -1], intercept=False,
+                   labels=labels, priors=priors, vars=vars, family=family,
+                   name=name, model=model)
+
 
 glm = GLM

--- a/pymc3/tests/test_glm.py
+++ b/pymc3/tests/test_glm.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 
 from .helpers import SeededTest
 from pymc3 import Model, Uniform, Normal, find_MAP, Slice, sample
@@ -79,3 +80,16 @@ class TestGLM(SeededTest):
                 self.data_logistic['y'],
                 family=families.Binomial(link=families.logit),
                 name='glm1')
+
+    def test_boolean_y(self):
+        model = GLM.from_formula('y ~ x', pd.DataFrame(
+                {'x': self.data_logistic['x'],
+                 'y': self.data_logistic['y']}
+            )
+        )
+        model_bool = GLM.from_formula('y ~ x', pd.DataFrame(
+                {'x': self.data_logistic['x'],
+                 'y': [bool(i) for i in self.data_logistic['y']]}
+            )
+        )
+        assert_equal(model.y.observations, model_bool.y.observations)


### PR DESCRIPTION
The incorrect sign associated with a boolean y value was cause by `y, x = patsy.dmatrices(formula, data)`. If a boolean value if given y with be a N*2 array and from_formula will return the first column which for boolean values is the column associated with `False`.

I changes the code to return the last column which will return the results for the `True` column.