### PR TITLE
Added backend option for VI sample trace

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,7 +8,7 @@
 - Sequential Monte Carlo - Approximate Bayesian Computation step method is now available. The implementation is in an experimental stage and will be further improved.
 - Added `Matern12` covariance function for Gaussian processes. This is the Matern kernel with nu=1/2.
 - Progressbar reports number of divergences in real time, when available [#3547](https://github.com/pymc-devs/pymc3/pull/3547).
-- Sampling from variational approximation now allows for alternative trace backends [#3557].
+- Sampling from variational approximation now allows for alternative trace backends [#3550].
 
 ### Maintenance
 - Moved math operations out of `Rice`, `TruncatedNormal`, `Triangular` and `ZeroInflatedNegativeBinomial` `random` methods. Math operations on values returned by `draw_values` might not broadcast well, and all the `size` aware broadcasting is left to `generate_samples`. Fixes [#3481](https://github.com/pymc-devs/pymc3/issues/3481) and [#3508](https://github.com/pymc-devs/pymc3/issues/3508)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,7 @@
 - Sequential Monte Carlo - Approximate Bayesian Computation step method is now available. The implementation is in an experimental stage and will be further improved.
 - Added `Matern12` covariance function for Gaussian processes. This is the Matern kernel with nu=1/2.
 - Progressbar reports number of divergences in real time, when available [#3547](https://github.com/pymc-devs/pymc3/pull/3547).
+- Sampling from variational approximation now allows for alternative trace backends [#3557].
 
 ### Maintenance
 - Moved math operations out of `Rice`, `TruncatedNormal`, `Triangular` and `ZeroInflatedNegativeBinomial` `random` methods. Math operations on values returned by `draw_values` might not broadcast well, and all the `size` aware broadcasting is left to `generate_samples`. Fixes [#3481](https://github.com/pymc-devs/pymc3/issues/3481) and [#3508](https://github.com/pymc-devs/pymc3/issues/3508)

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -156,7 +156,7 @@ def three_var_approx_single_group_mf(three_var_model):
         ('ndarray', None),
         ('text', 'test'),
         ('sqlite', 'test.sqlite'),
-        ('hdf5', 'test.h5'))
+        ('hdf5', 'test.h5')
     ]
 )
 def test_sample_simple(three_var_approx, request):

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -151,12 +151,16 @@ def three_var_approx(three_var_model, three_var_groups):
 def three_var_approx_single_group_mf(three_var_model):
     return MeanField(model=three_var_model)
 
-
-def test_sample_simple(three_var_approx):
-    for backend,name in (('ndarray', None), 
-                        ('text', 'test'), 
-                        ('sqlite', 'test.sqlite'), 
-                        ('hdf5', 'test.h5')):
+@pytest.fixture(
+    params = [
+        ('ndarray', None),
+        ('text', 'test'),
+        ('sqlite', 'test.sqlite'),
+        ('hdf5', 'test.h5'))
+    ]
+)
+def test_sample_simple(three_var_approx, request):
+        backend, name = request.param
         trace = three_var_approx.sample(100, backend=backend, name=name)
         assert set(trace.varnames) == {'one', 'one_log__', 'three', 'two'}
         assert len(trace) == 100

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -153,7 +153,7 @@ def three_var_approx_single_group_mf(three_var_model):
 
 
 def test_sample_simple(three_var_approx):
-    for backend,name in ((None, None), 
+    for backend,name in (('ndarray', None), 
                         ('text', 'test'), 
                         ('sqlite', 'test.sqlite'), 
                         ('hdf5', 'test.h5')):

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -153,12 +153,16 @@ def three_var_approx_single_group_mf(three_var_model):
 
 
 def test_sample_simple(three_var_approx):
-    trace = three_var_approx.sample(500)
-    assert set(trace.varnames) == {'one', 'one_log__', 'three', 'two'}
-    assert len(trace) == 500
-    assert trace[0]['one'].shape == (10, 2)
-    assert trace[0]['two'].shape == (10, )
-    assert trace[0]['three'].shape == (10, 1, 2)
+    for backend,name in ((None, None), 
+                        ('text', 'test'), 
+                        ('sqlite', 'test.sqlite'), 
+                        ('hdf5', 'test.h5')):
+        trace = three_var_approx.sample(100, backend=backend, name=name)
+        assert set(trace.varnames) == {'one', 'one_log__', 'three', 'two'}
+        assert len(trace) == 100
+        assert trace[0]['one'].shape == (10, 2)
+        assert trace[0]['two'].shape == (10, )
+        assert trace[0]['three'].shape == (10, 1, 2)
 
 
 @pytest.fixture


### PR DESCRIPTION
Allows VI samples to be saved to non-ndarray backends, as requested by #3550.

