### PR TITLE
Make parent class signature match child classes

### DIFF
--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -94,7 +94,7 @@ class QuadPotential(object):
         """
         pass
 
-    def raise_ok(self):
+    def raise_ok(self, vmap):
         pass
 
     def reset(self):

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -94,8 +94,23 @@ class QuadPotential(object):
         """
         pass
 
-    def raise_ok(self, vmap):
-        pass
+    def raise_ok(self, vmap=None):
+        """Check if the mass matrix is ok, and raise ValueError if not.
+
+        Parameters
+        ----------
+        vmap : blocking.ArrayOrdering.vmap
+            List of `VarMap`s, which are namedtuples with var, slc, shp, dtyp
+
+        Raises
+        ------
+        ValueError if any standard deviations are 0 or infinite
+
+        Returns
+        -------
+        None
+        """
+        return None
 
     def reset(self):
         pass
@@ -186,6 +201,21 @@ class QuadPotentialDiagAdapt(QuadPotential):
         self._n_samples += 1
 
     def raise_ok(self, vmap):
+        """Check if the mass matrix is ok, and raise ValueError if not.
+
+        Parameters
+        ----------
+        vmap : blocking.ArrayOrdering.vmap
+            List of `VarMap`s, which are namedtuples with var, slc, shp, dtyp
+
+        Raises
+        ------
+        ValueError if any standard deviations are 0 or infinite
+
+        Returns
+        -------
+        None
+        """
         if np.any(self._stds == 0):
             name_slc = []
             tmp_hold = list(range(self._stds.size))


### PR DESCRIPTION
This fixes #3206, by adding the one argument to the parent class. Decided not to use `*args`, since I'd prefer to be explicit (and get this exception), but can't change to that if anyone wants.