### PR TITLE
fixed docker unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,8 +138,8 @@ You may also use it to run the test suite, with
 
 ```bash
 $  docker exec -it pymc3  bash # logon to the container
-$  cd ~/pymc3  
-$  . ./scripts/test.sh # takes a while!
+$  cd ~/pymc3/tests
+$  . ./../../scripts/test.sh # takes a while!
 ```
 
 This should be quite close to how the tests run on TravisCI.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,5 +6,5 @@ if [[ "$RUN_PYLINT" == "true" ]]; then
     . ./scripts/lint.sh
 fi
 
-THEANO_FLAGS="floatX=${FLOATX},gcc.cxxflags='-march=core2'" pytest -v --cov=pymc3 "$@"
-
+_FLOATX=${FLOATX:=float64}
+THEANO_FLAGS="floatX=${_FLOATX},gcc.cxxflags='-march=core2'" pytest -v --cov=pymc3 "$@"


### PR DESCRIPTION
Checking out pymc3 for the first time, I noticed that the unit tests didn't run in docker as documented. Fixed the documentation and added a fallback value for FLOATX, if it is not manually set as ENV variable (which it is not in the docker build).