### PR TITLE
MAINT: import from collections.abc

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional, TYPE_CHECKING, cast
 if TYPE_CHECKING:
     from typing import Any
 from typing import Iterable as TIterable
-from collections import defaultdict, Iterable
+from collections.abc import defaultdict, Iterable
 from copy import copy
 import pickle
 import logging

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -2,7 +2,8 @@ from typing import Dict, List, Optional, TYPE_CHECKING, cast
 if TYPE_CHECKING:
     from typing import Any
 from typing import Iterable as TIterable
-from collections.abc import defaultdict, Iterable
+from collections.abc import Iterable
+from collections import defaultdict
 from copy import copy
 import pickle
 import logging


### PR DESCRIPTION
In Python 3.7 importing `from collections` is deprecated and raises a `DeprecationWarning`. In Python 3.8 (scheduled for release in mid October) it will raise an Error. This PR fixes the import. Hopefully a release of pymc3 and theano can be done before then, otherwise the packages won't work in Python 3.8.