### PR TITLE
Extend API documents

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -19,4 +19,5 @@ API Reference
    api/math
    api/data
    api/model
+   api/model_graph
    api/shape_utils

--- a/docs/source/api/backends.rst
+++ b/docs/source/api/backends.rst
@@ -7,6 +7,13 @@ Backends
 .. automodule:: pymc3.backends
    :members:
 
+basic Backends (including MultiTrace)
+^^^^^^^^
+
+.. automodule:: pymc3.backends.base
+  :members:
+
+
 ndarray
 ^^^^^^^
 
@@ -38,3 +45,4 @@ tracetab
 
 .. automodule:: pymc3.backends.tracetab
    :members:
+

--- a/docs/source/api/model_graph.rst
+++ b/docs/source/api/model_graph.rst
@@ -1,0 +1,7 @@
+Graphing Models
+-------------
+
+.. currentmodule:: pymc3.model_graph
+.. automodule:: pymc3.model_graph
+   :members:
+

--- a/docs/source/notebooks/table_of_contents_examples.js
+++ b/docs/source/notebooks/table_of_contents_examples.js
@@ -29,7 +29,6 @@ Gallery.contents = {
     "GP-MeansAndCovs": "Gaussian Processes",
     "GP-SparseApprox": "Gaussian Processes",
     "GP-TProcess": "Gaussian Processes",
-    "GP-slice-sampling": "Gaussian Processes",
     "GP-smoothing": "Gaussian Processes",
     "gaussian_process": "Gaussian Processes",
     "dependent_density_regression": "Mixture Models",


### PR DESCRIPTION
The model_graph.py and backends/base.py files were not being pulled in by autodoc, meaning that the graphviz display functions, and the critical MultiTrace object did not appear in the documentation.

This table of contents shows additions

![image](https://user-images.githubusercontent.com/3274/58982057-3c203300-8799-11e9-898e-01290b494c93.png)

Also removed reference to missing notebook that caused the doc build to fail.