### PR TITLE
Kronecker GP

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 - `njobs` and `nchains` kwarg are deprecated in favor of `cores` and `chains` for `sample`
 - `lag` kwarg in `pm.stats.autocorr` and `pm.stats.autocov` is deprecated.
 
+
 ## PyMC 3.3 (January 9, 2018)
 
 ### New features

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,13 +5,18 @@
 ### New features
 
 - Add `logit_p` keyword to `pm.Bernoulli`, so that users can specify the logit of the success probability. This is faster and more stable than using `p=tt.nnet.sigmoid(logit_p)`.
-- Add `random` keyword to `pm.DensityDist` thus enabling users to pass custom random method which in turn makes sampling from a `DensityDist` possible. 
+- Add `random` keyword to `pm.DensityDist` thus enabling users to pass custom random method which in turn makes sampling from a `DensityDist` possible.
 - Effective sample size computation is updated. The estimation uses Geyer's initial positive sequence, which no longer truncates the autocorrelation series inaccurately. `pm.diagnostics.effective_n` now can reports N_eff>N.
+- Added `KroneckerNormal` distribution and a corresponding `MarginalKron`
+  Gaussian Process implementation for efficient inference, along with
+  lower-level functions such as `cartesian` and `kronecker` products.
+- Added `Coregion` covariance function.
  
 
 ### Fixes
 
 - `VonMises` does not overflow for large values of kappa. i0 and i1 have been removed and we now use log_i0 to compute the logp.
+
 
 ### Deprecations
 

--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -57,6 +57,7 @@ from .mixture import NormalMixture
 
 from .multivariate import MvNormal
 from .multivariate import MatrixNormal
+from .multivariate import KroneckerNormal
 from .multivariate import MvStudentT
 from .multivariate import Dirichlet
 from .multivariate import Multinomial
