### PR TITLE
Add codecov coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null          # branch names that can post comment

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
 
 install:
   - . ./scripts/create_testenv.sh
-  - pip install coveralls
+  - pip install codecov
   - conda list && pip freeze
 
 env:
@@ -37,4 +37,4 @@ script:
   - . ./scripts/test.sh $TESTCMD
 
 after_success:
-  - coveralls
+  - codecov

--- a/README.rst
+++ b/README.rst
@@ -190,8 +190,8 @@ Sponsors
    :target: https://mybinder.org/v2/gh/pymc-devs/pymc3/master?filepath=%2Fdocs%2Fsource%2Fnotebooks
 .. |Build Status| image:: https://travis-ci.org/pymc-devs/pymc3.svg?branch=master
    :target: https://travis-ci.org/pymc-devs/pymc3
-.. |Coverage| image:: https://coveralls.io/repos/github/pymc-devs/pymc3/badge.svg?branch=master
-   :target: https://coveralls.io/github/pymc-devs/pymc3?branch=master
+.. |Coverage| image:: https://codecov.io/gh/pymc-devs/pymc3/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/pymc-devs/pymc3
 .. |NumFOCUS| image:: https://www.numfocus.org/wp-content/uploads/2017/03/1457562110.png
    :target: http://www.numfocus.org/
 .. |Quantopian| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/master/docs/quantopianlogo.jpg

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,4 +7,4 @@ if [[ "$RUN_PYLINT" == "true" ]]; then
 fi
 
 _FLOATX=${FLOATX:=float64}
-THEANO_FLAGS="floatX=${_FLOATX},gcc.cxxflags='-march=core2'" pytest -v --cov=pymc3 "$@"
+THEANO_FLAGS="floatX=${_FLOATX},gcc.cxxflags='-march=core2'" pytest -v --cov=pymc3 --cov-report=xml "$@"


### PR DESCRIPTION
Switch to [codecov](https://codecov.io) instead of coveralls for publishing code coverage reports. We still need to decide on whether to approve the permissions for the codecov app.