### PR TITLE
Fix deprecation warnings.

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -483,7 +483,7 @@ def _check_start_shape(model, start):
             # if start var has no shape
             else:
                 # if model var has a specified shape
-                if var_shape:
+                if var_shape.size > 0:
                     e += "\nExpected shape {} for var " \
                          "'{}', got scalar {}".format(
                              tuple(var_shape), var.name, start[var.name]

--- a/pymc3/tests/test_models_utils.py
+++ b/pymc3/tests/test_models_utils.py
@@ -13,15 +13,15 @@ class TestUtils:
         assert np.all(
                 np.equal(
                     m.eval(),
-                    mt if mt is not None else self.data.as_matrix()
+                    mt if mt is not None else self.data.values
                 )
             )
         assert l == list(lt or self.data.columns)
 
     def test_numpy_init(self):
-        m, l = utils.any_to_tensor_and_labels(self.data.as_matrix())
+        m, l = utils.any_to_tensor_and_labels(self.data.values
         self.assertMatrixLabels(m, l, lt=['x0', 'x1'])
-        m, l = utils.any_to_tensor_and_labels(self.data.as_matrix(), labels=['x2', 'x3'])
+        m, l = utils.any_to_tensor_and_labels(self.data.values, labels=['x2', 'x3'])
         self.assertMatrixLabels(m, l, lt=['x2', 'x3'])
 
     def test_pandas_init(self):
@@ -32,32 +32,32 @@ class TestUtils:
 
     def test_dict_input(self):
         m, l = utils.any_to_tensor_and_labels(self.data.to_dict('dict'))
-        self.assertMatrixLabels(m, l, mt=self.data.as_matrix(l), lt=l)
+        self.assertMatrixLabels(m, l, mt=self.data[l].values, lt=l)
 
         m, l = utils.any_to_tensor_and_labels(self.data.to_dict('series'))
-        self.assertMatrixLabels(m, l, mt=self.data.as_matrix(l), lt=l)
+        self.assertMatrixLabels(m, l, mt=self.data[l].values, lt=l)
 
         m, l = utils.any_to_tensor_and_labels(self.data.to_dict('list'))
-        self.assertMatrixLabels(m, l, mt=self.data.as_matrix(l), lt=l)
+        self.assertMatrixLabels(m, l, mt=self.data[l].values, lt=l)
 
         inp = {k: tt.as_tensor_variable(v) for k, v in self.data.to_dict('series').items()}
         m, l = utils.any_to_tensor_and_labels(inp)
-        self.assertMatrixLabels(m, l, mt=self.data.as_matrix(l), lt=l)
+        self.assertMatrixLabels(m, l, mt=self.data[l].values, lt=l)
 
     def test_list_input(self):
-        m, l = utils.any_to_tensor_and_labels(self.data.as_matrix().tolist())
+        m, l = utils.any_to_tensor_and_labels(self.data.values.tolist())
         self.assertMatrixLabels(m, l, lt=['x0', 'x1'])
-        m, l = utils.any_to_tensor_and_labels(self.data.as_matrix().tolist(), labels=['x2', 'x3'])
+        m, l = utils.any_to_tensor_and_labels(self.data.values.tolist(), labels=['x2', 'x3'])
         self.assertMatrixLabels(m, l, lt=['x2', 'x3'])
 
     def test_tensor_input(self):
         m, l = utils.any_to_tensor_and_labels(
-            tt.as_tensor_variable(self.data.as_matrix().tolist()),
+            tt.as_tensor_variable(self.data.values.tolist()),
             labels=['x0', 'x1']
         )
         self.assertMatrixLabels(m, l, lt=['x0', 'x1'])
         m, l = utils.any_to_tensor_and_labels(
-            tt.as_tensor_variable(self.data.as_matrix().tolist()),
+            tt.as_tensor_variable(self.data.values.tolist()),
             labels=['x2', 'x3'])
         self.assertMatrixLabels(m, l, lt=['x2', 'x3'])
 
@@ -65,9 +65,9 @@ class TestUtils:
         # no labels for tensor variable
         with pytest.raises(
             ValueError):
-            utils.any_to_tensor_and_labels(tt.as_tensor_variable(self.data.as_matrix().tolist()))
+            utils.any_to_tensor_and_labels(tt.as_tensor_variable(self.data.values.tolist()))
         # len of labels is bad
         with pytest.raises(
             ValueError):
-            utils.any_to_tensor_and_labels(self.data.as_matrix().tolist(),
+            utils.any_to_tensor_and_labels(self.data.values.tolist(),
             labels=['x'])

--- a/pymc3/tests/test_models_utils.py
+++ b/pymc3/tests/test_models_utils.py
@@ -19,7 +19,7 @@ class TestUtils:
         assert l == list(lt or self.data.columns)
 
     def test_numpy_init(self):
-        m, l = utils.any_to_tensor_and_labels(self.data.values
+        m, l = utils.any_to_tensor_and_labels(self.data.values)
         self.assertMatrixLabels(m, l, lt=['x0', 'x1'])
         m, l = utils.any_to_tensor_and_labels(self.data.values, labels=['x2', 'x3'])
         self.assertMatrixLabels(m, l, lt=['x2', 'x3'])


### PR DESCRIPTION
Noticed warnings about these showing up in travis.

There is also a deprecation warning in numdifftools that should be fixed by https://github.com/pbrod/numdifftools/issues/42.