### PR TITLE
Change tune method to not act inplace plus more sampler stats

### DIFF
--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -93,7 +93,9 @@ class Metropolis(ArrayStepShared):
     generates_stats = True
     stats_dtypes = [{
         'accept': np.float64,
+        'accepted': np.bool,
         'tune': np.bool,
+        'scaling': np.float64,
     }]
 
     def __init__(self, vars=None, S=None, proposal_dist=None, scaling=1.,
@@ -166,7 +168,9 @@ class Metropolis(ArrayStepShared):
 
         stats = {
             'tune': self.tune,
+            'scaling': self.scaling,
             'accept': np.exp(accept),
+            'accepted': accepted,
         }
 
         return q_new, [stats]
@@ -529,7 +533,9 @@ class DEMetropolis(PopulationArrayStepShared):
     generates_stats = True
     stats_dtypes = [{
         'accept': np.float64,
+        'accepted': np.bool,
         'tune': np.bool,
+        'scaling': np.float64,
     }]
 
     def __init__(self, vars=None, S=None, proposal_dist=None, lamb=None, scaling=0.001,
@@ -591,7 +597,9 @@ class DEMetropolis(PopulationArrayStepShared):
 
         stats = {
             'tune': self.tune,
+            'scaling': self.scaling,
             'accept': np.exp(accept),
+            'accepted': accepted
         }
 
         return q_new, [stats]

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -191,26 +191,24 @@ def tune(scale, acc_rate):
     >0.95         x 10
 
     """
-
-    # Switch statement
     if acc_rate < 0.001:
         # reduce by 90 percent
-        scale *= 0.1
+        return scale * 0.1
     elif acc_rate < 0.05:
         # reduce by 50 percent
-        scale *= 0.5
+        return scale * 0.5
     elif acc_rate < 0.2:
         # reduce by ten percent
-        scale *= 0.9
+        return scale * 0.9
     elif acc_rate > 0.95:
         # increase by factor of ten
-        scale *= 10.0
+        return scale * 10.0
     elif acc_rate > 0.75:
         # increase by double
-        scale *= 2.0
+        return scale * 2.0
     elif acc_rate > 0.5:
         # increase by ten percent
-        scale *= 1.1
+        return scale * 1.1
 
     return scale
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -548,7 +548,7 @@ class DEMetropolis(PopulationArrayStepShared):
         vars = pm.inputvars(vars)
 
         if S is None:
-            S = np.ones(sum(v.dsize for v in vars))
+            S = np.ones(model.ndim)
 
         if proposal_dist is not None:
             self.proposal_dist = proposal_dist(S)
@@ -557,7 +557,7 @@ class DEMetropolis(PopulationArrayStepShared):
 
         self.scaling = np.atleast_1d(scaling).astype('d')
         if lamb is None:
-            lamb = 2.38 / np.sqrt(2 * S.size)
+            lamb = 2.38 / np.sqrt(2 * model.ndim)
         self.lamb = float(lamb)
         self.tune = tune
         self.tune_interval = tune_interval

--- a/pymc3/tests/test_tuning.py
+++ b/pymc3/tests/test_tuning.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy import inf
+from pymc3.step_methods.metropolis import tune
 from pymc3.tuning import scaling, find_MAP
 from . import models
 
@@ -32,3 +33,11 @@ def test_mle_jacobian():
         map_estimate = find_MAP(method="BFGS", model=model)
 
     np.testing.assert_allclose(map_estimate["mu_i"], truth, rtol=rtol)
+
+
+def test_tune_not_inplace():
+    orig_scaling = np.array([0.001, 0.1])
+    returned_scaling = tune(orig_scaling, acc_rate=0.6)
+    assert not returned_scaling is orig_scaling
+    assert np.all(orig_scaling == np.array([0.001, 0.1]))
+    pass


### PR DESCRIPTION
By acting _inplace_, the `tune` method in `metropolis.py` modified that scaling of all parallel DEMetropolis chains at the same time.

When `DEMetropolis` is used with `cores = 1`, the step method instance is shallow-copied for each chain. The shallow-copying is memory-friendly (important for b/c of the model graph), but the shallow copies also share the reference to the original `scaling` attribute.

The following example shows why the in-place `tune` implementation is problematic:

```
import copy
import numpy

class Chain:
    def __init__(self):
        self.scaling = numpy.array([1,2,3], dtype=float)

chain1 = Chain()
chain2 = copy.copy(chain1)

print(chain1 is chain2)
#> False
print(chain1.scaling is chain2.scaling)
#> True

# In-place operation as previously done by tune method:
chain1.scaling *= 1.1

print(chain2.scaling)
#> [1.1, 2.2, 3.3]
```

### Changes
+ [x] added a regression test that checks the `tune` method to not act inplace
+ [x] changed tune method to return a new array instead of returning the modified original
+ [x] added `accepted` and `scaling` sampler stats for `Metropolis` and `DEMetropolis` because they were useful for testing

closes #3731 