### PR TITLE
Fixed bug in drawing of graphviz edges from interaction nodes 

### DIFF
--- a/pymc3/model_graph.py
+++ b/pymc3/model_graph.py
@@ -108,7 +108,7 @@ class ModelGraph:
             distribution = 'Deterministic'
             attrs['shape'] = 'box'
 
-        graph.node(var_name,
+        graph.node(var_name.replace(':', '&'),
                 '{var_name} ~ {distribution}'.format(var_name=var_name, distribution=distribution),
                 **attrs)
 
@@ -167,7 +167,7 @@ class ModelGraph:
 
         for key, values in self.make_compute_graph().items():
             for value in values:
-                graph.edge(value, key)
+                graph.edge(value.replace(':', '&'), key.replace(':', '&'))
         return graph
 
 


### PR DESCRIPTION
This PR fixes issue #3413, drawing of graphviz edges from interaction nodes by replacing colons in node names with ampersands.
Ampersands are a safe replacement: they will not cause accidental node name collisions because they aren't allowed in python names (nor, by extension, in patsy formulas).