### PR TITLE
Bugfix psis_lw

### DIFF
--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -334,7 +334,7 @@ def _psislw(lw, reff):
     kss = np.empty(m)
 
     # precalculate constants
-    cutoff_ind = - int(np.ceil(min(n / 0.5, 3 * (n / reff) ** 0.5))) - 1
+    cutoff_ind = - int(np.ceil(min(n / 5., 3 * (n / reff) ** 0.5))) - 1
     cutoffmin = np.log(np.finfo(float).tiny)
     k_min = 1. / 3
 

--- a/pymc3/tests/test_stats.py
+++ b/pymc3/tests/test_stats.py
@@ -339,3 +339,7 @@ class TestDfSummary(bf.ModelBackendSampledTestCase):
                                  ).reshape(rhat.shape)
             npt.assert_equal(rhat, rhat_df)
 
+    def test_psis(self):
+        lw = np.random.randn(20000, 10)
+        _, ks = pm.stats._psislw(lw, 1.)
+        npt.assert_array_less(ks, .5)


### PR DESCRIPTION
Should be using the largest min(n/5, 3*sqrt(n)) samples