### PR TITLE
Fix context stack

### DIFF
--- a/pymc3/data.py
+++ b/pymc3/data.py
@@ -1,3 +1,4 @@
+from typing import Dict, List, Any
 from copy import copy
 import io
 import os
@@ -232,7 +233,7 @@ class Minibatch(tt.TensorVariable):
     >>> assert x.eval().shape == (2, 20, 20, 40, 10)
     """
 
-    RNG = collections.defaultdict(list)
+    RNG = collections.defaultdict(list) # type: Dict[str, List[Any]]
 
     @theano.configparser.change_flags(compute_test_value='raise')
     def __init__(self, data, batch_size=128, dtype=None, broadcastable=None, name='Minibatch',

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -456,7 +456,7 @@ class _DrawValuesContext(Context, metaclass=InitContextMeta):
     def __new__(cls, *args, **kwargs):
         # resolves the parent instance
         instance = super().__new__(cls)
-        instance._parent = cls.get_context()
+        instance._parent = cls.get_context(error_if_none=False)
         return instance
 
     def __init__(self):

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -7,7 +7,7 @@ import theano
 from ..memoize import memoize
 from ..model import (
     Model, get_named_nodes_and_relations, FreeRV,
-    ObservedRV, MultiObservedRV, Context, InitContextMeta
+    ObservedRV, MultiObservedRV, ContextMeta
 )
 from ..vartypes import string_types, theano_constant
 from .shape_utils import (
@@ -449,7 +449,7 @@ class DensityDist(Distribution):
                             "Define a custom random method and pass it as kwarg random")
 
 
-class _DrawValuesContext(Context, metaclass=InitContextMeta):
+class _DrawValuesContext(metaclass=ContextMeta, context_class='_DrawValuesContext'):
     """ A context manager class used while drawing values with draw_values
     """
 
@@ -476,7 +476,7 @@ class _DrawValuesContext(Context, metaclass=InitContextMeta):
         return self._parent
 
 
-class _DrawValuesContextBlocker(_DrawValuesContext, metaclass=InitContextMeta):
+class _DrawValuesContextBlocker(_DrawValuesContext):
     """
     Context manager that starts a new drawn variables context disregarding all
     parent contexts. This can be used inside a random method to ensure that

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -456,16 +456,7 @@ class _DrawValuesContext(Context, metaclass=InitContextMeta):
     def __new__(cls, *args, **kwargs):
         # resolves the parent instance
         instance = super().__new__(cls)
-        if cls.get_contexts():
-            potential_parent = cls.get_contexts()[-1]
-            # We have to make sure that the context is a _DrawValuesContext
-            # and not a Model
-            if isinstance(potential_parent, _DrawValuesContext):
-                instance._parent = potential_parent
-            else:
-                instance._parent = None
-        else:
-            instance._parent = None
+        instance._parent = cls.get_context()
         return instance
 
     def __init__(self):

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -283,7 +283,7 @@ def modelcontext(model: Optional['Model']) -> Optional['Model']:
     none supplied.
     """
     if model is None:
-        found: Optional['Model'] = Model.get_context(error_if_none=False)
+        found = Model.get_context(error_if_none=False) # type: Optional['Model']
         if found is None:
             raise ValueError("No model on context stack.")
         return found

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -170,20 +170,22 @@ class ContextMeta(type):
     """Functionality for objects that put themselves in a context using
     the `with` statement.
     """
-    _context_class = None # type: Union[Type, str]
 
     def __new__(cls, name, bases, dct,  **kargs):
+        # this serves only to strip off keyword args, per the warning from
+        # StackExchange:
         # DO NOT send "**kargs" to "type.__new__".  It won't catch them and
         # you'll get a "TypeError: type() takes 1 or 3 arguments" exception.   
-        # dct['get_context'] = classmethod(_get_context)
-        # dct['get_contexts'] = classmethod(_get_contexts)
         return super().__new__(cls, name, bases, dct)
 
+    # FIXME: is there a more elegant way to automatically add methods to the class that
+    # are instance methods instead of class methods?
     def __init__(cls, name, bases, nmspc, context_class: Optional[Type]=None, **kwargs):
+        """Add ``__enter__`` and ``__exit__`` methods to the new class automatically."""
         if context_class is not None:
             cls._context_class = context_class
         super().__init__(name, bases, nmspc)
-        cls.contexts = threading.local()
+        
         def __enter__(self):
             self.__class__.context_class.get_contexts().append(self)
             # self._theano_config is set in Model.__new__
@@ -200,9 +202,11 @@ class ContextMeta(type):
         cls.__enter__ = __enter__
         cls.__exit__ = __exit__
 
+
     def get_context(cls, error_if_none=True) -> Optional[T]:
         """Return the most recently pushed context object of type ``cls``
