### PR TITLE
Remove Python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 cache:
   directories:
     - $HOME/.theano
-    - $HOME/miniconda2
     - $HOME/miniconda3
 
 addons:
@@ -22,17 +21,14 @@ install:
   - pip install coveralls travis-sphinx==2.0.0
 
 env:
-  - PYTHON_VERSION=2.7 FLOATX='float32' TESTCMD="--durations=10 --ignore=pymc3/tests/test_examples.py --cov-append --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py"
-  - PYTHON_VERSION=2.7 FLOATX='float32' RUN_PYLINT="true" TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py"
-  - PYTHON_VERSION=2.7 FLOATX='float32' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py"
-  - PYTHON_VERSION=2.7 FLOATX='float32' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py"
-  - PYTHON_VERSION=2.7 FLOATX='float64' TESTCMD="--durations=10 --ignore=pymc3/tests/test_examples.py --cov-append --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py"
-  - PYTHON_VERSION=2.7 FLOATX='float64' RUN_PYLINT="true" TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py"
-  - PYTHON_VERSION=2.7 FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py"
-  - PYTHON_VERSION=3.6 FLOATX='float64' TESTCMD="--durations=10 --cov-append --ignore=pymc3/tests/test_examples.py --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py"
-  - PYTHON_VERSION=3.6 FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py"
-  - PYTHON_VERSION=3.6 FLOATX='float64' BUILD_DOCS="true" TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py"
-  - PYTHON_VERSION=3.6 FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py"
+  - FLOATX='float32' TESTCMD="--durations=10 --ignore=pymc3/tests/test_examples.py --cov-append --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py"
+  - FLOATX='float32' RUN_PYLINT="true" TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py"
+  - FLOATX='float32' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py"
+  - FLOATX='float32' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py"
+  - FLOATX='float64' TESTCMD="--durations=10 --cov-append --ignore=pymc3/tests/test_examples.py --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py"
+  - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py"
+  - FLOATX='float64' BUILD_DOCS="true" TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py"
+  - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py"
 
 script:
   - . ./scripts/test.sh $TESTCMD

--- a/README.rst
+++ b/README.rst
@@ -104,8 +104,8 @@ Another option is to clone the repository and install PyMC3 using
 Dependencies
 ============
 
-PyMC3 is tested on Python 2.7 and 3.6 and depends on Theano, NumPy,
-SciPy, Pandas, and Matplotlib (see ``requirements.txt`` for version
+PyMC3 is tested on Python 3.6 and depends on Theano, NumPy,
+SciPy, and Pandas (see ``requirements.txt`` for version
 information).
 
 Optional

--- a/benchmarks/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks/benchmarks.py
@@ -58,7 +58,7 @@ def mixture_model(random_seed=1234):
     return model, start
 
 
-class OverheadSuite(object):
+class OverheadSuite:
     """
     Just tests how long sampling from a normal distribution takes for various
     samplers
@@ -77,7 +77,7 @@ class OverheadSuite(object):
                       progressbar=False, compute_convergence_checks=False)
 
 
-class ExampleSuite(object):
+class ExampleSuite:
     """Implements examples to keep up with benchmarking them."""
     timeout = 360.0  # give it a few minutes
     timer = timeit.default_timer
@@ -128,7 +128,7 @@ class ExampleSuite(object):
                       progressbar=False, compute_convergence_checks=False)
 
 
-class NUTSInitSuite(object):
+class NUTSInitSuite:
     """Tests initializations for NUTS sampler on models
     """
     timeout = 360.0
@@ -173,7 +173,7 @@ NUTSInitSuite.track_glm_hierarchical_ess.unit = 'Effective samples per second'
 NUTSInitSuite.track_marginal_mixture_model_ess.unit = 'Effective samples per second'
 
 
-class CompareMetropolisNUTSSuite(object):
+class CompareMetropolisNUTSSuite:
     timeout = 360.0
     # None will be the "sensible default", and include initialization, but should be fastest
     params = (None, pm.NUTS, pm.Metropolis)

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -25,7 +25,7 @@ A few important points to highlight in the Distribution Class:
 
 .. code:: python
 
-    class Distribution(object):
+    class Distribution:
         """Statistical distribution"""
         def __new__(cls, name, *args, **kwargs):
             ...
@@ -610,7 +610,7 @@ does not edit or rewrite the graph directly.
 
 .. code:: python
 
-    class ValueGradFunction(object):
+    class ValueGradFunction:
         """Create a theano function that computes a value and its gradient.
         ...
         """

--- a/docs/source/sphinxext/gallery_generator.py
+++ b/docs/source/sphinxext/gallery_generator.py
@@ -63,7 +63,7 @@ def create_thumbnail(infile, width=275, height=275, cx=0.5, cy=0.5, border=4):
     return fig
 
 
-class NotebookGenerator(object):
+class NotebookGenerator:
     """Tools for generating an example page from a file"""
 
     def __init__(self, filename, target_dir):
@@ -121,7 +121,7 @@ class NotebookGenerator(object):
         create_thumbnail(self.png_path)
 
 
-class TableOfContentsJS(object):
+class TableOfContentsJS:
     """Container to load table of contents JS file"""
 
     def load(self, path):

--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -20,7 +20,7 @@ class BackendError(Exception):
     pass
 
 
-class BaseTrace(object):
+class BaseTrace:
     """Base trace object
 
     Parameters
@@ -218,7 +218,7 @@ class BaseTrace(object):
             return set()
 
 
-class MultiTrace(object):
+class MultiTrace:
     """Main interface for accessing values from MCMC results
 
     The core method to select values is `get_values`. The method

--- a/pymc3/backends/hdf5.py
+++ b/pymc3/backends/hdf5.py
@@ -37,7 +37,7 @@ class HDF5(base.BaseTrace):
         self.hdf5_file = None
         self.draw_idx = 0
         self.draws = None
-        super(HDF5, self).__init__(name, model, vars, test_point)
+        super().__init__(name, model, vars, test_point)
 
     def _get_sampler_stats(self, varname, sampler_idx, burn, thin):
         with self.activate_file:

--- a/pymc3/backends/ndarray.py
+++ b/pymc3/backends/ndarray.py
@@ -157,7 +157,7 @@ class NDArray(base.BaseTrace):
     supports_sampler_stats = True
 
     def __init__(self, name=None, model=None, vars=None, test_point=None):
-        super(NDArray, self).__init__(name, model, vars, test_point)
+        super().__init__(name, model, vars, test_point)
         self.draw_idx = 0
         self.draws = None
         self.samples = {}
@@ -178,7 +178,7 @@ class NDArray(base.BaseTrace):
             Names and dtypes of the variables that are
             exported by the samplers.
         """
-        super(NDArray, self).setup(draws, chain, sampler_vars)
+        super().setup(draws, chain, sampler_vars)
 
         self.chain = chain
         if self.samples:  # Concatenate new array if chain is already present.

--- a/pymc3/backends/ndarray.py
+++ b/pymc3/backends/ndarray.py
@@ -78,7 +78,7 @@ def load_trace(directory, model=None):
     return base.MultiTrace(straces)
 
 
-class SerializeNDArray(object):
+class SerializeNDArray:
     metadata_file = 'metadata.json'
     samples_file = 'samples.npz'
 

--- a/pymc3/backends/report.py
+++ b/pymc3/backends/report.py
@@ -36,7 +36,7 @@ _LEVELS = {
 }
 
 
-class SamplerReport(object):
+class SamplerReport:
     def __init__(self):
         self._chain_warnings = {}
         self._global_warnings = []

--- a/pymc3/backends/sqlite.py
+++ b/pymc3/backends/sqlite.py
@@ -270,7 +270,7 @@ class SQLite(base.BaseTrace):
         return var_values
 
 
-class _SQLiteDB(object):
+class _SQLiteDB:
 
     def __init__(self, name):
         self.name = name

--- a/pymc3/backends/sqlite.py
+++ b/pymc3/backends/sqlite.py
@@ -75,7 +75,7 @@ class SQLite(base.BaseTrace):
     """
 
     def __init__(self, name, model=None, vars=None, test_point=None):
-        super(SQLite, self).__init__(name, model, vars, test_point)
+        super().__init__(name, model, vars, test_point)
         self._var_cols = {}
         self.var_inserts = {}  # varname -> insert statement
         self.draw_idx = 0

--- a/pymc3/backends/sqlite.py
+++ b/pymc3/backends/sqlite.py
@@ -347,8 +347,7 @@ def _get_var_strs(cursor, varname):
 def _get_chain_list(cursor, varname):
     """Return a list of sorted chains for `varname`."""
     cursor.execute('SELECT DISTINCT chain FROM [{}]'.format(varname))
-    chains = [chain[0] for chain in cursor.fetchall()]
-    chains.sort()
+    chains = sorted([chain[0] for chain in cursor.fetchall()])
     return chains
 
 

--- a/pymc3/backends/text.py
+++ b/pymc3/backends/text.py
@@ -43,7 +43,7 @@ class Text(base.BaseTrace):
     def __init__(self, name, model=None, vars=None, test_point=None):
         if not os.path.exists(name):
             os.mkdir(name)
-        super(Text, self).__init__(name, model, vars, test_point)
+        super().__init__(name, model, vars, test_point)
 
         self.flat_names = {v: ttab.create_flat_names(v, shape)
                            for v, shape in self.var_shapes.items()}

--- a/pymc3/blocking.py
+++ b/pymc3/blocking.py
@@ -16,7 +16,7 @@ DataMap = collections.namedtuple('DataMap', 'list_ind, slc, shp, dtype, name')
 # TODO Classes and methods need to be fully documented.
 
 
-class ArrayOrdering(object):
+class ArrayOrdering:
     """
     An ordering for an array space
     """
@@ -45,7 +45,7 @@ class ArrayOrdering(object):
         return self.by_name[key]
 
 
-class DictToArrayBijection(object):
+class DictToArrayBijection:
     """
     A mapping between a dict space and an array space
     """
@@ -106,7 +106,7 @@ class DictToArrayBijection(object):
         return Compose(f, self.rmap)
 
 
-class ListArrayOrdering(object):
+class ListArrayOrdering:
     """
     An ordering for a list to an array space. Takes also non theano.tensors.
     Modified from pymc3 blocking.
@@ -138,7 +138,7 @@ class ListArrayOrdering(object):
             self.size += array.size
 
 
-class ListToArrayBijection(object):
+class ListToArrayBijection:
     """
     A mapping between a List of arrays and an array space
 
@@ -217,7 +217,7 @@ class ListToArrayBijection(object):
         return a_list
 
 
-class DictToVarBijection(object):
+class DictToVarBijection:
     """
     A mapping between a dict space and the array space for one element within the dict space
     """
@@ -244,7 +244,7 @@ class DictToVarBijection(object):
         return Compose(f, self.rmap)
 
 
-class Compose(object):
+class Compose:
     """
     Compose two functions in a pickleable way
     """

--- a/pymc3/data.py
+++ b/pymc3/data.py
@@ -48,7 +48,7 @@ class GenTensorVariable(tt.TensorVariable):
         return cp
 
 
-class GeneratorAdapter(object):
+class GeneratorAdapter:
     """
     Helper class that helps to infer data type of generator with looking
     at the first item, preserving the order of the resulting generator
@@ -99,7 +99,7 @@ class Minibatch(tt.TensorVariable):
     data : :class:`ndarray`
         initial data
     batch_size : `int` or `List[int|tuple(size, random_seed)]`
-        batch size for inference, random seed is needed 
+        batch size for inference, random seed is needed
         for child random generators
     dtype : `str`
         cast data to specific type
@@ -110,10 +110,10 @@ class Minibatch(tt.TensorVariable):
     random_seed : `int`
         random seed that is used by default
     update_shared_f : `callable`
-        returns :class:`ndarray` that will be carefully 
+        returns :class:`ndarray` that will be carefully
         stored to underlying shared variable
-        you can use it to change source of 
-        minibatches programmatically 
+        you can use it to change source of
+        minibatches programmatically
     in_memory_size : `int` or `List[int|slice|Ellipsis]`
         data size for storing in theano.shared
 
@@ -141,7 +141,7 @@ class Minibatch(tt.TensorVariable):
     >>> x = Minibatch(data, batch_size=10)
 
     Note, that your data is cast to `floatX` if it is not integer type
-    But you still can add `dtype` kwarg for :class:`Minibatch` 
+    But you still can add `dtype` kwarg for :class:`Minibatch`
 
     in case we want 10 sampled rows and columns
     `[(size, seed), (size, seed)]` it is
@@ -182,7 +182,7 @@ class Minibatch(tt.TensorVariable):
     >>> x.update_shared()
 
     To be more concrete about how we get minibatch, here is a demo
-    1) create shared variable 
+    1) create shared variable
     >>> shared = theano.shared(data)
 
     2) create random slice of size 10
@@ -191,7 +191,7 @@ class Minibatch(tt.TensorVariable):
     3) take that slice
     >>> minibatch = shared[ridx]
 
-    That's done. Next you can use this minibatch somewhere else. 
+    That's done. Next you can use this minibatch somewhere else.
     You can see that implementation does not require fixed shape
     for shared variable. Feel free to use that if needed.
 
@@ -222,7 +222,7 @@ class Minibatch(tt.TensorVariable):
     We take slice only for the first and last dimension
     >>> assert x.eval().shape == (2, 20, 30, 40, 10)
 
-    2) Skipping particular dimension, `total_size = (10, None, 30)` 
+    2) Skipping particular dimension, `total_size = (10, None, 30)`
     >>> x = Minibatch(moredata, [2, None, 20])
     >>> assert x.eval().shape == (2, 20, 20, 40, 50)
 

--- a/pymc3/data.py
+++ b/pymc3/data.py
@@ -33,7 +33,7 @@ def get_data(filename):
 
 class GenTensorVariable(tt.TensorVariable):
     def __init__(self, op, type, name=None):
-        super(GenTensorVariable, self).__init__(type=type, name=name)
+        super().__init__(type=type, name=name)
         self.op = op
 
     def set_gen(self, gen):
@@ -249,8 +249,7 @@ class Minibatch(tt.TensorVariable):
             broadcastable = (False, ) * minibatch.ndim
         minibatch = tt.patternbroadcast(minibatch, broadcastable)
         self.minibatch = minibatch
-        super(Minibatch, self).__init__(
-            self.minibatch.type, None, None, name=name)
+        super().__init__(self.minibatch.type, None, None, name=name)
         theano.Apply(
             theano.compile.view_op,
             inputs=[self.minibatch], outputs=[self])

--- a/pymc3/diagnostics.py
+++ b/pymc3/diagnostics.py
@@ -292,7 +292,7 @@ def effective_n(mtrace, varnames=None, include_transformed=False):
             'of the same length.')
 
     if varnames is None:
-        varnames = get_default_varnames(mtrace.varnames,include_transformed=include_transformed)
+        varnames = get_default_varnames(mtrace.varnames, include_transformed=include_transformed)
 
     n_eff = {}
 

--- a/pymc3/distributions/bound.py
+++ b/pymc3/distributions/bound.py
@@ -26,7 +26,7 @@ class _Bounded(Distribution):
             defaults = ('_default',)
             self._default = default
 
