### PR TITLE
Mv cleanup

### DIFF
--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -3,7 +3,6 @@ from theano import scan
 
 from pymc3.util import get_variable_name
 from .continuous import get_tau_sd, Normal, Flat
-from .dist_math import Cholesky
 from . import multivariate
 from . import distribution
 
@@ -280,48 +279,8 @@ class EulerMaruyama(distribution.Continuous):
                                                 get_variable_name(dt))
 
 
-class _CovSet():
-    R"""
-    Convenience class to set Covariance, Inverse Covariance and Cholesky
-    descomposition of Covariance marrices.
-    """
-    def __initCov__(self, cov=None, tau=None, chol=None, lower=True):
-        if all([val is None for val in [cov, tau, chol]]):
-            raise ValueError('One of cov, tau or chol arguments must be provided.')
 
-        self.cov = self.tau = self.chol_cov = None
-
-        cholesky = Cholesky(nofail=True, lower=True)
-        if cov is not None:
-            self.k = cov.shape[0]
-            self._cov_type = 'cov'
-            cov = tt.as_tensor_variable(cov)
-            if cov.ndim != 2:
-                raise ValueError('cov must be two dimensional.')
-            self.chol_cov = cholesky(cov)
-            self.cov = cov
-            self._n = self.cov.shape[-1]
-        elif tau is not None:
-            self.k = tau.shape[0]
-            self._cov_type = 'tau'
-            tau = tt.as_tensor_variable(tau)
-            if tau.ndim != 2:
-                raise ValueError('tau must be two dimensional.')
-            self.chol_tau = cholesky(tau)
-            self.tau = tau
-            self._n = self.tau.shape[-1]
-        else:
-            if chol is not None and not lower:
-                chol = chol.T
-            self.k = chol.shape[0]
-            self._cov_type = 'chol'
-            if chol.ndim != 2:
-                raise ValueError('chol must be two dimensional.')
-            self.chol_cov = tt.as_tensor_variable(chol)
-            self._n = self.chol_cov.shape[-1]
-
-
-class MvGaussianRandomWalk(distribution.Continuous, _CovSet):
+class MvGaussianRandomWalk(distribution.Continuous):
     R"""
     Multivariate Random Walk with Normal innovations
 
@@ -346,19 +305,18 @@ class MvGaussianRandomWalk(distribution.Continuous, _CovSet):
     def __init__(self, mu=0., cov=None, tau=None, chol=None, lower=True, init=Flat.dist(),
                  *args, **kwargs):
         super(MvGaussianRandomWalk, self).__init__(*args, **kwargs)
-        super(MvGaussianRandomWalk, self).__initCov__(cov, tau, chol, lower)
 
         self.mu = mu = tt.as_tensor_variable(mu)
         self.init = init
         self.mean = tt.as_tensor_variable(0.)
+        self.innovArgs = (self.mu, cov, tau, chol, lower)
+        self.innov = multivariate.MvNormal.dist(*self.innovArgs)
 
     def logp(self, x):
         x_im1 = x[:-1]
         x_i = x[1:]
 
-        innov_like = multivariate.MvNormal.dist(mu=x_im1 + self.mu, cov=self.cov,
-                                                tau=self.tau, chol=self.chol_cov).logp(x_i)
-        return self.init.logp(x[0]) + tt.sum(innov_like)
+        return self.init.logp(x[0]) + self.innov.logp_sum(x_i - x_im1)
 
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:
@@ -371,7 +329,7 @@ class MvGaussianRandomWalk(distribution.Continuous, _CovSet):
                                                 get_variable_name(cov))
 
 
-class MvStudentTRandomWalk(distribution.Continuous, _CovSet):
+class MvStudentTRandomWalk(MvGaussianRandomWalk):
     R"""
     Multivariate Random Walk with StudentT innovations
 
