### PR TITLE
Fix shape_utils broken documentation

### DIFF
--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -1,5 +1,6 @@
 from . import timeseries
 from . import transforms
+from . import shape_utils
 
 from .continuous import Uniform
 from .continuous import Flat


### PR DESCRIPTION
add `shape_utils` to `pymc3.distributions` namespace to fix import error in docs

closes #3499