### PR TITLE
Fix for #3450

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -143,7 +143,7 @@ class _QuadFormBase(Continuous):
         if dist is None:
             dist = self
         if self._cov_type == 'chol':
-            chol = get_variable_name(self.chol)
+            chol = get_variable_name(self.chol_cov)
             return r'\mathit{{chol}}={}'.format(chol)
         elif self._cov_type == 'cov':
             cov = get_variable_name(self.cov)

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1327,7 +1327,7 @@ class TestLatex:
             sigma = HalfNormal('sigma', sigma=1)
 
             #Test Cholesky parameterization
-            Z = MvNormal('Z', mu = np.zeros(2), chol = np.eye(2), shape = 2)
+            Z = MvNormal('Z', mu=np.zeros(2), chol=np.eye(2), shape=(2,))
 
             # Expected value of outcome
             mu = Deterministic('mu', floatX(alpha + tt.dot(X, b)))
@@ -1340,7 +1340,7 @@ class TestLatex:
             r'$\text{sigma} \sim \text{HalfNormal}(\mathit{sigma}=1.0)$',
             r'$\text{mu} \sim \text{Deterministic}(\text{alpha},~\text{Constant},~\text{beta})$',
             r'$\text{beta} \sim \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$',
-            r'$\text{Z} \sim \text{MvNormal}(\mathit{mu}=array,~\mathit{chol}=array)$',
+            r'$Z \sim \text{MvNormal}(\mathit{mu}=array, \mathit{chol}=array)$',
             r'$\text{Y_obs} \sim \text{Normal}(\mathit{mu}=\text{mu},~\mathit{sigma}=f(\text{sigma}))$'
         )
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1326,17 +1326,21 @@ class TestLatex:
             b = Normal('beta', mu=0, sigma=10, shape=(2,), observed=beta)
             sigma = HalfNormal('sigma', sigma=1)
 
+            #Test Cholesky parameterization
+            Z = MvNormal('Z', mu = np.zeros(2), chol = np.eye(2), shape = 2)
+
             # Expected value of outcome
             mu = Deterministic('mu', floatX(alpha + tt.dot(X, b)))
 
             # Likelihood (sampling distribution) of observations
             Y_obs = Normal('Y_obs', mu=mu, sigma=sigma, observed=Y)
-        self.distributions = [alpha, sigma, mu, b, Y_obs]
+        self.distributions = [alpha, sigma, mu, b, Z, Y_obs]
         self.expected = (
             r'$\text{alpha} \sim \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$',
             r'$\text{sigma} \sim \text{HalfNormal}(\mathit{sigma}=1.0)$',
             r'$\text{mu} \sim \text{Deterministic}(\text{alpha},~\text{Constant},~\text{beta})$',
             r'$\text{beta} \sim \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$',
+            r'$\text{Z} \sim \text{MvNormal}(\mathit{mu}=array,~\mathit{chol}=array)$',
             r'$\text{Y_obs} \sim \text{Normal}(\mathit{mu}=\text{mu},~\mathit{sigma}=f(\text{sigma}))$'
         )
 


### PR DESCRIPTION
Commits fix for issue #3450 

` _repr_cov_params` now uses `self.chol_cov`.

Example in the issue
```
import numpy as np
import pymc3 as pm
with pm.Model() as model:
    d = pm.MvNormal('x', mu=np.zeros(2), chol=np.eye(2), shape=2)

    print(d.distribution._repr_latex_())
```

now returns

`$None \sim \text{MvNormal}(\mathit{mu}=array, \mathit{chol}=array)$
`