### PR TITLE
Small bugfix for InverseGamma

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1452,7 +1452,7 @@ class InverseGamma(PositiveContinuous):
     """
 
     def __init__(self, alpha, beta=1, *args, **kwargs):
-        super(InverseGamma, self).__init__(*args, defaults=['mode'], **kwargs)
+        super(InverseGamma, self).__init__(*args, defaults=('mode',), **kwargs)
         self.alpha = alpha = tt.as_tensor_variable(alpha)
         self.beta = beta = tt.as_tensor_variable(beta)
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1452,7 +1452,7 @@ class InverseGamma(PositiveContinuous):
     """
 
     def __init__(self, alpha, beta=1, *args, **kwargs):
-        super(InverseGamma, self).__init__(*args, **kwargs)
+        super(InverseGamma, self).__init__(*args, defaults=['mode'], **kwargs)
         self.alpha = alpha = tt.as_tensor_variable(alpha)
         self.beta = beta = tt.as_tensor_variable(beta)
 

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -311,7 +311,7 @@ class DiscreteWeibull(Discrete):
     ========  ======================
     """
     def __init__(self, q, beta, *args, **kwargs):
-        super(DiscreteWeibull, self).__init__(*args, defaults=['median'], **kwargs)
+        super(DiscreteWeibull, self).__init__(*args, defaults=('median',), **kwargs)
 
         self.q = q = tt.as_tensor_variable(q)
         self.beta = beta = tt.as_tensor_variable(beta)


### PR DESCRIPTION
Currently, the default for InverseGamma(a, b) is the mean, but when a, b < 1 the mean is unspecify and the RV assign 0. as the default, which crash the sampler.
This PR change the default to the mode.