### PR TITLE
SMC: change scaling computation

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,6 +15,7 @@
 - Parallelization of population steppers (`DEMetropolis`) is now set via the `cores` argument. ([#3559](https://github.com/pymc-devs/pymc3/pull/3559))
 - SMC: stabilize covariance matrix [3573](https://github.com/pymc-devs/pymc3/pull/3573)
 - SMC is no longer a step method of `pm.sample` now it should be called using `pm.sample_smc` [3579](https://github.com/pymc-devs/pymc3/pull/3579)
+- SMC: improve computation of the proposal scaling factor [3594](https://github.com/pymc-devs/pymc3/pull/3594)
 - Now uses `multiprocessong` rather than `psutil` to count CPUs, which results in reliable core counts on Chromebooks.
 - `sample_posterior_predictive` now preallocates the memory required for its output to improve memory usage. Addresses problems raised in this [discourse thread](https://discourse.pymc.io/t/memory-error-with-posterior-predictive-sample/2891/4).
 - Fixed a bug in `Categorical.logp`. In the case of multidimensional `p`'s, the indexing was done wrong leading to incorrectly shaped tensors that consumed `O(n**2)` memory instead of `O(n)`. This fixes issue [#3535](https://github.com/pymc-devs/pymc3/issues/3535)

--- a/pymc3/smc/smc.py
+++ b/pymc3/smc/smc.py
@@ -198,7 +198,7 @@ def sample_smc(
         else:
             results = [likelihood_logp(sample) for sample in posterior]
         likelihoods = np.array(results).squeeze()
-        beta, old_beta, weights, sj, = calc_beta(beta, likelihoods, threshold)
+        beta, old_beta, weights, sj = calc_beta(beta, likelihoods, threshold)
 
         model.marginal_likelihood *= sj
         # resample based on plausibility weights (selection)


### PR DESCRIPTION
Compute the scaling of the proposal distribution using the same function used by metropolis. This seems to work much more better than the previous function. Just as an example using the "two gaussian model" with n=20.

With the old scaling, the sampler generally get stuck at a single maximum :
![old_n20](https://user-images.githubusercontent.com/1338958/63194367-358a2380-c046-11e9-9cf1-c9df145e8f4d.png)

with the new scaling, while the solution is not perfect is much more better:

![new_n20](https://user-images.githubusercontent.com/1338958/63194375-3c189b00-c046-11e9-942a-4f2a6e10e6bb.png)

This PR also include some minor refactoring changes not related to the computation of the scaling factor. 
