### PR TITLE
Fix Binomial when p=0 and x=0

### DIFF
--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -65,7 +65,7 @@ def logpow(x, m):
     Calculates log(x**m) since m*log(x) will fail when m, x = 0.
     """
     # return m * log(x)
-    return tt.switch(tt.eq(x, 0), -np.inf, m * tt.log(x))
+    return tt.switch(tt.eq(x, 0) & ~tt.eq(m, 0), -np.inf, m * tt.log(x))
 
 
 def factln(n):

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -65,7 +65,7 @@ def logpow(x, m):
     Calculates log(x**m) since m*log(x) will fail when m, x = 0.
     """
     # return m * log(x)
-    return tt.switch(tt.eq(x, 0) & ~tt.eq(m, 0), -np.inf, m * tt.log(x))
+    return tt.switch(tt.eq(x, 0) & ~tt.eq(m + x, 0), -np.inf, m * tt.log(x))
 
 
 def factln(n):


### PR DESCRIPTION
`Binomial.dist(p=0.).logp(0)` should return 0. not -inf