### PR TITLE
Include pymc.model in documentation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -18,3 +18,4 @@ API Reference
    api/backends
    api/math
    api/data
+   api/model

--- a/docs/source/api/model.rst
+++ b/docs/source/api/model.rst
@@ -1,0 +1,7 @@
+Model
+-----
+
+.. currentmodule:: pymc3.model
+.. automodule:: pymc3.model
+   :members:
+

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -491,25 +491,26 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor, WithMemoization
     """Encapsulates the variables and likelihood factors of a model.
 
     Model class can be used for creating class based models. To create
-    a class based model you should inherit from `Model` and
-    override `__init__` with arbitrary definitions
-    (do not forget to call base class `__init__` first).
+    a class based model you should inherit from :class:`~.Model` and
+    override :meth:`~.__init__` with arbitrary definitions (do not
+    forget to call base class :meth:`__init__` first).
 
     Parameters
     ----------
-    name : str, default '' - name that will be used as prefix for
-        names of all random variables defined within model
-    model : Model, default None - instance of Model that is
-        supposed to be a parent for the new instance. If None,
-        context will be used. All variables defined within instance
-        will be passed to the parent instance. So that 'nested' model
-        contributes to the variables and likelihood factors of
-        parent model.
-    theano_config : dict, default=None
+    name : str
+        name that will be used as prefix for names of all random
+        variables defined within model
+    model : Model
+        instance of Model that is supposed to be a parent for the new
+        instance. If ``None``, context will be used. All variables
+        defined within instance will be passed to the parent instance.
+        So that 'nested' model contributes to the variables and
+        likelihood factors of parent model.
+    theano_config : dict
         A dictionary of theano config values that should be set
         temporarily in the model context. See the documentation
-        of theano for a complete list. Set `compute_test_value` to
-        `raise` if it is None.
+        of theano for a complete list. Set config key
+        ``compute_test_value`` to `raise` if it is None.
 
     Examples
     --------
@@ -742,7 +743,7 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor, WithMemoization
            If data is provided, the variable is observed. If None,
            the variable is unobserved.
         total_size : scalar
-            upscales logp of variable with :math:`coef = total_size/var.shape[0]`
+            upscales logp of variable with ``coef = total_size/var.shape[0]``
 
         Returns
         -------
@@ -837,8 +838,8 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor, WithMemoization
                 raise e
 
     def makefn(self, outs, mode=None, *args, **kwargs):
-        """Compiles a Theano function which returns `outs` and takes the variable
-        ancestors of `outs` as inputs.
+        """Compiles a Theano function which returns ``outs`` and takes the variable
+        ancestors of ``outs`` as inputs.
 
         Parameters
         ----------
@@ -857,7 +858,7 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor, WithMemoization
                                    mode=mode, *args, **kwargs)
 
     def fn(self, outs, mode=None, *args, **kwargs):
-        """Compiles a Theano function which returns the values of `outs`
+        """Compiles a Theano function which returns the values of ``outs``
         and takes values of model vars as arguments.
 
         Parameters
@@ -872,7 +873,7 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor, WithMemoization
         return LoosePointFunc(self.makefn(outs, mode, *args, **kwargs), self)
 
     def fastfn(self, outs, mode=None, *args, **kwargs):
-        """Compiles a Theano function which returns `outs` and takes values
+        """Compiles a Theano function which returns ``outs`` and takes values
         of model vars as a dict as an argument.
 
         Parameters
@@ -888,7 +889,7 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor, WithMemoization
         return FastPointFunc(f)
 
     def profile(self, outs, n=1000, point=None, profile=True, *args, **kwargs):
-        """Compiles and profiles a Theano function which returns `outs` and
+        """Compiles and profiles a Theano function which returns ``outs`` and
         takes values of model vars as a dict as an argument.
 
         Parameters
@@ -899,7 +900,7 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor, WithMemoization
         point : point
             Point to pass to the function
         profile : True or ProfileStats
-        *args, **kwargs
+        args, kwargs
             Compilation args
 
         Returns
@@ -918,10 +919,11 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor, WithMemoization
 
     def flatten(self, vars=None, order=None, inputvar=None):
         """Flattens model's input and returns:
-            FlatView with
+
+        FlatView with
             * input vector variable
