### PR TITLE
Better error message for NaN occurred in optimization

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,7 +9,8 @@
 - Add `check_test_point` method to `pm.Model`
 - Add `Ordered` Transformation and `OrderedLogistic` distribution
 - Add `Chain` transformation
-- Better warning message for `Mass matrix contains zeros on the diagonal. Some derivatives might always be zero`
+- Improve error message `Mass matrix contains zeros on the diagonal. Some derivatives might always be zero` during tuning of `pm.sample`
+- Improve error message `NaN occurred in optimization.` during ADVI
 - Save and load traces without `pickle` using `pm.save_trace` and `pm.load_trace`
 
 ### Fixes


### PR DESCRIPTION
Similar to #2977, this PR prints out where NaN occurred with potential strategy of how to debug it.