### PR TITLE
Added minimal python3.5 test env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,36 @@ cache:
     - $HOME/.theano
     - $HOME/miniconda3
 
+matrix:
+  include:
+  - name: "Python 3.6 float32 testset1"
+    python: 3.6
+    env: FLOATX='float32' TESTCMD="--durations=10 --ignore=pymc3/tests/test_examples.py --cov-append --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py --ignore=pymc3/tests/test_parallel_sampling.py --ignore=pymc3/tests/test_dist_math.py --ignore=pymc3/tests/test_distribution_defaults.py --ignore=pymc3/tests/test_distributions_timeseries.py --ignore=pymc3/tests/test_random.py --ignore=pymc3/tests/test_gp.py --ignore=pymc3/tests/test_shape_handling.py"
+  - name: "Python 3.6 float32 testset2"
+    python: 3.6
+    env: FLOATX='float32' RUN_PYLINT="true" TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py pymc3/tests/test_parallel_sampling.py pymc3/tests/test_dist_math.py pymc3/tests/test_distribution_defaults.py pymc3/tests/test_distributions_timeseries.py pymc3/tests/test_random.py"
+  - name: "Python 3.6 float32 testset3"
+    python: 3.6
+    env: FLOATX='float32' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py pymc3/tests/test_gp.py"
+  - name: "Python 3.6 float32 testset4"
+    python: 3.6
+    env: FLOATX='float32' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
+  - name: "Python 3.6 float64 testset1"
+    python: 3.6
+    env: FLOATX='float64' TESTCMD="--durations=10 --ignore=pymc3/tests/test_examples.py --cov-append --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py --ignore=pymc3/tests/test_parallel_sampling.py --ignore=pymc3/tests/test_dist_math.py --ignore=pymc3/tests/test_distribution_defaults.py --ignore=pymc3/tests/test_distributions_timeseries.py --ignore=pymc3/tests/test_random.py --ignore=pymc3/tests/test_gp.py --ignore=pymc3/tests/test_shape_handling.py"
+  - name: "Python 3.6 float64 testset2"
+    python: 3.6
+    env: FLOATX='float64' RUN_PYLINT="true" TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py pymc3/tests/test_parallel_sampling.py pymc3/tests/test_dist_math.py pymc3/tests/test_distribution_defaults.py pymc3/tests/test_distributions_timeseries.py pymc3/tests/test_random.py"
+  - name: "Python 3.6 float64 testset3"
+    python: 3.6
+    env: FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py pymc3/tests/test_gp.py"
+  - name: "Python 3.6 float64 testset4"
+    python: 3.6
+    env: FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
+  - name: "Python 3.5 float64 minitestset"
+    python: 3.5
+    env: PYTHON_VERSION=3.5 FLOATX='float64' ENVNAME="py35_testenv" TESTCMD="--cov-append pymc3/tests/test_sampling.py pymc3/tests/test_model_graph.py"
+
 addons:
   apt_packages:
     - pandoc
@@ -20,18 +50,6 @@ install:
   - . ./scripts/create_testenv.sh
   - pip install coveralls
   - conda list && pip freeze
-
-env:
-  - FLOATX='float32' TESTCMD="--durations=10 --ignore=pymc3/tests/test_examples.py --cov-append --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py --ignore=pymc3/tests/test_parallel_sampling.py --ignore=pymc3/tests/test_dist_math.py --ignore=pymc3/tests/test_distribution_defaults.py --ignore=pymc3/tests/test_distributions_timeseries.py --ignore=pymc3/tests/test_random.py --ignore=pymc3/tests/test_gp.py --ignore=pymc3/tests/test_shape_handling.py"
-  - FLOATX='float32' RUN_PYLINT="true" TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py pymc3/tests/test_parallel_sampling.py pymc3/tests/test_dist_math.py pymc3/tests/test_distribution_defaults.py pymc3/tests/test_distributions_timeseries.py pymc3/tests/test_random.py"
-  - FLOATX='float32' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py pymc3/tests/test_gp.py"
-  - FLOATX='float32' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
-  - FLOATX='float64' TESTCMD="--durations=10 --cov-append --ignore=pymc3/tests/test_examples.py --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py --ignore=pymc3/tests/test_parallel_sampling.py --ignore=pymc3/tests/test_dist_math.py --ignore=pymc3/tests/test_distribution_defaults.py --ignore=pymc3/tests/test_distributions_timeseries.py --ignore=pymc3/tests/test_random.py --ignore=pymc3/tests/test_gp.py --ignore=pymc3/tests/test_shape_handling.py"
-  - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py pymc3/tests/test_parallel_sampling.py pymc3/tests/test_dist_math.py pymc3/tests/test_distribution_defaults.py pymc3/tests/test_distributions_timeseries.py pymc3/tests/test_random.py"
-  - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py pymc3/tests/test_gp.py"
-  - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
-  - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
-  - PYTHON_VERSION=3.5 FLOATX='float64' TESTCMD="--cov-append pymc3/tests/test_sampling.py pymc3/tests/test_model_graph.py"
 
 script:
   - . ./scripts/test.sh $TESTCMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,36 +6,6 @@ cache:
     - $HOME/.theano
     - $HOME/miniconda3
 
