### PR TITLE
Add bad initial energy to warnings

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,7 @@
 - Add Incomplete Beta function `incomplete_beta(a, b, value)`
 - Add log CDF functions to continuous distributions: `Beta`, `Cauchy`, `ExGaussian`, `Exponential`, `Flat`, `Gumbel`, `HalfCauchy`, `HalfFlat`, `HalfNormal`, `Laplace`, `Logistic`, `Lognormal`, `Normal`, `Pareto`, `StudentT`, `Triangular`, `Uniform`, `Wald`, `Weibull`.
 - Behavior of `sample_posterior_predictive` is now to produce posterior predictive samples, in order, from all values of the `trace`. Previously, by default it would produce 1 chain worth of samples, using a random selection from the `trace` (#3212)
+- Show diagnostics for initial energy errors in HMC and NUTS.
 
 ### Maintenance
 

--- a/pymc3/backends/report.py
+++ b/pymc3/backends/report.py
@@ -19,6 +19,7 @@ class WarningType(enum.Enum):
     # Indications that chains did not converge, eg Rhat
     CONVERGENCE = 6
     BAD_ACCEPTANCE = 7
+    BAD_ENERGY = 8
 
 
 SamplerWarning = namedtuple(


### PR DESCRIPTION
This is a follow up to #3234 (written together by @aseyboldt  and @springcoil), to use the existing warning system. This prevents somewhat messed up output because of interference between the warning and the progressbar.
Most of the changes are to make sure we print warnings even if sampling failed with a SamplingError (which is only raised right now for an initial energy issue).