### PR TITLE
Add rice tests

### DIFF
--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -28,6 +28,7 @@ from .continuous import Gumbel
 from .continuous import Logistic
 from .continuous import LogitNormal
 from .continuous import Interpolated
+from .continuous import Rice
 
 from .discrete import Binomial
 from .discrete import BetaBinomial

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -26,7 +26,8 @@ __all__ = ['Uniform', 'Flat', 'HalfFlat', 'Normal', 'Beta', 'Exponential',
            'Laplace', 'StudentT', 'Cauchy', 'HalfCauchy', 'Gamma', 'Weibull',
            'HalfStudentT', 'Lognormal', 'ChiSquared', 'HalfNormal', 'Wald',
            'Pareto', 'InverseGamma', 'ExGaussian', 'VonMises', 'SkewNormal',
-           'Triangular', 'Gumbel', 'Logistic', 'LogitNormal', 'Interpolated']
+           'Triangular', 'Gumbel', 'Logistic', 'LogitNormal', 'Interpolated',
+           'Rice']
 
 
 class PositiveContinuous(Continuous):
@@ -68,7 +69,7 @@ def assert_negative_support(var, label, distname, value=-1e-6):
 
 def get_tau_sd(tau=None, sd=None):
     """
-    Find precision and standard deviation. The link between the two 
+    Find precision and standard deviation. The link between the two
     parameterizations is given by the inverse relationship:
 
     .. math::
@@ -275,14 +276,14 @@ class Normal(Continuous):
         Standard deviation (sd > 0) (only required if tau is not specified).
     tau : float
         Precision (tau > 0) (only required if sd is not specified).
-        
+
     Examples
     --------
     .. code-block:: python
 
         with pm.Model():
             x = pm.Normal('x', mu=0, sd=10)
-            
+
         with pm.Model():
             x = pm.Normal('x', mu=0, tau=1/23)
     """
@@ -887,7 +888,7 @@ class Lognormal(PositiveContinuous):
         Standard deviation. (sd > 0). (only required if tau is not specified).
     tau : float
         Scale parameter (tau > 0). (only required if sd is not specified).
-        
+
     Example
     -------
     .. code-block:: python
@@ -994,14 +995,14 @@ class StudentT(Continuous):
         Standard deviation (sd > 0) (only required if lam is not specified)
     lam : float
         Precision (lam > 0) (only required if sd is not specified)
-        
+
     Examples
     --------
     .. code-block:: python
 
         with pm.Model():
             x = pm.StudentT('x', nu=15, mu=0, sd=10)
-            
+
         with pm.Model():
             x = pm.StudentT('x', nu=15, mu=0, lam=1/23)
     """
@@ -1601,8 +1602,8 @@ class Weibull(PositiveContinuous):
         self.median = beta * tt.exp(gammaln(tt.log(2)))**(1. / alpha)
         self.variance = (beta**2) * \
             tt.exp(gammaln(1 + 2. / alpha - self.mean**2))
-        self.mode = tt.switch(alpha >= 1, 
-                              beta * ((alpha - 1)/alpha) ** (1 / alpha), 
+        self.mode = tt.switch(alpha >= 1,
+                              beta * ((alpha - 1)/alpha) ** (1 / alpha),
                               0)  # Reference: https://en.wikipedia.org/wiki/Weibull_distribution
 
         assert_negative_support(alpha, 'alpha', 'Weibull')
@@ -1682,7 +1683,7 @@ class HalfStudentT(PositiveContinuous):
     lam : float
         Scale parameter (lam > 0). Converges to the precision as nu
         increases. (only required if sd is not specified)
-        
+
     Examples
     --------
     .. code-block:: python
@@ -1690,7 +1691,7 @@ class HalfStudentT(PositiveContinuous):
         # Only pass in one of lam or sd, but not both.
         with pm.Model():
             x = pm.HalfStudentT('x', sd=10, nu=10)
-     
+
         with pm.Model():
             x = pm.HalfStudentT('x', lam=4, nu=10)
     """
@@ -2196,6 +2197,58 @@ class Gumbel(Continuous):
         return r'${} \sim \text{{Gumbel}}(\mathit{{mu}}={},~\mathit{{beta}}={})$'.format(name,
                                                                 get_variable_name(mu),
                                                                 get_variable_name(beta))
+
+
+class Rice(Continuous):
+    R"""
+    Rice distribution.
+
+    .. math::
+
+       f(x\mid \nu ,\sigma )=
+       {\frac  {x}{\sigma ^{2}}}\exp
+       \left({\frac  {-(x^{2}+\nu ^{2})}{2\sigma ^{2}}}\right)I_{0}\left({\frac  {x\nu }{\sigma ^{2}}}\right),
+
+    ========  ==============================================================
+    Support   :math:`x \in (0, +\infinity)`
+    Mean      :math:`\sigma {\sqrt  {\pi /2}}\,\,L_{{1/2}}(-\nu ^{2}/2\sigma ^{2})`
+    Variance  :math:`2\sigma ^{2}+\nu ^{2}-{\frac  {\pi \sigma ^{2}}{2}}L_{{1/2}}^{2}
+                        \left({\frac  {-\nu ^{2}}{2\sigma ^{2}}}\right)`
+    ========  ==============================================================
+
+
+    Parameters
+    ----------
+    nu : float
+        shape parameter.
+    sd : float
+        standard deviation.
+
+    """
+    def __init__(self, nu=None, sd=None, *args, **kwargs):
+        super(Rice, self).__init__(*args, **kwargs)
+        self.nu = nu = tt.as_tensor_variable(nu)
+        self.sd = sd = tt.as_tensor_variable(sd)
+        self.mean = sd * np.sqrt(np.pi / 2) * tt.exp((-nu**2 / (2 * sd**2)) / 2) * ((1 - (-nu**2 / (2 * sd**2)))
+                                 * i0(-(-nu**2 / (2 * sd**2)) / 2) - (-nu**2 / (2 * sd**2)) * i1(-(-nu**2 / (2 * sd**2)) / 2))
+        self.variance = 2 * sd**2 + nu**2 - (np.pi * sd**2 / 2) * (tt.exp((-nu**2 / (2 * sd**2)) / 2) * ((1 - (-nu**2 / (
+            2 * sd**2))) * i0(-(-nu**2 / (2 * sd**2)) / 2) - (-nu**2 / (2 * sd**2)) * i1(-(-nu**2 / (2 * sd**2)) / 2)))**2
+
+
+    def random(self, point=None, size=None, repeat=None):
+        nu, sd = draw_values([self.nu, self.sd],
+                                  point=point)
+        return generate_samples(stats.rice.rvs, b=nu, scale=sd, loc=0,
+                                dist_shape=self.shape, size=size)
+
+    def logp(self, value):
+        nu = self.nu
+        sd = self.sd
+        return bound(tt.log(value / (sd**2) * tt.exp(-(value**2 + nu**2) / (2 * sd**2)) * i0(value * nu / (sd**2))),
+                     sd >= 0,
+                     nu >= 0,
+                     value > 0,
+        )
 
 
 class Logistic(Continuous):

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -19,7 +19,7 @@ from . import transforms
 from pymc3.util import get_variable_name
 from .special import log_i0
 from ..math import invlogit, logit
-from .dist_math import bound, logpow, gammaln, betaln, std_cdf, alltrue_elemwise, SplineWrapper
+from .dist_math import bound, logpow, gammaln, betaln, std_cdf, alltrue_elemwise, SplineWrapper, i0, i1
 from .distribution import Continuous, draw_values, generate_samples
 
 __all__ = ['Uniform', 'Flat', 'HalfFlat', 'Normal', 'Beta', 'Exponential',
@@ -2237,18 +2237,19 @@ class Rice(Continuous):
 
     def random(self, point=None, size=None, repeat=None):
         nu, sd = draw_values([self.nu, self.sd],
-                                  point=point)
+                             point=point)
         return generate_samples(stats.rice.rvs, b=nu, scale=sd, loc=0,
                                 dist_shape=self.shape, size=size)
 
     def logp(self, value):
         nu = self.nu
         sd = self.sd
