### PR TITLE
Better error message for Mass matrix contains zeros

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,7 @@
 
 - Add `check_test_point` method to `pm.Model`
 - Add `Ordered` Transformation and `OrderedLogistic` distribution
+- Better warning message for `Mass matrix contains zeros on the diagonal. Some derivatives might always be zero`
 
 ### Fixes
 

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -112,7 +112,7 @@ class BaseHMC(arraystep.GradientSharedStep):
         start = self.integrator.compute_state(q0, p0)
 
         if not np.isfinite(start.energy):
-            self.potential.raise_ok()
+            self.potential.raise_ok(self._logp_dlogp_func._ordering.vmap)
             raise ValueError('Bad initial energy: %s. The model '
                              'might be misspecified.' % start.energy)
 

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -188,7 +188,7 @@ class QuadPotentialDiagAdapt(QuadPotential):
     def raise_ok(self, vmap):
         if np.any(self._stds == 0):
             name_slc = []
-            tmp_hold = list(range(_std.size))
+            tmp_hold = list(range(self._std.size))
             for vmap_ in vmap:
                 slclen = len(tmp_hold[vmap_.slc])
                 for i in range(slclen):

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -188,28 +188,31 @@ class QuadPotentialDiagAdapt(QuadPotential):
     def raise_ok(self, vmap):
         if np.any(self._stds == 0):
             name_slc = []
-            tmp_hold = list(range(self._std.size))
+            tmp_hold = list(range(self._stds.size))
             for vmap_ in vmap:
                 slclen = len(tmp_hold[vmap_.slc])
                 for i in range(slclen):
                     name_slc.append((i, vmap_.var))
-            index = np.where(self._std == 0)[0]
-            errmsg = ['The derivative of the element index at {} of Variable '
-                     '`{}` is zero.'.format(*name_slc[ii]) for ii in index]
-            raise ValueError('Mass matrix contains zeros on the diagonal. ' +
-                             errmsg)
+            index = np.where(self._stds == 0)[0]
+            errmsg = ['Mass matrix contains zeros on the diagonal. ']
+            for ii in index:
+                errmsg.append('The derivative of the element index at {}'
+                              ' of Variable `{}` is zero.'.format(*name_slc[ii]))
+            raise ValueError('\n'.join(errmsg))
+
         if np.any(~np.isfinite(self._stds)):
             name_slc = []
-            tmp_hold = list(range(self._std.size))
+            tmp_hold = list(range(self._stds.size))
             for vmap_ in vmap:
                 slclen = len(tmp_hold[vmap_.slc])
                 for i in range(slclen):
                     name_slc.append((i, vmap_.var))
             index = np.where(~np.isfinite(self._stds))[0]
-            errmsg = ['The derivative of the element index at {} of Variable '
-                     '`{}` is non-finite.'.format(*name_slc[ii]) for ii in index]
-            raise ValueError('Mass matrix contains non-finite values on the '
-                             'diagonal. ' + errmsg)
+            errmsg = ['Mass matrix contains non-finite values on the diagonal. ']
+            for ii in index:
+                errmsg.append('The derivative of the element index at {}'
+                              ' of Variable `{}` is non-finite.'.format(*name_slc[ii]))
+            raise ValueError('\n'.join(errmsg))
 
 
 class QuadPotentialDiagAdaptGrad(QuadPotentialDiagAdapt):

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -196,7 +196,7 @@ class QuadPotentialDiagAdapt(QuadPotential):
             index = np.where(self._stds == 0)[0]
             errmsg = ['Mass matrix contains zeros on the diagonal. ']
             for ii in index:
-                errmsg.append('The derivative of RV `{}`[{}]'
+                errmsg.append('The derivative of RV `{}`.ravel()[{}]'
                               ' is zero.'.format(*name_slc[ii]))
             raise ValueError('\n'.join(errmsg))
 
@@ -210,7 +210,7 @@ class QuadPotentialDiagAdapt(QuadPotential):
             index = np.where(~np.isfinite(self._stds))[0]
             errmsg = ['Mass matrix contains non-finite values on the diagonal. ']
             for ii in index:
-                errmsg.append('The derivative of RV `{}`[{}]'
+                errmsg.append('The derivative of RV `{}`.ravel()[{}]'
                               ' is non-finite.'.format(*name_slc[ii]))
             raise ValueError('\n'.join(errmsg))
 

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -185,15 +185,31 @@ class QuadPotentialDiagAdapt(QuadPotential):
 
         self._n_samples += 1
 
-    def raise_ok(self):
+    def raise_ok(self, vmap):
         if np.any(self._stds == 0):
-            raise ValueError('Mass matrix contains zeros on the diagonal. '
-                             'Some derivatives might always be zero.')
-        if np.any(self._stds < 0):
-            raise ValueError('Mass matrix contains negative values on the '
-                             'diagonal.')
+            name_slc = []
+            tmp_hold = list(range(_std.size))
+            for vmap_ in vmap:
+                slclen = len(tmp_hold[vmap_.slc])
+                for i in range(slclen):
+                    name_slc.append((i, vmap_.var))
+            index = np.where(self._std == 0)[0]
+            errmsg = ['The derivative of the element index at {} of Variable '
+                     '`{}` is zero.'.format(*name_slc[ii]) for ii in index]
+            raise ValueError('Mass matrix contains zeros on the diagonal. ' +
+                             errmsg)
         if np.any(~np.isfinite(self._stds)):
-            raise ValueError('Mass matrix contains non-finite values.')
+            name_slc = []
+            tmp_hold = list(range(self._std.size))
+            for vmap_ in vmap:
+                slclen = len(tmp_hold[vmap_.slc])
+                for i in range(slclen):
+                    name_slc.append((i, vmap_.var))
+            index = np.where(~np.isfinite(self._stds))[0]
+            errmsg = ['The derivative of the element index at {} of Variable '
+                     '`{}` is non-finite.'.format(*name_slc[ii]) for ii in index]
+            raise ValueError('Mass matrix contains non-finite values on the '
+                             'diagonal. ' + errmsg)
 
 
 class QuadPotentialDiagAdaptGrad(QuadPotentialDiagAdapt):

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -192,12 +192,12 @@ class QuadPotentialDiagAdapt(QuadPotential):
             for vmap_ in vmap:
                 slclen = len(tmp_hold[vmap_.slc])
                 for i in range(slclen):
-                    name_slc.append((i, vmap_.var))
+                    name_slc.append((vmap_.var, i))
             index = np.where(self._stds == 0)[0]
             errmsg = ['Mass matrix contains zeros on the diagonal. ']
             for ii in index:
-                errmsg.append('The derivative of the element index at {}'
-                              ' of Variable `{}` is zero.'.format(*name_slc[ii]))
+                errmsg.append('The derivative of RV `{}`[{}]'
+                              ' is zero.'.format(*name_slc[ii]))
             raise ValueError('\n'.join(errmsg))
 
         if np.any(~np.isfinite(self._stds)):
@@ -206,12 +206,12 @@ class QuadPotentialDiagAdapt(QuadPotential):
             for vmap_ in vmap:
                 slclen = len(tmp_hold[vmap_.slc])
                 for i in range(slclen):
-                    name_slc.append((i, vmap_.var))
+                    name_slc.append((vmap_.var, i))
             index = np.where(~np.isfinite(self._stds))[0]
             errmsg = ['Mass matrix contains non-finite values on the diagonal. ']
             for ii in index:
-                errmsg.append('The derivative of the element index at {}'
-                              ' of Variable `{}` is non-finite.'.format(*name_slc[ii]))
+                errmsg.append('The derivative of RV `{}`[{}]'
+                              ' is non-finite.'.format(*name_slc[ii]))
             raise ValueError('\n'.join(errmsg))
 
 


### PR DESCRIPTION
We see user having a hard time debugging their model when the error `Mass matrix contains zeros on the diagonal. Some derivatives might always be zero` arise. See eg https://discourse.pymc.io/t/unsupervised-clustering-mass-matrix-contains-zeros-on-the-diagonal/1222/.

This PR prints out where the error is, so user can easier address the bug by eg changing the scale of those RVs