### PR TITLE
Add undocumented distributions.

### DIFF
--- a/docs/source/api/distributions/continuous.rst
+++ b/docs/source/api/distributions/continuous.rst
@@ -9,6 +9,7 @@ Continuous
    Flat
    HalfFlat
    Normal
+   TruncatedNormal
    HalfNormal
    SkewNormal
    Beta
@@ -20,16 +21,17 @@ Continuous
    Cauchy
    HalfCauchy
    Gamma
+   InverseGamma 
    Weibull
    Lognormal
    ChiSquared
    Wald
    Pareto
-   InverseGamma
    ExGaussian
    VonMises
    Triangular
    Gumbel
+   Rice
    Logistic
    LogitNormal
    Interpolated


### PR DESCRIPTION
TruncatedNormal and Rice distributions were not in the summary of continuous distributions.