### PR TITLE
Removed step assignment logging from sample

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -139,7 +139,6 @@ def assign_step_methods(model, step=None, methods=STEP_METHODS,
             selected = max(methods, key=lambda method,
                            var=var, has_gradient=has_gradient:
                            method._competence(var, has_gradient))
-            pm._log.info('Assigned {0} to {1}'.format(selected.__name__, var))
             selected_steps[selected].append(var)
 
     return instantiate_steppers(model, steps, selected_steps, step_kwargs)


### PR DESCRIPTION
The verbose "Assigned <step_method> to <variable>" logging in `assign_step_methods` is redundant now that we summarize the assignments.