### PR TITLE
Increment version to 3.4.1

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -1,5 +1,5 @@
 # pylint: disable=wildcard-import
-__version__ = "3.4"
+__version__ = "3.4.1"
 
 from .blocking import *
 from .distributions import *


### PR DESCRIPTION
Having previously pushed a version to PyPI with an erroneous v3.4, partly due to the issue solved by #2926, we cannot push that version again to PyPI even if it has been deleted, because those are the rules. So, we have 3.4.1. 😐