### PR TITLE
Add test for pm.Model

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,8 +2,13 @@
 
 ## PyMC 3.3. (Unreleased)
 
+### New features
+
 - Improve NUTS initialization `advi+adapt_diag_grad` and add `jitter+adapt_diag_grad` (#2643)
+
+### Fixes
 - Fixed `compareplot` to use `loo` output.
+- Add test for `model.logp_array` and `model.bijection` (#2724)
 
 
 ## PyMC3 3.2 (October 10, 2017)

--- a/pymc3/tests/models.py
+++ b/pymc3/tests/models.py
@@ -14,7 +14,7 @@ def simple_model():
     with Model() as model:
         Normal('x', mu, tau=tau, shape=2, testval=tt.ones(2) * .1)
 
-    return model.test_point, model, (mu, tau ** -1)
+    return model.test_point, model, (mu, tau ** -.5)
 
 
 def simple_categorical():
@@ -34,7 +34,7 @@ def multidimensional_model():
     with Model() as model:
         Normal('x', mu, tau=tau, shape=(3, 2), testval=.1 * tt.ones((3, 2)))
 
-    return model.test_point, model, (mu, tau ** -1)
+    return model.test_point, model, (mu, tau ** -.5)
 
 
 def simple_arbitrary_det():

--- a/pymc3/tests/test_model_func.py
+++ b/pymc3/tests/test_model_func.py
@@ -45,10 +45,11 @@ def test_mapping():
     lparray = model.logp_array
     point = model.test_point
     parray = model.bijection.map(point)
-    assert lp(point)==lparray(parray)
+    assert lp(point) == lparray(parray)
+
     randarray = np.random.randn(*parray.shape)
     randpoint = model.bijection.rmap(randarray)
-    assert lp(randpoint)==lparray(randarray)
+    assert lp(randpoint) == lparray(randarray)
 
 
 

--- a/pymc3/tests/test_model_func.py
+++ b/pymc3/tests/test_model_func.py
@@ -1,20 +1,23 @@
 import pymc3 as pm
 import numpy as np
+import scipy.stats as sp
 from .checks import close_to
 from .models import simple_model, mv_simple
-from ..distributions import Normal
 
 
-def test_lop():
-    start, model, _ = simple_model()
+tol = 2.0**-11
+
+def test_logp():
+    start, model, (mu, sig) = simple_model()
     lp = model.fastlogp
     lp(start)
+    close_to(lp(start), sp.norm.logpdf(start['x'], mu, sig).sum(), tol)
 
 
 def test_dlogp():
     start, model, (mu, sig) = simple_model()
     dlogp = model.fastdlogp()
-    close_to(dlogp(start), -(start['x'] - mu) / sig, 1. / sig / 100.)
+    close_to(dlogp(start), -(start['x'] - mu) / sig**2, 1. / sig**2 / 100.)
 
 
 def test_dlogp2():
@@ -26,8 +29,26 @@ def test_dlogp2():
 
 def test_deterministic():
     with pm.Model() as model:
-        x = Normal('x', 0, 1)
+        x = pm.Normal('x', 0, 1)
         y = pm.Deterministic('y', x**2)
 
     assert model.y == y
     assert model['y'] == y
+
+
+def test_mapping():
+    with pm.Model() as model:
+        mu = pm.Normal('mu', 0, 1)
+        sd = pm.Gamma('sd', 1, 1)
+        y = pm.Normal('y', mu, sd, observed=np.array([.1, .5]))
+    lp = model.fastlogp
+    lparray = model.logp_array
+    point = model.test_point
+    parray = model.bijection.map(point)
+    assert lp(point)==lparray(parray)
+    randarray = np.random.randn(*parray.shape)
+    randpoint = model.bijection.rmap(randarray)
+    assert lp(randpoint)==lparray(randarray)
+
+
+


### PR DESCRIPTION
This PR add test for the following functions within pm.Model:
* model.bijection
* model.logp_array
I also change the output from simple_model() of the testset, so it outputs sd (same as we define in pm.Normal)