### PR TITLE
Implement half-Student's T as a first-class distribution

### DIFF
--- a/docs/source/api/distributions/continuous.rst
+++ b/docs/source/api/distributions/continuous.rst
@@ -15,7 +15,7 @@ Continuous
    Exponential
    Laplace
    StudentT
-   StudentTpos
+   HalfStudentT
    Cauchy
    HalfCauchy
    Gamma
@@ -29,6 +29,7 @@ Continuous
    VonMises
    Triangular
    Gumbel
+   Interpolated
 
 .. automodule:: pymc3.distributions.continuous
    :members:

--- a/docs/source/api/distributions/discrete.rst
+++ b/docs/source/api/distributions/discrete.rst
@@ -12,7 +12,7 @@ Discrete
    Poisson
    ZeroInflatedPoisson
    NegativeBinomial
-   ZeroInflatedPoisson
+   ZeroInflatedNegativeBinomial
    DiscreteUniform
    Geometric
    Categorical

--- a/docs/source/api/distributions/multivariate.rst
+++ b/docs/source/api/distributions/multivariate.rst
@@ -6,6 +6,7 @@ Multivariate
 .. autosummary::
 
    MvNormal
+   MvStudentT
    Wishart
    LKJCholeskyCov
    LKJCorr

--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -17,7 +17,6 @@ from .continuous import HalfStudentT
 from .continuous import Lognormal
 from .continuous import ChiSquared
 from .continuous import HalfNormal
-from .continuous import StudentTpos
 from .continuous import Wald
 from .continuous import Pareto
 from .continuous import InverseGamma
