### PR TITLE
WIP Refactor Distribution and random variables

### DIFF
--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -42,6 +42,7 @@ from .discrete import ZeroInflatedBinomial
 from .discrete import DiscreteUniform
 from .discrete import Geometric
 from .discrete import Categorical
+from .discrete import DiscreteFlat
 
 from .distribution import DensityDist
 from .distribution import Distribution

--- a/pymc3/distributions/bound.py
+++ b/pymc3/distributions/bound.py
@@ -19,7 +19,7 @@ class _Bounded(Distribution):
         self._wrapped = distribution.dist(*args, **kwargs)
 
         if default is None:
-            defaults = self._wrapped.defaults
+            defaults = self._wrapped._defaults
             for name in defaults:
                 setattr(self, name, getattr(self._wrapped, name))
         else:
@@ -27,9 +27,8 @@ class _Bounded(Distribution):
             self._default = default
 
         super(_Bounded, self).__init__(
-            shape=self._wrapped.shape,
+            atom_shape=self._wrapped.atom_shape,
             dtype=self._wrapped.dtype,
-            testval=self._wrapped.testval,
             defaults=defaults,
             transform=self._wrapped.transform)
 
@@ -142,10 +141,10 @@ class _ContinuousBounded(_Bounded, Continuous):
                 default = 0.5 * (lower + upper)
             elif upper is not None:
                 transform = transforms.upperbound(upper)
-                default = upper - 1
+                default = upper - 1.
             else:
                 transform = transforms.lowerbound(lower)
-                default = lower + 1
+                default = lower + 1.
         else:
             default = None
 

--- a/pymc3/glm/families.py
+++ b/pymc3/glm/families.py
@@ -86,7 +86,7 @@ class StudentT(Family):
     link = identity
     likelihood = pm_dists.StudentT
     parent = 'mu'
-    priors = {'lam': pm_dists.HalfCauchy.dist(beta=10, testval=1.),
+    priors = {'lam': pm_dists.HalfCauchy.dist(beta=10),
               'nu': 1}
 
 
@@ -94,7 +94,7 @@ class Normal(Family):
     link = identity
     likelihood = pm_dists.Normal
     parent = 'mu'
-    priors = {'sd': pm_dists.HalfCauchy.dist(beta=10, testval=1.)}
+    priors = {'sd': pm_dists.HalfCauchy.dist(beta=10)}
 
 
 class Binomial(Family):
@@ -107,12 +107,12 @@ class Poisson(Family):
     link = exp
     likelihood = pm_dists.Poisson
     parent = 'mu'
-    priors = {'mu': pm_dists.HalfCauchy.dist(beta=10, testval=1.)}
+    priors = {'mu': pm_dists.HalfCauchy.dist(beta=10)}
 
 
 class NegativeBinomial(Family):
     link = exp
     likelihood = pm_dists.NegativeBinomial
     parent = 'mu'
-    priors = {'mu': pm_dists.HalfCauchy.dist(beta=10, testval=1.),
-              'alpha': pm_dists.HalfCauchy.dist(beta=10, testval=1.)}
+    priors = {'mu': pm_dists.HalfCauchy.dist(beta=10),
+              'alpha': pm_dists.HalfCauchy.dist(beta=10)}

--- a/pymc3/tests/models.py
+++ b/pymc3/tests/models.py
@@ -12,7 +12,7 @@ def simple_model():
     mu = -2.1
     tau = 1.3
     with Model() as model:
-        Normal('x', mu, tau=tau, shape=2, testval=tt.ones(2) * .1)
+        Normal('x', mu, tau=tau, shape=2, testval=np.ones(2) * .1)
 
     return model.test_point, model, (mu, tau ** -.5)
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -6,15 +6,17 @@ from .helpers import SeededTest, select_by_precision
 from ..vartypes import continuous_types
 from ..model import Model, Point, Potential, Deterministic
 from ..blocking import DictToVarBijection, DictToArrayBijection, ArrayOrdering
-from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Dirichlet,
-                             MvStudentT, MvNormal, MatrixNormal, ZeroInflatedPoisson,
-                             ZeroInflatedNegativeBinomial, Constant, Poisson, Bernoulli, Beta,
-                             BetaBinomial, HalfStudentT, StudentT, Weibull, Pareto,
-                             InverseGamma, Gamma, Cauchy, HalfCauchy, Lognormal, Laplace,
-                             NegativeBinomial, Geometric, Exponential, ExGaussian, Normal,
-                             Flat, LKJCorr, Wald, ChiSquared, HalfNormal, DiscreteUniform,
-                             Bound, Uniform, Triangular, Binomial, SkewNormal, DiscreteWeibull,
-                             Gumbel, Logistic, Interpolated, ZeroInflatedBinomial, HalfFlat, AR1)
+from ..distributions import (
+    DensityDist, Categorical, Multinomial, VonMises, Dirichlet,
+    MvStudentT, MvNormal, MatrixNormal, ZeroInflatedPoisson,
+    ZeroInflatedNegativeBinomial, Constant, Poisson, Bernoulli, Beta,
+    BetaBinomial, HalfStudentT, StudentT, Weibull, Pareto,
+    InverseGamma, Gamma, Cauchy, HalfCauchy, Lognormal, Laplace,
+    NegativeBinomial, Geometric, Exponential, ExGaussian, Normal,
+    Flat, LKJCorr, Wald, ChiSquared, HalfNormal, DiscreteUniform,
+    Bound, Uniform, Triangular, Binomial, SkewNormal, DiscreteWeibull,
+    Gumbel, Logistic, Interpolated, ZeroInflatedBinomial, HalfFlat, AR1,
+    DiscreteFlat)
 from ..distributions import continuous
 from pymc3.theanof import floatX
 from numpy import array, inf, log, exp
