### PR TITLE
Specificy coveralls parallel env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ script:
   - . ./scripts/test.sh $TESTCMD
 
 after_success:
-  - coveralls
+  - COVERALLS_PARALLEL=true coveralls


### PR DESCRIPTION
This should fix the bad coverage results that we were getting from [coveralls](https://coveralls.io/github/pymc-devs/pymc3?branch=master).

The problem seemed to be that coveralls did not merge the coverage reports from our parallel builds. It simply added them as if they belonged to different code bases, increasing the file count and line count, and decreasing the final coverage percentage.

From [Coveralls documentation](https://docs.coveralls.io/parallel-build-webhook) it seems that we need to specify the `COVERALLS_PARALLEL=true` environment variable and then send a webhook after success. We are using the [coveralls](https://github.com/coveralls-clients/coveralls-python) python client. In its [docs](https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html) it specifies that it's enough just to run `COVERALLS_PARALLEL=true coveralls`. I'll start out trying just that, if it's not enough I'll export the environment variable 

I have no idea if this was always needed, and if yes, how did the coverage ever work.