### PR TITLE
Rewrite parallel sampling using multiprocessing

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,6 +13,11 @@
 - Improve error message `NaN occurred in optimization.` during ADVI
 - Save and load traces without `pickle` using `pm.save_trace` and `pm.load_trace`
 - Add `Kumaraswamy` distribution
+- Rewrite parallel sampling of multiple chains on py3. This resolves
+  long standing issues when tranferring large traces to the main process,
+  avoids pickleing issues on UNIX, and allows us to show a progress bar
+  for all chains. If parallel sampling is interrupted, we now return
+  partial results.
 
 ### Fixes
 

--- a/pymc3/backends/text.py
+++ b/pymc3/backends/text.py
@@ -99,8 +99,9 @@ class Text(base.BaseTrace):
         self._fh.write(','.join(columns) + '\n')
 
     def close(self):
-        self._fh.close()
-        self._fh = None  # Avoid serialization issue.
+        if self._fh is not None:
+            self._fh.close()
+            self._fh = None  # Avoid serialization issue.
 
     # Selection methods
 

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -285,14 +285,14 @@ class ParallelSampler(object):
                 if self._progress is not None:
                     self._progress[proc.chain - self._start_chain_num].close()
 
-            yield Draw(
-                proc.chain, is_last, draw, tuning,
-                stats, proc.shared_point_view
-            )
+            point = {name: val.copy()
+                     for name, val in proc.shared_point_view.items()}
 
             # Already called for new proc in _make_active
             if not is_last:
                 proc.write_next()
