### PR TITLE
Implement continuous distribution CDF methods

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,8 @@
 
 - Track the model log-likelihood as a sampler stat for NUTS and HMC samplers
   (accessible as `trace.get_sampler_stats('model_logp')`) (#3134)
+- Add Incomplete Beta function `incomplete_beta(a, b, value)` 
+- Add log CDF functions to continuous distributions: `Beta`, `Cauchy`, `ExGaussian`, `Exponential`, `Flat`, `Gumbel`, `HalfCauchy`, `HalfFlat`, `HalfNormal`, `Laplace`, `Logistic`, `Lognormal`, `Normal`, `Pareto`, `StudentT`, `Triangular`, `Uniform`, `Wald`, `Weibull`.
 
 ### Maintenance
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2655,6 +2655,28 @@ class Weibull(PositiveContinuous):
                                                                 get_variable_name(alpha),
                                                                 get_variable_name(beta))
 
+    def logcdf(self, value):
+        '''
+        Compute the log CDF for the Weibull distribution
+
+        References
+        ----------
+        .. [Machler2012] Martin Mächler (2012).
+            "Accurately computing log(1-exp(-|a|)) Assessed by the Rmpfr
+            package"
+        '''
+        alpha = self.alpha
+        beta = self.beta
+        a = (value / beta)**alpha
+        return tt.switch(
+            tt.le(value, 0.0),
+            -np.inf,
+            tt.switch(
+                tt.le(a, tt.log(2.0)),
+                tt.log(-tt.expm1(-a)),
+                tt.log1p(-tt.exp(-a)))
+        )
+
 
 class HalfStudentT(PositiveContinuous):
     R"""

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -239,6 +239,18 @@ class Uniform(BoundedContinuous):
         return r'${} \sim \text{{Uniform}}(\mathit{{lower}}={},~\mathit{{upper}}={})$'.format(
             name, get_variable_name(lower), get_variable_name(upper))
 
+    def logcdf(self, value):
+        return tt.switch(
+            tt.or_(tt.lt(value, self.lower), tt.gt(value, self.upper)),
+            -np.inf,
+            tt.switch(
+                tt.eq(value, self.upper),
+                0,
+                tt.log((value - self.lower)) -
+                tt.log((self.upper - self.lower))
+            )
+        )
+
 
 class Flat(Continuous):
     """

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -19,8 +19,8 @@ from pymc3.util import get_variable_name
 from .special import log_i0
 from ..math import invlogit, logit, logdiffexp
 from .dist_math import (
-    bound, logpow, gammaln, betaln, std_cdf, alltrue_elemwise,
-    SplineWrapper, i0e, normal_lcdf, normal_lccdf
+    alltrue_elemwise, betaln, bound, gammaln, i0e, logpow, normal_lccdf,
+    normal_lcdf, SplineWrapper, std_cdf, zvalue,
 )
 from .distribution import Continuous, draw_values, generate_samples
 
@@ -456,6 +456,9 @@ class Normal(Continuous):
         return r'${} \sim \text{{Normal}}(\mathit{{mu}}={},~\mathit{{sd}}={})$'.format(name,
                                                                 get_variable_name(mu),
                                                                 get_variable_name(sd))
+
+    def logcdf(self, value):
+        return normal_lcdf(self.mu, self.sd, value)
 
 
 class TruncatedNormal(BoundedContinuous):

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1571,6 +1571,22 @@ class Lognormal(PositiveContinuous):
                                                                 get_variable_name(mu),
                                                                 get_variable_name(tau))
 
+    def logcdf(self, value):
+        mu = self.mu
+        sd = self.sd
+        z = zvalue(tt.log(value), mu=mu, sd=sd)
+
+        return tt.switch(
+            tt.le(value, 0),
+            -np.inf,
+            tt.switch(
+                tt.lt(z, -1.0),
+                tt.log(tt.erfcx(-z / tt.sqrt(2.)) / 2.) -
+                tt.sqr(z) / 2,
+                tt.log1p(-tt.erfc(z / tt.sqrt(2.)) / 2.)
+            )
+        )
+
 
 class StudentT(Continuous):
     R"""

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2217,6 +2217,15 @@ class HalfCauchy(PositiveContinuous):
         return r'${} \sim \text{{HalfCauchy}}(\mathit{{beta}}={})$'.format(name,
                                                                 get_variable_name(beta))
 
+    def logcdf(self, value):
+        return tt.switch(
+            tt.le(value, 0),
+            -np.inf,
+            tt.log(
+                2 * tt.arctan(value / self.beta) / np.pi
+            ))
+
+
 class Gamma(PositiveContinuous):
     R"""
     Gamma log-likelihood.

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1970,6 +1970,11 @@ class Cauchy(Continuous):
                                                                 get_variable_name(alpha),
                                                                 get_variable_name(beta))
 