@@ -389,22 +347,10 @@ class MvStudentTRandomWalk(distribution.Continuous, _CovSet):
     init : distribution
         distribution for initial value (Defaults to Flat())
     """
-    def __init__(self, nu, mu=0., cov=None, tau=None, chol=None, lower=True, init=Flat.dist(),
-                 *args, **kwargs):
+    def __init__(self, nu, *args, **kwargs):
         super(MvStudentTRandomWalk, self).__init__(*args, **kwargs)
-        super(MvStudentTRandomWalk, self).__initCov__(cov, tau, chol, lower)
-        self.mu = mu = tt.as_tensor_variable(mu)
         self.nu = nu = tt.as_tensor_variable(nu)
-        self.init = init
-        self.mean = tt.as_tensor_variable(0.)
-
-    def logp(self, x):
-        x_im1 = x[:-1]
-        x_i = x[1:]
-        innov_like = multivariate.MvStudentT.dist(self.nu, mu=x_im1 + self.mu,
-                                                  cov=self.cov, tau=self.tau,
-                                                  chol=self.chol_cov).logp(x_i)
-        return self.init.logp(x[0]) + tt.sum(innov_like)
+        self.inov = multivariate.MvStudentT.dist(self.nu, *self.innovArgs)
 
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -316,13 +316,13 @@ class MvGaussianRandomWalk(distribution.Continuous):
         x_im1 = x[:-1]
         x_i = x[1:]
 
-        return self.init.logp(x[0]) + self.innov.logp_sum(x_i - x_im1)
+        return self.init.logp_sum(x[0]) + self.innov.logp_sum(x_i - x_im1)
 
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:
             dist = self
-        mu = dist.mu
-        cov = dist.cov
+        mu = dist.innov.mu
+        cov = dist.innov.cov
         name = r'\text{%s}' % name
         return r'${} \sim \text{MvGaussianRandomWalk}(\mathit{{mu}}={},~\mathit{{cov}}={})$'.format(name,
                                                 get_variable_name(mu),
@@ -349,15 +349,15 @@ class MvStudentTRandomWalk(MvGaussianRandomWalk):
     """
     def __init__(self, nu, *args, **kwargs):
         super(MvStudentTRandomWalk, self).__init__(*args, **kwargs)
-        self.nu = nu = tt.as_tensor_variable(nu)
+        self.nu = tt.as_tensor_variable(nu)
         self.innov = multivariate.MvStudentT.dist(self.nu, *self.innovArgs)
 
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:
             dist = self
-        nu = dist.nu
-        mu = dist.mu
-        cov = dist.cov
+        nu = dist.innov.nu
+        mu = dist.innov.mu
+        cov = dist.innov.cov
         name = r'\text{%s}' % name
         return r'${} \sim \text{MvStudentTRandomWalk}(\mathit{{nu}}={},~\mathit{{mu}}={},~\mathit{{cov}}={})$'.format(name,
                                                 get_variable_name(nu),

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -306,11 +306,10 @@ class MvGaussianRandomWalk(distribution.Continuous):
                  *args, **kwargs):
         super(MvGaussianRandomWalk, self).__init__(*args, **kwargs)
 
-        self.mu = mu = tt.as_tensor_variable(mu)
         self.init = init
-        self.mean = tt.as_tensor_variable(0.)
-        self.innovArgs = (self.mu, cov, tau, chol, lower)
+        self.innovArgs = (mu, cov, tau, chol, lower)
         self.innov = multivariate.MvNormal.dist(*self.innovArgs)
+        self.mean = tt.as_tensor_variable(0.)
 
     def logp(self, x):
         x_im1 = x[:-1]

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -350,7 +350,7 @@ class MvStudentTRandomWalk(MvGaussianRandomWalk):
     def __init__(self, nu, *args, **kwargs):
         super(MvStudentTRandomWalk, self).__init__(*args, **kwargs)
         self.nu = nu = tt.as_tensor_variable(nu)
