### PR TITLE
broadcasting in sample_ppc_w

### DIFF
--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -252,6 +252,33 @@ class TestSamplePPC(object):
             _, pval = stats.kstest(ppc['b'], stats.norm(scale=scale).cdf)
             assert pval > 0.001
 
+class TestSamplePPCW(object):
+    def test_sample_ppc_w(self):
+        data = np.random.normal(0, 1, size=200)
+        with pm.Model() as model_0:
+            mu = pm.Normal('mu', mu=0, sd=1)
+            y = pm.Normal('y', mu=mu, sd=1, observed=data)
+            trace_0 = pm.sample()
+
+        with pm.Model() as model_1:
+            mu = pm.Normal('mu', mu=0, sd=1, shape=len(data))
+            y = pm.Normal('y', mu=mu, sd=1, observed=data)
+            trace_1 = pm.sample()
+
+
+        traces = [trace_0, trace_0]
+        models = [model_0, model_0]
+        ppc = pm.sample_ppc_w(traces, 1000, models)
+
+        assert ppc['y'].shape == (1000,)
+        _, pval = stats.kstest(ppc['y'], stats.norm().cdf)
+        assert pval > 0.001
+
+        traces = [trace_0, trace_1]
+        models = [model_0, model_1]
+        ppc = pm.sample_ppc_w(traces, 50, models)
+        assert ppc['y'].shape == (50, 200)
+
 
 @pytest.mark.parametrize('method', [
     'jitter+adapt_diag', 'adapt_diag', 'advi', 'ADVI+adapt_diag',


### PR DESCRIPTION
This  PR removes the size argument from `sample_ppc_w`. The size is now inferred for each model and only if they match the averaged predictive posteriors are computed.

A simple example that motivates the PR is as follows:

```python
with pm.Model() as model_0:
    a = pm.Normal('a', 0, 1)
    y = pm.Normal('y, a, 1, observed=Y)

with pm.Model() as model_1:
    a = pm.Normal('a', 0, 1)
    b = pm.Normal('b', 0, 1)
    y = pm.Normal('y, a + b * X, 1, observed=Y)
```

when doing a `sample_ppc` we get samples of `size = 1` for `model_0` and of `size = x.shape` for `model_1`. This is problematic for  `samples_ppc_w` because we want a weighted samples from both models.

Not sure this is the best solution, but at least is more general than the current version.