-matrix:
-  include:
-  - name: "Python 3.6 float32 testset1"
-    python: 3.6
-    env: FLOATX='float32' TESTCMD="--durations=10 --ignore=pymc3/tests/test_examples.py --cov-append --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py --ignore=pymc3/tests/test_parallel_sampling.py --ignore=pymc3/tests/test_dist_math.py --ignore=pymc3/tests/test_distribution_defaults.py --ignore=pymc3/tests/test_distributions_timeseries.py --ignore=pymc3/tests/test_random.py --ignore=pymc3/tests/test_gp.py --ignore=pymc3/tests/test_shape_handling.py"
-  - name: "Python 3.6 float32 testset2"
-    python: 3.6
-    env: FLOATX='float32' RUN_PYLINT="true" TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py pymc3/tests/test_parallel_sampling.py pymc3/tests/test_dist_math.py pymc3/tests/test_distribution_defaults.py pymc3/tests/test_distributions_timeseries.py pymc3/tests/test_random.py"
-  - name: "Python 3.6 float32 testset3"
-    python: 3.6
-    env: FLOATX='float32' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py pymc3/tests/test_gp.py"
-  - name: "Python 3.6 float32 testset4"
-    python: 3.6
-    env: FLOATX='float32' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
-  - name: "Python 3.6 float64 testset1"
-    python: 3.6
-    env: FLOATX='float64' TESTCMD="--durations=10 --ignore=pymc3/tests/test_examples.py --cov-append --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py --ignore=pymc3/tests/test_parallel_sampling.py --ignore=pymc3/tests/test_dist_math.py --ignore=pymc3/tests/test_distribution_defaults.py --ignore=pymc3/tests/test_distributions_timeseries.py --ignore=pymc3/tests/test_random.py --ignore=pymc3/tests/test_gp.py --ignore=pymc3/tests/test_shape_handling.py"
-  - name: "Python 3.6 float64 testset2"
-    python: 3.6
-    env: FLOATX='float64' RUN_PYLINT="true" TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py pymc3/tests/test_parallel_sampling.py pymc3/tests/test_dist_math.py pymc3/tests/test_distribution_defaults.py pymc3/tests/test_distributions_timeseries.py pymc3/tests/test_random.py"
-  - name: "Python 3.6 float64 testset3"
-    python: 3.6
-    env: FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py pymc3/tests/test_gp.py"
-  - name: "Python 3.6 float64 testset4"
-    python: 3.6
-    env: FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
-  - name: "Python 3.5 float64 minitestset"
-    python: 3.5
-    env: PYTHON_VERSION=3.5 FLOATX='float64' ENVNAME="py35_testenv" TESTCMD="--cov-append pymc3/tests/test_sampling.py pymc3/tests/test_model_graph.py"
-
 addons:
   apt_packages:
     - pandoc
@@ -50,6 +20,18 @@ install:
   - . ./scripts/create_testenv.sh
   - pip install coveralls
   - conda list && pip freeze
