### PR TITLE
Split benchmarks to answer one question with each

### DIFF
--- a/benchmarks/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks/benchmarks.py
@@ -4,7 +4,49 @@ import numpy as np
 import pandas as pd
 import pymc3 as pm
 import theano
+import theano.tensor as tt
 
+
+def glm_hierarchical_model(random_seed=123):
+    """Sample glm hierarchical model to use in benchmarks"""
+    np.random.seed(random_seed)
+    data = pd.read_csv(pm.get_data('radon.csv'))
+    data['log_radon'] = data['log_radon'].astype(theano.config.floatX)
+    county_idx = data.county_code.values
+
+    n_counties = len(data.county.unique())
+    with pm.Model() as model:
+        mu_a = pm.Normal('mu_a', mu=0., sd=100**2)
+        sigma_a = pm.HalfCauchy('sigma_a', 5)
+        mu_b = pm.Normal('mu_b', mu=0., sd=100**2)
+        sigma_b = pm.HalfCauchy('sigma_b', 5)
+        a = pm.Normal('a', mu=mu_a, sd=sigma_a, shape=n_counties)
+        b = pm.Normal('b', mu=mu_b, sd=sigma_b, shape=n_counties)
+        eps = pm.HalfCauchy('eps', 5)
+        radon_est = a[county_idx] + b[county_idx] * data.floor.values
+        pm.Normal('radon_like', mu=radon_est, sd=eps, observed=data.log_radon)
+    return model
+
+
+def mixture_model(random_seed=1234):
+    """Sample mixture model to use in benchmarks"""
+    np.random.seed(1234)
+    size = 1000
+    self.chains = 4
+    w = np.array([0.35, 0.4, 0.25])
+    mu = np.array([0., 2., 5.])
+    sigma = np.array([0.5, 0.5, 1.])
+    component = np.random.choice(mu.size, size=size, p=w)
+    x = np.random.normal(mu[component], sigma[component], size=size)
+
+    with pm.Model() as model:
+        w = pm.Dirichlet('w', np.ones_like(w))
+
+        mu = pm.Normal('mu', 0., 10., shape=w.size)
+        tau = pm.Gamma('tau', 1., 1., shape=w.size)
+
+        pm.NormalMixture('x_obs', w, mu, tau=tau, observed=x)
+    return model
 
 class OverheadSuite(object):
     """
@@ -67,68 +109,31 @@ class ExampleSuite(object):
             pm.sample(2000, njobs=4)
 
     def time_glm_hierarchical(self):
-        data = pd.read_csv(pm.get_data('radon.csv'))
-        data['log_radon'] = data['log_radon'].astype(theano.config.floatX)
-        county_idx = data.county_code.values
-
-        n_counties = len(data.county.unique())
-        with pm.Model():
-            mu_a = pm.Normal('mu_a', mu=0., sd=100**2)
-            sigma_a = pm.HalfCauchy('sigma_a', 5)
-            mu_b = pm.Normal('mu_b', mu=0., sd=100**2)
-            sigma_b = pm.HalfCauchy('sigma_b', 5)
-            a = pm.Normal('a', mu=mu_a, sd=sigma_a, shape=n_counties)
-            b = pm.Normal('b', mu=mu_b, sd=sigma_b, shape=n_counties)
-            eps = pm.HalfCauchy('eps', 5)
-            radon_est = a[county_idx] + b[county_idx] * data.floor.values
-            pm.Normal('radon_like', mu=radon_est, sd=eps, observed=data.log_radon)
+        with glm_hierarchical_model():
             pm.sample(draws=2000, njobs=4)
 
 
-class EffectiveSampleSizeSuite(object):
-    """Tests effective sample size per second on models
+class NUTSInitSuite(object):
+    """Tests initializations for NUTS sampler on models
     """
     timeout = 360.0
-    params = (
-        [pm.NUTS, pm.Metropolis],  # Slice too slow, don't want to tune HMC
-        ['advi', 'jitter+adapt_diag', 'advi+adapt_diag_grad'],
-    )
-    param_names = ['step', 'init']
+    params = ('adapt_diag', 'jitter+adapt_diag', 'advi+adapt_diag_grad', 'advi', 'advi_map')
 
