### PR TITLE
Simple stick breaking (Formerly #3620)

### DIFF
--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -10,7 +10,6 @@ from ..math import logit, invlogit
 from .distribution import draw_values
 import numpy as np
 from scipy.special import logit as nplogit
-from scipy.special import expit
 
 
 __all__ = [

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -518,7 +518,7 @@ class StickBreaking2(Transform):
     Transforms K - 1 dimensional simplex space (k values in [0,1] and that sum to 1) to a K - 1 vector of real values.
     """
 
-    name = "stickbreaking2"
+    name = "stickbreaking"
 
     def __init__(self, eps=None):
         if eps is not None:

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -10,11 +10,13 @@ from ..math import logit, invlogit
 from .distribution import draw_values
 import numpy as np
 from scipy.special import logit as nplogit
+from scipy.special import expit
 
 
 __all__ = [
     "transform",
     "stick_breaking",
+    "stick_breaking2",
     "logodds",
     "interval",
     "log_exp_m1",
@@ -90,8 +92,7 @@ class Transform:
         raise NotImplementedError
 
     def jacobian_det(self, x):
-        """Calculates logarithm of the absolute value of the Jacobian determinant
-        of the backward transformation for input `x`.
+        """Calculates logarithm of the absolute value of the Jacobian determinant for input `x`.
 
         Parameters
         ----------
@@ -433,9 +434,91 @@ sum_to_1 = SumTo1()
 class StickBreaking(Transform):
     """
     Transforms K - 1 dimensional simplex space (k values in [0,1] and that sum to 1) to a K - 1 vector of real values.
+    Primarily borrowed from the STAN implementation.
+
+    Parameters
+    ----------
+    eps : float, positive value
+        A small value for numerical stability in invlogit.
     """
 
     name = "stickbreaking"
+
+    def __init__(self, eps=floatX(np.finfo(theano.config.floatX).eps)):
+        self.eps = eps
+
+    def forward(self, x_):
+        x = x_.T
+        # reverse cumsum
+        x0 = x[:-1]
+        s = tt.extra_ops.cumsum(x0[::-1], 0)[::-1] + x[-1]
+        z = x0 / s
+        Km1 = x.shape[0] - 1
+        k = tt.arange(Km1)[(slice(None),) + (None,) * (x.ndim - 1)]
+        eq_share = logit(1.0 / (Km1 + 1 - k).astype(str(x_.dtype)))
+        y = logit(z) - eq_share
+        return floatX(y.T)
+
+    def forward_val(self, x_, point=None):
+        x = x_.T
+        # reverse cumsum
+        x0 = x[:-1]
+        s = np.cumsum(x0[::-1], 0)[::-1] + x[-1]
+        z = x0 / s
+        Km1 = x.shape[0] - 1
+        k = np.arange(Km1)[(slice(None),) + (None,) * (x.ndim - 1)]
+        eq_share = nplogit(1.0 / (Km1 + 1 - k).astype(str(x_.dtype)))
+        y = nplogit(z) - eq_share
+        return floatX(y.T)
+
+    def backward(self, y_):
+        y = y_.T
+        Km1 = y.shape[0]
+        k = tt.arange(Km1)[(slice(None),) + (None,) * (y.ndim - 1)]
+        eq_share = logit(1.0 / (Km1 + 1 - k).astype(str(y_.dtype)))
+        z = invlogit(y + eq_share, self.eps)
+        yl = tt.concatenate([z, tt.ones(y[:1].shape)])
+        yu = tt.concatenate([tt.ones(y[:1].shape), 1 - z])
+        S = tt.extra_ops.cumprod(yu, 0)
+        x = S * yl
+        return floatX(x.T)
+
+    def backward_val(self, y_):
+        y = y_.T
+        Km1 = y.shape[0]
+        k = np.arange(Km1)[(slice(None),) + (None,) * (y.ndim - 1)]
+        eq_share = nplogit(1.0 / (Km1 + 1 - k).astype(str(y_.dtype)))
+        z = expit(y + eq_share)
+        yl = np.concatenate([z, np.ones(y[:1].shape)])
+        yu = np.concatenate([np.ones(y[:1].shape), 1 - z])
+        S = np.cumprod(yu, 0)
+        x = S * yl
+        return floatX(x.T)
+
+    def jacobian_det(self, y_):
+        y = y_.T
+        Km1 = y.shape[0]
+        k = tt.arange(Km1)[(slice(None),) + (None,) * (y.ndim - 1)]
+        eq_share = logit(1.0 / (Km1 + 1 - k).astype(str(y_.dtype)))
+        yl = y + eq_share
+        yu = tt.concatenate([tt.ones(y[:1].shape), 1 - invlogit(yl, self.eps)])
+        S = tt.extra_ops.cumprod(yu, 0)
+        return tt.sum(tt.log(S[:-1]) - tt.log1p(tt.exp(yl)) - tt.log1p(tt.exp(-yl)), 0).T
+
+
+stick_breaking = StickBreaking()
+
+
+def t_stick_breaking(eps):
+    return StickBreaking(eps)
+
+
+class StickBreaking2(Transform):
+    """
+    Transforms K - 1 dimensional simplex space (k values in [0,1] and that sum to 1) to a K - 1 vector of real values.
+    """
+
+    name = "stickbreaking2"
 
     def __init__(self, eps=None):
         if eps is not None:
@@ -482,11 +565,8 @@ class StickBreaking(Transform):
         d = tt.log(Km1) + (Km1*sy) - (Km1*sr)
         return tt.sum(d, 0).T
 
-stick_breaking = StickBreaking()
 
-
-def t_stick_breaking(eps):
-    return StickBreaking(eps)
+stick_breaking2 = StickBreaking2()
 
 
 class Circular(ElemwiseTransform):

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -481,7 +481,7 @@ class StickBreaking(Transform):
         # stable according to: http://deeplearning.net/software/theano_versions/0.9.X/NEWS.html
         sr = tt.log(tt.sum(tt.exp(r), 0, keepdims=True))
         d = tt.log(Km1) + (Km1*sy) - (Km1*sr)
-        return d.T
+        return tt.sum(d, 0).T
 
 stick_breaking = StickBreaking()
 

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -476,9 +476,9 @@ class StickBreaking(Transform):
     def jacobian_det(self, x_):
         x = x_.T
         n = x.shape[0]
-        # stable according to: http://deeplearning.net/software/theano_versions/0.9.X/NEWS.html
-        lse = tt.log(tt.sum(tt.exp(x), 0, keepdims=True))
-        d = tt.log(n) - (n*lse)
+        sx = tt.sum(x, 0, keepdims=True)
+        r = tt.log(floatX(1) + tt.sum(tt.exp(x + sx), 0,keepdims=True))
+        d = tt.log(n) + (n*sx) - (n*r)
         return d.T
 
 stick_breaking = StickBreaking()

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -473,14 +473,14 @@ class StickBreaking(Transform):
         x = np.exp(y)/np.sum(np.exp(y), 0, keepdims=True)
         return floatX(x.T)
 
-    def jacobian_det(self, x_):
-        x = x_.T
-        n = x.shape[0]
-        sx = tt.sum(x, 0, keepdims=True)
-        r = tt.concatenate([x+sx, tt.zeros(sx.shape)])
+    def jacobian_det(self, y_):
+        y = y_.T
+        Km1 = y.shape[0]
+        sy = tt.sum(y, 0, keepdims=True)
+        r = tt.concatenate([y+sy, tt.zeros(sy.shape)])
         # stable according to: http://deeplearning.net/software/theano_versions/0.9.X/NEWS.html
         sr = tt.log(tt.sum(tt.exp(r), 0, keepdims=True))
-        d = tt.log(n) + (n*sx) - (n*sr)
+        d = tt.log(Km1) + (Km1*sy) - (Km1*sr)
         return d.T
 
 stick_breaking = StickBreaking()

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -469,7 +469,7 @@ class StickBreaking(Transform):
 
     def backward_val(self, y_):
         y = y_.T
-        y = np.append(y, -np.sum(y, 0, keepdims=True))
+        y = np.concatenate([y, -np.sum(y, 0, keepdims=True)])
         x = np.exp(y)/np.sum(np.exp(y), 0, keepdims=True)
         return floatX(x.T)
 
@@ -477,8 +477,10 @@ class StickBreaking(Transform):
         x = x_.T
         n = x.shape[0]
         sx = tt.sum(x, 0, keepdims=True)
-        r = tt.log(floatX(1) + tt.sum(tt.exp(x + sx), 0,keepdims=True))
-        d = tt.log(n) + (n*sx) - (n*r)
+        r = tt.concatenate([x+sx, tt.zeros(sx.shape)])
+        # stable according to: http://deeplearning.net/software/theano_versions/0.9.X/NEWS.html
+        sr = tt.log(tt.sum(tt.exp(r), 0, keepdims=True))
+        d = tt.log(n) + (n*sx) - (n*sr)
         return d.T
 
 stick_breaking = StickBreaking()

--- a/pymc3/tests/test_transforms.py
+++ b/pymc3/tests/test_transforms.py
@@ -70,7 +70,7 @@ def check_jacobian_det(transform, domain,
             computed_ljd(yval), tol)
 
 
-def test_simplex():
+def test_stickbreaking():
     check_vector_transform(tr.stick_breaking, Simplex(2))
     check_vector_transform(tr.stick_breaking, Simplex(4))
 
@@ -78,7 +78,7 @@ def test_simplex():
         3, 2), constructor=tt.dmatrix, test=np.zeros((2, 2)))
 
 
-def test_simplex_bounds():
+def test_stickbreaking_bounds():
     vals = get_values(tr.stick_breaking, Vector(R, 2),
                       tt.dvector, np.array([0, 0]))
 
@@ -88,6 +88,27 @@ def test_simplex_bounds():
 
     check_jacobian_det(tr.stick_breaking, Vector(
         R, 2), tt.dvector, np.array([0, 0]), lambda x: x[:-1])
+
+
+def test_stickbreaking2():
+    check_vector_transform(tr.stick_breaking2, Simplex(2))
+    check_vector_transform(tr.stick_breaking2, Simplex(4))
+
+    check_transform(tr.stick_breaking2, MultiSimplex(
+        3, 2), constructor=tt.dmatrix, test=np.zeros((2, 2)))
+
+
+def test_stickbreaking2_bounds():
+    vals = get_values(tr.stick_breaking2, Vector(R, 2),
+                      tt.dvector, np.array([0, 0]))
+
+    close_to(vals.sum(axis=1), 1, tol)
+    close_to_logical(vals > 0, True, tol)
+    close_to_logical(vals < 1, True, tol)
+
+    check_jacobian_det(tr.stick_breaking2, Vector(R, 2),
+                       tt.dvector, np.array([0, 0]),
+                       lambda x: x[:-1])
 
 
 def test_sum_to_1():


### PR DESCRIPTION
I found a slight update of #3620 by @katosh to be very useful for my work, so I'm opening a new version of that now closed PR.

I'm not entirely sure what katosh meant by

> I don't get the tests to work. My jacobian must be wrong or not stable enough, And the problem at hand could not be solved.

But I think that the dimensionality of the Jacobian was wrong in his patch, so I've added a few additional commits that squeeze the last dimension.

I can also spend some time developing a minimal example (slash tests) showing the problems with stick-breaking for the current master (e81df2d as of this PR), but I don't currently have those.  Briefly, I've found through experience that the extreme edges of the simplex space are numerically unstable, and result in `inf`s terminating gradient descent.  NUTS also usually ends up with many divergences (often 100%) for what I think are related reasons.

This patch seems to have fixed both of those problems, and hasn't misbehaved for any 2-dimensional variables in my tests over the last few weeks.

It does NOT, however, work for random variables that are more complicated than a stacked array of Dirichlet RVs.  I believe that this is also an issue for the implementation at master.  I have no idea what the fix to that problem would be.
