### PR TITLE
Text backend does not support tallying a subset of variables (raises KeyError) #2560

### DIFF
--- a/pymc3/tests/test_text_backend.py
+++ b/pymc3/tests/test_text_backend.py
@@ -62,6 +62,14 @@ class TestTextDumpLoad(bf.DumpLoadTestCase):
     shape = (2, 3)
 
 
+class TestTextDumpLoadWithPartialChain(bf.DumpLoadTestCase):
+    backend = text.Text
+    load_func = staticmethod(text.load)
+    name = 'text-db'
+    shape = (2, 3)
+    write_partial_chain = True
+
+
 @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
 class TestTextDumpFunction(bf.BackendEqualityTestCase):
     backend0 = backend1 = ndarray.NDArray


### PR DESCRIPTION
Example:
```python
with pm.Model() as model:
    a = pm.Gamma('a', mu=10.0, shape=(2,3), sd=2.0)
    b = pm.Gamma('b', mu=10.0, sd=2.0)
    
    trace = pm.sample(trace=[model.a, model.a_log__])
    assert len(trace.varnames) == 2
    
    pm.backends.text.dump('trace.text', trace)
    loaded = pm.backends.text.load('trace.text', model=model)
    
x = loaded[0] #!!! Does not throw key error anymore
x
```

As described in the issue, the above code would not work in the past and now does.