-    def setup(self, step, init):
-        """Initialize model and get start position"""
-        np.random.seed(123)
-        self.chains = 4
-        data = pd.read_csv(pm.get_data('radon.csv'))
-        data['log_radon'] = data['log_radon'].astype(theano.config.floatX)
-        county_idx = data.county_code.values
-        n_counties = len(data.county.unique())
-        with pm.Model() as self.model:
-            mu_a = pm.Normal('mu_a', mu=0., sd=100**2)
-            sigma_a = pm.HalfCauchy('sigma_a', 5)
+    def time_glm_hierarchical_init(self, init):
+        """How long does it take to run the initialization."""
+        with glm_hierarchical_model():
+            pm.init_nuts(init=init, chains=4, progressbar=False)
 
-            mu_b = pm.Normal('mu_b', mu=0., sd=100**2)
-            sigma_b = pm.HalfCauchy('sigma_b', 5)
-
-            a = pm.Normal('a', mu=mu_a, sd=sigma_a, shape=n_counties)
-            b = pm.Normal('b', mu=mu_b, sd=sigma_b, shape=n_counties)
-            eps = pm.HalfCauchy('eps', 5)
-
-            radon_est = a[county_idx] + b[county_idx] * data.floor.values
-
-            pm.Normal('radon_like', mu=radon_est, sd=eps, observed=data.log_radon)
-            self.start, _ = pm.init_nuts(chains=self.chains, init=init)
-
-    def track_glm_hierarchical_ess(self, step, init):
-        with self.model:
+    def track_glm_hierarchical_ess(self, init):
+        with glm_hierarchical_model():
+            start, step = pm.init_nuts(init=init, chains=4, progressbar=False, random_seed=123)
             t0 = time.time()
-            trace = pm.sample(draws=20000, step=step(), njobs=4, chains=self.chains,
-                              start=self.start, random_seed=100)
+            trace = pm.sample(draws=20000, step=step, njobs=4, chains=4,
+                              start=start, random_seed=100)
             tot = time.time() - t0
         ess = pm.effective_n(trace, ('mu_a',))['mu_a']
         return ess / tot
 
