### PR TITLE
Improve random for ObservedRV

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -383,7 +383,17 @@ def _draw_value(param, point=None, givens=None, size=None):
         elif (hasattr(param, 'distribution') and
                 hasattr(param.distribution, 'random') and
                 param.distribution.random is not None):
-            return param.distribution.random(point=point, size=size)
+            # reset the dist shape for ObservedRV
+            if hasattr(param, 'observations'):
+                dist_tmp = param.distribution
+                try:
+                    distshape = param.observations.shape.eval()
+                except AttributeError:
+                    distshape = param.observations.shape
+                dist_tmp.shape = distshape
+                return dist_tmp.random(point=point, size=size)
+            else:
+                return param.distribution.random(point=point, size=size)
         else:
             if givens:
                 variables, values = list(zip(*givens))


### PR DESCRIPTION
To generate random array for ObservedRV in `sample_ppc` and `sample_prior_predictive` a `shape` kwarg sometimes is needed to make sure the generated array has the same shape as the observed.

This PR improved that to make sure the shape is inferred during random number generation.

Previously I tried to add the shape attr to `ObservedRV` at the model creation, but turns out it breaks the `sample_ppc` for `theano.shared` observation. I try a different approach here to always reset the distribution shape at generation.