### PR TITLE
Fix for #3225 Triangular c attribute

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,6 +13,7 @@
 
 ### Maintenance
 
+- Fixed Triangular distribution `c` attribute handling in `random` and updated sample codes for consistency (#3225)
 - Renamed `sample_ppc()` and `sample_ppc_w()` to `sample_posterior_predictive()` and `sample_posterior_predictive_w()`, respectively.
 - Refactor SMC and properly compute marginal likelihood (#3124)
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3262,13 +3262,15 @@ class Triangular(BoundedContinuous):
         plt.style.use('seaborn-darkgrid')
         x = np.linspace(-2, 10, 500)
         lowers = [0., -1, 2]
-        cs = [0.5, 0.5, 0.75]
-        uppers = [4., 2, 6]
-        for lower, c_, upper_ in zip(lowers, cs, uppers):
-            pdf = st.triang.pdf(x, loc=lower, c=c_, scale=upper_)
+        cs = [2., 0., 6.5]
+        uppers = [4., 1, 8]
+        for lower, c, upper in zip(lowers, cs, uppers):
+            scale = upper - lower
+            c_ = (c - lower) / scale
+            pdf = st.triang.pdf(x, loc=lower, c=c_, scale=scale)
             plt.plot(x, pdf, label='lower = {}, c = {}, upper = {}'.format(lower,
-                                                                           lower + upper_ * c_,
-                                                                           lower + upper_))
+                                                                           c,
+                                                                           upper))
         plt.xlabel('x', fontsize=12)
         plt.ylabel('f(x)', fontsize=12)
         plt.legend(loc=1)
@@ -3318,7 +3320,9 @@ class Triangular(BoundedContinuous):
         """
         c, lower, upper = draw_values([self.c, self.lower, self.upper],
                                       point=point, size=size)
-        return generate_samples(stats.triang.rvs, c=c-lower, loc=lower, scale=upper-lower,
+        scale = upper - lower
+        c_ = (c - lower) / scale
+        return generate_samples(stats.triang.rvs, c=c_, loc=lower, scale=scale,
                                 size=size, dist_shape=self.shape, random_state=None)
 
     def logp(self, value):

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -13,7 +13,7 @@ import pymc3 as pm
 from pymc3.distributions.distribution import draw_values
 from .helpers import SeededTest
 from .test_distributions import (
-    build_model, Domain, product, R, Rplus, Rplusbig, Rplusdunif,
+    build_model, Domain, product, R, Rplus, Rplusbig, Runif, Rplusdunif,
     Unit, Nat, NatSmall, I, Simplex, Vector, PdMatrix,
     PdMatrixChol, PdMatrixCholUpper, RealMatrix, RandomPdMatrix
 )
@@ -517,6 +517,13 @@ class TestScalarParameterSamples(SeededTest):
         def ref_rand(size, mu, kappa):
             return st.vonmises.rvs(size=size, loc=mu, kappa=kappa)
         pymc3_random(pm.VonMises, {'mu': R, 'kappa': Rplus}, ref_rand=ref_rand)
+
+    def test_triangular(self):
+        def ref_rand(size, lower, upper, c):
+            scale = upper - lower
+            c_ = (c - lower) / scale
+            return st.triang.rvs(size=size, loc=lower, scale=scale, c=c_)
+        pymc3_random(pm.Triangular, {'lower': Runif, 'upper': Runif + 3, 'c': Runif + 1}, ref_rand=ref_rand)
 
     def test_flat(self):
         with pm.Model():


### PR DESCRIPTION
Made `Triangular` `c` attribute be handled consistently with `scipy.stats`. Added a test for out of unit interval `c` values and updated example code from `Triangular`'s docstring.