### PR TITLE
use standard argument order (mu, sigma, tau) in NormalMixture

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,7 +8,6 @@
 - `GLM.from_formula` and `LinearComponent.from_formula` can extract variables from the calling scope. Customizable via the new `eval_env` argument. Fixing #3382.
 
 ### Maintenance
-- Add `sigma`, `tau`, and `sd` to signature of `NormalMixture`.
 - All occurances of `sd` as a parameter name have been renamed to `sigma`. `sd` will continue to function for backwards compatibility.
 - Made `BrokenPipeError` for parallel sampling more verbose on Windows.
 - Added the `broadcast_distribution_samples` function that helps broadcasting arrays of drawn samples, taking into account the requested `size` and the inferred distribution shape. This sometimes is needed by distributions that call several `rvs` separately within their `random` method, such as the `ZeroInflatedPoisson` (Fix issue #3310).
@@ -27,6 +26,7 @@
 - Changed `Categorical.mode` to preserve all the dimensions of `p` except the last one, which encodes each category's probability.
 - Changed initialization of `Categorical.p`. `p` is now normalized to sum to `1` inside `logp` and `random`, but not during initialization. This could hide negative values supplied to `p` as mentioned in #2082.
 - `Categorical` now accepts elements of `p` equal to `0`. `logp` will return `-inf` if there are `values` that index to the zero probability categories.
+- Add `sigma`, `tau`, and `sd` to signature of `NormalMixture`.
 
 ### Deprecations
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,7 +8,7 @@
 - `GLM.from_formula` and `LinearComponent.from_formula` can extract variables from the calling scope. Customizable via the new `eval_env` argument. Fixing #3382.
 
 ### Maintenance
-
+- Add `sigma`, `tau`, and `sd` to signature of `NormalMixture`.
 - All occurances of `sd` as a parameter name have been renamed to `sigma`. `sd` will continue to function for backwards compatibility.
 - Made `BrokenPipeError` for parallel sampling more verbose on Windows.
 - Added the `broadcast_distribution_samples` function that helps broadcasting arrays of drawn samples, taking into account the requested `size` and the inferred distribution shape. This sometimes is needed by distributions that call several `rvs` separately within their `random` method, such as the `ZeroInflatedPoisson` (Fix issue #3310).

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -567,7 +567,7 @@ class NormalMixture(Mixture):
     def __init__(self, w, mu, sigma=None, tau=None, sd=None, comp_shape=(), *args, **kwargs):
         if sd is not None:
             sigma = sd
-        tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
+        _, sigma = get_tau_sigma(tau=tau, sigma=sigma)
 
         self.mu = mu = tt.as_tensor_variable(mu)
         self.sigma = self.sd = sigma = tt.as_tensor_variable(sigma)

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -564,12 +564,10 @@ class NormalMixture(Mixture):
     Note: You only have to pass in sigma or tau, but not both.
     """
 
-    def __init__(self, w, mu, comp_shape=(), *args, **kwargs):
-        if 'sd' in kwargs.keys():
-            kwargs['sigma'] = kwargs.pop('sd')
-
-        _, sigma = get_tau_sigma(tau=kwargs.pop('tau', None),
-                           sigma=kwargs.pop('sigma', None))
+    def __init__(self, w, mu, sigma=None, tau=None, sd=None, comp_shape=(), *args, **kwargs):
+        if sd is not None:
+            sigma = sd
+        tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
 
         self.mu = mu = tt.as_tensor_variable(mu)
         self.sigma = self.sd = sigma = tt.as_tensor_variable(sigma)


### PR DESCRIPTION
I tested it by running notebooks/marginalized_gaussian_mixture_model.ipynb