### PR TITLE
Add Binder build trigger to CI for merged PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,19 @@ script:
 
 after_success:
   - codecov
+
+stages:
+  - test
+  - name: binder
+    if: (branch = master) AND (NOT (type IN (pull_request)))
+
+jobs:
+  include:
+  - stage: binder
+    before_install: skip
+    install: skip
+    script:
+    # Use Binder build API to trigger repo2docker to build image on GKE and OVH Binder Federation clusters
+    - bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/pymc-devs/pymc3/"${TRAVIS_BRANCH}"
+    - bash binder/trigger_binder.sh https://ovh.mybinder.org/build/gh/pymc-devs/pymc3/"${TRAVIS_BRANCH}"
+    after_success: skip

--- a/binder/trigger_binder.sh
+++ b/binder/trigger_binder.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function trigger_binder() {
+    local URL="${1}"
+
+    curl -L --connect-timeout 10 --max-time 30 "${URL}"
+    curl_return=$?
+
+    # Return code 28 is when the --max-time is reached
+    if [ "${curl_return}" -eq 0 ] || [ "${curl_return}" -eq 28 ]; then
+        if [[ "${curl_return}" -eq 28 ]]; then
+            printf "\nBinder build started.\nCheck back soon.\n"
+        fi
+    else
+        return "${curl_return}"
+    fi
+
+    return 0
+}
+
+function main() {
+    # 1: the Binder build API URL to curl
+    trigger_binder $1
+}
+
+main "$@" || exit 1


### PR DESCRIPTION
Use the Binder build API to trigger builds on both the GKE and OVH Binder Federation clusters when a PR is merged to `master`. This results in the Binder images always being current and should mean that a user never has to wait for an image to be built when they click on the Binder badge.

This PR is similar to [`pyhf` PR 383](https://github.com/diana-hep/pyhf/pull/383) and [`uproot` PR 202](https://github.com/scikit-hep/uproot/pull/202).

```
* Use the Binder build API endpoint with Python's built in webbrowser to trigger builds
   - https://gitter.im/jupyterhub/binder?at=5c2f87038dafa715c73ff54f
   - https://github.com/jupyterhub/binderhub/blob/9ca8fa68bb8b69c6a2736f2275279583073f314f/examples/binder-api.py#L28
* Add Binder stage to Travis CI
```