+
+env:
+  - FLOATX='float32' TESTCMD="--durations=10 --ignore=pymc3/tests/test_examples.py --cov-append --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py --ignore=pymc3/tests/test_parallel_sampling.py --ignore=pymc3/tests/test_dist_math.py --ignore=pymc3/tests/test_distribution_defaults.py --ignore=pymc3/tests/test_distributions_timeseries.py --ignore=pymc3/tests/test_random.py --ignore=pymc3/tests/test_gp.py --ignore=pymc3/tests/test_shape_handling.py"
+  - FLOATX='float32' RUN_PYLINT="true" TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py pymc3/tests/test_parallel_sampling.py pymc3/tests/test_dist_math.py pymc3/tests/test_distribution_defaults.py pymc3/tests/test_distributions_timeseries.py pymc3/tests/test_random.py"
+  - FLOATX='float32' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py pymc3/tests/test_gp.py"
+  - FLOATX='float32' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
+  - FLOATX='float64' TESTCMD="--durations=10 --cov-append --ignore=pymc3/tests/test_examples.py --ignore=pymc3/tests/test_distributions_random.py --ignore=pymc3/tests/test_variational_inference.py --ignore=pymc3/tests/test_shared.py --ignore=pymc3/tests/test_smc.py --ignore=pymc3/tests/test_updates.py --ignore=pymc3/tests/test_posteriors.py --ignore=pymc3/tests/test_sampling.py --ignore=pymc3/tests/test_parallel_sampling.py --ignore=pymc3/tests/test_dist_math.py --ignore=pymc3/tests/test_distribution_defaults.py --ignore=pymc3/tests/test_distributions_timeseries.py --ignore=pymc3/tests/test_random.py --ignore=pymc3/tests/test_gp.py --ignore=pymc3/tests/test_shape_handling.py"
+  - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py pymc3/tests/test_parallel_sampling.py pymc3/tests/test_dist_math.py pymc3/tests/test_distribution_defaults.py pymc3/tests/test_distributions_timeseries.py pymc3/tests/test_random.py"
+  - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py pymc3/tests/test_gp.py"
+  - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
+  - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
+  - PYTHON_VERSION=3.5 FLOATX='float64' ENVNAME="py35_testenv" TESTCMD="--cov-append pymc3/tests/test_sampling.py pymc3/tests/test_model_graph.py"
 
 script:
   - . ./scripts/test.sh $TESTCMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ env:
   - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py pymc3/tests/test_parallel_sampling.py pymc3/tests/test_dist_math.py pymc3/tests/test_distribution_defaults.py pymc3/tests/test_distributions_timeseries.py pymc3/tests/test_random.py"
   - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py pymc3/tests/test_gp.py"
   - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
+  - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
+  - PYTHON_VERSION=3.5 FLOATX='float64' TESTCMD="--cov-append pymc3/tests/test_sampling.py pymc3/tests/test_model_graph.py"
 
 script:
   - . ./scripts/test.sh $TESTCMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ env:
   - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py pymc3/tests/test_parallel_sampling.py pymc3/tests/test_dist_math.py pymc3/tests/test_distribution_defaults.py pymc3/tests/test_distributions_timeseries.py pymc3/tests/test_random.py"
   - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py pymc3/tests/test_gp.py"
   - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
-  - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
   - PYTHON_VERSION=3.5 FLOATX='float64' ENVNAME="py35_testenv" TESTCMD="--cov-append pymc3/tests/test_sampling.py pymc3/tests/test_model_graph.py"
 
 script:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -45,6 +45,7 @@
 - Fixed an issue in `model_graph` that caused construction of the graph of the model for rendering to hang: replaced a search over the powerset of the nodes with a breadth-first search over the nodes. Fix for #3458.
 - Removed variable annotations from `model_graph` but left type hints (Fix for #3465). This means that we support `python>=3.5.4`.
 - Default `target_accept`for `HamiltonianMC` is now 0.65, as suggested in Beskos et. al. 2010 and Neal 2001.
+- Fixed bug in `draw_values` that lead to intermittent errors in python3.5. This happened with some deterministic nodes that were drawn but not added to `givens`.
 
 ### Deprecations
 

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -401,8 +401,7 @@ def draw_values(params, point=None, size=None):
                     # nodes in the `params` list.
                     stack.extend([node for node in named_nodes_parents[next_]
                                   if node is not None and
-                                  (node, size) not in drawn and
-                                  node not in params])
+                                  (node, size) not in drawn])
 
         # the below makes sure the graph is evaluated in order
         # test_distributions_random::TestDrawValues::test_draw_order fails without it
