### PR TITLE
Track model logp during sampling

### DIFF
--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -8,6 +8,7 @@ import logging
 
 import numpy as np
 import warnings
+import pymc3 as pm
 import theano.tensor as tt
 
 from ..model import modelcontext

--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -33,18 +33,30 @@ class BaseTrace(object):
         Sampling values will be stored for these variables. If None,
         `model.unobserved_RVs` is used.
     test_point : dict
-        use different test point that might be with changed variables shapes
+        Use different test point that might be with changed variables shapes
+    likelihood_name : str
+        Name of the pymc3.Deterministic variable that contains the model
+        likelihood. Defaults to 'logp__'.
     """
 
     supports_sampler_stats = False
 
-    def __init__(self, name, model=None, vars=None, test_point=None):
+    def __init__(self, name, model=None, vars=None, test_point=None,
+                 likelihood_name='logp__'):
         self.name = name
 
         model = modelcontext(model)
         self.model = model
         if vars is None:
+            if not any(RV.name == likelihood_name for RV in model.unobserved_RVs):
+                pm._log.info('Adding model likelihood to RVs!')
+                with model:
+                    logp__ = pm.Deterministic(likelihood_name, model.logpt)
+            else:
+                pm._log.info('Using present model likelihood!')
+
             vars = model.unobserved_RVs
+
         self.vars = vars
         self.varnames = [var.name for var in vars]
         self.fn = model.fastfn(vars)

--- a/pymc3/step_methods/smc.py
+++ b/pymc3/step_methods/smc.py
@@ -73,9 +73,6 @@ class SMC(atext.ArrayStepSharedLLK):
     covariance : :class:`numpy.ndarray`
         (chains x chains)
         Initial Covariance matrix for proposal distribution, if None - identity matrix taken
-    likelihood_name : string
-        name of the :class:`pymc3.deterministic` variable that contains the model likelihood.
-        Defaults to 'l_like__'
     proposal_name :
         Type of proposal distribution, see smc.proposal_dists.keys() for options
     tune_interval : int
@@ -105,8 +102,8 @@ class SMC(atext.ArrayStepSharedLLK):
     default_blocked = True
 
     def __init__(self, vars=None, out_vars=None, n_steps=25, scaling=1., p_acc_rate=0.001,
-                 covariance=None, likelihood_name='l_like__', proposal_name='MultivariateNormal',
-                 tune_interval=10, threshold=0.5, check_bound=True, model=None, random_seed=-1):
+                 covariance=None, proposal_name='MultivariateNormal', tune_interval=10,
+                 threshold=0.5, check_bound=True, model=None, random_seed=-1):
 
         if random_seed != -1:
             nr.seed(random_seed)
@@ -119,13 +116,6 @@ class SMC(atext.ArrayStepSharedLLK):
         vars = inputvars(vars)
 
         if out_vars is None:
-            if not any(likelihood_name == RV.name for RV in model.unobserved_RVs):
-                pm._log.info('Adding model likelihood to RVs!')
-                with model:
-                    llk = pm.Deterministic(likelihood_name, model.logpt)
-            else:
-                pm._log.info('Using present model likelihood!')
-
             out_vars = model.unobserved_RVs
 
         out_varnames = [out_var.name for out_var in out_vars]

--- a/pymc3/step_methods/smc.py
+++ b/pymc3/step_methods/smc.py
@@ -31,6 +31,7 @@ __all__ = ['SMC', 'sample_smc']
 
 proposal_dists = {'MultivariateNormal': MultivariateNormalProposal}
 
+MODEL_LIKELIHOOD_NAME = 'logp__'
 
 def choose_proposal(proposal_name, scale=1.):
     """Initialize and select proposal distribution.
@@ -146,8 +147,6 @@ class SMC(atext.ArrayStepSharedLLK):
         self.stage = 0
         self.chain_index = 0
         self.threshold = threshold
-        self.likelihood_name = likelihood_name
-        self._llk_index = out_varnames.index(likelihood_name)
         self.discrete = np.concatenate([[v.dtype in discrete_types] * (v.dsize or 1) for v in vars])
         self.any_discrete = self.discrete.any()
         self.all_discrete = self.discrete.all()
@@ -311,7 +310,7 @@ class SMC(atext.ArrayStepSharedLLK):
             else:
                 array_population[:, slc] = slc_population
         # get likelihoods
-        likelihoods = mtrace.get_values(varname=self.likelihood_name,
+        likelihoods = mtrace.get_values(varname=MODEL_LIKELIHOOD_NAME,
                                         burn=n_steps - 1, combine=True)
 
         # map end array_endpoints to dict points
@@ -423,8 +422,8 @@ def sample_smc(samples=1000, chains=100, step=None, start=None, homepath=None, s
     progressbar : bool
         Flag for displaying a progress bar
     model : :class:`pymc3.Model`
-        (optional if in `with` context) has to contain deterministic variable name defined under
-        `step.likelihood_name` that contains the model likelihood
+        (optional if in `with` context) has to contain deterministic variable
+        with name 'logp__' that contains the model likelihood
     random_seed : int or list of ints
         A list is accepted, more if `cores` is greater than one.
     rm_flag : bool
@@ -450,9 +449,9 @@ def sample_smc(samples=1000, chains=100, step=None, start=None, homepath=None, s
         if not (chains / float(cores)).is_integer():
             raise TypeError('chains / cores has to be a whole number!')
 
-    if not any(step.likelihood_name in var.name for var in model.deterministics):
-        raise TypeError('Model (deterministic) variables need to contain a variable {} as defined '
-                        'in `step`.'.format(step.likelihood_name))
+    if not any(var.name == MODEL_LIKELIHOOD_NAME for var in model.deterministics):
+        raise TypeError("Model (deterministic) variables must contain a "
+                        "variable 'logp__' containing the model likelihood.")
 
     stage_handler = atext.TextStage(homepath)
 


### PR DESCRIPTION
Closes #2971.

This PR adds the models likelihood to the tracked variables during sampling. The guys over at Stan explain [why this is desirable](http://discourse.mc-stan.org/t/convergence-failure-maybe-in-brms/4148/7).

Currently, the `SMC` sampler adds the model logp manually, but it appears that none of the other samplers do. I moved the logic into the `BaseTrace` class, so that we don't need to repeat this code in all our samplers.

Still a WIP, will probably need a lot more work.