### PR TITLE
fix_discreteuniform_doc issue #3074

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -606,7 +606,7 @@ class DiscreteUniform(Discrete):
         us = [6, 2]
         for l, u in zip(ls, us):
             x = np.arange(l, u+1)
-            pmf = [1 / (u - l)] * len(x)
+            pmf = [1 / (u - l + 1)] * len(x)
             plt.plot(x, pmf, '-o', label='lower = {}, upper = {}'.format(l, u))
         plt.xlabel('x', fontsize=12)
         plt.ylabel('f(x)', fontsize=12)


### PR DESCRIPTION
Fix the error in discrete uniform distribution documentation of incorrect pmf.
Original documentation defines pmf as:
`pmf = [1 / (u - l)] * len(x)`
which causes probability to sum > 1
Fixed documentation to
`pmf = [1 / (u - l + 1)] * len(x)`
Now probability sum to 1 correctly.