### PR TITLE
[WIP] Proposed revision to sample_posterior_predictive()

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,8 +51,15 @@
 
 - `nuts_kwargs` and `step_kwargs` have been deprecated in favor of using the standard `kwargs` to pass optional step method arguments.
 - `SGFS` and `CSG` have been removed (Fix for [#3353](https://github.com/pymc-devs/pymc3/issues/3353)). They have been moved to [pymc3-experimental](https://github.com/pymc-devs/pymc3-experimental).
+<<<<<<< master
 - References to `live_plot` and corresponding notebooks have been removed.
 - Function `approx_hessian` was removed, due to `numdifftools` becoming incompatible with current `scipy`. The function was already optional, only available to a user who installed `numdifftools` separately, and not hit on any common codepaths. [#3485](https://github.com/pymc-devs/pymc3/pull/3485).
+- Deprecated `vars` parameter of `sample_posterior_predictive` in favor of `varnames`.
+=======
+-  References to `live_plot` and corresponding notebooks have been removed.
+- Deprecated `vars` parameters of `sample_posterior_predictive` and `sample_prior_predictive` in favor of `var_names`.  At least for the latter, this is more accurate, since the `vars` parameter actually took names.
+>>>>>>> Update release notes.
+
 
 ## PyMC3 3.6 (Dec 21 2018)
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -3,6 +3,7 @@ import functools
 import itertools
 import threading
 import warnings
+from typing import Optional, Dict, Any
 
 import numpy as np
 from pandas import Series
@@ -187,7 +188,7 @@ class Context:
             raise TypeError("No context on context stack")
 
 
-def modelcontext(model):
+def modelcontext(model: Optional['Model']) -> 'Model':
     """return the given model or try to find it in the context if there was
     none supplied.
     """

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -3,7 +3,7 @@ import functools
 import itertools
 import threading
 import warnings
-from typing import Optional, Dict, Any
+from typing import Optional
 
 import numpy as np
 from pandas import Series

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -529,7 +529,6 @@ def _sample_population(draws, chain, chains, start, random_seed, step, tune,
 def _sample(chain, progressbar, random_seed, start, draws=None, step=None,
             trace=None, tune=None, model=None, **kwargs):
     skip_first = kwargs.get('skip_first', 0)
-    refresh_every = kwargs.get('refresh_every', 100)
 
     sampling = _iter_sample(draws, step, start, trace, chain,
                             tune, model, random_seed)


### PR DESCRIPTION
Most other sampling functions take varnames, rather than var objects. Extend the set of parameters to accept varnames as an alternative to vars, preserving backwards compatibility.
Also revise the docstring, to clarify the return type and add type comments.