### PR TITLE
Fix for issue #2909

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -48,7 +48,7 @@ class Binomial(Discrete):
         self.mode = tt.cast(tround(n * p), self.dtype)
 
     def random(self, point=None, size=None, repeat=None):
-        n, p = draw_values([self.n, self.p], point=point)
+        n, p = draw_values([self.n, self.p], point=point, size=size)
         return generate_samples(stats.binom.rvs, n=n, p=p,
                                 dist_shape=self.shape,
                                 size=size)


### PR DESCRIPTION
I'm taking a stab at solving https://github.com/pymc-devs/pymc3/issues/2909 for the Hackathon.
It seems like size=None is pass in  at call to param.random in distribution.py at line 279
 