### PR TITLE
Renamed df_summary to summary and added deprecation warning

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -294,7 +294,7 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None,
         ...     p = pm.Beta('p', alpha=alpha, beta=beta)
         ...     y = pm.Binomial('y', n=n, p=p, observed=h)
         ...     trace = pm.sample(2000, tune=1000, njobs=4)
-        >>> pm.df_summary(trace)
+        >>> pm.summary(trace)
                mean        sd  mc_error   hpd_2.5  hpd_97.5
         p  0.604625  0.047086   0.00078  0.510498  0.694774
     """

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -727,7 +727,7 @@ def quantiles(x, qlist=(2.5, 25, 50, 75, 97.5), transform=lambda x: x):
         pm._log.warning("Too few elements for quantile calculation")
 
 
-def df_summary(trace, varnames=None, transform=lambda x: x, stat_funcs=None,
+def summary(trace, varnames=None, transform=lambda x: x, stat_funcs=None,
                extend=False, include_transformed=False,
                alpha=0.05, start=0, batches=None):
     R"""Create a data frame with summary statistics.
@@ -790,7 +790,7 @@ def df_summary(trace, varnames=None, transform=lambda x: x, stat_funcs=None,
         >>> import pymc3 as pm
         >>> trace.mu.shape
         (1000, 2)
-        >>> pm.df_summary(trace, ['mu'])
+        >>> pm.summary(trace, ['mu'])
                    mean        sd  mc_error     hpd_5    hpd_95
         mu__0  0.106897  0.066473  0.001818 -0.020612  0.231626
         mu__1 -0.046597  0.067513  0.002048 -0.174753  0.081924
@@ -806,7 +806,7 @@ def df_summary(trace, varnames=None, transform=lambda x: x, stat_funcs=None,
         >>> def trace_quantiles(x):
         ...     return pd.DataFrame(pm.quantiles(x, [5, 50, 95]))
         ...
-        >>> pm.df_summary(trace, ['mu'], stat_funcs=[trace_sd, trace_quantiles])
+        >>> pm.summary(trace, ['mu'], stat_funcs=[trace_sd, trace_quantiles])
                      sd         5        50        95
         mu__0  0.066473  0.000312  0.105039  0.214242
         mu__1  0.067513 -0.159097 -0.045637  0.062912
@@ -836,69 +836,15 @@ def df_summary(trace, varnames=None, transform=lambda x: x, stat_funcs=None,
         var_dfs.append(var_df)
     return pd.concat(var_dfs, axis=0)
 
+def df_summary(*args, **kwargs):
+    warnings.warn("df_summary has been deprecated. In future, use summary instead.",
+                DeprecationWarning)
+    return summary(*args, **kwargs)
 
 def _hpd_df(x, alpha):
     cnames = ['hpd_{0:g}'.format(100 * alpha / 2),
               'hpd_{0:g}'.format(100 * (1 - alpha / 2))]
     return pd.DataFrame(hpd(x, alpha), columns=cnames)
-
-
-def summary(trace, varnames=None, transform=lambda x: x, alpha=0.05, start=0,
-            batches=None, roundto=3, include_transformed=False, to_file=None):
-    R"""Generate a pretty-printed summary of the node.
-
-    Parameters
-    ----------
-    trace : Trace object
-      Trace containing MCMC sample
-    varnames : list of strings
-      List of variables to summarize. Defaults to None, which results
-      in all variables summarized.
-    transform : callable
-      Function to transform data (defaults to identity)
-    alpha : float
-      The alpha level for generating posterior intervals. Defaults to
-      0.05.
-    start : int
-      The starting index from which to summarize (each) chain. Defaults
-      to zero.
-    batches : None or int
-        Batch size for calculating standard deviation for non-independent
-        samples. Defaults to the smaller of 100 or the number of samples.
-        This is only meaningful when `stat_funcs` is None.
-    roundto : int
-      The number of digits to round posterior statistics.
-    include_transformed : bool
-      Flag for summarizing automatically transformed variables in addition to
-      original variables (defaults to False).
-    to_file : None or string
-      File to write results to. If not given, print to stdout.
-    """
-    if varnames is None:
-        varnames = get_default_varnames(trace.varnames, include_transformed=include_transformed)
-
-    if batches is None:
-        batches = min([100, len(trace)])
-
-    stat_summ = _StatSummary(roundto, batches, alpha)
-    pq_summ = _PosteriorQuantileSummary(roundto, alpha)
-
-    if to_file is None:
-        fh = sys.stdout
-    else:
-        fh = open(to_file, mode='w')
-
-    for var in varnames:
-        # Extract sampled values
-        sample = transform(trace.get_values(var, burn=start, combine=True))
-
-        fh.write('\n%s:\n\n' % var)
-
-        fh.write(stat_summ.output(sample))
-        fh.write(pq_summ.output(sample))
-
-    if fh is not sys.stdout:
-        fh.close()
 
 
 class _Summary(object):

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pandas as pd
 import itertools
-import sys
 from tqdm import tqdm
 import warnings
 from collections import namedtuple

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -203,7 +203,7 @@ class TestChooseBackend(object):
         assert backend.called
 
 
-class TestSamplePPC(object):
+class TestSamplePPC(SeededTest):
     def test_normal_scalar(self):
         with pm.Model() as model:
             a = pm.Normal('a', mu=0, sd=1)
@@ -252,7 +252,7 @@ class TestSamplePPC(object):
             _, pval = stats.kstest(ppc['b'], stats.norm(scale=scale).cdf)
             assert pval > 0.001
 
-class TestSamplePPCW(object):
+class TestSamplePPCW(SeededTest):
     def test_sample_ppc_w(self):
         data = np.random.normal(0, 1, size=200)
         with pm.Model() as model_0:

--- a/pymc3/tests/test_stats.py
+++ b/pymc3/tests/test_stats.py
@@ -6,7 +6,7 @@ import pymc3 as pm
 from .helpers import SeededTest
 from ..tests import backend_fixtures as bf
 from ..backends import ndarray
-from ..stats import df_summary, autocorr, hpd, mc_error, quantiles, make_indices, bfmi
+from ..stats import summary, autocorr, hpd, mc_error, quantiles, make_indices, bfmi
 from ..theanof import floatX_array
 import pymc3.stats as pmstats
 from numpy.random import random, normal
@@ -420,13 +420,13 @@ class TestDfSummary(bf.ModelBackendSampledTestCase):
     shape = (2, 3)
 
     def test_column_names(self):
-        ds = df_summary(self.mtrace, batches=3)
+        ds = summary(self.mtrace, batches=3)
         npt.assert_equal(np.array(['mean', 'sd', 'mc_error',
                                    'hpd_2.5', 'hpd_97.5']),
                          ds.columns)
 
     def test_column_names_decimal_hpd(self):
-        ds = df_summary(self.mtrace, batches=3, alpha=0.001)
+        ds = summary(self.mtrace, batches=3, alpha=0.001)
         npt.assert_equal(np.array(['mean', 'sd', 'mc_error',
                                    'hpd_0.05', 'hpd_99.95']),
                          ds.columns)
@@ -435,14 +435,14 @@ class TestDfSummary(bf.ModelBackendSampledTestCase):
         def customf(x):
             return pd.Series(np.mean(x, 0), name='my_mean')
 
-        ds = df_summary(self.mtrace, batches=3, stat_funcs=[customf])
+        ds = summary(self.mtrace, batches=3, stat_funcs=[customf])
         npt.assert_equal(np.array(['my_mean']), ds.columns)
 
     def test_column_names_custom_function_extend(self):
         def customf(x):
             return pd.Series(np.mean(x, 0), name='my_mean')
 
-        ds = df_summary(self.mtrace, batches=3,
+        ds = summary(self.mtrace, batches=3,
                         stat_funcs=[customf], extend=True)
         npt.assert_equal(np.array(['mean', 'sd', 'mc_error',
                                    'hpd_2.5', 'hpd_97.5', 'my_mean']),
@@ -450,7 +450,7 @@ class TestDfSummary(bf.ModelBackendSampledTestCase):
 
     def test_value_alignment(self):
         mtrace = self.mtrace
-        ds = df_summary(mtrace, batches=3)
+        ds = summary(mtrace, batches=3)
         for var in mtrace.varnames:
             result = mtrace[var].mean(0)
             for idx, val in np.ndenumerate(result):
@@ -465,6 +465,6 @@ class TestDfSummary(bf.ModelBackendSampledTestCase):
             pm.Uniform('x', 0, 1)
             step = Metropolis()
             trace = pm.sample(100, step=step)
-        ds = df_summary(trace, batches=3, include_transformed=True)
+        ds = summary(trace, batches=3, include_transformed=True)
         npt.assert_equal(np.array(['x_interval__', 'x']),
                          ds.index)


### PR DESCRIPTION
There is little need for the somewhat-antiquated `summary` function, so here I am proposing to rename `df_summary` to `summary` as the default trace summarization function. A deprecation warning has been added to `df_summary` which can be removed in a future release.