### PR TITLE
Fix typo in inverse gamma variance

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2399,7 +2399,7 @@ class InverseGamma(PositiveContinuous):
     ========  ======================================================
     Support   :math:`x \in (0, \infty)`
     Mean      :math:`\dfrac{\beta}{\alpha-1}` for :math:`\alpha > 1`
-    Variance  :math:`\dfrac{\beta^2}{(\alpha-1)^2(\alpha)}`
+    Variance  :math:`\dfrac{\beta^2}{(\alpha-1)^2(\alpha - 2)}`
               for :math:`\alpha > 2`
     ========  ======================================================
 
@@ -2419,7 +2419,7 @@ class InverseGamma(PositiveContinuous):
         self.mean = self._calculate_mean()
         self.mode = beta / (alpha + 1.)
         self.variance = tt.switch(tt.gt(alpha, 2),
-                                  (beta**2) / (alpha * (alpha - 1.)**2),
+                                  (beta**2) / ((alpha - 2) * (alpha - 1.)**2),
                                   np.inf)
         assert_negative_support(alpha, 'alpha', 'InverseGamma')
         assert_negative_support(beta, 'beta', 'InverseGamma')


### PR DESCRIPTION
Noticed this while looking at #3227. I'm using [wikipedia for the equation for variance](https://en.wikipedia.org/wiki/Inverse-gamma_distribution) since I forget my integrals, but it checks out in a computational experiment: 

![image](https://user-images.githubusercontent.com/2295568/47049314-f01d7100-d16a-11e8-8aa1-4533f56715a7.png)