-EffectiveSampleSizeSuite.track_glm_hierarchical_ess.unit = 'Effective samples per second'
 
 class EffectiveSampleSizeSuiteMarginal(object):
     """Tests effective sample size per second on models
@@ -148,24 +153,37 @@ class EffectiveSampleSizeSuiteMarginal(object):
         SIGMA = np.array([0.5, 0.5, 1.])
         component = np.random.choice(MU.size, size=N, p=W)
         x = np.random.normal(MU[component], SIGMA[component], size=N)
-
-        with pm.Model():
-            w = pm.Dirichlet('w', np.ones_like(W))
-
-            mu = pm.Normal('mu', 0., 10., shape=W.size)
-            tau = pm.Gamma('tau', 1., 1., shape=W.size)
-
-            x_obs = pm.NormalMixture('x_obs', w, mu, tau=tau, observed=x)
-            self.start, _ = pm.init_nuts(chains=self.chains, init=init)
-
-    def track_marginal_mixture_model(self, step, init):
-        with self.model:
+    def track_marginal_mixture_model_ess(self, init):
+        with mixure_model():
+            start, step = pm.init_nuts(init=init, chains=4, progressbar=False, random_seed=123)
             t0 = time.time()
-            trace = pm.sample(draws=20000, step=step(), njobs=4,
-                chains=self.chains, start=self.start, random_seed=100)
+            trace = pm.sample(draws=20000, step=step, njobs=4, chains=4,
+                              start=start, random_seed=100)
             tot = time.time() - t0
         ess = pm.effective_n(trace, ('w',))['mu']
         return ess / tot
 
-EffectiveSampleSizeSuiteMarginal.track_marginal_mixture_model.unit = 'Effective samples per second'
 
+NUTSInitSuite.track_glm_hierarchical_ess.unit = 'Effective samples per second'
+NUTSInitSuite.track_marginal_mixture_model_ess.unit = 'Effective samples per second'
+
+
+class CompareMetropolisNUTSSuite(object):
+    # None will be the "sensible default", and include initialization, but should be fastest
+    params = (None, pm.NUTS, pm.Metropolis)
+    number = 1
+    repeat = 1
+
+    def track_glm_hierarchical_ess(self, step):
+        with glm_hierarchical_model():
+            if step is not None:
+                step = step()
+            t0 = time.time()
+            trace = pm.sample(draws=20000, step=step, njobs=4, chains=4,
+                              random_seed=100)
+            tot = time.time() - t0
+        ess = pm.effective_n(trace, ('mu_a',))['mu_a']
+        return ess / tot
+
+
+CompareMetropolisNUTSSuite.track_glm_hierarchical_ess.unit = 'Effective samples per second'

--- a/benchmarks/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks/benchmarks.py
@@ -138,25 +138,6 @@ class NUTSInitSuite(object):
         ess = pm.effective_n(trace, ('mu_a',))['mu_a']
         return ess / tot
 
-
-class EffectiveSampleSizeSuiteMarginal(object):
-    """Tests effective sample size per second on models
-     """
-     timeout = 360.0
-     params = (
-         [pm.NUTS, pm.Metropolis],  # Slice too slow, don't want to tune HMC
-         ['advi', 'jitter+adapt_diag', 'advi+adapt_diag_grad'],
-     )
-     param_names = ['step', 'init']
-    def setup(self, step, init):
-        np.random.seed(1234)
-        N = 1000
-        self.chains = 4
-        W = np.array([0.35, 0.4, 0.25])
-        MU = np.array([0., 2., 5.])
-        SIGMA = np.array([0.5, 0.5, 1.])
-        component = np.random.choice(MU.size, size=N, p=W)
-        x = np.random.normal(MU[component], SIGMA[component], size=N)
     def track_marginal_mixture_model_ess(self, init):
         with mixture_model():
             start, step = pm.init_nuts(init=init, chains=4, progressbar=False, random_seed=123)
@@ -178,13 +159,14 @@ class CompareMetropolisNUTSSuite(object):
     params = (None, pm.NUTS, pm.Metropolis)
     number = 1
     repeat = 1
+    draws = 20000
 
     def track_glm_hierarchical_ess(self, step):
         with glm_hierarchical_model():
             if step is not None:
                 step = step()
             t0 = time.time()
-            trace = pm.sample(draws=10000, step=step, njobs=4, chains=4,
+            trace = pm.sample(draws=self.draws, step=step, njobs=4, chains=4,
                               random_seed=100)
             tot = time.time() - t0
         ess = pm.effective_n(trace, ('mu_a',))['mu_a']

--- a/benchmarks/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks/benchmarks.py
@@ -117,7 +117,9 @@ class NUTSInitSuite(object):
     """Tests initializations for NUTS sampler on models
     """
     timeout = 360.0
-    params = ('adapt_diag', 'jitter+adapt_diag', 'advi+adapt_diag_grad', 'advi', 'advi_map')
+    params = ('adapt_diag', 'jitter+adapt_diag', 'advi+adapt_diag_grad', 'advi_map')
+    number = 1
+    repeat = 1
 
     def time_glm_hierarchical_init(self, init):
         """How long does it take to run the initialization."""
@@ -128,7 +130,7 @@ class NUTSInitSuite(object):
         with glm_hierarchical_model():
             start, step = pm.init_nuts(init=init, chains=4, progressbar=False, random_seed=123)
             t0 = time.time()
-            trace = pm.sample(draws=20000, step=step, njobs=4, chains=4,
+            trace = pm.sample(draws=10000, step=step, njobs=4, chains=4,
                               start=start, random_seed=100)
             tot = time.time() - t0
         ess = pm.effective_n(trace, ('mu_a',))['mu_a']
@@ -169,6 +171,7 @@ NUTSInitSuite.track_marginal_mixture_model_ess.unit = 'Effective samples per sec
 
 
 class CompareMetropolisNUTSSuite(object):
+    timeout = 360.0
     # None will be the "sensible default", and include initialization, but should be fastest
     params = (None, pm.NUTS, pm.Metropolis)
     number = 1
@@ -179,7 +182,7 @@ class CompareMetropolisNUTSSuite(object):
             if step is not None:
                 step = step()
             t0 = time.time()
-            trace = pm.sample(draws=20000, step=step, njobs=4, chains=4,
+            trace = pm.sample(draws=10000, step=step, njobs=4, chains=4,
                               random_seed=100)
             tot = time.time() - t0
         ess = pm.effective_n(trace, ('mu_a',))['mu_a']


### PR DESCRIPTION
As noted by @aseyboldt in #2647 , we weren't benchmarking the right thing.  This splits up into three new benchmarks:

1. How long does each NUTS initialization method take?
2. What is the effective samples/second NUTS using each initialization method?
3. What is the effective samples/second for the default sampler (which includes initialization), `NUTS`, and `Metropolis`?