@@ -95,7 +94,6 @@ __all__ = ['Uniform',
            'Bound',
            'Lognormal',
            'HalfStudentT',
-           'StudentTpos',
            'ChiSquared',
            'HalfNormal',
            'Wald',

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -22,7 +22,6 @@ from .dist_math import (
     i1, alltrue_elemwise, SplineWrapper
 )
 from .distribution import Continuous, draw_values, generate_samples
-from .bound import Bound
 
 __all__ = ['Uniform', 'Flat', 'HalfFlat', 'Normal', 'Beta', 'Exponential',
            'Laplace', 'StudentT', 'Cauchy', 'HalfCauchy', 'Gamma', 'Weibull',

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1533,7 +1533,7 @@ class Weibull(PositiveContinuous):
                                                                 get_variable_name(beta))
 
 
-class HalfStudentT(Continuous):
+class HalfStudentT(PositiveContinuous):
     R"""
     Half Student's T log-likelihood
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -26,9 +26,9 @@ from .bound import Bound
 
 __all__ = ['Uniform', 'Flat', 'HalfFlat', 'Normal', 'Beta', 'Exponential',
            'Laplace', 'StudentT', 'Cauchy', 'HalfCauchy', 'Gamma', 'Weibull',
-           'HalfStudentT', 'StudentTpos', 'Lognormal', 'ChiSquared',
-           'HalfNormal', 'Wald', 'Pareto', 'InverseGamma', 'ExGaussian',
-           'VonMises', 'SkewNormal', 'Logistic', 'Interpolated']
+           'HalfStudentT', 'Lognormal', 'ChiSquared', 'HalfNormal', 'Wald',
+           'Pareto', 'InverseGamma', 'ExGaussian', 'VonMises', 'SkewNormal',
+           'Logistic', 'Interpolated']
 
 
 class PositiveContinuous(Continuous):
@@ -1534,12 +1534,79 @@ class Weibull(PositiveContinuous):
                                                                 get_variable_name(beta))
 
 
-def StudentTpos(*args, **kwargs):
-    warnings.warn("StudentTpos has been deprecated. In future, use HalfStudentT instead.",
-                DeprecationWarning)
-    return HalfStudentT(*args, **kwargs)
+class HalfStudentT(Continuous):
+    R"""
+    Half Student's T log-likelihood
 
-HalfStudentT = Bound(StudentT, lower=0)
+    .. math::
+
+        f(x \mid \beta,\nu) =
+            \frac{2\;\Gamma\left(\frac{\nu+1}{2}\right)}
+            {\Gamma\left(\frac{\nu}{2}\right)\sqrt{\nu\pi\beta^2}}
+            \left(1+\frac{1}{\nu}\frac{x^2}{\beta^2}\right)^{-\frac{\nu+1}{2}}
+
+    .. plot::
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import scipy.stats as st
+        x = np.linspace(-5.0, 5.0, 200)
+        fig, ax = plt.subplots()
+        f = lambda beta, nu : st.t.pdf(x, df=nu, loc=0, scale=beta)
+        plot_pdf = lambda beta, nu : ax.plot(x, f(beta, nu), label=r'$\beta$={}, $\nu$={}'.format(beta, nu))
+        plot_pdf(1, 0.5)
+        plot_pdf(1, 1)
+        plot_pdf(2, 1)
+        plot_pdf(1, 30)
+        plt.legend(loc='upper right', frameon=False)
+        ax.set(xlim=[0,5], ylim=[0, 0.4], xlabel='x', ylabel='f(x)')
+        plt.show()
+
+    ========  ========================
+    Support   :math:`x \in [0, \infty)`
+    ========  ========================
+
+    Parameters
+    ----------
+    nu : float
+        Degrees of freedom, also known as normality parameter (nu > 0).
+    beta : float
+        Scale parameter (beta > 0).
+    """
+    def __init__(self, nu=1, beta=1, *args, **kwargs):
+        super(HalfStudentT, self).__init__(*args, **kwargs)
+        self.mode = tt.as_tensor_variable(0)
+        self.median = tt.as_tensor_variable(beta)
+        self.beta = tt.as_tensor_variable(beta)
+        self.nu = nu = tt.as_tensor_variable(nu)
+
+        assert_negative_support(beta, 'beta', 'HalfStudentT')
+        assert_negative_support(nu, 'nu', 'HalfStudentT')
+
+    def random(self, point=None, size=None, repeat=None):
+        nu, beta = draw_values([self.nu, self.beta], point=point)
+        return np.abs(generate_samples(stats.t.rvs, nu, loc=0, scale=beta,
+                                       dist_shape=self.shape,
+                                       size=size))
+
+    def logp(self, value):
+        nu = self.nu
+        beta = self.beta
+
+        return bound(tt.log(2) + gammaln((nu + 1.0) / 2.0)
+                     - gammaln(nu / 2.0)
+                     - .5 * tt.log(nu * np.pi * beta**2)
+                     - (nu + 1.0) / 2.0 * tt.log1p(value ** 2 / (nu * beta**2)),
+                     beta > 0, nu > 0, value >= 0)
+
+    def _repr_latex_(self, name=None, dist=None):
+        if dist is None:
+            dist = self
+        nu = dist.nu
+        beta = dist.beta
+        return r'${} \sim \text{{HalfStudentT}}(\mathit{{nu}}={}, \mathit{{beta}}={})$'.format(name,
+                                                                get_variable_name(nu),
+                                                                get_variable_name(beta))
 
 
 class ExGaussian(Continuous):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -576,10 +576,15 @@ class TestMatchesScipy(SeededTest):
                                  scipy_exponweib_sucks,
                                  )
 
-    def test_student_tpos(self):
-        # TODO: this actually shouldn't pass
-        self.pymc3_matches_scipy(HalfStudentT, Rplus, {'nu': Rplus, 'mu': R, 'lam': Rplus},
-                                 lambda value, nu, mu, lam: sp.t.logpdf(value, nu, mu, lam**-.5))
+    def test_half_studentt(self):
+        # this is only testing for nu=1 (halfcauchy)
+        self.pymc3_matches_scipy(HalfStudentT, Rplus, {'beta': Rplus},
+                                 lambda value, beta: sp.halfcauchy.logpdf(value, 0, beta))
+        # this is only testing for large nu (approx-gaussian)
+        self.pymc3_matches_scipy(HalfStudentT, Rplus, {'beta': Rplusbig},
+                                 lambda value, beta: sp.halfnorm.logpdf(value, 0, beta),
+                                                                        decimal=3,
+                                                                        extra_args={'nu': 1E12})
 
     def test_skew_normal(self):
         self.pymc3_matches_scipy(SkewNormal, R, {'mu': R, 'sd': Rplusbig, 'alpha': R},

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -580,11 +580,6 @@ class TestMatchesScipy(SeededTest):
         # this is only testing for nu=1 (halfcauchy)
         self.pymc3_matches_scipy(HalfStudentT, Rplus, {'beta': Rplus},
                                  lambda value, beta: sp.halfcauchy.logpdf(value, 0, beta))
-        # this is only testing for large nu (approx-gaussian)
-        self.pymc3_matches_scipy(HalfStudentT, Rplus, {'beta': Rplusbig},
-                                 lambda value, beta: sp.halfnorm.logpdf(value, 0, beta),
-                                                                        decimal=3,
-                                                                        extra_args={'nu': 1E12})
 
     def test_skew_normal(self):
         self.pymc3_matches_scipy(SkewNormal, R, {'mu': R, 'sd': Rplusbig, 'alpha': R},


### PR DESCRIPTION
* Implement HalfStudentT like the rest of the distributions (better docs, LaTeX representation, random samples, etc)
* Finally remove StudentTpos (superseeded by HalfStudentT) and remove deprecation warning (it was introduced more than one year ago)
* (Partially) fix test for HalfStudentT
* Tidy up distributions in the API documentation
    * Replace StudetTpos by HalfStudentT 
    * Zero-inflated Poisson was duplicate and ZeroInflatedNegativeBinomial was missing
    * Other missing distributions were Interpolated and MvStudentT