### PR TITLE
DOCs: remove SMC-marginal likelihood calculation

### DIFF
--- a/docs/source/notebooks/Bayes_factor.ipynb
+++ b/docs/source/notebooks/Bayes_factor.ipynb
@@ -25,8 +25,6 @@
     "import pymc3 as pm\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
-    "from pymc3.step_methods import smc\n",
-    "from tempfile import mkdtemp\n",
     "from scipy.special import betaln\n",
     "from scipy.stats import beta\n",
     "\n",
@@ -38,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The \"Bayesian way\" to compare models is to compute the _marginal likelihood_ of each model $p(y \\mid M_k)$, _i.e._ the probability of the observed data $y$ given the $M_k$ model. This quantity, the marginal likelihood, is just the normalizing constant of the Bayes' theorem. We can see this if we write Bayes' theorem and make explicit the fact that all inferences are model-dependant. \n",
+    "The \"Bayesian way\" to compare models is to compute the _marginal likelihood_ of each model $p(y \\mid M_k)$, _i.e._ the probability of the observed data $y$ given the $M_k$ model. This quantity, the marginal likelihood, is just the normalizing constant of Bayes' theorem. We can see this if we write Bayes' theorem and make explicit the fact that all inferences are model-dependant. \n",
     "\n",
     "$$p (\\theta \\mid y, M_k ) = \\frac{p(\\theta \\mid \\theta, M_k) p(\\theta \\mid M_k)}{p( y \\mid M_k)}$$\n",
     "\n",
