### PR TITLE
Improve distribution docs - continued

### DIFF
--- a/pymc3/distributions/bound.py
+++ b/pymc3/distributions/bound.py
@@ -40,6 +40,18 @@ class _Bounded(Distribution):
         )
 
     def logp(self, value):
+        """
+        Calculate log-probability of Bounded distribution at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         logp = self._wrapped.logp(value)
         bounds = []
         if self.lower is not None:
@@ -76,6 +88,22 @@ class _Bounded(Distribution):
             return samples[0]
 
     def random(self, point=None, size=None):
+        """
+        Draw random values from Bounded distribution.
+
+        Parameters
+        ----------
+        point : dict, optional
+            Dict of variable values on which random values are to be
+            conditioned (uses default point if not specified).
+        size : int, optional
+            Desired size of random sample (returns one sample if not
+            specified).
+
+        Returns
+        -------
+        array
+        """
         if self.lower is None and self.upper is None:
             return self._wrapped.random(point=point, size=size)
         elif self.lower is not None and self.upper is not None:

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -233,6 +233,20 @@ class Uniform(BoundedContinuous):
             name, get_variable_name(lower), get_variable_name(upper))
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for Uniform distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         return tt.switch(
             tt.or_(tt.lt(value, self.lower), tt.gt(value, self.upper)),
             -np.inf,
@@ -290,6 +304,20 @@ class Flat(Continuous):
         return r'${} \sim \text{{Flat}}()$'.format(name)
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for Flat distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         return tt.switch(
             tt.eq(value, -np.inf),
             -np.inf,
@@ -343,6 +371,20 @@ class HalfFlat(PositiveContinuous):
         return r'${} \sim \text{{HalfFlat}}()$'.format(name)
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for HalfFlat distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         return tt.switch(
             tt.lt(value, np.inf),
             -np.inf,
@@ -487,6 +529,20 @@ class Normal(Continuous):
                                                                 get_variable_name(sigma))
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for Normal distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         return normal_lcdf(self.mu, self.sigma, value)
 
 
@@ -816,6 +872,20 @@ class HalfNormal(PositiveContinuous):
                                                                          get_variable_name(sigma))
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for HalfNormal distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         sigma = self.sigma
         z = zvalue(value, mu=0, sigma=sigma)
         return tt.switch(
@@ -1009,6 +1079,20 @@ class Wald(PositiveContinuous):
                                                                 get_variable_name(alpha))
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for Wald distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         # Distribution parameters
         mu = self.mu
         lam = self.lam
@@ -1192,6 +1276,20 @@ class Beta(UnitContinuous):
                      alpha > 0, beta > 0)
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for Beta distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         value = floatX(tt.as_tensor(value))
         a = floatX(tt.as_tensor(self.alpha))
         b = floatX(tt.as_tensor(self.beta))
@@ -1429,13 +1527,24 @@ class Exponential(PositiveContinuous):
 
     def logcdf(self, value):
         """
-        Compute the log CDF for the Exponential distribution
+        Compute the log of cumulative distribution function for the Exponential distribution
+        at the specified value.
 
         References
         ----------
         .. [Machler2012] Martin Mächler (2012).
             "Accurately computing log(1-exp(-|a|)) Assessed by the Rmpfr
             package"
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
         """
         value = floatX(tt.as_tensor(value))
         lam = self.lam
@@ -1554,6 +1663,20 @@ class Laplace(Continuous):
                                                                 get_variable_name(b))
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for Laplace distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         a = self.mu
         b = self.b
         y = (value - a) / b
@@ -1706,6 +1829,20 @@ class Lognormal(PositiveContinuous):
                                                                 get_variable_name(tau))
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for Lognormal distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         mu = self.mu
         sigma = self.sigma
         z = zvalue(tt.log(value), mu=mu, sigma=sigma)
@@ -1864,6 +2001,20 @@ class StudentT(Continuous):
                                                                 get_variable_name(lam))
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for Student's T distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         nu = self.nu
         mu = self.mu
         sigma = self.sigma
@@ -1995,6 +2146,20 @@ class Pareto(Continuous):
                                                                 get_variable_name(m))
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for Pareto distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         m = self.m
         alpha = self.alpha
         arg = (m / value) ** alpha
@@ -2119,6 +2284,20 @@ class Cauchy(Continuous):
                                                                 get_variable_name(beta))
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for Cauchy distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         return tt.log(
             0.5 + tt.arctan((value - self.alpha) / self.beta) / np.pi
         )
@@ -2223,6 +2402,20 @@ class HalfCauchy(PositiveContinuous):
                                                                 get_variable_name(beta))
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for HalfCauchy distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         return tt.switch(
             tt.le(value, 0),
             -np.inf,
@@ -2366,7 +2559,18 @@ class Gamma(PositiveContinuous):
 
     def logcdf(self, value):
         """
