### PR TITLE
Support mu and sd parameterization for inverse gamma.

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2455,7 +2455,6 @@ class InverseGamma(PositiveContinuous):
 
         return alpha, beta
 
-
     def random(self, point=None, size=None):
         """
         Draw random values from InverseGamma distribution.

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2409,10 +2409,16 @@ class InverseGamma(PositiveContinuous):
         Shape parameter (alpha > 0).
     beta : float
         Scale parameter (beta > 0).
+    mu : float
+        Alternative shape parameter (mu > 0).
+    sd : float
+        Alternative scale parameter (sd > 0).
     """
 
-    def __init__(self, alpha, beta=1, *args, **kwargs):
+    def __init__(self, alpha=None, beta=None, mu=None, sd=None, *args, **kwargs):
         super(InverseGamma, self).__init__(*args, defaults=('mode',), **kwargs)
+
+        alpha, beta = InverseGamma._get_alpha_beta(alpha, beta, mu, sd)
         self.alpha = alpha = tt.as_tensor_variable(alpha)
         self.beta = beta = tt.as_tensor_variable(beta)
 
@@ -2431,6 +2437,24 @@ class InverseGamma(PositiveContinuous):
         except ValueError:  # alpha is an array
             m[self.alpha <= 1] = np.inf
             return m
+
+    @staticmethod
+    def _get_alpha_beta(alpha, beta, mu, sd):
+        if (alpha is not None):
+            if (beta is not None):
+                pass
+            else:
+                beta = 1
+        elif (mu is not None) and (sd is not None):
+            alpha = (2 * sd**2 + mu**2)/sd**2
+            beta = mu * (mu**2 + sd**2) / sd**2
+        else:
+            raise ValueError('Incompatible parameterization. Either use '
+                             'alpha and (optionally) beta, or mu and sd to specify '
+                             'distribution.')
+
+        return alpha, beta
+
 
     def random(self, point=None, size=None):
         """

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -701,6 +701,10 @@ class TestMatchesScipy(SeededTest):
         self.pymc3_matches_scipy(
             InverseGamma, Rplus, {'alpha': Rplus, 'beta': Rplus},
             lambda value, alpha, beta: sp.invgamma.logpdf(value, alpha, scale=beta))
+        self.pymc3_matches_scipy(
+            InverseGamma, Rplus, {'mu': Rplus, 'sd': Rplus},
+            lambda value, mu, sd: sp.invgamma.logpdf(value, InverseGamma._get_alpha_beta(None, None, mu, sd)[0],
+                                                     scale=InverseGamma._get_alpha_beta(None, None, mu, sd)[1]))
 
     def test_pareto(self):
         self.pymc3_matches_scipy(Pareto, Rplus, {'alpha': Rplusbig, 'm': Rplusbig},

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -701,10 +701,15 @@ class TestMatchesScipy(SeededTest):
         self.pymc3_matches_scipy(
             InverseGamma, Rplus, {'alpha': Rplus, 'beta': Rplus},
             lambda value, alpha, beta: sp.invgamma.logpdf(value, alpha, scale=beta))
+
+    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"),
+                           reason="Fails on float32 due to scaling issues")
+    def test_inverse_gamma_alt_params(self):
+        def test_fun(value, mu, sd):
+            alpha, beta = InverseGamma._get_alpha_beta(None, None, mu, sd)
+            return sp.invgamma.logpdf(value, alpha, scale=beta)
         self.pymc3_matches_scipy(
-            InverseGamma, Rplus, {'mu': Rplus, 'sd': Rplus},
-            lambda value, mu, sd: sp.invgamma.logpdf(value, InverseGamma._get_alpha_beta(None, None, mu, sd)[0],
-                                                     scale=InverseGamma._get_alpha_beta(None, None, mu, sd)[1]))
+            InverseGamma, Rplus, {'mu': Rplus, 'sd': Rplus}, test_fun)
 
     def test_pareto(self):
         self.pymc3_matches_scipy(Pareto, Rplus, {'alpha': Rplusbig, 'm': Rplusbig},


### PR DESCRIPTION
Since the Gamma supports `mu` and `sd` as an alternative parameterization, I added support for this to Inverse Gamma.
Hoping this is useful.