### PR TITLE
Update benchmarks to work again

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -41,8 +41,7 @@
     // package (in PyPI) and the values are version numbers.  An empty
     // list indicates to just test against the default (latest)
     // version.
-    "matrix": {
-    },
+    "matrix": {},
 
     // The directory (relative to the current directory) that benchmarks are
     // stored in.  If not provided, defaults to "benchmarks"
@@ -66,7 +65,7 @@
     // `asv` will cache wheels of the recent builds in each
     // environment, making them faster to install next time.  This is
     // number of builds to keep, per environment.
-    "wheel_cache_size": 2,
+    "build_cache_size": 2,
 
     // The commits after which the regression search in `asv publish`
     // should start looking for regressions. Dictionary whose keys are

--- a/benchmarks/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks/benchmarks.py
@@ -151,7 +151,7 @@ class NUTSInitSuite:
                               start=start, random_seed=100, progressbar=False,
                               compute_convergence_checks=False)
             tot = time.time() - t0
-        ess = pm.effective_n(trace, ('mu_a',))['mu_a']
+        ess = float(pm.ess(trace, var_names=['mu_a'])['mu_a'].values)
         return ess / tot
 
     def track_marginal_mixture_model_ess(self, init):
@@ -165,7 +165,7 @@ class NUTSInitSuite:
                               start=start, random_seed=100, progressbar=False,
                               compute_convergence_checks=False)
             tot = time.time() - t0
-        ess = pm.effective_n(trace, ('mu',))['mu'].min()  # worst case
+        ess = pm.ess(trace, var_names=['mu'])['mu'].values.min()  # worst case
         return ess / tot
 
 
@@ -190,7 +190,7 @@ class CompareMetropolisNUTSSuite:
                               random_seed=100, progressbar=False,
                               compute_convergence_checks=False)
             tot = time.time() - t0
-        ess = pm.effective_n(trace, ('mu_a',))['mu_a']
+        ess = float(pm.ess(trace, var_names=['mu_a'])['mu_a'].values)
         return ess / tot
 
 


### PR DESCRIPTION
Running benchmarks locally before a release. I am checking these manually as I go, but this fixes failures in 3 of the benchmark metrics.

I'll publish a benchmark from my computer at 

- v3.7
- 530bc41d (just before robust U-Turn check)
- a01d0157 (robust U-Turn check)
- HEAD

let me know if anyone would like more checks! Each one takes ~30 mins to run on my machine, but i'm on a train for 3 hours, so...