### PR TITLE
Fix categorical random shape

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -712,6 +712,7 @@ class Categorical(Discrete):
 
     def random(self, point=None, size=None):
         p, k = draw_values([self.p, self.k], point=point, size=size)
+
         return generate_samples(random_choice,
                                 p=p,
                                 broadcast_shape=p.shape[:-1] or (1,),

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -302,7 +302,8 @@ def random_choice(*args, **kwargs):
     k = p.shape[-1]
 
     if p.ndim > 1:
-        samples = np.row_stack([np.random.choice(k, p=p_) for p_ in p])
+        # If a 2d vector of probabilities is passed return a sample for each row of categorical probability
+        samples = np.array([np.random.choice(k, p=p_) for p_ in p])
     else:
         samples = np.random.choice(k, p=p, size=size)
     return samples

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -194,8 +194,7 @@ class BaseTestCases(object):
         @pytest.mark.parametrize('shape', [(), (1,), (1, 1), (1, 2), (10, 10, 1), (10, 10, 2)], ids=str)
         def test_different_shapes_and_sample_sizes(self, shape):
             prefix = self.distribution.__name__
-            expected = []
-            actual = []
+
             rv = self.get_random_variable(shape, name='%s_%s' % (prefix, shape))
             for size in (None, 1, 5, (4, 5)):
                 if size is None:

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -402,6 +402,11 @@ class TestCategorical(BaseTestCases.BaseTestCase):
     def get_random_variable(self, shape, with_vector_params=False, **kwargs):  # don't transform categories
         return super(TestCategorical, self).get_random_variable(shape, with_vector_params=False, **kwargs)
 
+    def test_probability_vector_shape(self):
+        """Check that if a 2d array of probabilities are passed to categorical correct shape is returned"""
+        p = np.ones((10, 5))
+        assert pm.Categorical.dist(p=p).random().shape == (10,)
+
 
 class TestScalarParameterSamples(SeededTest):
     def test_bounded(self):


### PR DESCRIPTION
Hello,
This pull request is for https://github.com/pymc-devs/pymc3/issues/3035 and is very much in WIP.

To summarize I tried to hit two objectives per @junpenglao request, one was removing duplication of random draws from categorical, the other was address the shape.

For removing duplication
I created a function in distribution called *random_choice* and pointed the previous methods to it. All tests are passing in this structure.

Questions I have
Is this name good or should it be called categorical_random_choice?
Is distributions.py a good place for it?


For the shape comment
I believe there is an expectation that if a (10,5) size is requested, the method returns a (10,5) array. 
These tests specifically seem to test for that behavior.
`pymc3.tests.test_distributions_random.BaseTestCases.BaseTestCase#test_scalar_parameter_shape`
`pymc3.tests.test_distributions_random.BaseTestCases.BaseTestCase#test_scalar_shape`
Given that I don't understand how this test reconciles with the original issue, but this is not to suggest the request was wrong. I'm very much at the edge of my understanding and feel like I'm missing something.
How should I proceed?

I've attached some supporting screenshots that may help. Thanks for the chance to participate and leanr

![image](https://user-images.githubusercontent.com/7213793/41921156-178f89dc-7917-11e8-84c2-3f858f756488.png)
![image](https://user-images.githubusercontent.com/7213793/41921376-96d0f712-7917-11e8-8c8a-ee70a6f64ec1.png)


