### PR TITLE
Add graphviz to Binder image using apt.txt API 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,7 +186,7 @@ Sponsors
 
 |ODSC|
 
-.. |Binder| image:: https://mybinder.org/badge.svg
+.. |Binder| image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/pymc-devs/pymc3/master?filepath=%2Fdocs%2Fsource%2Fnotebooks
 .. |Build Status| image:: https://travis-ci.org/pymc-devs/pymc3.svg?branch=master
    :target: https://travis-ci.org/pymc-devs/pymc3

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,0 +1,1 @@
+graphviz


### PR DESCRIPTION
graphviz is needed for `pymc3.model_to_graphviz` and is used in some example notebooks. If Binder finds an `apt.txt` file it will then proceed to install its contents with apt-get in the image it builds with repo2docker.

c.f. https://github.com/binder-examples/latex

For an example of this fixing a broken notebook, you can see the Binder of the `putting_workflow` notebook ~~in my fork~~: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pymc-devs/pymc3/master?filepath=docs%2Fsource%2Fnotebooks%2Fputting_workflow.ipynb)

Additionally, this also updates the Binder badge to the new badge design as of mid-2019 (seen above).