-        on the stack, or ``None``."""
+        on the stack, or ``None``. If ``error_if_none`` is True (default),
+        raise a ``TypeError`` instead of returning ``None``."""
         idx = -1
         while True:
             try:
@@ -217,12 +221,32 @@ class ContextMeta(type):
             idx = idx - 1
 
     def get_contexts(cls) -> List[T]:
-        # no race-condition here, cls.contexts is a thread-local object
+        """Return a stack of context instances for the ``context_class``
+        of ``cls``."""
+        # This lazily creates the context class's contexts
+        # thread-local object, as needed. This seems inelegant to me,
+        # but since the context class is not guaranteed to exist when
+        # the metaclass is being instantiated, I couldn't figure out a
+        # better way. [2019/10/11:rpg]
+        
+        # no race-condition here, contexts is a thread-local object
         # be sure not to override contexts in a subclass however!
-        if not hasattr(cls.context_class, 'stack'):
-            cls.context_class.stack = []
-        return cls.context_class.stack
+        context_class = cls.context_class
+        assert isinstance(context_class, type), \
+            "Name of context class, %s was not resolvable to a class"%context_class
+        if not hasattr(context_class, 'contexts'):
+            context_class.contexts = threading.local()
 
+        contexts = context_class.contexts
+
+        if not hasattr(contexts, 'stack'):
+            contexts.stack = []
+        return contexts.stack
+
+    # the following complex property accessor is necessary because the
+    # context_class may not have been created at the point it is
+    # specified, so the context_class may be a class *name* rather
+    # than a class.
     @property
     def context_class(cls) -> Type:
         def resolve_type(c: Union[Type, str]) -> Type:
@@ -239,11 +263,13 @@ class ContextMeta(type):
                              (cls.__name__, cls._context_class))
         return cls._context_class
 
+    # Inherit context class from parent
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         cls.context_class = super().context_class
 
     # Initialize object in its own context...
+    # Merged from InitContextMeta in the original.
     def __call__(cls, *args, **kwargs):
         instance = cls.__new__(cls, *args, **kwargs)
         with instance:  # appends context

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -56,10 +56,10 @@ class InstanceMethod:
         return getattr(self.obj, self.method_name)(*args, **kwargs)
 
 
