### PR TITLE
Fix positional arguments for Bounded RVs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -30,6 +30,7 @@
 - `Categorical` now accepts elements of `p` equal to `0`. `logp` will return `-inf` if there are `values` that index to the zero probability categories.
 - Add `sigma`, `tau`, and `sd` to signature of `NormalMixture`.
 - Resolved issue #3248. Set default lower and upper values of -inf and inf for pm.distributions.continuous.TruncatedNormal. This avoids errors caused by their previous values of None.
+- Resolved issue #3399. Converted all calls to `pm.distributions.bound._ContinuousBounded` and `pm.distributions.bound._DiscreteBounded` to use only and all positional arguments.
 
 ### Deprecations
 

--- a/pymc3/distributions/bound.py
+++ b/pymc3/distributions/bound.py
@@ -103,8 +103,8 @@ class _DiscreteBounded(_Bounded, Discrete):
             default = lower + 1
 
         super().__init__(
-            distribution=distribution, lower=lower, upper=upper,
-            default=default, *args, **kwargs)
+            distribution, lower, upper,
+            default, *args, transform=transform, **kwargs)
 
 
 class _ContinuousBounded(_Bounded, Continuous):

--- a/pymc3/distributions/bound.py
+++ b/pymc3/distributions/bound.py
@@ -151,8 +151,8 @@ class _ContinuousBounded(_Bounded, Continuous):
             default = None
 
         super().__init__(
-            distribution=distribution, lower=lower, upper=upper,
-            transform=transform, default=default, *args, **kwargs)
+            distribution, lower, upper,
+            default, *args, transform=transform, **kwargs)
 
 
 class Bound:
@@ -214,12 +214,13 @@ class Bound:
                              'with the cumulative probability function. See '
                              'pymc3/examples/censored_data.py for an example.')
 
+        transform = kwargs.pop('transform', 'infer')
         if issubclass(self.distribution, Continuous):
-            return _ContinuousBounded(name, self.distribution,
-                                      self.lower, self.upper, *args, **kwargs)
+            return _ContinuousBounded(name, self.distribution, self.lower,
+                                    self.upper, transform, *args, **kwargs)
         elif issubclass(self.distribution, Discrete):
-            return _DiscreteBounded(name, self.distribution,
-                                    self.lower, self.upper, *args, **kwargs)
+            return _DiscreteBounded(name, self.distribution, self.lower,
+                                    self.upper, transform, *args, **kwargs)
         else:
             raise ValueError(
                 'Distribution is neither continuous nor discrete.')

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1295,6 +1295,10 @@ def test_bound():
         BoundPoisson = Bound(Poisson, upper=6)
         BoundPoisson(name="y", mu=1)
 
+    with Model():
+        BoundNormalNamedArgs = Bound(Normal, upper=6)("y", mu=2., sd=1.)
+        BoundNormalPositionalArgs = Bound(Normal, upper=6)("x", 2., 1.)
+
 
 class TestLatex:
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1300,6 +1300,11 @@ def test_bound():
         BoundNormalPositionalArgs = Bound(Normal, upper=6)("x", 2., 1.)
 
 
+    with Model():
+        BoundPoissonNamedArgs = Bound(Poisson, upper=6)("y", mu=2.)
+        BoundPoissonPositionalArgs = Bound(Poisson, upper=6)("x", 2.)
+
+
 class TestLatex:
 
     def setup_class(self):


### PR DESCRIPTION
Fixes #3399 . `*args` from `Bound.__call__` was mixing with parameters passed to `_ContinuousBounded`. i.e    

```python
    def __init__(self, distribution, lower, upper,
                 transform='infer', *args, **kwargs):
```
Here `*args` was supposed to be arguments for the `distribution` but [dist.init](https://github.com/pymc-devs/pymc3/blob/fbe86a49504b9720ea706932213445c0ffd6ee50/pymc3/distributions/distribution.py#L52) will put positional arguments `*args` before keyword arguments when calling the constructor for `_ContinuousBounded`, thus mixing the arguments.

I have changed all calls to the `_ContinuousBounded` constructor to use only (and all) positional arguments. Also added a test to reproduce the issue 