### PR TITLE
fix typo in bayes formula

### DIFF
--- a/docs/source/notebooks/Bayes_factor.ipynb
+++ b/docs/source/notebooks/Bayes_factor.ipynb
@@ -38,9 +38,10 @@
    "source": [
     "The \"Bayesian way\" to compare models is to compute the _marginal likelihood_ of each model $p(y \\mid M_k)$, _i.e._ the probability of the observed data $y$ given the $M_k$ model. This quantity, the marginal likelihood, is just the normalizing constant of Bayes' theorem. We can see this if we write Bayes' theorem and make explicit the fact that all inferences are model-dependant. \n",
     "\n",
-    "$$p (\\theta \\mid y, M_k ) = \\frac{p(\\theta \\mid \\theta, M_k) p(\\theta \\mid M_k)}{p( y \\mid M_k)}$$\n",
+    "$$p (\\theta \\mid y, M_k ) = \\frac{p(y \\mid \\theta, M_k) p(\\theta \\mid M_k)}{p( y \\mid M_k)}$$\n",
     "\n",
     "where:\n",
+    "\n",
     "* $y$ is the data\n",
     "* $\\theta$ the parameters\n",
     "* $M_k$ one model out of K competing models\n",
@@ -48,7 +49,7 @@
     "\n",
     "Usually when doing inference we do not need to compute this normalizing constant, so in practice we often compute the posterior up to a constant factor, that is:\n",
     "\n",
-    "$$p (\\theta \\mid y, M_k ) \\propto p(\\theta \\mid \\theta, M_k) p(\\theta \\mid M_k)$$\n",
+    "$$p (\\theta \\mid y, M_k ) \\propto p(y \\mid \\theta, M_k) p(\\theta \\mid M_k)$$\n",
     "\n",
     "However, for model comparison and model averaging the marginal likelihood is an important quantity. Although, it's not the only way to perform these tasks, you can read about model averaging and model selection using alternative methods [here](model_comparison.ipynb), [there](model_averaging.ipynb) and [elsewhere](GLM-model-selection.ipynb)."
    ]


### PR DESCRIPTION
Fix typo in the bayes formula in the Bayes Factors notebook:
http://docs.pymc.io/notebooks/Bayes_factor.html#Bayes-Factors-and-Marginal-Likelihood

Current formula:
p(θ∣y,Mk)=p(θ∣θ,Mk)p(θ∣Mk) / p(y∣Mk)

Should be:
p(θ∣y,Mk)=p(y∣θ,Mk)p(θ∣Mk) / p(y∣Mk)

The commit also fixes (hopefully) the formatting error of the list explaining the notation.