### PR TITLE
replaced all imports of tqdm with tqdm.auto

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,7 @@
 
 - Distinguish between `Data` and `Deterministic` variables when graphing models with graphviz. PR [#3491](https://github.com/pymc-defs/pymc3/pulls/3491).
 - Sequential Monte Carlo - Approximate Bayesian Computation step method is now available. The implementation is in an experimental stage and will be further improved.
+- Makes use of new `tqdm` auto import mode which adapts the progress bars to console or jupyter notebook environments.
 
 ### Maintenance
 - Moved math operations out of `Rice`, `TruncatedNormal`, `Triangular` and `ZeroInflatedNegativeBinomial` `random` methods. Math operations on values returned by `draw_values` might not broadcast well, and all the `size` aware broadcasting is left to `generate_samples`. Fixes [#3481](https://github.com/pymc-devs/pymc3/issues/3481) and [#3508](https://github.com/pymc-devs/pymc3/issues/3508)

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -347,9 +347,7 @@ class ParallelSampler:
         progressbar=True,
     ):
         if progressbar:
-            import tqdm
-
-            tqdm_ = tqdm.tqdm
+            from tqdm.auto import tqdm
 
         if any(len(arg) != chains for arg in [seeds, start_points]):
             raise ValueError("Number of seeds and start_points must be %s." % chains)
@@ -371,7 +369,7 @@ class ParallelSampler:
 
         self._progress = None
         if progressbar:
-            self._progress = tqdm_(
+            self._progress = tqdm(
                 total=chains * (draws + tune),
                 unit="draws",
                 desc="Sampling %s chains" % chains,

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -24,7 +24,7 @@ from .vartypes import discrete_types
 from .exceptions import IncorrectArgumentsError
 from pymc3.step_methods.hmc import quadpotential
 import pymc3 as pm
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 
 import sys

--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -9,7 +9,7 @@ import pandas as pd
 from scipy.stats import dirichlet
 from scipy.optimize import minimize
 from scipy.signal import fftconvolve
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from .model import modelcontext
 from .util import get_default_varnames
@@ -1110,4 +1110,3 @@ def r2_score(y_true, y_pred, round_to=2):
     r2_mean = np.around(np.mean(r2), round_to)
     r2_std = np.around(np.std(r2), round_to)
     return r2_r(r2_median, r2_mean, r2_std)
-

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -6,7 +6,7 @@ Created on Mar 12, 2011
 from scipy.optimize import minimize
 import numpy as np
 from numpy import isfinite, nan_to_num
-from tqdm import tqdm
+from tqdm.auto import tqdm
 import pymc3 as pm
 from ..vartypes import discrete_types, typefilter
 from ..model import modelcontext, Point

--- a/pymc3/variational/inference.py
+++ b/pymc3/variational/inference.py
@@ -3,7 +3,7 @@ import warnings
 import collections
 
 import numpy as np
-import tqdm
+from tqdm.auto import tqdm
 
 import pymc3 as pm
 from pymc3.variational import test_functions
@@ -73,7 +73,7 @@ class Inference:
             score=score, fn_kwargs=fn_kwargs,
             **kwargs
         )
-        progress = tqdm.trange(n)
+        progress = tqdm(range(n))
         try:
             for _ in progress:
                 step_func()
@@ -129,7 +129,7 @@ class Inference:
             callbacks = []
         score = self._maybe_score(score)
         step_func = self.objective.step_function(score=score, **kwargs)
-        with tqdm.trange(n, disable=not progressbar) as progress:
+        with tqdm(range(n), disable=not progressbar) as progress:
             if score:
                 state = self._iterate_with_loss(0, n, step_func, progress, callbacks)
             else:
@@ -259,7 +259,7 @@ class Inference:
         if self.state is None:
             raise TypeError('Need to call `.fit` first')
         i, step, callbacks, score = self.state
-        with tqdm.trange(n, disable=not progressbar) as progress:
+        with tqdm(range(n), disable=not progressbar) as progress:
             if score:
                 state = self._iterate_with_loss(i, n, step, progress, callbacks)
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ numpy>=1.13.0
 scipy>=0.18.1
 pandas>=0.18.0
 patsy>=0.4.0
-tqdm>=4.8.4
+tqdm>=4.28.1
 h5py>=2.7.0


### PR DESCRIPTION
Prototyping a pymc3 model inside a Jupyter notebook the tqdm progress bars can get ugly or buggy. There is a version of these progress bars tailored for notebooks and addressing these issues. The imports are now aware of the environment and load the appropriate ones.