### PR TITLE
Add ImputationWarning class.

### DIFF
--- a/pymc3/exceptions.py
+++ b/pymc3/exceptions.py
@@ -1,4 +1,9 @@
-__all__ = ['SamplingError', 'IncorrectArgumentsError', 'TraceDirectoryError']
+__all__ = [
+    "SamplingError",
+    "IncorrectArgumentsError",
+    "TraceDirectoryError",
+    "ImputationWarning",
+]
 
 
 class SamplingError(RuntimeError):
@@ -8,6 +13,14 @@ class SamplingError(RuntimeError):
 class IncorrectArgumentsError(ValueError):
     pass
 
+
 class TraceDirectoryError(ValueError):
-    '''Error from trying to load a trace from an incorrectly-structured directory,'''
+    """Error from trying to load a trace from an incorrectly-structured directory,"""
+
+    pass
+
+
+class ImputationWarning(UserWarning):
+    """Warning that there are missing values that will be imputed."""
+
     pass

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -21,6 +21,7 @@ from .theanof import gradient, hessian, inputvars, generator
 from .vartypes import typefilter, discrete_types, continuous_types, isgenerator
 from .blocking import DictToArrayBijection, ArrayOrdering
 from .util import get_transformed_name
+from .exceptions import ImputationWarning
 
 __all__ = [
     'Model', 'Factor', 'compilef', 'fn', 'fastfn', 'modelcontext',
@@ -1341,7 +1342,7 @@ def as_tensor(data, name, model, distribution):
         impute_message = ('Data in {name} contains missing values and'
                           ' will be automatically imputed from the'
                           ' sampling distribution.'.format(name=name))
-        warnings.warn(impute_message, UserWarning)
+        warnings.warn(impute_message, ImputationWarning)
         from .distributions import NoDistribution
         testval = np.broadcast_to(distribution.default(), data.shape)[data.mask]
         fakedist = NoDistribution.dist(shape=data.mask.sum(), dtype=dtype,


### PR DESCRIPTION
The idea is that a programmer be able to ignore imputation warnings if they know that data is being imputed. It's easier to do this with a distinct class than with just UserWarning.