-def incorporate_methods(source, destination, methods, default=None,
+def incorporate_methods(source, destination, methods,
                         wrapper=None, override=False):
     """
-    Add attributes to a destination object which points to
+    Add attributes to a destination object which point to
     methods from from a source object.
 
     Parameters
@@ -70,8 +70,6 @@ def incorporate_methods(source, destination, methods, default=None,
         The destination object for the methods.
     methods : list of str
         Names of methods to incorporate.
-    default : object
-        The value used if the source does not have one of the listed methods.
     wrapper : function
         An optional function to allow the source method to be
         wrapped. Should take the form my_wrapper(source, method_name)

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -192,14 +192,16 @@ class Context:
         return cls.contexts.stack
 
     @classmethod
-    def get_context(cls: Type[T]) -> Optional[T]:
+    def get_context(cls: Type[T], error_if_none=True) -> Optional[T]:
         """Return the most recently pushed context object of type ``cls``
         on the stack, or ``None``."""
         idx = -1
         while True:
             try:
                 candidate = cls.get_contexts()[idx]
-            except IndexError:
+            except IndexError as e:
+                if error_if_none:
+                    raise e
                 return None
             if isinstance(candidate, cls):
                 return candidate
@@ -210,7 +212,7 @@ def modelcontext(model: Optional['Model']) -> Optional['Model']:
     none supplied.
     """
     if model is None:
-        found: Optional['Model'] = Model.get_context()
+        found: Optional['Model'] = Model.get_context(error_if_none=False)
         if found is None:
             raise ValueError("No pymc3 model object on context stack.")
         return found

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -277,16 +277,15 @@ class ContextMeta(type):
         return instance
 
 
-
 def modelcontext(model: Optional['Model']) -> Optional['Model']:
-    """return the given model or try to find it in the context if there was
-    none supplied.
+    """
+    Return the given model or, if none was supplied, try to find one in
+    the context stack.
     """
     if model is None:
-        found = Model.get_context(error_if_none=False) # type: Optional['Model']
-        if found is None:
+        model = Model.get_context(error_if_none=False)
+        if model is None:
             raise ValueError("No model on context stack.")
-        return found
     return model
 
 

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -77,7 +77,7 @@ class TestData(SeededTest):
                                    atol=1e-1)
 
     def test_creation_of_data_outside_model_context(self):
-        with pytest.raises(TypeError) as error:
+        with pytest.raises((IndexError, TypeError)) as error:
             pm.Data('data', [1.1, 2.2, 3.3])
         error.match('No model on context stack')
 

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -52,10 +52,15 @@ class TestBaseModel:
 
     def test_context_passes_vars_to_parent_model(self):
         with pm.Model() as model:
+            assert pm.model.modelcontext(None) == model
+            assert pm.Model.get_context() == model
             # a set of variables is created
-            NewModel()
+            nm = NewModel()
+            assert pm.Model.get_context() == model
             # another set of variables are created but with prefix 'another'
             usermodel2 = NewModel(name='another')
+            assert pm.Model.get_context() == model
+            assert usermodel2._parent == model
             # you can enter in a context with submodel
             with usermodel2:
                 usermodel2.Var('v3', pm.Normal.dist())

--- a/pymc3/tests/test_modelcontext.py
+++ b/pymc3/tests/test_modelcontext.py
@@ -1,5 +1,8 @@
 import threading
+from pytest import raises
 from pymc3 import Model, Normal
+from pymc3.distributions.distribution import _DrawValuesContext, _DrawValuesContextBlocker
+from pymc3.model import modelcontext
 
 
 class TestModelContext:
@@ -42,3 +45,34 @@ class TestModelContext:
                 list(modelA.named_vars),
                 list(modelB.named_vars),
             ) == (['a'],['b'])
+
+def test_mixed_contexts():
+    modelA = Model()
+    modelB = Model()
+    with raises((ValueError, TypeError)):
+        modelcontext(None)
+    with modelA:
+        with modelB:
+            assert Model.get_context() == modelB
+            assert modelcontext(None) == modelB
+            dvc = _DrawValuesContext()
+            with dvc:
+                assert Model.get_context() == modelB
+                assert modelcontext(None) == modelB
+                assert _DrawValuesContext.get_context() == dvc
+                dvcb = _DrawValuesContextBlocker()
+                with dvcb:
+                    assert _DrawValuesContext.get_context() == dvcb
+                    assert _DrawValuesContextBlocker.get_context() == dvcb
+                assert _DrawValuesContext.get_context() == dvc
+                assert _DrawValuesContextBlocker.get_context() is None
+                assert Model.get_context() == modelB
+                assert modelcontext(None) == modelB
+            assert _DrawValuesContext.get_context() is None
+            assert Model.get_context() == modelB
+            assert modelcontext(None) == modelB
+        assert Model.get_context() == modelA
+        assert modelcontext(None) == modelA
+    assert Model.get_context() is None
+    with raises((ValueError, TypeError)):
+        modelcontext(None)

--- a/pymc3/tests/test_modelcontext.py
+++ b/pymc3/tests/test_modelcontext.py
@@ -65,14 +65,18 @@ def test_mixed_contexts():
                     assert _DrawValuesContext.get_context() == dvcb
                     assert _DrawValuesContextBlocker.get_context() == dvcb
                 assert _DrawValuesContext.get_context() == dvc
-                assert _DrawValuesContextBlocker.get_context() is None
+                assert _DrawValuesContextBlocker.get_context() is dvc
                 assert Model.get_context() == modelB
                 assert modelcontext(None) == modelB
-            assert _DrawValuesContext.get_context() is None
+            assert _DrawValuesContext.get_context(error_if_none=False) is None
+            with raises(TypeError):
+                _DrawValuesContext.get_context()
             assert Model.get_context() == modelB
             assert modelcontext(None) == modelB
         assert Model.get_context() == modelA
         assert modelcontext(None) == modelA
-    assert Model.get_context() is None
+    assert Model.get_context(error_if_none=False) is None
+    with raises(TypeError):
+        Model.get_context(error_if_none=True)
     with raises((ValueError, TypeError)):
         modelcontext(None)


### PR DESCRIPTION
Previously, it was possible to get the wrong type of `Context` subclass when using `Context.get_context()`.  The patch in the second commit fixes this error by searching the stack for values of the right type.  The first commit gives a test that illustrates the incorrect behavior.

If you wish to verify the error, fetch the branch for this PR, and then checkout the first commit only, and run `pymc3/tests/test_modelcontext.py`

I stumbled on this when vectorizing `sample_posterior_predictive`, because I used `modelcontext()` inside `with _DrawValuesContext():`, which does not happen in the current code base.

Nevertheless, I think that this is worth fixing now, because it's a bug waiting to catch us, and if the bug *does* manifest, then you can get back a `_DrawValuesContext` from a call to `modelcontext(None)`, and this bug is *not* guaranteed to be detected when you try to dereference a name inside what you *think* is a model, but is in fact a `_DrawValuesContext`.  Instead of an error, you just get back `None` when you should have gotten a variable, which is the worst kind of failure.