### PR TITLE
Add learn page

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -146,6 +146,7 @@ html_theme_options = {
          ("Quickstart", "intro"),
          ("API", "api"),
          ("Examples", "examples"),
+         ("Learn", "learn"),
     ],
 #     "fixed_sidebar": "false",
 #     "description": "Probabilistic Programming in Python: Bayesian Modeling and Probabilistic Machine Learning with Theano"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,25 +16,20 @@
                         Gaussian processes to fit a regression model.</p>
                 </div>
                 <div class="eight wide right floated column">
-
-::
-
+                    <pre><code class="python">
     X, y = linear_training_data()
 
     with pm.Model() as linear_model:
         weights = pm.Normal('weights', mu=0, sd=1)
         noise = pm.Gamma('noise', alpha=2, beta=1)
         y_observed = pm.Normal('y_observed',
-                            mu=X.dot(weights),
-                            sd=noise,
-                            observed=y)
+                    mu=X.dot(weights),
+                    sd=noise,
+                    observed=y)
 
         prior = pm.sample_prior_predictive()
         posterior = pm.sample()
-        posterior_pred = pm.sample_posterior_predictive(posterior)
-
-.. raw:: html
-
+        posterior_pred = pm.sample_posterior_predictive(posterior)</code></pre>
                 </div>
             </div>
         </div>
@@ -74,18 +69,15 @@
         </div>
 
         <div class="ui container">
-            <h2 class="ui dividing header">etc.</h2>
-            <div class="ui text container">
-                <h3 class="ui dividing header">License</h3>
-                <p>PyMC3 is licensed <a href="https://github.com/pymc-devs/pymc3/blob/master/LICENSE">under the Apache License, V2.</a></p>
-            </div>
+            <h2 class="ui dividing header">Licence</h2>
+            <p>PyMC3 is licensed <a href="https://github.com/pymc-devs/pymc3/blob/master/LICENSE">under the Apache License, V2.</a></p>
+        </div>
 
-            <div class="ui text container">
-                <h3 class="ui dividing header">Citing PyMC3</h3>
-                <p>Salvatier J., Wiecki T.V., Fonnesbeck C. (2016) Probabilistic programming in Python using PyMC3. PeerJ
-                    Computer Science 2:e55 <a href="https://doi.org/10.7717/peerj-cs.55">DOI: 10.7717/peerj-cs.55</a>.</p>
-                <p>See <a href="https://scholar.google.de/scholar?oi=bibs&hl=en&authuser=1&cites=6936955228135731011">Google Scholar</a> for a continuously updated list of papers citing PyMC3.</p>
-            </div>
+        <div class="ui container">
+            <h2 class="ui dividing header">Citing PyMC3</h2>
+            <p>Salvatier J., Wiecki T.V., Fonnesbeck C. (2016) Probabilistic programming in Python using PyMC3. PeerJ
+                Computer Science 2:e55 <a href="https://doi.org/10.7717/peerj-cs.55">DOI: 10.7717/peerj-cs.55</a>.</p>
+            <p>See <a href="https://scholar.google.de/scholar?oi=bibs&hl=en&authuser=1&cites=6936955228135731011">Google Scholar</a> for a continuously updated list of papers citing PyMC3.</p>
         </div>
 
         <div class="ui segment">

