### PR TITLE
fix #2627 by hardcoding links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ large suite of problems.
 
 Check out the `getting started guide <http://docs.pymc.io/notebooks/getting_started>`__!
 
+
 Features
 ========
 
@@ -37,10 +38,10 @@ Getting started
 If you already know about Bayesian statistics:
 ----------------------------------------------
 
-
 -  `API quickstart guide <http://docs.pymc.io/notebooks/api_quickstart>`__
 -  The `PyMC3 tutorial <http://docs.pymc.io/notebooks/getting_started>`__
 -  `PyMC3 examples <http://docs.pymc.io/examples>`__ and the `API reference <http://docs.pymc.io/api>`__
+
 
 Learn Bayesian statistics with a book together with PyMC3:
 ----------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ which focuses on advanced Markov chain Monte Carlo and variational fitting
 algorithms. Its flexibility and extensibility make it applicable to a
 large suite of problems.
 
-Check out the :ref:`getting started guide<http://docs.pymc.io/notebooks/getting_started>`!
+Check out the `getting started guide <http://docs.pymc.io/notebooks/getting_started>`__!
 
 Features
 ========
@@ -37,9 +37,10 @@ Getting started
 If you already know about Bayesian statistics:
 ----------------------------------------------
 
--  :ref:`API quickstart guide<http://docs.pymc.io/notebooks/api_quickstart>`
--  The :ref:`PyMC3 tutorial<http://docs.pymc.io/notebooks/getting_started>`
--  :ref:`PyMC3 examples<examples>` and the :ref:`API reference<api>`
+
+-  `API quickstart guide <http://docs.pymc.io/notebooks/api_quickstart>`__
+-  The `PyMC3 tutorial <http://docs.pymc.io/notebooks/getting_started>`__
+-  `PyMC3 examples <http://docs.pymc.io/examples>`__ and the `API reference <http://docs.pymc.io/api>`__
 
 Learn Bayesian statistics with a book together with PyMC3:
 ----------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,7 @@ which focuses on advanced Markov chain Monte Carlo and variational fitting
 algorithms. Its flexibility and extensibility make it applicable to a
 large suite of problems.
 
-Check out the `getting started guide <docs/source/notebooks/getting_started.ipynb>`__!
-
+Check out the :ref:`getting started guide<http://docs.pymc.io/notebooks/getting_started>`!
 
 Features
 ========
@@ -38,9 +37,9 @@ Getting started
 If you already know about Bayesian statistics:
 ----------------------------------------------
 
--  `API quickstart guide <notebooks/api_quickstart.ipynb>`__
--  The `PyMC3 tutorial <notebooks/getting_started.ipynb>`__
--  `PyMC3 examples <examples>`__ and the `API reference <api>`__
+-  :ref:`API quickstart guide<http://docs.pymc.io/notebooks/api_quickstart>`
+-  The :ref:`PyMC3 tutorial<http://docs.pymc.io/notebooks/getting_started>`
+-  :ref:`PyMC3 examples<examples>` and the :ref:`API reference<api>`
 
 Learn Bayesian statistics with a book together with PyMC3:
 ----------------------------------------------------------


### PR DESCRIPTION
The following links have been updated in the README file to point to absolute links

- docs/source/notebooks/getting_started.ipynb -> http://docs.pymc.io/notebooks/getting_started
- notebooks/api_quickstart.ipynb -> http://docs.pymc.io/notebooks/api_quickstart
- notebooks/getting_started.ipynb -> http://docs.pymc.io/notebooks/getting_started
- /examples -> http://docs.pymc.io/examples
- /api -> http://docs.pymc.io/api 
 