### PR TITLE
Check chain lengths when merging MultiTraces.

### DIFF
--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -566,7 +566,7 @@ def merge_traces(mtraces: List[MultiTrace]) -> MultiTrace:
     base_mtrace = mtraces[0]
     chain_len = len(base_mtrace)
     # check base trace
-    if any((len(st) != chain_len for _, st in base_mtrace._straces.items())):
+    if any(len(st) != chain_len for _, st in base_mtrace._straces.items()):  # pylint: disable=line-too-long
         raise ValueError("Chains are of different lengths.")
     for new_mtrace in mtraces[1:]:
         for new_chain, strace in new_mtrace._straces.items():

--- a/pymc3/tests/test_ndarray_backend.py
+++ b/pymc3/tests/test_ndarray_backend.py
@@ -112,6 +112,30 @@ class TestMultiTrace(bf.ModelBackendSetupTestCase):
         with pytest.raises(ValueError):
             base.MultiTrace([self.strace0, self.strace1])
 
+    def test_merge_traces_no_traces(self):
+        with pytest.raises(ValueError):
+            base.merge_traces([])
+
+    def test_merge_traces_diff_lengths(self):
+        with self.model:
+            strace0 = self.backend(self.name)
+            strace0.setup(self.draws, 1)
+            for i in range(self.draws):
+                strace0.record(self.test_point)
+            strace0.close()
+        mtrace0 = base.MultiTrace([self.strace0])
+
+        with self.model:
+            strace1 = self.backend(self.name)
+            strace1.setup(2 * self.draws, 1)
+            for i in range(2 * self.draws):
+                strace1.record(self.test_point)
+            strace1.close()
+        mtrace1 = base.MultiTrace([strace1])
+
+        with pytest.raises(ValueError):
+            base.merge_traces([mtrace0, mtrace1])
+
     def test_merge_traces_nonunique(self):
         mtrace0 = base.MultiTrace([self.strace0])
         mtrace1 = base.MultiTrace([self.strace1])


### PR DESCRIPTION
Lots of logic in PyMC3 assumes that all chains in a MultiTrace will have the same length. Added a check to make sure this is true.
Waiting for the results of the comprehensive test suite.