### PR TITLE
Replaced sigma argument with noise in MarginalSparse.marginal_likelihood

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,6 +13,7 @@
 
 - Fixed `KeyError` raised when only subset of variables are specified to be recorded in the trace.
 - Removed unused `repeat=None` arguments from all `random()` methods in distributions.
+- Deprecated the `sigma` argument in `MarginalSparse.marginal_likelihood` in favor of `noise`
 
 ## PyMC 3.4.1 (April 18 2018)
 

--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -702,8 +702,7 @@ class MarginalSparse(Marginal):
         self.X = X
         self.Xu = Xu
         self.y = y
-        self.sigma = noise
-        if self.sigma is None:
+        if noise is None:
             sigma = kwargs.get('sigma')
             if sigma is None:
                 raise ValueError('noise argument must be specified')
@@ -712,6 +711,8 @@ class MarginalSparse(Marginal):
                 warnings.warn(
                     "The 'sigma' argument has been deprecated. Use 'noise' instead.",
                 DeprecationWarning)
+        else:
+            self.sigma = noise
         logp = functools.partial(self._build_marginal_likelihood_logp,
                                  X=X, Xu=Xu, sigma=noise)
         if is_observed:

--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -1,4 +1,5 @@
 import functools
+import warnings
 
 import numpy as np
 import theano.tensor as tt

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -796,7 +796,7 @@ class TestGPAdditive(object):
 
         with pm.Model() as model2:
             gptot = pm.gp.MarginalSparse(reduce(add, self.means), reduce(add, self.covs), approx=approx)
-            fsum = gptot.marginal_likelihood("f", self.X, Xu, self.y, sigma=sigma)
+            fsum = gptot.marginal_likelihood("f", self.X, Xu, self.y, noise=sigma)
             model2_logp = model2.logp({"fsum": self.y})
         npt.assert_allclose(model1_logp, model2_logp, atol=0, rtol=1e-2)
 

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -791,7 +791,7 @@ class TestGPAdditive(object):
             gp3 = pm.gp.MarginalSparse(self.means[2], self.covs[2], approx=approx)
 
             gpsum = gp1 + gp2 + gp3
-            fsum = gpsum.marginal_likelihood("f", self.X, Xu, self.y, sigma=sigma)
+            fsum = gpsum.marginal_likelihood("f", self.X, Xu, self.y, noise=sigma)
             model1_logp = model1.logp({"fsum": self.y})
 
         with pm.Model() as model2:


### PR DESCRIPTION
Currently, `MarginalSparse.marginal_likelihood` uses a `sigma` argument, while `Marginal.marginal_likelihood` uses `noise`. Changed to `noise` to make it consistent, and deprecated `sigma`.