### PR TITLE
Use compact traceplot by default

### DIFF
--- a/pymc3/plots/__init__.py
+++ b/pymc3/plots/__init__.py
@@ -47,10 +47,16 @@ autocorrplot = map_args(az.plot_autocorr)
 forestplot = map_args(az.plot_forest)
 kdeplot = map_args(az.plot_kde)
 plot_posterior = map_args(az.plot_posterior)
-traceplot = map_args(az.plot_trace)
 energyplot = map_args(az.plot_energy)
 densityplot = map_args(az.plot_density)
 pairplot = map_args(az.plot_pair)
+
+# Use compact traceplot by default
+@map_args
+@functools.wraps(az.plot_trace)
+def traceplot(*args, **kwargs):
+    kwargs.setdefault('compact', True)
+    return az.plot_trace(*args, **kwargs)
 
 # addition arg mapping for compare plot
 @functools.wraps(az.plot_compare)

--- a/pymc3/plots/__init__.py
+++ b/pymc3/plots/__init__.py
@@ -55,8 +55,12 @@ pairplot = map_args(az.plot_pair)
 @map_args
 @functools.wraps(az.plot_trace)
 def traceplot(*args, **kwargs):
-    kwargs.setdefault('compact', True)
-    return az.plot_trace(*args, **kwargs)
+    try:
+        kwargs.setdefault('compact', True)
+        return az.plot_trace(*args, **kwargs)
+    except TypeError:
+        kwargs.pop('compact')
+        return az.plot_trace(*args, **kwargs)
 
 # addition arg mapping for compare plot
 @functools.wraps(az.plot_compare)


### PR DESCRIPTION
Fixes #3489 .

This is backwards compatible, and will effect anyone running arviz master, returning to its previous behavior.

![image](https://user-images.githubusercontent.com/2295568/58667150-42c72a00-8303-11e9-99b9-2625f8e68be5.png)
