### PR TITLE
Fix DiscreteUniform Graph

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -608,7 +608,7 @@ class DiscreteUniform(Discrete):
         us = [6, 2]
         for l, u in zip(ls, us):
             x = np.arange(l, u+1)
-            pmf = [1 / (u - l + 1)] * len(x)
+            pmf = [1.0 / (u - l + 1)] * len(x)
             plt.plot(x, pmf, '-o', label='lower = {}, upper = {}'.format(l, u))
         plt.xlabel('x', fontsize=12)
         plt.ylabel('f(x)', fontsize=12)


### PR DESCRIPTION
The graph of pmf of DiscreteUniform distribution in the [docs](https://docs.pymc.io/api/distributions/discrete.html#pymc3.distributions.discrete.DiscreteUniform) was taking value 0 at each point. This was pointed out in: [#3074](https://github.com/pymc-devs/pymc3/issues/3074#issuecomment-471631000). The PR to resolve that issue, [#3410](https://github.com/pymc-devs/pymc3/pull/3410), did not fix this specific issue. This is a small fix for that.