### PR TITLE
Remove use of matplotlib Axes.set_ylim keyword ymin  (#3279)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,6 +16,7 @@
 - Big rewrite of documentation (#3275)
 - Fixed Triangular distribution `c` attribute handling in `random` and updated sample codes for consistency (#3225)
 - Refactor SMC and properly compute marginal likelihood (#3124)
+- Removed use of deprecated `ymin` keyword in matplotlib's `Axes.set_ylim` (#3279)
 
 ### Deprecations
 

--- a/pymc3/plots/traceplot.py
+++ b/pymc3/plots/traceplot.py
@@ -142,7 +142,7 @@ def traceplot(trace, varnames=None, transform=identity_transform, figsize=None, 
                 ax[i, j].relim()
                 ax[i, j].autoscale_view(True, True, True)
             ax[i, 1].set_xlim(x0, x0 + width)
-        ax[i, 0].set_ylim(ymin=0)
+        ax[i, 0].set_ylim(bottom=0)
     if live_plot:
         ax[0, 0].figure.canvas.draw()
     plt.tight_layout()


### PR DESCRIPTION
matplotlib's `Axes.set_ylim` `ymin` keyword is deprecated as of version 3 (see #3279). This PR removes the use of the keyword in `traceplot`, which is the only location it is used as far as I can tell.