### PR TITLE
Deterministic copies passed variable

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1415,7 +1415,7 @@ def Deterministic(name, var, model=None):
     var : var, with name attribute
     """
     model = modelcontext(model)
-    var.name = model.name_for(name)
+    var = var.copy(model.name_for(name))
     model.deterministics.append(var)
     model.add_random_variable(var)
     var._repr_latex_ = functools.partial(_latex_repr_rv, var)


### PR DESCRIPTION
Fixes #2912 

This is a naive replacement for #2991 - from the discussion there, it may miss out on some compiler optimizations, but it is not clear to me how or whether that would be typical. 

This does fix the reported problem, as well as the model that I noticed the problem on:

![image](https://user-images.githubusercontent.com/2295568/44690471-f58ef280-aa28-11e8-969f-cdd99f9cb4e6.png)

Current master (notice all the variables named `z`):
![image](https://user-images.githubusercontent.com/2295568/44690534-31c25300-aa29-11e8-93c5-99a87a7cee7f.png)


With this change:
![image](https://user-images.githubusercontent.com/2295568/44690505-17887500-aa29-11e8-9c2d-65835b537840.png)
