### PR TITLE
Add logit parametrization of Bernoulli

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## PyMC 3.4 (unreleased)
+
+### New features
+
+- Add `logit_p` keyword to `pm.Bernoulli`, so that users can specify the logit
+  of the success probability. This is faster and more stable than using
+  `p=tt.nnet.sigmoid(logit_p)`.
+
 ## PyMC 3.3 (January 9, 2018)
 
 ### New features

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -36,18 +36,43 @@ def logsumexp(x, axis=None):
     x_max = tt.max(x, axis=axis, keepdims=True)
     return tt.log(tt.sum(tt.exp(x - x_max), axis=axis, keepdims=True)) + x_max
 
+
 def logaddexp(a, b):
     diff = b - a
     return tt.switch(diff > 0,
                     b + tt.log1p(tt.exp(-diff)),
                     a + tt.log1p(tt.exp(diff)))
 
+
 def invlogit(x, eps=sys.float_info.epsilon):
-    return (1. - 2. * eps) / (1. + tt.exp(-x)) + eps
+    """The inverse of the logit function, 1 / (1 + exp(-x))."""
+    return tt.nnet.sigmoid(x)
 
 
 def logit(p):
     return tt.log(p / (floatX(1) - p))
+
+
+def log1pexp(x):
+    """Return log(1 + exp(x)), also called softplus.
+
+    This function is numerically more stable than the naive approch.
+    """
+    return tt.nnet.softplus(x)
+
+
+def log1mexp(x):
+    """Return log(1 - exp(-x)).
+
+    This function is numerically more stable than the naive approch.
+
+    For details, see
+    https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
+    """
+    return tt.switch(
+        tt.lt(x, 0.683),
+        tt.log(-tt.expm1(-x)),
+        tt.log1p(-tt.exp(-x)))
 
 
 def flatten_list(tensors):

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -381,7 +381,7 @@ class ValueGradFunction(object):
                 raise TypeError('Invalid dtype for variable %s. Can not '
                                 'cast to %s with casting rule %s.'
                                 % (var.name, self.dtype, casting))
-            if not np.issubdtype(var.dtype, float):
+            if not np.issubdtype(var.dtype, np.floating):
                 raise TypeError('Invalid dtype for variable %s. Must be '
                                 'floating point but is %s.'
                                 % (var.name, var.dtype))

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -610,8 +610,12 @@ class TestMatchesScipy(SeededTest):
         self.checkd(BetaBinomial, Nat, {'alpha': Rplus, 'beta': Rplus, 'n': NatSmall})
 
     def test_bernoulli(self):
+        self.pymc3_matches_scipy(
+            Bernoulli, Bool, {'logit_p': R},
+            lambda value, logit_p: sp.bernoulli.logpmf(value, scipy.special.expit(logit_p)))
         self.pymc3_matches_scipy(Bernoulli, Bool, {'p': Unit},
                                  lambda value, p: sp.bernoulli.logpmf(value, p))
+
 
     def test_discrete_weibull(self):
         self.pymc3_matches_scipy(DiscreteWeibull, Nat,

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -43,15 +43,15 @@ class TestARM5_4(SeededTest):
         P['1'] = 1
 
         with pm.Model() as model:
-            effects = pm.Normal('effects', mu=0, tau=100. ** -2, shape=len(P.columns))
-            p = tt.nnet.sigmoid(tt.dot(floatX(np.array(P)), effects))
-            pm.Bernoulli('s', p, observed=floatX(np.array(data.switch)))
+            effects = pm.Normal('effects', mu=0, sd=100, shape=len(P.columns))
+            logit_p = tt.dot(floatX(np.array(P)), effects)
+            pm.Bernoulli('s', logit_p=logit_p, observed=floatX(data.switch.values))
         return model
 
     def test_run(self):
         model = self.build_model()
         with model:
-            pm.sample(50, tune=50, n_init=1000)
+            pm.sample(50, tune=50)
 
 
 class TestARM12_6(SeededTest):
@@ -247,7 +247,7 @@ class TestLatentOccupancy(SeededTest):
             # Estimated occupancy
             psi = pm.Beta('psi', 1, 1)
             # Latent variable for occupancy
-            pm.Bernoulli('z', psi, self.y.shape)
+            pm.Bernoulli('z', psi, shape=self.y.shape)
             # Estimated mean count
             theta = pm.Uniform('theta', 0, 100)
             # Poisson likelihood

--- a/pymc3/tests/test_math.py
+++ b/pymc3/tests/test_math.py
@@ -1,9 +1,11 @@
 import numpy as np
+import numpy.testing as npt
 import theano
 import theano.tensor as tt
 from theano.tests import unittest_tools as utt
 from pymc3.math import (
-    LogDet, logdet, probit, invprobit, expand_packed_triangular)
+    LogDet, logdet, probit, invprobit, expand_packed_triangular,
+    log1pexp, log1mexp)
 from .helpers import SeededTest
 import pytest
 from pymc3.theanof import floatX
@@ -12,6 +14,42 @@ from pymc3.theanof import floatX
 def test_probit():
     p = np.array([0.01, 0.25, 0.5, 0.75, 0.99])
     np.testing.assert_allclose(invprobit(probit(p)).eval(), p, atol=1e-5)
+
+
+def test_log1pexp():
+    vals = np.array([-1e20, -100, -10, -1e-4, 0, 1e-4, 10, 100, 1e20])
+    # import mpmath
+    # mpmath.mp.dps = 1000
+    # [float(mpmath.log(1 + mpmath.exp(x))) for x in vals]
+    expected = np.array([
+        0.0,
+        3.720075976020836e-44,
+        4.539889921686465e-05,
+        0.6930971818099453,
+        0.6931471805599453,
+        0.6931971818099453,
+        10.000045398899218,
+        100.0,
+        1e+20])
+    actual = log1pexp(vals).eval()
+    npt.assert_allclose(actual, expected)
+
+
+def test_log1mexp():
+    vals = np.array([-1, 0, 1e-20, 1e-4, 10, 100, 1e20])
+    # import mpmath
+    # mpmath.mp.dps = 1000
+    # [float(mpmath.log(1 - mpmath.exp(-x))) for x in vals]
+    expected = np.array([
+        np.nan,
+        -np.inf,
+        -46.051701859880914,
+        -9.210390371559516,
+        -4.540096037048921e-05,
+        -3.720075976020836e-44,
+        0.0])
+    actual = log1mexp(vals).eval()
+    npt.assert_allclose(actual, expected)
 
 
 class TestLogDet(SeededTest):


### PR DESCRIPTION
Most of the time we model the logit of the success probability when we use the Bernoulli distribution. This PR adds the option to specify this directly, which makes some numerical improvements possible.
We don't really use `math.log1mexp` anywhere at the moment, but it would be a bit strange to only have `log1pexp`, and I'm pretty sure it will come in handy for some users and also for us.