### PR TITLE
Make LaTeX repr a little prettier

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -178,9 +178,9 @@ class Uniform(Continuous):
             dist = self
         lower = dist.lower
         upper = dist.upper
-        return r'${} \sim \text{{Uniform}}(\mathit{{lower}}={}, \mathit{{upper}}={})$'.format(name,
-                                                                get_variable_name(lower),
-                                                                get_variable_name(upper))
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Uniform}}(\mathit{{lower}}={},~\mathit{{upper}}={})$'.format(
+            name, get_variable_name(lower), get_variable_name(upper))
 
 
 class Flat(Continuous):
@@ -200,6 +200,7 @@ class Flat(Continuous):
         return tt.zeros_like(value)
 
     def _repr_latex_(self, name=None, dist=None):
+        name = r'\text{%s}' % name
         return r'${} \sim \text{{Flat}}()$'.format(name)
 
 
@@ -217,6 +218,7 @@ class HalfFlat(PositiveContinuous):
         return bound(tt.zeros_like(value), value > 0)
 
     def _repr_latex_(self, name=None, dist=None):
+        name = r'\text{%s}' % name
         return r'${} \sim \text{{HalfFlat}}()$'.format(name)
 
 
@@ -304,7 +306,8 @@ class Normal(Continuous):
             dist = self
         sd = dist.sd
         mu = dist.mu
-        return r'${} \sim \text{{Normal}}(\mathit{{mu}}={}, \mathit{{sd}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Normal}}(\mathit{{mu}}={},~\mathit{{sd}}={})$'.format(name,
                                                                 get_variable_name(mu),
                                                                 get_variable_name(sd))
 
@@ -379,6 +382,7 @@ class HalfNormal(PositiveContinuous):
         if dist is None:
             dist = self
         sd = dist.sd
+        name = r'\text{%s}' % name
         return r'${} \sim \text{{HalfNormal}}(\mathit{{sd}}={})$'.format(name,
                                                                 get_variable_name(sd))
 
@@ -527,7 +531,8 @@ class Wald(PositiveContinuous):
         lam = dist.lam
         mu = dist.mu
         alpha = dist.alpha
-        return r'${} \sim \text{{Wald}}(\mathit{{mu}}={}, \mathit{{lam}}={}, \mathit{{alpha}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Wald}}(\mathit{{mu}}={},~\mathit{{lam}}={},~\mathit{{alpha}}={})$'.format(name,
                                                                 get_variable_name(mu),
                                                                 get_variable_name(lam),
                                                                 get_variable_name(alpha))
@@ -648,7 +653,8 @@ class Beta(UnitContinuous):
             dist = self
         alpha = dist.alpha
         beta = dist.beta
-        return r'${} \sim \text{{Beta}}(\mathit{{alpha}}={}, \mathit{{alpha}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Beta}}(\mathit{{alpha}}={},~\mathit{{alpha}}={})$'.format(name,
                                                                 get_variable_name(alpha),
                                                                 get_variable_name(beta))
 
@@ -714,6 +720,7 @@ class Exponential(PositiveContinuous):
         if dist is None:
             dist = self
         lam = dist.lam
+        name = r'\text{%s}' % name
         return r'${} \sim \text{{Exponential}}(\mathit{{lam}}={})$'.format(name,
                                                                 get_variable_name(lam))
 
@@ -783,7 +790,8 @@ class Laplace(Continuous):
             dist = self
         b = dist.b
         mu = dist.mu
-        return r'${} \sim \text{{Laplace}}(\mathit{{mu}}={}, \mathit{{b}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Laplace}}(\mathit{{mu}}={},~\mathit{{b}}={})$'.format(name,
                                                                 get_variable_name(mu),
                                                                 get_variable_name(b))
 
@@ -872,7 +880,8 @@ class Lognormal(PositiveContinuous):
             dist = self
         tau = dist.tau
         mu = dist.mu
-        return r'${} \sim \text{{Lognormal}}(\mathit{{mu}}={}, \mathit{{tau}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Lognormal}}(\mathit{{mu}}={},~\mathit{{tau}}={})$'.format(name,
                                                                 get_variable_name(mu),
                                                                 get_variable_name(tau))
 