+    def logcdf(self, value):
+        return tt.log(
+            0.5 + tt.arctan((value - self.alpha) / self.beta) / np.pi
+        )
+
 
 class HalfCauchy(PositiveContinuous):
     R"""

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2947,6 +2947,30 @@ class ExGaussian(Continuous):
                                                                 get_variable_name(sigma),
                                                                 get_variable_name(nu))
 
+    def logcdf(self, value):
+        """
+        Compute the log CDF for the ExGaussian distribution
+
+        References
+        ----------
+        .. [Rigby2005] R.A. Rigby (2005).
+           "Generalized additive models for location, scale and shape"
+           http://dx.doi.org/10.1111/j.1467-9876.2005.00510.x
+        """
+        mu = self.mu
+        sigma = self.sigma
+        sigma_2 = sigma**2
+        nu = self.nu
+        z = value - mu - sigma_2/nu
+        return tt.switch(
+            tt.gt(nu, 0.05 * sigma),
+            tt.log(std_cdf((value - mu)/sigma) -
+                   std_cdf(z/sigma) * tt.exp(
+                       ((mu + (sigma_2/nu))**2 -
+                        (mu**2) -
+                        2 * value * ((sigma_2)/nu))/(2 * sigma_2))),
+            normal_lcdf(mu, sigma, value))
+
 
 class VonMises(Continuous):
     R"""

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -350,6 +350,17 @@ class HalfFlat(PositiveContinuous):
         name = r'\text{%s}' % name
         return r'${} \sim \text{{HalfFlat}}()$'.format(name)
 
+    def logcdf(self, value):
+        return tt.switch(
+            tt.lt(value, np.inf),
+            -np.inf,
+            tt.switch(
+                tt.eq(value, np.inf),
+                0,
+                -np.inf
+            )
+        )
+
 
 class Normal(Continuous):
     R"""

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3434,6 +3434,12 @@ class Gumbel(Continuous):
                                                                 get_variable_name(mu),
                                                                 get_variable_name(beta))
 
+    def logcdf(self, value):
+        beta = self.beta
+        mu = self.mu
+
+        return -tt.exp(-(value - mu)/beta)
+
 
 class Rice(PositiveContinuous):
     R"""

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -296,6 +296,17 @@ class Flat(Continuous):
         name = r'\text{%s}' % name
         return r'${} \sim \text{{Flat}}()$'.format(name)
 
+    def logcdf(self, value):
+        return tt.switch(
+            tt.eq(value, -np.inf),
+            -np.inf,
+            tt.switch(
+                tt.eq(value, np.inf),
+                0,
+                tt.log(0.5)
+            )
+        )
+
 
 class HalfFlat(PositiveContinuous):
     """Improper flat prior over the positive reals."""

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1846,6 +1846,15 @@ class StudentT(Continuous):
                                                                 get_variable_name(mu),
                                                                 get_variable_name(lam))
 
+    def logcdf(self, value):
+        nu = self.nu
+        mu = self.mu
+        sd = self.sd
+        t = (value - mu)/sd
+        sqrt_t2_nu = tt.sqrt(t**2 + nu)
+        x = (t + sqrt_t2_nu)/(2.0 * sqrt_t2_nu)
+        return tt.log(incomplete_beta(nu/2., nu/2., x))
+
 
 class Pareto(Continuous):
     R"""

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1874,6 +1874,20 @@ class Pareto(Continuous):
                                                                 get_variable_name(alpha),
                                                                 get_variable_name(m))
 
+    def logcdf(self, value):
+        m = self.m
+        alpha = self.alpha
+        arg = (m / value) ** alpha
+        return tt.switch(
+            tt.lt(value, m),
+            -np.inf,
+            tt.switch(
+                tt.le(arg, 1e-5),
+                tt.log1p(-arg),
+                tt.log(1 - arg)
+            )
+        )
+
 
 class Cauchy(Continuous):
     R"""

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -781,6 +781,15 @@ class HalfNormal(PositiveContinuous):
         return r'${} \sim \text{{HalfNormal}}(\mathit{{sd}}={})$'.format(name,
                                                                          get_variable_name(sd))
 
