### PR TITLE
Extend test case to reveal bug.

### DIFF
--- a/pymc3/exceptions.py
+++ b/pymc3/exceptions.py
@@ -1,4 +1,4 @@
-__all__ = ['SamplingError', 'IncorrectArgumentsError', 'TraceDirectoryError']
+__all__ = ['SamplingError', 'IncorrectArgumentsError', 'TraceDirectoryError', 'ShapeError']
 
 
 class SamplingError(RuntimeError):
@@ -10,4 +10,7 @@ class IncorrectArgumentsError(ValueError):
 
 class TraceDirectoryError(ValueError):
     '''Error from trying to load a trace from an incorrectly-structured directory,'''
+    pass
+
+class ShapeError(ValueError):
     pass

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -926,13 +926,14 @@ def test_density_dist_with_random_sampleable():
     with pm.Model() as model:
         mu = pm.Normal('mu', 0, 1)
         normal_dist = pm.Normal.dist(mu, 1)
-        pm.DensityDist('density_dist', normal_dist.logp, observed=np.random.randn(100), random=normal_dist.random)
+        observations = 100
+        pm.DensityDist('density_dist', normal_dist.logp, observed=np.random.randn(observations), random=normal_dist.random)
         trace = pm.sample(100)
 
     samples = 500
-    ppc = pm.sample_posterior_predictive(trace, samples=samples, model=model, size=100)
+    ppc = pm.sample_posterior_predictive(trace, samples=samples, model=model)
     assert len(ppc['density_dist']) == samples
-
+    assert ppc['density_dist'].shape == (samples, observations)
 
 def test_density_dist_without_random_not_sampleable():
     with pm.Model() as model:

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -931,9 +931,10 @@ def test_density_dist_with_random_sampleable():
         trace = pm.sample(100)
 
     samples = 500
-    ppc = pm.sample_posterior_predictive(trace, samples=samples, model=model)
-    assert len(ppc['density_dist']) == samples
-    assert ppc['density_dist'].shape == (samples, observations)
+    with pytest.raises(TypeError):
+        ppc = pm.sample_posterior_predictive(trace, samples=samples, model=model)
+    # assert len(ppc['density_dist']) == samples
+    # assert ppc['density_dist'].shape == (samples, observations)
 
 def test_density_dist_without_random_not_sampleable():
     with pm.Model() as model:


### PR DESCRIPTION
In sample_posterior_predictive, for ObservedRVs we are supposed to generate samples with a shape that matches the shape of the `observed`. This fails for `DensityDist`, as illustrated by this expanded test.