@@ -964,7 +973,8 @@ class StudentT(Continuous):
         nu = dist.nu
         mu = dist.mu
         lam = dist.lam
-        return r'${} \sim \text{{StudentT}}(\mathit{{nu}}={}, \mathit{{mu}}={}, \mathit{{lam}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{StudentT}}(\mathit{{nu}}={},~\mathit{{mu}}={},~\mathit{{lam}}={})$'.format(name,
                                                                 get_variable_name(nu),
                                                                 get_variable_name(mu),
                                                                 get_variable_name(lam))
@@ -1052,7 +1062,8 @@ class Pareto(PositiveContinuous):
             dist = self
         alpha = dist.alpha
         m = dist.m
-        return r'${} \sim \text{{Pareto}}(\mathit{{alpha}}={}, \mathit{{m}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Pareto}}(\mathit{{alpha}}={},~\mathit{{m}}={})$'.format(name,
                                                                 get_variable_name(alpha),
                                                                 get_variable_name(m))
 
@@ -1130,7 +1141,8 @@ class Cauchy(Continuous):
             dist = self
         alpha = dist.alpha
         beta = dist.beta
-        return r'${} \sim \text{{Cauchy}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Cauchy}}(\mathit{{alpha}}={},~\mathit{{beta}}={})$'.format(name,
                                                                 get_variable_name(alpha),
                                                                 get_variable_name(beta))
 
@@ -1200,6 +1212,7 @@ class HalfCauchy(PositiveContinuous):
         if dist is None:
             dist = self
         beta = dist.beta
+        name = r'\text{%s}' % name
         return r'${} \sim \text{{HalfCauchy}}(\mathit{{beta}}={})$'.format(name,
                                                                 get_variable_name(beta))
 
@@ -1307,7 +1320,8 @@ class Gamma(PositiveContinuous):
             dist = self
         beta = dist.beta
         alpha = dist.alpha
-        return r'${} \sim \text{{Gamma}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Gamma}}(\mathit{{alpha}}={},~\mathit{{beta}}={})$'.format(name,
                                                                 get_variable_name(alpha),
                                                                 get_variable_name(beta))
 
@@ -1394,7 +1408,8 @@ class InverseGamma(PositiveContinuous):
             dist = self
         beta = dist.beta
         alpha = dist.alpha
-        return r'${} \sim \text{{InverseGamma}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{InverseGamma}}(\mathit{{alpha}}={},~\mathit{{beta}}={})$'.format(name,
                                                                 get_variable_name(alpha),
                                                                 get_variable_name(beta))
 
@@ -1447,6 +1462,7 @@ class ChiSquared(Gamma):
         if dist is None:
             dist = self
         nu = dist.nu
+        name = r'\text{%s}' % name
         return r'${} \sim \Chi^2(\mathit{{nu}}={})$'.format(name,
                                                                 get_variable_name(nu))
 
@@ -1528,7 +1544,8 @@ class Weibull(PositiveContinuous):
             dist = self
         beta = dist.beta
         alpha = dist.alpha
-        return r'${} \sim \text{{Weibull}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Weibull}}(\mathit{{alpha}}={},~\mathit{{beta}}={})$'.format(name,
                                                                 get_variable_name(alpha),
                                                                 get_variable_name(beta))
 
@@ -1610,7 +1627,8 @@ class HalfStudentT(PositiveContinuous):
             dist = self
         nu = dist.nu
         sd = dist.sd
-        return r'${} \sim \text{{HalfStudentT}}(\mathit{{nu}}={}, \mathit{{sd}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{HalfStudentT}}(\mathit{{nu}}={},~\mathit{{sd}}={})$'.format(name,
                                                                 get_variable_name(nu),
                                                                 get_variable_name(sd))
 
@@ -1719,7 +1737,8 @@ class ExGaussian(Continuous):
         sigma = dist.sigma
         mu = dist.mu
         nu = dist.nu
-        return r'${} \sim \text{{ExGaussian}}(\mathit{{mu}}={}, \mathit{{sigma}}={}, \mathit{{nu}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{ExGaussian}}(\mathit{{mu}}={},~\mathit{{sigma}}={},~\mathit{{nu}}={})$'.format(name,
                                                                 get_variable_name(mu),
                                                                 get_variable_name(sigma),
                                                                 get_variable_name(nu))
