### PR TITLE
Mixture random cleanup

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 - Restructured `Mixture.random` to allow better use of vectorized calls to `comp_dists.random`.
 - Added tests for mixtures of multidimensional distributions to the test suite.
 - Fixed incorrect usage of `broadcast_distribution_samples` in `DiscreteWeibull`.
+- `Mixture`'s default dtype is now determined by `theano.config.floatX`.
 
 ### Deprecations
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+- `Mixture` now supports mixtures of multidimensional probability distributions, not just lists of 1D distributions.
+
 ### Maintenance
 
 - All occurances of `sd` as a parameter name have been renamed to `sigma`. `sd` will continue to function for backwards compatibility.
@@ -13,6 +15,12 @@
 - Added a fix to allow the imputation of single missing values of observed data, which previously would fail (Fix issue #3122).
 - Fix for #3346. The `draw_values` function was too permissive with what could be grabbed from inside `point`, which lead to an error when sampling posterior predictives of variables that depended on shared variables that had changed their shape after `pm.sample()` had been called.
 - Fix for #3354. `draw_values` now adds the theano graph descendants of `TensorConstant` or `SharedVariables` to the named relationship nodes stack, only if these descendants are `ObservedRV` or `MultiObservedRV` instances.
+- Fixed bug in broadcast_distrution_samples, which did not handle correctly cases in which some samples did not have the size tuple prepended.
+- Changed `MvNormal.random`'s usage of `tensordot` for Cholesky encoded covariances. This lead to wrong axis broadcasting and seemed to be the cause for issue #3343.
+- Fixed defect in `Mixture.random` when multidimensional mixtures were involved. The mixture component was not preserved across all the elements of the dimensions of the mixture. This meant that the correlations across elements within a given draw of the mixture were partly broken.
+- Restructured `Mixture.random` to allow better use of vectorized calls to `comp_dists.random`.
+- Added tests for mixtures of multidimensional distributions to the test suite.
+- Fixed incorrect usage of `broadcast_distribution_samples` in `DiscreteWeibull`.
 
 ### Deprecations
 

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -347,12 +347,12 @@ class DiscreteWeibull(Discrete):
 
     def _random(self, q, beta, size=None):
         p = np.random.uniform(size=size)
-        p, q, beta = broadcast_distribution_samples([p, q, beta], size=size)
 
         return np.ceil(np.power(np.log(1 - p) / np.log(q), 1. / beta)) - 1
 
     def random(self, point=None, size=None):
         q, beta = draw_values([self.q, self.beta], point=point, size=size)
+        q, beta = broadcast_distribution_samples([q, beta], size=size)
 
         return generate_samples(self._random, q, beta,
                                 dist_shape=self.shape,

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -709,6 +709,11 @@ def broadcast_distribution_samples(samples, size=None):
     _size = to_tuple(size)
     # Raw samples shapes
     p_shapes = [p.shape for p in samples]
+    if (
+        all(len(p_shape) == 0 for p_shape in p_shapes) or
+        all(p_shape == p_shapes[0] for p_shape in p_shapes)
+    ):
+        return np.broadcast_arrays(*samples)
     # samples shapes without the size prepend
     sp_shapes = [s[len(_size):] if _size == s[:len(_size)] else s
                  for s in p_shapes]
@@ -722,5 +727,7 @@ def broadcast_distribution_samples(samples, size=None):
         slicer_tail = ([np.newaxis] * (len(broadcast_shape) -
                                        len(sp_shape)) +
                        [slice(None)] * len(sp_shape))
+        print(slicer_head, slicer_tail, _size, broadcast_shape, sp_shape, tuple(slicer_head + slicer_tail), param.shape)
         broadcasted_samples.append(param[tuple(slicer_head + slicer_tail)])
+    print([b.shape for b in broadcasted_samples])
     return np.broadcast_arrays(*broadcasted_samples)

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -599,6 +599,9 @@ def generate_samples(generator, *args, **kwargs):
         parameters. This may be required when the parameter shape
         does not determine the shape of a single sample, for example,
         the shape of the probabilities in the Categorical distribution.
+    not_broadcast_kwargs: dict or None
+        Key word argument dictionary to provide to the random generator, which
+        must not be broadcasted with the rest of the *args and **kwargs.
 
     Any remaining *args and **kwargs are passed on to the generator function.
     """
@@ -606,6 +609,9 @@ def generate_samples(generator, *args, **kwargs):
     one_d = _is_one_d(dist_shape)
     size = kwargs.pop('size', None)
     broadcast_shape = kwargs.pop('broadcast_shape', None)
+    not_broadcast_kwargs = kwargs.pop('not_broadcast_kwargs', None)
+    if not_broadcast_kwargs is None:
+        not_broadcast_kwargs = dict()
     if size is None:
         size = 1
 
@@ -625,6 +631,8 @@ def generate_samples(generator, *args, **kwargs):
             kwargs = {k: v.reshape(v.shape + (1,) * (max_dims - v.ndim)) for k, v in kwargs.items()}
             inputs = args + tuple(kwargs.values())
             broadcast_shape = np.broadcast(*inputs).shape  # size of generator(size=1)
+    # Update kwargs with the keyword arguments that were not broadcasted
+    kwargs.update(not_broadcast_kwargs)
 
     dist_shape = to_tuple(dist_shape)
     broadcast_shape = to_tuple(broadcast_shape)

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -707,24 +707,20 @@ def broadcast_distribution_samples(samples, size=None):
     if size is None:
         return np.broadcast_arrays(*samples)
     _size = to_tuple(size)
-    try:
-        broadcasted_samples = np.broadcast_arrays(*samples)
-    except ValueError:
-        # Raw samples shapes
-        p_shapes = [p.shape for p in samples]
-        # samples shapes without the size prepend
-        sp_shapes = [s[len(_size):] if _size == s[:len(_size)] else s
-                     for s in p_shapes]
-        broadcast_shape = np.broadcast(*[np.empty(s) for s in sp_shapes]).shape
-        broadcasted_samples = []
-        for param, p_shape, sp_shape in zip(samples, p_shapes, sp_shapes):
-            if _size == p_shape[:len(_size)]:
-                slicer_head = [slice(None)] * len(_size)
-            else:
-                slicer_head = [np.newaxis] * len(_size)
-            slicer_tail = ([np.newaxis] * (len(broadcast_shape) -
-                                           len(sp_shape)) +
-                           [slice(None)] * len(sp_shape))
-            broadcasted_samples.append(param[tuple(slicer_head + slicer_tail)])
-        broadcasted_samples = np.broadcast_arrays(*broadcasted_samples)
-    return broadcasted_samples
+    # Raw samples shapes
+    p_shapes = [p.shape for p in samples]
+    # samples shapes without the size prepend
+    sp_shapes = [s[len(_size):] if _size == s[:len(_size)] else s
+                 for s in p_shapes]
+    broadcast_shape = np.broadcast(*[np.empty(s) for s in sp_shapes]).shape
+    broadcasted_samples = []
+    for param, p_shape, sp_shape in zip(samples, p_shapes, sp_shapes):
+        if _size == p_shape[:len(_size)]:
+            slicer_head = [slice(None)] * len(_size)
+        else:
+            slicer_head = [np.newaxis] * len(_size)
+        slicer_tail = ([np.newaxis] * (len(broadcast_shape) -
+                                       len(sp_shape)) +
+                       [slice(None)] * len(sp_shape))
+        broadcasted_samples.append(param[tuple(slicer_head + slicer_tail)])
+    return np.broadcast_arrays(*broadcasted_samples)

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -254,12 +254,33 @@ class _DrawValuesContextBlocker(_DrawValuesContext, metaclass=InitContextMeta):
     """
     def __new__(cls, *args, **kwargs):
         # resolves the parent instance
-        instance = super(_DrawValuesContextBlocker, cls).__new__(cls)
+        instance = super().__new__(cls)
         instance._parent = None
         return instance
 
     def __init__(self):
         self.drawn_vars = dict()
+
+
+class _DrawValuesContextDetacher(_DrawValuesContext,
+                                 metaclass=InitContextMeta):
+    """
+    Context manager that starts a new drawn variables context copying the
+    parent's context drawn_vars dict. The following changes do not affect the
+    parent contexts but do affect the subsequent calls. This can be used to
+    iterate the same random method many times to get different results, while
+    respecting the drawn variables from previous contexts.
+    """
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls)
+
+    def __init__(self):
+        self.drawn_vars = self.drawn_vars.copy()
+
+    def update_parent(self):
+        parent = self.parent
+        if parent is not None:
+            parent.drawn_vars.update(self.drawn_vars)
 
 
 def is_fast_drawable(var):

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -172,13 +172,6 @@ class Mixture(Distribution):
         """
         def wrapped_random(*args, **kwargs):
             raw_size_ = kwargs.pop('raw_size_', None)
-            if raw_size_ is not None:
-                if isinstance(raw_size_, np.ndarray):
-                    # This may happen because generate_samples broadcasts
-                    # parameter values
-                    raw_size_ = raw_size_.ravel()[0]
-                else:
-                    raw_size_ = int(raw_size_)
             # Distribution.random's signature is always (point=None, size=None)
             # so size could be the second arg or be given as a kwarg
             if len(args) > 1:
@@ -294,7 +287,7 @@ class Mixture(Distribution):
                     broadcast_shape=broadcast_shape,
                     point=point,
                     size=size,
-                    raw_size_=size,
+                    not_broadcast_kwargs={'raw_size_': size},
                 )
                 samples.append(sample)
             samples = np.array(

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -9,8 +9,7 @@ from .dist_math import bound, random_choice
 from .distribution import (Discrete, Distribution, draw_values,
                            generate_samples, _DrawValuesContext,
                            _DrawValuesContextBlocker, to_tuple,
-                           broadcast_distribution_samples,
-                           _DrawValuesContextDetacher)
+                           broadcast_distribution_samples)
 from .continuous import get_tau_sigma, Normal
 from ..theanof import _conversion_map
 
@@ -192,7 +191,11 @@ class Mixture(Distribution):
                     # differently from scipy.*.rvs, and generate_samples
                     # follows the latter usage pattern. For this reason we
                     # decorate (horribly hack) the size kwarg of
-                    # comp_dist.random
+                    # comp_dist.random. We also have to disable pylint W0640
+                    # because comp_dist is changed at each iteration of the
+                    # for loop, and this generator function must be defined
+                    # for each comp_dist.
+                    # pylint: disable=W0640
                     if len(args) > 2:
                         args[1] = size
                     else:

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -422,7 +422,7 @@ class Mixture(Distribution):
         w_sample_size = []
         # Loop through the dist_shape to get the conditions 2 and 3 first
         for i in range(len(dist_shape)):
-            if dist_shape[i] != psh[i]:
+            if dist_shape[i] != psh[i] and wsh[i] == 1:
                 # self.shape[i] is a non singleton dimension (usually caused by
                 # observed data)
                 sh = dist_shape[i]
@@ -439,14 +439,14 @@ class Mixture(Distribution):
         # Semiflatten the mixture weights. The last axis is the number of
         # mixture mixture components, and the rest is all about size,
         # dist_shape and broadcasting
-        w = np.reshape(w, (-1, w.shape[-1]))
+        w_ = np.reshape(w, (-1, w.shape[-1]))
         w_samples = generate_samples(random_choice,
-                                     p=w,
+                                     p=w_,
                                      broadcast_shape=w.shape[:-1] or (1,),
                                      dist_shape=w.shape[:-1] or (1,),
-                                     size=np.prod(w_sample_size))
+                                     size=None) # w's shape already includes size
         # Now we broadcast the chosen components to the dist_shape
-        w_samples = np.reshape(w_samples, w_sample_size)
+        w_samples = np.reshape(w_samples, w.shape[:-1])
         if size is not None and dist_shape[:len(size)] != size:
             w_samples = np.broadcast_to(w_samples, size + dist_shape)
         else:

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -1,4 +1,6 @@
+from collections.abc import Iterable
 import numpy as np
+import theano
 import theano.tensor as tt
 
 from pymc3.util import get_variable_name
@@ -6,8 +8,11 @@ from ..math import logsumexp
 from .dist_math import bound, random_choice
 from .distribution import (Discrete, Distribution, draw_values,
                            generate_samples, _DrawValuesContext,
-                           _DrawValuesContextBlocker, to_tuple)
+                           _DrawValuesContextBlocker, to_tuple,
+                           broadcast_distribution_samples,
+                           _DrawValuesContextDetacher)
 from .continuous import get_tau_sigma, Normal
+from ..theanof import _conversion_map
 
 
 def all_discrete(comp_dists):
@@ -18,6 +23,256 @@ def all_discrete(comp_dists):
         return isinstance(comp_dists, Discrete)
     else:
         return all(isinstance(comp_dist, Discrete) for comp_dist in comp_dists)
+
+
+class _Mixture(Distribution):
+    def __init__(self, w, comp_dists, *args, **kwargs):
+        self.comp_dists = comp_dists
+        defaults = kwargs.pop('defaults', [])
+        
+        if all_discrete(comp_dists):
+            default_dtype = _conversion_map[theano.config.floatX]
+        else:
+            default_dtype = theano.config.floatX
+            try:
+                self.mean = (w * self._comp_means()).sum(axis=-1)
+
+                if 'mean' not in defaults:
+                    defaults.append('mean')
+            except AttributeError:
+                pass
+        dtype = kwargs.pop('dtype', default_dtype)
+
+        try:
+            comp_modes = self._comp_modes()
+            comp_mode_logps = self.logp(comp_modes)
+            self.mode = comp_modes[tt.argmax(w * comp_mode_logps, axis=-1)]
+
+            if 'mode' not in defaults:
+                defaults.append('mode')
+        except (AttributeError, ValueError, IndexError):
+            pass
+        super().__init__(shape=self.wrapped_shape,
+                         dtype=dtype,
+                         defaults=defaults,
+                         *args,
+                         **kwargs)
+
+    @property
+    def comp_dists(self):
+        return self._comp_dists
+
+    @comp_dists.setter
+    def comp_dists(self, comp_dists):
+        if isinstance(comp_dists, Distribution):
+            self._comp_dists = comp_dists
+            self._sample_shape = comp_dists.shape
+            self._ndim = len(self._sample_shape)
+            self.is_multidim_comp = True
+        elif isinstance(comp_dists, Iterable):
+            if not all((isinstance(comp_dist, Distribution)
+                        for comp_dist in comp_dists)):
+                raise TypeError('Supplied Mixture comp_dists must be a '
+                                'Distribution or an iterable of '
+                                'Distributions.')
+            self._comp_dists = comp_dists
+            # Now we check the comp_dists distribution shape, see what
+            # the broadcast shape would be. This shape will be the dist_shape
+            # used by generate samples (the shape of a single random sample)
+            # from the mixture
+            shapes = [comp_dist.shape for comp_dist in comp_dists]
+            ndim = max((len(shape) for shape in shapes))
+            # All component distributions must broadcast with each other
+            try:
+                broadcast_shape = np.broadcast(*[np.empty(shape)
+                                                 for shape in shapes]).shape
+            except Exception:
+                raise TypeError('Supplied comp_dists shapes do not broadcast '
+                                'with each other. comp_dists shapes are: '
+                                '{}'.format(shapes))
+            self._ndim = ndim
+            self._sample_shape = broadcast_shape
+            self.is_multidim_comp = False
+
+    def _random(self, point=None, size=None, sample_size=None):
+        if self.is_multidim_comp:
+            return self.wrapped_comp_dists.random(point=point, size=size)
+        else:
+            if sample_size is None:
+                sample_size = size
+            samples = np.array(
+                broadcast_distribution_samples(
+                    draw_values(
+                        self.wrapped_comp_dists,
+                        point=point,
+                        size=size),
+                    size=sample_size,
+                )
+            )
+            # In the logp we assume the last axis holds the mixture components
+            # so we move the axis to the last dimension
+            return np.moveaxis(samples, 0, -1)
+
+    def _comp_logp(self, value):
+        comp_dists = self.comp_dists
+
+        try:
+            value_ = value if value.ndim > 1 else tt.shape_padright(value)
+
+            return comp_dists.logp(value_)
+        except AttributeError:
+            return tt.squeeze(tt.stack([comp_dist.logp(value)
+                                        for comp_dist in comp_dists],
+                                       axis=1))
+
+    def _comp_means(self):
+        try:
+            return tt.as_tensor_variable(self.comp_dists.mean)
+        except AttributeError:
+            return tt.squeeze(tt.stack([comp_dist.mean
+                                        for comp_dist in self.comp_dists],
+                                       axis=1))
+
+    def _comp_modes(self):
+        try:
+            return tt.as_tensor_variable(self.comp_dists.mode)
+        except AttributeError:
+            return tt.squeeze(tt.stack([comp_dist.mode
+                                        for comp_dist in self.comp_dists],
+                                       axis=1))
+
+    def _comp_samples(self, point=None, size=None):
+        if self._comp_dists_vect or size is None:
+            try:
+                return self.comp_dists.random(point=point, size=size)
+            except AttributeError:
+                samples = np.array([comp_dist.random(point=point, size=size)
+                                    for comp_dist in self.comp_dists])
+                samples = np.moveaxis(samples, 0, samples.ndim - 1)
+        else:
+            # We must iterate the calls to random manually
+            size = to_tuple(size)
+            _size = int(np.prod(size))
+            try:
+                samples = np.array([self.comp_dists.random(point=point,
+                                                           size=None)
+                                    for _ in range(_size)])
+                samples = np.reshape(samples, size + samples.shape[1:])
+            except AttributeError:
+                samples = np.array([[comp_dist.random(point=point, size=None)
+                                     for _ in range(_size)]
+                                    for comp_dist in self.comp_dists])
+                samples = np.moveaxis(samples, 0, samples.ndim - 1)
+                samples = np.reshape(samples, size + samples[1:])
+
+        if samples.shape[-1] == 1:
+            return samples[..., 0]
+        else:
+            return samples
+
+    def logp(self, value):
+        w = self.w
+
+        return bound(logsumexp(tt.log(w) + self._comp_logp(value), axis=-1),
+                     w >= 0, w <= 1, tt.allclose(w.sum(axis=-1), 1),
+                     broadcast_conditions=False)
+
+    def random(self, point=None, size=None):
+        # Convert size to tuple
+        size = to_tuple(size)
+        # Draw mixture weights and a sample from each mixture to infer shape
+        with _DrawValuesContext() as draw_context:
+            # We first need to check w and comp_tmp shapes and re compute size
+            w = draw_values([self.w], point=point, size=size)[0]
+        with _DrawValuesContextBlocker():
+            # We don't want to store the values drawn here in the context
+            # because they wont have the correct size
+            comp_tmp = self._comp_random(point=point, size=None)
+
+        # When size is not None, it's hard to tell the w parameter shape
+        if size is not None and w.shape[:len(size)] == size:
+            w_shape = w.shape[len(size):]
+        else:
+            w_shape = w.shape
+
+        # Try to determine parameter shape and dist_shape
+        param_shape = np.broadcast(np.empty(w_shape),
+                                   comp_tmp).shape
+        if np.asarray(self.shape).size != 0:
+            dist_shape = np.broadcast(np.empty(self.shape),
+                                      np.empty(param_shape[:-1])).shape
+        else:
+            dist_shape = param_shape[:-1]
+
+        # When size is not None, maybe dist_shape partially overlaps with size
+        if size is not None:
+            if size == dist_shape:
+                sample_size = None
+            elif size[-len(dist_shape):] == dist_shape:
+                sample_size = size[:len(size) - len(dist_shape)]
+
+        # We get an integer _size instead of a tuple size for drawing the
+        # mixture, then we just reshape the output
+        if sample_size is None:
+            _size = None
+        else:
+            _size = int(np.prod(sample_size))
+
+        # Now we must broadcast w to the shape that considers size, dist_shape
+        # and param_shape. However, we must take care with the cases in which
+        # dist_shape and param_shape overlap
+        if size is not None and w.shape[:len(size)] == size:
+            if w.shape[:len(size + dist_shape)] != (size + dist_shape):
+                # To allow w to broadcast, we insert new axis in between the
+                # "size" axis and the "mixture" axis
+                _w = w[(slice(None),) * len(size) +  # Index the size axis
+                       (np.newaxis,) * len(dist_shape) +  # Add new axis for the dist_shape
+                       (slice(None),)]  # Close with the slice of mixture components
+                w = np.broadcast_to(_w, size + dist_shape + (param_shape[-1],))
+        elif size is not None:
+            w = np.broadcast_to(w, size + dist_shape + (param_shape[-1],))
+        else:
+            w = np.broadcast_to(w, dist_shape + (param_shape[-1],))
+
+        # Compute the total size of the mixture's random call with size
+        if _size is not None:
+            output_size = int(_size * np.prod(dist_shape) * param_shape[-1])
+        else:
+            output_size = int(np.prod(dist_shape) * param_shape[-1])
+        # Get the size we need for the mixture's random call
+        mixture_size = int(output_size // np.prod(comp_tmp.shape))
+        if mixture_size == 1 and _size is None:
+            mixture_size = None
+
+        # Semiflatten the mixture weights. The last axis is the number of
+        # mixture mixture components, and the rest is all about size,
+        # dist_shape and broadcasting
+        w = np.reshape(w, (-1, w.shape[-1]))
+        # Normalize mixture weights
+        w = w / w.sum(axis=-1, keepdims=True)
+
+        w_samples = generate_samples(random_choice,
+                                     p=w,
+                                     broadcast_shape=w.shape[:-1] or (1,),
+                                     dist_shape=w.shape[:-1] or (1,),
+                                     size=size)
+        # Sample from the mixture
+        with draw_context:
+            mixed_samples = self._comp_samples(point=point,
+                                               size=mixture_size)
+        w_samples = w_samples.flatten()
+        # Semiflatten the mixture to be able to zip it with w_samples
+        mixed_samples = np.reshape(mixed_samples, (-1, comp_tmp.shape[-1]))
+        # Select the samples from the mixture
+        samples = np.array([mixed[choice] for choice, mixed in
+                            zip(w_samples, mixed_samples)])
+        # Reshape the samples to the correct output shape
+        if size is None:
+            samples = np.reshape(samples, dist_shape)
+        else:
+            samples = np.reshape(samples, size + dist_shape)
+        return samples
+
 
 
 class Mixture(Distribution):
@@ -108,29 +363,37 @@ class Mixture(Distribution):
         return self._comp_dists
 
     @comp_dists.setter
-    def comp_dists(self, _comp_dists):
-        self._comp_dists = _comp_dists
-        # Tests if the comp_dists can call random with non None size
-        with _DrawValuesContextBlocker():
-            if isinstance(self.comp_dists, (list, tuple)):
-                try:
-                    [comp_dist.random(size=23)
-                     for comp_dist in self.comp_dists]
-                    self._comp_dists_vect = True
-                except Exception:
-                    # The comp_dists cannot call random with non None size or
-                    # without knowledge of the point so we assume that we will
-                    # have to iterate calls to random to get the correct size
-                    self._comp_dists_vect = False
-            else:
-                try:
-                    self.comp_dists.random(size=23)
-                    self._comp_dists_vect = True
-                except Exception:
-                    # The comp_dists cannot call random with non None size or
-                    # without knowledge of the point so we assume that we will
-                    # have to iterate calls to random to get the correct size
-                    self._comp_dists_vect = False
+    def comp_dists(self, comp_dists):
+        if isinstance(comp_dists, Distribution):
+            self._comp_dists = comp_dists
+            self._sample_shape = comp_dists.shape
+            self._ndim = len(self._sample_shape)
+            self.is_multidim_comp = True
+        elif isinstance(comp_dists, Iterable):
+            if not all((isinstance(comp_dist, Distribution)
+                        for comp_dist in comp_dists)):
+                raise TypeError('Supplied Mixture comp_dists must be a '
+                                'Distribution or an iterable of '
+                                'Distributions.')
+            self._comp_dists = comp_dists
+            print(comp_dists, type(comp_dists))
+            # Now we check the comp_dists distribution shape, see what
+            # the broadcast shape would be. This shape will be the dist_shape
+            # used by generate samples (the shape of a single random sample)
+            # from the mixture
+            shapes = [comp_dist.shape for comp_dist in comp_dists]
+            ndim = max((len(shape) for shape in shapes))
+            # All component distributions must broadcast with each other
+            try:
+                broadcast_shape = np.broadcast(*[np.empty(shape)
+                                                 for shape in shapes]).shape
+            except Exception:
+                raise TypeError('Supplied comp_dists shapes do not broadcast '
+                                'with each other. comp_dists shapes are: '
+                                '{}'.format(shapes))
+            self._ndim = ndim
+            self._sample_shape = broadcast_shape
+            self.is_multidim_comp = False
 
     def _comp_logp(self, value):
         comp_dists = self.comp_dists
@@ -160,34 +423,27 @@ class Mixture(Distribution):
                                         for comp_dist in self.comp_dists],
                                        axis=1))
 
-    def _comp_samples(self, point=None, size=None):
-        if self._comp_dists_vect or size is None:
-            try:
-                return self.comp_dists.random(point=point, size=size)
-            except AttributeError:
-                samples = np.array([comp_dist.random(point=point, size=size)
-                                    for comp_dist in self.comp_dists])
-                samples = np.moveaxis(samples, 0, samples.ndim - 1)
+    def _comp_samples(self, point=None, size=None, sample_size=None):
+        if self.is_multidim_comp:
+            return self._comp_dists.random(point=point, size=size)
         else:
-            # We must iterate the calls to random manually
-            size = to_tuple(size)
-            _size = int(np.prod(size))
-            try:
-                samples = np.array([self.comp_dists.random(point=point,
-                                                           size=None)
-                                    for _ in range(_size)])
-                samples = np.reshape(samples, size + samples.shape[1:])
-            except AttributeError:
-                samples = np.array([[comp_dist.random(point=point, size=None)
-                                     for _ in range(_size)]
-                                    for comp_dist in self.comp_dists])
-                samples = np.moveaxis(samples, 0, samples.ndim - 1)
-                samples = np.reshape(samples, size + samples[1:])
-
-        if samples.shape[-1] == 1:
-            return samples[..., 0]
-        else:
-            return samples
+            samples = []
+            for comp_dist in self.comp_dists:
+                sample = generate_samples(
+                    comp_dist.random,
+                    dist_shape=comp_dist.shape,
+                    broadcast_shape=self._sample_shape,
+                    size=size
+                )
+                samples.append(sample)
+            if sample_size is None:
+                sample_size = size
+            samples = np.array(
+                broadcast_distribution_samples(samples, size=sample_size)
+            )
+            # In the logp we assume the last axis holds the mixture components
+            # so we move the axis to the last dimension
+            return np.moveaxis(samples, 0, -1)
 
     def logp(self, value):
         w = self.w

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -267,7 +267,7 @@ class MvNormal(_QuadFormBase):
             else:
                 std_norm_shape = mu.shape
             standard_normal = np.random.standard_normal(std_norm_shape)
-            return mu + np.tensordot(standard_normal, chol, axes=[[-1], [-1]])
+            return mu + np.einsum('...ij,...j->...i', chol, standard_normal)
         else:
             mu, tau = draw_values([self.mu, self.tau], point=point, size=size)
             if mu.shape[-1] != tau[0].shape[-1]:

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -223,8 +223,9 @@ class TestSamplePPC(SeededTest):
             ppc = pm.sample_posterior_predictive(trace, samples=1000, vars=[a])
             assert 'a' in ppc
             assert ppc['a'].shape == (1000,)
-        _, pval = stats.kstest(ppc['a'],
-                               stats.norm(loc=0, scale=np.sqrt(2)).cdf)
+        # mu's standard deviation may have changed thanks to a's observed
+        _, pval = stats.kstest(ppc['a'] - trace['mu'],
+                               stats.norm(loc=0, scale=1).cdf)
         assert pval > 0.001
 
         with model:


### PR DESCRIPTION
In PR #3293, I had tried to fix the `Mixture.random` method (issue #3270). I had mistakenly not added WIP to the PR and it was merged with the tests passing but with some rough edges. This PR addresses one important thing that was poorly implemented in PR #3293: vectorization of `comp_dists.random`.

The most important changes are:
1. Compact `comp_dists` shape inference method.
2. `_comp_samples` method was rewritten to get a uniform interface with `distributions.distribution.generate_samples`.
3. The `size`, `dist_shape` and `broadcast_shape` are handled more clearly
4. I fixed a defect in `Multinomial.random`, which may be the cause of #3343 

Points that I would like to discuss:
1. I changed a particular test that was failing, `test_sampling.py::TestSamplePPC::test_normal_scalar`. The strange thing was that it was also failing for me on master. I made a slight edit to it and would like your opinion.
2. The `generator` decorator function around `comp_dist.random` to provide the raw `size` instead of the `size` that is combined with `dist_shape` and `broadcast_shape` that `generate_samples` gives to the generators required me to ignore a pylint warning. Could you suggest an alternative that does not have to do that or something less hackish regarding the `size` parameter?
3. Should we add a `sample_prior` and `sample_posterior_predictive` test for `NormalMixture` too?

This PR does not address another point that was lacking from #3293, which is that the `LKJCholeskyCorr.random` function is not tested. I will work on it and submit a separate PR.