+
+            yield Draw(proc.chain, is_last, draw, tuning, stats, point)
 
     def __enter__(self):
         self._in_context = True

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -1,0 +1,297 @@
+import multiprocessing
+import multiprocessing.sharedctypes
+import sys
+import ctypes
+import time
+import logging
+from collections import namedtuple
+
+import six
+import tqdm
+import numpy as np
+
+from . import theanof
+
+logger = logging.getLogger('pymc3')
+
+# Messages
+# ('writing_done', is_last, sample_idx, tuning, stats)
+# ('error', *exception_info)
+
+# ('abort', reason)
+# ('write_next',)
+# ('start',)
+
+
+class _Process(multiprocessing.Process):
+    """Seperate process for each chain.
+
+    We communicate with the main process using a pipe,
+    and send finished samples using shared memory.
+    """
+    def __init__(self, msg_pipe, step_method, shared_point, draws, tune, seed):
+        super(_Process, self).__init__(daemon=True)
+        self._msg_pipe = msg_pipe
+        self._step_method = step_method
+        self._shared_point = shared_point
+        self._seed = seed
+        self._tt_seed = seed + 1
+        self._draws = draws
+        self._tune = tune
+
+    def run(self):
+        try:
+            # We do not create this in __init__, as pickling this
+            # would destroy the shared memory.
+            self._point = self._make_numpy_refs()
+            self._start_loop()
+        except KeyboardInterrupt:
+            pass
+        except BaseException:
+            exc_info = sys.exc_info()
+            self._msg_pipe.send(('error', exc_info[:2]))
+        finally:
+            self._msg_pipe.close()
+
+    def _make_numpy_refs(self):
+        shape_dtypes = self._step_method.vars_shape_dtype
+        point = {}
+        for name, (shape, dtype) in shape_dtypes.items():
+            array = self._shared_point[name]
+            self._shared_point[name] = array
+            point[name] = np.frombuffer(array, dtype).reshape(shape)
+        return point
+
+    def _write_point(self, point):
+        for name, vals in point.items():
+            self._point[name][...] = vals
+
+    def _recv_msg(self):
+        return self._msg_pipe.recv()
+
+    def _start_loop(self):
+        np.random.seed(self._seed)
+        theanof.set_tt_rng(self._tt_seed)
+
+        draw = 0
+        tuning = True
+
+        msg = self._recv_msg()
+        if msg[0] == 'abort':
+            raise KeyboardInterrupt()
+        if msg[0] != 'start':
+            raise ValueError('Unexpected msg ' + msg[0])
+
+        while True:
+            if draw < self._draws + self._tune:
+                point, stats = self._compute_point()
+            else:
+                return
+
+            if draw == self._tune:
+                self._step_method.stop_tuning()
+                tuning = False
+
+            msg = self._recv_msg()
+            if msg[0] == 'abort':
+                raise KeyboardInterrupt()
+            elif msg[0] == 'write_next':
+                self._write_point(point)
+                is_last = draw + 1 == self._draws + self._tune
+                self._msg_pipe.send(
+                    ('writing_done', is_last, draw, tuning, stats))
+                draw += 1
+            else:
+                raise ValueError('Unknown message ' + msg[0])
+
+    def _compute_point(self):
+        if self._step_method.generates_stats:
+            point, stats = self._step_method.step(self._point)
+        else:
+            point = self._step_method.step(self._point)
+            stats = None
+        return point, stats
+
+
+class ProcessAdapter(object):
+    """Control a Chain process from the main thread."""
+    def __init__(self, draws, tune, step_method, chain, seed, start):
+        self.chain = chain
+        self._msg_pipe, remote_conn = multiprocessing.Pipe()
+
+        self._shared_point = {}
+        self._point = {}
+        for name, (shape, dtype) in step_method.vars_shape_dtype.items():
+            size = 1
+            for dim in shape:
+                size *= int(dim)
+            size *= dtype.itemsize
+            if size != ctypes.c_size_t(size).value:
+                raise ValueError('Variable %s is too large' % name)
+
+            array = multiprocessing.sharedctypes.RawArray('c', size)
+            self._shared_point[name] = array
+            array_np = np.frombuffer(array, dtype).reshape(shape)
+            array_np[...] = start[name]
+            self._point[name] = array_np
+
+        self._readable = True
+        self._num_samples = 0
+
+        self._process = _Process(
+            remote_conn, step_method, self._shared_point, draws, tune, seed)
+        # We fork right away, so that the main process can start tqdm threads
+        self._process.start()
+
+    @property
+    def shared_point_view(self):
+        """May only be written to or read between a `recv_draw`
+        call from the process and a `write_next` or `abort` call.
+        """
+        if not self._readable:
+            raise RuntimeError()
+        return self._point
+
+    def start(self):
+        self._msg_pipe.send(('start',))
+
+    def write_next(self):
+        self._readable = False
+        self._msg_pipe.send(('write_next',))
+
+    def abort(self):
+        self._msg_pipe.send(('abort',))
+
+    def join(self, timeout=None):
+        self._process.join(timeout)
+
+    def terminate(self):
+        self._process.terminate()
+
+    @staticmethod
+    def recv_draw(processes, timeout=3600):
+        if not processes:
+            raise ValueError('No processes.')
+        pipes = [proc._msg_pipe for proc in processes]
+        ready = multiprocessing.connection.wait(pipes)
+        if not ready:
+            raise multiprocessing.TimeoutError('No message from samplers.')
+        idxs = {id(proc._msg_pipe): proc for proc in processes}
+        proc = idxs[id(ready[0])]
+        msg = ready[0].recv()
+
+        if msg[0] == 'error':
+            old = msg[1][1]#.with_traceback(msg[1][2])
+            six.raise_from(RuntimeError('Chain %s failed.' % proc.chain), old)
+        elif msg[0] == 'writing_done':
+            proc._readable = True
+            proc._num_samples += 1
+            return (proc, *msg[1:])
+        else:
+            raise ValueError('Sampler sent bad message.')
+
+    @staticmethod
+    def terminate_all(processes, patience=2):
+        for process in processes:
+            try:
+                process.abort()
+            except EOFError:
+                pass
+
+        start_time = time.time()
+        try:
+            for process in processes:
+                timeout = start_time + patience - time.time()
+                if timeout < 0:
+                    raise multiprocessing.TimeoutError()
+                process.join(timeout)
+        except multiprocessing.TimeoutError:
+            logger.warn('Chain processes did not terminate as expected. '
+                        'Terminating forcefully...')
+            for process in processes:
+                process.terminate()
+            for process in processes:
+                process.join()
+
+
+Draw = namedtuple(
+    'Draw',
+    ['chain', 'is_last', 'draw_idx', 'tuning', 'stats', 'point']
+)
+
+
+class ParallelSampler(object):
+    def __init__(self, draws, tune, chains, cores, seeds, start_points,
+                 step_method, start_chain_num=0, progressbar=True):
+        self._samplers = [
+            ProcessAdapter(draws, tune, step_method,
+                           chain + start_chain_num, seed, start)
+            for chain, seed, start in zip(range(chains), seeds, start_points)
+        ]
+
+        self._inactive = self._samplers.copy()
+        self._finished = []
+        self._active = []
+        self._max_active = cores
+
+        self._in_context = False
+        self._start_chain_num = start_chain_num
+
+        self._global_progress = self._progress = None
+        if progressbar:
+            self._global_progress = tqdm.tqdm(
+                total=chains, unit='chains', position=1)
+            self._progress = [
+                tqdm.tqdm(
+                    desc='    Chain %i' % (chain + start_chain_num),
+                    unit='draws',
+                    position=chain + 2,
+                    total=draws + tune)
+                for chain in range(chains)
+            ]
+
+    def _make_active(self):
+        while self._inactive and len(self._active) < self._max_active:
+            proc = self._inactive.pop()
+            proc.start()
+            proc.write_next()
+            self._active.append(proc)
+
+    def __iter__(self):
+        if not self._in_context:
+            raise ValueError('Use ParallelSampler as context manager.')
+        self._make_active()
+
+        while self._active:
+            draw = ProcessAdapter.recv_draw(self._active)
+            proc, is_last, draw, tuning, stats = draw
+            if self._progress is not None:
+                self._progress[proc.chain - self._start_chain_num].update()
+
+            if is_last:
+                proc.join()
+                self._active.remove(proc)
+                self._finished.append(proc)
+                self._make_active()
+                if self._global_progress is not None:
+                    self._global_progress.update()
+
+            yield Draw(
+                proc.chain, is_last, draw, tuning,
+                stats, proc.shared_point_view
+            )
+
+            # Already called for new proc in _make_active
+            if not is_last:
+                proc.write_next()
+
+    def __enter__(self):
+        self._in_context = True
+        return self
+
+    def __exit__(self, *args):
+        ProcessAdapter.terminate_all(self._samplers)
+        if self._progress is not None:
+            self._global_progress.close()
+            for progress in self._progress:
+                progress.close()

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -7,7 +7,6 @@ import logging
 from collections import namedtuple
 
 import six
