### PR TITLE
Fix max_treedepth warning

### DIFF
--- a/pymc3/backends/report.py
+++ b/pymc3/backends/report.py
@@ -102,11 +102,17 @@ class SamplerReport(object):
             warn = SamplerWarning(
                 WarningType.CONVERGENCE, msg, 'error', None, None, effective_n)
             warnings.append(warn)
+        elif eff_min / n_samples < 0.1:
+            msg = ("The number of effective samples is smaller than "
+                   "10% for some parameters.")
+            warn = SamplerWarning(
+                WarningType.CONVERGENCE, msg, 'warn', None, None, effective_n)
+            warnings.append(warn)
         elif eff_min / n_samples < 0.25:
             msg = ("The number of effective samples is smaller than "
                    "25% for some parameters.")
             warn = SamplerWarning(
-                WarningType.CONVERGENCE, msg, 'warn', None, None, effective_n)
+                WarningType.CONVERGENCE, msg, 'info', None, None, effective_n)
             warnings.append(warn)
 
         self._add_warnings(warnings)

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -177,8 +177,9 @@ class BaseHMC(arraystep.GradientSharedStep):
                 WarningType.DIVERGENCES, msg, 'error', None, None, None)
             warnings.append(warning)
         elif n_divs > 0:
-            message = ('Divergences after tuning. Increase `target_accept` or '
-                       'reparameterize.')
+            message = ('There were %s divergences after tuning. Increase '
+                       '`target_accept` or reparameterize.'
+                       % n_divs)
             warning = SamplerWarning(
                 WarningType.DIVERGENCES, message, 'error', None, None, None)
             warnings.append(warning)

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -170,7 +170,8 @@ class NUTS(BaseHMC):
             if divergence_info or turning:
                 break
         else:
-            self._reached_max_treedepth += 1
+            if not self.tune:
+                self._reached_max_treedepth += 1
 
         stats = tree.stats()
         accept_stat = stats['mean_tree_accept']
@@ -185,8 +186,10 @@ class NUTS(BaseHMC):
 
     def warnings(self, strace):
         warnings = super(NUTS, self).warnings(strace)
+        n_samples = self._samples_after_tune
+        n_treedepth = self._reached_max_treedepth
 
-        if np.mean(self._reached_max_treedepth) > 0.05:
+        if n_samples > 0 and n_treedepth / float(n_samples) > 0.05:
             msg = ('The chain reached the maximum tree depth. Increase '
                    'max_treedepth, increase target_accept or reparameterize.')
             warn = SamplerWarning(WarningType.TREEDEPTH, msg, 'warn',


### PR DESCRIPTION
fixes #2800 

Also, make the error at <25% effective sample size a info and add a warning at <10%.
cc @junpenglao Do you think that is ok, or is the 25% still too much?