### PR TITLE
Fixed normalization constant in DiscreteUniform docs

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -608,7 +608,7 @@ class DiscreteUniform(Discrete):
         us = [6, 2]
         for l, u in zip(ls, us):
             x = np.arange(l, u+1)
-            pmf = [1 / (u - l)] * len(x)
+            pmf = [1 / (u - l + 1)] * len(x)
             plt.plot(x, pmf, '-o', label='lower = {}, upper = {}'.format(l, u))
         plt.xlabel('x', fontsize=12)
         plt.ylabel('f(x)', fontsize=12)


### PR DESCRIPTION
Fix the issue 3420
Previous:
"pmf = [1 / (u - l)] * len(x)"
Now:
"pmf = [1 / (u - l + 1)] * len(x)"
After the change, the sum can be 1.