### PR TITLE
fix PyMC3 variable is not replaced if provided in more_replacements (VI)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 
 - `VonMises` does not overflow for large values of kappa. i0 and i1 have been removed and we now use log_i0 to compute the logp.
 - The bandwidth for KDE plots is computed using a modified version of Scott's rule. The new version uses entropy instead of standard deviation. This works better for multimodal distributions. Functions using KDE plots has a new argument `bw` controlling the bandwidth.
+- fix PyMC3 variable is not replaced if provided in more_replacements (#2890)
 
 ### Deprecations
 

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -836,8 +836,8 @@ def test_sample_replacements(binomial_model_inference):
 
 
 def test_var_replacement():
-    X_mean = np.linspace(0, 10, 10, dtype='float32')
-    y = np.random.normal(X_mean*4, .05).astype('float32')
+    X_mean = pm.floatX(np.linspace(0, 10, 10))
+    y = pm.floatX(np.random.normal(X_mean*4, .05))
     with pm.Model():
         inp = pm.Normal('X', X_mean, shape=X_mean.shape)
         coef = pm.Normal('b', 4.)
@@ -845,7 +845,7 @@ def test_var_replacement():
         pm.Normal('y', mean, .1, observed=y)
         advi = pm.fit(100)
         assert advi.sample_node(mean).eval().shape == (10, )
-        x_new = np.linspace(0, 10, 11, dtype='float32')
+        x_new = pm.floatX(np.linspace(0, 10, 11))
         assert advi.sample_node(mean, more_replacements={inp: x_new}).eval().shape == (11, )
 
 

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -835,6 +835,20 @@ def test_sample_replacements(binomial_model_inference):
     assert sampled.shape[0] == 101
 
 
+def test_var_replacement():
+    X_mean = np.linspace(0, 10, 10, dtype='float32')
+    y = (np.random.randn(*X_mean.shape) * .05 + X_mean) * 4.
+    with pm.Model():
+        inp = pm.Normal('X', X_mean, shape=X_mean.shape)
+        coef = pm.Normal('b', 4.)
+        mean = inp * coef
+        pm.Normal('y', mean, .1, observed=y)
+        advi = pm.fit(100)
+        assert advi.sample_node(mean).eval().shape == (10, )
+        x_new = np.linspace(0, 10, 11, dtype='float32')
+        assert advi.sample_node(mean, more_replacements={inp: x_new}).eval().shape == (11, )
+
+
 def test_empirical_from_trace(another_simple_model):
     with another_simple_model:
         step = pm.Metropolis()

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -837,7 +837,7 @@ def test_sample_replacements(binomial_model_inference):
 
 def test_var_replacement():
     X_mean = np.linspace(0, 10, 10, dtype='float32')
-    y = (np.random.randn(*X_mean.shape) * .05 + X_mean) * 4.
+    y = np.random.normal(X_mean*4, .05).astype('float32')
     with pm.Model():
         inp = pm.Normal('X', X_mean, shape=X_mean.shape)
         coef = pm.Normal('b', 4.)

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -1459,6 +1459,7 @@ class Approximation(WithMemoization):
         sampled node(s) with replacements
         """
         node_in = node
+        node = theano.clone(node, more_replacements)
         if size is None:
             node_out = self.symbolic_single_sample(node)
         else:


### PR DESCRIPTION
fixes #2890