-        Compute the log CDF for the Gamma distribution
+        Compute the log of the cumulative distribution function for Gamma distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
         """
         alpha = self.alpha
         beta = self.beta
@@ -2702,15 +2906,26 @@ class Weibull(PositiveContinuous):
                                                                 get_variable_name(beta))
 
     def logcdf(self, value):
-        '''
-        Compute the log CDF for the Weibull distribution
+        """
+        Compute the log of the cumulative distribution function for Weibull distribution
+        at the specified value.
 
         References
         ----------
         .. [Machler2012] Martin Mächler (2012).
             "Accurately computing log(1-exp(-|a|)) Assessed by the Rmpfr
             package"
-        '''
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         alpha = self.alpha
         beta = self.beta
         a = (value / beta)**alpha
@@ -3004,15 +3219,25 @@ class ExGaussian(Continuous):
 
     def logcdf(self, value):
         """
-        Compute the log CDF for the ExGaussian distribution
+        Compute the log of the cumulative distribution function for ExGaussian distribution
+        at the specified value.
 
         References
         ----------
         .. [Rigby2005] R.A. Rigby (2005).
            "Generalized additive models for location, scale and shape"
            https://doi.org/10.1111/j.1467-9876.2005.00510.x
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
         """
-        mu = self.mu
         sigma = self.sigma
         sigma_2 = sigma**2
         nu = self.nu
@@ -3399,6 +3624,20 @@ class Triangular(BoundedContinuous):
                                                                 get_variable_name(upper))
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for Triangular distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         l = self.lower
         u = self.upper
         c = self.c
@@ -3528,6 +3767,20 @@ class Gumbel(Continuous):
                                                                 get_variable_name(beta))
 
     def logcdf(self, value):
+        """
+        Compute the log of the cumulative distribution function for Gumbel distribution
+        at the specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
+        """
         beta = self.beta
         mu = self.mu
 
@@ -3758,13 +4011,24 @@ class Logistic(Continuous):
 
     def logcdf(self, value):
         """
-        Compute the log CDF for the Logistic distribution
+        Compute the log of the cumulative distribution function for Logistic distribution
+        at the specified value.
 
         References
         ----------
         .. [Machler2012] Martin Mächler (2012).
             "Accurately computing log(1-exp(-|a|)) Assessed by the Rmpfr
             package"
+
+        Parameters
+        ----------
+        value: numeric
+            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            values are desired the values must be provided in a numpy array or theano tensor.
+
+        Returns
+        -------
+        TensorVariable
         """
         mu = self.mu
         s = self.s

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -240,7 +240,7 @@ class Uniform(BoundedContinuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -311,7 +311,7 @@ class Flat(Continuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -378,7 +378,7 @@ class HalfFlat(PositiveContinuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -536,7 +536,7 @@ class Normal(Continuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -879,7 +879,7 @@ class HalfNormal(PositiveContinuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -1086,7 +1086,7 @@ class Wald(PositiveContinuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -1283,7 +1283,7 @@ class Beta(UnitContinuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -1539,7 +1539,7 @@ class Exponential(PositiveContinuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -1670,7 +1670,7 @@ class Laplace(Continuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -1836,7 +1836,7 @@ class Lognormal(PositiveContinuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -2008,7 +2008,7 @@ class StudentT(Continuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -2153,7 +2153,7 @@ class Pareto(Continuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -2291,7 +2291,7 @@ class Cauchy(Continuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -2409,7 +2409,7 @@ class HalfCauchy(PositiveContinuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -2565,7 +2565,7 @@ class Gamma(PositiveContinuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -2919,7 +2919,7 @@ class Weibull(PositiveContinuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -3231,7 +3231,7 @@ class ExGaussian(Continuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -3632,7 +3632,7 @@ class Triangular(BoundedContinuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -3775,7 +3775,7 @@ class Gumbel(Continuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns
@@ -4024,7 +4024,7 @@ class Logistic(Continuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculate. If the log CDF for multiple
+            Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
         Returns

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3238,6 +3238,7 @@ class ExGaussian(Continuous):
         -------
         TensorVariable
         """
+        mu = self.mu
         sigma = self.sigma
         sigma_2 = sigma**2
         nu = self.nu

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -302,6 +302,19 @@ class MvNormal(_QuadFormBase):
             return mu + transformed.T
 
     def logp(self, value):
+        """
+        Calculate log-probability of Multivariate Normal distribution
+        at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         quaddist, logdet, ok = self._quaddist(value)
         k = value.shape[-1].astype(theano.config.floatX)
         norm = - 0.5 * k * pm.floatX(np.log(2 * np.pi))
@@ -403,6 +416,19 @@ class MvStudentT(_QuadFormBase):
         return (np.sqrt(nu) * samples.T / chi2(nu, size)).T + mu
 
     def logp(self, value):
+        """
+        Calculate log-probability of Multivariate Student's T distribution
+        at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         quaddist, logdet, ok = self._quaddist(value)
         k = value.shape[-1].astype(theano.config.floatX)
 
@@ -511,6 +537,19 @@ class Dirichlet(Continuous):
         return samples
 
     def logp(self, value):
+        """
+        Calculate log-probability of Dirichlet distribution
+        at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         k = self.k
         a = self.a
 
@@ -650,6 +689,19 @@ class Multinomial(Discrete):
         return samples
 
     def logp(self, x):
+        """
+        Calculate log-probability of Multinomial distribution
+        at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         n = self.n
         p = self.p
 
@@ -799,6 +851,19 @@ class Wishart(Continuous):
                                     broadcast_shape=(size,))
 
     def logp(self, X):
+        """
+        Calculate log-probability of Wishart distribution
+        at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         nu = self.nu
         p = self.p
         V = self.V
@@ -1060,6 +1125,19 @@ class LKJCholeskyCov(Continuous):
         self.mode[self.diag_idxs] = 1
 
     def logp(self, x):
+        """
+        Calculate log-probability of Covariance matrix with LKJ
+        distributed correlations at specified value.
+
+        Parameters
+        ----------
+        x : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         n = self.n
         eta = self.eta
 
@@ -1307,6 +1385,19 @@ class LKJCorr(Continuous):
         return samples
 
     def logp(self, x):
+        """
+        Calculate log-probability of LKJ distribution at specified
+        value.
+
+        Parameters
+        ----------
+        x : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         n = self.n
         eta = self.eta
 
@@ -1552,6 +1643,19 @@ class MatrixNormal(Continuous):
         return trquaddist, half_collogdet, half_rowlogdet
 
     def logp(self, value):
+        """
+        Calculate log-probability of Matrix-valued Normal distribution
+        at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         trquaddist, half_collogdet, half_rowlogdet = self._trquaddist(value)
         m = self.m
         n = self.n
@@ -1788,5 +1892,18 @@ class KroneckerNormal(Continuous):
         return quad, logdet
 
     def logp(self, value):
+        """
+        Calculate log-probability of Multivariate Normal distribution
+        with Kronecker-structured covariance at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         quad, logdet = self._quaddist(value)
         return - (quad + logdet + self.N*tt.log(2*np.pi)) / 2.0

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -226,6 +226,22 @@ class MvNormal(_QuadFormBase):
         self.mean = self.median = self.mode = self.mu = self.mu
 
     def random(self, point=None, size=None):
+        """
+        Draw random values from Multivariate Normal distribution.
+
+        Parameters
+        ----------
+        point : dict, optional
+            Dict of variable values on which random values are to be
+            conditioned (uses default point if not specified).
+        size : int, optional
+            Desired size of random sample (returns one sample if not
+            specified).
+
+        Returns
+        -------
+        array
+        """
         if size is None:
             size = tuple()
         else:
@@ -353,6 +369,22 @@ class MvStudentT(_QuadFormBase):
         self.mean = self.median = self.mode = self.mu = self.mu
 
     def random(self, point=None, size=None):
+        """
+        Draw random values from Multivariate Student's T distribution.
+
+        Parameters
+        ----------
+        point : dict, optional
+            Dict of variable values on which random values are to be
+            conditioned (uses default point if not specified).
+        size : int, optional
+            Desired size of random sample (returns one sample if not
+            specified).
+
+        Returns
+        -------
+        array
+        """
         with _DrawValuesContext():
             nu, mu = draw_values([self.nu, self.mu], point=point, size=size)
             if self._cov_type == 'cov':
@@ -455,6 +487,22 @@ class Dirichlet(Continuous):
         return samples
 
     def random(self, point=None, size=None):
+        """
+        Draw random values from Dirichlet distribution.
+
+        Parameters
+        ----------
+        point : dict, optional
+            Dict of variable values on which random values are to be
+            conditioned (uses default point if not specified).
+        size : int, optional
+            Desired size of random sample (returns one sample if not
+            specified).
+
+        Returns
+        -------
+        array
+        """
         a = draw_values([self.a], point=point, size=size)[0]
         samples = generate_samples(self._random,
                                    a=a,
@@ -578,6 +626,22 @@ class Multinomial(Discrete):
         return samples.astype(original_dtype)
 
     def random(self, point=None, size=None):
+        """
+        Draw random values from Multinomial distribution.
+
+        Parameters
+        ----------
+        point : dict, optional
+            Dict of variable values on which random values are to be
+            conditioned (uses default point if not specified).
+        size : int, optional
+            Desired size of random sample (returns one sample if not
+            specified).
+
+        Returns
+        -------
+        array
+        """
         n, p = draw_values([self.n, self.p], point=point, size=size)
         samples = generate_samples(self._random, n, p,
                                    dist_shape=self.shape,
@@ -713,6 +777,22 @@ class Wishart(Continuous):
                               np.nan)
 
     def random(self, point=None, size=None):
+        """
+        Draw random values from Wishart distribution.
+
+        Parameters
+        ----------
+        point : dict, optional
+            Dict of variable values on which random values are to be
+            conditioned (uses default point if not specified).
+        size : int, optional
+            Desired size of random sample (returns one sample if not
+            specified).
+
+        Returns
+        -------
+        array
+        """
         nu, V = draw_values([self.nu, self.V], point=point, size=size)
         size= 1 if size is None else size
         return generate_samples(stats.wishart.rvs, np.asscalar(nu), V,
@@ -1052,6 +1132,23 @@ class LKJCholeskyCov(Continuous):
         return np.linalg.cholesky(C)[..., tril_idx[0], tril_idx[1]]
 
     def random(self, point=None, size=None):
+        """
+        Draw random values from Covariance matrix with LKJ
+        distributed correlations.
+
+        Parameters
+        ----------
+        point : dict, optional
+            Dict of variable values on which random values are to be
+            conditioned (uses default point if not specified).
+        size : int, optional
+            Desired size of random sample (returns one sample if not
+            specified).
+
+        Returns
+        -------
+        array
+        """
         # Get parameters and broadcast them
         n, eta = draw_values([self.n, self.eta], point=point, size=size)
         broadcast_shape = np.broadcast(n, eta).shape
@@ -1187,6 +1284,22 @@ class LKJCorr(Continuous):
         return C[..., triu_idx[0], triu_idx[1]]
 
     def random(self, point=None, size=None):
+        """
+        Draw random values from LKJ distribution.
+
+        Parameters
+        ----------
+        point : dict, optional
+            Dict of variable values on which random values are to be
+            conditioned (uses default point if not specified).
+        size : int, optional
+            Desired size of random sample (returns one sample if not
+            specified).
+
+        Returns
+        -------
+        array
+        """
         n, eta = draw_values([self.n, self.eta], point=point, size=size)
         size= 1 if size is None else size
         samples = generate_samples(self._random, n, eta,
@@ -1375,6 +1488,22 @@ class MatrixNormal(Continuous):
             self.colchol_cov = tt.as_tensor_variable(colchol)
 
     def random(self, point=None, size=None):
+        """
+        Draw random values from Matrix-valued Normal distribution.
+
+        Parameters
+        ----------
+        point : dict, optional
+            Dict of variable values on which random values are to be
+            conditioned (uses default point if not specified).
+        size : int, optional
+            Desired size of random sample (returns one sample if not
+            specified).
+
+        Returns
+        -------
+        array
+        """
         mu, colchol, rowchol = draw_values(
                                 [self.mu, self.colchol_cov, self.rowchol_cov],
                                 point=point,
@@ -1609,6 +1738,23 @@ class KroneckerNormal(Continuous):
                 self.mv_params['cov'] = cov
 
     def random(self, point=None, size=None):
+        """
+        Draw random values from Multivariate Normal distribution
+        with Kronecker-structured covariance.
+
+        Parameters
+        ----------
+        point : dict, optional
+            Dict of variable values on which random values are to be
+            conditioned (uses default point if not specified).
+        size : int, optional
+            Desired size of random sample (returns one sample if not
+            specified).
+
+        Returns
+        -------
+        array
+        """
         # Expand params into terms MvNormal can understand to force consistency
         self._setup_random()
         dist = MvNormal.dist(**self.mv_params)

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -695,7 +695,7 @@ class Multinomial(Discrete):
 
         Parameters
         ----------
-        value : numeric
+        x : numeric
             Value for which log-probability is calculated.
 
         Returns
@@ -857,7 +857,7 @@ class Wishart(Continuous):
 
         Parameters
         ----------
-        value : numeric
+        X : numeric
             Value for which log-probability is calculated.
 
         Returns

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -43,7 +43,7 @@ class AR1(distribution.Continuous):
 
         Parameters
         ----------
-        value : numeric
+        x : numeric
             Value for which log-probability is calculated.
 
         Returns
@@ -199,7 +199,7 @@ class GaussianRandomWalk(distribution.Continuous):
 
         Parameters
         ----------
-        value : numeric
+        x : numeric
             Value for which log-probability is calculated.
 
         Returns
@@ -281,7 +281,7 @@ class GARCH11(distribution.Continuous):
 
         Parameters
         ----------
-        value : numeric
+        x : numeric
             Value for which log-probability is calculated.
 
         Returns
@@ -330,7 +330,7 @@ class EulerMaruyama(distribution.Continuous):
 
         Parameters
         ----------
-        value : numeric
+        x : numeric
             Value for which log-probability is calculated.
 
         Returns
@@ -391,7 +391,7 @@ class MvGaussianRandomWalk(distribution.Continuous):
 
         Parameters
         ----------
-        value : numeric
+        x : numeric
             Value for which log-probability is calculated.
 
         Returns

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -38,6 +38,18 @@ class AR1(distribution.Continuous):
         self.mode = tt.as_tensor_variable(0.)
 
     def logp(self, x):
+        """
+        Calculate log-probability of AR1 distribution at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         k = self.k
         tau_e = self.tau_e
 
@@ -125,6 +137,18 @@ class AR(distribution.Continuous):
         self.init = init
 
     def logp(self, value):
+        """
+        Calculate log-probability of AR distribution at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         if self.constant:
             x = tt.add(*[self.rho[i + 1] * value[self.p - (i + 1):-(i + 1)] for i in range(self.p)])
             eps = value[self.p:] - self.rho[0] - x
@@ -170,6 +194,18 @@ class GaussianRandomWalk(distribution.Continuous):
         self.mean = tt.as_tensor_variable(0.)
 
     def logp(self, x):
+        """
+        Calculate log-probability of Gaussian Random Walk distribution at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         tau = self.tau
         sigma = self.sigma
         mu = self.mu
@@ -240,6 +276,18 @@ class GARCH11(distribution.Continuous):
         return tt.concatenate([[self.initial_vol], vol])
 
     def logp(self, x):
+        """
+        Calculate log-probability of GARCH(1, 1) distribution at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         vol = self.get_volatility(x)
         return tt.sum(Normal.dist(0., sigma=vol).logp(x))
 
@@ -277,6 +325,18 @@ class EulerMaruyama(distribution.Continuous):
         self.sde_pars = sde_pars
 
     def logp(self, x):
+        """
+        Calculate log-probability of EulerMaruyama distribution at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         xt = x[:-1]
         f, g = self.sde_fn(x[:-1], *self.sde_pars)
         mu = xt + self.dt * f
@@ -325,6 +385,19 @@ class MvGaussianRandomWalk(distribution.Continuous):
         self.mean = tt.as_tensor_variable(0.)
 
     def logp(self, x):
+        """
+        Calculate log-probability of Multivariate Gaussian
+        Random Walk distribution at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         x_im1 = x[:-1]
         x_i = x[1:]
 

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -152,6 +152,19 @@ class TransformedDistribution(distribution.Distribution):
         return logp_nojac + jacobian_det
 
     def logp_nojac(self, x):
+        """
+        Calculate log-probability of Transformed distribution at specified value
+        without jacobian term for transforms.
+
+        Parameters
+        ----------
+        x : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         return self.dist.logp(self.transform_used.backward(x))
 
 transform = Transform

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -138,7 +138,7 @@ class TransformedDistribution(distribution.Distribution):
 
         Parameters
         ----------
-        value : numeric
+        x : numeric
             Value for which log-probability is calculated.
 
         Returns

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -133,6 +133,18 @@ class TransformedDistribution(distribution.Distribution):
             self.type = tt.TensorType(v.dtype, b)
 
     def logp(self, x):
+        """
+        Calculate log-probability of Transformed distribution at specified value.
+
+        Parameters
+        ----------
+        value : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         logp_nojac = self.logp_nojac(x)
         jacobian_det = self.transform_used.jacobian_det(x)
         if logp_nojac.ndim > jacobian_det.ndim:


### PR DESCRIPTION
This PR is a continuation of PR ##3474 and would hopefully close issue #2992. I've added the doc strings to public methods for distribution classes in `continuous.py`, `discrete.py` etc. As a relative newcomer to the project and being not totally familiar with all the different distributions, I wasn't sure if the wording is correct for some of the docstrings (e.g. the logp and random methods for the LKJCholeskyCov class in `multivariate.py`). 