-        super(_Bounded, self).__init__(
+        super().__init__(
             shape=self._wrapped.shape,
             dtype=self._wrapped.dtype,
             testval=self._wrapped.testval,
@@ -102,7 +102,7 @@ class _DiscreteBounded(_Bounded, Discrete):
         if lower is not None:
             default = lower + 1
 
-        super(_DiscreteBounded, self).__init__(
+        super().__init__(
             distribution=distribution, lower=lower, upper=upper,
             default=default, *args, **kwargs)
 
@@ -150,7 +150,7 @@ class _ContinuousBounded(_Bounded, Continuous):
         else:
             default = None
 
-        super(_ContinuousBounded, self).__init__(
+        super().__init__(
             distribution=distribution, lower=lower, upper=upper,
             transform=transform, default=default, *args, **kwargs)
 

--- a/pymc3/distributions/bound.py
+++ b/pymc3/distributions/bound.py
@@ -155,7 +155,7 @@ class _ContinuousBounded(_Bounded, Continuous):
             transform=transform, default=default, *args, **kwargs)
 
 
-class Bound(object):
+class Bound:
     R"""
     Create a Bound variable object that can be applied to create
     a new upper, lower, or upper and lower bounded distribution.

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3,8 +3,6 @@
 A collection of common probability distributions for stochastic
 nodes in PyMC.
 """
-from __future__ import division
-
 import numpy as np
 import theano.tensor as tt
 from scipy import stats

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -35,16 +35,14 @@ class PositiveContinuous(Continuous):
     """Base class for positive continuous distributions"""
 
     def __init__(self, transform=transforms.log, *args, **kwargs):
-        super(PositiveContinuous, self).__init__(
-            transform=transform, *args, **kwargs)
+        super().__init__(transform=transform, *args, **kwargs)
 
 
 class UnitContinuous(Continuous):
     """Base class for continuous distributions on [0,1]"""
 
     def __init__(self, transform=transforms.logodds, *args, **kwargs):
-        super(UnitContinuous, self).__init__(
-            transform=transform, *args, **kwargs)
+        super().__init__(transform=transform, *args, **kwargs)
 
 
 class BoundedContinuous(Continuous):
@@ -66,8 +64,7 @@ class BoundedContinuous(Continuous):
             else:
                 transform = transforms.interval(lower, upper)
 
-        super(BoundedContinuous, self).__init__(
-            transform=transform, *args, **kwargs)
+        super().__init__(transform=transform, *args, **kwargs)
 
 
 def assert_negative_support(var, label, distname, value=-1e-6):
@@ -183,8 +180,7 @@ class Uniform(BoundedContinuous):
         self.mean = (upper + lower) / 2.
         self.median = self.mean
 
-        super(Uniform, self).__init__(
-            lower=lower, upper=upper, *args, **kwargs)
+        super().__init__(lower=lower, upper=upper, *args, **kwargs)
 
     def random(self, point=None, size=None):
         """
@@ -259,7 +255,7 @@ class Flat(Continuous):
 
     def __init__(self, *args, **kwargs):
         self._default = 0
-        super(Flat, self).__init__(defaults=('_default',), *args, **kwargs)
+        super().__init__(defaults=('_default',), *args, **kwargs)
 
     def random(self, point=None, size=None):
         """Raises ValueError as it is not possible to sample from Flat distribution
@@ -312,7 +308,7 @@ class HalfFlat(PositiveContinuous):
 
     def __init__(self, *args, **kwargs):
         self._default = 1
-        super(HalfFlat, self).__init__(defaults=('_default',), *args, **kwargs)
+        super().__init__(defaults=('_default',), *args, **kwargs)
 
     def random(self, point=None, size=None):
         """Raises ValueError as it is not possible to sample from HalfFlat distribution
@@ -434,7 +430,7 @@ class Normal(Continuous):
         assert_negative_support(sd, 'sd', 'Normal')
         assert_negative_support(tau, 'tau', 'Normal')
 
-        super(Normal, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def random(self, point=None, size=None):
         """
@@ -589,9 +585,8 @@ class TruncatedNormal(BoundedContinuous):
         assert_negative_support(sd, 'sd', 'TruncatedNormal')
         assert_negative_support(tau, 'tau', 'TruncatedNormal')
 
-        super(TruncatedNormal, self).__init__(
-            defaults=('_defaultval',), transform=transform,
-            lower=lower, upper=upper, *args, **kwargs)
+        super().__init__(defaults=('_defaultval',), transform=transform,
+                         lower=lower, upper=upper, *args, **kwargs)
 
     def random(self, point=None, size=None):
         """
@@ -752,7 +747,7 @@ class HalfNormal(PositiveContinuous):
     """
 
     def __init__(self, sd=None, tau=None, *args, **kwargs):
-        super(HalfNormal, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         tau, sd = get_tau_sd(tau=tau, sd=sd)
 
         self.sd = sd = tt.as_tensor_variable(sd)
@@ -903,7 +898,7 @@ class Wald(PositiveContinuous):
     """
 
     def __init__(self, mu=None, lam=None, phi=None, alpha=0., *args, **kwargs):
-        super(Wald, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         mu, lam, phi = self.get_mu_lam_phi(mu, lam, phi)
         self.alpha = alpha = tt.as_tensor_variable(alpha)
         self.mu = mu = tt.as_tensor_variable(mu)
@@ -1113,7 +1108,7 @@ class Beta(UnitContinuous):
 
     def __init__(self, alpha=None, beta=None, mu=None, sd=None,
                  *args, **kwargs):
-        super(Beta, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         alpha, beta = self.get_alpha_beta(alpha, beta, mu, sd)
         self.alpha = alpha = tt.as_tensor_variable(alpha)
@@ -1256,7 +1251,7 @@ class Kumaraswamy(UnitContinuous):
     """
 
     def __init__(self, a, b, *args, **kwargs):
-        super(Kumaraswamy, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.a = a = tt.as_tensor_variable(a)
         self.b = b = tt.as_tensor_variable(b)
@@ -1368,7 +1363,7 @@ class Exponential(PositiveContinuous):
     """
 
     def __init__(self, lam, *args, **kwargs):
-        super(Exponential, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.lam = lam = tt.as_tensor_variable(lam)
         self.mean = 1. / self.lam
         self.median = self.mean * tt.log(2)
@@ -1492,7 +1487,7 @@ class Laplace(Continuous):
     """
 
     def __init__(self, mu, b, *args, **kwargs):
-        super(Laplace, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.b = b = tt.as_tensor_variable(b)
         self.mean = self.median = self.mode = self.mu = mu = tt.as_tensor_variable(mu)
 
@@ -1628,7 +1623,7 @@ class Lognormal(PositiveContinuous):
     """
 
     def __init__(self, mu=0, sd=None, tau=None, *args, **kwargs):
-        super(Lognormal, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         tau, sd = get_tau_sd(tau=tau, sd=sd)
 
         self.mu = mu = tt.as_tensor_variable(mu)
@@ -1781,7 +1776,7 @@ class StudentT(Continuous):
     """
 
     def __init__(self, nu, mu=0, lam=None, sd=None, *args, **kwargs):
-        super(StudentT, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.nu = nu = tt.as_tensor_variable(nu)
         lam, sd = get_tau_sd(tau=lam, sd=sd)
         self.lam = lam = tt.as_tensor_variable(lam)
@@ -1927,7 +1922,7 @@ class Pareto(Continuous):
 
         if transform == 'lowerbound':
             transform = transforms.lowerbound(self.m)
-        super(Pareto, self).__init__(transform=transform, *args, **kwargs)
+        super().__init__(transform=transform, *args, **kwargs)
 
     def _random(self, alpha, m, size=None):
         u = np.random.uniform(size=size)
@@ -2047,7 +2042,7 @@ class Cauchy(Continuous):
     """
 
     def __init__(self, alpha, beta, *args, **kwargs):
-        super(Cauchy, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.median = self.mode = self.alpha = tt.as_tensor_variable(alpha)
         self.beta = tt.as_tensor_variable(beta)
 
@@ -2155,7 +2150,7 @@ class HalfCauchy(PositiveContinuous):
     """
 
     def __init__(self, beta, *args, **kwargs):
-        super(HalfCauchy, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.mode = tt.as_tensor_variable(0)
         self.median = tt.as_tensor_variable(beta)
         self.beta = tt.as_tensor_variable(beta)
@@ -2284,7 +2279,7 @@ class Gamma(PositiveContinuous):
 
     def __init__(self, alpha=None, beta=None, mu=None, sd=None,
                  *args, **kwargs):
-        super(Gamma, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         alpha, beta = self.get_alpha_beta(alpha, beta, mu, sd)
         self.alpha = alpha = tt.as_tensor_variable(alpha)
         self.beta = beta = tt.as_tensor_variable(beta)
@@ -2414,7 +2409,7 @@ class InverseGamma(PositiveContinuous):
     """
 
     def __init__(self, alpha=None, beta=None, mu=None, sd=None, *args, **kwargs):
-        super(InverseGamma, self).__init__(*args, defaults=('mode',), **kwargs)
+        super().__init__(*args, defaults=('mode',), **kwargs)
 
         alpha, beta = InverseGamma._get_alpha_beta(alpha, beta, mu, sd)
         self.alpha = alpha = tt.as_tensor_variable(alpha)
@@ -2547,8 +2542,7 @@ class ChiSquared(Gamma):
 
     def __init__(self, nu, *args, **kwargs):
         self.nu = nu = tt.as_tensor_variable(nu)
-        super(ChiSquared, self).__init__(alpha=nu / 2., beta=0.5,
-                                         *args, **kwargs)
+        super().__init__(alpha=nu / 2., beta=0.5, *args, **kwargs)
 
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:
@@ -2604,7 +2598,7 @@ class Weibull(PositiveContinuous):
     """
 
     def __init__(self, alpha, beta, *args, **kwargs):
-        super(Weibull, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.alpha = alpha = tt.as_tensor_variable(alpha)
         self.beta = beta = tt.as_tensor_variable(beta)
         self.mean = beta * tt.exp(gammaln(1 + 1. / alpha))
@@ -2757,7 +2751,7 @@ class HalfStudentT(PositiveContinuous):
     """
 
     def __init__(self, nu=1, sd=None, lam=None, *args, **kwargs):
-        super(HalfStudentT, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.mode = tt.as_tensor_variable(0)
         lam, sd = get_tau_sd(lam, sd)
         self.median = tt.as_tensor_variable(sd)
@@ -2892,7 +2886,7 @@ class ExGaussian(Continuous):
     """
 
     def __init__(self, mu, sigma, nu, *args, **kwargs):
-        super(ExGaussian, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.mu = mu = tt.as_tensor_variable(mu)
         self.sigma = sigma = tt.as_tensor_variable(sigma)
         self.nu = nu = tt.as_tensor_variable(nu)
@@ -3041,7 +3035,7 @@ class VonMises(Continuous):
                  *args, **kwargs):
         if transform == 'circular':
             transform = transforms.Circular()
-        super(VonMises, self).__init__(transform=transform, *args, **kwargs)
+        super().__init__(transform=transform, *args, **kwargs)
         self.mean = self.median = self.mode = self.mu = mu = tt.as_tensor_variable(mu)
         self.kappa = kappa = floatX(tt.as_tensor_variable(kappa))
 
@@ -3160,7 +3154,7 @@ class SkewNormal(Continuous):
     """
 
     def __init__(self, mu=0.0, sd=None, tau=None, alpha=1, *args, **kwargs):
-        super(SkewNormal, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         tau, sd = get_tau_sd(tau=tau, sd=sd)
         self.mu = mu = tt.as_tensor_variable(mu)
         self.tau = tt.as_tensor_variable(tau)
@@ -3296,8 +3290,7 @@ class Triangular(BoundedContinuous):
         self.lower = lower = tt.as_tensor_variable(lower)
         self.upper = upper = tt.as_tensor_variable(upper)
 
-        super(Triangular, self).__init__(lower=lower, upper=upper,
-                                         *args, **kwargs)
+        super().__init__(lower=lower, upper=upper, *args, **kwargs)
 
     def random(self, point=None, size=None):
         """
@@ -3438,7 +3431,7 @@ class Gumbel(Continuous):
         self.mode = self.mu
         self.variance = (np.pi ** 2 / 6.0) * self.beta ** 2
 
-        super(Gumbel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def random(self, point=None, size=None):
         """
@@ -3529,7 +3522,7 @@ class Rice(PositiveContinuous):
     :math:`Y\sim N(\nu \sin{\theta}, \sigma^2)` are independent and for any
     real :math:`\theta`.
 
-    The distribution is defined with either nu or b. 
+    The distribution is defined with either nu or b.
     The link between the two parametrizations is given by
 
     .. math::
@@ -3539,7 +3532,7 @@ class Rice(PositiveContinuous):
     """
 
     def __init__(self, nu=None, sd=None, b=None, *args, **kwargs):
-        super(Rice, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         nu, b, sd = self.get_nu_b(nu, b, sd)
         self.nu = nu = tt.as_tensor_variable(nu)
         self.sd = sd = tt.as_tensor_variable(sd)
@@ -3652,7 +3645,7 @@ class Logistic(Continuous):
     """
 
     def __init__(self, mu=0., s=1., *args, **kwargs):
-        super(Logistic, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.mu = tt.as_tensor_variable(mu)
         self.s = tt.as_tensor_variable(s)
@@ -3794,7 +3787,7 @@ class LogitNormal(UnitContinuous):
         assert_negative_support(sd, 'sd', 'LogitNormal')
         assert_negative_support(tau, 'tau', 'LogitNormal')
 
-        super(LogitNormal, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def random(self, point=None, size=None):
         """
@@ -3882,8 +3875,7 @@ class Interpolated(BoundedContinuous):
         self.lower = lower = tt.as_tensor_variable(x_points[0])
         self.upper = upper = tt.as_tensor_variable(x_points[-1])
 
-        super(Interpolated, self).__init__(lower=lower, upper=upper,
-                                           *args, **kwargs)
+        super().__init__(lower=lower, upper=upper, *args, **kwargs)
 
         interp = InterpolatedUnivariateSpline(
             x_points, pdf_points, k=1, ext='zeros')

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -59,7 +59,7 @@ class Binomial(Discrete):
     """
 
     def __init__(self, n, p, *args, **kwargs):
-        super(Binomial, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.n = n = tt.as_tensor_variable(n)
         self.p = p = tt.as_tensor_variable(p)
         self.mode = tt.cast(tround(n * p), self.dtype)
@@ -145,7 +145,7 @@ class BetaBinomial(Discrete):
     """
 
     def __init__(self, alpha, beta, n, *args, **kwargs):
-        super(BetaBinomial, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.alpha = alpha = tt.as_tensor_variable(alpha)
         self.beta = beta = tt.as_tensor_variable(beta)
         self.n = n = tt.as_tensor_variable(n)
@@ -238,7 +238,7 @@ class Bernoulli(Discrete):
     """
 
     def __init__(self, p=None, logit_p=None, *args, **kwargs):
-        super(Bernoulli, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if sum(int(var is None) for var in [p, logit_p]) != 1:
             raise ValueError('Specify one of p and logit_p')
         if p is not None:
@@ -317,7 +317,7 @@ class DiscreteWeibull(Discrete):
     ========  ======================
     """
     def __init__(self, q, beta, *args, **kwargs):
-        super(DiscreteWeibull, self).__init__(*args, defaults=('median',), **kwargs)
+        super().__init__(*args, defaults=('median',), **kwargs)
 
         self.q = q = tt.as_tensor_variable(q)
         self.beta = beta = tt.as_tensor_variable(beta)
@@ -411,7 +411,7 @@ class Poisson(Discrete):
     """
 
     def __init__(self, mu, *args, **kwargs):
-        super(Poisson, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.mu = mu = tt.as_tensor_variable(mu)
         self.mode = tt.floor(mu).astype('int32')
 
@@ -490,7 +490,7 @@ class NegativeBinomial(Discrete):
     """
 
     def __init__(self, mu, alpha, *args, **kwargs):
-        super(NegativeBinomial, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.mu = mu = tt.as_tensor_variable(mu)
         self.alpha = alpha = tt.as_tensor_variable(alpha)
         self.mode = tt.floor(mu).astype('int32')
@@ -565,7 +565,7 @@ class Geometric(Discrete):
     """
 
     def __init__(self, p, *args, **kwargs):
-        super(Geometric, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.p = p = tt.as_tensor_variable(p)
         self.mode = 1
 
@@ -629,7 +629,7 @@ class DiscreteUniform(Discrete):
     """
 
     def __init__(self, lower, upper, *args, **kwargs):
-        super(DiscreteUniform, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.lower = tt.floor(lower).astype('int32')
         self.upper = tt.floor(upper).astype('int32')
         self.mode = tt.maximum(
@@ -701,7 +701,7 @@ class Categorical(Discrete):
     """
 
     def __init__(self, p, *args, **kwargs):
-        super(Categorical, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         try:
             self.k = tt.shape(p)[-1].tag.test_value
         except AttributeError:
@@ -758,7 +758,7 @@ class Constant(Discrete):
     def __init__(self, c, *args, **kwargs):
         warnings.warn("Constant has been deprecated. We recommend using a Deterministic object instead.",
                     DeprecationWarning)
-        super(Constant, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.mean = self.median = self.mode = self.c = c = tt.as_tensor_variable(c)
 
     def random(self, point=None, size=None):
@@ -836,7 +836,7 @@ class ZeroInflatedPoisson(Discrete):
     """
 
     def __init__(self, psi, theta, *args, **kwargs):
-        super(ZeroInflatedPoisson, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.theta = theta = tt.as_tensor_variable(theta)
         self.psi = psi = tt.as_tensor_variable(psi)
         self.pois = Poisson.dist(theta)
@@ -927,7 +927,7 @@ class ZeroInflatedBinomial(Discrete):
     """
 
     def __init__(self, psi, n, p, *args, **kwargs):
-        super(ZeroInflatedBinomial, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.n = n = tt.as_tensor_variable(n)
         self.p = p = tt.as_tensor_variable(p)
         self.psi = psi = tt.as_tensor_variable(psi)
@@ -1043,7 +1043,7 @@ class ZeroInflatedNegativeBinomial(Discrete):
     """
 
     def __init__(self, psi, mu, alpha, *args, **kwargs):
-        super(ZeroInflatedNegativeBinomial, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.mu = mu = tt.as_tensor_variable(mu)
         self.alpha = alpha = tt.as_tensor_variable(alpha)
         self.psi = psi = tt.as_tensor_variable(psi)
@@ -1174,7 +1174,7 @@ class OrderedLogistic(Categorical):
         ], axis=1)
         p = p_cum[:, 1:] - p_cum[:, :-1]
 
-        super(OrderedLogistic, self).__init__(p=p, *args, **kwargs)
+        super().__init__(p=p, *args, **kwargs)
 
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -3,8 +3,6 @@ Created on Mar 7, 2011
 
 @author: johnsalvatier
 '''
-from __future__ import division
-
 import numpy as np
 import scipy.linalg
 import theano.tensor as tt

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -130,9 +130,9 @@ class NoDistribution(Distribution):
 
     def __init__(self, shape, dtype, testval=None, defaults=(),
                  transform=None, parent_dist=None, *args, **kwargs):
-        super(NoDistribution, self).__init__(shape=shape, dtype=dtype,
-                                             testval=testval, defaults=defaults,
-                                             *args, **kwargs)
+        super().__init__(shape=shape, dtype=dtype,
+                         testval=testval, defaults=defaults,
+                         *args, **kwargs)
         self.parent_dist = parent_dist
 
     def __getattr__(self, name):
@@ -164,8 +164,7 @@ class Discrete(Distribution):
             raise ValueError("Transformations for discrete distributions "
                              "are not allowed.")
 
-        super(Discrete, self).__init__(
-            shape, dtype, defaults=defaults, *args, **kwargs)
+        super().__init__(shape, dtype, defaults=defaults, *args, **kwargs)
 
 
 class Continuous(Distribution):
@@ -175,8 +174,7 @@ class Continuous(Distribution):
                  *args, **kwargs):
         if dtype is None:
             dtype = theano.config.floatX
-        super(Continuous, self).__init__(
-            shape, dtype, defaults=defaults, *args, **kwargs)
+        super().__init__(shape, dtype, defaults=defaults, *args, **kwargs)
 
 
 class DensityDist(Distribution):
@@ -200,8 +198,7 @@ class DensityDist(Distribution):
     def __init__(self, logp, shape=(), dtype=None, testval=0, random=None, *args, **kwargs):
         if dtype is None:
             dtype = theano.config.floatX
-        super(DensityDist, self).__init__(
-            shape, dtype, testval, *args, **kwargs)
+        super().__init__(shape, dtype, testval, *args, **kwargs)
         self.logp = logp
         self.rand = random
 
@@ -219,7 +216,7 @@ class _DrawValuesContext(Context, metaclass=InitContextMeta):
 
     def __new__(cls, *args, **kwargs):
         # resolves the parent instance
-        instance = super(_DrawValuesContext, cls).__new__(cls)
+        instance = super().__new__(cls)
         if cls.get_contexts():
             potential_parent = cls.get_contexts()[-1]
             # We have to make sure that the context is a _DrawValuesContext

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -15,11 +15,11 @@ __all__ = ['DensityDist', 'Distribution', 'Continuous', 'Discrete',
            'NoDistribution', 'TensorType', 'draw_values', 'generate_samples']
 
 
-class _Unpickling(object):
+class _Unpickling:
     pass
 
 
-class Distribution(object):
+class Distribution:
     """Statistical distribution"""
     def __new__(cls, name, *args, **kwargs):
         if name is _Unpickling:
@@ -213,7 +213,7 @@ class DensityDist(Distribution):
                             "Define a custom random method and pass it as kwarg random")
 
 
-class _DrawValuesContext(Context, meta=InitContextMeta):
+class _DrawValuesContext(Context, metaclass=InitContextMeta):
     """ A context manager class used while drawing values with draw_values
     """
 

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -1,4 +1,3 @@
-import six
 import numbers
 
 import numpy as np
@@ -214,7 +213,7 @@ class DensityDist(Distribution):
                             "Define a custom random method and pass it as kwarg random")
 
 
-class _DrawValuesContext(six.with_metaclass(InitContextMeta, Context)):
+class _DrawValuesContext(Context, meta=InitContextMeta):
     """ A context manager class used while drawing values with draw_values
     """
 
@@ -222,11 +221,11 @@ class _DrawValuesContext(six.with_metaclass(InitContextMeta, Context)):
         # resolves the parent instance
         instance = super(_DrawValuesContext, cls).__new__(cls)
         if cls.get_contexts():
-            potencial_parent = cls.get_contexts()[-1]
+            potential_parent = cls.get_contexts()[-1]
             # We have to make sure that the context is a _DrawValuesContext
             # and not a Model
-            if isinstance(potencial_parent, cls):
-                instance._parent = potencial_parent
+            if isinstance(potential_parent, cls):
+                instance._parent = potential_parent
             else:
                 instance._parent = None
         else:

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -100,8 +100,7 @@ class Mixture(Distribution):
         except (AttributeError, ValueError, IndexError):
             pass
 
-        super(Mixture, self).__init__(shape, dtype, defaults=defaults,
-                                      *args, **kwargs)
+        super().__init__(shape, dtype, defaults=defaults, *args, **kwargs)
 
     def _comp_logp(self, value):
         comp_dists = self.comp_dists
@@ -227,8 +226,7 @@ class NormalMixture(Mixture):
         self.mu = mu = tt.as_tensor_variable(mu)
         self.sd = sd = tt.as_tensor_variable(sd)
 
-        super(NormalMixture, self).__init__(w, Normal.dist(mu, sd=sd, shape=comp_shape),
-                                            *args, **kwargs)
+        super().__init__(w, Normal.dist(mu, sd=sd, shape=comp_shape), *args, **kwargs)
 
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -34,7 +34,7 @@ __all__ = ['MvNormal', 'MvStudentT', 'Dirichlet',
 class _QuadFormBase(Continuous):
     def __init__(self, mu=None, cov=None, chol=None, tau=None, lower=True,
                  *args, **kwargs):
-        super(_QuadFormBase, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if len(self.shape) > 2:
             raise ValueError("Only 1 or 2 dimensions are allowed.")
 
@@ -221,8 +221,7 @@ class MvNormal(_QuadFormBase):
 
     def __init__(self, mu, cov=None, tau=None, chol=None, lower=True,
                  *args, **kwargs):
-        super(MvNormal, self).__init__(mu=mu, cov=cov, tau=tau, chol=chol,
-                                       lower=lower, *args, **kwargs)
+        super().__init__(mu=mu, cov=cov, tau=tau, chol=chol, lower=lower, *args, **kwargs)
         self.mean = self.median = self.mode = self.mu = self.mu
 
     def random(self, point=None, size=None):
@@ -333,8 +332,7 @@ class MvStudentT(_QuadFormBase):
             if cov is not None:
                 raise ValueError('Specify only one of cov and Sigma')
             cov = Sigma
-        super(MvStudentT, self).__init__(mu=mu, cov=cov, tau=tau, chol=chol,
-                                         lower=lower, *args, **kwargs)
+        super().__init__(mu=mu, cov=cov, tau=tau, chol=chol, lower=lower, *args, **kwargs)
         self.nu = nu = tt.as_tensor_variable(nu)
         self.mean = self.median = self.mode = self.mu = self.mu
 
@@ -408,7 +406,7 @@ class Dirichlet(Continuous):
         shape = np.atleast_1d(a.shape)[-1]
 
         kwargs.setdefault("shape", shape)
-        super(Dirichlet, self).__init__(transform=transform, *args, **kwargs)
+        super().__init__(transform=transform, *args, **kwargs)
 
         self.size_prefix = tuple(self.shape[:-1])
         self.k = tt.as_tensor_variable(shape)
@@ -501,7 +499,7 @@ class Multinomial(Discrete):
     """
 
     def __init__(self, n, p, *args, **kwargs):
-        super(Multinomial, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         p = p / tt.sum(p, axis=-1, keepdims=True)
         n = np.squeeze(n) # works also if n is a tensor
@@ -742,7 +740,7 @@ class Wishart(Continuous):
     """
 
     def __init__(self, nu, V, *args, **kwargs):
-        super(Wishart, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         warnings.warn('The Wishart distribution can currently not be used '
                       'for MCMC sampling. The probability of sampling a '
                       'symmetric matrix is basically zero. Instead, please '
@@ -1017,7 +1015,7 @@ class LKJCholeskyCov(Continuous):
 
         kwargs['shape'] = shape
         kwargs['transform'] = transform
-        super(LKJCholeskyCov, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.sd_dist = sd_dist
         self.diag_idxs = transform.diag_idxs
@@ -1120,8 +1118,7 @@ class LKJCorr(Continuous):
         if transform == 'interval':
             transform = transforms.interval(-1, 1)
 
-        super(LKJCorr, self).__init__(shape=shape, transform=transform,
-                                      *args, **kwargs)
+        super().__init__(shape=shape, transform=transform, *args, **kwargs)
         warnings.warn('Parameters in LKJCorr have been rename: shape parameter n -> eta '
                       'dimension parameter p -> n. Please double check your initialization.',
                       DeprecationWarning)
@@ -1270,7 +1267,7 @@ class MatrixNormal(Continuous):
             raise TypeError('shape is a required argument')
         assert len(shape) == 2, "shape must have length 2: mxn"
         self.shape = shape
-        super(MatrixNormal, self).__init__(shape=shape, *args, **kwargs)
+        super().__init__(shape=shape, *args, **kwargs)
         self.mu = tt.as_tensor_variable(mu)
         self.mean = self.median = self.mode = self.mu
         self.solve_lower = tt.slinalg.solve_lower_triangular
@@ -1485,7 +1482,7 @@ class KroneckerNormal(Continuous):
     def __init__(self, mu, covs=None, chols=None, evds=None, sigma=None,
                  *args, **kwargs):
         self._setup(covs, chols, evds, sigma)
-        super(KroneckerNormal, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.mu = tt.as_tensor_variable(mu)
         self.mean = self.median = self.mode = self.mu
 

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -31,7 +31,7 @@ class AR1(distribution.Continuous):
     """
 
     def __init__(self, k, tau_e, *args, **kwargs):
-        super(AR1, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.k = k = tt.as_tensor_variable(k)
         self.tau_e = tau_e = tt.as_tensor_variable(tau_e)
         self.tau = tau_e * (1 - k ** 2)
@@ -93,7 +93,7 @@ class AR(distribution.Continuous):
                  constant=False, init=Flat.dist(),
                  *args, **kwargs):
 
-        super(AR, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         tau, sd = get_tau_sd(tau=tau, sd=sd)
         self.sd = tt.as_tensor_variable(sd)
         self.tau = tt.as_tensor_variable(tau)
@@ -157,7 +157,7 @@ class GaussianRandomWalk(distribution.Continuous):
 
     def __init__(self, tau=None, init=Flat.dist(), sd=None, mu=0.,
                  *args, **kwargs):
-        super(GaussianRandomWalk, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         tau, sd = get_tau_sd(tau=tau, sd=sd)
         self.tau = tau = tt.as_tensor_variable(tau)
         self.sd = sd = tt.as_tensor_variable(sd)
@@ -214,7 +214,7 @@ class GARCH11(distribution.Continuous):
 
     def __init__(self, omega, alpha_1, beta_1,
                  initial_vol, *args, **kwargs):
-        super(GARCH11, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.omega = omega = tt.as_tensor_variable(omega)
         self.alpha_1 = alpha_1 = tt.as_tensor_variable(alpha_1)
@@ -267,7 +267,7 @@ class EulerMaruyama(distribution.Continuous):
         parameters of the SDE, passed as *args to sde_fn
     """
     def __init__(self, dt, sde_fn, sde_pars, *args, **kwds):
-        super(EulerMaruyama, self).__init__(*args, **kwds)
+        super().__init__(*args, **kwds)
         self.dt = dt = tt.as_tensor_variable(dt)
         self.sde_fn = sde_fn
         self.sde_pars = sde_pars
@@ -313,7 +313,7 @@ class MvGaussianRandomWalk(distribution.Continuous):
     """
     def __init__(self, mu=0., cov=None, tau=None, chol=None, lower=True, init=Flat.dist(),
                  *args, **kwargs):
-        super(MvGaussianRandomWalk, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.init = init
         self.innovArgs = (mu, cov, tau, chol, lower)
@@ -356,7 +356,7 @@ class MvStudentTRandomWalk(MvGaussianRandomWalk):
         distribution for initial value (Defaults to Flat())
     """
     def __init__(self, nu, *args, **kwargs):
-        super(MvStudentTRandomWalk, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.nu = tt.as_tensor_variable(nu)
         self.innov = multivariate.MvStudentT.dist(self.nu, *self.innovArgs)
 

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -14,7 +14,7 @@ __all__ = ['transform', 'stick_breaking', 'logodds', 'interval', 'log_exp_m1',
            't_stick_breaking']
 
 
-class Transform(object):
+class Transform:
     """A transformation of a random variable from one space into another.
 
     Attributes

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -125,9 +125,7 @@ class TransformedDistribution(distribution.Distribution):
         v = forward(FreeRV(name='v', distribution=dist))
         self.type = v.type
 
-        super(TransformedDistribution, self).__init__(
-            v.shape.tag.test_value, v.dtype,
-            testval, dist.defaults, *args, **kwargs)
+        super().__init__(v.shape.tag.test_value, v.dtype, testval, dist.defaults, *args, **kwargs)
 
         if transform.name == 'stickbreaking':
             b = np.hstack(((np.atleast_1d(self.shape) == 1)[:-1], False))

--- a/pymc3/glm/families.py
+++ b/pymc3/glm/families.py
@@ -14,7 +14,7 @@ __all__ = ['Normal', 'StudentT', 'Binomial', 'Poisson', 'NegativeBinomial']
 # it as a method.
 
 
-class Identity():
+class Identity:
 
     def __call__(self, x):
         return x
@@ -25,7 +25,7 @@ inverse = tt.inv
 exp = tt.exp
 
 
-class Family(object):
+class Family:
     """Base class for Family of likelihood distribution and link functions.
     """
     priors = {}

--- a/pymc3/glm/linear.py
+++ b/pymc3/glm/linear.py
@@ -37,7 +37,7 @@ class LinearComponent(Model):
 
     def __init__(self, x, y, intercept=True, labels=None,
                  priors=None, vars=None, name='', model=None, offset=0.):
-        super(LinearComponent, self).__init__(name, model)
+        super().__init__(name, model)
         if priors is None:
             priors = {}
         if vars is None:
@@ -118,9 +118,9 @@ class GLM(LinearComponent):
     def __init__(self, x, y, intercept=True, labels=None,
                  priors=None, vars=None, family='normal', name='',
                  model=None, offset=0.):
-        super(GLM, self).__init__(
+        super().__init__(
             x, y, intercept=intercept, labels=labels,
-            priors=priors, vars=vars, name=name, 
+            priors=priors, vars=vars, name=name,
             model=model, offset=offset
         )
 

--- a/pymc3/glm/utils.py
+++ b/pymc3/glm/utils.py
@@ -1,4 +1,3 @@
-import six
 import pandas as pd
 import numpy as np
 import theano.tensor as tt
@@ -27,7 +26,7 @@ def any_to_tensor_and_labels(x, labels=None):
     -------
     (x, labels) - tensor and labels for its columns
     """
-    if isinstance(labels, six.string_types):
+    if isinstance(labels, str):
         labels = [labels]
     # pandas.DataFrame
     # labels can come from here

--- a/pymc3/gp/cov.py
+++ b/pymc3/gp/cov.py
@@ -21,7 +21,7 @@ __all__ = ['Constant',
            'Kron']
 
 
-class Covariance(object):
+class Covariance:
     R"""
     Base class for all kernels/covariance functions.
 

--- a/pymc3/gp/cov.py
+++ b/pymc3/gp/cov.py
@@ -105,7 +105,7 @@ class Combination(Covariance):
     def __init__(self, factor_list):
         input_dim = max([factor.input_dim for factor in factor_list
                              if isinstance(factor, Covariance)])
-        super(Combination, self).__init__(input_dim=input_dim)
+        super().__init__(input_dim=input_dim)
         self.factor_list = []
         for factor in factor_list:
             if isinstance(factor, self.__class__):
@@ -165,7 +165,7 @@ class Kron(Covariance):
     def __init__(self, factor_list):
         self.input_dims = [factor.input_dim for factor in factor_list]
         input_dim = sum(self.input_dims)
-        super(Kron, self).__init__(input_dim=input_dim)
+        super().__init__(input_dim=input_dim)
         self.factor_list = factor_list
 
     def _split(self, X, Xs):
@@ -194,7 +194,7 @@ class Constant(Covariance):
     """
 
     def __init__(self, c):
-        super(Constant, self).__init__(1, None)
+        super().__init__(1, None)
         self.c = c
 
     def diag(self, X):
@@ -217,7 +217,7 @@ class WhiteNoise(Covariance):
     """
 
     def __init__(self, sigma):
-        super(WhiteNoise, self).__init__(1, None)
+        super().__init__(1, None)
         self.sigma = sigma
 
     def diag(self, X):
@@ -242,7 +242,7 @@ class Stationary(Covariance):
     """
 
     def __init__(self, input_dim, ls=None, ls_inv=None, active_dims=None):
-        super(Stationary, self).__init__(input_dim, active_dims)
+        super().__init__(input_dim, active_dims)
         if (ls is None and ls_inv is None) or (ls is not None and ls_inv is not None):
             raise ValueError("Only one of 'ls' or 'ls_inv' must be provided")
         elif ls_inv is not None:
@@ -285,7 +285,7 @@ class Periodic(Stationary):
     """
 
     def __init__(self, input_dim, period, ls=None, ls_inv=None, active_dims=None):
-        super(Periodic, self).__init__(input_dim, ls, ls_inv, active_dims)
+        super().__init__(input_dim, ls, ls_inv, active_dims)
         self.period = period
     def full(self, X, Xs=None):
         X, Xs = self._slice(X, Xs)
@@ -323,7 +323,7 @@ class RatQuad(Stationary):
     """
 
     def __init__(self, input_dim, alpha, ls=None, ls_inv=None, active_dims=None):
-        super(RatQuad, self).__init__(input_dim, ls, ls_inv, active_dims)
+        super().__init__(input_dim, ls, ls_inv, active_dims)
         self.alpha = alpha
 
     def full(self, X, Xs=None):
@@ -402,7 +402,7 @@ class Linear(Covariance):
     """
 
     def __init__(self, input_dim, c, active_dims=None):
-        super(Linear, self).__init__(input_dim, active_dims)
+        super().__init__(input_dim, active_dims)
         self.c = c
 
     def _common(self, X, Xs=None):
@@ -432,16 +432,16 @@ class Polynomial(Linear):
     """
 
     def __init__(self, input_dim, c, d, offset, active_dims=None):
-        super(Polynomial, self).__init__(input_dim, c, active_dims)
+        super().__init__(input_dim, c, active_dims)
         self.d = d
         self.offset = offset
 
     def full(self, X, Xs=None):
-        linear = super(Polynomial, self).full(X, Xs)
+        linear = super().full(X, Xs)
         return tt.power(linear + self.offset, self.d)
 
     def diag(self, X):
-        linear = super(Polynomial, self).diag(X)
+        linear = super().diag(X)
         return tt.power(linear + self.offset, self.d)
 
 
@@ -464,7 +464,7 @@ class WarpedInput(Covariance):
 
     def __init__(self, input_dim, cov_func, warp_func, args=None,
                  active_dims=None):
-        super(WarpedInput, self).__init__(input_dim, active_dims)
+        super().__init__(input_dim, active_dims)
         if not callable(warp_func):
             raise TypeError("warp_func must be callable")
         if not isinstance(cov_func, Covariance):
@@ -505,7 +505,7 @@ class Gibbs(Covariance):
 
     def __init__(self, input_dim, lengthscale_func, args=None,
                  active_dims=None):
-        super(Gibbs, self).__init__(input_dim, active_dims)
+        super().__init__(input_dim, active_dims)
         if active_dims is not None:
             if len(active_dims) > 1:
                 raise NotImplementedError(("Higher dimensional inputs ",
@@ -567,7 +567,7 @@ class ScaledCov(Covariance):
         Additional inputs (besides X or Xs) to lengthscale_func.
     """
     def __init__(self, input_dim, cov_func, scaling_func, args=None, active_dims=None):
-        super(ScaledCov, self).__init__(input_dim, active_dims)
+        super().__init__(input_dim, active_dims)
         if not callable(scaling_func):
             raise TypeError("scaling_func must be callable")
         if not isinstance(cov_func, Covariance):
@@ -626,7 +626,7 @@ class Coregion(Covariance):
     """
 
     def __init__(self, input_dim, W=None, kappa=None, B=None, active_dims=None):
-        super(Coregion, self).__init__(input_dim, active_dims)
+        super().__init__(input_dim, active_dims)
         if len(self.active_dims) != 1:
             raise ValueError('Coregion requires exactly one dimension to be active')
         make_B = W is not None or kappa is not None

--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -17,7 +17,7 @@ from ..math import (cartesian, kron_dot, kron_diag,
 __all__ = ['Latent', 'Marginal', 'TP', 'MarginalSparse', 'LatentKron', 'MarginalKron']
 
 
-class Base(object):
+class Base:
     R"""
     Base class.
     """

--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -104,7 +104,7 @@ class Latent(Base):
     """
 
     def __init__(self, mean_func=Zero(), cov_func=Constant(0.0)):
-        super(Latent, self).__init__(mean_func, cov_func)
+        super().__init__(mean_func, cov_func)
 
     def _build_prior(self, name, X, reparameterize=True, **kwargs):
         mu = self.mean_func(X)
@@ -242,7 +242,7 @@ class TP(Latent):
         if nu is None:
             raise ValueError("Student's T process requires a degrees of freedom parameter, 'nu'")
         self.nu = nu
-        super(TP, self).__init__(mean_func, cov_func)
+        super().__init__(mean_func, cov_func)
 
     def __add__(self, other):
         raise TypeError("Student's T processes aren't additive")
@@ -373,7 +373,7 @@ class Marginal(Base):
     """
 
     def __init__(self, mean_func=Zero(), cov_func=Constant(0.0)):
-        super(Marginal, self).__init__(mean_func, cov_func)
+        super().__init__(mean_func, cov_func)
 
     def _build_marginal_likelihood(self, X, noise):
         mu = self.mean_func(X)
@@ -626,11 +626,11 @@ class MarginalSparse(Marginal):
         if approx not in self._available_approx:
             raise NotImplementedError(approx)
         self.approx = approx
-        super(MarginalSparse, self).__init__(mean_func, cov_func)
+        super().__init__(mean_func, cov_func)
 
     def __add__(self, other):
         # new_gp will default to FITC approx
-        new_gp = super(MarginalSparse, self).__add__(other)
+        new_gp = super().__add__(other)
         # make sure new gp has correct approx
         if not self.approx == other.approx:
             raise TypeError("Cannot add GPs with different approximations")
@@ -858,7 +858,7 @@ class LatentKron(Base):
         except TypeError:
             self.cov_funcs = [cov_funcs]
         cov_func = pm.gp.cov.Kron(self.cov_funcs)
-        super(LatentKron, self).__init__(mean_func, cov_func)
+        super().__init__(mean_func, cov_func)
 
     def __add__(self, other):
         raise TypeError('Additive, Kronecker-structured processes not implemented')
@@ -1014,7 +1014,7 @@ class MarginalKron(Base):
         except TypeError:
             self.cov_funcs = [cov_funcs]
         cov_func = pm.gp.cov.Kron(self.cov_funcs)
-        super(MarginalKron, self).__init__(mean_func, cov_func)
+        super().__init__(mean_func, cov_func)
 
     def __add__(self, other):
         raise TypeError('Additive, Kronecker-structured processes not implemented')

--- a/pymc3/gp/mean.py
+++ b/pymc3/gp/mean.py
@@ -3,7 +3,7 @@ import theano.tensor as tt
 __all__ = ['Zero', 'Constant', 'Linear']
 
 
-class Mean(object):
+class Mean:
     R"""
     Base class for mean functions
     """

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import sys
 import theano.tensor as tt
 # pylint: disable=unused-import

--- a/pymc3/memoize.py
+++ b/pymc3/memoize.py
@@ -46,7 +46,7 @@ def clear_cache(obj=None):
             obj.cache.clear()
 
 
-class WithMemoization(object):
+class WithMemoization:
     def __hash__(self):
         return hash(id(self))
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -196,7 +196,7 @@ class Factor:
     associated with them.
     """
     def __init__(self, *args, **kwargs):
-        super(Factor, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @property
     def logp(self):
@@ -304,7 +304,7 @@ class treelist(list):
     Extending treelist you will also extend its parent
     """
     def __init__(self, iterable=(), parent=None):
-        super(treelist, self).__init__(iterable)
+        super().__init__(iterable)
         assert isinstance(parent, list) or parent is None
         self.parent = parent
         if self.parent is not None:
@@ -342,7 +342,7 @@ class treedict(dict):
     Extending treedict you will also extend its parent
     """
     def __init__(self, iterable=(), parent=None, **kwargs):
-        super(treedict, self).__init__(iterable, **kwargs)
+        super().__init__(iterable, **kwargs)
         assert isinstance(parent, dict) or parent is None
         self.parent = parent
         if self.parent is not None:
@@ -568,7 +568,7 @@ class Model(Context, Factor, WithMemoization, metaclass=InitContextMeta):
                 # 2) call super's init first, passing model and name
                 # to it name will be prefix for all variables here if
                 # no name specified for model there will be no prefix
-                super(CustomModel, self).__init__(name, model)
+                super().__init__(name, model)
                 # now you are in the context of instance,
                 # `modelcontext` will return self you can define
                 # variables in several ways note, that all variables
@@ -620,7 +620,7 @@ class Model(Context, Factor, WithMemoization, metaclass=InitContextMeta):
     """
     def __new__(cls, *args, **kwargs):
         # resolves the parent instance
-        instance = super(Model, cls).__new__(cls)
+        instance = super().__new__(cls)
         if kwargs.get('model') is not None:
             instance._parent = kwargs.get('model')
         elif cls.get_contexts():
@@ -1197,7 +1197,7 @@ class FreeRV(Factor, TensorVariable):
         """
         if type is None:
             type = distribution.type
-        super(FreeRV, self).__init__(type, owner, index, name)
+        super().__init__(type, owner, index, name)
 
         if distribution is not None:
             self.dshape = tuple(distribution.shape)
@@ -1314,7 +1314,7 @@ class ObservedRV(Factor, TensorVariable):
 
         self.observations = data
 
-        super(ObservedRV, self).__init__(type, owner, index, name)
+        super().__init__(type, owner, index, name)
 
         if distribution is not None:
             data = as_tensor(data, name, model, distribution)
@@ -1475,7 +1475,7 @@ class TransformedRV(TensorVariable):
                  total_size=None):
         if type is None:
             type = distribution.type
-        super(TransformedRV, self).__init__(type, owner, index, name)
+        super().__init__(type, owner, index, name)
 
         self.transformation = transform
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -119,7 +119,7 @@ def _get_named_nodes_and_relations(graph, parent, leaf_nodes,
                 try:
                     node_parents[graph].add(parent)
                 except KeyError:
-                    node_parents[graph] = set([parent])
+                    node_parents[graph] = {parent}
                 node_children[parent].add(graph)
             # Flag that the leaf node has no children
             node_children[graph] = set()
@@ -129,7 +129,7 @@ def _get_named_nodes_and_relations(graph, parent, leaf_nodes,
                 try:
                     node_parents[graph].add(parent)
                 except KeyError:
-                    node_parents[graph] = set([parent])
+                    node_parents[graph] = {parent}
                 node_children[parent].add(graph)
             # The current node will be set as the parent of the next
             # nodes only if it is a named node

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -28,7 +28,7 @@ __all__ = [
 FlatView = collections.namedtuple('FlatView', 'input, replacements, view')
 
 
-class InstanceMethod(object):
+class InstanceMethod:
     """Class for hiding references to instance methods so they can be pickled.
 
     >>> self.method = InstanceMethod(some_object, 'method_name')
@@ -146,7 +146,7 @@ def _get_named_nodes_and_relations(graph, parent, leaf_nodes,
     return leaf_nodes, node_parents, node_children
 
 
-class Context(object):
+class Context:
     """Functionality for objects that put themselves in a context using
     the `with` statement.
     """
@@ -191,7 +191,7 @@ def modelcontext(model):
     return model
 
 
-class Factor(object):
+class Factor:
     """Common functionality for objects with a log probability density
     associated with them.
     """
@@ -363,7 +363,7 @@ class treedict(dict):
             return dict.__contains__(self, item)
 
 
-class ValueGradFunction(object):
+class ValueGradFunction:
     """Create a theano function that computes a value and its gradient.
 
     Parameters
@@ -530,7 +530,7 @@ class ValueGradFunction(object):
         return args_joined, theano.clone(cost, replace=replace)
 
 
-class Model(Context, Factor, WithMemoization, meta=InitContextMeta):
+class Model(Context, Factor, WithMemoization, metaclass=InitContextMeta):
     """Encapsulates the variables and likelihood factors of a model.
 
     Model class can be used for creating class based models. To create
@@ -1097,7 +1097,7 @@ def Point(*args, **kwargs):
                 if str(k) in map(str, model.vars))
 
 
-class FastPointFunc(object):
+class FastPointFunc:
     """Wraps so a function so it takes a dict of arguments instead of arguments."""
 
     def __init__(self, f):
@@ -1107,7 +1107,7 @@ class FastPointFunc(object):
         return self.f(**state)
 
 
-class LoosePointFunc(object):
+class LoosePointFunc:
     """Wraps so a function so it takes a dict of arguments instead of arguments
     but can still take arguments."""
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -2,7 +2,6 @@ import collections
 import functools
 import itertools
 import threading
-import six
 import warnings
 
 import numpy as np
@@ -531,7 +530,7 @@ class ValueGradFunction(object):
         return args_joined, theano.clone(cost, replace=replace)
 
 
-class Model(six.with_metaclass(InitContextMeta, Context, Factor, WithMemoization)):
+class Model(Context, Factor, WithMemoization, meta=InitContextMeta):
     """Encapsulates the variables and likelihood factors of a model.
 
     Model class can be used for creating class based models. To create

--- a/pymc3/model_graph.py
+++ b/pymc3/model_graph.py
@@ -17,7 +17,7 @@ def powerset(iterable):
     return itertools.chain.from_iterable(itertools.combinations(s, r) for r in range(1, len(s)+1))
 
 
-class ModelGraph(object):
+class ModelGraph:
     def __init__(self, model):
         self.model = model
         self.var_names = get_default_varnames(self.model.named_vars, include_transformed=False)

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -7,7 +7,6 @@ from collections import namedtuple
 import traceback
 from pymc3.exceptions import SamplingError
 
-import six
 import numpy as np
 
 from . import theanof
@@ -246,7 +245,7 @@ class ProcessAdapter(object):
                 error = ParallelSamplingError(str(old_error), proc.chain, warns)
             else:
                 error = RuntimeError("Chain %s failed." % proc.chain)
-            six.raise_from(error, old_error)
+            raise error from old_error
         elif msg[0] == "writing_done":
             proc._readable = True
             proc._num_samples += 1

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("pymc3")
 
 class ParallelSamplingError(Exception):
     def __init__(self, message, chain, warnings=None):
-        super(ParallelSamplingError, self).__init__(message)
+        super().__init__(message)
         if warnings is None:
             warnings = []
         self._chain = chain
@@ -64,7 +64,7 @@ class _Process(multiprocessing.Process):
     """
 
     def __init__(self, name, msg_pipe, step_method, shared_point, draws, tune, seed):
-        super(_Process, self).__init__(daemon=True, name=name)
+        super().__init__(daemon=True, name=name)
         self._msg_pipe = msg_pipe
         self._step_method = step_method
         self._shared_point = shared_point

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -163,7 +163,7 @@ class _Process(multiprocessing.Process):
             return []
 
 
-class ProcessAdapter(object):
+class ProcessAdapter:
     """Control a Chain process from the main thread."""
 
     def __init__(self, draws, tune, step_method, chain, seed, start):
@@ -284,7 +284,7 @@ Draw = namedtuple(
 )
 
 
-class ParallelSampler(object):
+class ParallelSampler:
     def __init__(
         self,
         draws,

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -722,7 +722,7 @@ class PopulationStepper:
             else:
                 _log.info('Chains are not parallelized. You can enable this by passing '
                           'pm.sample(parallelize=True).')
-        return super(PopulationStepper, self).__init__()
+        return super().__init__()
 
     def __enter__(self):
         """Does nothing because processes are already started in __init__."""

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -666,7 +666,7 @@ def _iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
             strace._add_warnings(warns)
 
 
-class PopulationStepper(object):
+class PopulationStepper:
     def __init__(self, steppers, parallelize):
         """Tries to use multiprocessing to parallelize chains.
 

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -4,7 +4,6 @@ import pickle
 import logging
 import warnings
 
-from six import integer_types
 from joblib import Parallel, delayed
 import numpy as np
 import theano.gradient as tg
@@ -347,9 +346,9 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None, trace=N
             start = [start] * chains
         if random_seed == -1:
             random_seed = None
-        if chains == 1 and isinstance(random_seed, integer_types):
+        if chains == 1 and isinstance(random_seed, int):
             random_seed = [random_seed]
-        if random_seed is None or isinstance(random_seed, integer_types):
+        if random_seed is None or isinstance(random_seed, int):
             if random_seed is not None:
                 np.random.seed(random_seed)
             random_seed = [np.random.randint(2 ** 30) for _ in range(chains)]

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -4,7 +4,6 @@ import pickle
 import logging
 import warnings
 
-from joblib import Parallel, delayed
 import numpy as np
 import theano.gradient as tg
 

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -190,7 +190,7 @@ def _cpu_count():
 def sample(draws=500, step=None, init='auto', n_init=200000, start=None, trace=None, chain_idx=0,
            chains=None, cores=None, tune=500, nuts_kwargs=None, step_kwargs=None, progressbar=True,
            model=None, random_seed=None, live_plot=False, discard_tuned_samples=True,
-           live_plot_kwargs=None, compute_convergence_checks=True, use_mmap=False, **kwargs):
+           live_plot_kwargs=None, compute_convergence_checks=True, **kwargs):
     """Draw samples from the posterior using the given step methods.
 
     Multiple step methods are supported via compound step methods.
@@ -288,9 +288,6 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None, trace=N
     compute_convergence_checks : bool, default=True
         Whether to compute sampler statistics like gelman-rubin and effective_n.
         Ignored when using 'SMC'
-    use_mmap : bool, default=False
-        Whether to use joblib's memory mapping to share numpy arrays when sampling across multiple
-        cores. Ignored when using 'SMC'
 
     Returns
     -------
@@ -422,8 +419,7 @@ def sample(draws=500, step=None, init='auto', n_init=200000, start=None, trace=N
                        'random_seed': random_seed,
                        'live_plot': live_plot,
                        'live_plot_kwargs': live_plot_kwargs,
-                       'cores': cores,
-                       'use_mmap': use_mmap}
+                       'cores': cores,}
 
         sample_args.update(kwargs)
 
@@ -950,8 +946,7 @@ def _choose_backend(trace, chain, shortcuts=None, **kwds):
 
 
 def _mp_sample(draws, tune, step, chains, cores, chain, random_seed,
-               start, progressbar, trace=None, model=None, use_mmap=False,
-               **kwargs):
+               start, progressbar, trace=None, model=None, **kwargs):
 
     import pymc3.parallel_sampling as ps
     # We did draws += tune in pm.sample

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -59,7 +59,7 @@ class BlockedStep:
             # and append them to a CompoundStep
             steps = []
             for var in vars:
-                step = super(BlockedStep, cls).__new__(cls)
+                step = super().__new__(cls)
                 # If we don't return the instance we have to manually
                 # call __init__
                 step.__init__([var], *args, **kwargs)
@@ -69,7 +69,7 @@ class BlockedStep:
 
             return CompoundStep(steps)
         else:
-            step = super(BlockedStep, cls).__new__(cls)
+            step = super().__new__(cls)
             # Hack for creating the class correctly when unpickling.
             step.__newargs = (vars, ) + args, kwargs
             return step
@@ -197,7 +197,7 @@ class PopulationArrayStepShared(ArrayStepShared):
         self.population = None
         self.this_chain = None
         self.other_chains = None
-        return super(PopulationArrayStepShared, self).__init__(vars, shared, blocked)
+        return super().__init__(vars, shared, blocked)
 
     def link_population(self, population, chain_index):
         """Links the sampler to the population.

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -25,7 +25,7 @@ class Competence(IntEnum):
     IDEAL = 3
 
 
-class BlockedStep(object):
+class BlockedStep:
 
     generates_stats = False
 

--- a/pymc3/step_methods/compound.py
+++ b/pymc3/step_methods/compound.py
@@ -6,7 +6,7 @@ Created on Mar 7, 2011
 import numpy as np
 
 
-class CompoundStep(object):
+class CompoundStep:
     """Step method composed of a list of several other step
     methods applied in sequence."""
 

--- a/pymc3/step_methods/elliptical_slice.py
+++ b/pymc3/step_methods/elliptical_slice.py
@@ -79,7 +79,7 @@ class EllipticalSlice(ArrayStep):
             vars = self.model.cont_vars
         vars = inputvars(vars)
 
-        super(EllipticalSlice, self).__init__(vars, [self.model.fastlogp], **kwargs)
+        super().__init__(vars, [self.model.fastlogp], **kwargs)
 
     def astep(self, q0, logp):
         """q0 : current state

--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -36,8 +36,7 @@ class ElemwiseCategorical(ArrayStep):
         else:
             self.values = values
 
-        super(ElemwiseCategorical, self).__init__(
-            vars, [elemwise_logp(model, self.var)])
+        super().__init__(vars, [elemwise_logp(model, self.var)])
 
     def astep(self, q, logp):
         p = array([logp(v * self.sh) for v in self.values])

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -71,9 +71,7 @@ class BaseHMC(arraystep.GradientSharedStep):
             vars = self._model.cont_vars
         vars = inputvars(vars)
 
-        super(BaseHMC, self).__init__(
-            vars, blocked=blocked, model=model, dtype=dtype, **theano_kwargs
-        )
+        super().__init__(vars, blocked=blocked, model=model, dtype=dtype, **theano_kwargs)
 
         self.adapt_step_size = adapt_step_size
         self.Emax = Emax

--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -85,7 +85,7 @@ class HamiltonianMC(BaseHMC):
             The model
         **kwargs : passed to BaseHMC
         """
-        super(HamiltonianMC, self).__init__(vars, **kwargs)
+        super().__init__(vars, **kwargs)
         self.path_length = path_length
 
     def _hamiltonian_step(self, start, p0, step_size):

--- a/pymc3/step_methods/hmc/integration.py
+++ b/pymc3/step_methods/hmc/integration.py
@@ -11,7 +11,7 @@ class IntegrationError(RuntimeError):
     pass
 
 
-class CpuLeapfrogIntegrator(object):
+class CpuLeapfrogIntegrator:
     def __init__(self, potential, logp_dlogp_func):
         """Leapfrog integrator using CPU."""
         self._potential = potential

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from collections import namedtuple
 
 import numpy as np

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -209,7 +209,7 @@ Subtree = namedtuple(
     "left, right, p_sum, proposal, log_size, accept_sum, n_proposals")
 
 
-class _Tree(object):
+class _Tree:
     def __init__(self, ndim, integrator, start, step_size, Emax):
         """Binary tree from the NUTS algorithm.
 

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -151,7 +151,7 @@ class NUTS(BaseHMC):
         This is usually achieved by setting the `tune` parameter if
         `pm.sample` to the desired number of tuning steps.
         """
-        super(NUTS, self).__init__(vars, **kwargs)
+        super().__init__(vars, **kwargs)
 
         self.max_treedepth = max_treedepth
         self.early_max_treedepth = early_max_treedepth
@@ -187,7 +187,7 @@ class NUTS(BaseHMC):
         return Competence.INCOMPATIBLE
 
     def warnings(self):
-        warnings = super(NUTS, self).warnings()
+        warnings = super().warnings()
         n_samples = self._samples_after_tune
         n_treedepth = self._reached_max_treedepth
 

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -72,7 +72,7 @@ class PositiveDefiniteError(ValueError):
                 % (self.msg, self.idx))
 
 
-class QuadPotential(object):
+class QuadPotential:
     def velocity(self, x, out=None):
         """Compute the current velocity at a position in parameter space."""
         raise NotImplementedError('Abstract method')
@@ -286,7 +286,7 @@ class QuadPotentialDiagAdaptGrad(QuadPotentialDiagAdapt):
             self._grads2[:] = 1
 
 
-class _WeightedVariance(object):
+class _WeightedVariance:
     """Online algorithm for computing mean of variance."""
 
     def __init__(self, nelem, initial_mean=None, initial_variance=None,

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -63,7 +63,7 @@ def partial_check_positive_definite(C):
 
 class PositiveDefiniteError(ValueError):
     def __init__(self, msg, idx):
-        super(PositiveDefiniteError, self).__init__(msg)
+        super().__init__(msg)
         self.idx = idx
         self.msg = msg
 
@@ -252,7 +252,7 @@ class QuadPotentialDiagAdaptGrad(QuadPotentialDiagAdapt):
     """
 
     def __init__(self, *args, **kwargs):
-        super(QuadPotentialDiagAdaptGrad, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._grads1 = np.zeros(self._n, dtype=self.dtype)
         self._ngrads1 = 0
         self._grads2 = np.zeros(self._n, dtype=self.dtype)

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -134,7 +134,7 @@ class Metropolis(ArrayStepShared):
 
         shared = pm.make_shared_replacements(vars, model)
         self.delta_logp = delta_logp(model.logpt, vars, shared)
-        super(Metropolis, self).__init__(vars, shared)
+        super().__init__(vars, shared)
 
     def astep(self, q0):
         if not self.steps_until_tune and self.tune:
@@ -256,7 +256,7 @@ class BinaryMetropolis(ArrayStep):
             raise ValueError(
                 'All variables must be Bernoulli for BinaryMetropolis')
 
-        super(BinaryMetropolis, self).__init__(vars, [model.fastlogp])
+        super().__init__(vars, [model.fastlogp])
 
     def astep(self, q0, logp):
 
@@ -337,7 +337,7 @@ class BinaryGibbsMetropolis(ArrayStep):
             raise ValueError(
                 'All variables must be binary for BinaryGibbsMetropolis')
 
-        super(BinaryGibbsMetropolis, self).__init__(vars, [model.fastlogp])
+        super().__init__(vars, [model.fastlogp])
 
     def astep(self, q0, logp):
         order = self.order
@@ -424,7 +424,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
             raise ValueError('Argument \'proposal\' should either be ' +
                     '\'uniform\' or \'proportional\'')
 
-        super(CategoricalGibbsMetropolis, self).__init__(vars, [model.fastlogp])
+        super().__init__(vars, [model.fastlogp])
 
     def astep_unif(self, q0, logp):
         dimcats = self.dimcats
@@ -567,7 +567,7 @@ class DEMetropolis(PopulationArrayStepShared):
 
         shared = pm.make_shared_replacements(vars, model)
         self.delta_logp = delta_logp(model.logpt, vars, shared)
-        super(DEMetropolis, self).__init__(vars, shared)
+        super().__init__(vars, shared)
 
     def astep(self, q0):
         if not self.steps_until_tune and self.tune:

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -16,7 +16,7 @@ __all__ = ['Metropolis', 'DEMetropolis', 'BinaryMetropolis', 'BinaryGibbsMetropo
 # Available proposal distributions for Metropolis
 
 
-class Proposal(object):
+class Proposal:
     def __init__(self, s):
         self.s = s
 

--- a/pymc3/step_methods/sgmcmc.py
+++ b/pymc3/step_methods/sgmcmc.py
@@ -167,7 +167,7 @@ class BaseStochasticGradient(ArrayStepShared):
             self.updates.update(updates)
 
         self._initialize_values()
-        super(BaseStochasticGradient, self).__init__(vars, shared)
+        super().__init__(vars, shared)
 
     def _initialize_values(self):
         """Initializes the parameters for the stochastic gradient minibatch
@@ -212,9 +212,9 @@ class SGFS(BaseStochasticGradient):
     B : np.array
         the pre-conditioner matrix for the fisher scoring step
     step_size_decay : int
-        Step size decay rate. Every `step_size_decay` iteration the step size reduce 
+        Step size decay rate. Every `step_size_decay` iteration the step size reduce
         to the half of the previous step size
- 
+
     References
     ----------
     -   Bayesian Posterior Sampling via Stochastic Gradient Fisher Scoring
@@ -234,7 +234,7 @@ class SGFS(BaseStochasticGradient):
         """
         self.B = B
         self.step_size_decay = step_size_decay
-        super(SGFS, self).__init__(vars, **kwargs)
+        super().__init__(vars, **kwargs)
 
     def _initialize_values(self):
         # Init avg_I
@@ -317,16 +317,16 @@ class SGFS(BaseStochasticGradient):
 class CSG(BaseStochasticGradient):
     R"""
     CSG: ConstantStochasticGradient
-    
+
     It is an approximate stochastic variational inference algorithm
     while SGFS and many other MCMC techniques provably
-    converge towards the exact posterior. The referenced paper 
+    converge towards the exact posterior. The referenced paper
     discusses a proof for the optimal preconditioning matrix
     based on variational inference, so there is no parameter tuning required
     like in the case of 'B' matrix used for preconditioning in SGFS.
-    Take a look at this example notebook 
+    Take a look at this example notebook
     https://github.com/pymc-devs/pymc3/tree/master/docs/source/notebooks/constant_stochastic_gradient.ipynb
-     
+
     Parameters
     ----------
     vars : list
@@ -343,11 +343,11 @@ class CSG(BaseStochasticGradient):
         """
         Parameters
         ----------
-        vars : list 
+        vars : list
             Theano variables, default continuous vars
         kwargs: passed to BaseHMC
         """
-        super(CSG, self).__init__(vars, **kwargs)
+        super().__init__(vars, **kwargs)
 
     def _initialize_values(self):
         # Init avg_C: Noise Covariance Moving Average
@@ -380,7 +380,7 @@ class CSG(BaseStochasticGradient):
         gt_diff = (self.dlogp_elemwise - self.dlogp_elemwise.mean(axis=0))
         V = (1. / (S - 1)) * theano.dot(gt_diff.T, gt_diff)
         C_t = (1. - 1. / t) * avg_C + (1. / t) * V
-        # BB^T = C 
+        # BB^T = C
         B = tt.switch(t < 0, tt.eye(q_size), tt.slinalg.cholesky(C_t))
         # Optimal Preconditioning Matrix
         H = (2. * S / N) * tt.nlinalg.matrix_inverse(C_t)
@@ -395,7 +395,7 @@ class CSG(BaseStochasticGradient):
         # step + noise term
         dq = (step + noise_term).flatten()
 
-        # update time and avg_C 
+        # update time and avg_C
         updates.update({avg_C: C_t, t: t + 1})
 
         f = theano.function(

--- a/pymc3/step_methods/slicer.py
+++ b/pymc3/step_methods/slicer.py
@@ -44,7 +44,7 @@ class Slice(ArrayStep):
             vars = self.model.cont_vars
         vars = inputvars(vars)
 
-        super(Slice, self).__init__(vars, [self.model.fastlogp], **kwargs)
+        super().__init__(vars, [self.model.fastlogp], **kwargs)
 
     def astep(self, q0, logp):
         self.w = np.resize(self.w, len(q0))  # this is a repmat
@@ -101,4 +101,3 @@ class Slice(ArrayStep):
                 return Competence.PREFERRED
             return Competence.COMPATIBLE
         return Competence.INCOMPATIBLE
-       

--- a/pymc3/step_methods/step_sizes.py
+++ b/pymc3/step_methods/step_sizes.py
@@ -4,7 +4,7 @@ from scipy import stats
 from pymc3.backends.report import SamplerWarning, WarningType
 
 
-class DualAverageAdaptation(object):
+class DualAverageAdaptation:
     def __init__(self, initial_step, target, gamma, k, t0):
         self._log_step = np.log(initial_step)
         self._log_bar = self._log_step

--- a/pymc3/tests/backend_fixtures.py
+++ b/pymc3/tests/backend_fixtures.py
@@ -10,7 +10,7 @@ import pytest
 import theano
 
 
-class ModelBackendSetupTestCase(object):
+class ModelBackendSetupTestCase:
     """Set up a backend trace.
 
     Provides the attributes
@@ -69,7 +69,7 @@ class ModelBackendSetupTestCase(object):
             remove_file_or_directory(self.name)
 
 
-class StatsTestCase(object):
+class StatsTestCase:
     """Test for init and setup of backups.
 
     Provides the attributes
@@ -105,7 +105,7 @@ class StatsTestCase(object):
             remove_file_or_directory(self.name)
 
 
-class ModelBackendSampledTestCase(object):
+class ModelBackendSampledTestCase:
     """Setup and sample a backend trace.
 
     Provides the attributes

--- a/pymc3/tests/backend_fixtures.py
+++ b/pymc3/tests/backend_fixtures.py
@@ -435,7 +435,7 @@ class DumpLoadTestCase(ModelBackendSampledTestCase):
     """
     @classmethod
     def setup_class(cls):
-        super(DumpLoadTestCase, cls).setup_class()
+        super().setup_class()
         try:
             with cls.model:
                 cls.dumped = cls.load_func(cls.name)
@@ -479,12 +479,12 @@ class BackendEqualityTestCase(ModelBackendSampledTestCase):
     def setup_class(cls):
         cls.backend = cls.backend0
         cls.name = cls.name0
-        super(BackendEqualityTestCase, cls).setup_class()
+        super().setup_class()
         cls.mtrace0 = cls.mtrace
 
         cls.backend = cls.backend1
         cls.name = cls.name1
-        super(BackendEqualityTestCase, cls).setup_class()
+        super().setup_class()
         cls.mtrace1 = cls.mtrace
 
     @classmethod

--- a/pymc3/tests/helpers.py
+++ b/pymc3/tests/helpers.py
@@ -74,9 +74,9 @@ class Matcher:
         """
         Try to match a single stored value (dv) with a supplied value (v).
         """
-        if type(v) != type(dv):
+        if isinstance(v, type(dv)):
             result = False
-        elif type(dv) is not str or k not in self._partial_matches:
+        elif not isinstance(df, str) or k not in self._partial_matches:
             result = (v == dv)
         else:
             result = dv.find(v) >= 0

--- a/pymc3/tests/helpers.py
+++ b/pymc3/tests/helpers.py
@@ -6,7 +6,7 @@ from ..theanof import set_tt_rng, tt_rng
 import theano
 
 
-class SeededTest(object):
+class SeededTest:
     random_seed = 20160911
 
     @classmethod
@@ -49,7 +49,7 @@ class LoggingHandler(BufferingHandler):
         return result
 
 
-class Matcher(object):
+class Matcher:
 
     _partial_matches = ('msg', 'message')
 

--- a/pymc3/tests/sampler_fixtures.py
+++ b/pymc3/tests/sampler_fixtures.py
@@ -124,7 +124,7 @@ class LKJCholeskyCovFixture(KnownCDF):
 class BaseSampler(SeededTest):
     @classmethod
     def setup_class(cls):
-        super(BaseSampler, cls).setup_class()
+        super().setup_class()
         cls.model = cls.make_model()
         with cls.model:
             cls.step = cls.make_step()

--- a/pymc3/tests/sampler_fixtures.py
+++ b/pymc3/tests/sampler_fixtures.py
@@ -7,21 +7,21 @@ import theano.tensor as tt
 from .helpers import SeededTest
 
 
-class KnownMean(object):
+class KnownMean:
     def test_mean(self):
         for varname, expected in self.means.items():
             samples = self.samples[varname]
             npt.assert_allclose(expected, samples.mean(0), self.rtol, self.atol)
 
 
-class KnownVariance(object):
+class KnownVariance:
     def test_var(self):
         for varname, expected in self.variances.items():
             samples = self.samples[varname]
             npt.assert_allclose(expected, samples.var(0), self.rtol, self.atol)
 
 
-class KnownCDF(object):
+class KnownCDF:
     ks_thin = 5
     alpha = 0.001
 

--- a/pymc3/tests/test_dist_math.py
+++ b/pymc3/tests/test_dist_math.py
@@ -176,7 +176,7 @@ class TestMvNormalLogp():
         tt.grad(g_delta.sum() + g_cov.sum(), [delta, cov])
 
 
-class TestSplineWrapper(object):
+class TestSplineWrapper:
     @theano.configparser.change_flags(compute_test_value="ignore")
     def test_grad(self):
         x = np.linspace(0, 1, 100)
@@ -195,7 +195,7 @@ class TestSplineWrapper(object):
             tt.grad(g_x, [x_var])
 
 
-class TestI0e(object):
+class TestI0e:
     @theano.configparser.change_flags(compute_test_value="ignore")
     def test_grad(self):
         utt.verify_grad(i0e, [0.5])

--- a/pymc3/tests/test_dist_math.py
+++ b/pymc3/tests/test_dist_math.py
@@ -68,7 +68,7 @@ def test_alltrue_shape():
 
 class MultinomialA(Discrete):
     def __init__(self, n, p, *args, **kwargs):
-        super(MultinomialA, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.n = n
         self.p = p
@@ -87,7 +87,7 @@ class MultinomialA(Discrete):
 
 class MultinomialB(Discrete):
     def __init__(self, n, p, *args, **kwargs):
-        super(MultinomialB, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.n = n
         self.p = p

--- a/pymc3/tests/test_distribution_defaults.py
+++ b/pymc3/tests/test_distribution_defaults.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from ..model import Model
 from ..distributions import DiscreteUniform, Continuous
 

--- a/pymc3/tests/test_distribution_defaults.py
+++ b/pymc3/tests/test_distribution_defaults.py
@@ -10,7 +10,7 @@ import pytest
 class DistTest(Continuous):
 
     def __init__(self, a, b, *args, **kwargs):
-        super(DistTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.a = a
         self.b = b
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -55,7 +55,7 @@ def get_lkj_cases():
 LKJ_CASES = get_lkj_cases()
 
 
-class Domain(object):
+class Domain:
     def __init__(self, vals, dtype=None, edges=None, shape=None):
         avals = array(vals, dtype=dtype)
         if dtype is None and not str(avals.dtype).startswith('int'):
@@ -204,7 +204,7 @@ def beta_mu_sd(value, mu, sd):
         return -inf
 
 
-class ProductDomain(object):
+class ProductDomain:
     def __init__(self, domains):
         self.vals = list(itertools.product(*[d.vals for d in domains]))
         self.shape = (len(domains),) + domains[0].shape
@@ -349,14 +349,14 @@ def orderedlogistic_logpdf(value, eta, cutpoints):
     p = invlogit(eta - c[value]) - invlogit(eta - c[value + 1])
     return np.log(p)
 
-class Simplex(object):
+class Simplex:
     def __init__(self, n):
         self.vals = list(simplex_values(n))
         self.shape = (n,)
         self.dtype = Unit.dtype
 
 
-class MultiSimplex(object):
+class MultiSimplex:
     def __init__(self, n_dependent, n_independent):
         self.vals = []
         for simplex_value in itertools.product(simplex_values(n_dependent), repeat=n_independent):
@@ -1276,7 +1276,7 @@ def test_bound():
         BoundPoisson(name="y", mu=1)
 
 
-class TestLatex(object):
+class TestLatex:
 
     def setup_class(self):
         # True parameter values

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1194,11 +1194,7 @@ class TestMatchesScipy(SeededTest):
                     def __init__(self, **kwargs):
                         x_points = np.linspace(xmin, xmax, 100000)
                         pdf_points = sp.norm.pdf(x_points, loc=mu, scale=sd)
-                        super(TestedInterpolated, self).__init__(
-                            x_points=x_points,
-                            pdf_points=pdf_points,
-                            **kwargs
-                        )
+                        super().__init__(x_points=x_points, pdf_points=pdf_points, **kwargs)
 
                 def ref_pdf(value):
                     return np.where(

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import itertools
 import sys
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -336,8 +336,8 @@ def mvt_logpdf(value, nu, Sigma, mu=0):
     return logp.sum()
 
 def AR1_logpdf(value, k, tau_e):
-    return (sp.norm(loc=0,scale=1/np.sqrt(tau_e)).logpdf(value[0]) +
-            sp.norm(loc=k*value[:-1],scale=1/np.sqrt(tau_e)).logpdf(value[1:]).sum())
+    return (sp.norm(loc=0, scale=1/np.sqrt(tau_e)).logpdf(value[0]) +
+            sp.norm(loc=k*value[:-1], scale=1/np.sqrt(tau_e)).logpdf(value[1:]).sum())
 
 def invlogit(x, eps=sys.float_info.epsilon):
     return (1. - 2. * eps) / (1. + np.exp(-x)) + eps
@@ -927,7 +927,7 @@ class TestMatchesScipy(SeededTest):
                                  {'nu': Rplus, 'Sigma': PdMatrix(n), 'mu': Vector(R, n)},
                                  mvt_logpdf)
 
-    @pytest.mark.parametrize('n',[2,3,4])
+    @pytest.mark.parametrize('n', [2, 3, 4])
     def test_AR1(self, n):
         self.pymc3_matches_scipy(AR1, Vector(R, n), {'k': Unit, 'tau_e': Rplus}, AR1_logpdf)
 
@@ -1006,13 +1006,13 @@ class TestMatchesScipy(SeededTest):
 
     def test_multinomial_mode_with_shape(self):
         n = [1, 10]
-        p = np.asarray([[.25,.25,.25,.25], [.26, .26, .26, .22]])
+        p = np.asarray([[.25, .25, .25, .25], [.26, .26, .26, .22]])
         with Model() as model:
             m = Multinomial('m', n=n, p=p, shape=(2, 4))
         assert_allclose(m.distribution.mode.eval().sum(axis=-1), n)
 
     def test_multinomial_vec(self):
-        vals = np.array([[2,4,4], [3,3,4]])
+        vals = np.array([[2, 4, 4], [3, 3, 4]])
         p = np.array([0.2, 0.3, 0.5])
         n = 10
 
@@ -1035,7 +1035,7 @@ class TestMatchesScipy(SeededTest):
                             decimal=4)
 
     def test_multinomial_vec_1d_n(self):
-        vals = np.array([[2,4,4], [4,3,4]])
+        vals = np.array([[2, 4, 4], [4, 3, 4]])
         p = np.array([0.2, 0.3, 0.5])
         ns = np.array([10, 11])
 
@@ -1047,7 +1047,7 @@ class TestMatchesScipy(SeededTest):
                             decimal=4)
 
     def test_multinomial_vec_1d_n_2d_p(self):
-        vals = np.array([[2,4,4], [4,3,4]])
+        vals = np.array([[2, 4, 4], [4, 3, 4]])
         ps = np.array([[0.2, 0.3, 0.5],
                        [0.9, 0.09, 0.01]])
         ns = np.array([10, 11])
@@ -1060,7 +1060,7 @@ class TestMatchesScipy(SeededTest):
                             decimal=4)
 
     def test_multinomial_vec_2d_p(self):
-        vals = np.array([[2,4,4], [3,3,4]])
+        vals = np.array([[2, 4, 4], [3, 3, 4]])
         ps = np.array([[0.2, 0.3, 0.5],
                        [0.3, 0.3, 0.4]])
         n = 10

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import pytest
 import numpy as np
 import numpy.testing as npt

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -116,7 +116,7 @@ class TestDrawValues(SeededTest):
         assert isinstance(tau, np.ndarray)
 
 
-class BaseTestCases(object):
+class BaseTestCases:
     class BaseTestCase(SeededTest):
         shape = 5
 

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -121,7 +121,7 @@ class BaseTestCases:
         shape = 5
 
         def setup_method(self, *args, **kwargs):
-            super(BaseTestCases.BaseTestCase, self).setup_method(*args, **kwargs)
+            super().setup_method(*args, **kwargs)
             self.model = pm.Model()
 
         def get_random_variable(self, shape, with_vector_params=False, name=None):
@@ -399,7 +399,7 @@ class TestCategorical(BaseTestCases.BaseTestCase):
     params = {'p': np.ones(BaseTestCases.BaseTestCase.shape)}
 
     def get_random_variable(self, shape, with_vector_params=False, **kwargs):  # don't transform categories
-        return super(TestCategorical, self).get_random_variable(shape, with_vector_params=False, **kwargs)
+        return super().get_random_variable(shape, with_vector_params=False, **kwargs)
 
     def test_probability_vector_shape(self):
         """Check that if a 2d array of probabilities are passed to categorical correct shape is returned"""
@@ -746,11 +746,7 @@ class TestScalarParameterSamples(SeededTest):
                     def __init__(self, **kwargs):
                         x_points = np.linspace(mu - 5 * sd, mu + 5 * sd, 100)
                         pdf_points = st.norm.pdf(x_points, loc=mu, scale=sd)
-                        super(TestedInterpolated, self).__init__(
-                            x_points=x_points,
-                            pdf_points=pdf_points,
-                            **kwargs
-                        )
+                        super().__init__(x_points=x_points, pdf_points=pdf_points, **kwargs)
 
                 pymc3_random(TestedInterpolated, {}, ref_rand=ref_rand)
 
@@ -780,10 +776,7 @@ class TestScalarParameterSamples(SeededTest):
 
                 def __init__(self, **kwargs):
                     kwargs.pop('shape', None)
-                    super(TestedLKJCorr, self).__init__(
-                            n=n,
-                            **kwargs
-                    )
+                    super().__init__(n=n, **kwargs)
 
             pymc3_random(TestedLKJCorr,
                      {'eta': Domain([1., 10., 100.])},

--- a/pymc3/tests/test_distributions_timeseries.py
+++ b/pymc3/tests/test_distributions_timeseries.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from ..model import Model
 from ..distributions.continuous import Flat, Normal
 from ..distributions.timeseries import EulerMaruyama, AR1, AR, GARCH11

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -33,8 +33,8 @@ def get_city_data():
 class TestARM5_4(SeededTest):
     def build_model(self):
         data = pd.read_csv(pm.get_data('wells.dat'),
-                           delimiter=u' ', index_col=u'id',
-                           dtype={u'switch': np.int8})
+                           delimiter=' ', index_col='id',
+                           dtype={'switch': np.int8})
         data.dist /= 100
         data.educ /= 4
         col = data.columns

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -232,7 +232,7 @@ class TestLatentOccupancy(SeededTest):
     Copyright (c) 2008 University of Otago. All rights reserved.
     """
     def setup_method(self):
-        super(TestLatentOccupancy, self).setup_method()
+        super().setup_method()
         # Sample size
         n = 100
         # True mean count, given occupancy

--- a/pymc3/tests/test_glm.py
+++ b/pymc3/tests/test_glm.py
@@ -16,7 +16,7 @@ def generate_data(intercept, slope, size=700):
 class TestGLM(SeededTest):
     @classmethod
     def setup_class(cls):
-        super(TestGLM, cls).setup_class()
+        super().setup_class()
         cls.intercept = 1
         cls.slope = 3
         cls.sd = .05

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -12,7 +12,7 @@ import pytest
 np.random.seed(101)
 
 
-class TestZeroMean(object):
+class TestZeroMean:
     def test_value(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -22,7 +22,7 @@ class TestZeroMean(object):
         assert M.shape == (10, )
 
 
-class TestConstantMean(object):
+class TestConstantMean:
     def test_value(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -32,7 +32,7 @@ class TestConstantMean(object):
         assert M.shape == (10, )
 
 
-class TestLinearMean(object):
+class TestLinearMean:
     def test_value(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -42,7 +42,7 @@ class TestLinearMean(object):
         assert M.shape == (10, )
 
 
-class TestAddProdMean(object):
+class TestAddProdMean:
     def test_add(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -84,7 +84,7 @@ class TestAddProdMean(object):
         npt.assert_allclose(M[1], 10.8965 * 2 * 2, atol=1e-3)
 
 
-class TestCovAdd(object):
+class TestCovAdd:
     def test_symadd_cov(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -152,7 +152,7 @@ class TestCovAdd(object):
         assert np.allclose(K, K_true)
 
 
-class TestCovProd(object):
+class TestCovProd:
     def test_symprod_cov(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -224,7 +224,7 @@ class TestCovProd(object):
         npt.assert_allclose(np.diag(K2), K1d, atol=1e-5)
 
 
-class TestCovKron(object):
+class TestCovKron:
     def test_symprod_cov(self):
         X1 = np.linspace(0, 1, 10)[:, None]
         X2 = np.linspace(0, 1, 10)[:, None]
@@ -255,7 +255,7 @@ class TestCovKron(object):
         npt.assert_allclose(K_true, K)
 
 
-class TestCovSliceDim(object):
+class TestCovSliceDim:
     def test_slice1(self):
         X = np.linspace(0, 1, 30).reshape(10, 3)
         with pm.Model() as model:
@@ -303,7 +303,7 @@ class TestCovSliceDim(object):
             pm.gp.cov.ExpQuad(2, lengthscales, [True])
 
 
-class TestStability(object):
+class TestStability:
     def test_stable(self):
         X = np.random.uniform(low=320., high=400., size=[2000, 2])
         with pm.Model() as model:
@@ -312,7 +312,7 @@ class TestStability(object):
         assert not np.any(dists < 0)
 
 
-class TestExpQuad(object):
+class TestExpQuad:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -358,7 +358,7 @@ class TestExpQuad(object):
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
-class TestWhiteNoise(object):
+class TestWhiteNoise:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -376,7 +376,7 @@ class TestWhiteNoise(object):
         npt.assert_allclose(K[0, 0], 0.0, atol=1e-3)
 
 
-class TestConstant(object):
+class TestConstant:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -392,7 +392,7 @@ class TestConstant(object):
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
-class TestRatQuad(object):
+class TestRatQuad:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -406,7 +406,7 @@ class TestRatQuad(object):
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
-class TestExponential(object):
+class TestExponential:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -420,7 +420,7 @@ class TestExponential(object):
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
-class TestMatern52(object):
+class TestMatern52:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -434,7 +434,7 @@ class TestMatern52(object):
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
-class TestMatern32(object):
+class TestMatern32:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -448,7 +448,7 @@ class TestMatern32(object):
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
-class TestCosine(object):
+class TestCosine:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -462,7 +462,7 @@ class TestCosine(object):
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
-class TestPeriodic(object):
+class TestPeriodic:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -476,7 +476,7 @@ class TestPeriodic(object):
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
-class TestLinear(object):
+class TestLinear:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -490,7 +490,7 @@ class TestLinear(object):
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
-class TestPolynomial(object):
+class TestPolynomial:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
@@ -504,7 +504,7 @@ class TestPolynomial(object):
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
-class TestWarpedInput(object):
+class TestWarpedInput:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         def warp_func(x, a, b, c):
@@ -528,7 +528,7 @@ class TestWarpedInput(object):
             pm.gp.cov.WarpedInput(1, "str is not Covariance object", lambda x: x)
 
 
-class TestGibbs(object):
+class TestGibbs:
     def test_1d(self):
         X = np.linspace(0, 2, 10)[:, None]
         def tanh_func(x, x1, x2, w, x0):
@@ -552,7 +552,7 @@ class TestGibbs(object):
             pm.gp.cov.Gibbs(3, lambda x: x, active_dims=[0,1])
 
 
-class TestScaledCov(object):
+class TestScaledCov:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         def scaling_func(x, a, b):
@@ -576,7 +576,7 @@ class TestScaledCov(object):
             pm.gp.cov.ScaledCov(1, "str is not Covariance object", lambda x: x)
 
 
-class TestHandleArgs(object):
+class TestHandleArgs:
     def test_handleargs(self):
         def func_noargs(x):
             return x
@@ -595,7 +595,7 @@ class TestHandleArgs(object):
         assert func_twoarg(x, a, b) == func_twoarg2(x, args=(a, b))
 
 
-class TestCoregion(object):
+class TestCoregion:
     def setup_method(self):
         self.nrows = 6
         self.ncols = 3
@@ -663,7 +663,7 @@ class TestCoregion(object):
                 B = pm.gp.cov.Coregion(1)
 
 
-class TestMarginalVsLatent(object):
+class TestMarginalVsLatent:
     R"""
     Compare the logp of models Marginal, noise=0 and Latent.
     """
@@ -707,7 +707,7 @@ class TestMarginalVsLatent(object):
         npt.assert_allclose(latent_logp, self.logp, atol=5)
 
 
-class TestMarginalVsMarginalSparse(object):
+class TestMarginalVsMarginalSparse:
     R"""
     Compare logp of models Marginal and MarginalSparse.
     Should be nearly equal when inducing points are same as inputs.
@@ -767,7 +767,7 @@ class TestMarginalVsMarginalSparse(object):
         npt.assert_allclose(cov1, cov2, atol=0, rtol=1e-3)
 
 
-class TestGPAdditive(object):
+class TestGPAdditive:
     def setup_method(self):
         self.X = np.random.randn(50,3)
         self.y = np.random.randn(50)*0.01
@@ -884,7 +884,7 @@ class TestGPAdditive(object):
                 gp1 + gp2
 
 
-class TestTP(object):
+class TestTP:
     R"""
     Compare TP with high degress of freedom to GP
     """
@@ -935,7 +935,7 @@ class TestTP(object):
                 gp1 + gp2
 
 
-class TestLatentKron(object):
+class TestLatentKron:
     """
     Compare gp.LatentKron to gp.Latent, both with Gaussian noise.
     """
@@ -992,7 +992,7 @@ class TestLatentKron(object):
                               np.linspace(0, 1, 5)[:, None]])
 
 
-class TestMarginalKron(object):
+class TestMarginalKron:
     """
     Compare gp.MarginalKron to gp.Marginal.
     """

--- a/pymc3/tests/test_math.py
+++ b/pymc3/tests/test_math.py
@@ -121,7 +121,7 @@ def test_log1mexp():
 
 class TestLogDet(SeededTest):
     def setup_method(self):
-        super(TestLogDet, self).setup_method()
+        super().setup_method()
         utt.seed_rng()
         self.op_class = LogDet
         self.op = logdet

--- a/pymc3/tests/test_minibatches.py
+++ b/pymc3/tests/test_minibatches.py
@@ -13,7 +13,7 @@ from pymc3.tests.helpers import select_by_precision
 from pymc3.theanof import GeneratorOp
 
 
-class _DataSampler(object):
+class _DataSampler:
     """
     Not for users
     """
@@ -57,7 +57,7 @@ def integers_ndim(ndim):
 
 
 @pytest.mark.usefixtures('strict_float32')
-class TestGenerator(object):
+class TestGenerator:
 
     def test_basic(self):
         generator = GeneratorAdapter(integers())
@@ -148,7 +148,7 @@ def gen2():
         i += 1
 
 
-class TestScaling(object):
+class TestScaling:
     """
     Related to minibatch training
     """
@@ -279,7 +279,7 @@ class TestScaling(object):
 
 
 @pytest.mark.usefixtures('strict_float32')
-class TestMinibatch(object):
+class TestMinibatch:
     data = np.random.rand(30, 10, 40, 10, 50)
 
     def test_1d(self):

--- a/pymc3/tests/test_mixture.py
+++ b/pymc3/tests/test_mixture.py
@@ -27,7 +27,7 @@ def generate_poisson_mixture_data(w, mu, size=1000):
 class TestMixture(SeededTest):
     @classmethod
     def setup_class(cls):
-        super(TestMixture, cls).setup_class()
+        super().setup_class()
 
         cls.norm_w = np.array([0.75, 0.25])
         cls.norm_mu = np.array([0., 5.])

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -13,7 +13,7 @@ from pymc3.model import ValueGradFunction
 
 class NewModel(pm.Model):
     def __init__(self, name='', model=None):
-        super(NewModel, self).__init__(name, model)
+        super().__init__(name, model)
         assert pm.modelcontext(None) is self
         # 1) init variables with Var method
         self.Var('v1', pm.Normal.dist())
@@ -26,7 +26,7 @@ class NewModel(pm.Model):
 
 class DocstringModel(pm.Model):
     def __init__(self, mean=0, sd=1, name='', model=None):
-        super(DocstringModel, self).__init__(name, model)
+        super().__init__(name, model)
         self.Var('v1', Normal.dist(mu=mean, sd=sd))
         Normal('v2', mu=mean, sd=sd)
         Normal('v3', mu=mean, sd=HalfCauchy('sd', beta=10, testval=1.))

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -34,7 +34,7 @@ class DocstringModel(pm.Model):
         Potential('p1', tt.constant(1))
 
 
-class TestBaseModel(object):
+class TestBaseModel:
     def test_setattr_properly_works(self):
         with pm.Model() as model:
             pm.Normal('v1')
@@ -77,7 +77,7 @@ class TestBaseModel(object):
         assert m['one_more_d'] is model['one_more_d']
 
 
-class TestNested(object):
+class TestNested:
     def test_nest_context_works(self):
         with pm.Model() as m:
             new = NewModel()
@@ -123,7 +123,7 @@ class TestNested(object):
                 assert model is sub.root
 
 
-class TestObserved(object):
+class TestObserved:
     def test_observed_rv_fail(self):
         with pytest.raises(TypeError):
             with pm.Model():
@@ -141,7 +141,7 @@ class TestObserved(object):
         assert x2.type == X.type
 
 
-class TestTheanoConfig(object):
+class TestTheanoConfig:
     def test_set_testval_raise(self):
         with theano.configparser.change_flags(compute_test_value='off'):
             with pm.Model():

--- a/pymc3/tests/test_model_helpers.py
+++ b/pymc3/tests/test_model_helpers.py
@@ -10,7 +10,7 @@ import theano.tensor as tt
 import theano.sparse as sparse
 
 
-class TestHelperFunc(object):
+class TestHelperFunc:
     def test_pandas_to_array(self):
         """
         Ensure that pandas_to_array returns the dense array, masked array,

--- a/pymc3/tests/test_modelcontext.py
+++ b/pymc3/tests/test_modelcontext.py
@@ -2,7 +2,7 @@ import threading
 from pymc3 import Model, Normal
 
 
-class TestModelContext(object):
+class TestModelContext:
     def test_thread_safety(self):
         """ Regression test for issue #1552: Thread safety of model context manager
 

--- a/pymc3/tests/test_models_linear.py
+++ b/pymc3/tests/test_models_linear.py
@@ -15,7 +15,7 @@ def generate_data(intercept, slope, size=700):
 class TestGLM(SeededTest):
     @classmethod
     def setup_class(cls):
-        super(TestGLM, cls).setup_class()
+        super().setup_class()
         cls.intercept = 1
         cls.slope = 3
         cls.sd = .05

--- a/pymc3/tests/test_models_utils.py
+++ b/pymc3/tests/test_models_utils.py
@@ -5,7 +5,7 @@ from pymc3.glm import utils
 import pytest
 
 
-class TestUtils(object):
+class TestUtils:
     def setup_method(self):
         self.data = pd.DataFrame(dict(a=[1, 2, 3], b=[4, 5, 6]))
 

--- a/pymc3/tests/test_ndarray_backend.py
+++ b/pymc3/tests/test_ndarray_backend.py
@@ -139,7 +139,7 @@ class TestMultiTrace_add_remove_values(bf.ModelBackendSampledTestCase):
         assert name not in mtrace.varnames
 
 
-class TestSqueezeCat(object):
+class TestSqueezeCat:
 
     def setup_method(self):
         self.x = np.arange(10)
@@ -170,7 +170,7 @@ class TestSqueezeCat(object):
         result = base._squeeze_cat([self.x, self.y], True, True)
         npt.assert_equal(result, expected)
 
-class TestSaveLoad(object):
+class TestSaveLoad:
     @staticmethod
     def model():
         with pm.Model() as model:

--- a/pymc3/tests/test_ndarray_backend.py
+++ b/pymc3/tests/test_ndarray_backend.py
@@ -102,10 +102,10 @@ class TestMultiTrace(bf.ModelBackendSetupTestCase):
     shape = ()
 
     def setup_method(self):
-        super(TestMultiTrace, self).setup_method()
+        super().setup_method()
         self.strace0 = self.strace
 
-        super(TestMultiTrace, self).setup_method()
+        super().setup_method()
         self.strace1 = self.strace
 
     def test_multitrace_nonunique(self):

--- a/pymc3/tests/test_parallel_sampling.py
+++ b/pymc3/tests/test_parallel_sampling.py
@@ -1,7 +1,3 @@
-import time
-import sys
-import pytest
-
 import pymc3.parallel_sampling as ps
 import pymc3 as pm
 
@@ -32,7 +28,6 @@ def test_explicit_sample():
 
     step = pm.CompoundStep([step1, step2])
 
-    start = time.time()
     proc = ps.ProcessAdapter(10, 10, step, chain=3, seed=1,
                              start={'a': 1., 'b_log__': 2.})
     proc.start()
@@ -45,7 +40,6 @@ def test_explicit_sample():
         if out[1]:
             break
     proc.join()
-    print(time.time() - start)
 
 
 def test_iterator():
@@ -57,7 +51,6 @@ def test_iterator():
 
     step = pm.CompoundStep([step1, step2])
 
-    start = time.time()
     start = {'a': 1., 'b_log__': 2.}
     sampler = ps.ParallelSampler(10, 10, 3, 2, [2, 3, 4], [start] * 3,
                                  step, 0, False)

--- a/pymc3/tests/test_parallel_sampling.py
+++ b/pymc3/tests/test_parallel_sampling.py
@@ -6,8 +6,6 @@ import pymc3.parallel_sampling as ps
 import pymc3 as pm
 
 
-@pytest.mark.skipif(sys.version_info < (3,3),
-                    reason="requires python3.3")
 def test_abort():
     with pm.Model() as model:
         a = pm.Normal('a', shape=1)
@@ -25,8 +23,6 @@ def test_abort():
     proc.join()
 
 
-@pytest.mark.skipif(sys.version_info < (3,3),
-                    reason="requires python3.3")
 def test_explicit_sample():
     with pm.Model() as model:
         a = pm.Normal('a', shape=1)
@@ -52,8 +48,6 @@ def test_explicit_sample():
     print(time.time() - start)
 
 
-@pytest.mark.skipif(sys.version_info < (3,3),
-                    reason="requires python3.3")
 def test_iterator():
     with pm.Model() as model:
         a = pm.Normal('a', shape=1)

--- a/pymc3/tests/test_pickling.py
+++ b/pymc3/tests/test_pickling.py
@@ -3,7 +3,7 @@ import traceback
 from .models import simple_model
 
 
-class TestPickling(object):
+class TestPickling:
     def setup_method(self):
         _, self.model, _ = simple_model()
 

--- a/pymc3/tests/test_profile.py
+++ b/pymc3/tests/test_profile.py
@@ -1,7 +1,7 @@
 from .models import simple_model
 
 
-class TestProfile(object):
+class TestProfile:
     def setup_method(self):
         _, self.model, _ = simple_model()
 

--- a/pymc3/tests/test_quadpotential.py
+++ b/pymc3/tests/test_quadpotential.py
@@ -130,7 +130,7 @@ def test_user_potential():
     class Potential(quadpotential.QuadPotentialDiag):
         def energy(self, x, velocity=None):
             called.append(1)
-            return super(Potential, self).energy(x, velocity)
+            return super().energy(x, velocity)
 
     pot = Potential(floatX([1]))
     with model:

--- a/pymc3/tests/test_random.py
+++ b/pymc3/tests/test_random.py
@@ -44,7 +44,7 @@ def test_draw_value():
     err.match('Unexpected type')
 
 
-class TestDrawValues(object):
+class TestDrawValues:
     def test_empty(self):
         assert draw_values([]) == []
 
@@ -86,7 +86,7 @@ class TestDrawValues(object):
         val2 = draw_values([a], point={'sd': np.array([2., 3.])})[0]
         val3 = draw_values([a], point={'sd_log__': np.array([2., 3.])})[0]
         val4 = draw_values([a], point={'sd_log__': np.array([2., 3.])})[0]
-        
+
         assert all([np.all(val1 != val2), np.all(val1 != val3),
                     np.all(val1 != val4), np.all(val2 != val3),
                     np.all(val2 != val4), np.all(val3 != val4)])

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -20,7 +20,7 @@ import pytest
 @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
 class TestSample(SeededTest):
     def setup_method(self):
-        super(TestSample, self).setup_method()
+        super().setup_method()
         self.model, self.start, self.step, _ = simple_init()
 
     def test_sample_does_not_set_seed(self):

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -187,7 +187,7 @@ class TestNamedSampling(SeededTest):
             assert np.isclose(res, 0.)
 
 
-class TestChooseBackend(object):
+class TestChooseBackend:
     def test_choose_backend_none(self):
         with mock.patch('pymc3.sampling.NDArray') as nd:
             pm.sampling._choose_backend(None, 'chain')

--- a/pymc3/tests/test_smc.py
+++ b/pymc3/tests/test_smc.py
@@ -8,7 +8,7 @@ from .helpers import SeededTest
 class TestSMC(SeededTest):
 
     def setup_class(self):
-        super(TestSMC, self).setup_class()
+        super().setup_class()
         self.samples = 1000
         n = 4
         mu1 = np.ones(n) * (1. / 2)

--- a/pymc3/tests/test_stats.py
+++ b/pymc3/tests/test_stats.py
@@ -89,7 +89,7 @@ def test_compare():
     models = [model0, model1, model2]
 
     model_dict = dict(zip(models, traces))
-    
+
     w_st = pm.compare(model_dict, method='stacking')['weight']
     w_bb_bma = pm.compare(model_dict, method='BB-pseudo-BMA')['weight']
     w_bma = pm.compare(model_dict, method='pseudo-BMA')['weight']
@@ -106,7 +106,7 @@ def test_compare():
 class TestStats(SeededTest):
     @classmethod
     def setup_class(cls):
-        super(TestStats, cls).setup_class()
+        super().setup_class()
         cls.normal_sample = normal(0, 1, 200000)
 
     def test_autocorr(self):
@@ -331,7 +331,7 @@ class TestDfSummary(bf.ModelBackendSampledTestCase):
                     pm.summary(trace, varnames=[varname])['n_eff']
                                  ).reshape(n_eff.shape)
             npt.assert_equal(n_eff, n_eff_df)
-            
+
             # test Rhat value
             rhat = pm.gelman_rubin(trace, varnames=[varname])[varname]
             rhat_df = np.asarray(

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -47,7 +47,7 @@ import theano.tensor as tt
 from .helpers import select_by_precision
 
 
-class TestStepMethods(object):  # yield test doesn't work subclassing object
+class TestStepMethods:  # yield test doesn't work subclassing object
     master_samples = {
         Slice: np.array(
             [
@@ -826,7 +826,7 @@ class TestStepMethods(object):  # yield test doesn't work subclassing object
             self.check_stat(check, trace, step.__class__.__name__)
 
 
-class TestMetropolisProposal(object):
+class TestMetropolisProposal:
     def test_proposal_choice(self):
         _, model, _ = mv_simple()
         with model:
@@ -849,7 +849,7 @@ class TestMetropolisProposal(object):
         npt.assert_allclose(np.cov(samples.T), cov, rtol=0.2)
 
 
-class TestCompoundStep(object):
+class TestCompoundStep:
     samplers = (Metropolis, Slice, HamiltonianMC, NUTS, DEMetropolis)
 
     @pytest.mark.skipif(
@@ -876,7 +876,7 @@ class TestCompoundStep(object):
                 assert isinstance(sampler_instance, sampler)
 
 
-class TestAssignStepMethods(object):
+class TestAssignStepMethods:
     def test_bernoulli(self):
         """Test bernoulli distribution is assigned binary gibbs metropolis method"""
         with Model() as model:
@@ -932,7 +932,7 @@ class TestAssignStepMethods(object):
         assert isinstance(steps, Slice)
 
 
-class TestPopulationSamplers(object):
+class TestPopulationSamplers:
 
     steppers = [DEMetropolis]
 
@@ -966,7 +966,7 @@ class TestPopulationSamplers(object):
 @pytest.mark.xfail(
     condition=(theano.config.floatX == "float32"), reason="Fails on float32"
 )
-class TestNutsCheckTrace(object):
+class TestNutsCheckTrace:
     def test_multiple_samplers(self, caplog):
         with Model():
             prob = Beta("prob", alpha=5.0, beta=3.0)

--- a/pymc3/tests/test_text_backend.py
+++ b/pymc3/tests/test_text_backend.py
@@ -5,7 +5,7 @@ import pytest
 import theano
 
 
-class TestTextSampling(object):
+class TestTextSampling:
     name = 'text-db'
 
     def test_supports_sampler_stats(self):

--- a/pymc3/tests/test_text_backend.py
+++ b/pymc3/tests/test_text_backend.py
@@ -71,7 +71,7 @@ class TestTextDumpFunction(bf.BackendEqualityTestCase):
 
     @classmethod
     def setup_class(cls):
-        super(TestTextDumpFunction, cls).setup_class()
+        super().setup_class()
         text.dump(cls.name1, cls.mtrace1)
         with cls.model:
             cls.mtrace1 = text.load(cls.name1)

--- a/pymc3/tests/test_theanof.py
+++ b/pymc3/tests/test_theanof.py
@@ -6,7 +6,7 @@ from theano import theano
 from pymc3.theanof import set_theano_conf
 
 
-class TestSetTheanoConfig(object):
+class TestSetTheanoConfig:
     def test_invalid_key(self):
         with pytest.raises(ValueError) as e:
             set_theano_conf({'bad_key': True})

--- a/pymc3/tests/test_types.py
+++ b/pymc3/tests/test_types.py
@@ -11,7 +11,7 @@ from pymc3.theanof import change_flags
 import numpy as np
 
 
-class TestType(object):
+class TestType:
     samplers = (Metropolis, Slice, HamiltonianMC, NUTS)
 
     def setup_method(self):

--- a/pymc3/tests/test_util.py
+++ b/pymc3/tests/test_util.py
@@ -7,7 +7,7 @@ from .helpers import SeededTest
 from pymc3.distributions.transforms import Transform
 
 
-class TestTransformName(object):
+class TestTransformName:
     cases = [
         ('var', 'var_test__'),
         ('var_test_', 'var_test__test__')
@@ -36,25 +36,25 @@ class TestTransformName(object):
 class TestUpdateStartVals(SeededTest):
     def setup_method(self):
         super(TestUpdateStartVals, self).setup_method()
-    
+
     def test_soft_update_all_present(self):
         start = {'a': 1, 'b': 2}
         test_point = {'a': 3, 'b': 4}
         pm.util.update_start_vals(start, test_point, model=None)
         assert start == {'a': 1, 'b': 2}
-    
+
     def test_soft_update_one_missing(self):
         start = {'a': 1, }
         test_point = {'a': 3, 'b': 4}
         pm.util.update_start_vals(start, test_point, model=None)
         assert start == {'a': 1, 'b': 4}
-    
+
     def test_soft_update_empty(self):
         start = {}
         test_point = {'a': 3, 'b': 4}
         pm.util.update_start_vals(start, test_point, model=None)
         assert start == test_point
-    
+
     def test_soft_update_transformed(self):
         with pm.Model() as model:
             pm.Exponential('a', 1)
@@ -62,7 +62,7 @@ class TestUpdateStartVals(SeededTest):
         test_point = {'a_log__': 0}
         pm.util.update_start_vals(start, test_point, model)
         assert_almost_equal(np.exp(start['a_log__']), start['a'])
-    
+
     def test_soft_update_parent(self):
         with pm.Model() as model:
             a = pm.Uniform('a', lower=0., upper=1.)
@@ -70,7 +70,7 @@ class TestUpdateStartVals(SeededTest):
             pm.Uniform('lower', lower=a, upper=3.)
             pm.Uniform('upper', lower=0., upper=b)
             pm.Uniform('interv', lower=a, upper=b)
-        
+
         start = {'a': .3, 'b': 2.1, 'lower': 1.4, 'upper': 1.4, 'interv':1.4}
         test_point = {'lower_interval__': -0.3746934494414109,
             'upper_interval__': 0.693147180559945,

--- a/pymc3/tests/test_util.py
+++ b/pymc3/tests/test_util.py
@@ -35,7 +35,7 @@ class TestTransformName:
 
 class TestUpdateStartVals(SeededTest):
     def setup_method(self):
-        super(TestUpdateStartVals, self).setup_method()
+        super().setup_method()
 
     def test_soft_update_all_present(self):
         start = {'a': 1, 'b': 2}

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -1,6 +1,6 @@
 import pytest
-import six
 import functools
+import io
 import operator
 import numpy as np
 from theano import theano, tensor as tt
@@ -694,7 +694,7 @@ def test_remove_scan_op():
     with pm.Model():
         pm.Normal('n', 0, 1)
         inference = ADVI()
-        buff = six.StringIO()
+        buff = io.StringIO()
         inference.run_profiling(n=10).summary(buff)
         assert 'theano.scan_module.scan_op.Scan' not in buff.getvalue()
         buff.close()

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -69,7 +69,7 @@ def floatX(X):
 
 def smartfloatX(x):
     """
-    Convert non int types to floatX 
+    Convert non int types to floatX
     """
     if str(x.dtype).startswith('float'):
         x = floatX(x)
@@ -254,7 +254,7 @@ def reshape_t(x, shape):
         return x[0]
 
 
-class CallableTensor(object):
+class CallableTensor:
     """Turns a symbolic variable with one input into a function that returns symbolic arguments
     with the one variable replaced with the input.
     """

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -180,7 +180,7 @@ class IdentityOp(scalar.UnaryScalarOp):
         return "{z} = {x};".format(x=inp[0], z=out[0])
 
     def __eq__(self, other):
-        return type(self) == type(other)
+        return isinstance(self, type(other))
 
     def __hash__(self):
         return hash(type(self))

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -298,7 +298,7 @@ class GeneratorOp(Op):
     __props__ = ('generator',)
 
     def __init__(self, gen, default=None):
-        super(GeneratorOp, self).__init__()
+        super().__init__()
         if not isinstance(gen, GeneratorAdapter):
             gen = GeneratorAdapter(gen)
         self.generator = gen

--- a/pymc3/tuning/scaling.py
+++ b/pymc3/tuning/scaling.py
@@ -1,9 +1,3 @@
-'''
-Created on Mar 12, 2011
-
-from __future__ import division
-@author: johnsalvatier
-'''
 import numpy as np
 from numpy import exp, log, sqrt
 from ..model import modelcontext, Point

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -164,7 +164,7 @@ def allinmodel(vars, model):
         raise ValueError("Some variables not in the model: " + str(notin))
 
 
-class CostFuncWrapper(object):
+class CostFuncWrapper:
     def __init__(self, maxeval=5000, progressbar=True, logp_func=None, dlogp_func=None):
         self.n_eval = 0
         self.maxeval = maxeval

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -25,7 +25,7 @@ def escape_latex(strng):
         A string with LaTeX escaped
     """
     if strng is None:
-        return u'None'
+        return 'None'
     return LATEX_ESCAPE_RE.sub(r'\\\1', strng)
 
 
@@ -80,8 +80,7 @@ def get_untransformed_name(name):
         String with untransformed version of the name.
     """
     if not is_transformed_name(name):
-        raise ValueError(
-            u'{} does not appear to be a transformed name'.format(name))
+        raise ValueError('{} does not appear to be a transformed name'.format(name))
     return '_'.join(name.split('_')[:-3])
 
 

--- a/pymc3/variational/approximations.py
+++ b/pymc3/variational/approximations.py
@@ -54,7 +54,7 @@ class MeanFieldGroup(Group):
 
     @change_flags(compute_test_value='off')
     def __init_group__(self, group):
-        super(MeanFieldGroup, self).__init_group__(group)
+        super().__init_group__(group)
         if not self._check_user_params():
             self.shared_params = self.create_shared_params(
                 self._kwargs.get('start', None)
@@ -110,7 +110,7 @@ class FullRankGroup(Group):
 
     @change_flags(compute_test_value='off')
     def __init_group__(self, group):
-        super(FullRankGroup, self).__init_group__(group)
+        super().__init_group__(group)
         if not self._check_user_params():
             self.shared_params = self.create_shared_params(
                 self._kwargs.get('start', None)
@@ -222,7 +222,7 @@ class EmpiricalGroup(Group):
 
     @change_flags(compute_test_value='off')
     def __init_group__(self, group):
-        super(EmpiricalGroup, self).__init_group__(group)
+        super().__init_group__(group)
         self._check_trace()
         if not self._check_user_params(spec_kw=dict(s=-1)):
             self.shared_params = self.create_shared_params(
@@ -381,7 +381,7 @@ class NormalizingFlowGroup(Group):
 
     @change_flags(compute_test_value='off')
     def __init_group__(self, group):
-        super(NormalizingFlowGroup, self).__init_group__(group)
+        super().__init_group__(group)
         # objects to be resolved
         # 1. string formula
         # 2. not changed default value
@@ -494,7 +494,7 @@ class NormalizingFlowGroup(Group):
     @node_property
     def bdim(self):
         if not self.local:
-            return super(NormalizingFlowGroup, self).bdim
+            return super().bdim
         else:
             return next(iter(self.user_params[0].values())).shape[0]
 
@@ -534,13 +534,13 @@ class SingleGroupApproximation(Approximation):
         if local_rv is not None:
             groups.extend([Group([v], params=p, local=True, model=kwargs.get('model'))
                            for v, p in local_rv.items()])
-        super(SingleGroupApproximation, self).__init__(groups, model=kwargs.get('model'))
+        super().__init__(groups, model=kwargs.get('model'))
 
     def __getattr__(self, item):
         return getattr(self.groups[0], item)
 
     def __dir__(self):
-        d = set(super(SingleGroupApproximation, self).__dir__())
+        d = set(super().__dir__())
         d.update(self.groups[0].__dir__())
         return list(sorted(d))
 
@@ -568,7 +568,7 @@ class Empirical(SingleGroupApproximation):
     def __init__(self, trace=None, size=None, **kwargs):
         if kwargs.get('local_rv', None) is not None:
             raise opvi.LocalGroupError('Empirical approximation does not support local variables')
-        super(Empirical, self).__init__(trace=trace, size=size, **kwargs)
+        super().__init__(trace=trace, size=size, **kwargs)
 
     def evaluate_over_trace(self, node):
         R"""
@@ -599,4 +599,4 @@ class NormalizingFlow(SingleGroupApproximation):
 
     def __init__(self, flow=NormalizingFlowGroup.default_flow, *args, **kwargs):
         kwargs['flow'] = flow
-        super(NormalizingFlow, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)

--- a/pymc3/variational/callbacks.py
+++ b/pymc3/variational/callbacks.py
@@ -9,7 +9,7 @@ __all__ = [
 ]
 
 
-class Callback(object):
+class Callback:
     def __call__(self, approx, loss, i):
         raise NotImplementedError
 
@@ -96,7 +96,7 @@ class Tracker(Callback):
 
     Examples
     --------
-    Consider we want time on each iteration    
+    Consider we want time on each iteration
     >>> import time
     >>> tracker = Tracker(time=time.time)
     >>> with model:

--- a/pymc3/variational/flows.py
+++ b/pymc3/variational/flows.py
@@ -18,7 +18,7 @@ __all__ = [
 ]
 
 
-class Formula(object):
+class Formula:
     """
     Helpful class to use string like formulas with
     __call__ syntax similar to Flow.__init__
@@ -263,7 +263,7 @@ flow_for_params = AbstractFlow.flow_for_params
 flow_for_short_name = AbstractFlow.flow_for_short_name
 
 
-class FlowFn(object):
+class FlowFn:
     @staticmethod
     def fn(*args):
         raise NotImplementedError

--- a/pymc3/variational/flows.py
+++ b/pymc3/variational/flows.py
@@ -286,7 +286,7 @@ class LinearFlow(AbstractFlow):
     @change_flags(compute_test_value='off')
     def __init__(self, h, u=None, w=None, b=None, **kwargs):
         self.h = h
-        super(LinearFlow, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         u = self.add_param(u, 'u')
         w = self.add_param(w, 'w')
         b = self.add_param(b, 'b')
@@ -369,7 +369,7 @@ class PlanarFlow(LinearFlow):
     short_name = 'planar'
 
     def __init__(self, **kwargs):
-        super(PlanarFlow, self).__init__(h=Tanh(), **kwargs)
+        super().__init__(h=Tanh(), **kwargs)
 
     def make_uw(self, u, w):
         if not self.batched:
@@ -402,7 +402,7 @@ class ReferencePointFlow(AbstractFlow):
 
     @change_flags(compute_test_value='off')
     def __init__(self, h, a=None, b=None, z_ref=None, **kwargs):
-        super(ReferencePointFlow, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         a = self.add_param(a, 'a')
         b = self.add_param(b, 'b')
         if hasattr(self.z0, 'tag') and hasattr(self.z0.tag, 'test_value'):
@@ -500,7 +500,7 @@ class RadialFlow(ReferencePointFlow):
     short_name = 'radial'
 
     def __init__(self, **kwargs):
-        super(RadialFlow, self).__init__(Radial(), **kwargs)
+        super().__init__(Radial(), **kwargs)
 
     def make_ab(self, a, b):
         a = tt.exp(a)
@@ -514,7 +514,7 @@ class LocFlow(AbstractFlow):
     short_name = 'loc'
 
     def __init__(self, loc=None, **kwargs):
-        super(LocFlow, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         loc = self.add_param(loc, 'loc')
         self.shared_params = dict(loc=loc)
 
@@ -538,7 +538,7 @@ class ScaleFlow(AbstractFlow):
 
     @change_flags(compute_test_value='off')
     def __init__(self, rho=None, **kwargs):
-        super(ScaleFlow, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         rho = self.add_param(rho, 'rho')
         self.scale = rho2sd(rho)
         self.shared_params = dict(rho=rho)
@@ -563,7 +563,7 @@ class HouseholderFlow(AbstractFlow):
 
     @change_flags(compute_test_value='raise')
     def __init__(self, v=None, **kwargs):
-        super(HouseholderFlow, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         v = self.add_param(v, 'v')
         self.shared_params = dict(v=v)
         if self.batched:

--- a/pymc3/variational/inference.py
+++ b/pymc3/variational/inference.py
@@ -294,7 +294,7 @@ class KLqp(Inference):
         arXiv preprint 1804.03599
     """
     def __init__(self, approx, beta=1.):
-        super(KLqp, self).__init__(KL, approx, None, beta=beta)
+        super().__init__(KL, approx, None, beta=beta)
 
 
 class ADVI(KLqp):
@@ -442,7 +442,7 @@ class ADVI(KLqp):
     """
 
     def __init__(self, *args, **kwargs):
-        super(ADVI, self).__init__(MeanField(*args, **kwargs))
+        super().__init__(MeanField(*args, **kwargs))
 
 
 class FullRankADVI(KLqp):
@@ -477,7 +477,7 @@ class FullRankADVI(KLqp):
     """
 
     def __init__(self, *args, **kwargs):
-        super(FullRankADVI, self).__init__(FullRank(*args, **kwargs))
+        super().__init__(FullRank(*args, **kwargs))
 
 
 class ImplicitGradient(Inference):
@@ -492,12 +492,7 @@ class ImplicitGradient(Inference):
     samples but there is no theoretical approach to choose the best one in such case.
     """
     def __init__(self, approx, estimator=KSD, kernel=test_functions.rbf, **kwargs):
-        super(ImplicitGradient, self).__init__(
-            op=estimator,
-            approx=approx,
-            tf=kernel,
-            **kwargs
-        )
+        super().__init__(op=estimator, approx=approx, tf=kernel, **kwargs)
 
 
 class SVGD(ImplicitGradient):
@@ -558,12 +553,7 @@ class SVGD(ImplicitGradient):
         empirical = Empirical(
             size=n_particles, jitter=jitter,
             start=start, model=model, random_seed=random_seed)
-        super(SVGD, self).__init__(
-            approx=empirical,
-            estimator=estimator,
-            kernel=kernel,
-            **kwargs
-        )
+        super().__init__(approx=empirical, estimator=estimator, kernel=kernel, **kwargs)
 
 
 class ASVGD(ImplicitGradient):
@@ -624,22 +614,16 @@ class ASVGD(ImplicitGradient):
                 model=kwargs.pop('model', None),
                 local_rv=kwargs.pop('local_rv', None)
             )
-        super(ASVGD, self).__init__(
-            estimator=estimator,
-            approx=approx,
-            kernel=kernel,
-            **kwargs
-        )
+        super().__init__(estimator=estimator, approx=approx, kernel=kernel, **kwargs)
 
     def fit(self, n=10000, score=None, callbacks=None, progressbar=True,
             obj_n_mc=500, **kwargs):
-        return super(ASVGD, self).fit(
+        return super().fit(
             n=n, score=score, callbacks=callbacks,
             progressbar=progressbar, obj_n_mc=obj_n_mc, **kwargs)
 
     def run_profiling(self, n=1000, score=None, obj_n_mc=500, **kwargs):
-        return super(ASVGD, self).run_profiling(
-            n=n, score=score, obj_n_mc=obj_n_mc, **kwargs)
+        return super().run_profiling(n=n, score=score, obj_n_mc=obj_n_mc, **kwargs)
 
 
 class NFVI(KLqp):
@@ -694,7 +678,7 @@ class NFVI(KLqp):
     """
 
     def __init__(self, *args, **kwargs):
-        super(NFVI, self).__init__(NormalizingFlow(*args, **kwargs))
+        super().__init__(NormalizingFlow(*args, **kwargs))
 
 
 def fit(n=10000, local_rv=None, method='advi', model=None,

--- a/pymc3/variational/inference.py
+++ b/pymc3/variational/inference.py
@@ -32,7 +32,7 @@ __all__ = [
 State = collections.namedtuple('State', 'i,step,callbacks,score')
 
 
-class Inference(object):
+class Inference:
     R"""**Base class for Variational Inference**
 
     Communicates Operator, Approximation and Test Function to build Objective Function

--- a/pymc3/variational/inference.py
+++ b/pymc3/variational/inference.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import logging
 import warnings
 import collections

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -144,7 +144,7 @@ def _warn_not_used(smth, where):
     warnings.warn('`%s` is not used for %s and ignored' % (smth, where))
 
 
-class ObjectiveFunction(object):
+class ObjectiveFunction:
     """Helper class for construction loss and updates for variational inference
 
     Parameters
@@ -358,7 +358,7 @@ class ObjectiveFunction(object):
         return m * self.op.T(a)
 
 
-class Operator(object):
+class Operator:
     R"""**Base class for Operator**
 
     Parameters
@@ -465,7 +465,7 @@ def collect_shared_to_list(params):
             'Unknown type %s for %r, need dict or None')
 
 
-class TestFunction(object):
+class TestFunction:
     def __init__(self):
         self._inited = False
         self.shared_params = None

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -759,13 +759,13 @@ class Group(WithMemoization):
             if vfam is not None and params is not None:
                 raise TypeError('Cannot call Group with both `vfam` and `params` provided')
             elif vfam is not None:
-                return super(Group, cls).__new__(cls.group_for_short_name(vfam))
+                return super().__new__(cls.group_for_short_name(vfam))
             elif params is not None:
-                return super(Group, cls).__new__(cls.group_for_params(params))
+                return super().__new__(cls.group_for_params(params))
             else:
                 raise TypeError('Need to call Group with either `vfam` or `params` provided')
         else:
-            return super(Group, cls).__new__(cls)
+            return super().__new__(cls)
 
     def __init__(self, group,
                  vfam=None,

--- a/pymc3/vartypes.py
+++ b/pymc3/vartypes.py
@@ -1,5 +1,3 @@
-import sys
-
 __all__ = ['bool_types', 'int_types', 'float_types', 'complex_types', 'continuous_types',
            'discrete_types', 'typefilter', 'isgenerator']
 

--- a/pymc3/vartypes.py
+++ b/pymc3/vartypes.py
@@ -20,10 +20,7 @@ complex_types = set(['complex64',
 continuous_types = float_types | complex_types
 discrete_types = bool_types | int_types
 
-if sys.version_info[0] == 3:
-    string_types = str
-else:
-    string_types = basestring
+string_types = str
 
 
 def typefilter(vars, types):

--- a/pymc3/vartypes.py
+++ b/pymc3/vartypes.py
@@ -1,7 +1,5 @@
 import sys
 
-import six
-
 __all__ = ['bool_types', 'int_types', 'float_types', 'complex_types', 'continuous_types',
            'discrete_types', 'typefilter', 'isgenerator']
 
@@ -34,5 +32,4 @@ def typefilter(vars, types):
 
 
 def isgenerator(obj):
-    return ((hasattr(obj, '__next__') and six.PY3) or
-            (hasattr(obj, 'next') and six.PY2))
+    return hasattr(obj, '__next__')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ h5py>=2.7.0
 ipython
 Keras>=2.0.8
 matplotlib>=1.5.0
-mock>=2.0.0; python_version < '3.4'
 nbsphinx>=0.2.13
 nose>=1.3.7
 nose-parameterized==0.6.0
@@ -18,7 +17,6 @@ pylint>=1.7.4
 pytest-cov>=2.5.1
 pytest>=3.0.7
 recommonmark>=0.4.0
-scipy>=0.12.0
 seaborn>=0.8.1
 sphinx-autobuild==0.7.1
 sphinx>=1.5.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ joblib<0.13.0
 tqdm>=4.8.4
 six>=1.10.0
 h5py>=2.7.0
-enum34>=1.1.6; python_version < '3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,5 @@ numpy>=1.13.0
 scipy>=0.18.1
 pandas>=0.18.0
 patsy>=0.4.0
-joblib<0.13.0
 tqdm>=4.8.4
-six>=1.10.0
 h5py>=2.7.0

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -33,7 +33,7 @@ then
     fi
     source activate ${ENVNAME}
 fi
-conda install --yes numpy scipy mkl-service
+conda install --yes numpy scipy mkl-service matplotlib
 conda install --yes -c conda-forge python-graphviz
 
 pip install --upgrade pip
@@ -41,18 +41,10 @@ pip install --upgrade pip
 #  Install editable using the setup.py
 pip install -e .
 
-# Install extra testing stuff
-if [ ${PYTHON_VERSION} == "2.7" ]; then
-    pip install mock
-fi
-
 pip install -r requirements-dev.txt
 
 # Install untested, non-required code (linter fails without them)
 pip install ipython ipywidgets
-
-# matplotlib is not required for the library, but is for tests
-pip install matplotlib
 
 if [ -z ${NO_SETUP} ]; then
     python setup.py build_ext --inplace

--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,7 @@ REQUIREMENTS_FILE = join(PROJECT_ROOT, 'requirements.txt')
 with open(REQUIREMENTS_FILE) as f:
     install_reqs = f.read().splitlines()
 
-if sys.version_info < (3, 4):
-    install_reqs.append('enum34')
-
 test_reqs = ['pytest', 'pytest-cov']
-if sys.version_info[0] == 2:  # py3 has mock in stdlib
-    test_reqs.append('mock')
 
 def get_version():
     VERSIONFILE = join('pymc3', '__init__.py')

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,7 @@ LICENSE = "Apache License, Version 2.0"
 
 classifiers = ['Development Status :: 5 - Production/Stable',
                'Programming Language :: Python',
-               'Programming Language :: Python :: 2',
                'Programming Language :: Python :: 3',
-               'Programming Language :: Python :: 2.7',
-               'Programming Language :: Python :: 3.4',
                'Programming Language :: Python :: 3.5',
                'Programming Language :: Python :: 3.6',
                'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
This drops support for python 2.7.

 [x] Remove all uses of six
 [x] Remove documentation saying we use python 2.7
 [x] Remove python 2.7 from testing grid

Open to suggestions for other easy places to remove support.