### PR TITLE
Remove variable annotations

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,7 +12,6 @@
 - Used `numpy.vectorize` in `distributions.distribution._compile_theano_function`. This enables `sample_prior_predictive` and `sample_posterior_predictive` to ask for tuples of samples instead of just integers. This fixes issue #3422.
 
 ### Maintenance
-- Fixed an issue in `model_graph` that caused construction of the graph of the model for rendering to hang: replaced a search over the powerset of the nodes with a breadth-first search over the nodes. Fix for #3458.
 - All occurances of `sd` as a parameter name have been renamed to `sigma`. `sd` will continue to function for backwards compatibility.
 - Made `BrokenPipeError` for parallel sampling more verbose on Windows.
 - Added the `broadcast_distribution_samples` function that helps broadcasting arrays of drawn samples, taking into account the requested `size` and the inferred distribution shape. This sometimes is needed by distributions that call several `rvs` separately within their `random` method, such as the `ZeroInflatedPoisson` (Fix issue #3310).
@@ -38,6 +37,8 @@
 - Fixed the `Multinomial.random` and `Multinomial.random_` methods to make them compatible with the new `generate_samples` function. In the process, a bug of the `Multinomial.random_` shape handling was discovered and fixed.
 - Fixed a defect found in `Bound.random` where the `point` dictionary was passed to `generate_samples` as an `arg` instead of in `not_broadcast_kwargs`.
 - Fixed a defect found in `Bound.random_` where `total_size` could end up as a `float64` instead of being an integer if given `size=tuple()`.
+- Fixed an issue in `model_graph` that caused construction of the graph of the model for rendering to hang: replaced a search over the powerset of the nodes with a breadth-first search over the nodes. Fix for #3458.
+- Removed variable annotations from `model_graph` but left type hints (Fix for #3465). This means that we support `python>=3.5.4`.
 
 ### Deprecations
 

--- a/pymc3/model_graph.py
+++ b/pymc3/model_graph.py
@@ -47,10 +47,10 @@ class ModelGraph:
         """
 
         # this contains all of the variables in the model EXCEPT var...
-        vars: MutableSet[RV] = set(self.var_list)
+        vars = set(self.var_list)
         vars.remove(var)
-        
-        blockers: MutableSet[RV] = set()
+
+        blockers = set()
         retval = set()
         def _expand(node) -> Optional[Iterator[Tensor]]:
             if node in blockers:

--- a/pymc3/model_graph.py
+++ b/pymc3/model_graph.py
@@ -1,4 +1,3 @@
-import itertools
 from collections import deque
 from typing import Iterator, Optional, MutableSet
 
@@ -12,17 +11,6 @@ import pymc3 as pm
 # this is a placeholder for a better characterization of the type
 # of variables in a model.
 RV = Tensor
-
-
-def powerset(iterable):
-    """All *nonempty* subsets of an iterable.
-
-    From itertools docs.
-
-    powerset([1,2,3]) --> (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)
-    """
-    s = list(iterable)
-    return itertools.chain.from_iterable(itertools.combinations(s, r) for r in range(1, len(s)+1))
 
 
 class ModelGraph:


### PR DESCRIPTION
Variable annotations were added in python 3.6, and are not supported by python 3.5. This was breaking Arviz's CI.

This PR fixes #3465 but now makes pymc3 support python>=3.5.4.