@@ -1795,7 +1814,8 @@ class VonMises(Continuous):
             dist = self
         kappa = dist.kappa
         mu = dist.mu
-        return r'${} \sim \text{{VonMises}}(\mathit{{mu}}={}, \mathit{{kappa}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{VonMises}}(\mathit{{mu}}={},~\mathit{{kappa}}={})$'.format(name,
                                                                 get_variable_name(mu),
                                                                 get_variable_name(kappa))
 
@@ -1899,7 +1919,8 @@ class SkewNormal(Continuous):
         sd = dist.sd
         mu = dist.mu
         alpha = dist.alpha
-        return r'${} \sim \text{{Skew-Normal}}(\mathit{{mu}}={}, \mathit{{sd}}={}, \mathit{{alpha}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Skew-Normal}}(\mathit{{mu}}={},~\mathit{{sd}}={},~\mathit{{alpha}}={})$'.format(name,
                                                                 get_variable_name(mu),
                                                                 get_variable_name(sd),
                                                                 get_variable_name(alpha))
@@ -1950,7 +1971,8 @@ class Triangular(Continuous):
         lower = dist.lower
         upper = dist.upper
         c = dist.c
-        return r'${} \sim \text{{Triangular}}(\mathit{{c}}={}, \mathit{{lower}}={}, \mathit{{upper}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Triangular}}(\mathit{{c}}={},~\mathit{{lower}}={},~\mathit{{upper}}={})$'.format(name,
                                                                 get_variable_name(c),
                                                                 get_variable_name(lower),
                                                                 get_variable_name(upper))
@@ -2004,7 +2026,8 @@ class Gumbel(Continuous):
             dist = self
         beta = dist.beta
         mu = dist.mu
-        return r'${} \sim \text{{Gumbel}}(\mathit{{mu}}={}, \mathit{{beta}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Gumbel}}(\mathit{{mu}}={},~\mathit{{beta}}={})$'.format(name,
                                                                 get_variable_name(mu),
                                                                 get_variable_name(beta))
 
@@ -2081,7 +2104,8 @@ class Logistic(Continuous):
             dist = self
         mu = dist.mu
         s = dist.s
-        return r'${} \sim \text{{Logistic}}(\mathit{{mu}}={}, \mathit{{s}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Logistic}}(\mathit{{mu}}={},~\mathit{{s}}={})$'.format(name,
                                                                 get_variable_name(mu),
                                                                 get_variable_name(s))
 

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -67,7 +67,8 @@ class Binomial(Discrete):
             dist = self
         n = dist.n
         p = dist.p
-        return r'${} \sim \text{{Binomial}}(\mathit{{n}}={}, \mathit{{p}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{Binomial}}(\mathit{{n}}={},~\mathit{{p}}={})$'.format(name,
                                                 get_variable_name(n),
                                                 get_variable_name(p))
 
@@ -140,7 +141,8 @@ class BetaBinomial(Discrete):
             dist = self
         alpha = dist.alpha
         beta = dist.beta
-        return r'${} \sim \text{{NegativeBinomial}}(\mathit{{alpha}}={}, \mathit{{beta}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{NegativeBinomial}}(\mathit{{alpha}}={},~\mathit{{beta}}={})$'.format(name,
                                                 get_variable_name(alpha),
                                                 get_variable_name(beta))
 
@@ -187,6 +189,7 @@ class Bernoulli(Discrete):
         if dist is None:
             dist = self
         p = dist.p
+        name = r'\text{%s}' % name
         return r'${} \sim \text{{Bernoulli}}(\mathit{{p}}={})$'.format(name,
                                                 get_variable_name(p))
 
@@ -249,7 +252,8 @@ class DiscreteWeibull(Discrete):
             dist = self
         q = dist.q
         beta = dist.beta
-        return r'${} \sim \text{{DiscreteWeibull}}(\mathit{{q}}={}, \mathit{{beta}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{DiscreteWeibull}}(\mathit{{q}}={},~\mathit{{beta}}={})$'.format(name,
                                                 get_variable_name(q),
                                                 get_variable_name(beta))
 
@@ -305,6 +309,7 @@ class Poisson(Discrete):
         if dist is None:
             dist = self
         mu = dist.mu
