### PR TITLE
drop python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
   - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_distributions_random.py pymc3/tests/test_shared.py pymc3/tests/test_smc.py pymc3/tests/test_sampling.py pymc3/tests/test_parallel_sampling.py pymc3/tests/test_dist_math.py pymc3/tests/test_distribution_defaults.py pymc3/tests/test_distributions_timeseries.py pymc3/tests/test_random.py"
   - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_examples.py pymc3/tests/test_posteriors.py pymc3/tests/test_gp.py"
   - FLOATX='float64' TESTCMD="--durations=10 --cov-append pymc3/tests/test_variational_inference.py pymc3/tests/test_updates.py pymc3/tests/test_shape_handling.py"
-  - PYTHON_VERSION=3.5 FLOATX='float64' ENVNAME="py35_testenv" TESTCMD="--cov-append pymc3/tests/test_sampling.py pymc3/tests/test_model_graph.py"
 
 script:
   - . ./scripts/test.sh $TESTCMD

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ LICENSE = "Apache License, Version 2.0"
 classifiers = ['Development Status :: 5 - Production/Stable',
                'Programming Language :: Python',
                'Programming Language :: Python :: 3',
-               'Programming Language :: Python :: 3.5',
                'Programming Language :: Python :: 3.6',
                'Programming Language :: Python :: 3.7',
                'License :: OSI Approved :: Apache Software License',
@@ -59,7 +58,7 @@ if __name__ == "__main__":
           package_data={'docs': ['*']},
           include_package_data=True,
           classifiers=classifiers,
-          python_requires=">=3.5.4",
+          python_requires=">=3.6",
           install_requires=install_reqs,
           tests_require=test_reqs,
           test_suite='nose.collector')


### PR DESCRIPTION
Do not test Python 3.5. ArviZ will also drop 3.5 I think that was the main reason to include 3.5 in PyMC3 tests. 