### PR TITLE
Updated NumFOCUS donation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,7 @@ page <https://github.com/pymc-devs/pymc3/graphs/contributors>`__
 Support
 =======
 
-PyMC3 is a non-profit project under NumFOCUS umbrella. If you want to support PyMC3 financially, you can donate `here <https://www.flipcause.com/widget/widget_home/MTE4OTc=>`__.
+PyMC3 is a non-profit project under NumFOCUS umbrella. If you want to support PyMC3 financially, you can donate `here <https://numfocus.salsalabs.org/donate-to-pymc3/index.html>`__.
 
 Sponsors
 ========

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -127,7 +127,7 @@
 
         <div class="ui bottom attached segment">
             <h2 class="ui dividing header">Support and sponsors</h2>
-            <p>PyMC3 is a non-profit project under NumFOCUS umbrella. If you want to support PyMC3 financially, you <a href="https://www.flipcause.com/widget/widget_home/MTE4OTc=">can donate here</a>.</p>
+            <p>PyMC3 is a non-profit project under NumFOCUS umbrella. If you want to support PyMC3 financially, you <a href="https://numfocus.salsalabs.org/donate-to-pymc3/index.html">can donate here</a>.</p>
 
             <div class="ui equal width grid">
                 <div class="column">


### PR DESCRIPTION
Hi, I am a new staff member at NumFOCUS. We have updated our donation provider from Flipcause to Salsa. The new link is: 

https://numfocus.salsalabs.org/donate-to-pymc3/index.html

Please update your website accordingly. : )

Thanks, 

Lisa Martin
NumFOCUS