### PR TITLE
Fix TestNUTSLKJCholeskyCov

### DIFF
--- a/pymc3/tests/sampler_fixtures.py
+++ b/pymc3/tests/sampler_fixtures.py
@@ -110,7 +110,7 @@ class LKJCholeskyCovFixture(KnownCDF):
         with pm.Model() as model:
             sd_mu = np.array([1, 2, 3, 4, 5])
             sd_dist = pm.Lognormal.dist(mu=sd_mu, sd=sd_mu / 10., shape=5)
-            chol_packed = pm.LKJCholeskyCov('chol_packed', 5, 3, sd_dist)
+            chol_packed = pm.LKJCholeskyCov('chol_packed', 3, 5, sd_dist)
             chol = pm.expand_packed_triangular(5, chol_packed, lower=True)
             cov = tt.dot(chol, chol.T)
             stds = tt.sqrt(tt.diag(cov))

--- a/pymc3/tests/sampler_fixtures.py
+++ b/pymc3/tests/sampler_fixtures.py
@@ -110,7 +110,7 @@ class LKJCholeskyCovFixture(KnownCDF):
         with pm.Model() as model:
             sd_mu = np.array([1, 2, 3, 4, 5])
             sd_dist = pm.Lognormal.dist(mu=sd_mu, sd=sd_mu / 10., shape=5)
-            chol_packed = pm.LKJCholeskyCov('chol_packed', 3, 5, sd_dist)
+            chol_packed = pm.LKJCholeskyCov('chol_packed', eta=3, n=5, sd_dist=sd_dist)
             chol = pm.expand_packed_triangular(5, chol_packed, lower=True)
             cov = tt.dot(chol, chol.T)
             stds = tt.sqrt(tt.diag(cov))


### PR DESCRIPTION
It appears this test is usually skipped, but not always (#2984).  I do not know why that was happening, but now this test at least passes locally on Python 3.6...