+    def logcdf(self, value):
+        sd = self.sd
+        z = zvalue(value, mu=0, sd=sd)
+        return tt.switch(
+            tt.lt(z, -1.0),
+            tt.log(tt.erfcx(-z / tt.sqrt(2.))) - tt.sqr(z),
+            tt.log1p(-tt.erfc(z / tt.sqrt(2.)))
+        )
+
 
 class Wald(PositiveContinuous):
     R"""

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1401,6 +1401,30 @@ class Exponential(PositiveContinuous):
         return r'${} \sim \text{{Exponential}}(\mathit{{lam}}={})$'.format(name,
                                                                 get_variable_name(lam))
 
+    def logcdf(self, value):
+        """
+        Compute the log CDF for the Exponential distribution
+
+        References
+        ----------
+        .. [Machler2012] Martin Mächler (2012).
+            "Accurately computing log(1-exp(-|a|)) Assessed by the Rmpfr
+            package"
+        """
+        value = floatX(tt.as_tensor(value))
+        lam = self.lam
+        a = lam * value
+        return tt.switch(
+            tt.le(value, 0.0),
+            -np.inf,
+            tt.switch(
+                tt.le(a, tt.log(2.0)),
+                tt.log(-tt.expm1(-a)),
+                tt.log1p(-tt.exp(-a)),
+            )
+        )
+
+
 class Laplace(Continuous):
     R"""
     Laplace log-likelihood.

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1448,6 +1448,20 @@ class Laplace(Continuous):
                                                                 get_variable_name(mu),
                                                                 get_variable_name(b))
 
+    def logcdf(self, value):
+        a = self.mu
+        b = self.b
+        y = (value - a) / b
+        return tt.switch(
+            tt.le(value, a),
+            tt.log(0.5) + y,
+            tt.switch(
+                tt.gt(y, 1),
+                tt.log1p(-0.5 * tt.exp(-y)),
+                tt.log(1 - 0.5 * tt.exp(-y))
+            )
+        )
+
 
 class Lognormal(PositiveContinuous):
     R"""

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3630,6 +3630,30 @@ class Logistic(Continuous):
                                                                 get_variable_name(mu),
                                                                 get_variable_name(s))
 
+    def logcdf(self, value):
+        """
+        Compute the log CDF for the Logistic distribution
+
+        References
+        ----------
+        .. [Machler2012] Martin Mächler (2012).
+            "Accurately computing log(1-exp(-|a|)) Assessed by the Rmpfr
+            package"
+        """
+        mu = self.mu
+        s = self.s
+        a = -(value - mu)/s
+        return - tt.switch(
+            tt.le(a, -37),
+            tt.exp(a),
+            tt.switch(
+                tt.le(a, 18),
+                tt.log1p(tt.exp(a)),
+                tt.switch(
+                    tt.le(a, 33.3),
+                    tt.exp(-a) + a,
+                    a)))
+
 
 class LogitNormal(UnitContinuous):
     R"""

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3152,6 +3152,24 @@ class Triangular(BoundedContinuous):
                                                                 get_variable_name(lower),
                                                                 get_variable_name(upper))
 
+    def logcdf(self, value):
+        l = self.lower
+        u = self.upper
+        c = self.c
+        return tt.switch(
+            tt.le(value, l),
+            -np.inf,
+            tt.switch(
+                tt.le(value, c),
+                tt.log(((value - l) ** 2) / ((u - l) * (c - l))),
+                tt.switch(
+                    tt.lt(value, u),
+                    tt.log1p(-((u - value) ** 2) / ((u - l) * (u - c))),
+                    0
+                )
+            )
+        )
+
 
 class Gumbel(Continuous):
     R"""

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -11,6 +11,8 @@ import theano.tensor as tt
 import theano
 from theano.scalar import UnaryScalarOp, upgrade_to_float
 from theano.tensor.slinalg import Cholesky
+from theano.scan_module import until
+from theano import scan
 
 from .special import gammaln
 from pymc3.theanof import floatX
@@ -314,3 +316,189 @@ def zvalue(value, sd, mu):
     Calculate the z-value for a normal distribution.
     """
     return (value - mu) / sd