-        return bound(tt.log(value / (sd**2) * tt.exp(-(value**2 + nu**2) / (2 * sd**2)) * i0(value * nu / (sd**2))),
+        x = value / sd
+        return bound(tt.log(x * tt.exp((-(x ** 2 + nu ** 2)) / 2)) + log_i0(x * nu) - tt.log(sd),
                      sd >= 0,
                      nu >= 0,
                      value > 0,
-        )
+                     )
 
 
 class Logistic(Continuous):

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -461,3 +461,23 @@ class EighGrad(theano.Op):
 def eigh(a, UPLO='L'):
     """A copy, remove with Eigh and EighGrad when possible"""
     return Eigh(UPLO)(a)
+
+
+def i0(x):
+    """
+    Calculates the 0 order modified Bessel function of the first kind""
+    """
+    return tt.switch(tt.lt(x, 5), 1 + x**2 / 4 + x**4 / 64 + x**6 / 2304 + x**8 / 147456
+                     + x**10 / 14745600 + x**12 / 2123366400,
+                     np.e**x / (2 * np.pi * x)**0.5 * (1 + 1 / (8 * x) + 9 / (128 * x**2) + 225 / (3072 * x**3)
+                                                       + 11025 / (98304 * x**4)))
+
+
+def i1(x):
+    """
+    Calculates the 1 order modified Bessel function of the first kind""
+    """
+    return tt.switch(tt.lt(x, 5), x / 2 + x**3 / 16 + x**5 / 384 + x**7 / 18432 +
+                     x**9 / 1474560 + x**11 / 176947200 + x**13 / 29727129600,
+                     np.e**x / (2 * np.pi * x)**0.5 * (1 - 3 / (8 * x) + 15 / (128 * x**2) + 315 / (3072 * x**3)
+                                                       + 14175 / (98304 * x**4)))

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -9,6 +9,7 @@ import numpy as np
 import scipy.linalg
 import theano.tensor as tt
 import theano
+from theano.scalar import UnaryScalarOp, upgrade_to_float
 
 from .special import gammaln
 from pymc3.theanof import floatX
@@ -463,21 +464,14 @@ def eigh(a, UPLO='L'):
     return Eigh(UPLO)(a)
 
 
-def i0(x):
+class I0e(UnaryScalarOp):
     """
-    Calculates the 0 order modified Bessel function of the first kind""
+    Modified Bessel function of the first kind of order 0, exponentially scaled.
     """
-    return tt.switch(tt.lt(x, 5), 1 + x**2 / 4 + x**4 / 64 + x**6 / 2304 + x**8 / 147456
-                     + x**10 / 14745600 + x**12 / 2123366400,
-                     np.e**x / (2 * np.pi * x)**0.5 * (1 + 1 / (8 * x) + 9 / (128 * x**2) + 225 / (3072 * x**3)
-                                                       + 11025 / (98304 * x**4)))
+    nfunc_spec = ('scipy.special.i0e', 1, 1)
+
+    def impl(self, x):
+        return scipy.special.i0e(x)
 
 
-def i1(x):
-    """
-    Calculates the 1 order modified Bessel function of the first kind""
-    """
-    return tt.switch(tt.lt(x, 5), x / 2 + x**3 / 16 + x**5 / 384 + x**7 / 18432 +
-                     x**9 / 1474560 + x**11 / 176947200 + x**13 / 29727129600,
-                     np.e**x / (2 * np.pi * x)**0.5 * (1 - 3 / (8 * x) + 15 / (128 * x**2) + 315 / (3072 * x**3)
-                                                       + 14175 / (98304 * x**4)))
+i0e = I0e(upgrade_to_float, name='i0e')

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1057,9 +1057,9 @@ class TestMatchesScipy(SeededTest):
             Beta('beta', alpha=1., beta=1., shape=(10, 20))
 
     def test_rice(self):
