### PR TITLE
deepcopy(step) when SequentialSampling

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1,5 +1,6 @@
 from collections import defaultdict, Iterable
 from copy import copy
+from copy import deepcopy
 import pickle
 import logging
 import warnings
@@ -479,7 +480,7 @@ def _sample_many(draws, chain, chains, start, random_seed, step, **kwargs):
     traces = []
     for i in range(chains):
         trace = _sample(draws=draws, chain=chain + i, start=start[i],
-                        step=step, random_seed=random_seed[i], **kwargs)
+                        step=deepcopy(step), random_seed=random_seed[i], **kwargs)
         if trace is None:
             if len(traces) == 0:
                 raise ValueError('Sampling stopped before a sample was created.')

--- a/pymc3/tests/test_sgfs.py
+++ b/pymc3/tests/test_sgfs.py
@@ -32,8 +32,7 @@ def test_minibatch():
 
         step_method = pm.SGFS(batch_size=batch_size, step_size=1., total_size=total_size)
         
-        chains = 1
-        njobs = max(1, chains) # njobs >= chains
+        chains = 2
+        njobs = 1 
         trace = pm.sample(draws=draws, step=step_method, njobs=njobs, chains=chains)
-        
     np.testing.assert_allclose(np.mean(trace['abc'], axis=0), np.asarray([a, b, c]), rtol=0.1)

--- a/pymc3/tests/test_sgfs.py
+++ b/pymc3/tests/test_sgfs.py
@@ -31,6 +31,9 @@ def test_minibatch():
         pm.Normal('y', mu=y, observed=y_obs)
 
         step_method = pm.SGFS(batch_size=batch_size, step_size=1., total_size=total_size)
-        trace = pm.sample(draws=draws, step=step_method, init=None, njobs=2)
-
+        
+        chains = 1
+        njobs = max(1, chains) # njobs >= chains
+        trace = pm.sample(draws=draws, step=step_method, njobs=njobs, chains=chains)
+        
     np.testing.assert_allclose(np.mean(trace['abc'], axis=0), np.asarray([a, b, c]), rtol=0.1)


### PR DESCRIPTION
Fixes #2784 

The explanation for the test failing, was found in this code for `def sample`:

https://github.com/pymc-devs/pymc3/blob/master/pymc3/sampling.py#L329-L330

When njobs=1 and chains>=2, the chains with index>0 are sampling the initial values repetitively, which is (1.0, 1.0, 1.0) for  'abc' parameter as defined in https://github.com/pymc-devs/pymc3/blob/master/pymc3/tests/test_sgfs.py#L24-L31. This was causing the test to fail, because the mean estimate with chains=2 and njobs=1 was not accurate.

The reason being, that the initialized step method has state variables. This implies an initialized step method can be used in a SequentialSampling only on one chain.

Therefore, a  deepcopy of the stepmethod when SequentialSampling fixes this issue and the repetitive sampling.