### PR TITLE
Correction to Nomenclature in Volatility Model

### DIFF
--- a/docs/source/notebooks/getting_started.ipynb
+++ b/docs/source/notebooks/getting_started.ipynb
@@ -820,11 +820,11 @@
     "  \\sigma &\\sim exp(50) \\\\\n",
     "  \\nu &\\sim exp(.1) \\\\\n",
     "  s_i &\\sim \\mathcal{N}(s_{i-1}, \\sigma^{-2}) \\\\\n",
-    "  log(y_i) &\\sim t(\\nu, 0, exp(-2 s_i))\n",
+    "  log(r_i) &\\sim t(\\nu, 0, exp(-2 s_i))\n",
     "\\end{aligned}\n",
     "$$\n",
     "\n",
-    "Here, $y$ is the daily return series which is modeled with a Student-t distribution with an unknown degrees of freedom parameter, and a scale parameter determined by a latent process $s$. The individual $s_i$ are the individual daily log volatilities in the latent log volatility process. "
+    "Here, $r$ is the daily return series which is modeled with a Student-t distribution with an unknown degrees of freedom parameter, and a scale parameter determined by a latent process $s$. The individual $s_i$ are the individual daily log volatilities in the latent log volatility process. "
    ]
   },
   {
@@ -933,7 +933,7 @@
     "    s = pm.GaussianRandomWalk('s', sigma**-2, shape=len(returns))\n",
     "    volatility_process = pm.Deterministic('volatility_process', pm.math.exp(-2*s))\n",
     "\n",
-    "    r = pm.StudentT('r', nu, lam=1/volatility_process, observed=returns)"
+    "    r = pm.StudentT('r', nu, lam=volatility_process, observed=returns)"
    ]
   },
   {


### PR DESCRIPTION
This small correction is in response to issue Stochastic Volatility Example #2566.  It concerns the two different examples of the Volatility Model used in the PyMC3 notebooks to introduce users to the
wonder that is Bayesian modeling.  In getting_started.ipynb, under:
## Case Study 1: Stochastic volatility
### The Model
the model specification uses `y_i` to represent the daily precentage returns.  However, later on in
the `with pm.Model() as sp500_model:` block the dummy variable `r` is used to represent the daily
returns as well as the tensor variable name.

The second correction also concerns the useage of `s_i` to represent the volatility process in daily
returns.  In both Volatility Process walkthroughs (there is a stand-alone notebook dedicated to it)
the model specs treat `s_i` as the standard deviation of the StudentT distribution used to model the
log-returns.  In the PyMC3 API docs on the StudentT, the distribution is defined with `lambda`
representing the precision.  This is why the `volatility_process` variable is mapped from
`pm.math.exp(-2 * s)` in the `pm.Model()` block.  However, when the returns were defined in the
model block the **kwarg was `lambda=1/volatility_process`.  This has been fixed.

Thanks to @twiecki and the OP for highlighting this error.  Alternatively, if there is apprehension to the second change since model specs will not correspond to the trace that was returned, one could simply keep `lambda=1/volatility_process` and change the model specification to `log(r_i) \sim t(\nu, 0, exp(2s_{i})`.  Then at least the MCMC sampler would not need to be re-run (difficult considering that Google has blocked requests to the historical finance data API).