+        name = r'\text{%s}' % name
         return r'${} \sim \text{{Poisson}}(\mathit{{mu}}={})$'.format(name,
                                                 get_variable_name(mu))
 
@@ -367,7 +372,8 @@ class NegativeBinomial(Discrete):
             dist = self
         mu = dist.mu
         alpha = dist.alpha
-        return r'${} \sim \text{{NegativeBinomial}}(\mathit{{mu}}={}, \mathit{{alpha}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{NegativeBinomial}}(\mathit{{mu}}={},~\mathit{{alpha}}={})$'.format(name,
                                                 get_variable_name(mu),
                                                 get_variable_name(alpha))
 
@@ -413,6 +419,7 @@ class Geometric(Discrete):
         if dist is None:
             dist = self
         p = dist.p
+        name = r'\text{%s}' % name
         return r'${} \sim \text{{Geometric}}(\mathit{{p}}={})$'.format(name,
                                                 get_variable_name(p))
 
@@ -468,7 +475,8 @@ class DiscreteUniform(Discrete):
             dist = self
         lower = dist.lower
         upper = dist.upper
-        return r'${} \sim \text{{DiscreteUniform}}(\mathit{{lower}}={}, \mathit{{upper}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{DiscreteUniform}}(\mathit{{lower}}={},~\mathit{{upper}}={})$'.format(name,
                                                 get_variable_name(lower),
                                                 get_variable_name(upper))
 
@@ -540,6 +548,7 @@ class Categorical(Discrete):
         if dist is None:
             dist = self
         p = dist.p
+        name = r'\text{%s}' % name
         return r'${} \sim \text{{Categorical}}(\mathit{{p}}={})$'.format(name,
                                                 get_variable_name(p))
 
@@ -577,6 +586,7 @@ class Constant(Discrete):
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:
             dist = self
+        name = r'\text{%s}' % name
         return r'${} \sim \text{{Constant}}()$'.format(name)
 
 
@@ -647,7 +657,8 @@ class ZeroInflatedPoisson(Discrete):
             dist = self
         theta = dist.theta
         psi = dist.psi
-        return r'${} \sim \text{{ZeroInflatedPoisson}}(\mathit{{theta}}={}, \mathit{{psi}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{ZeroInflatedPoisson}}(\mathit{{theta}}={},~\mathit{{psi}}={})$'.format(name,
                                                 get_variable_name(theta),
                                                 get_variable_name(psi))
 
@@ -722,8 +733,9 @@ class ZeroInflatedBinomial(Discrete):
         name_n = get_variable_name(n)
         name_p = get_variable_name(p)
         name_psi = get_variable_name(psi)
+        name = r'\text{%s}' % name
         return (r'${} \sim \text{{ZeroInflatedBinomial}}'
-                r'(\mathit{{n}}={}, \mathit{{p}}={}, '
+                r'(\mathit{{n}}={},~\mathit{{p}}={},~'
                 r'\mathit{{psi}}={})$'
                 .format(name, name_n, name_p, name_psi))
 
@@ -817,7 +829,8 @@ class ZeroInflatedNegativeBinomial(Discrete):
         name_mu = get_variable_name(mu)
         name_alpha = get_variable_name(alpha)
         name_psi = get_variable_name(psi)
+        name = r'\text{%s}' % name
         return (r'${} \sim \text{{ZeroInflatedNegativeBinomial}}'
-                r'(\mathit{{mu}}={}, \mathit{{alpha}}={}, '
+                r'(\mathit{{mu}}={},~\mathit{{alpha}}={},~'
                 r'\mathit{{psi}}={})$'
                 .format(name, name_mu, name_alpha, name_psi))

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -180,7 +180,8 @@ class NormalMixture(Mixture):
         mu = dist.mu
         w = dist.w
         sd = dist.sd
-        return r'${} \sim \text{{NormalMixture}}(\mathit{{w}}={}, \mathit{{mu}}={}, \mathit{{sigma}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{NormalMixture}}(\mathit{{w}}={},~\mathit{{mu}}={},~\mathit{{sigma}}={})$'.format(name,
                                                 get_variable_name(w),
                                                 get_variable_name(mu),
                                                 get_variable_name(sd))

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -54,7 +54,8 @@ class AR1(distribution.Continuous):
             dist = self
         k = dist.k
         tau_e = dist.tau_e
