### PR TITLE
Added imputation warning to model

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -3,6 +3,7 @@ import functools
 import itertools
 import threading
 import six
+import warnings
 
 import numpy as np
 from pandas import Series
@@ -1259,6 +1260,10 @@ def as_tensor(data, name, model, distribution):
     data = pandas_to_array(data).astype(dtype)
 
     if hasattr(data, 'mask'):
+        impute_message = ('Data in {name} contains missing values and'
+                          ' will be automatically imputed from the'
+                          ' sampling distribution.'.format(name=name))
+        warnings.warn(impute_message, UserWarning)
         from .distributions import NoDistribution
         testval = np.broadcast_to(distribution.default(), data.shape)[data.mask]
         fakedist = NoDistribution.dist(shape=data.mask.sum(), dtype=dtype,


### PR DESCRIPTION
Currently, imputation occurs whenever a pandas data structure with missing values or a masked array is passed as `observed` in a likelihood. This may confuse some who are using pandas data structures that may not be aware of the missing values.

This PR adds a `UserWarning` with a friendly message if imputation will happen for the current model, so that nobody is surprised.