### PR TITLE
Fix step method assignment

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -117,25 +117,27 @@ def assign_step_methods(model, step=None, methods=STEP_METHODS,
         List of step methods associated with the model's variables.
     """
     steps = []
-    assigned_vars = set()
+    selected_steps = defaultdict(list)
 
     if step is not None:
         try:  # If `step` is a list, concatenate
             steps += list(step)
-        except TypeError:  # If `step` is a single step method, append
+        except TypeError:  # If `step` is not iterable, append
             steps.append(step)
 
         for step in steps:
             try:
-                assigned_vars = assigned_vars.union(set(step.vars))
+                selected_steps[step] += step.vars
             except AttributeError:
                 for method in step.methods:
-                    assigned_vars = assigned_vars.union(set(method.vars))
+                    selected_steps[step] += method.vars
 
     # Use competence classmethods to select step methods for remaining
     # variables
-    selected_steps = defaultdict(list)
     for var in model.free_RVs:
+        # Flatten assigned variables into a set
+        assigned_vars = set(var for lst in selected_steps.values()
+                            for var in lst)
         if var not in assigned_vars:
             # Determine if a gradient can be computed
             has_gradient = var.dtype not in discrete_types

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -52,7 +52,8 @@ def instantiate_steppers(model, steps, selected_steps, step_kwargs=None):
         One or more step functions that have been assigned to some subset of
         the model's parameters. Defaults to None (no assigned variables).
     selected_steps: dictionary of step methods and variables
-        The step methods and the variables that have were assigned to them.
+        Variables with selected step methods. Keys are the step methods, and
+        values are the variables that have been assigned to them.
     step_kwargs : dict
         Parameters for the samplers. Keys are the lower case names of
         the step method, values a dict of arguments.
@@ -100,7 +101,7 @@ def assign_step_methods(model, step=None, methods=STEP_METHODS,
     ----------
     model : Model object
         A fully-specified model object
-    step : step function or vector of step functions
+    step : step function or list of step functions
         One or more step functions that have been assigned to some subset of
         the model's parameters. Defaults to None (no assigned variables).
     methods : vector of step method classes
@@ -119,9 +120,9 @@ def assign_step_methods(model, step=None, methods=STEP_METHODS,
     assigned_vars = set()
 
     if step is not None:
-        try:
+        try:  # If `step` is a list, concatenate
             steps += list(step)
-        except TypeError:
+        except TypeError:  # If `step` is a single step method, append
             steps.append(step)
         for step in steps:
             try:
@@ -135,7 +136,7 @@ def assign_step_methods(model, step=None, methods=STEP_METHODS,
     selected_steps = defaultdict(list)
     for var in model.free_RVs:
         if var not in assigned_vars:
-            # determine if a gradient can be computed
+            # Determine if a gradient can be computed
             has_gradient = var.dtype not in discrete_types
             if has_gradient:
                 try:
@@ -144,7 +145,7 @@ def assign_step_methods(model, step=None, methods=STEP_METHODS,
                         NotImplementedError,
                         tg.NullTypeGradError):
                     has_gradient = False
-            # select the best method
+            # Select the method with maximum competence
             selected = max(methods, key=lambda method,
                            var=var, has_gradient=has_gradient:
                            method._competence(var, has_gradient))

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -48,7 +48,7 @@ def instantiate_steppers(model, steps, selected_steps, step_kwargs=None):
     ----------
     model : Model object
         A fully-specified model object
-    step : step function or list of step functions
+    step : step function or iterable of step functions
         One or more step functions that have been assigned to some subset of
         the model's parameters. Defaults to None (no assigned variables).
     selected_steps: dictionary of step methods and variables
@@ -77,7 +77,7 @@ def instantiate_steppers(model, steps, selected_steps, step_kwargs=None):
     unused_args = set(step_kwargs).difference(used_args)
     if unused_args:
         raise ValueError('Unused arguments for step method(s): %s'
-                         % [s.title() for s in unused_args])
+                         % [s for s in unused_args])
 
     if len(steps) == 1:
         steps = steps[0]
@@ -101,7 +101,7 @@ def assign_step_methods(model, step=None, methods=STEP_METHODS,
     ----------
     model : Model object
         A fully-specified model object
-    step : step function or list of step functions
+    step : step function or iterable of step functions
         One or more step functions that have been assigned to some subset of
         the model's parameters. Defaults to None (no assigned variables).
     methods : vector of step method classes

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -48,7 +48,7 @@ def instantiate_steppers(model, steps, selected_steps, step_kwargs=None):
     ----------
     model : Model object
         A fully-specified model object
-    step : step function or vector of step functions
+    step : step function or list of step functions
         One or more step functions that have been assigned to some subset of
         the model's parameters. Defaults to None (no assigned variables).
     selected_steps: dictionary of step methods and variables
@@ -72,8 +72,7 @@ def instantiate_steppers(model, steps, selected_steps, step_kwargs=None):
             continue
         args = step_kwargs.get(step_class.name, {})
         used_keys.add(step_class.name)
-        step = step_class(vars=vars, **args)
-        steps.append(step)
+        steps.append(step_class)
 
     unused_args = set(step_kwargs).difference(used_keys)
     if unused_args:

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -124,6 +124,7 @@ def assign_step_methods(model, step=None, methods=STEP_METHODS,
             steps += list(step)
         except TypeError:  # If `step` is a single step method, append
             steps.append(step)
+
         for step in steps:
             try:
                 assigned_vars = assigned_vars.union(set(step.vars))

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -76,7 +76,8 @@ def instantiate_steppers(model, steps, selected_steps, step_kwargs=None):
 
     unused_args = set(step_kwargs).difference(used_args)
     if unused_args:
-        raise ValueError('Unused step method arguments: %s' % unused_args)
+        raise ValueError('Unused arguments for step method(s): %s'
+                         % [s.title() for s in unused_args])
 
     if len(steps) == 1:
         steps = steps[0]

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -66,15 +66,15 @@ def instantiate_steppers(model, steps, selected_steps, step_kwargs=None):
     if step_kwargs is None:
         step_kwargs = {}
 
-    used_keys = set()
-    for step_class, vars in selected_steps.items():
-        if len(vars) == 0:
+    used_args = set()
+    for step, var_list in selected_steps.items():
+        if len(var_list) == 0:
             continue
-        args = step_kwargs.get(step_class.name, {})
-        used_keys.add(step_class.name)
-        steps.append(step_class)
+        args = step_kwargs.get(step.name, {})
+        used_args.add(step.name)
+        steps.append(step)
 
-    unused_args = set(step_kwargs).difference(used_keys)
+    unused_args = set(step_kwargs).difference(used_args)
     if unused_args:
         raise ValueError('Unused step method arguments: %s' % unused_args)
 

--- a/pymc3/step_methods/compound.py
+++ b/pymc3/step_methods/compound.py
@@ -9,6 +9,7 @@ import numpy as np
 class CompoundStep(object):
     """Step method composed of a list of several other step
     methods applied in sequence."""
+    name = 'compound'
 
     def __init__(self, methods):
         self.methods = list(methods)

--- a/pymc3/step_methods/elliptical_slice.py
+++ b/pymc3/step_methods/elliptical_slice.py
@@ -66,7 +66,7 @@ class EllipticalSlice(ArrayStep):
        Artificial Intelligence and Statistics (AISTATS), JMLR W&CP
        9:541-548, 2010.
     """
-
+    name = 'elliptical_slice'
     default_blocked = True
 
     def __init__(self, vars=None, prior_cov=None, prior_chol=None, model=None,


### PR DESCRIPTION
Closes #3197 

This PR does away with the `assigned_vars` set, and instead uses the `selected_steps` dictionary all the way. It was a fairly clunky implementation to begin with, so this shouldn't be too much of a surprise.

What was strange was the line that I deleted: `step = step_class(vars=vars, **args)`
I think this line was _supposed_ to instantiate `step_class`, but the problem is that `step_class` is _already_ an instantiated step method. So as far as I can tell, this method never really worked at all! Not sure how we got here, but `test_sampling.py` is passing locally, so...

Asides from that, some readability edits: more explicit variable names, clearer/more docstrings, friendlier error messages.