### PR TITLE
[WIP] Add docstring for MultiTrace to API doc.

### DIFF
--- a/docs/source/api/inference.rst
+++ b/docs/source/api/inference.rst
@@ -47,6 +47,15 @@ Hamiltonian Monte Carlo
    :members:
 
 
+MultiTrace
+^^^^^^^^
+
+.. currentmodule:: pymc3.backends.base
+.. autoclass:: pymc3.backends.base.MultiTrace
+    :members:
+
+.. autoclass:: pymc3.backends.base.BaseTrace
+
 Variational
 -----------
 


### PR DESCRIPTION
Previously the documentation for the MultiTrace class did not appear in the generated documents, because it was not referenced in the rst files.