### PR TITLE
Cap coverage for now

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 arviz
 bokeh>=0.12.13
+coverage<5.0
 graphviz>=0.8.3
 h5py>=2.7.0
 ipython


### PR DESCRIPTION
This should actually fix #3735 . Related to a new release of coverage.py. We get the latest from pytest-cov.

