### PR TITLE
Only deploy docs after a successful build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,5 @@ script:
   - . ./scripts/confirm_mpl_optional.sh
 
 after_success:
+  - if [[ "$BUILD_DOCS" == "true" ]]; then travis-sphinx deploy -c "docs.pymc.io"; fi
   - coveralls

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,7 +4,6 @@ set -e
 
 if [[ "$BUILD_DOCS" == "true" ]]; then
     travis-sphinx build -n -s docs/source
-    travis-sphinx deploy -c "docs.pymc.io"
 fi
 
 if [[ "$RUN_PYLINT" == "true" ]]; then


### PR DESCRIPTION
A problem is currently breaking the build, but we are still pushing unbuilt docs to docs.pymc.io (which breaks the docs).  This fix will propagate once the current problem is fixed...