### PR TITLE
Small fix for fast_kde

### DIFF
--- a/pymc3/plots/kdeplot.py
+++ b/pymc3/plots/kdeplot.py
@@ -77,6 +77,8 @@ def fast_kde(x, bw=4.5):
 
     dx = (xmax - xmin) / (nx - 1)
     std_x = entropy((x - xmin) / dx) * bw
+    if ~np.isfinite(std_x):
+        std_x = 0.
     grid, _ = np.histogram(x, bins=nx)
 
     scotts_factor = n ** (-0.2)


### PR DESCRIPTION
After #2837 fast_kde failed with stale trace (ie, trast with only one value like [0, 0, 0, 0, ...]). This PR make sure the fast_kde behavior is the same as before.