### PR TITLE
override multitrace.__contains__ for dictionary-like behavior

### DIFF
--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -286,6 +286,9 @@ class MultiTrace(object):
     @property
     def report(self):
         return self._report
+    
+    def __contains__(self, key):
+        return key in self.varnames
 
     def __getitem__(self, idx):
         if isinstance(idx, slice):


### PR DESCRIPTION
With this change, one can write `varname in multitrace` just like one would expect from something that behaves like a dictionary.

```
with pm.Model():
    pm.Normal('n')
    trace = pm.sample()

assert 'n' in trace.varnames
assert trace['n'] is not None
assert 'n' in trace
```