### PR TITLE
Distributed draws evenly among chains by default

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -330,6 +330,11 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None,
             _check_start_shape(model, start_vals)
 
     draws_per_chain = int(draws/chains)
+    if draws % chains:
+        msg = "Specified draws do not evenly divide among chains. "
+        msg += "Realized trace will consist of {} samples.".format(int(draws/chains)*chains)
+        warnings.warn(msg, UserWarning)
+        
     draws_per_chain += tune
 
     if nuts_kwargs is not None:

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -279,7 +279,7 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None,
     Returns
     -------
     trace : pymc3.backends.base.MultiTrace
-        A `MultiTrace` object that contains the samples.
+        A `MultiTrace` object that contains `draws` number samples per variable.
 
     Examples
     --------
@@ -329,7 +329,8 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None,
         for start_vals in start:
             _check_start_shape(model, start_vals)
 
-    draws += tune
+    draws_per_chain = int(draws/chains)
+    draws_per_chain += tune
 
     if nuts_kwargs is not None:
         if step_kwargs is not None:
@@ -363,9 +364,9 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None,
         start = [None] * chains
     if isinstance(start, dict):
         start = [start] * chains
-
+    
     sample_args = {
-        'draws': draws,
+        'draws': draws_per_chain,
         'step': step,
         'start': start,
         'trace': trace,

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -165,7 +165,7 @@ def _cpu_count():
     return cpus
 
 
-def sample(draws=500, step=None, init='auto', n_init=200000, start=None,
+def sample(draws=1000, step=None, init='auto', n_init=200000, start=None,
            trace=None, chain_idx=0, chains=None, njobs=None, tune=500,
            nuts_kwargs=None, step_kwargs=None, progressbar=True, model=None,
            random_seed=None, live_plot=False, discard_tuned_samples=True,

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -425,9 +425,6 @@ class NutsReport(object):
 
     def _check_len(self, tuning):
         n = (~tuning).sum()
-        if n < 500:
-            warnings.warn('Chain %s contains only %s samples.'
-                          % (self._chain_id, n))
         if np.all(tuning):
             warnings.warn('Step size tuning was enabled throughout the whole '
                           'trace. You might want to specify the number of '

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -53,11 +53,11 @@ class TestSample(SeededTest):
         assert (draws[0] == draws[1]).all()
 
     def test_sample(self):
-        test_njobs = [1]
+        test_chains = [1]
         with self.model:
-            for njobs in test_njobs:
+            for chains in test_chains:
                 for steps in [1, 10, 300]:
-                    pm.sample(steps, tune=0, step=self.step, njobs=njobs,
+                    pm.sample(steps, tune=0, step=self.step, chains=chains,
                               random_seed=self.random_seed)
 
     def test_sample_init(self):
@@ -100,15 +100,18 @@ class TestSample(SeededTest):
         assert tr.get_values('x', chains=0)[0][0] > 0
         assert tr.get_values('x', chains=1)[0][0] < 0
 
-    def test_sample_tune_len(self):
+    def test_sample_len(self):
         with self.model:
-            trace = pm.sample(draws=100, tune=50, njobs=1)
-            assert len(trace) == 100
+            trace = pm.sample(draws=100, tune=50, chains=1)
+            assert trace['x'].shape[0] == 100
+            trace = pm.sample(draws=100, tune=50, chains=1,
+                              discard_tuned_samples=False)
+            assert trace['x'].shape[0] == 150
             trace = pm.sample(draws=100, tune=50, njobs=1,
                               discard_tuned_samples=False)
-            assert len(trace) == 150
-            trace = pm.sample(draws=100, tune=50, njobs=4)
-            assert len(trace) == 100
+            assert trace['x'].shape[0] == 200
+            trace = pm.sample(draws=100, tune=50, chains=4)
+            assert trace['x'].shape[0] == 100
 
     @pytest.mark.parametrize(
         'start, error', [


### PR DESCRIPTION
This addresses the issue in #2739 where the number of samples drawn does not reflect what was requested. Draws are now evenly distributed among chains. Now, the following occurs, as expected:

```python
In [1]: import pymc3 as pm

In [2]: with pm.Model() as m: x = pm.Normal('x')

In [3]: with m: trace = pm.sample(1000)
Auto-assigning NUTS sampler...
Initializing NUTS using jitter+adapt_diag...
100%|█████████████████████████████████████| 1000/1000 [00:00<00:00, 1273.81it/s]

In [4]: trace['x'].shape
Out[4]: (1000,)
```

I also removed the sampler warning for chains with <500 samples. If you ask for fewer than 500 samples, you should receive them without generating a warning. 