-        self.inov = multivariate.MvStudentT.dist(self.nu, *self.innovArgs)
+        self.innov = multivariate.MvStudentT.dist(self.nu, *self.innovArgs)
 
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:

--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -7,15 +7,14 @@ import theano.tensor as tt
 import pymc3 as pm
 from pymc3.gp.cov import Covariance, Constant
 from pymc3.gp.mean import Zero
-from pymc3.gp.util import (conditioned_vars,
-                           infer_shape, stabilize, solve_lower, solve_upper)
+from pymc3.gp.util import (conditioned_vars, infer_shape,
+                           stabilize, cholesky, solve_lower, solve_upper)
 from pymc3.distributions import draw_values
 from pymc3.distributions.dist_math import eigh
 from ..math import cartesian, kron_dot, kron_diag
 
 __all__ = ['Latent', 'Marginal', 'TP', 'MarginalSparse', 'MarginalKron']
 
-cholesky = tt.slinalg.cholesky
 
 class Base(object):
     R"""

--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -416,7 +416,6 @@ class Marginal(Base):
         if not isinstance(noise, Covariance):
             noise = pm.gp.cov.WhiteNoise(noise)
         mu, cov = self._build_marginal_likelihood(X, noise)
-        cov = stabilize(cov)
         self.X = X
         self.y = y
         self.noise = noise
@@ -465,7 +464,7 @@ class Marginal(Base):
             cov = Kss - tt.dot(tt.transpose(A), A)
             if pred_noise:
                 cov += noise(Xnew)
-            return mu, stabilize(cov)
+            return mu, cov if pred_noise else stabilize(cov)
 
     def conditional(self, name, Xnew, pred_noise=False, given=None, **kwargs):
         R"""
@@ -751,7 +750,7 @@ class MarginalSparse(Marginal):
                    tt.dot(tt.transpose(C), C))
             if pred_noise:
                 cov += sigma2 * tt.identity_like(cov)
-            return mu, stabilize(cov)
+            return mu, cov if pred_noise else stabilize(cov)
 
     def _get_given_vals(self, given):
         if given is None:
@@ -955,7 +954,7 @@ class MarginalKron(Base):
             cov = Km - Asq
             if pred_noise:
                 cov += sigma * np.eye(cov.shape)
-        return mu, stabilize(cov)
+        return mu, cov if pred_noise else stabilize(cov)
 
     def conditional(self, name, Xnew, pred_noise=False, **kwargs):
         """

--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -8,13 +8,14 @@ import pymc3 as pm
 from pymc3.gp.cov import Covariance, Constant
 from pymc3.gp.mean import Zero
 from pymc3.gp.util import (conditioned_vars,
-                           infer_shape, stabilize, cholesky, solve_lower, solve_upper)
+                           infer_shape, stabilize, solve_lower, solve_upper)
 from pymc3.distributions import draw_values
 from pymc3.distributions.dist_math import eigh
 from ..math import cartesian, kron_dot, kron_diag
 
 __all__ = ['Latent', 'Marginal', 'TP', 'MarginalSparse', 'MarginalKron']
 
+cholesky = tt.slinalg.cholesky
 
 class Base(object):
     R"""
@@ -107,13 +108,13 @@ class Latent(Base):
 
     def _build_prior(self, name, X, reparameterize=True, **kwargs):
         mu = self.mean_func(X)
-        chol = cholesky(stabilize(self.cov_func(X)))
+        cov = stabilize(self.cov_func(X))
         shape = infer_shape(X, kwargs.pop("shape", None))
         if reparameterize:
             v = pm.Normal(name + "_rotated_", mu=0.0, sd=1.0, shape=shape, **kwargs)
-            f = pm.Deterministic(name, mu + tt.dot(chol, v))
+            f = pm.Deterministic(name, mu + cholesky(cov).dot(v))
         else:
