### PR TITLE
Parallelize call to likelihood_logp

### DIFF
--- a/pymc3/step_methods/smc.py
+++ b/pymc3/step_methods/smc.py
@@ -196,7 +196,15 @@ def sample_smc(
 
     while beta < 1:
 
-        likelihoods = np.array([likelihood_logp(sample) for sample in posterior]).squeeze()
+        if step.parallel and cores > 1:
+            pool = mp.Pool(processes=cores)
+            results = pool.starmap(
+                likelihood_logp,
+                [(sample,) for sample in posterior],
+            )
+        else:
+            results = [likelihood_logp(sample) for sample in posterior]
+        likelihoods = np.array(results).squeeze()
         beta, old_beta, weights, sj = calc_beta(beta, likelihoods, step.threshold)
         model.marginal_likelihood *= sj
         # resample based on plausibility weights (selection)


### PR DESCRIPTION
As discussed [here](https://discourse.pymc.io/t/smc-further-parallel-computing/3601/2), this gives the possibility to compute another call to the likelihood function in parallel, which can be useful for expensive models.