### PR TITLE
Refix the documentation on Weibull Distribution

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2622,7 +2622,7 @@ class Weibull(PositiveContinuous):
     ========  ====================================================
     Support   :math:`x \in [0, \infty)`
     Mean      :math:`\beta \Gamma(1 + \frac{1}{\alpha})`
-    Variance  :math:`\beta^2 \Gamma(1 + \frac{2}{\alpha} - \mu^2)`
+    Variance  :math:`\beta^2(\Gamma(1 + \frac{2}{\alpha}) - \mu^2/\beta^2)`
     ========  ====================================================
 
     Parameters


### PR DESCRIPTION
fix the issue [3432](https://github.com/pymc-devs/pymc3/issues/3432)
previous:
\beta^2\Gamma(1+2/\alpha-\mu^2)
now:
\beta^2(\Gamma(1 + \frac{2}{\alpha}) - \mu^2/\beta^2)