### PR TITLE
Fix array order in advi init

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -366,7 +366,7 @@ class ValueGradFunction(object):
         if cost.ndim > 0:
             raise ValueError('Cost must be a scalar.')
 
-        self._grad_vars = grad_vars
+        self.grad_vars = grad_vars
         self._extra_vars = extra_vars
         self._extra_var_names = set(var.name for var in extra_vars)
         self._cost = cost
@@ -376,7 +376,7 @@ class ValueGradFunction(object):
         if dtype is None:
             dtype = theano.config.floatX
         self.dtype = dtype
-        for var in self._grad_vars:
+        for var in self.grad_vars:
             if not np.can_cast(var.dtype, self.dtype, casting):
                 raise TypeError('Invalid dtype for variable %s. Can not '
                                 'cast to %s with casting rule %s.'

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -206,13 +206,22 @@ class PopulationArrayStepShared(ArrayStepShared):
 
 class GradientSharedStep(BlockedStep):
     def __init__(self, vars, model=None, blocked=True,
-                 dtype=None, **theano_kwargs):
+                 dtype=None, logp_dlogp_function=None, **theano_kwargs):
         model = modelcontext(model)
-        self.vars = vars
         self.blocked = blocked
-
-        self._logp_dlogp_func = model.logp_dlogp_function(
-            vars, dtype=dtype, **theano_kwargs)
+        if vars is None:
+            if logp_dlogp_function is None:
+                raise ValueError('One of logp_dlogp_function and vars has '
+                                 'to be specified.')
+            self.vars = None
+            self._logp_dlogp_func = logp_dlogp_function
+        else:
+            if logp_dlogp_function is not None:
+                raise ValueError('Only one of logp_dlogp_function and vars can '
+                                 'be specified.')
+            self.vars = vars
+            self._logp_dlogp_func = model.logp_dlogp_function(
+                vars, dtype=dtype, **theano_kwargs)
 
     def step(self, point):
         self._logp_dlogp_func.set_extra_values(point)

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -15,7 +15,8 @@ class BaseHMC(arraystep.GradientSharedStep):
 
     def __init__(self, vars=None, scaling=None, step_scale=0.25, is_cov=False,
                  model=None, blocked=True, potential=None,
-                 integrator="leapfrog", dtype=None, **theano_kwargs):
+                 integrator="leapfrog", dtype=None,
+                 logp_dlogp_function=None, **theano_kwargs):
         """Set up Hamiltonian samplers with common structures.
 
         Parameters
@@ -38,12 +39,20 @@ class BaseHMC(arraystep.GradientSharedStep):
         """
         model = modelcontext(model)
 
-        if vars is None:
+        if vars is None and logp_dlogp_function is None:
             vars = model.cont_vars
-        vars = inputvars(vars)
+        elif vars is not None and logp_dlogp_function is not None:
+            raise ValueError('Specify only one of logp_dlogp_function and vars')
+        elif logp_dlogp_function is not None:
+            vars = logp_dlogp_function.grad_vars
+
+        if vars is not None:
+            vars = inputvars(vars)
 
         super(BaseHMC, self).__init__(vars, blocked=blocked, model=model,
-                                      dtype=dtype, **theano_kwargs)
+                                      dtype=dtype,
+                                      logp_dlogp_function=logp_dlogp_function,
+                                      **theano_kwargs)
 
         size = self._logp_dlogp_func.size
 

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -11,7 +11,6 @@ from pymc3.step_methods import (NUTS, BinaryGibbsMetropolis, CategoricalGibbsMet
                                 MultivariateNormalProposal, HamiltonianMC,
                                 EllipticalSlice, smc, DEMetropolis)
 from pymc3.theanof import floatX
-from pymc3 import SamplingError
 from pymc3.distributions import (
     Binomial, Normal, Bernoulli, Categorical, Beta, HalfNormal)
 
@@ -423,7 +422,8 @@ class TestPopulationSamplers(object):
         pass
 
 
-@pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+@pytest.mark.xfail(condition=(theano.config.floatX == "float32"),
+                   reason="Fails on float32")
 class TestNutsCheckTrace(object):
     def test_multiple_samplers(self):
         with Model():


### PR DESCRIPTION
There is no guaranty that the order of variables is the same in `model.array_to_dict` and `model.logp_dlogp_function().array_to_dict`. I think this is usually the case, but we should use the right one during `init_nuts`.
This also adds `init='jitter+adapt_diag_grad'`. (before, we only had `advi+adapt_diag_grad`.