### PR TITLE
raise an error when model has discrete vars

### DIFF
--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -841,7 +841,7 @@ def test_discrete_not_allowed():
     y = np.random.normal(mu_true[z_true], np.ones_like(z_true))
 
     with pm.Model():
-        mu = pm.Normal('μ', mu=0, sd=10, shape=3)
+        mu = pm.Normal('mu', mu=0, sd=10, shape=3)
         z = pm.Categorical('z', p=tt.ones(3) / 3, shape=len(y))
         pm.Normal('y_obs', mu=mu[z], sd=1., observed=y)
         with pytest.raises(opvi.ParametrizationError):

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -894,6 +894,9 @@ class Group(WithMemoization):
         self.replacements = dict()
         self.group = [get_transformed(var) for var in self.group]
         for var in self.group:
+            if isinstance(var.distribution, pm.Discrete):
+                raise ParametrizationError('Discrete variables are not supported by VI: {}'
+                                           .format(var))
             begin = self.ddim
             if self.batched:
                 if var.ndim < 1:


### PR DESCRIPTION
Following #2907, now raising an error with informative message when model has discrete variables