### PR TITLE
Update NUTS docs to reflect integrators being gone

### DIFF
--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -121,7 +121,7 @@ class NUTS(BaseHMC):
             Whether step size adaptation should be enabled. If this is
             disabled, `k`, `t0`, `gamma` and `target_accept` are ignored.
         max_treedepth : int, default=10
-            The maximum tree depth. Trajectories are stoped when this
+            The maximum tree depth. Trajectories are stopped when this
             depth is reached.
         early_max_treedepth : int, default=8
             The maximum tree depth during the first 200 tuning samples.

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -125,10 +125,6 @@ class NUTS(BaseHMC):
             depth is reached.
         early_max_treedepth : int, default=8
             The maximum tree depth during the first 200 tuning samples.
-        integrator : str, default "leapfrog"
-            The integrator to use for the trajectories. One of "leapfrog",
-            "two-stage" or "three-stage". The second two can increase
-            sampling speed for some high dimensional problems.
         scaling : array_like, ndim = {1,2}
             The inverse mass, or precision matrix. One dimensional arrays are
             interpreted as diagonal matrices. If `is_cov` is set to True,


### PR DESCRIPTION
Fixes #3581. 

We still pass an integrator _object_ around, which I left in as helpful, but this is the only place I could find a reference remaining.