### PR TITLE
catching errors indicating unavailability of gradients in find_MAP

### DIFF
--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -11,6 +11,7 @@ import pymc3 as pm
 from ..vartypes import discrete_types, typefilter
 from ..model import modelcontext, Point
 from ..theanof import inputvars
+import theano.gradient as tg
 from ..blocking import DictToArrayBijection, ArrayOrdering
 from ..util import update_start_vals, get_default_varnames
 
@@ -75,7 +76,7 @@ def find_MAP(start=None, vars=None, method="L-BFGS-B",
     try:
         dlogp_func = bij.mapf(model.fastdlogp_nojac(vars))
         compute_gradient = True
-    except AttributeError:
+    except (AttributeError, NotImplementedError, tg.NullTypeGradError):
         compute_gradient = False
 
     if disc_vars or not compute_gradient:


### PR DESCRIPTION
When a custom `Op.grad` is implemented according to the [theano docs](http://deeplearning.net/software/theano/sandbox/how_to_make_ops.html#grad), it will raise either `NotImplementedError` or `theano.gradient.NullTypeGradientError`.
The `AttributeError` is only raised when the `as_op` decorator is used.

The test in [`test_starting:L45`](https://github.com/pymc-devs/pymc3/blob/master/pymc3/tests/test_starting.py#L45) did not catch the other two because the [testing model](https://github.com/pymc-devs/pymc3/blob/master/pymc3/tests/models.py#L40) uses `@as_op`.

Linking to #2628 for reference, but otherwise this is quite a trivial PR..