### PR TITLE
Fix ValueError raised when mask is empty

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1308,7 +1308,10 @@ def pandas_to_array(data):
         else:
             ret = data.values
     elif hasattr(data, 'mask'):
-        ret = data
+        if data.mask.any():
+            ret = data
+        else:  # empty mask
+            ret = data.filled()
     elif isinstance(data, theano.gof.graph.Variable):
         ret = data
     elif sps.issparse(data):


### PR DESCRIPTION
This fixes #3576. There was a bug when you provide a masked array with the empty mask (all values are unmasked), then ValueError was raised. Now, we check if there are not any masked elements we convert it to a regular ndarray.