### PR TITLE
Switching travis badges to svg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,7 +181,7 @@ Sponsors
 
 .. |Binder| image:: https://mybinder.org/badge.svg
    :target: https://mybinder.org/v2/gh/pymc-devs/pymc3/master?filepath=%2Fdocs%2Fsource%2Fnotebooks
-.. |Build Status| image:: https://travis-ci.org/pymc-devs/pymc3.png?branch=master
+.. |Build Status| image:: https://travis-ci.org/pymc-devs/pymc3.svg?branch=master
    :target: https://travis-ci.org/pymc-devs/pymc3
 .. |Coverage| image:: https://coveralls.io/repos/github/pymc-devs/pymc3/badge.svg?branch=master
    :target: https://coveralls.io/github/pymc-devs/pymc3?branch=master

--- a/docs/source/semantic_sphinx/layout.html
+++ b/docs/source/semantic_sphinx/layout.html
@@ -76,7 +76,7 @@ such as on Chrome for documents on localhost #}
             <img src="https://mybinder.org/badge.svg">
         </a>
         <a class="ui image" href="https://travis-ci.org/pymc-devs/pymc3">
-            <img src="https://travis-ci.org/pymc-devs/pymc3.png?branch=master">
+            <img src="https://travis-ci.org/pymc-devs/pymc3.svg?branch=master">
         </a>
         <a class="ui image" href="https://coveralls.io/github/pymc-devs/pymc3?branch=master">
             <img src="https://coveralls.io/repos/github/pymc-devs/pymc3/badge.svg?branch=master">


### PR DESCRIPTION
Hey team, Loving the new docs site! The fact that it looks so good makes that png badge for Travis really stick out for me. This pull request switches the two Travis badges that I could find (in the README and in the docs) to svg. Feel free to ignore especially if there's a reason to use png that I don't know.