-        return r'${} \sim \text{{AR1}}(\mathit{{k}}={}, \mathit{{tau_e}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{AR1}}(\mathit{{k}}={},~\mathit{{tau_e}}={})$'.format(name,
                  get_variable_name(k), get_variable_name(tau_e))
 
 
@@ -173,7 +174,8 @@ class GaussianRandomWalk(distribution.Continuous):
             dist = self
         mu = dist.mu
         sd = dist.sd
-        return r'${} \sim \text{{GaussianRandomWalk}}(\mathit{{mu}}={}, \mathit{{sd}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{{GaussianRandomWalk}}(\mathit{{mu}}={},~\mathit{{sd}}={})$'.format(name,
                                                 get_variable_name(mu),
                                                 get_variable_name(sd))
 
@@ -234,7 +236,8 @@ class GARCH11(distribution.Continuous):
         omega = dist.omega
         alpha_1 = dist.alpha_1
         beta_1 = dist.beta_1
-        return r'${} \sim \text{GARCH}(1, 1, \mathit{{omega}}={}, \mathit{{alpha_1}}={}, \mathit{{beta_1}}={})$'.format(
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{GARCH}(1,~1,~\mathit{{omega}}={},~\mathit{{alpha_1}}={},~\mathit{{beta_1}}={})$'.format(
             name,
             get_variable_name(omega),
             get_variable_name(alpha_1),
@@ -271,6 +274,7 @@ class EulerMaruyama(distribution.Continuous):
         if dist is None:
             dist = self
         dt = dist.dt
+        name = r'\text{%s}' % name
         return r'${} \sim \text{EulerMaruyama}(\mathit{{dt}}={})$'.format(name,
                                                 get_variable_name(dt))
 
@@ -360,7 +364,8 @@ class MvGaussianRandomWalk(distribution.Continuous, _CovSet):
             dist = self
         mu = dist.mu
         cov = dist.cov
-        return r'${} \sim \text{MvGaussianRandomWalk}(\mathit{{mu}}={}, \mathit{{cov}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{MvGaussianRandomWalk}(\mathit{{mu}}={},~\mathit{{cov}}={})$'.format(name,
                                                 get_variable_name(mu),
                                                 get_variable_name(cov))
 
@@ -406,7 +411,8 @@ class MvStudentTRandomWalk(distribution.Continuous, _CovSet):
         nu = dist.nu
         mu = dist.mu
         cov = dist.cov
-        return r'${} \sim \text{MvStudentTRandomWalk}(\mathit{{nu}}={}, \mathit{{mu}}={}, \mathit{{cov}}={})$'.format(name,
+        name = r'\text{%s}' % name
+        return r'${} \sim \text{MvStudentTRandomWalk}(\mathit{{nu}}={},~\mathit{{mu}}={},~\mathit{{cov}}={})$'.format(name,
                                                 get_variable_name(nu),
                                                 get_variable_name(mu),
                                                 get_variable_name(cov))

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -953,13 +953,14 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor)):
         tex_vars = []
         for rv in itertools.chain(self.unobserved_RVs, self.observed_RVs):
             rv_tex = rv.__latex__()
