### PR TITLE
Wrap DensityDist's random with generate_samples

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,7 +17,9 @@
 - SMC is no longer a step method of `pm.sample` now it should be called using `pm.sample_smc` [3579](https://github.com/pymc-devs/pymc3/pull/3579)
 - Now uses `multiprocessong` rather than `psutil` to count CPUs, which results in reliable core counts on Chromebooks.
 - `sample_posterior_predictive` now preallocates the memory required for its output to improve memory usage. Addresses problems raised in this [discourse thread](https://discourse.pymc.io/t/memory-error-with-posterior-predictive-sample/2891/4).
-- Wrapped `DensityDist.rand` with `generate_samples` to make it aware of the distribution's shape. Added control flow attributes to still be able to behave as in earlier versions. Fixes [3553](https://github.com/pymc-devs/pymc3/issues/3553)
+- Fixed a bug in `Categorical.logp`. In the case of multidimensional `p`'s, the indexing was done wrong leading to incorrectly shaped tensors that consumed `O(n**2)` memory instead of `O(n)`. This fixes issue [#3535](https://github.com/pymc-devs/pymc3/issues/3535)
+- Fixed a defect in `OrderedLogistic.__init__` that unnecessarily increased the dimensionality of the underlying `p`. Related to issue issue [#3535](https://github.com/pymc-devs/pymc3/issues/3535) but was not the true cause of it.
+- Wrapped `DensityDist.rand` with `generate_samples` to make it aware of the distribution's shape. Added control flow attributes to still be able to behave as in earlier versions, and to control how to interpret the `size` parameter in the `random` callable signature. Fixes [3553](https://github.com/pymc-devs/pymc3/issues/3553)
 
 
 ## PyMC3 3.7 (May 29 2019)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,6 +17,7 @@
 - SMC is no longer a step method of `pm.sample` now it should be called using `pm.sample_smc` [3579](https://github.com/pymc-devs/pymc3/pull/3579)
 - Now uses `multiprocessong` rather than `psutil` to count CPUs, which results in reliable core counts on Chromebooks.
 - `sample_posterior_predictive` now preallocates the memory required for its output to improve memory usage. Addresses problems raised in this [discourse thread](https://discourse.pymc.io/t/memory-error-with-posterior-predictive-sample/2891/4).
+- Wrapped `DensityDist.rand` with `generate_samples` to make it aware of the distribution's shape. Added control flow attributes to still be able to behave as in earlier versions. Fixes [3553](https://github.com/pymc-devs/pymc3/issues/3553)
 
 
 ## PyMC3 3.7 (May 29 2019)

--- a/docs/source/api/distributions.rst
+++ b/docs/source/api/distributions.rst
@@ -9,3 +9,4 @@ Distributions
    distributions/multivariate
    distributions/mixture
    distributions/timeseries
+   distributions/utilities

--- a/docs/source/api/distributions/utilities.rst
+++ b/docs/source/api/distributions/utilities.rst
@@ -1,0 +1,26 @@
+*******************************************
+Distribution utility classes and functions
+*******************************************
+
+.. currentmodule:: pymc3.distributions
+.. autosummary::
+
+  Distribution
+  Discrete
+  Continuous
+  NoDistribution
+  TensorType
+
+  draw_values
+  generate_samples
+
+
+.. autoclass:: Distribution
+.. autoclass:: Discrete
+.. autoclass:: Continuous
+.. autoclass:: NoDistribution
+.. autofunction:: TensorType
+
+.. autofunction:: draw_values
+.. autofunction:: generate_samples
+

--- a/docs/source/api/distributions/utilities.rst
+++ b/docs/source/api/distributions/utilities.rst
@@ -9,6 +9,7 @@ Distribution utility classes and functions
   Discrete
   Continuous
   NoDistribution
+  DensityDist
   TensorType
 
   draw_values
@@ -19,6 +20,8 @@ Distribution utility classes and functions
 .. autoclass:: Discrete
 .. autoclass:: Continuous
 .. autoclass:: NoDistribution
+.. autoclass:: DensityDist
+    :members:
 .. autofunction:: TensorType
 
 .. autofunction:: draw_values

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -231,8 +231,10 @@ class DensityDist(Distribution):
             A callable that has the following signature ``logp(value)`` and
             returns a theano tensor that represents the distribution's log
             probability density.
-        shape: tuple (Optional)
-            The shape of the distribution.
+        shape: tuple (Optional): defaults to `()`
+            The shape of the distribution. The default value indicates a scalar.
+            If the distribution is *not* scalar-valued, the programmer should pass
+            a value here.
         dtype: None, str (Optional)
             The dtype of the distribution.
         testval: number or array (Optional)
@@ -241,7 +243,7 @@ class DensityDist(Distribution):
         random: None or callable (Optional)
             If ``None``, no random method is attached to the ``DensityDist``
             instance.
-            If a callable, it is used as the distribution ``random`` method.
+            If a callable, it is used as the distribution's ``random`` method.
             The behavior of this callable can be altered with the
             ``wrap_random_with_dist_shape`` parameter.
         wrap_random_with_dist_shape: bool (Optional)
@@ -255,6 +257,12 @@ class DensityDist(Distribution):
             test is only performed if ``wrap_random_with_dist_shape is False``.
         args, kwargs: (Optional)
             These are passed to the parent class' ``__init__``.
+        Note
+        ----
+            If the `random` method is wrapped with shape, what this means is
+            that it will be invoked with an additional `dist_shape` keyword
+            argument that can be consulted by the `random` argument callable to
+            retrieve the `DensityDist`'s shape.
         """
         if dtype is None:
             dtype = theano.config.floatX

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -259,10 +259,11 @@ class DensityDist(Distribution):
             These are passed to the parent class' ``__init__``.
         Note
         ----
-            If the `random` method is wrapped with shape, what this means is
-            that it will be invoked with an additional `dist_shape` keyword
-            argument that can be consulted by the `random` argument callable to
-            retrieve the `DensityDist`'s shape.
+            If the ``random`` method is wrapped with dist shape, what this means
+            is that the ``random`` callable will be wrapped with the
+            :func:`~genereate_samples` function. The distribution's shape will
+            be passed to :func:`~generate_samples` as the ``dist_shape``
+            parameter.
         """
         if dtype is None:
             dtype = theano.config.floatX

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -382,13 +382,15 @@ class DensityDist(Distribution):
 
     def random(self, point=None, size=None, **kwargs):
         if self.rand is not None:
+            not_broadcast_kwargs = dict(point=point)
+            not_broadcast_kwargs.update(**kwargs)
             if self.wrap_random_with_dist_shape:
                 size = to_tuple(size)
                 with _DrawValuesContextBlocker():
                     test_draw = generate_samples(
                         self.rand,
                         size=None,
-                        not_broadcast_kwargs=kwargs,
+                        not_broadcast_kwargs=not_broadcast_kwargs,
                     )
                     test_shape = test_draw.shape
                 if self.shape[:len(size)] == size:
@@ -406,10 +408,10 @@ class DensityDist(Distribution):
                     self.rand,
                     broadcast_shape=broadcast_shape,
                     size=size,
-                    not_broadcast_kwargs=kwargs,
+                    not_broadcast_kwargs=not_broadcast_kwargs,
                 )
             else:
-                samples = self.rand(size=size, **kwargs)
+                samples = self.rand(point=point, size=size, **kwargs)
                 if self.check_shape_in_random:
                     expected_shape = (
                         self.shape

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -981,26 +981,6 @@ class TestDensityDist():
         assert len(ppc['density_dist']) == samples
         assert ((samples,) + obs.distribution.shape) != ppc['density_dist'].shape
 
-    @pytest.mark.parametrize("shape", [(), (3,), (3, 2)], ids=str)
-    def test_density_dist_with_stats_random_sampleable(self, shape):
-        with pm.Model() as model:
-            mu = pm.Normal('mu', 0, 1)
-            normal_dist = pm.Normal.dist(mu, 1, shape=shape)
-            obs = pm.DensityDist(
-                'density_dist',
-                normal_dist.logp,
-                observed=np.random.randn(100, *shape),
-                shape=shape,
-                random=st.norm.rvs,
-                pymc3_size_interpretation=False
-            )
-            trace = pm.sample(100)
-
-        samples = 500
-        ppc = pm.sample_posterior_predictive(trace, samples=samples, model=model)
-        assert len(ppc['density_dist']) == samples
-        assert ((samples,) + obs.distribution.shape) == ppc['density_dist'].shape
-
     def test_density_dist_with_random_sampleable_handcrafted_success(self):
         with pm.Model() as model:
             mu = pm.Normal('mu', 0, 1)

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -922,28 +922,85 @@ def test_mixture_random_shape():
     assert ppc['like3'].shape == (200, 20)
 
 
-def test_density_dist_with_random_sampleable():
-    with pm.Model() as model:
-        mu = pm.Normal('mu', 0, 1)
-        normal_dist = pm.Normal.dist(mu, 1)
-        pm.DensityDist('density_dist', normal_dist.logp, observed=np.random.randn(100), random=normal_dist.random)
-        trace = pm.sample(100)
+class TestDensityDist():
+    def test_density_dist_with_random_sampleable(self):
+        with pm.Model() as model:
+            mu = pm.Normal('mu', 0, 1)
+            normal_dist = pm.Normal.dist(mu, 1)
+            obs = pm.DensityDist('density_dist', normal_dist.logp, observed=np.random.randn(100), random=normal_dist.random)
+            trace = pm.sample(100)
 
-    samples = 500
-    ppc = pm.sample_posterior_predictive(trace, samples=samples, model=model, size=100)
-    assert len(ppc['density_dist']) == samples
+        samples = 500
+        size = 100
+        ppc = pm.sample_posterior_predictive(trace, samples=samples, model=model, size=size)
+        assert ppc['density_dist'].shape == (samples, size) + obs.distribution.shape
 
+    def test_density_dist_with_random_sampleable_failure(self):
+        with pm.Model() as model:
+            mu = pm.Normal('mu', 0, 1)
+            normal_dist = pm.Normal.dist(mu, 1)
+            pm.DensityDist(
+                'density_dist',
+                normal_dist.logp,
+                observed=np.random.randn(100),
+                random=normal_dist.random,
+                wrap_random_with_dist_shape=False
+            )
+            trace = pm.sample(100)
 
-def test_density_dist_without_random_not_sampleable():
-    with pm.Model() as model:
-        mu = pm.Normal('mu', 0, 1)
-        normal_dist = pm.Normal.dist(mu, 1)
-        pm.DensityDist('density_dist', normal_dist.logp, observed=np.random.randn(100))
-        trace = pm.sample(100)
+        samples = 500
+        with pytest.raises(RuntimeError):
+            pm.sample_posterior_predictive(trace, samples=samples, model=model, size=100)
 
-    samples = 500
-    with pytest.raises(ValueError):
-        pm.sample_posterior_predictive(trace, samples=samples, model=model, size=100)
+    def test_density_dist_with_random_sampleable_hidden_error(self):
+        with pm.Model() as model:
+            mu = pm.Normal('mu', 0, 1)
+            normal_dist = pm.Normal.dist(mu, 1)
+            obs = pm.DensityDist(
+                'density_dist',
+                normal_dist.logp,
+                observed=np.random.randn(100),
+                random=normal_dist.random,
+                wrap_random_with_dist_shape=False,
+                check_shape_in_random=False
+            )
+            trace = pm.sample(100)
+
+        samples = 500
+        ppc = pm.sample_posterior_predictive(trace, samples=samples, model=model)
+        assert len(ppc['density_dist']) == samples
+        assert ((samples,) + obs.distribution.shape) != ppc['density_dist'].shape
+        print(obs.distribution.shape, ppc['density_dist'].shape)
+
+    def test_density_dist_with_random_sampleable_handcrafted_success(self):
+        with pm.Model() as model:
+            mu = pm.Normal('mu', 0, 1)
+            normal_dist = pm.Normal.dist(mu, 1)
+            rvs = pm.Normal.dist(mu, 1, shape=100).random
+            obs = pm.DensityDist(
+                'density_dist',
+                normal_dist.logp,
+                observed=np.random.randn(100),
+                random=rvs,
+                wrap_random_with_dist_shape=False
+            )
+            trace = pm.sample(100)
+
+        samples = 500
+        size = 100
+        ppc = pm.sample_posterior_predictive(trace, samples=samples, model=model, size=size)
+        assert ppc['density_dist'].shape == (samples, size) + obs.distribution.shape
+
+    def test_density_dist_without_random_not_sampleable(self):
+        with pm.Model() as model:
+            mu = pm.Normal('mu', 0, 1)
+            normal_dist = pm.Normal.dist(mu, 1)
+            pm.DensityDist('density_dist', normal_dist.logp, observed=np.random.randn(100))
+            trace = pm.sample(100)
+    
+        samples = 500
+        with pytest.raises(ValueError):
+            pm.sample_posterior_predictive(trace, samples=samples, model=model, size=100)
 
 
 class TestNestedRandom(SeededTest):

--- a/pymc3/tests/test_models_utils.py
+++ b/pymc3/tests/test_models_utils.py
@@ -41,7 +41,7 @@ class TestUtils:
         m, l = utils.any_to_tensor_and_labels(self.data.to_dict('list'))
         self.assertMatrixLabels(m, l, mt=self.data[l].values, lt=l)
 
-        inp = {k: tt.as_tensor_variable(v) for k, v in self.data.to_dict('series').items()}
+        inp = {k: tt.as_tensor_variable(v.values) for k, v in self.data.to_dict('series').items()}
         m, l = utils.any_to_tensor_and_labels(inp)
         self.assertMatrixLabels(m, l, mt=self.data[l].values, lt=l)
 


### PR DESCRIPTION
This fixes issue #3553 by relying on `generate_samples` to make the random number generators aware of the distribution's shape. The old _incorrect_ behavior can still be achieved with some extra arguments during initialization.