### PR TITLE
Replace load_trace() with load().

### DIFF
--- a/pymc3/backends/ndarray.py
+++ b/pymc3/backends/ndarray.py
@@ -54,7 +54,7 @@ def save_trace(trace, directory=None, overwrite=False):
     return directory
 
 
-def load_trace(directory, model=None):
+def load(directory, model=None):
     """Loads a multitrace that has been written to file.
 
     A the model used for the trace must be passed in, or the command
@@ -76,6 +76,9 @@ def load_trace(directory, model=None):
         if os.path.isdir(directory):
             straces.append(SerializeNDArray(directory).load(model))
     return base.MultiTrace(straces)
+
+# Old name for load method: doesn't agree with documentation.
+load_trace = load
 
 
 class SerializeNDArray(object):

--- a/pymc3/backends/ndarray.py
+++ b/pymc3/backends/ndarray.py
@@ -72,16 +72,19 @@ def load(directory, model=None):
     pm.Multitrace that was saved in the directory
     """
     straces = []
-    assert os.path.isdir(directory), "No such trace directory: " + directory
+    if not os.path.isdir(directory):
+        raise FileNotFoundError(directory)
     for directory in glob.glob(os.path.join(directory, '*')):
         if os.path.isdir(directory):
             straces.append(SerializeNDArray(directory).load(model))
     return base.MultiTrace(straces)
 
+
 # Old name for load method: doesn't agree with documentation.
 def load_trace(directory, model=None):
     """Deprecated load function, replaced by pymc3.backends.ndarray.load()."""
     return load(directory, model)
+
 
 class SerializeNDArray(object):
     metadata_file = 'metadata.json'

--- a/pymc3/backends/ndarray.py
+++ b/pymc3/backends/ndarray.py
@@ -72,14 +72,16 @@ def load(directory, model=None):
     pm.Multitrace that was saved in the directory
     """
     straces = []
+    assert os.path.isdir(directory), "No such trace directory: " + directory
     for directory in glob.glob(os.path.join(directory, '*')):
         if os.path.isdir(directory):
             straces.append(SerializeNDArray(directory).load(model))
     return base.MultiTrace(straces)
 
 # Old name for load method: doesn't agree with documentation.
-load_trace = load
-
+def load_trace(directory, model=None):
+    """Deprecated load function, replaced by pymc3.backends.ndarray.load()."""
+    return load(directory, model)
 
 class SerializeNDArray(object):
     metadata_file = 'metadata.json'


### PR DESCRIPTION
**This patch is not ready for prime time.  Please ignore for now.**

Keep load_trace() as alias.  But load() is the function name dictated
by the backends documentation.

See issue #3184 