@@ -61,7 +59,7 @@
    "source": [
     "## Bayesian model selection\n",
     "\n",
-    "If our main objective is to choose only one model, the _best_ one, from a set of models we can just choose the one with the largest $p(y \\div M_k)$. This is totally fine if all models are assumed to have the same _a priori_ probability. Otherwise, we have to take into account that not all models are equally likely _a priori_ and compute:\n",
+    "If our main objective is to choose only one model, the _best_ one, from a set of models we can just choose the one with the largest $p(y \\mid M_k)$. This is totally fine if all models are assumed to have the same _a priori_ probability. Otherwise, we have to take into account that not all models are equally likely _a priori_ and compute:\n",
     "\n",
     "$$p(M_k \\mid y) \\propto p(y \\mid M_k) p(M_k)$$\n",
     "\n",
@@ -69,7 +67,7 @@
     "\n",
     "$$BF =  \\frac{p(y \\mid M_0)}{p(y \\mid M_1)}$$\n",
     "\n",
-    "that is, the ratio between the marginal likelihood of two models. The larger the BF the _better_ the model in the numerator (M_0 in this example). To ease the interpretation of the BF some authors have proposed tables with levels of _support_ or _strength_, a way to put numbers into words. \n",
+    "that is, the ratio between the marginal likelihood of two models. The larger the BF the _better_ the model in the numerator ($M_0$ in this example). To ease the interpretation of BFs some authors have proposed tables with levels of _support_ or _strength_, just a way to put numbers into words. \n",
     "\n",
     "* 1-3: anecdotal\n",
     "* 3-10: moderate\n",
@@ -79,7 +77,7 @@
     "\n",
     "Notice that if you get numbers below 1 then the support is for the model in the denominator, tables for those cases are also available. Of course, you can also just take the inverse of the values in the above table or take the inverse of the BF value and you will be OK.\n",
     "\n",
-    "Is very important to remember that these rules are just conventions, simple guides at best. Results should always be put into context of our problems and should be accompanied with enough details that others could potentially check if they agree with our conclusions. The evidence necessary to make a claim is not the same in particle physics, or a court, or to evacuate a town to prevent hundreds of deaths. "
+    "Is very important to remember that these rules are just conventions, simple guides at best. Results should always be put into context of our problems and should be accompanied with enough details so others could evaluate by themselves if they agree with our conclusions. The evidence necessary to make a claim is not the same in particle physics, or a court, or to evacuate a town to prevent hundreds of deaths."
    ]
   },
   {
@@ -278,106 +276,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Sequential Monte Carlo\n",
-    "\n",
-    "The [Sequential Monte Carlo](SMC2_gaussians.ipynb) sampler is a method that basically progress by a series of successive interpolated (or _annealed_) sequences from the prior to the posterior. A nice _by product_ of this process is that we get an estimation of the marginal likelihood."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/dsr/Documents/HustleProjects/pymc3/venv/lib/python2.7/site-packages/pymc3/step_methods/smc.py:491: UserWarning: Warning: SMC is an experimental step method, and not yet recommended for use in PyMC3!\n",
-      "  warnings.warn(EXPERIMENTAL_WARNING)\n",
-      "Argument `step` is None. Auto-initialising step object using given/default parameters.\n",
-      "/Users/dsr/Documents/HustleProjects/pymc3/venv/lib/python2.7/site-packages/pymc3/step_methods/smc.py:118: UserWarning: Warning: SMC is an experimental step method, and not yet recommended for use in PyMC3!\n",
-      "  warnings.warn(EXPERIMENTAL_WARNING)\n",
-      "Adding model likelihood to RVs!\n",
-      "Init new trace!\n",
-      "Sample initial stage: ...\n",
-      "Beta: 0.000000 Stage: 0\n",
-      "Initializing chain traces ...\n",
-      "Sampling ...\n",
-      "Beta: 0.096191 Stage: 1\n",
-      "Initializing chain traces ...\n",
-      "Sampling ...\n",
-      "Beta: 0.728315 Stage: 2\n",
-      "Initializing chain traces ...\n",
-      "Sampling ...\n",
-      "Beta > 1.: 1.999999\n",
-      "Sample final stage\n",
-      "Initializing chain traces ...\n",
-      "Sampling ...\n",
-      "Argument `step` is None. Auto-initialising step object using given/default parameters.\n",
-      "Adding model likelihood to RVs!\n",
-      "Init new trace!\n",
-      "Sample initial stage: ...\n",
-      "Beta: 0.000000 Stage: 0\n",
-      "Initializing chain traces ...\n",
-      "Sampling ...\n",
-      "Beta > 1.: 1.999999\n",
-      "Sample final stage\n",
-      "Initializing chain traces ...\n",
-      "Sampling ...\n"
-     ]
-    }
-   ],
-   "source": [
-    "n_chains = 1000\n",
-    "\n",
-    "models = []\n",
-    "traces = []\n",
-    "for alpha, beta in priors:\n",
-    "    test_folder = mkdtemp(prefix='SMC_TEST')\n",
-    "    with pm.Model() as model:\n",
-    "        a = pm.Beta('a', alpha, beta)\n",
-    "        yl = pm.Bernoulli('yl', a, observed=y)\n",
-    "        trace = smc.sample_smc(samples=2000,\n",
-    "                               n_chains=n_chains,\n",
-    "                               progressbar=False,\n",
-    "                               homepath=test_folder,\n",
-    "                               stage=0,\n",
-    "                               random_seed=42)\n",
-    "        models.append(model)\n",
-    "        traces.append(trace)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5.0\n"
-     ]
-    }
-   ],
-   "source": [
-    "BF_smc = models[1].marginal_likelihood / models[0].marginal_likelihood\n",
-    "print(round(BF_smc))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As we can see from the previous cell, SMC give essentially the same answer than the analytical calculation! \n",
-    "\n",
-    "The advantage of using SMC is that we can use it to compute the _marginal likelihood_ for a wider range of models, given that we do not need an analytical expression for the _marginal likelihood_. The cost we pay is that the computations is more expensive with SMC, we should take into account that for more complex models we should need to increase the number of `n_steps` and `n_chains` for a more accurate estimation of the _marginal likelihood_."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Bayes factors and inference\n",
     "\n",
     "In this example we have used Bayes factors to judge which model seems to be better at explaining the data, and we get that one of the models is $\\approx 5$ _better_ than the other. \n",
@@ -559,21 +457,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Calculation of marginal likelihood using SMC is not reliable. Following this [discussion](https://discourse.pymc.io/t/trouble-using-smc-sampler-for-marginal-likelihood-bayes-factor-computation/1256/2) and until we settle this issue it is better to remove it from the documentation. We are going to explore this issue with @agustinaarroyuelo during GSoC 2018. 