+
+
+def incomplete_beta_cfe(a, b, x, small):
+    '''Incomplete beta continued fraction expansions
+    based on Cephes library by Steve Moshier (incbet.c).
+    small: Choose element-wise which continued fraction expansion to use.
+    '''
+    BIG = tt.constant(4.503599627370496e15, dtype='float64')
+    BIGINV = tt.constant(2.22044604925031308085e-16, dtype='float64')
+    THRESH = tt.constant(3. * np.MachAr().eps, dtype='float64')
+
+    zero = tt.constant(0., dtype='float64')
+    one = tt.constant(1., dtype='float64')
+    two = tt.constant(2., dtype='float64')
+
+    r = one
+    k1 = a
+    k3 = a
+    k4 = a + one
+    k5 = one
+    k8 = a + two
+
+    k2 = tt.switch(small, a + b, b - one)
+    k6 = tt.switch(small, b - one, a + b)
+    k7 = tt.switch(small, k4, a + one)
+    k26update = tt.switch(small, one, -one)
+    x = tt.switch(small, x, x / (one - x))
+
+    pkm2 = zero
+    qkm2 = one
+    pkm1 = one
+    qkm1 = one
+    r = one
+
+    def _step(
+            i,
+            pkm1, pkm2, qkm1, qkm2,
+            k1, k2, k3, k4, k5, k6, k7, k8, r
+    ):
+        xk = -(x * k1 * k2) / (k3 * k4)
+        pk = pkm1 + pkm2 * xk
+        qk = qkm1 + qkm2 * xk
+        pkm2 = pkm1
+        pkm1 = pk
+        qkm2 = qkm1
+        qkm1 = qk
+
+        xk = (x * k5 * k6) / (k7 * k8)
+        pk = pkm1 + pkm2 * xk
+        qk = qkm1 + qkm2 * xk
+        pkm2 = pkm1
+        pkm1 = pk
+        qkm2 = qkm1
+        qkm1 = qk
+
+        old_r = r
+        r = tt.switch(tt.eq(qk, zero), r, pk/qk)
+
+        k1 += one
+        k2 += k26update
+        k3 += two
+        k4 += two
+        k5 += one
+        k6 -= k26update
+        k7 += two
+        k8 += two
+
+        big_cond = tt.gt(tt.abs_(qk) + tt.abs_(pk), BIG)
+        biginv_cond = tt.or_(
+            tt.lt(tt.abs_(qk), BIGINV),
+            tt.lt(tt.abs_(pk), BIGINV)
+        )
+
+        pkm2 = tt.switch(big_cond, pkm2 * BIGINV, pkm2)
+        pkm1 = tt.switch(big_cond, pkm1 * BIGINV, pkm1)
+        qkm2 = tt.switch(big_cond, qkm2 * BIGINV, qkm2)
+        qkm1 = tt.switch(big_cond, qkm1 * BIGINV, qkm1)
+
+        pkm2 = tt.switch(biginv_cond, pkm2 * BIG, pkm2)
+        pkm1 = tt.switch(biginv_cond, pkm1 * BIG, pkm1)
+        qkm2 = tt.switch(biginv_cond, qkm2 * BIG, qkm2)
+        qkm1 = tt.switch(biginv_cond, qkm1 * BIG, qkm1)
+
+        return ((pkm1, pkm2, qkm1, qkm2,
+                 k1, k2, k3, k4, k5, k6, k7, k8, r),
+                until(tt.abs_(old_r - r) < (THRESH * tt.abs_(r))))
+
+    (pkm1, pkm2, qkm1, qkm2,
+     k1, k2, k3, k4, k5, k6, k7, k8, r), _ = scan(
+        _step,
+        sequences=[tt.arange(0, 300)],
+        outputs_info=[
+            e for e in
+            tt.cast((pkm1, pkm2, qkm1, qkm2,
+                     k1, k2, k3, k4, k5, k6, k7, k8, r),
+                    'float64')
+        ]
+    )
+
+    return r[-1]
+
+
+def incomplete_beta_ps(a, b, value):
+    '''Power series for incomplete beta
+    Use when b*x is small and value not too close to 1.
+    Based on Cephes library by Steve Moshier (incbet.c)
+    '''
+    one = tt.constant(1, dtype='float64')
+    ai = one / a
+    u = (one - b) * value
+    t1 = u / (a + one)
+    t = u
+    threshold = np.MachAr().eps * ai
+    s = tt.constant(0, dtype='float64')
+
+    def _step(i, t, s):
+        t *= (i - b) * value / i
+        step = t / (a + i)
+        s += step
+        return ((t, s), until(tt.abs_(step) < threshold))
+
+    (t, s), _ = scan(
+        _step,
+        sequences=[tt.arange(2, 302)],
+        outputs_info=[
+            e for e in
+            tt.cast((t, s),
+                    'float64')
+        ]
+    )
+
+    s = s[-1] + t1 + ai
+
+    t = (
+        gammaln(a + b) - gammaln(a) - gammaln(b) +
+        a * tt.log(value) +
+        tt.log(s)
+    )
+    return tt.exp(t)
+
+
+def incomplete_beta(a, b, value):
+    '''Incomplete beta implementation
+    Power series and continued fraction expansions chosen for best numerical
+    convergence across the board based on inputs.
+    '''
+    machep = tt.constant(np.MachAr().eps, dtype='float64')
+    one = tt.constant(1, dtype='float64')
+    w = one - value
+
+    ps = incomplete_beta_ps(a, b, value)
+
+    flip = tt.gt(value, (a / (a + b)))
+    aa, bb = a, b
+    a = tt.switch(flip, bb, aa)
+    b = tt.switch(flip, aa, bb)
+    xc = tt.switch(flip, value, w)
+    x = tt.switch(flip, w, value)
+
+    tps = incomplete_beta_ps(a, b, x)
+    tps = tt.switch(tt.le(tps, machep), one - machep, one - tps)
+
+    # Choose which continued fraction expansion for best convergence.
+    small = tt.lt(x * (a + b - 2.0) - (a - one), 0.0)
+    cfe = incomplete_beta_cfe(a, b, x, small)
+    w = tt.switch(small, cfe, cfe / xc)
+
+    # Direct incomplete beta accounting for flipped a, b.
+    t = tt.exp(
+        a * tt.log(x) + b * tt.log(xc) +
+        gammaln(a + b) - gammaln(a) - gammaln(b) +
+        tt.log(w / a)
+    )
+
+    t = tt.switch(
+        flip,
+        tt.switch(tt.le(t, machep), one - machep, one - t),
+        t
+    )
+    return tt.switch(
+        tt.and_(flip, tt.and_(tt.le((b * x), one), tt.le(x, 0.95))),
+        tps,
+        tt.switch(
+            tt.and_(tt.le(b * value, one), tt.le(value, 0.95)),
+            ps,
+            t))

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -308,3 +308,9 @@ def random_choice(*args, **kwargs):
         samples = np.random.choice(k, p=p, size=size)
     return samples
 
