### PR TITLE
Update the name variable of the CategoricalGibbsMetropolis class. Because of a typo

### DIFF
--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -382,7 +382,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
        which was introduced by Liu in his 1996 technical report
        "Metropolized Gibbs Sampler: An Improvement".
     """
-    name = 'caregorical_gibbs_metropolis'
+    name = 'categorical_gibbs_metropolis'
 
     def __init__(self, vars, proposal='uniform', order='random', model=None):
 


### PR DESCRIPTION
I'm unsure if this is accepted, but I found a typo when I was looking through the code.