### PR TITLE
Expand posterior_predictive sampling docs

### DIFF
--- a/pymc3/exceptions.py
+++ b/pymc3/exceptions.py
@@ -1,5 +1,9 @@
-__all__ = ['SamplingError']
+__all__ = ['SamplingError', 'IncorrectArgumentsError']
 
 
 class SamplingError(RuntimeError):
+    pass
+
+
+class IncorrectArgumentsError(ValueError):
     pass

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1066,7 +1066,7 @@ def sample_posterior_predictive(trace,
         predictive samples are needed.
     keep_size : bool, optional
         Force posterior predictive sample to have the same shape of posterior and sample stats
-        data: ``(nchains, ndraws, ...)``.
+        data: ``(nchains, ndraws, ...)``. Overrides samples and size parameters.
     random_seed : int
         Seed for the random number generator.
     progressbar : bool
@@ -1086,7 +1086,11 @@ def sample_posterior_predictive(trace,
     except AttributeError:
         nchain = 1
 
-    if samples is None or keep_size:
+    if keep_size:
+        samples = len_trace * nchain
+        size = None
+
+    if samples is None:
         samples = sum(len(v) for v in trace._straces.values())
 
     model = modelcontext(model)

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -21,6 +21,7 @@ from .step_methods import (NUTS, HamiltonianMC, Metropolis, BinaryMetropolis,
                            Slice, CompoundStep, arraystep, smc)
 from .util import update_start_vals, get_untransformed_name, is_transformed_name, get_default_varnames
 from .vartypes import discrete_types
+from .exceptions import IncorrectArgumentsError
 from pymc3.step_methods.hmc import quadpotential
 import pymc3 as pm
 from tqdm import tqdm
@@ -1087,17 +1088,15 @@ def sample_posterior_predictive(trace,
         nchain = 1
 
     if keep_size and samples is not None:
-        samples = None
-        _log.warning("keep_size is True but samples is present: Overriding samples parameter")
+        raise IncorrectArgumentsError("Should not specify both keep_size and samples argukments")
     if keep_size and size is not None:
-        size = None
-        _log.warning("keep_size is True but size is present: Overriding size parameter")
+        raise IncorrectArgumentsError("Should not specify both keep_size and size argukments")
 
     if samples is None:
         samples = sum(len(v) for v in trace._straces.values())
 
     if samples < len_trace * nchain:
-        _log.warning("samples parameter is smaller than nchains times ndraws, some draws "
+        warnings.warn("samples parameter is smaller than nchains times ndraws, some draws "
                      "and/or chains may not be represented in the returned posterior "
                      "predictive sample")
 
@@ -1105,7 +1104,7 @@ def sample_posterior_predictive(trace,
 
     if var_names is not None:
         if vars is not None:
-            raise ValueError("Should not specify both vars and var_names arguments.")
+            raise IncorrectArgumentsError("Should not specify both vars and var_names arguments.")
         else:
             vars = [model[x] for x in var_names]
     elif vars is not None: # var_names is None, and vars is not.

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1065,7 +1065,7 @@ def sample_posterior_predictive(trace,
         sample of the trace. Not recommended unless more than ndraws times nchains posterior
         predictive samples are needed.
     keep_size : bool, optional
-        Force posterior predictive sample to have the same shape of posterior and sample stats
+        Force posterior predictive sample to have the same shape as posterior and sample stats
         data: ``(nchains, ndraws, ...)``. Overrides samples and size parameters.
     random_seed : int
         Seed for the random number generator.
@@ -1086,9 +1086,12 @@ def sample_posterior_predictive(trace,
     except AttributeError:
         nchain = 1
 
-    if keep_size:
-        samples = len_trace * nchain
+    if keep_size and samples is not None:
+        samples = None
+        _log.warning("keep_size is True but samples is present: Overriding samples parameter")
+    if keep_size and size is not None:
         size = None
+        _log.warning("keep_size is True but size is present: Overriding size parameter")
 
     if samples is None:
         samples = sum(len(v) for v in trace._straces.values())

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1096,6 +1096,11 @@ def sample_posterior_predictive(trace,
     if samples is None:
         samples = sum(len(v) for v in trace._straces.values())
 
+    if samples < len_trace * nchain:
+        _log.warning("samples parameter is smaller than nchains times ndraws, some draws "
+                     "and/or chains may not be represented in the returned posterior "
+                     "predictive sample")
+
     model = modelcontext(model)
 
     if var_names is not None:

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -239,7 +239,7 @@ class TestChooseBackend:
 
 
 class TestSamplePPC(SeededTest):
-    def test_normal_scalar(self):
+    def test_normal_scalar(self, caplog):
         nchains = 2
         ndraws = 500
         with pm.Model() as model:
@@ -258,8 +258,11 @@ class TestSamplePPC(SeededTest):
             assert len(ppc) == 0
             # test keep_size parameter
             ppc = pm.sample_posterior_predictive(
-                trace, samples=10, keep_size=True, size=5
+                trace, keep_size=True, size=5
             )
+            msg = caplog.records[-1].message
+            assert "keep_size" in msg
+            assert "Overriding size" in msg
             assert ppc["a"].shape == (nchains, ndraws)
             # test default case
             ppc = pm.sample_posterior_predictive(trace, var_names=["a"])
@@ -273,7 +276,7 @@ class TestSamplePPC(SeededTest):
             ppc = pm.sample_posterior_predictive(trace, size=5, var_names=["a"])
             assert ppc["a"].shape == (nchains * ndraws, 5)
 
-    def test_normal_vector(self):
+    def test_normal_vector(self, caplog):
         with pm.Model() as model:
             mu = pm.Normal("mu", 0.0, 1.0)
             a = pm.Normal("a", mu=mu, sigma=1, observed=np.array([0.5, 0.2]))
@@ -288,6 +291,9 @@ class TestSamplePPC(SeededTest):
             ppc = pm.sample_posterior_predictive(
                 trace, samples=10, keep_size=True
             )
+            msg = caplog.records[-1].message
+            assert "keep_size" in msg
+            assert "Overriding samples" in msg
             assert ppc["a"].shape == (trace.nchains, len(trace), 2)
             ppc = pm.sample_posterior_predictive(trace, samples=10, var_names=["a"])
             assert "a" in ppc

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -258,7 +258,7 @@ class TestSamplePPC(SeededTest):
             assert len(ppc) == 0
             # test keep_size parameter
             ppc = pm.sample_posterior_predictive(
-                trace, samples=10, keep_size=True
+                trace, samples=10, keep_size=True, size=5
             )
             assert ppc["a"].shape == (nchains, ndraws)
             # test default case

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -240,27 +240,38 @@ class TestChooseBackend:
 
 class TestSamplePPC(SeededTest):
     def test_normal_scalar(self):
+        nchains = 2
+        ndraws = 500
         with pm.Model() as model:
             mu = pm.Normal("mu", 0.0, 1.0)
             a = pm.Normal("a", mu=mu, sigma=1, observed=0.0)
-            trace = pm.sample()
+            trace = pm.sample(draws=ndraws, chains=nchains)
 
         with model:
             # test list input
-            n = trace["mu"].shape[0]
             ppc0 = pm.sample_posterior_predictive([model.test_point], samples=10)
-            ppc = pm.sample_posterior_predictive(trace, samples=n, vars=[])
+            # test DeprecationWarning
+            with pytest.warns(DeprecationWarning):
+                ppc = pm.sample_posterior_predictive(trace, vars=[a])
+            # test empty ppc
+            ppc = pm.sample_posterior_predictive(trace, var_names=[])
             assert len(ppc) == 0
-            ppc = pm.sample_posterior_predictive(trace, samples=n, vars=[a])
+            # test keep_size parameter
+            ppc = pm.sample_posterior_predictive(
+                trace, samples=10, keep_size=True
+            )
+            assert ppc["a"].shape == (nchains, ndraws)
+            # test default case
+            ppc = pm.sample_posterior_predictive(trace, var_names=["a"])
             assert "a" in ppc
-            assert ppc["a"].shape == (n,)
+            assert ppc["a"].shape == (nchains * ndraws,)
         # mu's standard deviation may have changed thanks to a's observed
         _, pval = stats.kstest(ppc["a"] - trace["mu"], stats.norm(loc=0, scale=1).cdf)
         assert pval > 0.001
 
         with model:
-            ppc = pm.sample_posterior_predictive(trace, samples=10, size=5, vars=[a])
-            assert ppc["a"].shape == (10, 5)
+            ppc = pm.sample_posterior_predictive(trace, size=5, var_names=["a"])
+            assert ppc["a"].shape == (nchains * ndraws, 5)
 
     def test_normal_vector(self):
         with pm.Model() as model:
@@ -271,13 +282,18 @@ class TestSamplePPC(SeededTest):
         with model:
             # test list input
             ppc0 = pm.sample_posterior_predictive([model.test_point], samples=10)
-            ppc = pm.sample_posterior_predictive(trace, samples=10, vars=[])
+            ppc = pm.sample_posterior_predictive(trace, samples=10, var_names=[])
             assert len(ppc) == 0
-            ppc = pm.sample_posterior_predictive(trace, samples=10, vars=[a])
+            # test keep_size parameter
+            ppc = pm.sample_posterior_predictive(
+                trace, samples=10, keep_size=True
+            )
+            assert ppc["a"].shape == (trace.nchains, len(trace), 2)
+            ppc = pm.sample_posterior_predictive(trace, samples=10, var_names=["a"])
             assert "a" in ppc
             assert ppc["a"].shape == (10, 2)
 
-            ppc = pm.sample_posterior_predictive(trace, samples=10, vars=[a], size=4)
+            ppc = pm.sample_posterior_predictive(trace, samples=10, var_names=["a"], size=4)
             assert "a" in ppc
             assert ppc["a"].shape == (10, 4, 2)
 
@@ -290,13 +306,13 @@ class TestSamplePPC(SeededTest):
         with model:
             # test list input
             ppc0 = pm.sample_posterior_predictive([model.test_point], samples=10)
-            ppc = pm.sample_posterior_predictive(trace, samples=10, vars=[])
+            ppc = pm.sample_posterior_predictive(trace, samples=10, var_names=[])
             assert len(ppc) == 0
-            ppc = pm.sample_posterior_predictive(trace, samples=10, vars=[a])
+            ppc = pm.sample_posterior_predictive(trace, samples=10, var_names=["a"])
             assert "a" in ppc
             assert ppc["a"].shape == (10, 2)
 
-            ppc = pm.sample_posterior_predictive(trace, samples=10, vars=[a], size=4)
+            ppc = pm.sample_posterior_predictive(trace, samples=10, var_names=["a"], size=4)
             assert "a" in ppc
             assert ppc["a"].shape == (10, 4, 2)
 
@@ -309,7 +325,7 @@ class TestSamplePPC(SeededTest):
         with model:
             # test list input
             ppc0 = pm.sample_posterior_predictive([model.test_point], samples=10)
-            ppc = pm.sample_posterior_predictive(trace, samples=1000, vars=[b])
+            ppc = pm.sample_posterior_predictive(trace, samples=1000, var_names=["b"])
             assert len(ppc) == 1
             assert ppc["b"].shape == (1000,)
             scale = np.sqrt(1 + 0.2 ** 2)
@@ -349,7 +365,7 @@ class TestSamplePPC(SeededTest):
         samples = 100
         with model:
             post_pred = pm.sample_posterior_predictive(
-                trace, samples=samples, vars=[logistic, obs]
+                trace, samples=samples, var_names=["p", "obs"]
             )
 
         expected_p = np.array(


### PR DESCRIPTION
PR to expand a little the documentation on sample_posterior_predictive and include one extra parameter to force the output to have shape `(nchains, ndraws, ...)`. 

I have already included tests for the new parameter, and modified the other posterior predictive tests that used `vars` parameter to use `var_names`