### PR TITLE
Add live divergence statistics

### DIFF
--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -368,11 +368,14 @@ class ParallelSampler:
         self._start_chain_num = start_chain_num
 
         self._progress = None
+        self._divergences = 0
+        self._desc = "Sampling {0._chains:d} chains, {0._divergences:,d} divergences"
+        self._chains = chains
         if progressbar:
             self._progress = tqdm(
                 total=chains * (draws + tune),
                 unit="draws",
-                desc="Sampling %s chains" % chains,
+                desc=self._desc.format(self)
             )
 
     def _make_active(self):
@@ -391,6 +394,9 @@ class ParallelSampler:
             draw = ProcessAdapter.recv_draw(self._active)
             proc, is_last, draw, tuning, stats, warns = draw
             if self._progress is not None:
+                if not tuning and stats and stats[0].get('diverging'):
+                    self._divergences += 1
+                    self._progress.set_description(self._desc.format(self))
                 self._progress.update()
 
             if is_last:

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -102,7 +102,7 @@ class TestSample(SeededTest):
                 tune=0,
                 random_seed=self.random_seed,
             )
-            for i, (trace, _) in enumerate(samps):
+            for i, trace in enumerate(samps):
                 assert i == len(trace) - 1, "Trace does not have correct length."
 
     def test_parallel_start(self):

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -102,7 +102,7 @@ class TestSample(SeededTest):
                 tune=0,
                 random_seed=self.random_seed,
             )
-            for i, trace in enumerate(samps):
+            for i, (trace, _) in enumerate(samps):
                 assert i == len(trace) - 1, "Trace does not have correct length."
 
     def test_parallel_start(self):


### PR DESCRIPTION
This adds to the progressbar description the number of divergences, if available. It should show up for either single core or parallel sampling, and I _think_ it will not effect population samplers.

Here's a preview of what it looks like.

![diverging](https://user-images.githubusercontent.com/2295568/61315770-7f74b500-a7cd-11e9-800f-f8710290e1ac.gif)


