### PR TITLE
fix default prior variable names

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1292,7 +1292,7 @@ def sample_prior_predictive(samples=500,
         samples.  *DEPRECATED* - Use ``var_names`` argument instead.
     var_names : Iterable[str]
         A list of names of variables for which to compute the posterior predictive
-        samples. Defaults to ``model.named_vars``.
+        samples. Defaults to both observed and unobserved RVs.
     random_seed : int
         Seed for the random number generator.
 

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1305,8 +1305,10 @@ def sample_prior_predictive(samples=500,
     model = modelcontext(model)
 
     if vars is None and var_names is None:
-        vars = set(model.named_vars.keys())
-        vars_ = model.named_vars
+        prior_pred_vars = model.observed_RVs
+        prior_vars = get_default_varnames(model.unobserved_RVs, include_transformed=True)
+        vars_ = [var.name for var in prior_vars + prior_pred_vars]
+        vars = set(vars_)
     elif vars is None:
         vars = var_names
         vars_ = vars

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1306,7 +1306,10 @@ def sample_prior_predictive(samples=500,
 
     if vars is None and var_names is None:
         prior_pred_vars = model.observed_RVs
-        prior_vars = get_default_varnames(model.unobserved_RVs, include_transformed=True)
+        prior_vars = (
+            get_default_varnames(model.unobserved_RVs, include_transformed=True) +
+            model.potentials
+        )
         vars_ = [var.name for var in prior_vars + prior_pred_vars]
         vars = set(vars_)
     elif vars is None:

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -505,12 +505,14 @@ class TestSamplePriorPredictive(SeededTest):
         observed = np.random.normal(10, 1, size=200)
         with pm.Model():
             # Use a prior that's way off to show we're ignoring the observed variables
+            observed_data = pm.Data("observed_data", observed)
             mu = pm.Normal("mu", mu=-100, sigma=1)
             positive_mu = pm.Deterministic("positive_mu", np.abs(mu))
             z = -1 - positive_mu
-            pm.Normal("x_obs", mu=z, sigma=1, observed=observed)
+            pm.Normal("x_obs", mu=z, sigma=1, observed=observed_data)
             prior = pm.sample_prior_predictive()
 
+        assert "observed_data" not in prior
         assert (prior["mu"] < 90).all()
         assert (prior["positive_mu"] > 90).all()
         assert (prior["x_obs"] < 90).all()


### PR DESCRIPTION
Fix #3588. I have also noted that `sample_prior_predictive` samples both the prior and the prior_predictive. Considering how default var names are defined now. It would be quite easy to divide the function in 2, a `sample_prior` and a `sample_prior_predictive` but it would be quite a breaking change. Are you interested in dividing the function at all? Would you rather do in now or in some future PR after having added FutureWarnings here?

I think the best idea will probably be to make this PR only about fixing #3588 so it can be merged before the discussion about prior and prior predictive. I can send another PR afterwards with whatever is decided.