+
+def zvalue(value, sd, mu):
+    """
+    Calculate the z-value for a normal distribution.
+    """
+    return (value - mu) / sd

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -684,6 +684,8 @@ class TestMatchesScipy(SeededTest):
     def test_half_cauchy(self):
         self.pymc3_matches_scipy(HalfCauchy, Rplus, {'beta': Rplusbig},
                                  lambda value, beta: sp.halfcauchy.logpdf(value, scale=beta))
+        self.check_logcdf(HalfCauchy, Rplus, {'beta': Rplusbig},
+                          lambda value, beta: sp.halfcauchy.logcdf(value, scale=beta))
 
     def test_gamma(self):
         self.pymc3_matches_scipy(

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -713,6 +713,9 @@ class TestMatchesScipy(SeededTest):
         self.pymc3_matches_scipy(Weibull, Rplus, {'alpha': Rplusbig, 'beta': Rplusbig},
                                  lambda value, alpha, beta: sp.exponweib.logpdf(value, 1, alpha, scale=beta),
                                  )
+        self.check_logcdf(Weibull, Rplus, {'alpha': Rplusbig, 'beta': Rplusbig},
+                          lambda value, alpha, beta:
+                          sp.exponweib.logcdf(value, 1, alpha, scale=beta),)
 
     def test_half_studentt(self):
         # this is only testing for nu=1 (halfcauchy)

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -657,6 +657,8 @@ class TestMatchesScipy(SeededTest):
     def test_cauchy(self):
         self.pymc3_matches_scipy(Cauchy, R, {'alpha': R, 'beta': Rplusbig},
                                  lambda value, alpha, beta: sp.cauchy.logpdf(value, alpha, beta))
+        self.check_logcdf(Cauchy, R, {'alpha': R, 'beta': Rplusbig},
+                          lambda value, alpha, beta: sp.cauchy.logcdf(value, alpha, beta))
 
     def test_half_cauchy(self):
         self.pymc3_matches_scipy(HalfCauchy, Rplus, {'beta': Rplusbig},

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -668,6 +668,8 @@ class TestMatchesScipy(SeededTest):
     def test_t(self):
         self.pymc3_matches_scipy(StudentT, R, {'nu': Rplus, 'mu': R, 'lam': Rplus},
                                  lambda value, nu, mu, lam: sp.t.logpdf(value, nu, mu, lam**-0.5))
+        self.check_logcdf(StudentT, R, {'nu': Rplus, 'mu': R, 'lam': Rplus},
+                          lambda value, nu, mu, lam: sp.t.logcdf(value, nu, mu, lam**-0.5))
 
     def test_cauchy(self):
         self.pymc3_matches_scipy(Cauchy, R, {'alpha': R, 'beta': Rplusbig},

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -539,6 +539,10 @@ class TestMatchesScipy(SeededTest):
         with Model():
             x = Flat('a')
             assert_allclose(x.tag.test_value, 0)
+        self.check_logcdf(Flat, Runif, {}, lambda value: np.log(0.5))
+        # Check infinite cases individually.
+        assert 0. == Flat.dist().logcdf(np.inf).tag.test_value
+        assert -np.inf == Flat.dist().logcdf(-np.inf).tag.test_value
 
     def test_half_flat(self):
         self.pymc3_matches_scipy(HalfFlat, Rplus, {}, lambda value: 0)

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -511,6 +511,8 @@ class TestMatchesScipy(SeededTest):
         self.pymc3_matches_scipy(
             Uniform, Runif, {'lower': -Rplusunif, 'upper': Rplusunif},
             lambda value, lower, upper: sp.uniform.logpdf(value, lower, upper - lower))
+        self.check_logcdf(Uniform, Runif, {'lower': -Rplusunif, 'upper': Rplusunif},
+                          lambda value, lower, upper: sp.uniform.logcdf(value, lower, upper - lower))
 
     def test_triangular(self):
         self.pymc3_matches_scipy(

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -550,6 +550,10 @@ class TestMatchesScipy(SeededTest):
             x = HalfFlat('a', shape=2)
             assert_allclose(x.tag.test_value, 1)
             assert x.tag.test_value.shape == (2,)
+        self.check_logcdf(HalfFlat, Runif, {}, lambda value: -np.inf)
+        # Check infinite cases individually.
+        assert 0. == HalfFlat.dist().logcdf(np.inf).tag.test_value
+        assert -np.inf == HalfFlat.dist().logcdf(-np.inf).tag.test_value
 
     def test_normal(self):
         self.pymc3_matches_scipy(Normal, R, {'mu': R, 'sd': Rplus},

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1134,6 +1134,9 @@ class TestMatchesScipy(SeededTest):
         self.pymc3_matches_scipy(Logistic, R, {'mu': R, 's': Rplus},
                                  lambda value, mu, s: sp.logistic.logpdf(value, mu, s),
                                  decimal=select_by_precision(float64=6, float32=1))
+        self.check_logcdf(Logistic, R, {'mu': R, 's': Rplus},
+                          lambda value, mu, s: sp.logistic.logcdf(value, mu, s),
+                          decimal=select_by_precision(float64=6, float32=1))
 
     def test_logitnormal(self):
         self.pymc3_matches_scipy(LogitNormal, Unit, {'mu': R, 'sd': Rplus},

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -573,6 +573,8 @@ class TestMatchesScipy(SeededTest):
                                  lambda value, sd: sp.halfnorm.logpdf(value, scale=sd),
                                  decimal=select_by_precision(float64=6, float32=-1)
                                  )
+        self.check_logcdf(HalfNormal, Rplus, {'sd': Rplus},
+                          lambda value, sd: sp.halfnorm.logcdf(value, scale=sd))
 
     def test_chi_squared(self):
         self.pymc3_matches_scipy(ChiSquared, Rplus, {'nu': Rplusdunif},

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -686,6 +686,8 @@ class TestMatchesScipy(SeededTest):
     def test_pareto(self):
         self.pymc3_matches_scipy(Pareto, Rplus, {'alpha': Rplusbig, 'm': Rplusbig},
                                  lambda value, alpha, m: sp.pareto.logpdf(value, alpha, scale=m))
+        self.check_logcdf(Pareto, Rplus, {'alpha': Rplusbig, 'm': Rplusbig},
+                          lambda value, alpha, m: sp.pareto.logcdf(value, alpha, scale=m))
 
     @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32 due to inf issues")
     def test_weibull(self):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -645,6 +645,8 @@ class TestMatchesScipy(SeededTest):
         self.pymc3_matches_scipy(
             Lognormal, Rplus, {'mu': R, 'tau': Rplusbig},
             lambda value, mu, tau: floatX(sp.lognorm.logpdf(value, tau**-.5, 0, np.exp(mu))))
+        self.check_logcdf(Lognormal, Rplus, {'mu': R, 'tau': Rplusbig},
+                          lambda value, mu, tau: sp.lognorm.logcdf(value, tau**-.5, 0, np.exp(mu)))
 
     def test_t(self):
         self.pymc3_matches_scipy(StudentT, R, {'nu': Rplus, 'mu': R, 'lam': Rplus},

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1126,6 +1126,10 @@ class TestMatchesScipy(SeededTest):
             return floatX(sp.gumbel_r.logpdf(value, loc=mu, scale=beta))
         self.pymc3_matches_scipy(Gumbel, R, {'mu': R, 'beta': Rplusbig}, gumbel)
 
+        def gumbellcdf(value, mu, beta):
+            return floatX(sp.gumbel_r.logcdf(value, loc=mu, scale=beta))
+        self.check_logcdf(Gumbel, R, {'mu': R, 'beta': Rplusbig}, gumbellcdf)
+
     def test_logistic(self):
         self.pymc3_matches_scipy(Logistic, R, {'mu': R, 's': Rplus},
                                  lambda value, mu, s: sp.logistic.logpdf(value, mu, s),

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -518,6 +518,8 @@ class TestMatchesScipy(SeededTest):
         self.pymc3_matches_scipy(
             Triangular, Runif, {'lower': -Rplusunif, 'c': Runif, 'upper': Rplusunif},
             lambda value, c, lower, upper: sp.triang.logpdf(value, c-lower, lower, upper-lower))
+        self.check_logcdf(Triangular, Runif, {'lower': -Rplusunif, 'c': Runif, 'upper': Rplusunif},
+                          lambda value, c, lower, upper: sp.triang.logcdf(value, c-lower, lower, upper-lower))
 
     def test_bound_normal(self):
         PositiveNormal = Bound(Normal, lower=0.)

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1115,6 +1115,25 @@ class TestMatchesScipy(SeededTest):
         pt = {'eg': value}
         assert_almost_equal(model.fastlogp(pt), logp, decimal=select_by_precision(float64=6, float32=2), err_msg=str(pt))
 
+    @pytest.mark.parametrize('value,mu,sigma,nu,logcdf', [
+        (0.5, -50.000, 0.500, 0.500, 0.0000000),
+        (1.0, -1.000, 0.001, 0.001, 0.0000000),
+        (2.0, 0.001, 1.000, 1.000, -0.2365674),
+        (5.0, 0.500, 2.500, 2.500, -0.2886489),
+        (7.5, 2.000, 5.000, 5.000, -0.5655104),
+        (15.0, 5.000, 7.500, 7.500, -0.4545255),
+        (50.0, 50.000, 10.000, 10.000, -1.433714),
+        (1000.0, 500.000, 10.000, 20.000, -1.573708e-11),
+    ])
+    def test_ex_gaussian_cdf(self, value, mu, sigma, nu, logcdf):
+        """Log probabilities calculated using the pexGAUS function from the R package gamlss.
+        See e.g., doi: 10.1111/j.1467-9876.2005.00510.x, or http://www.gamlss.org/."""
+        assert_almost_equal(
+            ExGaussian.dist(mu=mu, sigma=sigma, nu=nu).logcdf(value).tag.test_value,
+            logcdf,
+            decimal=select_by_precision(float64=6, float32=2),
+            err_msg=str((value, mu, sigma, nu, logcdf)))
+
     @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
     def test_vonmises(self):
         self.pymc3_matches_scipy(

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -588,11 +588,14 @@ class TestMatchesScipy(SeededTest):
         self.pymc3_matches_scipy(ChiSquared, Rplus, {'nu': Rplusdunif},
                                  lambda value, nu: sp.chi2.logpdf(value, df=nu))
 
+    @pytest.mark.xfail(reason="Poor CDF in SciPy. See scipy/scipy#869 for details.")
     def test_wald_scipy(self):
-        self.pymc3_matches_scipy(Wald, Rplus, {'mu': Rplus},
-                                 lambda value, mu: sp.invgauss.logpdf(value, mu),
+        self.pymc3_matches_scipy(Wald, Rplus, {'mu': Rplus, 'alpha': Rplus},
+                                 lambda value, mu, alpha: sp.invgauss.logpdf(value, mu=mu, loc=alpha),
                                  decimal=select_by_precision(float64=6, float32=1)
                                  )
+        self.check_logcdf(Wald, Rplus, {'mu': Rplus, 'alpha': Rplus},
+                          lambda value, mu, alpha: sp.invgauss.logcdf(value, mu=mu, loc=alpha))
 
     @pytest.mark.parametrize('value,mu,lam,phi,alpha,logp', [
         (.5, .001, .5, None, 0., -124500.7257914),

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -637,6 +637,8 @@ class TestMatchesScipy(SeededTest):
     def test_exponential(self):
         self.pymc3_matches_scipy(Exponential, Rplus, {'lam': Rplus},
                                  lambda value, lam: sp.expon.logpdf(value, 0, 1 / lam))
+        self.check_logcdf(Exponential, Rplus, {'lam': Rplus},
+                          lambda value, lam: sp.expon.logcdf(value, 0, 1 / lam))
 
     def test_geometric(self):
         self.pymc3_matches_scipy(Geometric, Nat, {'p': Unit},

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -642,6 +642,8 @@ class TestMatchesScipy(SeededTest):
     def test_laplace(self):
         self.pymc3_matches_scipy(Laplace, R, {'mu': R, 'b': Rplus},
                                  lambda value, mu, b: sp.laplace.logpdf(value, mu, b))
+        self.check_logcdf(Laplace, R, {'mu': R, 'b': Rplus},
+                          lambda value, mu, b: sp.laplace.logcdf(value, mu, b))
 
     def test_lognormal(self):
         self.pymc3_matches_scipy(

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -627,6 +627,8 @@ class TestMatchesScipy(SeededTest):
         self.pymc3_matches_scipy(Beta, Unit, {'alpha': Rplus, 'beta': Rplus},
                                  lambda value, alpha, beta: sp.beta.logpdf(value, alpha, beta))
         self.pymc3_matches_scipy(Beta, Unit, {'mu': Unit, 'sd': Rplus}, beta_mu_sd)
+        self.check_logcdf(Beta, Unit, {'alpha': Rplus, 'beta': Rplus},
+                                lambda value, alpha, beta: sp.beta.logcdf(value, alpha, beta))
 
     def test_kumaraswamy(self):
         # Scipy does not have a built-in Kumaraswamy pdf


### PR DESCRIPTION
This completes the work started in #2048 and continued in #2073 and includes #2678, but rebased on top of a recent `master` and in more compact commits.

These can then be used to more adequately implement censored distributions as described in #1867 and #1864 .