### PR TITLE
Get the transform docs into the API pages.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -32,6 +32,7 @@
 - Wrapped `DensityDist.rand` with `generate_samples` to make it aware of the distribution's shape. Added control flow attributes to still be able to behave as in earlier versions, and to control how to interpret the `size` parameter in the `random` callable signature. Fixes [3553](https://github.com/pymc-devs/pymc3/issues/3553)
 - Added `theano.gof.graph.Constant` to type checks done in `_draw_value` (fixes issue [3595](https://github.com/pymc-devs/pymc3/issues/3595))
 - `HalfNormal` did not used to work properly in `draw_values`, `sample_prior_predictive`, or `sample_posterior_predictive` (fixes issue [3686](https://github.com/pymc-devs/pymc3/pull/3686))
+- Random variable transforms were inadvertently left out of the API documentation. Added them. (See PR [3690](https://github.com/pymc-devs/pymc3/pull/3690)).
 
 ## PyMC3 3.7 (May 29 2019)
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -20,6 +20,7 @@ API Reference
    api/data
    api/model
    api/model_graph
+   api/variables
    api/shape_utils
 
 

--- a/docs/source/api/distributions.rst
+++ b/docs/source/api/distributions.rst
@@ -9,4 +9,5 @@ Distributions
    distributions/multivariate
    distributions/mixture
    distributions/timeseries
+   distributions/transforms
    distributions/utilities

--- a/docs/source/api/distributions/transforms.rst
+++ b/docs/source/api/distributions/transforms.rst
@@ -1,6 +1,10 @@
-*******************************************
+****************************************************************
 Transformations of a random variable from one space to another.
-*******************************************
+****************************************************************
+
+Note that for convenience these entities can be addressed as
+``pm.transforms.``\ *X* for any name *X*, although they are actually
+implemented as ``pm.distributions.transforms.``\*X*.
 
 .. currentmodule:: pymc3.distributions.transforms
 .. autosummary::
@@ -20,25 +24,72 @@ circular
 CholeskyCovPacked
 Chain
 
+
+
 Transform Instances
 ~~~~~~~~~~~~~~~~~~~
 
 Transform instances are the entities that should be used in the
-`transform` parameter to a random variable constructor.  These are
+``transform`` parameter to a random variable constructor.  These are
 initialized instances of the Transform Classes, which are described
 below.
 
-.. autodata::  stick_breaking
-.. autodata::  logodds
-.. autodata::  interval
-.. autodata::  log_exp_m1
-.. autodata::  lowerbound
-.. autodata::  upperbound
-.. autodata::  ordered
-.. autodata::  log
-.. autodata::  sum_to_1
-.. autodata::  t_stick_breaking 
-.. autodata::  circular
+.. glossary::
+``stick_breaking``
+    Instantiation of :class:`~pymc3.distributions.transforms.StickBreaking`
+    :class:`~pymc3.distributions.transforms.Transform` class for use in the ``transform``
+    argument of a random variable.
+
+``logodds``
+    Instantiation of
+    :class:`~pymc3.distributions.transforms.LogOdds` :class:`~pymc3.distributions.transforms.Transform` class
+    for use in the ``transform`` argument of a random variable.
+
+``interval``
+    Alias of
+    :class:`~pymc3.distributions.transforms.Interval` :class:`~pymc3.distributions.transforms.Transform` class
+    for use in the ``transform`` argument of a random variable.
+
+``log_exp_m1``
+    Instantiation of
+    :class:`~pymc3.distributions.transforms.LogExpM1` :class:`~pymc3.distributions.transforms.Transform` class
+    for use in the ``transform`` argument of a random variable.
+
+``lowerbound``
+    Alias of
+    :class:`~pymc3.distributions.transforms.LowerBound` :class:`~pymc3.distributions.transforms.Transform` class
+    for use in the ``transform`` argument of a random variable.
+
+``upperbound``
+    Alias of
+    :class:`~pymc3.distributions.transforms.UpperBound` :class:`~pymc3.distributions.transforms.Transform` class
+    for use in the ``transform`` argument of a random variable.
+
+``ordered``
+    Instantiation of
+    :class:`~pymc3.distributions.transforms.Ordered` :class:`~pymc3.distributions.transforms.Transform` class
+    for use in the ``transform`` argument of a random variable.
+
+``log``
+    Instantiation of
+    :class:`~pymc3.distributions.transforms.Log` :class:`~pymc3.distributions.transforms.Transform` class
+    for use in the ``transform`` argument of a random variable.
+
+
+``sum_to_1``
+    Instantiation of
+    :class:`~pymc3.distributions.transforms.SumTo1` :class:`~pymc3.distributions.transforms.Transform` class
+    for use in the ``transform`` argument of a random variable.
+
+
+``circular``
+    Instantiation of
+    :class:`~pymc3.distributions.transforms.Circular` :class:`~pymc3.distributions.transforms.Transform` class
+    for use in the ``transform`` argument of a random variable.
+
+
+.. autofunction::  t_stick_breaking 
+
 
 Transform Base Classes
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -59,10 +110,11 @@ Transform Composition Classes
 .. autoclass:: Chain
     :members:
 .. autoclass:: CholeskyCovPacked
+    :members:
 
 
 Specific Transform Classes
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass::  Log
     :members:
@@ -84,10 +136,3 @@ Specific Transform Classes
     :members:
 .. autoclass::  Circular
     :members:
-
-
-
-
-
-
-

--- a/docs/source/api/distributions/transforms.rst
+++ b/docs/source/api/distributions/transforms.rst
@@ -1,0 +1,93 @@
+*******************************************
+Transformations of a random variable from one space to another.
+*******************************************
+
+.. currentmodule:: pymc3.distributions.transforms
+.. autosummary::
+
+transform
+stick_breaking
+logodds
+interval
+log_exp_m1
+lowerbound
+upperbound
+ordered
+log
+sum_to_1
+t_stick_breaking
+circular
+CholeskyCovPacked
+Chain
+
+Transform Instances
+~~~~~~~~~~~~~~~~~~~
+
+Transform instances are the entities that should be used in the
+`transform` parameter to a random variable constructor.  These are
+initialized instances of the Transform Classes, which are described
+below.
+
+.. autodata::  stick_breaking
+.. autodata::  logodds
+.. autodata::  interval
+.. autodata::  log_exp_m1
+.. autodata::  lowerbound
+.. autodata::  upperbound
+.. autodata::  ordered
+.. autodata::  log
+.. autodata::  sum_to_1
+.. autodata::  t_stick_breaking 
+.. autodata::  circular
+
+Transform Base Classes
+~~~~~~~~~~~~~~~~~~~~~~
+
+Typically the programmer will not use these directly.
+
+.. autoclass::  Transform
+    :members:
+.. autoclass::  transform
+    :members:
+.. autoclass::  TransformedDistribution
+    :members:
+
+
+Transform Composition Classes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Chain
+    :members:
+.. autoclass:: CholeskyCovPacked
+
+
+Specific Transform Classes
+~~~~~~~~~~~~~~~~~
+
+.. autoclass::  Log
+    :members:
+.. autoclass::  LogExpM1
+    :members:
+.. autoclass::  LogOdds
+    :members:
+.. autoclass::  Interval
+    :members:
+.. autoclass::  LowerBound
+    :members:
+.. autoclass::  UpperBound
+    :members:
+.. autoclass::  Ordered
+    :members:
+.. autoclass::  SumTo1
+    :members:
+.. autoclass::  StickBreaking
+    :members:
+.. autoclass::  Circular
+    :members:
+
+
+
+
+
+
+

--- a/docs/source/api/distributions/transforms.rst
+++ b/docs/source/api/distributions/transforms.rst
@@ -7,22 +7,27 @@ Note that for convenience these entities can be addressed as
 implemented as ``pm.distributions.transforms.``\*X*.
 
 .. currentmodule:: pymc3.distributions.transforms
-.. autosummary::
 
-transform
-stick_breaking
-logodds
-interval
-log_exp_m1
-lowerbound
-upperbound
-ordered
-log
-sum_to_1
-t_stick_breaking
-circular
-CholeskyCovPacked
-Chain
+
+.. contents ::
+
+..
+   .. autosummary::
+
+   transform
+   stick_breaking
+   logodds
+   interval
+   log_exp_m1
+   lowerbound
+   upperbound
+   ordered
+   log
+   sum_to_1
+   t_stick_breaking
+   circular
+   CholeskyCovPacked
+   Chain
 
 
 

--- a/docs/source/api/variables.rst
+++ b/docs/source/api/variables.rst
@@ -1,0 +1,28 @@
+Random Variables
+----------------
+
+.. currentmodule:: pymc3.model
+
+The normal PyMC3 programmer will typically not need to interact with these classes, except possibly when debugging.  Otherwise they are primarily of interest to developers.
+
+
+.. autoclass:: PyMC3Variable
+    :members:
+
+
+.. autoclass:: ValueGradFunction
+    :members:
+
+
+.. autoclass:: FreeRV
+    :members:
+
+.. autoclass:: ObservedRV
+    :members:
+
+.. autoclass:: MultiObservedRV
+    :members:
+
+.. autoclass:: TransformedRV
+    :members:
+

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -378,11 +378,13 @@ https://github.com/pymc-devs/pymc3/blob/6d07591962a6c135640a3c31903eba66b34e71d8
         self.add_random_variable(var)
         return var
 
-In general, if there is observed, the RV is defined as a ``ObservedRV``,
-otherwise if it has a transformed method, it is a ``TransformedRV``, otherwise, it returns the
-most elementary form: a ``FreeRV``.
+In general, if a variable has observations (``observed`` parameter), the RV is defined as an ``ObservedRV``,
+otherwise if it has a ``transformed`` (``transform`` parameter) attribute, it is a
+``TransformedRV``, otherwise, it will be the most elementary form: a
+``FreeRV``.  Note that this means that random variables with
+observations cannot be transformed.
 
-Below, I will take a deeper look into ``TransformedRV``, a normal user
+Below, I will take a deeper look into ``TransformedRV``. A normal user
 might not necessary come in contact with the concept, as
 ``TransformedRV`` and ``TransformedDistribution`` are intentionally not
 user facing.
@@ -390,13 +392,13 @@ user facing.
 Because in PyMC3 there is no bijector class like in TFP or pyro, we only
 have a partial implementation called ``Transform``, which implements
 Jacobian correction for forward mapping only (there is no Jacobian
-correction for inverse mapping). The use case we considered are limited
+correction for inverse mapping). The uses case we considered are limited
 to the set of distributions that are bounded, and the transformation
 maps the bounded set to the real line - see
 `doc <https://docs.pymc.io/notebooks/api_quickstart.html#Automatic-transforms-of-bounded-RVs>`__.
 In general, PyMC3 does not provide explicit functionality to transform
 one distribution to another. Instead, a dedicated distribution is
-usually created in consideration of optimising performance. But getting a
+usually created in order to optimise performance. But getting a
 ``TransformedDistribution`` is also possible (see also in
 `doc <https://docs.pymc.io/notebooks/api_quickstart.html#Transformed-distributions-and-changes-of-variables>`__):
 

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -392,10 +392,12 @@ user facing.
 Because in PyMC3 there is no bijector class like in TFP or pyro, we only
 have a partial implementation called ``Transform``, which implements
 Jacobian correction for forward mapping only (there is no Jacobian
-correction for inverse mapping). The uses case we considered are limited
+correction for inverse mapping). The use cases we considered are limited
 to the set of distributions that are bounded, and the transformation
 maps the bounded set to the real line - see
-`doc <https://docs.pymc.io/notebooks/api_quickstart.html#Automatic-transforms-of-bounded-RVs>`__.
+`doc
+<https://docs.pymc.io/notebooks/api_quickstart.html#Automatic-transforms-of-bounded-RVs>`__.
+However, other transformations are possible.
 In general, PyMC3 does not provide explicit functionality to transform
 one distribution to another. Instead, a dedicated distribution is
 usually created in order to optimise performance. But getting a
@@ -424,7 +426,7 @@ usually created in order to optimise performance. But getting a
 
 
 
-Now, back to ``model.RV(...)`` - things return from ``model.RV(...)``
+Now, back to ``model.RV(...)`` - things returned from ``model.RV(...)``
 are Theano tensor variables, and it is clear from looking at
 ``TransformedRV``:
 
@@ -433,19 +435,19 @@ are Theano tensor variables, and it is clear from looking at
     class TransformedRV(TensorVariable):
         ...
 
-as for ``FreeRV`` and ``ObservedRV``, they are TensorVariable with
-Factor:
+as for ``FreeRV`` and ``ObservedRV``, they are ``TensorVariable``\s with
+``Factor`` as mixin:
 
 .. code:: python
 
     class FreeRV(Factor, TensorVariable):
         ...
 
-and ``Factor`` basically `enable and assign the
+``Factor`` basically `enable and assign the
 logp <https://github.com/pymc-devs/pymc3/blob/6d07591962a6c135640a3c31903eba66b34e71d8/pymc3/model.py#L195-L276>`__
 (representated as a tensor also) property to a Theano tensor (thus
-making it a random variable). For a ``TransformedRV``, it transform the
-distribution into a ``TransformedDistribution``, and then model.Var is
+making it a random variable). For a ``TransformedRV``, it transforms the
+distribution into a ``TransformedDistribution``, and then ``model.Var`` is
 called again to added the RV associated with the
 ``TransformedDistribution`` as a ``FreeRV``:
 
@@ -485,11 +487,11 @@ the model logp), and also deterministic transformation (as bookkeeping):
 named\_vars, free\_RVs, observed\_RVs, deterministics, potentials,
 missing\_values. The model context then computes some simple model
 properties, builds a bijection mapping that transforms between
-dictionary and numpy/Theano ndarray, thus allowing logp/dlogp function
-to have two equivalent version: one take a dict as input and the other
-take a ndarray as input. More importantly, a pm.Model() contains methods
-to compile Theano function that takes Random Variables (that are also
-initialised within the same model) as input.
+dictionary and numpy/Theano ndarray, thus allowing the ``logp``/``dlogp`` functions
+to have two equivalent versions: one takes a ``dict`` as input and the other
+takes an ``ndarray`` as input. More importantly, a ``pm.Model()`` contains methods
+to compile Theano functions that take Random Variables (that are also
+initialised within the same model) as input, for example:
 
 .. code:: python
 

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -3,6 +3,7 @@ __version__ = "3.7"
 
 from .blocking import *
 from .distributions import *
+from .distributions import transforms
 from .glm import *
 from . import gp
 from .math import logaddexp, logsumexp, logit, invlogit, expand_packed_triangular, probit, invprobit

--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -81,8 +81,6 @@ from .timeseries import GARCH11
 from .timeseries import MvGaussianRandomWalk
 from .timeseries import MvStudentTRandomWalk
 
-from .transforms import *
-
 from .bound import Bound
 
 __all__ = ['Uniform',

--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -81,11 +81,7 @@ from .timeseries import GARCH11
 from .timeseries import MvGaussianRandomWalk
 from .timeseries import MvStudentTRandomWalk
 
-from .transforms import transform
-from .transforms import stick_breaking
-from .transforms import logodds
-from .transforms import log
-from .transforms import sum_to_1
+from .transforms import *
 
 from .bound import Bound
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -98,8 +98,8 @@ def get_tau_sigma(tau=None, sigma=None):
 
     Parameters
     ----------
-    tau : array-like, optional
-    sigma : array-like, optional
+    tau: array-like, optional
+    sigma: array-like, optional
 
     Results
     -------
@@ -166,9 +166,9 @@ class Uniform(BoundedContinuous):
 
     Parameters
     ----------
-    lower : float
+    lower: float
         Lower limit.
-    upper : float
+    upper: float
         Upper limit.
     """
 
@@ -186,10 +186,10 @@ class Uniform(BoundedContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -211,7 +211,7 @@ class Uniform(BoundedContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value for which log-probability is calculated.
 
         Returns
@@ -274,8 +274,8 @@ class Flat(Continuous):
 
         Parameters
         ----------
-        point : dict, optional
-        size : int, optional
+        point: dict, optional
+        size: int, optional
 
         Raises
         -------
@@ -289,7 +289,7 @@ class Flat(Continuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -341,8 +341,8 @@ class HalfFlat(PositiveContinuous):
 
         Parameters
         ----------
-        point : dict, optional
-        size : int, optional
+        point: dict, optional
+        size: int, optional
 
         Raises
         -------
@@ -356,7 +356,7 @@ class HalfFlat(PositiveContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -441,11 +441,11 @@ class Normal(Continuous):
 
     Parameters
     ----------
-    mu : float
+    mu: float
         Mean.
-    sigma : float
+    sigma: float
         Standard deviation (sigma > 0) (only required if tau is not specified).
-    tau : float
+    tau: float
         Precision (tau > 0) (only required if sigma is not specified).
 
     Examples
@@ -480,10 +480,10 @@ class Normal(Continuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -503,7 +503,7 @@ class Normal(Continuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -594,13 +594,13 @@ class TruncatedNormal(BoundedContinuous):
 
     Parameters
     ----------
-    mu : float
+    mu: float
         Mean.
-    sigma : float
+    sigma: float
         Standard deviation (sigma > 0).
-    lower : float (optional)
+    lower: float (optional)
         Left bound.
-    upper : float (optional)
+    upper: float (optional)
         Right bound.
 
     Examples
@@ -652,10 +652,10 @@ class TruncatedNormal(BoundedContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -698,7 +698,7 @@ class TruncatedNormal(BoundedContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -806,9 +806,9 @@ class HalfNormal(PositiveContinuous):
 
     Parameters
     ----------
-    sigma : float
+    sigma: float
         Scale parameter :math:`sigma` (``sigma`` > 0) (only required if ``tau`` is not specified).
-    tau : float
+    tau: float
         Precision :math:`tau` (tau > 0) (only required if sigma is not specified).
 
     Examples
@@ -844,10 +844,10 @@ class HalfNormal(PositiveContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -866,7 +866,7 @@ class HalfNormal(PositiveContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -958,13 +958,13 @@ class Wald(PositiveContinuous):
 
     Parameters
     ----------
-    mu : float, optional
+    mu: float, optional
         Mean of the distribution (mu > 0).
-    lam : float, optional
+    lam: float, optional
         Relative precision (lam > 0).
-    phi : float, optional
+    phi: float, optional
         Alternative shape parameter (phi > 0).
-    alpha : float, optional
+    alpha: float, optional
         Shift/location parameter (alpha >= 0).
 
     Notes
@@ -1039,10 +1039,10 @@ class Wald(PositiveContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -1063,7 +1063,7 @@ class Wald(PositiveContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -1198,13 +1198,13 @@ class Beta(UnitContinuous):
 
     Parameters
     ----------
-    alpha : float
+    alpha: float
         alpha > 0.
-    beta : float
+    beta: float
         beta > 0.
-    mu : float
+    mu: float
         Alternative mean (0 < mu < 1).
-    sigma : float
+    sigma: float
         Alternative standard deviation (0 < sigma < sqrt(mu * (1 - mu))).
 
     Notes
@@ -1248,10 +1248,10 @@ class Beta(UnitContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -1271,7 +1271,7 @@ class Beta(UnitContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -1366,9 +1366,9 @@ class Kumaraswamy(UnitContinuous):
 
     Parameters
     ----------
-    a : float
+    a: float
         a > 0.
-    b : float
+    b: float
         b > 0.
     """
 
@@ -1396,10 +1396,10 @@ class Kumaraswamy(UnitContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -1419,7 +1419,7 @@ class Kumaraswamy(UnitContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -1480,7 +1480,7 @@ class Exponential(PositiveContinuous):
 
     Parameters
     ----------
-    lam : float
+    lam: float
         Rate or inverse scale (lam > 0)
     """
 
@@ -1501,10 +1501,10 @@ class Exponential(PositiveContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -1523,7 +1523,7 @@ class Exponential(PositiveContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -1613,9 +1613,9 @@ class Laplace(Continuous):
 
     Parameters
     ----------
-    mu : float
+    mu: float
         Location parameter.
-    b : float
+    b: float
         Scale parameter (b > 0).
     """
 
@@ -1634,10 +1634,10 @@ class Laplace(Continuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -1656,7 +1656,7 @@ class Laplace(Continuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -1750,11 +1750,11 @@ class Lognormal(PositiveContinuous):
 
     Parameters
     ----------
-    mu : float
+    mu: float
         Location parameter.
-    sigma : float
+    sigma: float
         Standard deviation. (sigma > 0). (only required if tau is not specified).
-    tau : float
+    tau: float
         Scale parameter (tau > 0). (only required if sigma is not specified).
 
     Examples
@@ -1799,10 +1799,10 @@ class Lognormal(PositiveContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -1821,7 +1821,7 @@ class Lognormal(PositiveContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -1918,14 +1918,14 @@ class StudentT(Continuous):
 
     Parameters
     ----------
-    nu : float
+    nu: float
         Degrees of freedom, also known as normality parameter (nu > 0).
-    mu : float
+    mu: float
         Location parameter.
-    sigma : float
+    sigma: float
         Scale parameter (sigma > 0). Converges to the standard deviation as nu
         increases. (only required if lam is not specified)
-    lam : float
+    lam: float
         Scale parameter (lam > 0). Converges to the precision as nu
         increases. (only required if sigma is not specified)
 
@@ -1964,10 +1964,10 @@ class StudentT(Continuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -1987,7 +1987,7 @@ class StudentT(Continuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -2081,9 +2081,9 @@ class Pareto(Continuous):
 
     Parameters
     ----------
-    alpha : float
+    alpha: float
         Shape parameter (alpha > 0).
-    m : float
+    m: float
         Scale parameter (m > 0).
     """
 
@@ -2116,10 +2116,10 @@ class Pareto(Continuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -2139,7 +2139,7 @@ class Pareto(Continuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -2231,9 +2231,9 @@ class Cauchy(Continuous):
 
     Parameters
     ----------
-    alpha : float
+    alpha: float
         Location parameter
-    beta : float
+    beta: float
         Scale parameter > 0
     """
 
@@ -2254,10 +2254,10 @@ class Cauchy(Continuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -2277,7 +2277,7 @@ class Cauchy(Continuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -2355,7 +2355,7 @@ class HalfCauchy(PositiveContinuous):
 
     Parameters
     ----------
-    beta : float
+    beta: float
         Scale parameter (beta > 0).
     """
 
@@ -2376,10 +2376,10 @@ class HalfCauchy(PositiveContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -2398,7 +2398,7 @@ class HalfCauchy(PositiveContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -2490,13 +2490,13 @@ class Gamma(PositiveContinuous):
 
     Parameters
     ----------
-    alpha : float
+    alpha: float
         Shape parameter (alpha > 0).
-    beta : float
+    beta: float
         Rate parameter (beta > 0).
-    mu : float
+    mu: float
         Alternative shape parameter (mu > 0).
-    sigma : float
+    sigma: float
         Alternative scale parameter (sigma > 0).
     """
 
@@ -2535,10 +2535,10 @@ class Gamma(PositiveContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -2558,7 +2558,7 @@ class Gamma(PositiveContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -2647,13 +2647,13 @@ class InverseGamma(PositiveContinuous):
 
     Parameters
     ----------
-    alpha : float
+    alpha: float
         Shape parameter (alpha > 0).
-    beta : float
+    beta: float
         Scale parameter (beta > 0).
-    mu : float
+    mu: float
         Alternative shape parameter (mu > 0).
-    sigma : float
+    sigma: float
         Alternative scale parameter (sigma > 0).
     """
 
@@ -2707,10 +2707,10 @@ class InverseGamma(PositiveContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -2730,7 +2730,7 @@ class InverseGamma(PositiveContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -2789,7 +2789,7 @@ class ChiSquared(Gamma):
 
     Parameters
     ----------
-    nu : int
+    nu: int
         Degrees of freedom (nu > 0).
     """
 
@@ -2844,9 +2844,9 @@ class Weibull(PositiveContinuous):
 
     Parameters
     ----------
-    alpha : float
+    alpha: float
         Shape parameter (alpha > 0).
-    beta : float
+    beta: float
         Scale parameter (beta > 0).
     """
 
@@ -2870,10 +2870,10 @@ class Weibull(PositiveContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -2897,7 +2897,7 @@ class Weibull(PositiveContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -2992,12 +2992,12 @@ class HalfStudentT(PositiveContinuous):
 
     Parameters
     ----------
-    nu : float
+    nu: float
         Degrees of freedom, also known as normality parameter (nu > 0).
-    sigma : float
+    sigma: float
         Scale parameter (sigma > 0). Converges to the standard deviation as nu
         increases. (only required if lam is not specified)
-    lam : float
+    lam: float
         Scale parameter (lam > 0). Converges to the precision as nu
         increases. (only required if sigma is not specified)
 
@@ -3036,10 +3036,10 @@ class HalfStudentT(PositiveContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -3058,7 +3058,7 @@ class HalfStudentT(PositiveContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -3132,11 +3132,11 @@ class ExGaussian(Continuous):
 
     Parameters
     ----------
-    mu : float
+    mu: float
         Mean of the normal distribution.
-    sigma : float
+    sigma: float
         Standard deviation of the normal distribution (sigma > 0).
-    nu : float
+    nu: float
         Mean of the exponential distribution (nu > 0).
 
     References
@@ -3174,10 +3174,10 @@ class ExGaussian(Continuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -3202,7 +3202,7 @@ class ExGaussian(Continuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -3308,9 +3308,9 @@ class VonMises(Continuous):
 
     Parameters
     ----------
-    mu : float
+    mu: float
         Mean.
-    kappa : float
+    kappa: float
         Concentration (\frac{1}{kappa} is analogous to \sigma^2).
     """
 
@@ -3330,10 +3330,10 @@ class VonMises(Continuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -3353,7 +3353,7 @@ class VonMises(Continuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -3419,13 +3419,13 @@ class SkewNormal(Continuous):
 
     Parameters
     ----------
-    mu : float
+    mu: float
         Location parameter.
-    sigma : float
+    sigma: float
         Scale parameter (sigma > 0).
-    tau : float
+    tau: float
         Alternative scale parameter (tau > 0).
-    alpha : float
+    alpha: float
         Skewness parameter.
 
     Notes
@@ -3462,10 +3462,10 @@ class SkewNormal(Continuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -3486,7 +3486,7 @@ class SkewNormal(Continuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -3564,11 +3564,11 @@ class Triangular(BoundedContinuous):
 
     Parameters
     ----------
-    lower : float
+    lower: float
         Lower limit.
     c: float
         mode
-    upper : float
+    upper: float
         Upper limit.
     """
 
@@ -3586,10 +3586,10 @@ class Triangular(BoundedContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -3622,7 +3622,7 @@ class Triangular(BoundedContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -3728,9 +3728,9 @@ class Gumbel(Continuous):
 
     Parameters
     ----------
-    mu : float
+    mu: float
         Location parameter.
-    beta : float
+    beta: float
         Scale parameter (beta > 0).
     """
 
@@ -3753,10 +3753,10 @@ class Gumbel(Continuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -3775,7 +3775,7 @@ class Gumbel(Continuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -3836,11 +3836,11 @@ class Rice(PositiveContinuous):
 
     Parameters
     ----------
-    nu : float
+    nu: float
         noncentrality parameter.
-    sigma : float
+    sigma: float
         scale parameter.
-    b : float
+    b: float
         shape parameter (alternative to nu).
 
     Notes
@@ -3891,10 +3891,10 @@ class Rice(PositiveContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -3925,7 +3925,7 @@ class Rice(PositiveContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -3981,9 +3981,9 @@ class Logistic(Continuous):
 
     Parameters
     ----------
-    mu : float
+    mu: float
         Mean.
-    s : float
+    s: float
         Scale (s > 0).
     """
 
@@ -4002,7 +4002,7 @@ class Logistic(Continuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -4022,10 +4022,10 @@ class Logistic(Continuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -4123,11 +4123,11 @@ class LogitNormal(UnitContinuous):
 
     Parameters
     ----------
-    mu : float
+    mu: float
         Location parameter.
-    sigma : float
+    sigma: float
         Scale parameter (sigma > 0).
-    tau : float
+    tau: float
         Scale parameter (tau > 0).
     """
 
@@ -4151,10 +4151,10 @@ class LogitNormal(UnitContinuous):
 
         Parameters
         ----------
-        point : dict, optional
+        point: dict, optional
             Dict of variable values on which random values are to be
             conditioned (uses default point if not specified).
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -4173,7 +4173,7 @@ class LogitNormal(UnitContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 
@@ -4221,9 +4221,9 @@ class Interpolated(BoundedContinuous):
 
     Parameters
     ----------
-    x_points : array-like
+    x_points: array-like
         A monotonically growing list of values
-    pdf_points : array-like
+    pdf_points: array-like
         Probability density function evaluated on lattice ``x_points``
     """
 
@@ -4272,7 +4272,7 @@ class Interpolated(BoundedContinuous):
 
         Parameters
         ----------
-        size : int, optional
+        size: int, optional
             Desired size of random sample (returns one sample if not
             specified).
 
@@ -4290,7 +4290,7 @@ class Interpolated(BoundedContinuous):
 
         Parameters
         ----------
-        value : numeric
+        value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or theano tensor
 

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -12,6 +12,7 @@ from scipy.special import expit
 
 
 __all__ = [
+    "Transform",
     "transform",
     "stick_breaking",
     "logodds",
@@ -234,6 +235,7 @@ class LogExpM1(ElemwiseTransform):
 log_exp_m1 = LogExpM1()
 
 
+
 class LogOdds(ElemwiseTransform):
     name = "logodds"
 
@@ -251,6 +253,7 @@ class LogOdds(ElemwiseTransform):
 
 
 logodds = LogOdds()
+
 
 
 class Interval(ElemwiseTransform):
@@ -328,6 +331,10 @@ class LowerBound(ElemwiseTransform):
 
 
 lowerbound = LowerBound
+'''
+Alias for ``LowerBound`` (:class: LowerBound) Transform (:class: Transform) class
+for use in the ``transform`` argument of a random variable.
+'''
 
 
 class UpperBound(ElemwiseTransform):
@@ -365,6 +372,11 @@ class UpperBound(ElemwiseTransform):
 
 
 upperbound = UpperBound
+'''
+Alias for ``UpperBound`` (:class: UpperBound) Transform (:class: Transform) class
+for use in the ``transform`` argument of a random variable.
+'''
+
 
 
 class Ordered(Transform):
@@ -399,6 +411,10 @@ class Ordered(Transform):
 
 
 ordered = Ordered()
+'''
+Instantiation of ``Ordered`` (:class: Ordered) Transform (:class: Transform) class
+for use in the ``transform`` argument of a random variable.
+'''
 
 
 class SumTo1(Transform):
@@ -509,6 +525,7 @@ class StickBreaking(Transform):
 stick_breaking = StickBreaking()
 
 
+
 def t_stick_breaking(eps):
     return StickBreaking(eps)
 
@@ -536,7 +553,6 @@ class Circular(ElemwiseTransform):
 
 
 circular = Circular()
-
 
 class CholeskyCovPacked(Transform):
     name = "cholesky-cov-packed"

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -35,7 +35,7 @@ class Transform:
 
     Attributes
     ----------
-    name : str
+    name: str
     """
 
     name = ""
@@ -47,7 +47,7 @@ class Transform:
 
         Parameters
         ----------
-        x : tensor
+        x: tensor
             Input tensor to be transformed.
 
         Returns
@@ -63,9 +63,9 @@ class Transform:
 
         Parameters
         ----------
-        x : array_like
+        x: array_like
             Input array to be transformed.
-        point : array_like, optional
+        point: array_like, optional
             Test value used to draw (fix) bounds-like transformations
 
         Returns
@@ -82,7 +82,7 @@ class Transform:
 
         Parameters
         ----------
-        z : tensor
+        z: tensor
             Input tensor to be inverse transformed.
 
         Returns
@@ -97,7 +97,7 @@ class Transform:
 
         Parameters
         ----------
-        x : tensor
+        x: tensor
             Input to calculate Jacobian determinant of.
 
         Returns
@@ -128,8 +128,8 @@ class TransformedDistribution(distribution.Distribution):
         """
         Parameters
         ----------
-        dist : Distribution
-        transform : Transform
+        dist: Distribution
+        transform: Transform
         args, kwargs
             arguments to Distribution"""
         forward = transform.forward
@@ -154,7 +154,7 @@ class TransformedDistribution(distribution.Distribution):
 
         Parameters
         ----------
-        x : numeric
+        x: numeric
             Value for which log-probability is calculated.
 
         Returns
@@ -174,7 +174,7 @@ class TransformedDistribution(distribution.Distribution):
 
         Parameters
         ----------
-        x : numeric
+        x: numeric
             Value for which log-probability is calculated.
 
         Returns
@@ -454,7 +454,7 @@ class StickBreaking(Transform):
 
     Parameters
     ----------
-    eps : float, positive value
+    eps: float, positive value
         A small value for numerical stability in invlogit.
     """
 

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -23,6 +23,9 @@ __all__ = [
     "log",
     "sum_to_1",
     "t_stick_breaking",
+    "circular",
+    "CholeskyCovPacked",
+    "Chain",
 ]
 
 
@@ -557,7 +560,6 @@ class CholeskyCovPacked(Transform):
 
     def jacobian_det(self, y):
         return tt.sum(y[self.diag_idxs])
-
 
 class Chain(Transform):
     def __init__(self, transform_list):

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -526,7 +526,9 @@ stick_breaking = StickBreaking()
 
 
 
-def t_stick_breaking(eps):
+def t_stick_breaking(eps: float) -> StickBreaking:
+    '''Return a new :class:`StickBreaking` transform with specified eps(ilon),
+    instead of the default.'''
     return StickBreaking(eps)
 
 


### PR DESCRIPTION
I'm marking this as WIP, because the entries for the transform instances in the docs are not formatted as well as I would like.

Someone should also vet my additional exports. I found that the transforms were not being exported from distributions into pymc3 -- some of them were dropped and only exported from distributions.

If we want to have a hierarchical namespace like this, we should probably spend a little time deciding how it will be laid out.