### PR TITLE
Make docker build work

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -15,4 +15,4 @@ RUN pip install seaborn
 # Import matplotlib the first time to build the font cache.
 RUN python -c "import matplotlib.pyplot"
 
-ENV PYTHONPATH $PYTHONPATH:"$HOME"/pymc3
+ENV PYTHONPATH $PYTHONPATH:"$HOME"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,22 +1,11 @@
 FROM jupyter/minimal-notebook
 
+ARG SRC_DIR
+
 MAINTAINER Austin Rochford <austin.rochford@gmail.com>
 
-USER root
-
-# install libav-tools to support matplotlib animations
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libav-tools && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-USER $NB_USER
-
-COPY scripts/create_testenv.sh /tmp/create_testenv.sh
-COPY setup.py $HOME/setup.py
-COPY requirements.txt $HOME/requirements.txt
-COPY requirements-dev.txt $HOME/requirements-dev.txt
-RUN /bin/bash /tmp/create_testenv.sh --global --no-setup
+ADD $SRC_DIR /home/jovyan/
+RUN /bin/bash /home/jovyan/scripts/create_testenv.sh --global --no-setup
 
 #  matplotlib nonsense
 ENV XDG_CACHE_HOME /home/$NB_USER/.cache/

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -12,6 +12,7 @@ docker build \
     -f $SRC_DIR/scripts/Dockerfile \
     --build-arg SRC_DIR=. \
     $SRC_DIR
+
 docker run -d \
     -p $PORT:8888 \
     -v $NOTEBOOK_DIR:/home/jovyan/work/ \

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -5,8 +5,8 @@ SRC_DIR=${SRC_DIR:-`pwd`}
 NOTEBOOK_DIR=${NOTEBOOK_DIR:-$SRC_DIR/notebooks}
 TOKEN=$(openssl rand -hex 24)
 
-# note that all paths are relative to the build context, so SRC_DIR is the same
-# . represents SRC_DIR to Docker
+# note that all paths are relative to the build context, so . represents
+# SRC_DIR to Docker
 docker build \
     -t pymc3 \
     -f $SRC_DIR/scripts/Dockerfile \

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -5,10 +5,15 @@ SRC_DIR=${SRC_DIR:-`pwd`}
 NOTEBOOK_DIR=${NOTEBOOK_DIR:-$SRC_DIR/notebooks}
 TOKEN=$(openssl rand -hex 24)
 
-docker build -t pymc3 -f $SRC_DIR/scripts/Dockerfile $SRC_DIR
+# note that all paths are relative to the build context, so SRC_DIR is the same
+# . represents SRC_DIR to Docker
+docker build \
+    -t pymc3 \
+    -f $SRC_DIR/scripts/Dockerfile \
+    --build-arg SRC_DIR=. \
+    $SRC_DIR
 docker run -d \
     -p $PORT:8888 \
-    -v $SRC_DIR:/home/jovyan/pymc3 \
     -v $NOTEBOOK_DIR:/home/jovyan/work/ \
     --name pymc3 pymc3 \
     start-notebook.sh --NotebookApp.token=${TOKEN}


### PR DESCRIPTION
Will eventually resolve #3003.

`libav-tools` were only used for an unimportant part of one notebook, so are safe to remove.  Removing `libav-tools` exposed some problems with the new version of `pip`.