### PR TITLE
Fix minor bug in the Sphinx configuration.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -133,7 +133,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme_path = "./semantic_sphinx"
+html_theme_path = ["."]
 html_theme = "semantic_sphinx"
 
 


### PR DESCRIPTION
Warning revealed that the value of `html_theme_path` was of the wrong type.