### PR TITLE
Use multiprocessing instead of psutil to count cores

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,6 +15,9 @@
 - Parallelization of population steppers (`DEMetropolis`) is now set via the `cores` argument. ([#3559](https://github.com/pymc-devs/pymc3/pull/3559))
 - SMC: stabilize covariance matrix [3573](https://github.com/pymc-devs/pymc3/pull/3573)
 - SMC is no longer a step method of `pm.sample` now it should be called using `pm.sample_smc` [3579](https://github.com/pymc-devs/pymc3/pull/3579)
+- Now uses `multiprocessong` rather than `psutil` to count CPUs, which results in reliable core counts on Chromebooks.
+
+
 
 ## PyMC3 3.7 (May 29 2019)
 

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -433,7 +433,6 @@ def _cpu_count():
     If not, we use the number provided by multiprocessing, but assume
     that half of the cpus are only hardware threads and ignore those.
     """
-    import multiprocessing
     try:
         cpus = multiprocessing.cpu_count() // 2
     except NotImplementedError:

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -433,14 +433,9 @@ def _cpu_count():
     If not, we use the number provided by multiprocessing, but assume
     that half of the cpus are only hardware threads and ignore those.
     """
+    import multiprocessing
     try:
-        import psutil
-        cpus = psutil.cpu_count(False)
-    except ImportError:
-        try:
-            cpus = multiprocessing.cpu_count() // 2
-        except NotImplementedError:
-            cpus = 1
-    if cpus is None:
+        cpus = multiprocessing.cpu_count() // 2
+    except NotImplementedError:
         cpus = 1
     return cpus


### PR DESCRIPTION
`psutil` gives the wrong count on some architectures. This PR just uses `multiprocessing`.