@@ -146,8 +148,12 @@ def build_model(distfam, valuedomain, vardomains, extra_args=None):
     with Model() as m:
         vals = {}
         for v, dom in vardomains.items():
-            vals[v] = Flat(v, dtype=dom.dtype, shape=dom.shape,
-                           testval=dom.vals[0])
+            if np.issubdtype(dom.dtype, np.integer):
+                vals[v] = DiscreteFlat(v, dtype=dom.dtype, shape=dom.shape,
+                                       testval=dom.vals[0])
+            else:
+                vals[v] = Flat(v, dtype=dom.dtype, shape=dom.shape,
+                               testval=dom.vals[0])
         vals.update(extra_args)
         distfam('value', shape=valuedomain.shape, transform=None, **vals)
     return m


### PR DESCRIPTION
**Work in progress!!**

Refactoring the Distribution class and the various random variable classes a bit. The goal here is to decouple those, to make things cleaner, and I think it should also make it easier to play with different backends.
It should also make it much easier to implement support for changing the dimension of free variables after model creation (if they depend on a shared variable for instance), and to get rid of the test_value thing in theano.

This changes a bit how we think about the shapes of variables. Previously the shape was set statically by inspecting the test_value of the created theano variable, and then fixed in the distribution. With this PR, each distribution has _two_ shapes: `atom_shape` and `param_shape`. The atom shape is the shape of one observation, so for most distributions this will just be `()`. For eg the MVNormal this will be `(n,)`. `param_shape` is the shape implied by the parameters of the distribution. So if we have a `pm.Normal('a', mu=np.zeros(5), sd=1)`, the param shape is `(5,)`. Since parameters can be theano variables the `param_shape` is not known statically, but can only be computed given values for all previous variables. (The same should probably be true for the `atom_shape`, but I haven't implemented that yet).
The distribution itself doesn't know the shape of the random variable anymore, this really belongs into the random variable. 
Since we do not use the test_values to infer that shape anymore, we need to keep track of the variable shapes in the model. It keeps dicts of shapes and default values (`model._RV_shapes, model._default_values`), and uses those shapes and default values to infer the shape of newly created variables `.