### PR TITLE
Add bibtex key for citation.

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,12 @@
+@article{Salvatier2016,
+  doi = {10.7717/peerj-cs.55},
+  url = {https://doi.org/10.7717/peerj-cs.55},
+  year  = {2016},
+  month = {apr},
+  publisher = {{PeerJ}},
+  volume = {2},
+  pages = {e55},
+  author = {John Salvatier and Thomas V. Wiecki and Christopher Fonnesbeck},
+  title = {Probabilistic programming in Python using {PyMC}3},
+  journal = {{PeerJ} Computer Science}
+}


### PR DESCRIPTION
Not sure if this should better go into the README directly?

Arash Bahramian alerted me that peerj doesn't easily provide a bibtex key so adding it here seems helpful.