### PR TITLE
remove previous instance of docker container in start_container script

### DIFF
--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -7,7 +7,7 @@ TOKEN=$(openssl rand -hex 24)
 CONTAINER_NAME=${CONTAINER_NAME:-pymc3}
 
 # stop and remove previous instances of the pymc3 container to avoid naming conflicts
-if [[ $(docker ps -q -f name=${CONTAINER_NAME}) ]]; then
+if [[ $(docker ps -aq -f name=${CONTAINER_NAME}) ]]; then
    echo "Shutting down and removing previous instance of ${CONTAINER_NAME} container..."
    docker rm -f ${CONTAINER_NAME}
 fi

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -5,6 +5,10 @@ SRC_DIR=${SRC_DIR:-`pwd`}
 NOTEBOOK_DIR=${NOTEBOOK_DIR:-$SRC_DIR/notebooks}
 TOKEN=$(openssl rand -hex 24)
 
+# stop and remove previous instances of the pymc3 container to avoid naming conflicts
+docker stop pymc3
+docker rm pymc3
+
 # note that all paths are relative to the build context, so . represents
 # SRC_DIR to Docker
 docker build \

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -4,15 +4,18 @@ PORT=${PORT:-8888}
 SRC_DIR=${SRC_DIR:-`pwd`}
 NOTEBOOK_DIR=${NOTEBOOK_DIR:-$SRC_DIR/notebooks}
 TOKEN=$(openssl rand -hex 24)
+CONTAINER_NAME=${CONTAINER_NAME:-pymc3}
 
 # stop and remove previous instances of the pymc3 container to avoid naming conflicts
-docker stop pymc3
-docker rm pymc3
+if [[ $(docker ps -q -f name=${CONTAINER_NAME}) ]]; then
+   echo "Shutting down and removing previous instance of ${CONTAINER_NAME} container..."
+   docker rm -f ${CONTAINER_NAME}
+fi
 
 # note that all paths are relative to the build context, so . represents
 # SRC_DIR to Docker
 docker build \
-    -t pymc3 \
+    -t ${CONTAINER_NAME} \
     -f $SRC_DIR/scripts/Dockerfile \
     --build-arg SRC_DIR=. \
     $SRC_DIR
@@ -21,7 +24,7 @@ docker run -d \
     -p $PORT:8888 \
     -v $SRC_DIR:/home/jovyan/ \
     -v $NOTEBOOK_DIR:/home/jovyan/work/ \
-    --name pymc3 pymc3 \
+    --name ${CONTAINER_NAME} ${CONTAINER_NAME} \
     start-notebook.sh --NotebookApp.token=${TOKEN}
 
 if [[ $* != *--no-browser* ]]; then


### PR DESCRIPTION
Checking out pymc3 the first time I noticed that the start_container script will crash, when a previous instance of the container already exists. Added two lines that will stop and remove an existing instance of the pymc3 container before building and running again.

This improves convenience and (as far as I can see) has no downsides.