### PR TITLE
Manually set theano TensorType for length 1 shared variables

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,7 @@
 - Made `BrokenPipeError` for parallel sampling more verbose on Windows.
 - Added the `broadcast_distribution_samples` function that helps broadcasting arrays of drawn samples, taking into account the requested `size` and the inferred distribution shape. This sometimes is needed by distributions that call several `rvs` separately within their `random` method, such as the `ZeroInflatedPoisson` (Fix issue #3310).
 - The `Wald`, `Kumaraswamy`, `LogNormal`, `Pareto`, `Cauchy`, `HalfCauchy`, `Weibull` and `ExGaussian` distributions `random` method used a hidden `_random` function that was written with scalars in mind. This could potentially lead to artificial correlations between random draws. Added shape guards and broadcasting of the distribution samples to prevent this (Similar to issue #3310).
+- Added a fix to allow the imputation of single missing values of oberserved data, which previously would fail (Fix issue #3122).
 
 ### Deprecations
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,7 +10,7 @@
 - Made `BrokenPipeError` for parallel sampling more verbose on Windows.
 - Added the `broadcast_distribution_samples` function that helps broadcasting arrays of drawn samples, taking into account the requested `size` and the inferred distribution shape. This sometimes is needed by distributions that call several `rvs` separately within their `random` method, such as the `ZeroInflatedPoisson` (Fix issue #3310).
 - The `Wald`, `Kumaraswamy`, `LogNormal`, `Pareto`, `Cauchy`, `HalfCauchy`, `Weibull` and `ExGaussian` distributions `random` method used a hidden `_random` function that was written with scalars in mind. This could potentially lead to artificial correlations between random draws. Added shape guards and broadcasting of the distribution samples to prevent this (Similar to issue #3310).
-- Added a fix to allow the imputation of single missing values of oberserved data, which previously would fail (Fix issue #3122).
+- Added a fix to allow the imputation of single missing values of observed data, which previously would fail (Fix issue #3122).
 
 ### Deprecations
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -440,8 +440,9 @@ class ValueGradFunction:
             # manually set the TensorType for length 1 arrays due to a
             # theano conversion problem
             if isinstance(var.tag.test_value, np.ndarray):
-                if len(var.tag.test_value) == 1:
-                    shared.type = theano.tensor.TensorType(var.dtype, (True,))
+                if var.tag.test_value.ndim == 1:
+                    if len(var.tag.test_value) == 1:
+                        shared.type = theano.tensor.TensorType(var.dtype, (True,))
             self._extra_vars_shared[var.name] = shared
             givens.append((var, shared))
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -437,6 +437,9 @@ class ValueGradFunction:
         self._extra_vars_shared = {}
         for var in extra_vars:
             shared = theano.shared(var.tag.test_value, var.name + '_shared__')
+            if isinstance(var.tag.test_value, np.ndarray):
+                if len(var.tag.test_value) == 1:
+                    shared.type = theano.tensor.TensorType(var.dtype, (True,))
             self._extra_vars_shared[var.name] = shared
             givens.append((var, shared))
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -437,6 +437,8 @@ class ValueGradFunction:
         self._extra_vars_shared = {}
         for var in extra_vars:
             shared = theano.shared(var.tag.test_value, var.name + '_shared__')
+            # manually set the TensorType for length 1 arrays due to a
+            # theano conversion problem
             if isinstance(var.tag.test_value, np.ndarray):
                 if len(var.tag.test_value) == 1:
                     shared.type = theano.tensor.TensorType(var.dtype, (True,))

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -401,6 +401,8 @@ class ValueGradFunction:
     """
     def __init__(self, cost, grad_vars, extra_vars=None, dtype=None,
                  casting='no', **kwargs):
+        from .distributions import TensorType
+
         if extra_vars is None:
             extra_vars = []
 
@@ -437,12 +439,12 @@ class ValueGradFunction:
         self._extra_vars_shared = {}
         for var in extra_vars:
             shared = theano.shared(var.tag.test_value, var.name + '_shared__')
-            # manually set the TensorType for length 1 arrays due to a
-            # theano conversion problem
-            if isinstance(var.tag.test_value, np.ndarray):
-                if var.tag.test_value.ndim == 1:
-                    if len(var.tag.test_value) == 1:
-                        shared.type = theano.tensor.TensorType(var.dtype, (True,))
+            # test TensorType compatibility
+            if hasattr(var.tag.test_value, 'shape'):
+                testtype = TensorType(var.dtype, var.tag.test_value.shape)
+
+                if testtype != shared.type:
+                    shared.type = testtype
             self._extra_vars_shared[var.name] = shared
             givens.append((var, shared))
 

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -288,3 +288,16 @@ class TestValueGradFunction(unittest.TestCase):
         assert logp.size == 1
         assert dlogp.size == 4
         npt.assert_allclose(dlogp, 0., atol=1e-5)
+
+    def test_tensor_type_conversion(self):
+        # case described in #3122
+        X = np.random.binomial(1, 0.5, 10)
+        X[0] = -1  # masked a single value
+        X = np.ma.masked_values(X, value=-1)
+        with pm.Model() as m:
+            x1 = pm.Uniform('x1', 0., 1.)
+            x2 = pm.Bernoulli('x2', x1, observed=X)
+
+        gf = m.logp_dlogp_function()
+
+        assert m['x2_missing'].type == gf._extra_vars_shared['x2_missing'].type


### PR DESCRIPTION
In #3122 it shows an error caused when trying to impute the values of a single missing variable. The error thrown by theano is, e.g.:

    TypeError: Cannot convert Type TensorType(int64, vector) (of Variable obs_t_minus_1_missing_missing_shared__) into Type TensorType(int64, (True,)). You can try to manually convert obs_t_minus_1_missing_missing_shared__ into a TensorType(int64, (True,)).

This PR fixes the problem by doing as the theano error suggests. So when shared variables are being set they are checked to see if they are arrays with length 1, and if so the TensorType of the shared variable is changes.

This is a slight hack, but hopefully one that works. I have added a comment above the change in the code, but maybe this should be changed to a `UserWarning` message?