### PR TITLE
Reverts 3654

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ script:
   - . ./scripts/test.sh $TESTCMD
 
 after_success:
-  - COVERALLS_PARALLEL=true coveralls
+  - coveralls


### PR DESCRIPTION
For some reason setting `COVERALLS_PARALLEL=true` prevented our coverage reports to be sent to coveralls. This PR reverts #3654. This means that:

- Our coverage reports are published to coveralls.
- The reports across our parallel builds are not merged so we get the wrong coverage percentage.