### PR TITLE
Update short and long descriptions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
+from codecs import open
 from os.path import realpath, dirname, join
 from setuptools import setup, find_packages
 import sys
 
 
 DISTNAME = 'pymc3'
-DESCRIPTION = "PyMC3"
-LONG_DESCRIPTION = """Bayesian estimation, particularly using Markov chain Monte Carlo (MCMC), is an increasingly relevant approach to statistical estimation. However, few statistical software packages implement MCMC samplers, and they are non-trivial to code by hand. ``pymc3`` is a python package that implements the Metropolis-Hastings algorithm as a python class, and is extremely flexible and applicable to a large suite of problems. ``pymc3`` includes methods for summarizing output, plotting, goodness-of-fit and convergence diagnostics."""
+DESCRIPTION = "Probabilistic Programming in Python: Bayesian Modeling and Probabilistic Machine Learning with Theano"
 AUTHOR = 'PyMC Developers'
 AUTHOR_EMAIL = 'pymc.devs@gmail.com'
 URL = "http://github.com/pymc-devs/pymc3"
@@ -28,6 +28,11 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Operating System :: OS Independent']
 
 PROJECT_ROOT = dirname(realpath(__file__))
+
+# Get the long description from the README file
+with open(join(PROJECT_ROOT, 'README.rst'), encoding='utf-8') as buff:
+    LONG_DESCRIPTION = buff.read()
+
 REQUIREMENTS_FILE = join(PROJECT_ROOT, 'requirements.txt')
 
 with open(REQUIREMENTS_FILE) as f:


### PR DESCRIPTION
The description on pypi.org should now track the README file.  Also updated the short description. 

I tested `python setup.py sdist_wheel` locally, and confirmed that the `PKG-INFO` builds fine.