--- a/docs/source/learn.rst
+++ b/docs/source/learn.rst
@@ -1,0 +1,242 @@
+.. title:: Learn
+
+.. raw:: html
+
+    <h1 class="ui header">Learn Bayesian statistics</h1>
+
+    <h2 class="ui header">...with others!</h2>
+    <div class="ui celled list">
+
+        <div class="item">
+            <i class="large discourse middle aligned icon"></i>
+            <div class="content">
+                <a href="https://discourse.pymc.io/" class="header">Discourse Forum</a>
+                <div class="description">
+                    The PyMC3 discourse forum is a great place to ask general questions about Bayesian statistics, or more specific ones about PyMC3 usage.
+                </div>
+            </div>
+        </div>
+
+        <div class="item">
+            <i class="large python middle aligned icon"></i>
+            <div class="content">
+                <div class="header">Conferences</div>
+                <div class="description">
+                    PyMC3 talks have been given at a number of conferences, including <a href="https://us.pycon.org/">PyCon</a>, <a href="https://pydata.org/events/">PyData</a>, and <a href="https://odsc.com/">ODSC</a> events.
+                </div>
+            </div>
+        </div>
+
+        <div class="item">
+            <i class="large meetup middle aligned icon"></i>
+            <div class="content">
+                <a href="https://www.meetup.com/" class="header">Meetup Groups</a>
+                <div class="description">
+                    Many areas have an local Bayesian, PyData, or Stan meetup.
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+    <h2 class="ui header">...with a book!</h2>
+    <div class="ui link four stackable cards">
+
+        <div class="card">
+            <div class="image">
+                <img src="https://camo.githubusercontent.com/4a0aca82ca82efab71747d00db30f3a68de98e82/687474703a2f2f692e696d6775722e636f6d2f36444b596250622e706e673f31">
+            </div>
+            <div class="content">
+                <div class="header">Bayesian Methods for Hackers</div>
+                <div class="meta">Cameron Davidson-Pilon</div>
+                <div class="description">
+                Fantastic book with many applied code examples.
+                </div>
+            </div>
+            <table class="ui table">
+                <tbody>
+                    <tr>
+                        <td>
+                            <a href="https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers">
+                                <i class="linkify icon"></i> Github Repo
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/">
+                                <i class="linkify icon"></i> Project homepage
+                            </a>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="card">
+            <div class="image">
+                <img src="https://camo.githubusercontent.com/dbb5f926b3bfe7e2196044462ce2411ee3a001ee/68747470733a2f2f39623865303033322d612d36326362336131612d732d73697465732e676f6f676c6567726f7570732e636f6d2f736974652f646f696e67626179657369616e64617461616e616c797369732f776861742d732d6e65772d696e2d326e642d65642f436f7665724442444132452d46726f6e744f6e6c792d363030776964652e706e67">
+            </div>
+            <div class="content">
+                <div class="header">Doing Bayesian Data Analysis</div>
+                <div class="meta">John Kruschke</div>
+                <div class="description">
+                Principled introduction to Bayesian data analysis.
+                </div>
+            </div>
+            <table class="ui table">
+                <tbody>
+                    <tr>
+                        <td>
+                            <a href="http://doingbayesiandataanalysis.blogspot.com/">
+                                <i class="linkify icon"></i> Book website
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="https://github.com/aloctavodia/Doing_bayesian_data_analysis">
+                                <i class="linkify icon"></i> PyMC3 notebooks for <em>first edition</em>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="https://github.com/JWarmenhoven/DBDA-python">
+                                <i class="linkify icon"></i> PyMC3 notebooks for <em>second edition</em>
+                            </a>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="card">
+            <div class="image">
+                <img src="http://xcelab.net/rm/wp-content/uploads/2012/01/9781482253443-191x300.jpg">
+            </div>
+            <div class="content">
+                <div class="header">Statistical Rethinking</div>
+                <div class="meta">Richard McElreath</div>
+                <div class="description">
+                A Bayesian Course with Examples in R and Stan.
+                </div>
+            </div>
+            <table class="ui table">
+                <tbody>
+                    <tr>
+                        <td>
+                            <a href="http://xcelab.net/rm/statistical-rethinking/">
+                                <i class="linkify icon"></i> Book website
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="https://github.com/pymc-devs/resources/tree/master/Rethinking">
+                                <i class="linkify icon"></i> PyMC3 port of the code
+                            </a>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="card">
+            <div class="image">
+                <img src="https://images-na.ssl-images-amazon.com/images/I/51K33XI2I8L._SX330_BO1,204,203,200_.jpg">
+            </div>
+            <div class="content">
+                <div class="header">Bayesian Cognitive Modeling: A Practical Course</div>
+                <div class="meta">Michael Lee and Eric-Jan Wagenmakers</div>
+                <div class="description">
+                Focused on using Bayesian statistics in cognitive modeling.
+                </div>
+            </div>
+            <table class="ui table">
+                <tbody>
+                    <tr>
+                        <td>
+                            <a href="https://bayesmodels.com/">
+                                <i class="linkify icon"></i> Book website
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="https://github.com/pymc-devs/resources/tree/master/BCM">
+                                <i class="linkify icon"></i> PyMC3 implementations
+                            </a>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="card">
+            <div class="image">
+                <img src="https://dz13w8afd47il.cloudfront.net/sites/default/files/imagecache/ppv4_main_book_cover/3804OS_4958_Bayesian%20Analysis%20with%20Python.png">
+            </div>
+            <div class="content">
+                <div class="header">Bayesian Analysis with Python</div>
+                <div class="meta">Osvaldo Martin</div>
+                <div class="description">
+                A great introductory book written by a maintainer of PyMC3.
+                </div>
+            </div>
+            <table class="ui table">
+                <tbody>
+                    <tr>
+                        <td>
+                            <a href="https://www.packtpub.com/big-data-and-business-intelligence/bayesian-analysis-python">
+                                <i class="linkify icon"></i> Book website
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="https://github.com/aloctavodia/BAP">
+                                <i class="linkify icon"></i> Code and errata in PyMC3
+                            </a>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="card">
+            <div class="image">
+                <img src="http://www.stat.columbia.edu/~gelman/book/bda_cover.png">
+            </div>
+            <div class="content">
+                <div class="header">Bayesian Data Analysis</div>
+                <div class="meta">Andrew Gelman, John Carlin, Hal Stern, David Dunson, Aki Vehtari, and Donald Rubin</div>
+                <div class="description">
+                A comprehensive, standard, and wonderful textbook on Bayesian methods.
+                </div>
+            </div>
+            <table class="ui table">
+                <tbody>
+                    <tr>
+                        <td>
+                            <a href="https://www.stat.columbia.edu/~gelman/book/">
+                                <i class="linkify icon"></i> Book website
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="https://github.com/pymc-devs/resources/tree/master/BDA3">
+                                <i class="linkify icon"></i> Examples and exercises implemented in PyMC3
+                            </a>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+    </div>
+
+    <h2 class="ui header">...with a video!</h2>
+
+    <p> There is an <a href="https://www.youtube.com/playlist?list=PL1Ma_1DBbE82OVW8Fz_6Ts1oOeyOAiovy">actively curated playlist of PyMC3 talks</a> on YouTube.

--- a/docs/source/semantic_sphinx/layout.html
+++ b/docs/source/semantic_sphinx/layout.html
@@ -25,9 +25,10 @@
 
     <div class="ui container">
         <div class="ui large secondary pointing menu">
-            {% if theme_navbar_links %}
-            {%- for link in theme_navbar_links %}
-            <a href="{{ pathto(*link[1:]) }}" class="item">{{ link[0] }}</a>
+            <img class="ui bottom aligned tiny image item" src="https://cdn.rawgit.com/pymc-devs/pymc3/master/docs/logos/svg/PyMC3_banner.svg" />
+            {% if
+            theme_navbar_links %} {%- for link in theme_navbar_links %} <a href="{{ pathto(*link[1:]) }}" class="item">{{
+                link[0] }}</a>
             {%- endfor %}
             {% endif %}
             <div class="right menu">


### PR DESCRIPTION
Added a "Learn" page for learning about bayesian statistics. It copies a section currently in the readme, and adds a bit. It is live at https://colindcarroll.com/static/pymc3/learn.html and a screen shot is below:


![image](https://user-images.githubusercontent.com/2295568/48678358-3a21ba00-eb50-11e8-8165-69d859acd0fb.png)