@@ -418,9 +417,22 @@ def draw_values(params, point=None, size=None):
                 param = params[param_idx]
                 if (param, size) in drawn:
                     evaluated[param_idx] = drawn[(param, size)]
-                    givens[param.name] = (param, value)
                 else:
                     try:  # might evaluate in a bad order,
+                        # Sometimes _draw_value recurrently calls draw_values.
+                        # This may set values for certain nodes in the drawn
+                        # dictionary, but they don't get added to the givens
+                        # dictionary. Here, we try to fix that.
+                        if param in named_nodes_children:
+                            for node in named_nodes_children[param]:
+                                if (
+                                    node.name not in givens and
+                                    (node, size) in drawn
+                                ):
+                                    givens[node.name] = (
+                                        node,
+                                        drawn[(node, size)]
+                                    )
                         value = _draw_value(param,
                                             point=point,
                                             givens=givens.values(),

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -418,6 +418,7 @@ def draw_values(params, point=None, size=None):
                 param = params[param_idx]
                 if (param, size) in drawn:
                     evaluated[param_idx] = drawn[(param, size)]
+                    givens[param.name] = (param, value)
                 else:
                     try:  # might evaluate in a bad order,
                         value = _draw_value(param,

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -34,7 +34,6 @@ then
     source activate ${ENVNAME}
 fi
 pip install --upgrade pip
-pip uninstall -y numpy
 
 conda install --yes mkl-service
 conda install --yes -c conda-forge python-graphviz

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -20,7 +20,7 @@ command -v conda >/dev/null 2>&1 || {
   exit 1;
 }
 
-ENVNAME="testenv"
+ENVNAME="${ENVNAME:-testenv}" # if no ENVNAME is specified, use testenv
 PYTHON_VERSION=${PYTHON_VERSION:-3.6} # if no python specified, use 3.6
 
 if [ -z ${GLOBAL} ]

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -36,7 +36,7 @@ fi
 pip install --upgrade pip
 pip uninstall -y numpy
 
-conda install --yes numpy scipy mkl-service
+conda install --yes mkl-service
 conda install --yes -c conda-forge python-graphviz
 
 

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -34,7 +34,7 @@ then
     source activate ${ENVNAME}
 fi
 pip install --upgrade pip
-pip uninstall numpy
+pip uninstall -y numpy
 
 conda install --yes numpy scipy mkl-service
 conda install --yes -c conda-forge python-graphviz

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -33,10 +33,12 @@ then
     fi
     source activate ${ENVNAME}
 fi
+pip install --upgrade pip
+pip uninstall numpy
+
 conda install --yes numpy scipy mkl-service
 conda install --yes -c conda-forge python-graphviz
 
-pip install --upgrade pip
 
 #  Install editable using the setup.py
 

--- a/scripts/install_miniconda.sh
+++ b/scripts/install_miniconda.sh
@@ -46,4 +46,5 @@ fi
 export PATH="$INSTALL_FOLDER/bin:$PATH"
 echo "Adding $INSTALL_FOLDER to PATH.  Consider adding it in your .rc file as well."
 conda update -q -y conda
+# Uninstalling miniconda's numpy to avoid conflicting versions when creating the test env
 pip uninstall -y numpy

--- a/scripts/install_miniconda.sh
+++ b/scripts/install_miniconda.sh
@@ -46,3 +46,4 @@ fi
 export PATH="$INSTALL_FOLDER/bin:$PATH"
 echo "Adding $INSTALL_FOLDER to PATH.  Consider adding it in your .rc file as well."
 conda update -q -y conda
+pip uninstall -y numpy

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ if __name__ == "__main__":
           package_data={'docs': ['*']},
           include_package_data=True,
           classifiers=classifiers,
+          python_requires=">=3.5.4",
           install_requires=install_reqs,
           extras_require={
               "plots": ["arviz"],


### PR DESCRIPTION
After #3465 and taking into account that we want to keep a tight integration with Arviz, I think that we should add a small test environment for python 3.5. I added test_sampling.py and test_model_graph.py because we introduced type hints into sampling.py and model_graph.py, and we need to check if those work well or break python 3.5.