@@ -123,6 +124,7 @@ __all__ = ['Uniform',
            'TensorType',
            'MvNormal',
            'MatrixNormal',
+           'KroneckerNormal',
            'MvStudentT',
            'Dirichlet',
            'Multinomial',

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -13,6 +13,9 @@ import theano
 from .special import gammaln
 from pymc3.theanof import floatX
 
+from six.moves import xrange
+from functools import partial
+
 f = floatX
 c = - .5 * np.log(2. * np.pi)
 
@@ -326,3 +329,135 @@ class SplineWrapper(theano.Op):
         x_grad, = grads
 
         return [x_grad * self.grad_op(x)]
+
+
+# Custom Eigh, EighGrad, and eigh are required until
+# https://github.com/Theano/Theano/pull/6557 is handled, since lambda's
+# cannot be used with pickling.
+class Eigh(tt.nlinalg.Eig):
+    """
+    Return the eigenvalues and eigenvectors of a Hermitian or symmetric matrix.
+
+    This is a copy of Eigh from theano that calls an EighGrad which uses
+    partial instead of lambda. Once this has been merged with theano this
+    should be removed.
+    """
+
+    _numop = staticmethod(np.linalg.eigh)
+    __props__ = ('UPLO',)
+
+    def __init__(self, UPLO='L'):
+        assert UPLO in ['L', 'U']
+        self.UPLO = UPLO
+
+    def make_node(self, x):
+        x = tt.as_tensor_variable(x)
+        assert x.ndim == 2
+        # Numpy's linalg.eigh may return either double or single
+        # presision eigenvalues depending on installed version of
+        # LAPACK.  Rather than trying to reproduce the (rather
+        # involved) logic, we just probe linalg.eigh with a trivial
+        # input.
+        w_dtype = self._numop([[np.dtype(x.dtype).type()]])[0].dtype.name
+        w = theano.tensor.vector(dtype=w_dtype)
+        v = theano.tensor.matrix(dtype=x.dtype)
+        return theano.gof.Apply(self, [x], [w, v])
+
+    def perform(self, node, inputs, outputs):
+        (x,) = inputs
+        (w, v) = outputs
+        w[0], v[0] = self._numop(x, self.UPLO)
+
+    def grad(self, inputs, g_outputs):
+        r"""The gradient function should return
+           .. math:: \sum_n\left(W_n\frac{\partial\,w_n}
+                           {\partial a_{ij}} +
+                     \sum_k V_{nk}\frac{\partial\,v_{nk}}
+                           {\partial a_{ij}}\right),
+        where [:math:`W`, :math:`V`] corresponds to ``g_outputs``,
+        :math:`a` to ``inputs``, and  :math:`(w, v)=\mbox{eig}(a)`.
+        Analytic formulae for eigensystem gradients are well-known in
+        perturbation theory:
+           .. math:: \frac{\partial\,w_n}
+                          {\partial a_{ij}} = v_{in}\,v_{jn}
+           .. math:: \frac{\partial\,v_{kn}}
+                          {\partial a_{ij}} =
+                \sum_{m\ne n}\frac{v_{km}v_{jn}}{w_n-w_m}
+        """
+        x, = inputs
+        w, v = self(x)
+        # Replace gradients wrt disconnected variables with
+        # zeros. This is a work-around for issue #1063.
+        gw, gv = tt.nlinalg._zero_disconnected([w, v], g_outputs)
+        return [EighGrad(self.UPLO)(x, w, v, gw, gv)]
+
+
+class EighGrad(theano.Op):
+    """
+    Gradient of an eigensystem of a Hermitian matrix.
+
+    This is a copy of EighGrad from theano that uses partial instead of lambda.
+    Once this has been merged with theano this should be removed.
+    """
+
+    __props__ = ('UPLO',)
+
+    def __init__(self, UPLO='L'):
+        assert UPLO in ['L', 'U']
+        self.UPLO = UPLO
+        if UPLO == 'L':
+            self.tri0 = np.tril
+            self.tri1 = partial(np.triu, k=1)
+        else:
+            self.tri0 = np.triu
+            self.tri1 = partial(np.tril, k=-1)
+
+    def make_node(self, x, w, v, gw, gv):
+        x, w, v, gw, gv = map(tt.as_tensor_variable, (x, w, v, gw, gv))
+        assert x.ndim == 2
+        assert w.ndim == 1
+        assert v.ndim == 2
+        assert gw.ndim == 1
+        assert gv.ndim == 2
+        out_dtype = theano.scalar.upcast(x.dtype, w.dtype, v.dtype,
+                                         gw.dtype, gv.dtype)
+        out = theano.tensor.matrix(dtype=out_dtype)
+        return theano.gof.Apply(self, [x, w, v, gw, gv], [out])
+
+    def perform(self, node, inputs, outputs):
+        """
+        Implements the "reverse-mode" gradient for the eigensystem of
+        a square matrix.
+        """
+        x, w, v, W, V = inputs
+        N = x.shape[0]
+        outer = np.outer
+
+        def G(n):
+            return sum(v[:, m] * V.T[n].dot(v[:, m]) / (w[n] - w[m])
+                       for m in xrange(N) if m != n)
+
+        g = sum(outer(v[:, n], v[:, n] * W[n] + G(n))
+                for n in xrange(N))
+
+        # Numpy's eigh(a, 'L') (eigh(a, 'U')) is a function of tril(a)
+        # (triu(a)) only.  This means that partial derivative of
+        # eigh(a, 'L') (eigh(a, 'U')) with respect to a[i,j] is zero
+        # for i < j (i > j).  At the same time, non-zero components of
+        # the gradient must account for the fact that variation of the
+        # opposite triangle contributes to variation of two elements
+        # of Hermitian (symmetric) matrix. The following line
+        # implements the necessary logic.
+        out = self.tri0(g) + self.tri1(g).T
+
+        # Make sure we return the right dtype even if NumPy performed
+        # upcasting in self.tri0.
+        outputs[0][0] = np.asarray(out, dtype=node.outputs[0].dtype)
+
+    def infer_shape(self, node, shapes):
+        return [shapes[0]]
+
+
+def eigh(a, UPLO='L'):
+    """A copy, remove with Eigh and EighGrad when possible"""
+    return Eigh(UPLO)(a)

--- a/pymc3/gp/__init__.py
+++ b/pymc3/gp/__init__.py
@@ -1,4 +1,4 @@
 from . import cov
 from . import mean
 from . import util
-from .gp import Latent, Marginal, MarginalSparse, TP
+from .gp import Latent, Marginal, MarginalSparse, TP, MarginalKron

--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -9,8 +9,10 @@ from pymc3.gp.mean import Zero
 from pymc3.gp.util import (conditioned_vars,
                            infer_shape, stabilize, cholesky, solve_lower, solve_upper)
 from pymc3.distributions import draw_values
+from pymc3.distributions.dist_math import eigh
+from ..math import cartesian, kron_dot, kron_diag
 
-__all__ = ['Latent', 'Marginal', 'TP', 'MarginalSparse']
+__all__ = ['Latent', 'Marginal', 'TP', 'MarginalSparse', 'MarginalKron']
 
 
 class Base(object):
@@ -787,3 +789,245 @@ class MarginalSparse(Marginal):
         chol = cholesky(cov)
         shape = infer_shape(Xnew, kwargs.pop("shape", None))
         return pm.MvNormal(name, mu=mu, chol=chol, shape=shape, **kwargs)
+
+
+@conditioned_vars(["Xs", "y", "sigma"])
+class MarginalKron(Base):
+    R"""
+    Marginal Gaussian process whose covariance is a tensor product kernel.
+
+    The `gp.MarginalKron` class is an implementation of the sum of a Kronecker
+    GP prior and additive white noise. It has `marginal_likelihood`,
+    `conditional` and `predict` methods. This GP implementation can be used to
+    efficiently implement regression on data that are normally distributed with
+    a tensor product kernel and are measured on a full grid of inputs:
+    `cartesian(*Xs)`. `MarginalKron` is based on the `KroneckerNormal`
+    distribution, see its docstring for more information. For more information
+    on the `prior` and `conditional` methods, see their docstrings.
+
+    Parameters
+    ----------
+    cov_funcs : list of Covariance objects
+        The covariance functions that compose the tensor (Kronecker) product.
+        Defaults to [zero].
+    mean_func : None, instance of Mean
+        The mean function.  Defaults to zero.
+
+    Examples
+    --------
+    .. code:: python
+
+        # One dimensional column vectors of inputs
+        X1 = np.linspace(0, 1, 10)[:, None]
+        X2 = np.linspace(0, 2, 5)[:, None]
+        Xs = [X1, X2]
+        y = np.random.randn(len(X1)*len(X2))  # toy data
+        with pm.Model() as model:
+            # Specify the covariance functions for each Xi
+            cov_func1 = pm.gp.cov.ExpQuad(1, ls=0.1)  # Must accept X1 without error
+            cov_func2 = pm.gp.cov.ExpQuad(1, ls=0.3)  # Must accept X2 without error
+
+            # Specify the GP.  The default mean function is `Zero`.
+            gp = pm.gp.MarginalKron(cov_funcs=[cov_func1, cov_func2])
+
+            # Place a GP prior over the function f.
+            sigma = pm.HalfCauchy("sigma", beta=3)
+            y_ = gp.marginal_likelihood("y", Xs=Xs, y=y, sigma=sigma)
+
+            # ...
+
+        # After fitting or sampling, specify the distribution
+        # at new points with .conditional
+        # Xnew need not be on a full grid
+        Xnew1 = np.linspace(-1, 2, 10)[:, None]
+        Xnew2 = np.linspace(0, 3, 10)[:, None]
+        Xnew = np.concatenate((Xnew1, Xnew2), axis=1)  # Not full grid, works
+        Xnew = pm.math.cartesian(Xnew1, Xnew2)  # Full grid, also works
+
+        with model:
+            fcond = gp.conditional("fcond", Xnew=Xnew)
+    """
+
+    def __init__(self, mean_func=Zero(), cov_funcs=(Constant(0.0))):
+        try:
+            self.cov_funcs = list(cov_funcs)
+        except TypeError:
+            self.cov_funcs = [cov_funcs]
+        cov_func = pm.gp.cov.Kron(self.cov_funcs)
+        super(MarginalKron, self).__init__(mean_func, cov_func)
+
+    def __add__(self, other):
+        raise TypeError("Efficient implementation of additive, Kronecker-structured processes not implemented")
+
+    def _build_marginal_likelihood(self, Xs):
+        self.X = cartesian(*Xs)
+        mu = self.mean_func(self.X)
+        covs = [f(X) for f, X in zip(self.cov_funcs, Xs)]
+        return mu, covs
+
+    def _check_inputs(self, Xs, y, sigma):
+        N = np.prod([len(X) for X in Xs])
+        if len(Xs) != len(self.cov_funcs):
+            raise ValueError('Must provide a covariance function for each X')
+        if N != len(y):
+            raise ValueError('Length of y must match cartesian product of Xs')
+
+    def marginal_likelihood(self, name, Xs, y, sigma, is_observed=True, **kwargs):
+        """
+        Returns the marginal likelihood distribution, given the input
+        locations `cartesian(*Xs)` and the data `y`.
+
+        Parameters
+        ----------
+        name : string
+            Name of the random variable
+        Xs : list of array-like
+            Function input values for each covariance function. Each entry
+            must be passable to its respective covariance without error. The
+            total covariance function is measured on the full grid
+            `cartesian(*Xs)`.
+        y : array-like
+            Data that is the sum of the function with the GP prior and Gaussian
+            noise.  Must have shape `(n, )`.
+        sigma : scalar, Variable
+            Standard deviation of the white Gaussian noise.
+        is_observed : bool
+            Whether to set `y` as an `observed` variable in the `model`.
+            Default is `True`.
+        **kwargs
+            Extra keyword arguments that are passed to `KroneckerNormal`
+            distribution constructor.
+        """
+        self._check_inputs(Xs, y, sigma)
+        mu, covs = self._build_marginal_likelihood(Xs)
+        self.Xs = Xs
+        self.y = y
+        self.sigma = sigma
+        if is_observed:
+            return pm.KroneckerNormal(name, mu=mu, covs=covs, sigma=sigma,
+                                      observed=y, **kwargs)
+        else:
+            shape = np.prod([len(X) for X in Xs])
+            return pm.KroneckerNormal(name, mu=mu, covs=covs, sigma=sigma,
+                                      shape=shape, **kwargs)
+
+    def _build_conditional(self, Xnew, pred_noise, diag):
+        Xs, y, sigma = self.Xs, self.y, self.sigma
+
+        # Old points
+        X = cartesian(*Xs)
+        delta = y - self.mean_func(X)
+        Kns = [f(x) for f, x in zip(self.cov_funcs, Xs)]
+        eigs_sep, Qs = zip(*map(eigh, Kns))  # Unzip
+        QTs = list(map(tt.transpose, Qs))
+        eigs = kron_diag(*eigs_sep)  # Combine separate eigs
+        if sigma is not None:
+            eigs += sigma**2
+
+        # New points
+        Km = self.cov_func(Xnew, diag=diag)
+        Knm = self.cov_func(X, Xnew)
+        Kmn = Knm.T
+
+        # Build conditional mu
+        alpha = kron_dot(QTs, delta)
+        alpha = alpha/eigs[:, None]
+        alpha = kron_dot(Qs, alpha)
+        mu = tt.dot(Kmn, alpha).ravel() + self.mean_func(Xnew)
+
+        # Build conditional cov
+        A = kron_dot(QTs, Knm)
+        A = A/tt.sqrt(eigs[:, None])
+        if diag:
+            Asq = tt.sum(tt.square(A), 0)
+            cov = Km - Asq
+            if pred_noise:
+                cov += sigma
+        else:
+            Asq = tt.dot(A.T, A)
+            cov = Km - Asq
+            if pred_noise:
+                cov += sigma * np.eye(cov.shape)
+        return mu, cov
+
+    def conditional(self, name, Xnew, pred_noise=False, **kwargs):
+        """
+        Returns the conditional distribution evaluated over new input
+        locations `Xnew`, just as in `Marginal`.
+
+        `Xnew` will be split
+        by columns and fed to the relevant covariance functions based on their
+        `input_dim`. For example, if `cov_func1`, `cov_func2`, and `cov_func3`
+        have `input_dim` of 2, 1, and 4, respectively, then `Xnew` must have
+        7 columns and a covariance between the prediction points
+
+        .. code:: python
+
+            cov_func(Xnew) = cov_func1(Xnew[:, :2]) * cov_func1(Xnew[:, 2:3]) * cov_func1(Xnew[:, 3:])
+
+        This `cov_func` does not have a Kronecker structure without a full
+        grid, but the conditional distribution does not have a Kronecker
+        structure regardless. Thus, the conditional method must fall back to
+        using `MvNormal` rather than `KroneckerNormal` in either case.
+
+        Parameters
+        ----------
+        name : string
+            Name of the random variable
+        Xnew : array-like
+            Function input values.  If one-dimensional, must be a column
+            vector with shape `(n, 1)`.
+        pred_noise : bool
+            Whether or not observation noise is included in the conditional.
+            Default is `False`.
+        **kwargs
+            Extra keyword arguments that are passed to `MvNormal` distribution
+            constructor.
+        """
+        mu, cov = self._build_conditional(Xnew, pred_noise, False)
+        chol = cholesky(stabilize(cov))
+        shape = infer_shape(Xnew, kwargs.pop("shape", None))
+        return pm.MvNormal(name, mu=mu, chol=chol, shape=shape, **kwargs)
+
+    def predict(self, Xnew, point=None, diag=False, pred_noise=False):
+        R"""
+        Return the mean vector and covariance matrix of the conditional
+        distribution as numpy arrays, given a `point`, such as the MAP
+        estimate or a sample from a `trace`.
+
+        Parameters
+        ----------
+        Xnew : array-like
+            Function input values.  If one-dimensional, must be a column
+            vector with shape `(n, 1)`.
+        point : pymc3.model.Point
+            A specific point to condition on.
+        diag : bool
+            If `True`, return the diagonal instead of the full covariance
+            matrix.  Default is `False`.
+        pred_noise : bool
+            Whether or not observation noise is included in the conditional.
+            Default is `False`.
+        """
+        mu, cov = self._build_conditional(Xnew, pred_noise, diag)
+        return draw_values([mu, cov], point=point)
+
+    def predictt(self, Xnew, diag=False, pred_noise=False):
+        R"""
+        Return the mean vector and covariance matrix of the conditional
+        distribution as symbolic variables.
+
+        Parameters
+        ----------
+        Xnew : array-like
+            Function input values.  If one-dimensional, must be a column
+            vector with shape `(n, 1)`.
+        diag : bool
+            If `True`, return the diagonal instead of the full covariance
+            matrix.  Default is `False`.
+        pred_noise : bool
+            Whether or not observation noise is included in the conditional.
+            Default is `False`.
+        """
+        mu, cov = self._build_conditional(Xnew, pred_noise, diag)
+        return mu, cov

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -47,12 +47,12 @@ def cartesian(*arrays):
 
 
 def kron_matrix_op(krons, m, op):
-    """Apply op to krons and m in a way that reproduces op(kronecker(krons), m)
+    """Apply op to krons and m in a way that reproduces op(kronecker(*krons), m)
 
     Parameters
     -----------
-    krons: list of 2D array-like objects
-           D matrices [A_1, A_2, ..., A_D] to be Kronecker'ed:
+    krons: list of square 2D array-like objects
+           D square matrices [A_1, A_2, ..., A_D] to be Kronecker'ed:
               A = A_1 \otimes A_2 \otimes ... \otimes A_D
            Product of column dimensions must be N
     m    : NxM array or 1D array (treated as Nx1)
@@ -70,7 +70,7 @@ def kron_matrix_op(krons, m, op):
     if m.ndim == 1:
         m = m[:, None]  # Treat 1D array as Nx1 matrix
     if m.ndim != 2:  # Has not been tested otherwise
-        raise TypeError('m must have ndim == 2 instead of {}'.format(mat.ndim))
+        raise ValueError('m must have ndim <= 2, not {}'.format(mat.ndim))
     m = m.T
     res, _ = theano.scan(kron_vector_op, sequences=[m])
     return res.T

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -18,8 +18,82 @@ import scipy as sp
 import scipy.sparse
 from scipy.linalg import block_diag as scipy_block_diag
 from pymc3.theanof import floatX, largest_common_dtype, ix_
+from functools import reduce, partial
 
 # pylint: enable=unused-import
+
+
+def kronecker(*Ks):
+    """Return the Kronecker product of arguments:
+            K_1 \otimes K_2 \otimes ... \otimes K_D
+
+    Parameters
+    ----------
+    Ks: 2D array-like
+    """
+    return reduce(tt.slinalg.kron, Ks)
+
+
+def cartesian(*arrays):
+    """Makes the Cartesian product of arrays.
+
+    Parameters
+    ----------
+    arrays: 1D array-like
+            1D arrays where earlier arrays loop more slowly than later ones
+    """
+    N = len(arrays)
+    return np.stack(np.meshgrid(*arrays, indexing='ij'), -1).reshape(-1, N)
+
+
+def kron_matrix_op(krons, m, op):
+    """Apply op to krons and m in a way that reproduces op(kronecker(krons), m)
+
+    Parameters
+    -----------
+    krons: list of 2D array-like objects
+           D matrices [A_1, A_2, ..., A_D] to be Kronecker'ed:
+              A = A_1 \otimes A_2 \otimes ... \otimes A_D
+           Product of column dimensions must be N
+    m    : NxM array or 1D array (treated as Nx1)
+           Object that krons act upon
+    """
+    def flat_matrix_op(flat_mat, mat):
+        Nmat = mat.shape[1]
+        flat_shape = flat_mat.shape
+        mat2 = flat_mat.reshape((Nmat, -1))
+        return op(mat, mat2).T.reshape(flat_shape)
+
+    def kron_vector_op(v):
+        return reduce(flat_matrix_op, krons, v)
+
+    if m.ndim == 1:
+        m = m[:, None]  # Treat 1D array as Nx1 matrix
+    if m.ndim != 2:  # Has not been tested otherwise
+        raise TypeError('m must have ndim == 2 instead of {}'.format(mat.ndim))
+    m = m.T
+    res, _ = theano.scan(kron_vector_op, sequences=[m])
+    return res.T
+
+
+# Define kronecker functions that work on 1D and 2D arrays
+kron_dot = partial(kron_matrix_op, op=tt.dot)
+kron_solve_lower = partial(kron_matrix_op, op=tt.slinalg.solve_lower_triangular)
+
+
+def flat_outer(a, b):
+    return tt.outer(a, b).ravel()
+
+
+def kron_diag(*diags):
+    """Returns diagonal of a kronecker product.
+
+    Parameters
+    ----------
+    diags: 1D arrays
+           The diagonals of matrices that are to be Kroneckered
+    """
+    return reduce(flat_outer, diags)
 
 
 def tround(*args, **kwargs):

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -13,16 +13,20 @@ from .helpers import SeededTest
 from .test_distributions import (
     build_model, Domain, product, R, Rplus, Rplusbig, Rplusdunif,
     Unit, Nat, NatSmall, I, Simplex, Vector, PdMatrix,
-    PdMatrixChol, PdMatrixCholUpper, RealMatrix
+    PdMatrixChol, PdMatrixCholUpper, RealMatrix, RandomPdMatrix
 )
 
 
 def pymc3_random(dist, paramdomains, ref_rand, valuedomain=Domain([0]),
-                 size=10000, alpha=0.05, fails=10, extra_args=None):
+                 size=10000, alpha=0.05, fails=10, extra_args=None,
+                 model_args=None):
+    if model_args is None:
+        model_args = {}
     model = build_model(dist, valuedomain, paramdomains, extra_args)
     domains = paramdomains.copy()
     for pt in product(domains, n_samples=100):
         pt = pm.Point(pt, model=model)
