### PR TITLE
Reset iter_count in hmc in `_iter_sample`

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -605,6 +605,8 @@ def _iter_sample(draws, step, start=None, trace=None, chain=0, tune=None,
     try:
         step.tune = bool(tune)
         for i in range(draws):
+            if i == 0 and hasattr(step, 'iter_count'):
+                step.iter_count = 0
             if i == tune:
                 step = stop_tuning(step)
             if step.generates_stats:


### PR DESCRIPTION
So that early max tree is correct for each independent chain.
Fix #3627