### PR TITLE
Fix for #3310 and some more

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,6 +36,8 @@ This will be the last release to support Python 2.
 - Fixed `Rice` distribution, which inconsistently mixed two parametrizations (#3286).
 - `Rice` distribution now accepts multiple parameters and observations and is usable with NUTS (#3289).
 - `sample_posterior_predictive` no longer calls `draw_values` to initialize the shape of the ppc trace. This called could lead to `ValueError`'s when sampling the ppc from a model with `Flat` or `HalfFlat` prior distributions (Fix issue #3294).
+- Added the `broadcast_distribution_samples` function that helps broadcasting arrays of drawn samples, taking into account the requested `size` and the inferred distribution shape. This sometimes is needed by distributions that call several `rvs` separately within their `random` method, such as the `ZeroInflatedPoisson` (Fix issue #3310).
+- The `Wald`, `Kumaraswamy`, `LogNormal`, `Pareto`, `Cauchy`, `HalfCauchy`, `Weibull` and `ExGaussian` distributions `random` method used a hidden `_random` function that was written with scalars in mind. This could potentially lead to artificial correlations between random draws. Added shape guards and broadcasting of the distribution samples to prevent this (Similar to issue #3310).
 
 
 ### Deprecations

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,9 @@
 
 ### Maintenance
 
+- Added the `broadcast_distribution_samples` function that helps broadcasting arrays of drawn samples, taking into account the requested `size` and the inferred distribution shape. This sometimes is needed by distributions that call several `rvs` separately within their `random` method, such as the `ZeroInflatedPoisson` (Fix issue #3310).
+- The `Wald`, `Kumaraswamy`, `LogNormal`, `Pareto`, `Cauchy`, `HalfCauchy`, `Weibull` and `ExGaussian` distributions `random` method used a hidden `_random` function that was written with scalars in mind. This could potentially lead to artificial correlations between random draws. Added shape guards and broadcasting of the distribution samples to prevent this (Similar to issue #3310).
+
 ### Deprecations
 
 ## PyMC3 3.6 (Dec 21 2018)
@@ -44,8 +47,6 @@ This will be the last release to support Python 2.
 - Fixed `Rice` distribution, which inconsistently mixed two parametrizations (#3286).
 - `Rice` distribution now accepts multiple parameters and observations and is usable with NUTS (#3289).
 - `sample_posterior_predictive` no longer calls `draw_values` to initialize the shape of the ppc trace. This called could lead to `ValueError`'s when sampling the ppc from a model with `Flat` or `HalfFlat` prior distributions (Fix issue #3294).
-- Added the `broadcast_distribution_samples` function that helps broadcasting arrays of drawn samples, taking into account the requested `size` and the inferred distribution shape. This sometimes is needed by distributions that call several `rvs` separately within their `random` method, such as the `ZeroInflatedPoisson` (Fix issue #3310).
-- The `Wald`, `Kumaraswamy`, `LogNormal`, `Pareto`, `Cauchy`, `HalfCauchy`, `Weibull` and `ExGaussian` distributions `random` method used a hidden `_random` function that was written with scalars in mind. This could potentially lead to artificial correlations between random draws. Added shape guards and broadcasting of the distribution samples to prevent this (Similar to issue #3310).
 
 
 ### Deprecations

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -938,15 +938,10 @@ class Wald(PositiveContinuous):
                          'mu and lam, mu and phi, or lam and phi.')
 
     def _random(self, mu, lam, alpha, size=None):
-        _size = alpha.shape
-        if size is not None:
-            size = to_tuple(size)
-            if _size[:len(size)] != size:
-                _size = size + _size
-        v = np.random.normal(size=_size)**2
+        v = np.random.normal(size=size)**2
         value = (mu + (mu**2) * v / (2. * lam) - mu / (2. * lam)
                  * np.sqrt(4. * mu * lam * v + (mu * v)**2))
-        z = np.random.uniform(size=_size)
+        z = np.random.uniform(size=size)
         i = np.floor(z - mu / (mu + value)) * 2 + 1
         value = (value**-i) * (mu**(i + 1))
         return value + alpha
@@ -970,8 +965,11 @@ class Wald(PositiveContinuous):
         """
         mu, lam, alpha = draw_values([self.mu, self.lam, self.alpha],
                                      point=point, size=size)
+        print(mu.shape, lam.shape, alpha.shape)
         mu, lam, alpha = broadcast_distribution_samples([mu, lam, alpha],
                                                         size=size)
+        print(mu.shape, lam.shape, alpha.shape)
+        print(self.shape, size)
         return generate_samples(self._random,
                                 mu, lam, alpha,
                                 dist_shape=self.shape,
@@ -1278,12 +1276,7 @@ class Kumaraswamy(UnitContinuous):
         assert_negative_support(b, 'b', 'Kumaraswamy')
 
     def _random(self, a, b, size=None):
-        _size = a.shape
-        if size is not None:
-            size = to_tuple(size)
-            if _size[:len(size)] != size:
-                _size = size + _size
-        u = np.random.uniform(size=_size)
+        u = np.random.uniform(size=size)
         return (1 - (1 - u) ** (1 / b)) ** (1 / a)
 
     def random(self, point=None, size=None):
@@ -1658,12 +1651,7 @@ class Lognormal(PositiveContinuous):
         assert_negative_support(sd, 'sd', 'Lognormal')
 
     def _random(self, mu, tau, size=None):
-        _size = tau.shape
-        if size is not None:
-            size = to_tuple(size)
-            if _size[:len(size)] != size:
-                _size = size + _size
-        samples = np.random.normal(size=_size)
+        samples = np.random.normal(size=size)
         return np.exp(mu + (tau**-0.5) * samples)
 
     def random(self, point=None, size=None):
@@ -1950,12 +1938,7 @@ class Pareto(Continuous):
         super(Pareto, self).__init__(transform=transform, *args, **kwargs)
 
     def _random(self, alpha, m, size=None):
-        _size = alpha.shape
-        if size is not None:
-            size = to_tuple(size)
-            if _size[:len(size)] != size:
-                _size = size + _size
-        u = np.random.uniform(size=_size)
+        u = np.random.uniform(size=size)
         return m * (1. - u)**(-1. / alpha)
 
     def random(self, point=None, size=None):
@@ -2080,12 +2063,7 @@ class Cauchy(Continuous):
         assert_negative_support(beta, 'beta', 'Cauchy')
 
     def _random(self, alpha, beta, size=None):
-        _size = alpha.shape
-        if size is not None:
-            size = to_tuple(size)
-            if _size[:len(size)] != size:
-                _size = size + _size
-        u = np.random.uniform(size=_size)
+        u = np.random.uniform(size=size)
         return alpha + beta * np.tan(np.pi * (u - 0.5))
 
     def random(self, point=None, size=None):
@@ -2195,12 +2173,7 @@ class HalfCauchy(PositiveContinuous):
         assert_negative_support(beta, 'beta', 'HalfCauchy')
 
     def _random(self, beta, size=None):
-        _size = beta.shape
-        if size is not None:
-            size = to_tuple(size)
-            if _size[:len(size)] != size:
-                _size = size + _size
-        u = np.random.uniform(size=_size)
+        u = np.random.uniform(size=size)
         return beta * np.abs(np.tan(np.pi * (u - 0.5)))
 
     def random(self, point=None, size=None):
@@ -2677,12 +2650,7 @@ class Weibull(PositiveContinuous):
         alpha, beta = broadcast_distribution_samples([alpha, beta], size=size)
 
         def _random(a, b, size=None):
-            _size = a.shape
-            if size is not None:
-                size = to_tuple(size)
-                if _size[:len(size)] != size:
-                    _size = size + _size
-            return b * (-np.log(np.random.uniform(size=_size)))**(1 / a)
+            return b * (-np.log(np.random.uniform(size=size)))**(1 / a)
 
         return generate_samples(_random, alpha, beta,
                                 dist_shape=self.shape,

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -22,7 +22,7 @@ from .dist_math import (
     normal_lccdf, normal_lcdf, SplineWrapper, std_cdf, zvalue,
 )
 from .distribution import (Continuous, draw_values, generate_samples,
-                           to_tuple, broadcast_distribution_samples)
+                           broadcast_distribution_samples)
 
 __all__ = ['Uniform', 'Flat', 'HalfFlat', 'Normal', 'TruncatedNormal', 'Beta',
            'Kumaraswamy', 'Exponential', 'Laplace', 'StudentT', 'Cauchy',

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -958,11 +958,8 @@ class Wald(PositiveContinuous):
         """
         mu, lam, alpha = draw_values([self.mu, self.lam, self.alpha],
                                      point=point, size=size)
-        print(mu.shape, lam.shape, alpha.shape)
         mu, lam, alpha = broadcast_distribution_samples([mu, lam, alpha],
                                                         size=size)
-        print(mu.shape, lam.shape, alpha.shape)
-        print(self.shape, size)
         return generate_samples(self._random,
                                 mu, lam, alpha,
                                 dist_shape=self.shape,

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -640,3 +640,30 @@ def generate_samples(generator, *args, **kwargs):
     if one_d and samples.shape[-1] == 1:
         samples = samples.reshape(samples.shape[:-1])
     return np.asarray(samples)
+
+
+def broadcast_distribution_samples(samples, size=None):
+    if size is None:
+        return np.broadcast_arrays(*samples)
+    _size = to_tuple(size)
+    try:
+        broadcasted_samples = np.broadcast_arrays(*samples)
+    except ValueError:
+        # Raw samples shapes
+        p_shapes = [p.shape for p in samples]
+        # samples shapes without the size prepend
+        sp_shapes = [s[len(_size):] if _size == s[:len(_size)] else s
+                     for s in p_shapes]
+        broadcast_shape = np.broadcast(*[np.empty(s) for s in sp_shapes]).shape
+        broadcasted_samples = []
+        for param, p_shape, sp_shape in zip(samples, p_shapes, sp_shapes):
+            if _size == p_shape[:len(_size)]:
+                slicer_head = [slice(None)] * len(_size)
+            else:
+                slicer_head = [np.newaxis] * len(_size)
+            slicer_tail = ([np.newaxis] * (len(broadcast_shape) -
+                                           len(sp_shape)) +
+                           [slice(None)] * len(sp_shape))
+            broadcasted_samples.append(param[tuple(slicer_head + slicer_tail)])
+        broadcasted_samples = np.broadcast_arrays(*broadcasted_samples)
+    return broadcasted_samples

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -467,3 +467,13 @@ class TestSamplePriorPredictive(SeededTest):
             x = pm.Normal('x', mu=mu, sd=sd, shape=5)
             prior = pm.sample_prior_predictive(10)
         assert prior['mu'].shape == (10, 5)
+
+    def test_zeroinflatedpoisson(self):
+        with pm.Model():
+            theta = pm.Beta('theta', alpha=1, beta=1)
+            psi = pm.HalfNormal('psi', sd=1)
+            pm.ZeroInflatedPoisson('suppliers', psi=psi, theta=theta, shape=20)
+            gen_data = pm.sample_prior_predictive(samples=5000)
+            assert gen_data['theta'].shape == (5000,)
+            assert gen_data['psi'].shape == (5000,)
+            assert gen_data['suppliers'].shape == (5000, 20)


### PR DESCRIPTION
Added `broadcast_distribution_samples`, which helps broadcasting multiple rvs calls with different `size` and distribution parameter shapes. Added shape guards to other continuous distributions. In particular, this fixes #3310, but it also prevents similar things from happening in other discrete and continuous distributions that could encounter the same pathological behavior.