### PR TITLE
Update Code of Conduct to v1.4

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -62,7 +62,7 @@ is a member of NumFOCUS and subscribes to their code of conduct as a
 precondition for continued membership. All complaints will be reviewed and
 investigated and will result in a response that is deemed necessary and
 appropriate to the circumstances. The project team is obligated to maintain
-confidentiality with regard to the reporter of an incident.  Further details of
+confidentiality with regard to the reporter of an incident. Further details of
 specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,5 @@
 # PyMC3 Code of Conduct
 
-## Reporting Inappropriate Conduct
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,26 +1,78 @@
 # PyMC3 Code of Conduct
 
 ## Reporting Inappropriate Conduct
+## Our Pledge
 
-If you have experienced or witnessed behavior that violates the PyMC3 Code of Conduct, please reach out to PyMC3 developer Christopher Fonnesbeck via email or by phone (615-955-0380). Alternatively, you may also contact NumFOCUS Executive Director Leah Silen (512-222-5449), as PyMC3 is a member of NumFOCUS and subscribes to their code of conduct as a precondition for continued membership. The PyMC3 team takes reports of misconduct very seriously and is committed to preserving and maintaining the welcoming nature of our project.
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
 
-## Contributor Code of Conduct ​
+## Our Standards
 
-As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
-​
-We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
-* The use of sexualized language or imagery
-* Personal attacks
-* Trolling or insulting/derogatory comments
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing other's private information, such as physical or electronic addresses, without explicit permission
-* Other unethical or unprofessional conduct
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+## Our Responsibilities
 
-This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
-​
-This Code of Conduct is adapted from the [Contributor Covenant, version 1.2.0](http://contributor-covenant.org/version/1/2/0/)
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting PyMC3 developer Christopher Fonnesbeck via email
+(chris.fonnesbeck@vanderbilt.edu) or phone (615-955-0380). Alternatively, you
+may also contact NumFOCUS Executive Director Leah Silen (512-222-5449), as PyMC3
+is a member of NumFOCUS and subscribes to their code of conduct as a
+precondition for continued membership. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident.  Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org


### PR DESCRIPTION
Previously, we've been using [v1.2 of the Contributor Covenant](https://www.contributor-covenant.org/version/1/2/0/code-of-conduct). The current version is [v1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct), where I modified the `Enforcement` section to include contact details and our relation to NumFOCUS.

Requesting review from @fonnesbeck (since your email/phone number are on the code!)