### PR TITLE
Issue 3569: check for type of observed vars and reshape if 2-dim

### DIFF
--- a/pymc3/glm/linear.py
+++ b/pymc3/glm/linear.py
@@ -38,6 +38,10 @@ class LinearComponent(Model):
     def __init__(self, x, y, intercept=True, labels=None,
                  priors=None, vars=None, name='', model=None, offset=0.):
         super().__init__(name, model)
+        if len(y.shape) > 1:
+            err_msg = 'Only one-dimensional observed variable objects (i.e.'\
+                       ' of shape `(n, )`) are supported'
+            raise TypeError(err_msg)
         if priors is None:
             priors = {}
         if vars is None:


### PR DESCRIPTION
PR implementing a simple "fix" for https://github.com/pymc-devs/pymc3/issues/3569 (and https://github.com/pymc-devs/pymc3/issues/3565) by raising a `TypeError` when observed variable object has more than 1 dimension (tested by `len(y.shape) > 1`.

<details>
<summary>Screenshot</summary>
<p>

![image](https://user-images.githubusercontent.com/15376817/62078909-8b3c8e80-b245-11e9-95a8-5a0094dd54e8.png)

</p>
</details>

<details>
<summary>Working code</summary>
<p>

```
%matplotlib inline

import pymc3 as pm

import pandas as pd
import numpy as np
import patsy as pt
import matplotlib.pyplot as plt
import seaborn as sns

##

np.random.seed(42)

samples = 1000

size = 200
int_1, slo_1 = 1, 3
i_1, i_2, i_3 = 2, -1.5, 0

# Create priors
priors_patsy = {"x": pm.Normal.dist(mu=3, sd=0.01),
                "C(i, Treatment(-1.5))[2.0]": pm.Normal.dist(mu=3.5, sd=0.01)}

priors_formula = {"x": pm.Normal.dist(mu=3, sd=0.01),
                  "C(i)[T.2.0]": pm.Normal.dist(mu=3.5, sd=0.01),}

x = np.linspace(0, 1, size)

# Get y's as y = (a + b * x) + i
y_clean_1 = (int_1 + slo_1 * x) + i_1
y_clean_2 = (int_1 + slo_1 * x) + i_2
y_clean_3 = (int_1 + slo_1 * x) + i_3

# Add some randomness
y_1 = y_clean_1 + np.random.normal(scale=.5, size=size)
y_2 = y_clean_2 + np.random.normal(scale=.5, size=size)
y_3 = y_clean_3 + np.random.normal(scale=.5, size=size)

df = pd.DataFrame({"y": np.concatenate([y_1, y_2, y_3]),
                   "x": np.concatenate([x, x, x]),
                   "i": np.concatenate(
                       [np.repeat(i_1, size),
                        np.repeat(i_2, size),
                        np.repeat(i_3, size)])})

y, X = pt.dmatrices("y ~ x + C(i, Treatment(-1.5))", df, return_type="dataframe")

##

traces = []
for y_check in [
        y["y"],                       # pass, `pd.Series`
        np.asarray(y.values)[:, -1],  # pass, 1-d `np.ndarray`
        y,                            # fail, single column `pd.DataFrame`
        y.values]:                    # fail, 2-d `np.ndarray`
    try:
        with pm.Model() as model_patsy:
            pm.glm.GLM(y=y_check, x=X, priors=priors_patsy, intercept=False)
            traces.append(pm.sample(samples, cores=2, tune=1000))
    except Exception as e:
        print(e)

##

# Formula interface
with pm.Model() as model_formula:
    pm.glm.GLM.from_formula("y ~ x + C(i)", df, priors=priors_formula)
    trace_formula = pm.sample(samples, cores=2, tune=1000)
```

</p>
</details>