### PR TITLE
Add Rice distribution to main pymc3 namespace

### DIFF
--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -156,4 +156,5 @@ __all__ = ['Uniform',
            'LogitNormal',
            'Interpolated',
            'Bound',
+           'Rice',
            ]


### PR DESCRIPTION
At the moment, the recently added Rice distribution can only be accessed via ``pymc3.distributions.continuous.Rice`` or ``pymc3.distributions.Rice``. All other distributions (AFAIK) are in the main namespace (``pymc3.Normal`` for example).

This PR makes possible to perform ``pymc3.Rice`` without error.

For the record, the following objects are imported in `` pymc3/distributions/__init__.py`` but *not* in ``__all__``: ``logodds``, ``Rice`` (fixed in this PR), ``stick_breaking``, ``sum_to_1``, ``timeseries``, ``transform``, ``transforms``. I don't know if it's intended.