### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/docs/source/notebooks/model_comparison.ipynb
+++ b/docs/source/notebooks/model_comparison.ipynb
@@ -567,7 +567,7 @@
     "\n",
     "## Reference\n",
     "\n",
-    "[Gelman, A., Hwang, J., & Vehtari, A. (2014). Understanding predictive information criteria for Bayesian models. Statistics and Computing, 24(6), 997–1016.](http://doi.org/10.1007/s11222-013-9416-2)\n",
+    "[Gelman, A., Hwang, J., & Vehtari, A. (2014). Understanding predictive information criteria for Bayesian models. Statistics and Computing, 24(6), 997–1016.](https://doi.org/10.1007/s11222-013-9416-2)\n",
     "\n",
     "[Vehtari, A, Gelman, A, Gabry, J. (2016). Practical Bayesian model evaluation using leave-one-out cross-validation and WAIC. Statistics and Computing](http://link.springer.com/article/10.1007/s11222-016-9696-4)"
    ]

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3018,7 +3018,7 @@ class ExGaussian(Continuous):
         ----------
         .. [Rigby2005] R.A. Rigby (2005).
            "Generalized additive models for location, scale and shape"
-           http://dx.doi.org/10.1111/j.1467-9876.2005.00510.x
+           https://doi.org/10.1111/j.1467-9876.2005.00510.x
         """
         mu = self.mu
         sigma = self.sigma


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!