### PR TITLE
Improve Inference API docs.

### DIFF
--- a/docs/source/api/inference.rst
+++ b/docs/source/api/inference.rst
@@ -12,10 +12,10 @@ Sampling
 
 
 Step-methods
-------------
+^^^^^^^^^^^^
 
 NUTS
-^^^^
+~~~~
 
 .. currentmodule:: pymc3.step_methods.hmc.nuts
 
@@ -23,7 +23,7 @@ NUTS
    :members:
 
 Metropolis
-^^^^^^^^^^
+~~~~~~~~~~
 
 .. currentmodule:: pymc3.step_methods.metropolis
 
@@ -31,7 +31,7 @@ Metropolis
    :members:
 
 Slice
-^^^^^
+~~~~~
 
 .. currentmodule:: pymc3.step_methods.slicer
 
@@ -39,11 +39,19 @@ Slice
    :members:
 
 Hamiltonian Monte Carlo
-^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: pymc3.step_methods.hmc.hmc
 
 .. autoclass:: pymc3.step_methods.hmc.hmc.HamiltonianMC
+   :members:
+
+Sequential Monte Carlo
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pymc3.step_methods.smc
+
+.. autoclass:: pymc3.step_methods.smc.SMC
    :members:
 
 
@@ -56,8 +64,8 @@ MultiTrace
 
 .. autoclass:: pymc3.backends.base.BaseTrace
 
-Variational
------------
+Variational Inference
+----------------
 
 OPVI
 ^^^^


### PR DESCRIPTION
Add the SMC inference method.
Also, restructure the hierarchy so the "step methods" are part of the sampling section, instead of being siblings.