### PR TITLE
Fix grammar in divergence warning; refactor code

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -31,6 +31,7 @@
 
 ### Fixes
 
+- Fixed grammar in divergence warning, previously `There were 1 divergences ...` could be raised.
 - Fixed `KeyError` raised when only subset of variables are specified to be recorded in the trace.
 - Removed unused `repeat=None` arguments from all `random()` methods in distributions.
 - Deprecated the `sigma` argument in `MarginalSparse.marginal_likelihood` in favor of `noise`

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -169,23 +169,19 @@ class BaseHMC(arraystep.GradientSharedStep):
         warnings = self._warnings[:]
 
         # Generate a global warning for divergences
+        message = ''
         n_divs = self._num_divs_sample
         if n_divs and self._samples_after_tune == n_divs:
             message = ('The chain contains only diverging samples. The model '
                        'is probably misspecified.')
-            warning = SamplerWarning(
-                WarningType.DIVERGENCES, message, 'error', None, None, None)
-            warnings.append(warning)
         elif n_divs == 1:
             message = ('There was 1 divergence after tuning. Increase '
                        '`target_accept` or reparameterize.')
-            warning = SamplerWarning(
-                WarningType.DIVERGENCES, message, 'error', None, None, None)
-            warnings.append(warning)
         elif n_divs > 1:
             message = ('There were %s divergences after tuning. Increase '
-                       '`target_accept` or reparameterize.'
-                       % n_divs)
+                       '`target_accept` or reparameterize.' % n_divs)
+
+        if message:
             warning = SamplerWarning(
                 WarningType.DIVERGENCES, message, 'error', None, None, None)
             warnings.append(warning)

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -173,17 +173,22 @@ class BaseHMC(arraystep.GradientSharedStep):
         if n_divs and self._samples_after_tune == n_divs:
             message = ('The chain contains only diverging samples. The model '
                        'is probably misspecified.')
+            warning = SamplerWarning(
+                WarningType.DIVERGENCES, message, 'error', None, None, None)
+            warnings.append(warning)
         elif n_divs == 1:
             message = ('There was 1 divergence after tuning. Increase '
                        '`target_accept` or reparameterize.')
+            warning = SamplerWarning(
+                WarningType.DIVERGENCES, message, 'error', None, None, None)
+            warnings.append(warning)
         elif n_divs > 1:
             message = ('There were %s divergences after tuning. Increase '
                        '`target_accept` or reparameterize.'
                        % n_divs)
+            warning = SamplerWarning(
+                WarningType.DIVERGENCES, message, 'error', None, None, None)
+            warnings.append(warning)
 
-        warning = SamplerWarning(
-            WarningType.DIVERGENCES, message, 'error', None, None, None)
-        warnings.append(warning)
         warnings.extend(self.step_adapt.warnings())
-
         return warnings

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -171,18 +171,19 @@ class BaseHMC(arraystep.GradientSharedStep):
         # Generate a global warning for divergences
         n_divs = self._num_divs_sample
         if n_divs and self._samples_after_tune == n_divs:
-            msg = ('The chain contains only diverging samples. The model is '
-                   'probably misspecified.')
-            warning = SamplerWarning(
-                WarningType.DIVERGENCES, msg, 'error', None, None, None)
-            warnings.append(warning)
+            message = ('The chain contains only diverging samples. The model '
+                       'is probably misspecified.')
+        elif n_divs == 1:
+            message = ('There was 1 divergence after tuning. Increase '
+                       '`target_accept` or reparameterize.')
         elif n_divs > 0:
             message = ('There were %s divergences after tuning. Increase '
                        '`target_accept` or reparameterize.'
                        % n_divs)
-            warning = SamplerWarning(
-                WarningType.DIVERGENCES, message, 'error', None, None, None)
-            warnings.append(warning)
 
+        warning = SamplerWarning(
+            WarningType.DIVERGENCES, message, 'error', None, None, None)
+        warnings.append(warning)
         warnings.extend(self.step_adapt.warnings())
+
         return warnings

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -176,7 +176,7 @@ class BaseHMC(arraystep.GradientSharedStep):
         elif n_divs == 1:
             message = ('There was 1 divergence after tuning. Increase '
                        '`target_accept` or reparameterize.')
-        elif n_divs > 0:
+        elif n_divs > 1:
             message = ('There were %s divergences after tuning. Increase '
                        '`target_accept` or reparameterize.'
                        % n_divs)

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -446,6 +446,9 @@ class TestNutsCheckTrace(object):
             warns = [msg.msg for msg in caplog.records]
             assert np.any(trace['diverging'])
             assert (
+                any('divergence after tuning' in warn
+                    for warn in warns)
+                or
                 any('divergences after tuning' in warn
                     for warn in warns)
                 or


### PR DESCRIPTION
Sorry if this is nitpicky but it's sad to see PyMC3 make a grammatical mistake 😕 

This PR changes the error warning for divergences from `There were 1 divergences ...` to `There was 1 divergence ...`. It also refactors the code a bit.