### PR TITLE
Fix online documentation and docstring mainly of Data container class

### DIFF
--- a/docs/source/Advanced_usage_of_Theano_in_PyMC3.rst
+++ b/docs/source/Advanced_usage_of_Theano_in_PyMC3.rst
@@ -30,7 +30,7 @@ be time consuming if the number of datasets is large)::
     observed_data = [mu + np.random.randn(20) for mu in true_mu]
 
     data = theano.shared(observed_data[0])
-    pm.Model() as model:
+    with pm.Model() as model:
         mu = pm.Normal('mu', 0, 10)
         pm.Normal('y', mu=mu, sigma=1, observed=data)
 

--- a/docs/source/notebooks/data_container.ipynb
+++ b/docs/source/notebooks/data_container.ipynb
@@ -235,6 +235,7 @@
    "metadata": {},
    "source": [
     "The methods and functions related to the Data container class are:\n",
+    "\n",
     "- `data_container.get_value` (method inherited from the theano SharedVariable): gets the value associated with the `data_container`.\n",
     "- `data_container.set_value` (method inherited from the theano SharedVariable): sets the value associated with the `data_container`.\n",
     "- `pm.set_data`: PyMC3 function that sets the value associated with each Data container variable indicated in the dictionary `new_data` with it corresponding new value."

--- a/docs/source/notebooks/table_of_contents_examples.js
+++ b/docs/source/notebooks/table_of_contents_examples.js
@@ -39,9 +39,6 @@ Gallery.contents = {
     "gaussian_mixture_model": "Mixture Models",
     "marginalized_gaussian_mixture_model": "Mixture Models",
     "SMC2_gaussians": "Simulation-based Inference",
-    // "bayesian_neural_network_with_sgfs": "Stochastic Gradients", Moved to pymc3-experimental
-    // "constant_stochastic_gradient": "Stochastic Gradients", Moved to pymc3-experimental
-    // "sgfs_simple_optimization": "Stochastic Gradients", Moved to pymc3-experimental
     "bayes_param_survival_pymc3": "Survival Analysis",
     "censored_data": "Survival Analysis",
     "survival_analysis": "Survival Analysis",

--- a/pymc3/data.py
+++ b/pymc3/data.py
@@ -426,7 +426,7 @@ class Data:
         ...         traces.append(pm.sample())
 
     To set the value of the data container variable, check out
-    :func:`pm.set_data()`.
+    :func:`pymc3.model.set_data()`.
 
     For more information, take a look at this example notebook
     https://docs.pymc.io/notebooks/data_container.html

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1083,6 +1083,7 @@ def set_data(new_data, model=None):
     Set the value of `x` to predict on new data.
 
     .. code:: ipython
+
         >>> with model:
         ...     pm.set_data({'x': [5,6,9]})
         ...     y_test = pm.sample_posterior_predictive(trace)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 arviz
 bokeh>=0.12.13
-CommonMark==0.5.4
 graphviz>=0.8.3
 h5py>=2.7.0
 ipython


### PR DESCRIPTION
I compiled the documentation locally and detected some errors in [the code I introduced](https://github.com/pymc-devs/pymc3/pull/3389).

This pull request fix them:

- Add new line to the notebook [data_container.ipynb](https://github.com/pymc-devs/pymc3/blob/master/docs/source/notebooks/data_container.ipynb) so it renders correctly.
- Remove commented lines in [table_of_contents_examples.js](https://github.com/pymc-devs/pymc3/blob/master/docs/source/notebooks/table_of_contents_examples.js) so the online docs compile correctly.
- Fix link to online documentation in `pymc3/data.py` (cross reference to another function) and example usage in docstring of `pymc3/model.py`.

I also fixed some errors that are not related to the code I added in the previous pull request:
- Fix typo in `Advanced_usage_of_Theano_in_PyMC3.rst`.
- Remove _CommonMark_ from `requirements-dev.txt`. To compile the documentation locally I removed this package from the requirements, otherwise _pip_ installs a version that is incompatible with `recommonmark`.

Any comments or suggestions are more than welcome. :smiley: