### PR TITLE
Only set random seed if specified.

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -258,8 +258,8 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None,
     tune : int
         Number of iterations to tune, if applicable (defaults to 500).
         Samplers adjust the step sizes, scalings or similar during
-        tuning. Tuning samples will be drawn in addition to the number 
-        specified in the `draws` argument, and will be discarded 
+        tuning. Tuning samples will be drawn in addition to the number
+        specified in the `draws` argument, and will be discarded
         unless `discard_tuned_samples` is set to False.
     nuts_kwargs : dict
         Options for the NUTS sampler. See the docstring of NUTS
@@ -1028,7 +1028,8 @@ def sample_ppc(trace, samples=None, model=None, vars=None, size=None,
     if vars is None:
         vars = model.observed_RVs
 
-    np.random.seed(random_seed)
+    if random_seed is not None:
+        np.random.seed(random_seed)
 
     indices = np.random.randint(0, nchain * len_trace, samples)
 


### PR DESCRIPTION
This is trying to continue to enforce the practice that these two patterns are deterministic:

```
np.random.seed(1)
pm.anything()
np.random.random()
```
and

```
pm.anything(random_seed=1)
np.random.random()
```

This pattern is also not enforced yet in the `PopulationStepper`, but I think that will take a little more care.