### PR TITLE
Swap parameter documentation of LKJCholeskyCov

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -997,12 +997,12 @@ class LKJCholeskyCov(Continuous):
 
     Parameters
     ----------
-    n : int
-        Dimension of the covariance matrix (n > 1).
     eta : float
         The shape parameter (eta > 0) of the LKJ distribution. eta = 1
         implies a uniform distribution of the correlation matrices;
         larger values put more weight on matrices with few correlations.
+    n : int
+        Dimension of the covariance matrix (n > 1).
     sd_dist : pm.Distribution
         A distribution for the standard deviations.
 


### PR DESCRIPTION
Currently, the order of the `eta` and `n` parameters is flipped between the `__init__` and the docstring. `eta` was the first argument to the `__init__` but the second according to the docstring, and vice versa for the `n` parameter. 

This can cause accidental misspecifications which are tedious to debug.