### PR TITLE
Add rice distribution

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -19,14 +19,15 @@ from . import transforms
 from pymc3.util import get_variable_name
 from .special import log_i0
 from ..math import invlogit, logit
-from .dist_math import bound, logpow, gammaln, betaln, std_cdf, alltrue_elemwise, SplineWrapper
+from .dist_math import bound, logpow, gammaln, betaln, std_cdf, alltrue_elemwise, SplineWrapper, i0, i1
 from .distribution import Continuous, draw_values, generate_samples
 
 __all__ = ['Uniform', 'Flat', 'HalfFlat', 'Normal', 'Beta', 'Exponential',
            'Laplace', 'StudentT', 'Cauchy', 'HalfCauchy', 'Gamma', 'Weibull',
            'HalfStudentT', 'Lognormal', 'ChiSquared', 'HalfNormal', 'Wald',
            'Pareto', 'InverseGamma', 'ExGaussian', 'VonMises', 'SkewNormal',
-           'Triangular', 'Gumbel', 'Logistic', 'LogitNormal', 'Interpolated', 'Rice']
+           'Triangular', 'Gumbel', 'Logistic', 'LogitNormal', 'Interpolated',
+           'Rice']
 
 
 class PositiveContinuous(Continuous):
@@ -2477,7 +2478,8 @@ class Rice(Continuous):
     def logp(self, value):
         nu = self.nu
         sd = self.sd
-        return bound(tt.log(value / (sd**2) * tt.exp(-(value**2 + nu**2) / (2 * sd**2)) * i0(value * nu / (sd**2))),
+        x = value / sd
+        return bound(tt.log(x * tt.exp((-(x**2 + nu**2)) / 2) * i0(x * nu) / sd),
                      sd >= 0,
                      nu >= 0,
                      value > 0,

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1376,12 +1376,13 @@ class Rice(Continuous):
     """
     def __init__(self, nu=None, sd=None, *args, **kwargs):
         super(Rice, self).__init__(*args, **kwargs)
-        self.nu = tt.as_tensor_variable(nu)
-        self.sd = tt.as_tensor_variable(sd)
+        self.nu = nu = tt.as_tensor_variable(nu)
+        self.sd = sd = tt.as_tensor_variable(sd)
         self.mean = sd * np.sqrt(np.pi / 2) * tt.exp((-nu**2 / (2 * sd**2)) / 2) * ((1 - (-nu**2 / (2 * sd**2)))
                                  * i0(-(-nu**2 / (2 * sd**2)) / 2) - (-nu**2 / (2 * sd**2)) * i1(-(-nu**2 / (2 * sd**2)) / 2))
         self.variance = 2 * sd**2 + nu**2 - (np.pi * sd**2 / 2) * (tt.exp((-nu**2 / (2 * sd**2)) / 2) * ((1 - (-nu**2 / (
             2 * sd**2))) * i0(-(-nu**2 / (2 * sd**2)) / 2) - (-nu**2 / (2 * sd**2)) * i1(-(-nu**2 / (2 * sd**2)) / 2)))**2
+
 
     def random(self, point=None, size=None, repeat=None):
         nu, sd = draw_values([self.nu, self.sd],
@@ -1392,5 +1393,8 @@ class Rice(Continuous):
     def logp(self, value):
         nu = self.nu
         sd = self.sd
-        return bound(tt.log(value / (sd**2)*tt.exp(-(value**2 + nu**2) / (2 * sd**2))*i0(value * nu / (sd**2))), 
-                     nu>0)
+        return bound(tt.log(value / (sd**2) * tt.exp(-(value**2 + nu**2) / (2 * sd**2)) * i0(value * nu / (sd**2))),
+                     sd >= 0,
+                     nu >= 0,
+                     value > 0,
+        )

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -461,3 +461,23 @@ class EighGrad(theano.Op):
 def eigh(a, UPLO='L'):
     """A copy, remove with Eigh and EighGrad when possible"""
     return Eigh(UPLO)(a)
+
+
+def i0(x):
+    """
+    Calculates the 0 order modified Bessel function of the first kind""
+    """
+    return tt.switch(tt.lt(x, 5), 1 + x**2 / 4 + x**4 / 64 + x**6 / 2304 + x**8 / 147456
+                     + x**10 / 14745600 + x**12 / 2123366400,
+                     np.e**x / (2 * np.pi * x)**0.5 * (1 + 1 / (8 * x) + 9 / (128 * x**2) + 225 / (3072 * x**3)
+                                                       + 11025 / (98304 * x**4)))
+
+
+def i1(x):
+    """
+    Calculates the 1 order modified Bessel function of the first kind""
+    """
+    return tt.switch(tt.lt(x, 5), x / 2 + x**3 / 16 + x**5 / 384 + x**7 / 18432 +
+                     x**9 / 1474560 + x**11 / 176947200 + x**13 / 29727129600,
+                     np.e**x / (2 * np.pi * x)**0.5 * (1 - 3 / (8 * x) + 15 / (128 * x**2) + 315 / (3072 * x**3)
++ 14175 / (98304 * x**4)))

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 import itertools
 
+from pymc3.distributions.continuous import Rice
 from .helpers import SeededTest, select_by_precision
 from ..vartypes import continuous_types
 from ..model import Model, Point, Potential, Deterministic
@@ -1048,7 +1049,9 @@ class TestMatchesScipy(SeededTest):
 
     def test_rice(self):
         self.pymc3_matches_scipy(Rice, Rplus, {'nu': Rplus, 'sd': Rplus},
-                                 lambda value, nu, sd: sp.rice.logpdf(value / sd, loc=nu, scale=sd))
+                                 lambda value, nu, sd: sp.rice.logpdf(value, b=nu, loc=0, scale=sd),
+                                 decimal=select_by_precision(float64=5, float32=1)
+                                 )
 
     @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
     def test_interpolated(self):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -532,7 +532,7 @@ class TestMatchesScipy(SeededTest):
     def test_mvnormal(self, n):
         self.pymc3_matches_scipy(MvNormal, Vector(R, n),
                                  {'mu': Vector(R, n), 'tau': PdMatrix(n)}, normal_logpdf)
-                                 
+
     def test_mvnormal_init_fail(self):
         with Model():
             with self.assertRaises(ValueError):
@@ -690,7 +690,7 @@ class TestMatchesScipy(SeededTest):
     def test_multidimensional_beta_construction(self):
         with Model():
             Beta('beta', alpha=1., beta=1., shape=(10, 20))
-    
+
     def test_rice(self):
-        self.pymc3_matches_scipy(Normal, R, {'nu': R, 'sd': Rplus},
-                                 lambda value, mu, sd: sp.norm.logpdf(value, mu, sd))
+        self.pymc3_matches_scipy(Rice, Rplus, {'nu': Rplus, 'sd': Rplus},
+                                 lambda value, nu, sd: sp.rice.logpdf(value / sd, loc=nu, scale=sd))


### PR DESCRIPTION
I tried taking a shot at #1862 and #1638. The main difference between the earlier implementation and the Scipy version seemed to be in how the scaling was implemented. I altered the implementation to match the Scipy implementation.

There are two things I'm not really sure about:
- I had to re-add the `i0` and `i1` functions to dist_math which were probably removed for good reasons
- There still seems to be an issue when the `value` and the `nu` are large, as the i0(value*nu) goes to infinity

Any pointers on how to deal with these two points?