### PR TITLE
remove logp from simulator

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -150,7 +150,7 @@ class NoDistribution(Distribution):
         return getattr(self.parent_dist, name)
 
     def logp(self, x):
-        return 0
+        return tt.zeros_like(x)
 
 
 class Discrete(Distribution):

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -134,10 +134,9 @@ def TensorType(dtype, shape, broadcastable=None):
 
 class NoDistribution(Distribution):
 
-    def __init__(self, shape, dtype, testval=None, defaults=(),
-                 transform=None, parent_dist=None, *args, **kwargs):
-        super().__init__(shape=shape, dtype=dtype,
-                         testval=testval, defaults=defaults,
+    def __init__(self, shape, dtype, testval=None, defaults=(), transform=None, parent_dist=None,
+                 *args, **kwargs):
+        super().__init__(shape=shape, dtype=dtype, testval=testval, defaults=defaults,
                          *args, **kwargs)
         self.parent_dist = parent_dist
 
@@ -150,6 +149,17 @@ class NoDistribution(Distribution):
         return getattr(self.parent_dist, name)
 
     def logp(self, x):
+        """Calculate log probability.
+
+        Parameters
+        ----------
+        x : numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         return tt.zeros_like(x)
 
 

--- a/pymc3/distributions/simulator.py
+++ b/pymc3/distributions/simulator.py
@@ -38,18 +38,6 @@ class Simulator(NoDistribution):
 
         raise NotImplementedError("Not implemented yet")
 
-    def logp(self, value):
-        """
-        Parameters
-        ----------
-        value : numeric
-            Value for which log-probability is calculated.
-        Returns
-        -------
-        TensorVariable
-        """
-        return tt.zeros_like(value)
-
     def _repr_latex_(self, name=None, dist=None):
         if dist is None:
             dist = self

--- a/pymc3/distributions/simulator.py
+++ b/pymc3/distributions/simulator.py
@@ -1,4 +1,3 @@
-import theano.tensor as tt
 import numpy as np
 from .distribution import NoDistribution
 


### PR DESCRIPTION
`Simulator` inherits from `NoDistribution` that already defines `logp`