-            * replacements `input_var -> vars`
-            * view {variable: VarMap}
+            * replacements ``input_var -> vars``
+            * view `{variable: VarMap}`
 
         Parameters
         ----------
@@ -970,7 +972,7 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor, WithMemoization
 
 
 def fn(outs, mode=None, model=None, *args, **kwargs):
-    """Compiles a Theano function which returns the values of `outs` and
+    """Compiles a Theano function which returns the values of ``outs`` and
     takes values of model vars as arguments.
 
     Parameters
@@ -987,7 +989,7 @@ def fn(outs, mode=None, model=None, *args, **kwargs):
 
 
 def fastfn(outs, mode=None, model=None):
-    """Compiles a Theano function which returns `outs` and takes values of model
+    """Compiles a Theano function which returns ``outs`` and takes values of model
     vars as a dict as an argument.
 
     Parameters
@@ -1009,7 +1011,7 @@ def Point(*args, **kwargs):
 
     Parameters
     ----------
-    *args, **kwargs
+    args, kwargs
         arguments to build a dict
     """
     model = modelcontext(kwargs.pop('model', None))
@@ -1365,22 +1367,22 @@ def Potential(name, var, model=None):
 
 
 class TransformedRV(TensorVariable):
+    """
+    Parameters
+    ----------
+
+    type : theano type (optional)
+    owner : theano owner (optional)
+    name : str
+    distribution : Distribution
+    model : Model
+    total_size : scalar Tensor (optional)
+        needed for upscaling logp
+    """
 
     def __init__(self, type=None, owner=None, index=None, name=None,
                  distribution=None, model=None, transform=None,
                  total_size=None):
-        """
-        Parameters
-        ----------
-
-        type : theano type (optional)
-        owner : theano owner (optional)
-        name : str
-        distribution : Distribution
-        model : Model
-        total_size : scalar Tensor (optional)
-            needed for upscaling logp
-        """
         if type is None:
             type = distribution.type
         super(TransformedRV, self).__init__(type, owner, index, name)
@@ -1431,8 +1433,8 @@ def as_iterargs(data):
 
 
 def all_continuous(vars):
-    """Check that vars not include discrete variables, excepting ObservedRVs.
-    """
+    """Check that vars not include discrete variables, excepting
+    ObservedRVs.  """
     vars_ = [var for var in vars if not isinstance(var, pm.model.ObservedRV)]
     if any([var.dtype in pm.discrete_types for var in vars_]):
         return False

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -522,34 +522,37 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor, WithMemoization
         class CustomModel(Model):
             # 1) override init
             def __init__(self, mean=0, sd=1, name='', model=None):
-                # 2) call super's init first, passing model and name to it
-                # name will be prefix for all variables here
-                # if no name specified for model there will be no prefix
+                # 2) call super's init first, passing model and name
+                # to it name will be prefix for all variables here if
+                # no name specified for model there will be no prefix
                 super(CustomModel, self).__init__(name, model)
                 # now you are in the context of instance,
-                # `modelcontext` will return self
-                # you can define variables in several ways
-                # note, that all variables will get model's name prefix
+                # `modelcontext` will return self you can define
+                # variables in several ways note, that all variables
+                # will get model's name prefix
 
                 # 3) you can create variables with Var method
                 self.Var('v1', Normal.dist(mu=mean, sd=sd))
                 # this will create variable named like '{prefix_}v1'
-                # and assign attribute 'v1' to instance
-                # created variable can be accessed with self.v1 or self['v1']
+                # and assign attribute 'v1' to instance created
+                # variable can be accessed with self.v1 or self['v1']
 
-                # 4) this syntax will also work as we are in the context
-                # of instance itself, names are given as usual
+                # 4) this syntax will also work as we are in the
+                # context of instance itself, names are given as usual
                 Normal('v2', mu=mean, sd=sd)
 
-                # something more complex is allowed too
-                Normal('v3', mu=mean, sd=HalfCauchy('sd', beta=10, testval=1.))
+                # something more complex is allowed, too
+                half_cauchy = HalfCauchy('sd', beta=10, testval=1.)
+                Normal('v3', mu=mean, sd=half_cauchy)
 
                 # Deterministic variables can be used in usual way
                 Deterministic('v3_sq', self.v3 ** 2)
+
                 # Potentials too
                 Potential('p1', tt.constant(1))
 
-        # After defining a class CustomModel you can use it in several ways
+        # After defining a class CustomModel you can use it in several
+        # ways
 
         # I:
         #   state the model within a context

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -513,59 +513,63 @@ class Model(six.with_metaclass(InitContextMeta, Context, Factor, WithMemoization
 
     Examples
     --------
-    # How to define a custom model
-    class CustomModel(Model):
-        # 1) override init
-        def __init__(self, mean=0, sd=1, name='', model=None):
-            # 2) call super's init first, passing model and name to it
-            # name will be prefix for all variables here
-            # if no name specified for model there will be no prefix
-            super(CustomModel, self).__init__(name, model)
-            # now you are in the context of instance,
-            # `modelcontext` will return self
-            # you can define variables in several ways
-            # note, that all variables will get model's name prefix
 
-            # 3) you can create variables with Var method
-            self.Var('v1', Normal.dist(mu=mean, sd=sd))
-            # this will create variable named like '{prefix_}v1'
-            # and assign attribute 'v1' to instance
-            # created variable can be accessed with self.v1 or self['v1']
+    How to define a custom model
 
-            # 4) this syntax will also work as we are in the context
-            # of instance itself, names are given as usual
-            Normal('v2', mu=mean, sd=sd)
+    .. code-block:: python
 
-            # something more complex is allowed too
-            Normal('v3', mu=mean, sd=HalfCauchy('sd', beta=10, testval=1.))
+        class CustomModel(Model):
+            # 1) override init
+            def __init__(self, mean=0, sd=1, name='', model=None):
+                # 2) call super's init first, passing model and name to it
+                # name will be prefix for all variables here
+                # if no name specified for model there will be no prefix
+                super(CustomModel, self).__init__(name, model)
+                # now you are in the context of instance,
+                # `modelcontext` will return self
+                # you can define variables in several ways
+                # note, that all variables will get model's name prefix
 
-            # Deterministic variables can be used in usual way
-            Deterministic('v3_sq', self.v3 ** 2)
-            # Potentials too
-            Potential('p1', tt.constant(1))
+                # 3) you can create variables with Var method
+                self.Var('v1', Normal.dist(mu=mean, sd=sd))
+                # this will create variable named like '{prefix_}v1'
+                # and assign attribute 'v1' to instance
+                # created variable can be accessed with self.v1 or self['v1']
 
-    # After defining a class CustomModel you can use it in several ways
+                # 4) this syntax will also work as we are in the context
+                # of instance itself, names are given as usual
+                Normal('v2', mu=mean, sd=sd)
 
-    # I:
-    #   state the model within a context
-    with Model() as model:
-        CustomModel()
-        # arbitrary actions
+                # something more complex is allowed too
+                Normal('v3', mu=mean, sd=HalfCauchy('sd', beta=10, testval=1.))
 
-    # II:
-    #   use new class as entering point in context
-    with CustomModel() as model:
-        Normal('new_normal_var', mu=1, sd=0)
+                # Deterministic variables can be used in usual way
+                Deterministic('v3_sq', self.v3 ** 2)
+                # Potentials too
+                Potential('p1', tt.constant(1))
 
-    # III:
-    #   just get model instance with all that was defined in it
-    model = CustomModel()
+        # After defining a class CustomModel you can use it in several ways
 
-    # IV:
-    #   use many custom models within one context
-    with Model() as model:
-        CustomModel(mean=1, name='first')
-        CustomModel(mean=2, name='second')
+        # I:
+        #   state the model within a context
+        with Model() as model:
+            CustomModel()
+            # arbitrary actions
+
+        # II:
+        #   use new class as entering point in context
+        with CustomModel() as model:
+            Normal('new_normal_var', mu=1, sd=0)
+
+        # III:
+        #   just get model instance with all that was defined in it
+        model = CustomModel()
+
+        # IV:
+        #   use many custom models within one context
+        with Model() as model:
+            CustomModel(mean=1, name='first')
+            CustomModel(mean=2, name='second')
     """
     def __new__(cls, *args, **kwargs):
         # resolves the parent instance


### PR DESCRIPTION
While reading the docs, I realized that `pymc.model` was not included in the API docs. This PR adds it and makes some fixes to the docstrings. 

I also added a .gitignignore file to the `_static` directory which does away with a warning about that directory being missing.