### PR TITLE
Removed preference for slice sampler for continuous variables

### DIFF
--- a/pymc3/step_methods/slicer.py
+++ b/pymc3/step_methods/slicer.py
@@ -97,5 +97,8 @@ class Slice(ArrayStep):
     @staticmethod
     def competence(var, has_grad):
         if var.dtype in continuous_types:
+            if not has_grad and (var.shape is None or var.shape.ndim == 1):
+                return Competence.PREFERRED
             return Competence.COMPATIBLE
         return Competence.INCOMPATIBLE
+       

--- a/pymc3/step_methods/slicer.py
+++ b/pymc3/step_methods/slicer.py
@@ -97,7 +97,5 @@ class Slice(ArrayStep):
     @staticmethod
     def competence(var, has_grad):
         if var.dtype in continuous_types:
-            if not var.shape or var.shape.ndim == 1:
-                return Competence.PREFERRED
             return Competence.COMPATIBLE
         return Competence.INCOMPATIBLE


### PR DESCRIPTION
The `competence` for the slice sampler currently in master makes it preferred for the condition `not var.shape or var.shape.ndim == 1`. This should not be the case. Moreover, `var.shape` should not be evaluated as false, because it will be a Theano object:

```python
with Model() as model:
     x = Normal('x', 0, 1)
```

```
In [9]: x.shape
Out[9]: Shape.0
```

I noticed this issue when `Slice` was chosen as the sampler for a matrix-valued uniform, which seemed odd:

```python
B = pm.Uniform('B', lower=meng_B-0.2*meng_B, upper=meng_B+0.2*meng_B, shape=meng_B.shape)
```
```
>Slice: [B_interval__]
```
