### PR TITLE
Removed unused local parameter from GaussianRandomWalk

### DIFF
--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -206,7 +206,6 @@ class GaussianRandomWalk(distribution.Continuous):
         -------
         TensorVariable
         """
-        tau = self.tau
         sigma = self.sigma
         mu = self.mu
         init = self.init


### PR DESCRIPTION
Just a quick cleanup: tau and sigma are both created locally when only the latter is used.