### PR TITLE
Changed support of exponential to include zero

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -29,6 +29,7 @@
 - fix PyMC3 variable is not replaced if provided in more_replacements (#2890)
 - Fix for issue #2900. For many situations, named node-inputs do not have a `random` method, while some intermediate node may have it. This meant that if the named node-input at the leaf of the graph did not have a fixed value, `theano` would try to compile it and fail to find inputs, raising a `theano.gof.fg.MissingInputError`. This was fixed by going through the theano variable's owner inputs graph, trying to get intermediate named-nodes values if the leafs had failed.
 - In `distribution.draw_values`, some named nodes could be `theano.tensor.TensorConstant`s or `theano.tensor.sharedvar.SharedVariable`s. Nevertheless, in `distribution._draw_value`, these would be passed to `distribution._compile_theano_function` as if they were `theano.tensor.TensorVariable`s. This could lead to the following exceptions `TypeError: ('Constants not allowed in param list', ...)` or `TypeError: Cannot use a shared variable (...)`. The fix was to not add `theano.tensor.TensorConstant` or `theano.tensor.sharedvar.SharedVariable` named nodes into the `givens` dict that could be used in `distribution._compile_theano_function`.
+- Exponential support changed to include zero values.
 
 ### Deprecations
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -755,7 +755,7 @@ class Exponential(PositiveContinuous):
 
     def logp(self, value):
         lam = self.lam
-        return bound(tt.log(lam) - lam * value, value > 0, lam > 0)
+        return bound(tt.log(lam) - lam * value, value >= 0, lam > 0)
 
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:


### PR DESCRIPTION
The `bound` of `Exponential.logp` is currently `value > 0`, which is incorrect given the support of the exponential RV. This PR changes the lower bound to be closed.