### PR TITLE
Fix sample_prior_predictive edge case

### DIFF
--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -432,3 +432,11 @@ class TestSamplePriorPredictive(SeededTest):
             prior = pm.sample_prior_predictive()
 
         npt.assert_almost_equal(prior['a'].mean(), 0, decimal=1)
+
+    def test_shape_edgecase(self):
+        with pm.Model():
+            mu = pm.Normal('mu', shape=5)
+            sd = pm.Uniform('sd', lower=2, upper=3)
+            x = pm.Normal('x', mu=mu, sd=sd, shape=5)
+            prior = pm.sample_prior_predictive(10)
+        assert prior['mu'].shape == (10, 5)


### PR DESCRIPTION
Found another problem (and another tiny solution)

```python
with pm.Model():
    mu = pm.Normal('mu', shape=5)
    sd = pm.Uniform('sd', lower=2, upper=3)
    x = pm.Normal('x', mu=mu, sd=sd, shape=5)
    prior = pm.sample_prior_predictive()
```

fails because it attempts to broadcast `mu`, which has shape `(500, 5)`, with `sd`, which has `(500,)` Making all variables have the same `ndim` should fix it.  This is not a good solution in general, so I used a `try/except`: a different test fails if we match `ndim` this way by default.
