### PR TITLE
Fix Doc of MvNormal

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -156,7 +156,7 @@ class MvNormal(_QuadFormBase):
     .. math::
 
        f(x \mid \pi, T) =
-           \frac{|T|^{1/2}}{(2\pi)^{1/2}}
+           \frac{|T|^{1/2}}{(2\pi)^{k/2}}
            \exp\left\{ -\frac{1}{2} (x-\mu)^{\prime} T (x-\mu) \right\}
 
     ========  ==========================


### PR DESCRIPTION
Following [https://discourse.pymc.io/t/wrong-info-displayed-for-pdf-of-mvnormal-in-the-documentation-code-ok/615](https://discourse.pymc.io/t/wrong-info-displayed-for-pdf-of-mvnormal-in-the-documentation-code-ok/615) here is the change.
The remark in that thread about the doc saying it is showing the log-likelihood instead of the pdf is also valid for many other distributions (maybe all? I didn't check them all, just a few) so I didn't make any change with regards to that because maybe it is intended/obvious that it is the pdf that is shown? Otherwise probably some overhaul of the documentation needs to happen in that respect.