### PR TITLE
DOCS: 2973 Fix to doctring based on new behaviour in `distribution.de…

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -860,7 +860,7 @@ class LKJCholeskyCov(Continuous):
             vals = pm.MvNormal('vals', mu=np.zeros(10), chol=chol, shape=10)
 
             # Or transform an uncorrelated normal:
-            vals_raw = pm.Normal('vals_raw', mu=np.zeros(10), sd=1)
+            vals_raw = pm.Normal('vals_raw', mu=0, sd=1, shape=10)
             vals = tt.dot(chol, vals_raw)
 
             # Or compute the covariance matrix


### PR DESCRIPTION
Due to new behaviour on distribution.default`

Based on https://github.com/pymc-devs/pymc3/issues/2973 cc @JackCaster

I fixed the docstring rather than fixing the behaviour because I prefer the new API. 