-            array_rv = rv_tex.replace(r'\sim', r'&\sim &')
-            tex_vars.append(array_rv)
+            if rv_tex is not None:
+                array_rv = rv_tex.replace(r'\sim', r'&\sim &').strip('$')
+                tex_vars.append(array_rv)
         return r'''$$
             \begin{{array}}{{rcl}}
             {}
             \end{{array}}
-            $$'''.format('\\\\'.join([tex.strip('$') for tex in tex_vars if tex is not None]))
+            $$'''.format('\\\\'.join(tex_vars))
 
     __latex__ = _repr_latex_
 
@@ -1308,7 +1309,7 @@ def _walk_up_rv(rv):
             all_rvs.extend(_walk_up_rv(parent))
     else:
         if rv.name:
-            all_rvs.append(rv.name)
+            all_rvs.append(r'\text{%s}' % rv.name)
         else:
             all_rvs.append(r'\text{Constant}')
     return all_rvs
@@ -1316,8 +1317,7 @@ def _walk_up_rv(rv):
 
 def _latex_repr_rv(rv):
     """Make latex string for a Deterministic variable"""
-    return r'$\text{{}} \sim \text{{Deterministic}}({})$'.format(rv.name,
-                                                                 r',~'.join(_walk_up_rv(rv)))
+    return r'$\text{%s} \sim \text{Deterministic}(%s)$' % (rv.name, r',~'.join(_walk_up_rv(rv)))
 
 
 def Deterministic(name, var, model=None):

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -953,11 +953,10 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor)):
         tex_vars = []
         for rv in itertools.chain(self.unobserved_RVs, self.observed_RVs):
             rv_tex = rv.__latex__()
-            tilde_index = rv_tex.index('\\sim')
-            array_rv = rv_tex[:tilde_index] + '&' + rv_tex[tilde_index:]
+            array_rv = rv_tex.replace(r'\sim', r'&\sim &')
             tex_vars.append(array_rv)
         return r'''$$
