### PR TITLE
Update Virtual Envs Documentation Link in CONTRIBUTE.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ The preferred workflow for contributing to PyMC3 is to fork the [GitHub reposito
 
    Always use a ``feature`` branch. It's good practice to never routinely work on the ``master`` branch of any repository.
 
-4. Project requirements are in ``requirements.txt``, and libraries used for development are in ``requirements-dev.txt``.  To set up a development environment, you may (probably in a [virtual environment](http://python-guide-pt-br.readthedocs.io/en/latest/dev/virtualenvs/)) run:
+4. Project requirements are in ``requirements.txt``, and libraries used for development are in ``requirements-dev.txt``.  To set up a development environment, you may (probably in a [virtual environment](https://docs.python-guide.org/dev/virtualenvs/) run:
 
    ```bash
    $ pip install -r requirements.txt


### PR DESCRIPTION
# Update Virtual Envs Documentation Link in [CONTRIBUTE.md](https://github.com/CloudChaoszero/pymc3/blob/master/CONTRIBUTING.md)

Update Read-the-docs hyperlink to .org latest version instead of .io version

It looks like Guide to Python's links shifted from .io to a .org version. 

The website endpoint `en` seems to be reserved for Filipino translations, [based off this past commit in the HTML](https://github.com/realpython/python-guide/blob/b4da9ce9fe86c4cb6ccf4dad30bd6ded53770ed0/docs/_templates/sidebarintro.html) from the group.

> However, do note that a developement version of the site may be around endpoint `pt_BR` https://python-guide-pt-br.readthedocs.io/pt_BR/latest/#