### PR TITLE
KDE: compute bandwith using entropy instead of standard deviation

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,8 @@
 ### Fixes
 
 - `VonMises` does not overflow for large values of kappa. i0 and i1 have been removed and we now use log_i0 to compute the logp.
+- The bandwidth for KDE plots is computed using a modified version of Scott's rule. The new version uses entropy instead of standard
+deviation. This works better for multimodal distributions. Functions using KDE plots has a new argument `bw` controlling the bandwidth.
 
 ### Deprecations
 

--- a/pymc3/plots/artists.py
+++ b/pymc3/plots/artists.py
@@ -22,14 +22,14 @@ def histplot_op(ax, data, alpha=.35):
     return hs
 
 
-def kdeplot_op(ax, data, prior=None, prior_alpha=1, prior_style='--'):
+def kdeplot_op(ax, data, bw, prior=None, prior_alpha=1, prior_style='--'):
     """Get a list of density and likelihood plots, if a prior is provided."""
     ls = []
     pls = []
     errored = []
     for i, d in enumerate(data.T):
         try:
-            density, l, u = fast_kde(d)
+            density, l, u = fast_kde(d, bw)
             x = np.linspace(l, u, len(density))
             if prior is not None:
                 p = prior.logp(x).eval()
@@ -48,7 +48,7 @@ def kdeplot_op(ax, data, prior=None, prior_alpha=1, prior_style='--'):
     return ls, pls
 
 
-def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
+def plot_posterior_op(trace_values, ax, bw, kde_plot, point_estimate, round_to,
                       alpha_level, ref_val, rope, text_size=16, **kwargs):
     """Artist to draw posterior."""
     def format_as_percent(x, round_to=0):
@@ -83,7 +83,7 @@ def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
             point_value = trace_values.mean()
         elif point_estimate == 'mode':
             if isinstance(trace_values[0], float):
-                density, l, u = fast_kde(trace_values)
+                density, l, u = fast_kde(trace_values, bw)
                 x = np.linspace(l, u, len(density))
                 point_value = x[np.argmax(density)]
             else:
@@ -127,7 +127,7 @@ def plot_posterior_op(trace_values, ax, kde_plot, point_estimate, round_to,
             d[key] = value
 
     if kde_plot and isinstance(trace_values[0], float):
-        kdeplot(trace_values, alpha=kwargs.pop('alpha', 0.35), ax=ax, **kwargs)
+        kdeplot(trace_values, alpha=kwargs.pop('alpha', 0.35), bw=bw, ax=ax, **kwargs)
 
     else:
         set_key_if_doesnt_exist(kwargs, 'bins', 30)

--- a/pymc3/plots/energyplot.py
+++ b/pymc3/plots/energyplot.py
@@ -8,8 +8,8 @@ except ImportError:  # mpl is optional
 from .kdeplot import kdeplot
 
 
-def energyplot(trace, kind='kde', figsize=None, ax=None, legend=True,
-               shade=0.35, frame=True, kwargs_shade=None, **kwargs):
+def energyplot(trace, kind='kde', figsize=None, ax=None, legend=True, shade=0.35, bw=4.5,
+               frame=True, kwargs_shade=None, **kwargs):
     """Plot energy transition distribution and marginal energy distribution in
     order to diagnose poor exploration by HMC algorithms.
 
@@ -28,6 +28,10 @@ def energyplot(trace, kind='kde', figsize=None, ax=None, legend=True,
     shade : float
         Alpha blending value for the shaded area under the curve, between 0
         (no shade) and 1 (opaque). Defaults to 0.35
+    bw : float
+        Bandwidth scaling factor for the KDE. Should be larger than 0. The higher this number the
+        smoother the KDE will be. Defaults to 4.5 which is essentially the same as the Scott's rule
+        of thumb (the default rule used by SciPy). Only works if `kind='kde'`.
     frame : bool
         Flag for plotting frame around figure.
     kwargs_shade : dicts, optional
@@ -61,8 +65,8 @@ def energyplot(trace, kind='kde', figsize=None, ax=None, legend=True,
 
     if kind == 'kde':
         for label, value in series:
-            kdeplot(value, label=label, shade=shade, ax=ax,
-                    kwargs_shade=kwargs_shade, **kwargs)
+            kdeplot(value, label=label, shade=shade, bw=bw, ax=ax, kwargs_shade=kwargs_shade,
+                    **kwargs)
 
     elif kind == 'hist':
         for label, value in series:

--- a/pymc3/plots/kdeplot.py
+++ b/pymc3/plots/kdeplot.py
@@ -68,7 +68,7 @@ def fast_kde(x):
     xmin, xmax = np.min(x), np.max(x)
 
     dx = (xmax - xmin) / (nx - 1)
-    std_x = entropy((x - xmin) / dx) * 3
+    std_x = entropy((x - xmin) / dx) * 4.5
     grid, _ = np.histogram(x, bins=nx)
 
     scotts_factor = n ** (-0.2)

--- a/pymc3/plots/kdeplot.py
+++ b/pymc3/plots/kdeplot.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.signal import gaussian, convolve
+from scipy.stats import entropy
 
 try:
     import matplotlib.pyplot as plt
@@ -67,7 +68,7 @@ def fast_kde(x):
     xmin, xmax = np.min(x), np.max(x)
 
     dx = (xmax - xmin) / (nx - 1)
-    std_x = np.std((x - xmin) / dx)
+    std_x = entropy((x - xmin) / dx) * 3
     grid, _ = np.histogram(x, bins=nx)
 
     scotts_factor = n ** (-0.2)

--- a/pymc3/plots/kdeplot.py
+++ b/pymc3/plots/kdeplot.py
@@ -8,7 +8,7 @@ except ImportError:  # mpl is optional
     pass
 
 
-def kdeplot(values, label=None, shade=0, ax=None, kwargs_shade=None, **kwargs):
+def kdeplot(values, label=None, shade=0, bw=4.5, ax=None, kwargs_shade=None, **kwargs):
     """
     1D KDE plot taking into account boundary conditions
 
@@ -21,6 +21,10 @@ def kdeplot(values, label=None, shade=0, ax=None, kwargs_shade=None, **kwargs):
     shade : float
         Alpha blending value for the shaded area under the curve, between 0
         (no shade) and 1 (opaque). Defaults to 0
+    bw : float
+        Bandwidth scaling factor. Should be larger than 0. The higher this number the smoother the
+        KDE will be. Defaults to 4.5 which is essentially the same as the Scott's rule of thumb
+        (the default rule used by SciPy).
     ax : matplotlib axes
     kwargs_shade : dicts, optional
         Additional keywords passed to `matplotlib.axes.Axes.fill_between`
@@ -36,7 +40,7 @@ def kdeplot(values, label=None, shade=0, ax=None, kwargs_shade=None, **kwargs):
     if kwargs_shade is None:
         kwargs_shade = {}
 
-    density, l, u = fast_kde(values)
+    density, l, u = fast_kde(values, bw)
     x = np.linspace(l, u, len(density))
     ax.plot(x, density, label=label, **kwargs)
     ax.set_ylim(0, auto=True)
@@ -45,7 +49,7 @@ def kdeplot(values, label=None, shade=0, ax=None, kwargs_shade=None, **kwargs):
     return ax
 
 
-def fast_kde(x):
+def fast_kde(x, bw=4.5):
     """
     A fft-based Gaussian kernel density estimate (KDE)
     The code was adapted from https://github.com/mfouesneau/faststats
@@ -53,6 +57,10 @@ def fast_kde(x):
     Parameters
     ----------
     x : Numpy array or list
+    bw : float
+        Bandwidth scaling factor for the KDE. Should be larger than 0. The higher this number the
+        smoother the KDE will be. Defaults to 4.5 which is essentially the same as the Scott's rule
+        of thumb (the default rule used by SciPy).
 
     Returns
     -------
@@ -68,7 +76,7 @@ def fast_kde(x):
     xmin, xmax = np.min(x), np.max(x)
 
     dx = (xmax - xmin) / (nx - 1)
-    std_x = entropy((x - xmin) / dx) * 4.5
+    std_x = entropy((x - xmin) / dx) * bw
     grid, _ = np.histogram(x, bins=nx)
 
     scotts_factor = n ** (-0.2)

--- a/pymc3/plots/posteriorplot.py
+++ b/pymc3/plots/posteriorplot.py
@@ -12,7 +12,7 @@ from .utils import identity_transform, get_default_varnames
 
 def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=None, text_size=None,
                    alpha_level=0.05, round_to=3, point_estimate='mean', rope=None,
-                   ref_val=None, kde_plot=False, plot_transformed=False, ax=None, **kwargs):
+                   ref_val=None, kde_plot=False, plot_transformed=False, bw=4.5, ax=None, **kwargs):
     """Plot Posterior densities in style of John K. Kruschke book.
 
     Parameters
@@ -44,6 +44,10 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
     plot_transformed : bool
         Flag for plotting automatically transformed variables in addition to
         original variables (defaults to False).
+    bw : float
+        Bandwidth scaling factor for the KDE. Should be larger than 0. The higher this number the
+        smoother the KDE will be. Defaults to 4.5 which is essentially the same as the Scott's rule
+        of thumb (the default rule used by SciPy). Only works if `kde_plot` is True.
     ax : axes
         Matplotlib axes. Defaults to None.
     **kwargs
@@ -103,10 +107,9 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
         if ax is None:
             fig, ax = plt.subplots(figsize=figsize)
 
-        plot_posterior_op(transform(trace), ax=ax, kde_plot=kde_plot,
-                          point_estimate=point_estimate, round_to=round_to,
-                          alpha_level=alpha_level, ref_val=ref_val, rope=rope,
-                          text_size=scale_text(figsize), **kwargs)
+        plot_posterior_op(transform(trace), ax=ax, bw=bw, kde_plot=kde_plot,
+                          point_estimate=point_estimate, round_to=round_to, alpha_level=alpha_level,
+                          ref_val=ref_val, rope=rope, text_size=scale_text(figsize), **kwargs)
     else:
         if varnames is None:
             varnames = get_default_varnames(trace.varnames, plot_transformed)
@@ -129,7 +132,7 @@ def plot_posterior(trace, varnames=None, transform=identity_transform, figsize=N
 
         for idx, (a, v) in enumerate(zip(np.atleast_1d(ax), trace_dict)):
             tr_values = transform(trace_dict[v])
-            plot_posterior_op(tr_values, ax=a, kde_plot=kde_plot,
+            plot_posterior_op(tr_values, ax=a, bw=bw, kde_plot=kde_plot,
                               point_estimate=point_estimate, round_to=round_to,
                               alpha_level=alpha_level, ref_val=ref_val[idx],
                               rope=rope[idx], text_size=scale_text(figsize), **kwargs)

--- a/pymc3/plots/traceplot.py
+++ b/pymc3/plots/traceplot.py
@@ -10,7 +10,7 @@ from .utils import identity_transform, get_default_varnames, get_axis, make_2d
 
 def traceplot(trace, varnames=None, transform=identity_transform, figsize=None, lines=None,
               combined=False, plot_transformed=False, grid=False, alpha=0.35, priors=None,
-              prior_alpha=1, prior_style='--', ax=None, live_plot=False,
+              prior_alpha=1, prior_style='--', bw=4.5, ax=None, live_plot=False,
               skip_first=0, refresh_every=100, roll_over=1000):
     """Plot samples histograms and values.
 
@@ -47,6 +47,10 @@ def traceplot(trace, varnames=None, transform=identity_transform, figsize=None, 
         Alpha value for prior plot. Defaults to 1.
     prior_style : str
         Line style for prior plot. Defaults to '--' (dashed line).
+    bw : float
+        Bandwidth scaling factor for the KDE. Should be larger than 0. The higher this number the
+        smoother the KDE will be. Defaults to 4.5 which is essentially the same as the Scott's rule
+        of thumb (the default rule used by SciPy).
     ax : axes
         Matplotlib axes. Accepts an array of axes, e.g.:
     live_plot: bool
@@ -107,7 +111,7 @@ def traceplot(trace, varnames=None, transform=identity_transform, figsize=None, 
                 hist_objs = histplot_op(ax[i, 0], d, alpha=alpha)
                 colors = [h[-1][0].get_facecolor() for h in hist_objs]
             else:
-                artists = kdeplot_op(ax[i, 0], d, prior, prior_alpha, prior_style)[0]
+                artists = kdeplot_op(ax[i, 0], d, bw, prior, prior_alpha, prior_style)[0]
                 colors = [a[0].get_color() for a in artists]
             ax[i, 0].set_title(str(v))
             ax[i, 0].grid(grid)


### PR DESCRIPTION
This is important for multimodal distributions. Left column previous method, right column new one. What do you think?

![std_s](https://user-images.githubusercontent.com/1338958/35771289-fd54fbb6-0908-11e8-9dd5-62a8a9889bf7.png)