-        self.pymc3_matches_scipy(Rice, Rplusbig, {'nu': Rplusbig, 'sd': Rplusbig},
+        self.pymc3_matches_scipy(Rice, Rplus, {'nu': Rplus, 'sd': Rplus},
                                  lambda value, nu, sd: sp.rice.logpdf(value, b=nu, loc=0, scale=sd),
-                                 decimal=select_by_precision(float64=3, float32=1))
+                                 decimal=select_by_precision(float64=6, float32=1))
 
     @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
     def test_interpolated(self):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1057,9 +1057,8 @@ class TestMatchesScipy(SeededTest):
             Beta('beta', alpha=1., beta=1., shape=(10, 20))
 
     def test_rice(self):
-        self.pymc3_matches_scipy(Rice, Rplus, {'nu': Rplus, 'sd': Rplus},
-                                 lambda value, nu, sd: sp.rice.logpdf(value, b=nu, loc=0, scale=sd),
-                                 decimal=select_by_precision(float64=6, float32=1))
+        self.pymc3_matches_scipy(Rice, Rplus, {'nu': Rplus, 'sd': Rplusbig},
+                                 lambda value, nu, sd: sp.rice.logpdf(value, b=nu, loc=0, scale=sd))
 
     @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
     def test_interpolated(self):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -16,7 +16,7 @@ from ..distributions import (DensityDist, Categorical, Multinomial, VonMises, Di
                              Flat, LKJCorr, Wald, ChiSquared, HalfNormal, DiscreteUniform,
                              Bound, Uniform, Triangular, Binomial, SkewNormal, DiscreteWeibull,
                              Gumbel, Logistic, OrderedLogistic, LogitNormal, Interpolated,
-                             ZeroInflatedBinomial, HalfFlat, AR1, KroneckerNormal)
+                             ZeroInflatedBinomial, HalfFlat, AR1, KroneckerNormal, Rice)
 
 from ..distributions import continuous
 from pymc3.theanof import floatX
@@ -1057,8 +1057,9 @@ class TestMatchesScipy(SeededTest):
             Beta('beta', alpha=1., beta=1., shape=(10, 20))
 
     def test_rice(self):
-        self.pymc3_matches_scipy(Rice, Rplus, {'nu': Rplus, 'sd': Rplus},
-                                 lambda value, nu, sd: sp.rice.logpdf(value / sd, loc=nu, scale=sd))
+        self.pymc3_matches_scipy(Rice, Rplusbig, {'nu': Rplusbig, 'sd': Rplusbig},
+                                 lambda value, nu, sd: sp.rice.logpdf(value, b=nu, loc=0, scale=sd),
+                                 decimal=select_by_precision(float64=3, float32=1))
 
     @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
     def test_interpolated(self):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1056,6 +1056,10 @@ class TestMatchesScipy(SeededTest):
         with Model():
             Beta('beta', alpha=1., beta=1., shape=(10, 20))
 
+    def test_rice(self):
+        self.pymc3_matches_scipy(Rice, Rplus, {'nu': Rplus, 'sd': Rplus},
+                                 lambda value, nu, sd: sp.rice.logpdf(value / sd, loc=nu, scale=sd))
+
     @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
     def test_interpolated(self):
         for mu in R.vals:


### PR DESCRIPTION
Continuation from #2963. I rebased to get rid of the merge commit and got the tests to pass by changing the tested domain to `Rplusbig`. 

The problem with large values of `value` and `nu`  is that the regular `i0` function will overflow to `inf`. Scipy seems to go around this by slightly modifying the original function from:

`x * exp(-(x**2+b**2)/2) * I[0](x*b)`  to: `x * np.exp(-(x-b)*(x-b)/2.0) * sc.i0e(x*b)`

The i0e function is then partitioned into two intervals: [0, 8] and (8, infinity) which are implemented slightly different: 

```
  if (x <= 8.0) {
	y = (x / 2.0) - 2.0;
	return (chbevl(y, A, 30));
    }

    return (chbevl(32.0 / x - 2.0, B, 25) / sqrt(x));
```

If we want the Rice distribution to be able to handle larger values for `value` and `nu` we would need to implement a similar strategy but I am unsure on how exactly to implement this in PyMC3. Would this PR be acceptable without that?
