### PR TITLE
[MAINT] Prevent repeated logging statements

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -31,5 +31,6 @@ import logging
 _log = logging.getLogger('pymc3')
 if not logging.root.handlers:
     _log.setLevel(logging.INFO)
-    handler = logging.StreamHandler()
-    _log.addHandler(handler)
+    if len(_log.handlers) == 0:
+        handler = logging.StreamHandler()
+        _log.addHandler(handler)


### PR DESCRIPTION
Sometimes I edit batch scripts using spyder, and whenever I re run a code, pymc3 is reloaded. In `pymc3.__init__.py`, a logging handler was always added, leading to duplicate logs. To avoid this, I add the handler if no handlers were already added for the pymc3 logger. For a similar issue refer to [this stackoverflow thread](https://stackoverflow.com/questions/7173033/duplicate-log-output-when-using-python-logging-module).