### PR TITLE
Fully vectorized sample posterior predictive

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,7 @@
 - Progressbar reports number of divergences in real time, when available [#3547](https://github.com/pymc-devs/pymc3/pull/3547).
 - Sampling from variational approximation now allows for alternative trace backends [#3550].
 - [ArviZ](https://arviz-devs.github.io/arviz/) is now a requirement, and handles plotting, diagnostics, and statistical checks.
+- Included `fast_sample_posterior_predictive`, which draws samples from the posterior predictive distribution taking the maximum advantage possible from operation vectorization. This will implementation is likely to run into problems with multivariate distributions for now.
 
 ### Maintenance
 - Moved math operations out of `Rice`, `TruncatedNormal`, `Triangular` and `ZeroInflatedNegativeBinomial` `random` methods. Math operations on values returned by `draw_values` might not broadcast well, and all the `size` aware broadcasting is left to `generate_samples`. Fixes [#3481](https://github.com/pymc-devs/pymc3/issues/3481) and [#3508](https://github.com/pymc-devs/pymc3/issues/3508)
@@ -26,6 +27,7 @@
 - Fixed a defect in `OrderedLogistic.__init__` that unnecessarily increased the dimensionality of the underlying `p`. Related to issue issue [#3535](https://github.com/pymc-devs/pymc3/issues/3535) but was not the true cause of it.
 - Wrapped `DensityDist.rand` with `generate_samples` to make it aware of the distribution's shape. Added control flow attributes to still be able to behave as in earlier versions, and to control how to interpret the `size` parameter in the `random` callable signature. Fixes [3553](https://github.com/pymc-devs/pymc3/issues/3553)
 - Added `theano.gof.graph.Constant` to type checks done in `_draw_value` (fixes issue [3595](https://github.com/pymc-devs/pymc3/issues/3595))
+- Adapted `DensityDist.random` to better handle vectorization.
 
 
 ## PyMC3 3.7 (May 29 2019)


### PR DESCRIPTION
I opened this PR to show a working fully vectorized implementation of `sample_posterior_predictive`. It is based on the proposal I did on [this gist](https://gist.github.com/lucianopaz/eda06bc4d4ce8c28af8295156eb1f7bd)

* It leaves all of the `draw_values`, `_draw_value` and `generate_samples` infrastructure as is. 
* It makes a single call to `draw_values` and passes the entire content held in the passed `trace` as a `point` dictionary.
* To allow for the vectorization, it takes advantage of the `size` aware broadcasting rules introduced in #3456. It makes a view of each variable's sampled chain held in the trace so that its shape prepend matches the number of posterior predictive draws desired.
* I had to patch up `DensityDist.random` to make it work properly when the distribution is observed.

This proposal is intended only as a wishful implementation that can serve as comparison to #3597, because it is likely that models that have **observed `MultiVariate`** distributions will raise various exceptions. However, none of the tests present at the moment of writing this PR failed (at least locally), so I'll later try to make a model with observed `MultiVariate`s that fail to draw samples from the posterior predictive.

As such, the notes added into RELEASE-NOTES.md are kind of a mock. If we discuss and agree that this approach is worth it, I can make a better note and also add the proper deprecations to `sample_posterior_predictive`'s arguments