### PR TITLE
Fix for trace of subset of variables

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,14 @@
 # Release Notes
 
-## PyMC 3.4 (unreleased)
+
+## PyMC 3.5 (Unreleaased)
+
+
+### Fixes
+
+- Fixed `KeyError` raised when only subset of variables are specified to be recorded in the trace.
+
+## PyMC 3.4.1 (April 18 2018)
 
 ### New features
 

--- a/pymc3/backends/report.py
+++ b/pymc3/backends/report.py
@@ -77,7 +77,8 @@ class SamplerReport(object):
             if is_transformed_name(rv_name):
                 rv_name2 = get_untransformed_name(rv_name)
                 rv_name = rv_name2 if rv_name2 in valid_name else rv_name
-            varnames.append(rv_name)
+            if rv_name in trace.varnames:
+                varnames.append(rv_name)
 
         self._effective_n = effective_n = diagnostics.effective_n(trace, varnames)
         self._gelman_rubin = gelman_rubin = diagnostics.gelman_rubin(trace, varnames)

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -140,6 +140,11 @@ def test_empty_model():
             pm.sample()
         error.match('any free variables')
 
+def test_partial_trace_sample():
+    with pm.Model() as model:
+        a = pm.Normal('a', mu=0, sd=1)
+        b = pm.Normal('b', mu=0, sd=1)
+        trace = pm.sample(trace=[a])
 
 @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
 class TestNamedSampling(SeededTest):


### PR DESCRIPTION
Fixes `KeyError` raised when sampling a model with only a subset of variables specified in the trace. Added test also.

Closes #2933