-            f = pm.MvNormal(name, mu=mu, chol=chol, shape=shape, **kwargs)
+            f = pm.MvNormal(name, mu=mu, cov=cov, shape=shape, **kwargs)
         return f
 
     def prior(self, name, X, reparameterize=True, **kwargs):
@@ -203,9 +204,8 @@ class Latent(Base):
         """
         givens = self._get_given_vals(given)
         mu, cov = self._build_conditional(Xnew, *givens)
-        chol = cholesky(stabilize(cov))
         shape = infer_shape(Xnew, kwargs.pop("shape", None))
-        return pm.MvNormal(name, mu=mu, chol=chol, shape=shape, **kwargs)
+        return pm.MvNormal(name, mu=mu, cov=cov, shape=shape, **kwargs)
 
 
 @conditioned_vars(["X", "f", "nu"])
@@ -249,14 +249,14 @@ class TP(Latent):
 
     def _build_prior(self, name, X, reparameterize=True, **kwargs):
         mu = self.mean_func(X)
-        chol = cholesky(stabilize(self.cov_func(X)))
+        cov = stabilize(self.cov_func(X))
         shape = infer_shape(X, kwargs.pop("shape", None))
         if reparameterize:
             chi2 = pm.ChiSquared("chi2_", self.nu)
             v = pm.Normal(name + "_rotated_", mu=0.0, sd=1.0, shape=shape, **kwargs)
-            f = pm.Deterministic(name, (tt.sqrt(self.nu) / chi2) * (mu + tt.dot(chol, v)))
+            f = pm.Deterministic(name, (tt.sqrt(self.nu) / chi2) * (mu + cholesky(cov).dot(v)))
         else:
-            f = pm.MvStudentT(name, nu=self.nu, mu=mu, chol=chol, shape=shape, **kwargs)
+            f = pm.MvStudentT(name, nu=self.nu, mu=mu, cov=cov, shape=shape, **kwargs)
         return f
 
     def prior(self, name, X, reparameterize=True, **kwargs):
@@ -321,10 +321,9 @@ class TP(Latent):
 
         X = self.X
         f = self.f
-        nu2, mu, covT = self._build_conditional(Xnew, X, f)
-        chol = cholesky(stabilize(covT))
+        nu2, mu, cov = self._build_conditional(Xnew, X, f)
         shape = infer_shape(Xnew, kwargs.pop("shape", None))
-        return pm.MvStudentT(name, nu=nu2, mu=mu, chol=chol, shape=shape, **kwargs)
+        return pm.MvStudentT(name, nu=nu2, mu=mu, cov=cov, shape=shape, **kwargs)
 
 
 @conditioned_vars(["X", "y", "noise"])
@@ -418,15 +417,15 @@ class Marginal(Base):
         if not isinstance(noise, Covariance):
             noise = pm.gp.cov.WhiteNoise(noise)
         mu, cov = self._build_marginal_likelihood(X, noise)
-        chol = cholesky(stabilize(cov))
+        cov = stabilize(cov)
         self.X = X
         self.y = y
         self.noise = noise
         if is_observed:
-            return pm.MvNormal(name, mu=mu, chol=chol, observed=y, **kwargs)
+            return pm.MvNormal(name, mu=mu, cov=cov, observed=y, **kwargs)
         else:
             shape = infer_shape(X, kwargs.pop("shape", None))
-            return pm.MvNormal(name, mu=mu, chol=chol, shape=shape, **kwargs)
+            return pm.MvNormal(name, mu=mu, cov=cov, shape=shape, **kwargs)
 
     def _get_given_vals(self, given):
         if given is None:
@@ -504,9 +503,8 @@ class Marginal(Base):
 
         givens = self._get_given_vals(given)
         mu, cov = self._build_conditional(Xnew, pred_noise, False, *givens)
-        chol = cholesky(cov)
         shape = infer_shape(Xnew, kwargs.pop("shape", None))
-        return pm.MvNormal(name, mu=mu, chol=chol, shape=shape, **kwargs)
+        return pm.MvNormal(name, mu=mu, cov=cov, shape=shape, **kwargs)
 
     def predict(self, Xnew, point=None, diag=False, pred_noise=False, given=None):
         R"""
