### PR TITLE
Modified posteriorplot.py to allow font scaling of title, axis labels etc.

### DIFF
--- a/pymc3/plots/posteriorplot.py
+++ b/pymc3/plots/posteriorplot.py
@@ -10,7 +10,7 @@ from .artists import plot_posterior_op
 from .utils import identity_transform, get_default_varnames
 
 
-def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=None, text_size=16,
+def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=None, text_size=None,
                    alpha_level=0.05, round_to=3, point_estimate='mean', rope=None,
                    ref_val=None, kde_plot=False, plot_transformed=False, ax=None, **kwargs):
     """Plot Posterior densities in style of John K. Kruschke book.
@@ -58,6 +58,18 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
     ax : matplotlib axes
 
     """
+
+    def scale_text(figsize, text_size=text_size):
+        """Scale text to figsize."""
+
+        if text_size is None and figsize is not None:
+            if figsize[0] <= 11:
+                return 12
+            else:
+                return figsize[0]
+        else:
+            return text_size
+
     def create_axes_grid(figsize, traces):
         l_trace = len(traces)
         if l_trace == 1:
@@ -90,10 +102,11 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
             figsize = (6, 2)
         if ax is None:
             fig, ax = plt.subplots(figsize=figsize)
+
         plot_posterior_op(transform(trace), ax=ax, kde_plot=kde_plot,
                           point_estimate=point_estimate, round_to=round_to,
                           alpha_level=alpha_level, ref_val=ref_val, rope=rope,
-                          text_size=text_size, **kwargs)
+                          text_size=scale_text(figsize), **kwargs)
     else:
         if varnames is None:
             varnames = get_default_varnames(trace.varnames, plot_transformed)
@@ -119,8 +132,8 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
             plot_posterior_op(tr_values, ax=a, kde_plot=kde_plot,
                               point_estimate=point_estimate, round_to=round_to,
                               alpha_level=alpha_level, ref_val=ref_val[idx],
-                              rope=rope[idx], text_size=text_size, **kwargs)
-            a.set_title(v)
+                              rope=rope[idx], text_size=scale_text(figsize), **kwargs)
+            a.set_title(v, fontsize=scale_text(figsize))
 
         plt.tight_layout()
     return ax


### PR DESCRIPTION
Hi,

I worked on this yesterday during Python Sprint with someone else. He probably submitted his solution as well.

This allows for scaling of the font sizes flexibly and if the figure is made very small it keeps the font size at 12.

![image](https://user-images.githubusercontent.com/26039401/32015274-7bb5b59a-b9b8-11e7-98da-da64a307667e.png)

The text size can still be set manually:

![image](https://user-images.githubusercontent.com/26039401/32015314-a3ba7972-b9b8-11e7-9703-727461d03f8f.png)

In case of missing figsize it will default to whatever is already set in the posteriorplot.py now (I think its 6 or 5) but the text_size will be then set to 12.

![image](https://user-images.githubusercontent.com/26039401/32015398-e8e2a5ec-b9b8-11e7-9344-0da197b884b3.png)



