### PR TITLE
Typos in API quickstart notebook

### DIFF
--- a/docs/source/notebooks/api_quickstart.ipynb
+++ b/docs/source/notebooks/api_quickstart.ipynb
@@ -505,7 +505,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "While these transformations work seamlessly, its results are not stored automatically. Thus, if you want to keep track of a transformed variable, you have to use `pm.Determinstic`:"
+    "While these transformations work seamlessly, their results are not stored automatically. Thus, if you want to keep track of a transformed variable, you have to use `pm.Deterministic`:"
    ]
   },
   {


### PR DESCRIPTION
Simply fixing a couple typos that I notice when using this part of the docs. If the second change is quite obvious, the first one seems to be the right thing to write to me but I am not a native English-speaker...

FWIW, the changes were done in the online GH editor, so no tests were run.