### PR TITLE
Add rtd theme to requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ recommonmark>=0.4.0
 scipy>=0.12.0
 sphinx-autobuild==0.7.1
 sphinx>=1.5.5
+sphinx-rtd-theme==0.2.4


### PR DESCRIPTION
Turns out the alabaster theme is the fallback -- this installs the `rtd` theme so that it builds just like it used to with the right navbar.  Will work on getting the same navbar in the `alabaster` theme...