### PR TITLE
set default color plot_posterior to hex 87ceeb (sky blue)

### DIFF
--- a/pymc3/plots/artists.py
+++ b/pymc3/plots/artists.py
@@ -134,6 +134,7 @@ def plot_posterior_op(trace_values, ax, bw, kde_plot, point_estimate, round_to,
         set_key_if_doesnt_exist(kwargs, 'bins', 30)
         set_key_if_doesnt_exist(kwargs, 'edgecolor', 'w')
         set_key_if_doesnt_exist(kwargs, 'align', 'right')
+        set_key_if_doesnt_exist(kwargs, 'color', '#87ceeb')
         ax.hist(trace_values, **kwargs)
 
     plot_height = ax.get_ylim()[1]


### PR DESCRIPTION
The documentation for `plot_posterior` says that the default color for the histogram is #87ceeb, to match the skyblue color in the Kruschke's book. However, the color was not set in the code. This PR fixes that.