### PR TITLE
add numpy=1.13 as a dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ nbsphinx>=0.2.13
 nose>=1.3.7
 nose-parameterized==0.6.0
 numdifftools>=0.9.20
-numpy>=1.11.0
+numpy>=1.13.0
 numpydoc==0.7.0
 pycodestyle>=2.3.1
 pyflakes>=1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 theano>=1.0.0
+numpy>=1.13.0
 pandas>=0.18.0
 patsy>=0.4.0
 joblib>=0.9


### PR DESCRIPTION
We use `np.divmod` that was introduced in NumPy = 1.13