### PR TITLE
Compatibility change for scipy imports

### DIFF
--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -1,22 +1,22 @@
 """Statistical utility functions for PyMC"""
+from collections import namedtuple
+import itertools
+import pkg_resources
+import warnings
 
 import numpy as np
 import pandas as pd
-import itertools
+from scipy.stats import dirichlet
+from scipy.optimize import minimize
+from scipy.signal import fftconvolve
 from tqdm import tqdm
-import warnings
-from collections import namedtuple
+
 from .model import modelcontext
 from .util import get_default_varnames
 import pymc3 as pm
 from pymc3.theanof import floatX
 
-import scipy.__version__ as scipy_version
-from scipy.stats import dirichlet
-from scipy.optimize import minimize
-from scipy.signal import fftconvolve
-
-if scipy_version < '1.0.0':
+if pkg_resources.get_distribution('scipy').version < '1.0.0':
     from scipy.misc import logsumexp
 else:
     from scipy.special import logsumexp

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -11,10 +11,15 @@ from .util import get_default_varnames
 import pymc3 as pm
 from pymc3.theanof import floatX
 
-from scipy.special import logsumexp
+import scipy.__version__ as scipy_version
 from scipy.stats import dirichlet
 from scipy.optimize import minimize
 from scipy.signal import fftconvolve
+
+if scipy_version < '1.0.0':
+    from scipy.misc import logsumexp
+else:
+    from scipy.special import logsumexp
 
 
 __all__ = ['autocorr', 'autocov', 'waic', 'loo', 'hpd', 'quantiles',
@@ -190,7 +195,7 @@ def waic(trace, model=None, pointwise=False, progressbar=False):
     waic: widely available information criterion
     waic_se: standard error of waic
     p_waic: effective number parameters
-    var_warn: 1 if posterior variance of the log predictive 
+    var_warn: 1 if posterior variance of the log predictive
          densities exceeds 0.4
     waic_i: and array of the pointwise predictive accuracy, only if pointwise True
     """
@@ -260,7 +265,7 @@ def loo(trace, model=None, pointwise=False, reff=None, progressbar=False):
     loo: approximated Leave-one-out cross-validation
     loo_se: standard error of loo
     p_loo: effective number of parameters
-    shape_warn: 1 if the estimated shape parameter of 
+    shape_warn: 1 if the estimated shape parameter of
         Pareto distribution is greater than 0.7 for one or more samples
     loo_i: array of pointwise predictive accuracy, only if pointwise True
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 theano>=1.0.0
 numpy>=1.13.0
+scipy>=0.18.1
 pandas>=0.18.0
 patsy>=0.4.0
 joblib>=0.9


### PR DESCRIPTION
This is a bit of an edge case that came up in testing arviz (https://github.com/arviz-devs/arviz/pull/162): if you have a python 3.4 environment and `conda install numpy scipy matplotlib pandas xarray`, you get `scipy==0.18.1`, which has `logsumexp` in a different spot.