+        pt.update(model_args)
         p = alpha
         # Allow KS test to fail (i.e., the samples be different)
         # a certain number of times. Crude, but necessary.
@@ -585,6 +589,54 @@ class TestScalarParameterSamples(SeededTest):
             #     size=n, valuedomain=RealMatrix(n, n), ref_rand=ref_rand_uchol,
             #     extra_args={'lower': False}
             # )
+
+    def test_kronecker_normal(self):
+        def ref_rand(size, mu, covs, sigma):
+            cov = pm.math.kronecker(covs[0], covs[1]).eval()
+            cov += sigma**2 * np.identity(cov.shape[0])
+            return st.multivariate_normal.rvs(mean=mu, cov=cov, size=size)
+
+        def ref_rand_chol(size, mu, chols, sigma):
+            covs = [np.dot(chol, chol.T) for chol in chols]
+            return ref_rand(size, mu, covs, sigma)
+
+        def ref_rand_evd(size, mu, evds, sigma):
+            covs = []
+            for eigs, Q in evds:
+                covs.append(np.dot(Q, np.dot(np.diag(eigs), Q.T)))
+            return ref_rand(size, mu, covs, sigma)
+
+        sizes = [2, 3]
+        sigmas = [0, 1]
+        for n, sigma in zip(sizes, sigmas):
+            N = n**2
+            covs = [RandomPdMatrix(n), RandomPdMatrix(n)]
+            chols = list(map(np.linalg.cholesky, covs))
+            evds = list(map(np.linalg.eigh, covs))
+            dom = Domain([np.random.randn(N)*0.1], edges=(None, None), shape=N)
+            mu = Domain([np.random.randn(N)*0.1], edges=(None, None), shape=N)
+
+            std_args = {'mu': mu}
+            cov_args = {'covs': covs}
+            chol_args = {'chols': chols}
+            evd_args = {'evds': evds}
+            if sigma is not None and sigma != 0:
+                std_args['sigma'] = Domain([sigma], edges=(None, None))
+            else:
+                for args in [cov_args, chol_args, evd_args]:
+                    args['sigma'] = sigma
+
+            pymc3_random(
+                 pm.KroneckerNormal, std_args, valuedomain=dom,
+                 ref_rand=ref_rand, extra_args=cov_args, model_args=cov_args)
+            pymc3_random(
+                 pm.KroneckerNormal, std_args, valuedomain=dom,
+                 ref_rand=ref_rand_chol, extra_args=chol_args,
+                 model_args=chol_args)
+            pymc3_random(
+                 pm.KroneckerNormal, std_args, valuedomain=dom,
+                 ref_rand=ref_rand_evd, extra_args=evd_args,
+                 model_args=evd_args)
 
     def test_mv_t(self):
         def ref_rand(size, nu, Sigma, mu):


### PR DESCRIPTION
Added the required classes for building a GP that takes advantage of a Kronecker-structured covariance matrix. See [this](https://discourse.pymc.io/t/extending-gaussian-process-functionality-coregion-and-beyond/479/15) discussion. This PR includes

* Efficient Kronecker operations
* A KroneckerNormal distribution
* A MarginalKron GP (LatentKron should be easy to add soon too)
* A Coregion kernel

Tests have not been implemented yet, but are coming.