### PR TITLE
Allow passing `name` as kwarg to pm.Bound RVs

### DIFF
--- a/pymc3/distributions/bound.py
+++ b/pymc3/distributions/bound.py
@@ -201,23 +201,23 @@ class Bound(object):
         self.lower = lower
         self.upper = upper
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, name, *args, **kwargs):
         if 'observed' in kwargs:
             raise ValueError('Observed Bound distributions are not supported. '
                              'If you want to model truncated data '
                              'you can use a pm.Potential in combination '
                              'with the cumulative probability function. See '
                              'pymc3/examples/censored_data.py for an example.')
-        first, args = args[0], args[1:]
 
         if issubclass(self.distribution, Continuous):
-            return _ContinuousBounded(first, self.distribution,
+            return _ContinuousBounded(name, self.distribution,
                                       self.lower, self.upper, *args, **kwargs)
         elif issubclass(self.distribution, Discrete):
-            return _DiscreteBounded(first, self.distribution,
+            return _DiscreteBounded(name, self.distribution,
                                     self.lower, self.upper, *args, **kwargs)
         else:
-            raise ValueError('Distribution is neither continuous nor discrete.')
+            raise ValueError(
+                'Distribution is neither continuous nor discrete.')
 
     def dist(self, *args, **kwargs):
         if issubclass(self.distribution, Continuous):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1183,6 +1183,10 @@ def test_bound():
     assert rand.dtype in [np.int16, np.int32, np.int64]
     assert rand >= 5 and rand <= 8
 
+    with Model():
+        BoundPoisson = Bound(Poisson, upper=6)
+        BoundPoisson(name="y", mu=1)
+
 
 class TestLatex(object):
 


### PR DESCRIPTION
fix #3149.