### PR TITLE
Update doc-compilation requirements.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,11 +4,11 @@ graphviz>=0.8.3
 h5py>=2.7.0
 ipython
 Keras>=2.0.8
-nbsphinx>=0.2.13
+nbsphinx>=0.4.2
 nose>=1.3.7
 nose-parameterized==0.6.0
 numpy>=1.13.0
-numpydoc==0.7.0
+numpydoc>=0.9.1
 pycodestyle>=2.3.1
 pyflakes>=1.5.0
 pylint>=1.7.4


### PR DESCRIPTION
numpydoc added a critically important error-message improvement, enabling further doc improvements.
Pick up newer nbsphinx at the same time.

Need to check that this passes tests, but assuming it does, this should be a big win.  I already have a couple of pages of saved documentation fixes to do!