### PR TITLE
To fix the 3074

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -596,7 +596,7 @@ class DiscreteUniform(Discrete):
     Discrete uniform distribution.
     The pmf of this distribution is
 
-    .. math:: f(x \mid lower, upper) = \frac{1}{upper-lower}
+    .. math:: f(x \mid lower, upper) = \frac{1}{upper-lower+1}
 
     .. plot::
 


### PR DESCRIPTION
fix [3074](https://github.com/pymc-devs/pymc3/issues/3074)

Previously:
math:: f(x \mid lower, upper) = \frac{1}{upper-lower}
now:
math:: f(x \mid lower, upper) = \frac{1}{upper-lower+1}