@@ -797,9 +795,8 @@ class MarginalSparse(Marginal):
 
         givens = self._get_given_vals(given)
         mu, cov = self._build_conditional(Xnew, pred_noise, False, *givens)
-        chol = cholesky(cov)
         shape = infer_shape(Xnew, kwargs.pop("shape", None))
-        return pm.MvNormal(name, mu=mu, chol=chol, shape=shape, **kwargs)
+        return pm.MvNormal(name, mu=mu, cov=cov, shape=shape, **kwargs)
 
 
 @conditioned_vars(["Xs", "y", "sigma"])
@@ -959,7 +956,7 @@ class MarginalKron(Base):
             cov = Km - Asq
             if pred_noise:
                 cov += sigma * np.eye(cov.shape)
-        return mu, cov
+        return mu, stabilize(cov)
 
     def conditional(self, name, Xnew, pred_noise=False, **kwargs):
         """
@@ -996,9 +993,8 @@ class MarginalKron(Base):
             constructor.
         """
         mu, cov = self._build_conditional(Xnew, pred_noise, False)
-        chol = cholesky(stabilize(cov))
         shape = infer_shape(Xnew, kwargs.pop("shape", None))
-        return pm.MvNormal(name, mu=mu, chol=chol, shape=shape, **kwargs)
+        return pm.MvNormal(name, mu=mu, cov=cov, shape=shape, **kwargs)
 
     def predict(self, Xnew, point=None, diag=False, pred_noise=False):
         R"""

--- a/pymc3/gp/util.py
+++ b/pymc3/gp/util.py
@@ -4,7 +4,6 @@ import pymc3 as pm
 import theano.tensor as tt
 
 
-cholesky = pm.distributions.dist_math.Cholesky(nofail=True, lower=True)
 solve_lower = tt.slinalg.Solve(A_structure='lower_triangular')
 solve_upper = tt.slinalg.Solve(A_structure='upper_triangular')
 solve = tt.slinalg.Solve(A_structure='general')
@@ -89,6 +88,3 @@ def plot_gp_dist(ax, samples, x, plot_samples=True, palette="Reds"):
         # plot a few samples
         idx = np.random.randint(0, samples.shape[1], 30)
         ax.plot(x, samples[:,idx], color=cmap(0.9), lw=1, alpha=0.1)
-
-
-

--- a/pymc3/gp/util.py
+++ b/pymc3/gp/util.py
@@ -1,6 +1,5 @@
 from scipy.cluster.vq import kmeans
 import numpy as np
-import pymc3 as pm
 import theano.tensor as tt
 
 

--- a/pymc3/gp/util.py
+++ b/pymc3/gp/util.py
@@ -2,7 +2,7 @@ from scipy.cluster.vq import kmeans
 import numpy as np
 import theano.tensor as tt
 
-
+cholesky = tt.slinalg.cholesky
 solve_lower = tt.slinalg.Solve(A_structure='lower_triangular')
 solve_upper = tt.slinalg.Solve(A_structure='upper_triangular')
 solve = tt.slinalg.Solve(A_structure='general')


### PR DESCRIPTION
This picks up some of the most straight-forward edits from #2847. Guiding principle:
>  Whatever is implemented by the Mv distributions, is best delegated to Mv distributions

Aka DRY. 

**For review:**
In GP it appeared that covariance matrices were being stabilised multiple times over. Perhaps this was a side-effect of not following the above principle, *unless* there was some ground for doing this, eg the `_build_marginals()` have some way of screwing up (rendering non-positive definite) the covs even after they have first been stabilised. Please review.