-            \begin{{array}}{{ll}}
+            \begin{{array}}{{rcl}}
             {}
             \end{{array}}
             $$'''.format('\\\\'.join([tex.strip('$') for tex in tex_vars if tex is not None]))
@@ -1147,7 +1146,7 @@ class FreeRV(Factor, TensorVariable):
             name = self.name
         if dist is None:
             dist = self.distribution
-        return self.distribution._repr_latex_(name=r'\text{%s}' % name, dist=dist)
+        return self.distribution._repr_latex_(name=name, dist=dist)
 
     __latex__ = _repr_latex_
 
@@ -1256,7 +1255,7 @@ class ObservedRV(Factor, TensorVariable):
             name = self.name
         if dist is None:
             dist = self.distribution
-        return self.distribution._repr_latex_(name=r'\text{%s}' % name, dist=dist)
+        return self.distribution._repr_latex_(name=name, dist=dist)
 
     __latex__ = _repr_latex_
 
@@ -1317,7 +1316,8 @@ def _walk_up_rv(rv):
 
 def _latex_repr_rv(rv):
     """Make latex string for a Deterministic variable"""
-    return r'${} \sim \text{{Deterministic}}({})$'.format(rv.name, r', '.join(_walk_up_rv(rv)))
+    return r'$\text{{}} \sim \text{{Deterministic}}({})$'.format(rv.name,
+                                                                 r',~'.join(_walk_up_rv(rv)))
 
 
 def Deterministic(name, var, model=None):
@@ -1409,7 +1409,7 @@ class TransformedRV(TensorVariable):
             name = self.name
         if dist is None:
             dist = self.distribution
-        return self.distribution._repr_latex_(name=r'\text{%s}' % name, dist=dist)
+        return self.distribution._repr_latex_(name=name, dist=dist)
 
     __latex__ = _repr_latex_
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -17,7 +17,7 @@ from .memoize import memoize
 from .theanof import gradient, hessian, inputvars, generator
 from .vartypes import typefilter, discrete_types, continuous_types, isgenerator
 from .blocking import DictToArrayBijection, ArrayOrdering
-from .util import get_transformed_name, escape_latex
+from .util import get_transformed_name
 
 __all__ = [
     'Model', 'Factor', 'compilef', 'fn', 'fastfn', 'modelcontext',
@@ -952,8 +952,15 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor)):
     def _repr_latex_(self, name=None, dist=None):
         tex_vars = []
         for rv in itertools.chain(self.unobserved_RVs, self.observed_RVs):
-            tex_vars.append(rv.__latex__())
-        return u'$${}$$'.format('\\\\'.join([tex.strip('$') for tex in tex_vars if tex is not None]))
+            rv_tex = rv.__latex__()
+            tilde_index = rv_tex.index('\\sim')
+            array_rv = rv_tex[:tilde_index] + '&' + rv_tex[tilde_index:]
+            tex_vars.append(array_rv)
+        return r'''$$
+            \begin{{array}}{{ll}}
+            {}
+            \end{{array}}
+            $$'''.format('\\\\'.join([tex.strip('$') for tex in tex_vars if tex is not None]))
 
     __latex__ = _repr_latex_
 
@@ -1140,7 +1147,7 @@ class FreeRV(Factor, TensorVariable):
             name = self.name
         if dist is None:
             dist = self.distribution
-        return self.distribution._repr_latex_(name=escape_latex(name), dist=dist)
+        return self.distribution._repr_latex_(name=r'\text{%s}' % name, dist=dist)
 
     __latex__ = _repr_latex_
 
@@ -1249,7 +1256,7 @@ class ObservedRV(Factor, TensorVariable):
             name = self.name
         if dist is None:
             dist = self.distribution
-        return self.distribution._repr_latex_(name=escape_latex(name), dist=dist)
+        return self.distribution._repr_latex_(name=r'\text{%s}' % name, dist=dist)
 
     __latex__ = _repr_latex_
 
@@ -1402,7 +1409,7 @@ class TransformedRV(TensorVariable):
             name = self.name
         if dist is None:
             dist = self.distribution
-        return self.distribution._repr_latex_(name=escape_latex(name), dist=dist)
+        return self.distribution._repr_latex_(name=r'\text{%s}' % name, dist=dist)
 
     __latex__ = _repr_latex_
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1064,11 +1064,11 @@ class TestLatex(object):
             Y_obs = Normal('Y_obs', mu=mu, sd=sigma, observed=Y)
         self.distributions = [alpha, sigma, mu, b, Y_obs]
         self.expected = (
-            r'$alpha \sim \text{Normal}(\mathit{mu}=0, \mathit{sd}=10.0)$',
-            r'$sigma \sim \text{HalfNormal}(\mathit{sd}=1.0)$',
-            r'$mu \sim \text{Deterministic}(alpha, \text{Constant}, beta)$',
-            r'$beta \sim \text{Normal}(\mathit{mu}=0, \mathit{sd}=10.0)$',
-            r'$Y\_obs \sim \text{Normal}(\mathit{mu}=mu, \mathit{sd}=f(sigma))$'
+            r'$\text{alpha} \sim \text{Normal}(\mathit{mu}=0,~\mathit{sd}=10.0)$',
+            r'$\text{sigma} \sim \text{HalfNormal}(\mathit{sd}=1.0)$',
+            r'$\text{mu} \sim \text{Deterministic}(\text{alpha},~\text{Constant},~\text{beta})$',
+            r'$\text{beta} \sim \text{Normal}(\mathit{mu}=0,~\mathit{sd}=10.0)$',
+            r'$\text{Y_obs} \sim \text{Normal}(\mathit{mu}=\text{mu},~\mathit{sd}=f(\text{sigma}))$'
         )
 
     def test__repr_latex_(self):
@@ -1078,7 +1078,8 @@ class TestLatex(object):
         model_tex = self.model._repr_latex_()
 
         for tex in self.expected:  # make sure each variable is in the model
-            assert tex.strip('$') in model_tex
+            for segment in tex.strip('$').split(r'\sim'):
+                assert segment in model_tex
 
     def test___latex__(self):
         for distribution, tex in zip(self.distributions, self.expected):

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -117,14 +117,14 @@ def get_variable_name(variable):
                 names = [get_variable_name(item)
                          for item in variable.get_parents()[0].inputs]
                 # do not escape_latex these, since it is not idempotent
-                return 'f(%s)' % ','.join([n for n in names if isinstance(n, str)])
+                return 'f(%s)' % ',~'.join([n for n in names if isinstance(n, str)])
             except IndexError:
                 pass
         value = variable.eval()
         if not value.shape:
             return asscalar(value)
         return 'array'
-    return escape_latex(name)
+    return r'\text{%s}' % name
 
 
 def update_start_vals(a, b, model):


### PR DESCRIPTION
Wraps the model representation in an `\begin{array}` environment, and variable names in `\text{...}`.

New: 
<img width="1142" alt="screen shot 2017-11-11 at 2 36 55 pm" src="https://user-images.githubusercontent.com/2295568/32692874-258c889a-c6ee-11e7-9eb5-c857b4d49cb9.png">

Old:
<img width="1029" alt="screen shot 2017-11-11 at 2 39 18 pm" src="https://user-images.githubusercontent.com/2295568/32692876-28dc12ea-c6ee-11e7-892b-1c903663b991.png">