-import tqdm
 import numpy as np
 
 from . import theanof
@@ -222,7 +221,15 @@ Draw = namedtuple(
 
 class ParallelSampler(object):
     def __init__(self, draws, tune, chains, cores, seeds, start_points,
-                 step_method, start_chain_num=0, progressbar=True):
+                 step_method, start_chain_num=0, progressbar=True,
+                 notebook=True):
+        if progressbar and notebook:
+            import tqdm
+            tqdm_ = tqdm.tqdm_notebook
+        elif progressbar:
+            import tqdm
+            tqdm_ = tqdm.tqdm
+
         self._samplers = [
             ProcessAdapter(draws, tune, step_method,
                            chain + start_chain_num, seed, start)
@@ -239,10 +246,10 @@ class ParallelSampler(object):
 
         self._global_progress = self._progress = None
         if progressbar:
-            self._global_progress = tqdm.tqdm(
+            self._global_progress = tqdm_(
                 total=chains, unit='chains', position=1)
             self._progress = [
-                tqdm.tqdm(
+                tqdm_(
                     desc='    Chain %i' % (chain + start_chain_num),
                     unit='draws',
                     position=chain + 2,

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -247,19 +247,19 @@ class ParallelSampler(object):
         self._global_progress = self._progress = None
         if progressbar:
             self._global_progress = tqdm_(
-                total=chains, unit='chains', position=1)
+                total=chains, unit='chains', position=0)
             self._progress = [
                 tqdm_(
                     desc='    Chain %i' % (chain + start_chain_num),
                     unit='draws',
-                    position=chain + 2,
+                    position=chain + 1,
                     total=draws + tune)
                 for chain in range(chains)
             ]
 
     def _make_active(self):
         while self._inactive and len(self._active) < self._max_active:
-            proc = self._inactive.pop()
+            proc = self._inactive.pop(0)
             proc.start()
             proc.write_next()
             self._active.append(proc)
@@ -282,6 +282,8 @@ class ParallelSampler(object):
                 self._make_active()
                 if self._global_progress is not None:
                     self._global_progress.update()
+                if self._progress is not None:
+                    self._progress[proc.chain - self._start_chain_num].close()
 
             yield Draw(
                 proc.chain, is_last, draw, tuning,

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -30,7 +30,7 @@ class _Process(multiprocessing.Process):
     """
     def __init__(self, name, msg_pipe, step_method, shared_point,
                  draws, tune, seed):
-        super(_Process, self).__init__(daemon=True)
+        super(_Process, self).__init__(daemon=True, name=name)
         self._msg_pipe = msg_pipe
         self._step_method = step_method
         self._shared_point = shared_point

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -87,12 +87,25 @@ class BlockedStep(object):
         vars = np.atleast_1d(vars)
         have_grad = np.atleast_1d(have_grad)
         competences = []
-        for var,has_grad in zip(vars, have_grad):
+        for var, has_grad in zip(vars, have_grad):
             try:
                 competences.append(cls.competence(var, has_grad))
             except TypeError:
                 competences.append(cls.competence(var))
         return competences
+
+    @property
+    def vars_shape_dtype(self):
+        shape_dtypes = {}
+        for var in self.vars:
+            dtype = np.dtype(var.dtype)
+            shape = var.dshape
+            shape_dtypes[var.name] = (shape, dtype)
+        return shape_dtypes
+
+    def stop_tuning(self):
+        if hasattr(self, 'tune'):
+            self.tune = False
 
 
 class ArrayStep(BlockedStep):

--- a/pymc3/step_methods/compound.py
+++ b/pymc3/step_methods/compound.py
@@ -33,11 +33,11 @@ class CompoundStep(object):
                 point = method.step(point)
             return point
 
-    def warnings(self, strace):
+    def warnings(self):
         warns = []
         for method in self.methods:
             if hasattr(method, 'warnings'):
-                warns.extend(method.warnings(strace))
+                warns.extend(method.warnings())
         return warns
 
     def stop_tuning(self):

--- a/pymc3/step_methods/compound.py
+++ b/pymc3/step_methods/compound.py
@@ -6,11 +6,13 @@ Created on Mar 7, 2011
 
 
 class CompoundStep(object):
-    """Step method composed of a list of several other step methods applied in sequence."""
+    """Step method composed of a list of several other step
+    methods applied in sequence."""
 
     def __init__(self, methods):
         self.methods = list(methods)
-        self.generates_stats = any(method.generates_stats for method in self.methods)
+        self.generates_stats = any(
+            method.generates_stats for method in self.methods)
         self.stats_dtypes = []
         for method in self.methods:
             if method.generates_stats:
@@ -37,3 +39,14 @@ class CompoundStep(object):
             if hasattr(method, 'warnings'):
                 warns.extend(method.warnings(strace))
         return warns
+
+    def stop_tuning(self):
+        for method in self.methods:
+            method.stop_tuning()
+
+    @property
+    def vars_shape_dtype(self):
+        dtype_shapes = {}
+        for method in self.methods:
+            dtype_shapes.update(method.vars_shape_dtype)
+        return dtype_shapes

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -164,7 +164,7 @@ class BaseHMC(arraystep.GradientSharedStep):
         self.tune = True
         self.potential.reset()
 
-    def warnings(self, strace):
+    def warnings(self):
         # list.copy() is not available in python2
         warnings = self._warnings[:]
 

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -184,8 +184,8 @@ class NUTS(BaseHMC):
             return Competence.IDEAL
         return Competence.INCOMPATIBLE
 
-    def warnings(self, strace):
-        warnings = super(NUTS, self).warnings(strace)
+    def warnings(self):
+        warnings = super(NUTS, self).warnings()
         n_samples = self._samples_after_tune
         n_treedepth = self._reached_max_treedepth
 

--- a/pymc3/tests/sampler_fixtures.py
+++ b/pymc3/tests/sampler_fixtures.py
@@ -82,13 +82,13 @@ class BetaBinomialFixture(KnownCDF):
 
 class StudentTFixture(KnownMean, KnownCDF):
     means = {'a': 0}
-    cdfs = {'a': stats.t(df=3).cdf}
+    cdfs = {'a': stats.t(df=4).cdf}
     ks_thin = 10
 
     @classmethod
     def make_model(cls):
         with pm.Model() as model:
-            a = pm.StudentT("a", nu=3, mu=0, sd=1)
+            a = pm.StudentT("a", nu=4, mu=0, sd=1)
         return model
 
 

--- a/pymc3/tests/test_parallel_sampling.py
+++ b/pymc3/tests/test_parallel_sampling.py
@@ -1,9 +1,13 @@
 import time
+import sys
+import pytest
 
 import pymc3.parallel_sampling as ps
 import pymc3 as pm
 
 
+@pytest.mark.skipif(sys.version_info < (3,3),
+                    reason="requires python3.3")
 def test_abort():
     with pm.Model() as model:
         a = pm.Normal('a', shape=1)
@@ -21,6 +25,8 @@ def test_abort():
     proc.join()
 
 
+@pytest.mark.skipif(sys.version_info < (3,3),
+                    reason="requires python3.3")
 def test_explicit_sample():
     with pm.Model() as model:
         a = pm.Normal('a', shape=1)
@@ -46,6 +52,8 @@ def test_explicit_sample():
     print(time.time() - start)
 
 
+@pytest.mark.skipif(sys.version_info < (3,3),
+                    reason="requires python3.3")
 def test_iterator():
     with pm.Model() as model:
         a = pm.Normal('a', shape=1)

--- a/pymc3/tests/test_parallel_sampling.py
+++ b/pymc3/tests/test_parallel_sampling.py
@@ -1,0 +1,64 @@
+import time
+
+import pymc3.parallel_sampling as ps
+import pymc3 as pm
+
+
+def test_abort():
+    with pm.Model() as model:
+        a = pm.Normal('a', shape=1)
+        pm.HalfNormal('b')
+        step1 = pm.NUTS([a])
+        step2 = pm.Metropolis([model.b_log__])
+
+    step = pm.CompoundStep([step1, step2])
+
+    proc = ps.ProcessAdapter(10, 10, step, chain=3, seed=1,
+                             start={'a': 1., 'b_log__': 2.})
+    proc.start()
+    proc.write_next()
+    proc.abort()
+    proc.join()
+
+
+def test_explicit_sample():
+    with pm.Model() as model:
+        a = pm.Normal('a', shape=1)
+        pm.HalfNormal('b')
+        step1 = pm.NUTS([a])
+        step2 = pm.Metropolis([model.b_log__])
+
+    step = pm.CompoundStep([step1, step2])
+
+    start = time.time()
+    proc = ps.ProcessAdapter(10, 10, step, chain=3, seed=1,
+                             start={'a': 1., 'b_log__': 2.})
+    proc.start()
+    while True:
+        proc.write_next()
+        out = ps.ProcessAdapter.recv_draw([proc])
+        view = proc.shared_point_view
+        for name in view:
+            view[name].copy()
+        if out[1]:
+            break
+    proc.join()
+    print(time.time() - start)
+
+
+def test_iterator():
+    with pm.Model() as model:
+        a = pm.Normal('a', shape=1)
+        pm.HalfNormal('b')
+        step1 = pm.NUTS([a])
+        step2 = pm.Metropolis([model.b_log__])
+
+    step = pm.CompoundStep([step1, step2])
+
+    start = time.time()
+    start = {'a': 1., 'b_log__': 2.}
+    sampler = ps.ParallelSampler(10, 10, 3, 2, [2, 3, 4], [start] * 3,
+                                 step, 0, False)
+    with sampler:
+        for draw in sampler:
+            pass


### PR DESCRIPTION
This PR gets rid of joblib altogether, and replaces it with a custom implementation.
This should solve some long standing problems:
- Pickling models in not always possible, and with this approach we only need to do this on windows now.
- Problems pickling large traces. Right now we send the finished trace to the main thread by pickling it and sending it though a pipe. This causes problems if the trace is very large, as on many systems there is a limit for the size of one `pipe.send`. Very large traces can't use multiprocessing right now.
- joblib doesn't seem to be particularly reliable. I've seen lots of cases where processes got stuck, and I had to kill them manually, or interrupting sampling works only after sending several interrupts. (One caviat with the proposed method is that we can only interrupt traces between samples. So very slow samplers might be stuck for a few seconds. We can still kill them though.)
- More control over how exceptions are reported. We can format the remote exceptions nicely. This is not implemented yet, but there is code for this here: https://hg.python.org/cpython/rev/c4f92b597074
- Better progress bars, as the main processes always knows how far the individual processes are. (but there seem to be tqdm bugs that still mess that up...)
- We can implement trace backends so that the main process writes all samples to the file as they come in, and we never need to keep many of them in memory, and can avoid parallel io.

---

We start one process per chain, that communicates with the main thread by sending messages through a pipe. Ones a draw is ready, it is stored in shared memory, and the main process can access it. Then the sampler process is asked to write the next sample to that shared memory.

Performance wise it shouldn't be much different, the pipes seem to be fast enough to deal with the speed of our sampler. It is possible that we gain a bit of speed for large models with cheap computations, as we have a dedicated thread for sampling, that doesn't also have to deal with storing data in the trace. For very small models it might be a bit slower, as we do have some small constant overhead for sending messages.

Since I use a couple of py3 only features, the old code is still used if py<3

### TODO
- [x] Add warnings (they are not working yet)
- [x] Fix progress bar
- [x] Better formatting of exceptions
- [x] Test on windows
- [ ] Optional, improve exception printing in jupyter via `set_custom_exc`