### PR TITLE
Add sample_prior function

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,8 +11,7 @@
   Gaussian Process implementation for efficient inference, along with
   lower-level functions such as `cartesian` and `kronecker` products.
 - Added `Coregion` covariance function.
-- Add new 'pairplot' function, for plotting scatter or hexbin matrices of sampled parameters.
-  Optionally it can plot divergences.
+- Add new 'pairplot' function, for plotting scatter or hexbin matrices of sampled parameters. Optionally it can plot divergences.
 - Plots of discrete distributions in the docstrings
 - Add logitnormal distribution
 - Densityplot: add support for discrete variables
@@ -21,6 +20,7 @@
 - Changed the `compare` function to accept a dictionary of model-trace pairs instead of two separate lists of models and traces.
 - add test and support for creating multivariate mixture and mixture of mixtures
 - `distribution.draw_values`, now is also able to draw values from conditionally dependent RVs, such as autotransformed RVs (Refer to PR #2902).
+- New function `pm.sample_prior` which generates test data from a model in the absence of data.
 
 ### Fixes
 

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -1,3 +1,4 @@
+import collections
 import numbers
 import numpy as np
 import theano.tensor as tt
@@ -307,13 +308,14 @@ def draw_values(params, point=None, size=None):
             raise ValueError('Cannot resolve inputs for {}'.format([str(params[j]) for j in to_eval]))
         to_eval = set(missing_inputs)
         missing_inputs = set()
-        for param in to_eval:
+        for param_idx in to_eval:
+            param = params[param_idx]
             try:  # might evaluate in a bad order,
-                evaluated[param] = _draw_value(params[param], point=point, givens=givens.values(), size=size)
-                if any(params[param] in j for j in named_nodes_children.values()):
-                    givens[params[param].name] = (params[param], evaluated[param])
+                evaluated[param_idx] = _draw_value(param, point=point, givens=givens.values(), size=size)
+                if isinstance(param, collections.Hashable) and named_nodes_parents.get(param):
+                    givens[param.name] = (param, evaluated[param_idx])
             except theano.gof.fg.MissingInputError:
-                missing_inputs.add(param)
+                missing_inputs.add(param_idx)
         
             
     return [evaluated[j] for j in params] # set the order back

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -304,14 +304,14 @@ def draw_values(params, point=None, size=None):
     missing_inputs = set(params)
     while to_eval or missing_inputs:
         if to_eval == missing_inputs:
-            raise ValueError('Cannot resolve inputs for {}'.format([str(j) for j in to_eval]))
+            raise ValueError('Cannot resolve inputs for {}'.format([str(params[j]) for j in to_eval]))
         to_eval = set(missing_inputs)
         missing_inputs = set()
         for param in to_eval:
             try:  # might evaluate in a bad order,
                 evaluated[param] = _draw_value(params[param], point=point, givens=givens.values(), size=size)
-                if any(param in j for j in named_nodes_children.values()):
-                    givens[param.name] = (params[param], evaluated[param])
+                if any(params[param] in j for j in named_nodes_children.values()):
+                    givens[params[param].name] = (params[param], evaluated[param])
             except theano.gof.fg.MissingInputError:
                 missing_inputs.add(param)
         

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -210,7 +210,7 @@ class DensityDist(Distribution):
 
 
 
-def draw_values(params, point=None):
+def draw_values(params, point=None, size=None):
     """
     Draw (fix) parameter values. Handles a number of cases:
 
@@ -254,7 +254,7 @@ def draw_values(params, point=None):
     
     # Init givens and the stack of nodes to try to `_draw_value` from
     givens = {}
-    stored = set([])  # Some nodes 
+    stored = set()  # Some nodes 
     stack = list(leaf_nodes.values())  # A queue would be more appropriate
     while stack:
         next_ = stack.pop(0)
@@ -279,13 +279,14 @@ def draw_values(params, point=None):
             # The named node's children givens values must also be taken
             # into account.
             children = named_nodes_children[next_]
-            temp_givens = [givens[k] for k in givens.keys() if k in children]
+            temp_givens = [givens[k] for k in givens if k in children]
             try:
                 # This may fail for autotransformed RVs, which don't
                 # have the random method
                 givens[next_.name] = (next_, _draw_value(next_,
                                                          point=point,
-                                                         givens=temp_givens))
+                                                         givens=temp_givens,
+                                                         size=size))
                 stored.add(next_.name)
             except theano.gof.fg.MissingInputError:
                 # The node failed, so we must add the node's parents to
@@ -295,10 +296,27 @@ def draw_values(params, point=None):
                               if node is not None and
                               node.name not in stored and
                               node not in params])
-    values = []
-    for param in params:
-        values.append(_draw_value(param, point=point, givens=givens.values()))
-    return values
+
+    # Funny dance to resolve missing nodes
+    params = dict(enumerate(params))  # some nodes are not hashable
+    evaluated = {}
+    to_eval = set()
+    missing_inputs = set(params)
+    while to_eval or missing_inputs:
+        if to_eval == missing_inputs:
+            raise ValueError('Cannot resolve inputs for {}'.format([str(j) for j in to_eval]))
+        to_eval = set(missing_inputs)
+        missing_inputs = set()
+        for param in to_eval:
+            try:  # might evaluate in a bad order,
+                evaluated[param] = _draw_value(params[param], point=point, givens=givens.values(), size=size)
+                if any(param in j for j in named_nodes_children.values()):
+                    givens[param.name] = (params[param], evaluated[param])
+            except theano.gof.fg.MissingInputError:
+                missing_inputs.add(param)
+        
+            
+    return [evaluated[j] for j in params] # set the order back
 
 
 @memoize
@@ -326,7 +344,7 @@ def _compile_theano_function(param, vars, givens=None):
                     allow_input_downcast=True)
 
 
-def _draw_value(param, point=None, givens=None):
+def _draw_value(param, point=None, givens=None, size=None):
     """Draw a random value from a distribution or return a constant.
 
     Parameters
@@ -355,14 +373,19 @@ def _draw_value(param, point=None, givens=None):
         if point and hasattr(param, 'model') and param.name in point:
             return point[param.name]
         elif hasattr(param, 'random') and param.random is not None:
-            return param.random(point=point, size=None)
+            return param.random(point=point, size=size)
+        elif hasattr(param, 'distribution') and hasattr(param.distribution, 'random') and param.distribution.random is not None:
+            return param.distribution.random(point=point, size=size)
         else:
             if givens:
                 variables, values = list(zip(*givens))
             else:
                 variables = values = []
             func = _compile_theano_function(param, variables)
-            return func(*values)
+            if size is None:
+                return func(*values)
+            else:
+                return np.array([func(*value) for value in zip(*values)])
     else:
         raise ValueError('Unexpected type in draw_value: %s' % type(param))
 

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1249,8 +1249,7 @@ def sample_prior(samples=500, model=None, vars=None, size=None,
             point = {}
             for var_name, var in model.named_vars.items():
                 if is_transformed_name(var_name):
-                    trans = var.distribution.transform_used.forward
-                    val = trans(var.distribution.dist.random(point=point, size=size)).eval()
+                    val = var.distribution.dist.random(point=point, size=size)
                 else:
                     val = var.distribution.random(point=point, size=size)
                 point[var_name] = val

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -15,7 +15,7 @@ from .model import modelcontext, Point, all_continuous
 from .step_methods import (NUTS, HamiltonianMC, Metropolis, BinaryMetropolis,
                            BinaryGibbsMetropolis, CategoricalGibbsMetropolis,
                            Slice, CompoundStep, arraystep)
-from .util import update_start_vals
+from .util import update_start_vals, is_transformed_name
 from .vartypes import discrete_types
 from pymc3.step_methods.hmc import quadpotential
 from pymc3 import plots
@@ -1248,7 +1248,11 @@ def sample_prior(samples=500, model=None, vars=None, size=None,
         for _ in indices:
             point = {}
             for var_name, var in model.named_vars.items():
-                val = var.distribution.random(point=point, size=size)
+                if is_transformed_name(var_name):
+                    trans = var.distribution.transform_used.forward
+                    val = trans(var.distribution.dist.random(point=point, size=size)).eval()
+                else:
+                    val = var.distribution.random(point=point, size=size)
                 point[var_name] = val
                 if var_name in vars:
                     prior[var_name].append(val)

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1248,10 +1248,14 @@ def sample_prior(samples=500, model=None, vars=None, size=None,
         for _ in indices:
             point = {}
             for var_name, var in model.named_vars.items():
-                if is_transformed_name(var_name):
-                    val = var.distribution.dist.random(point=point, size=size)
+                if hasattr(var, 'distribution'):
+                    if is_transformed_name(var_name):
+                        val = var.distribution.dist.random(point=point, size=size)
+                    else:
+                        val = var.distribution.random(point=point, size=size)
                 else:
-                    val = var.distribution.random(point=point, size=size)
+                    val = var.eval({model.named_vars[v]: point[v] for v in pm.model.get_named_nodes(var)})
+
                 point[var_name] = val
                 if var_name in vars:
                     prior[var_name].append(val)

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -304,14 +304,14 @@ def test_exec_nuts_init(method):
         assert 'a' in start[0] and 'b_log__' in start[0]
 
 
-def test_sample_prior():
+def test_sample_generative():
     observed = np.random.normal(10, 1, size=200)
     with pm.Model():
         # Use a prior that's way off to show we're actually sampling from it
         mu = pm.Normal('mu', mu=-10, sd=1)
         positive_mu = pm.Deterministic('positive_mu', np.abs(mu))
         pm.Normal('x_obs', mu=mu, sd=1, observed=observed)
-        prior = pm.sample_prior()
+        prior = pm.sample_generative()
     
     assert (prior['mu'] < 0).all()
     assert (prior['positive_mu'] > 0).all()

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -309,8 +309,10 @@ def test_sample_prior():
     with pm.Model():
         # Use a prior that's way off to show we're actually sampling from it
         mu = pm.Normal('mu', mu=-10, sd=1)
+        positive_mu = pm.Deterministic('positive_mu', np.abs(mu))
         pm.Normal('x_obs', mu=mu, sd=1, observed=observed)
         prior = pm.sample_prior()
     
     assert (prior['mu'] < 0).all()
+    assert (prior['positive_mu'] > 0).all()
     assert (prior['x_obs'] < 0).all()

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -302,3 +302,15 @@ def test_exec_nuts_init(method):
         assert len(start) == 2
         assert isinstance(start[0], dict)
         assert 'a' in start[0] and 'b_log__' in start[0]
+
+
+def test_sample_prior():
+    observed = np.random.normal(10, 1, size=200)
+    with pm.Model():
+        # Use a prior that's way off to show we're actually sampling from it
+        mu = pm.Normal('mu', mu=-10, sd=1)
+        pm.Normal('x_obs', mu=mu, sd=1, observed=observed)
+        prior = pm.sample_prior()
+    
+    assert (prior['mu'] < 0).all()
+    assert (prior['x_obs'] < 0).all()


### PR DESCRIPTION
This allows samples from a model, ignoring all observed variables.  See the screenshot below for an example in a simple model.

Right now it relies on unofficial python3.6 behavior, and [official python3.7 behavior](https://mail.python.org/pipermail/python-dev/2017-December/151283.html).  Namely, dictionaries keeping insertion order. I would love a suggestion to avoid that requirement, but I can also take a swing at having `tree_dict` subclass from `OrderedDict` instead.


![image](https://user-images.githubusercontent.com/2295568/36700677-87c7b582-1b1e-11e8-8dc0-cfd0efb5db09.png)
