### PR TITLE
Don't tune DEMetropolis by default

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,7 @@
 
 ### New features
 - use [fastprogress](https://github.com/fastai/fastprogress) instead of tqdm [#3693](https://github.com/pymc-devs/pymc3/pull/3693)
+- `DEMetropolis` can now tune both `lambda` and `scaling` parameters, but by default neither of them are tuned. See [#3743](https://github.com/pymc-devs/pymc3/pull/3743) for more info.
 
 ## PyMC3 3.8 (November 29 2019)
 

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -719,6 +719,24 @@ class TestPopulationSamplers:
                 )
         pass
 
+    def test_demcmc_tune_parameter(self):
+        """Tests that validity of the tune setting is checked"""
+        with Model() as model:
+            Normal("n", mu=0, sigma=1, shape=(2,3))
+            
+            step = DEMetropolis()
+            assert step.tune is None
+
+            step = DEMetropolis(tune='scaling')
+            assert step.tune == 'scaling'
+
+            step = DEMetropolis(tune='lambda')
+            assert step.tune == 'lambda'
+
+            with pytest.raises(ValueError):
+                DEMetropolis(tune='foo')
+        pass
+
     def test_nonparallelized_chains_are_random(self):
         with Model() as model:
             x = Normal("x", 0, 1)


### PR DESCRIPTION
### Why
Until now, our implementation tunes `scaling`, which is a bit pointless, because as soon as the population spreads much more than the scaled proposal distribution, it doesn't really make a difference. Only in situations where `n_chains < n_dim+1`, tuning `scaling` should have a real impact, but that's not recommended anyways and since #3719 we have a warning about that.

As I mentioned in #3720, [Nelson _et al._ (2013)](https://arxiv.org/abs/1311.5229), section 4.1.2 describes a procedure where they tune `lambda`. For non-Normal densities, where the `2.38/sqrt(2*ndim)` rule of thumb is not necessarily the best setting, this sounds like a great idea. However, tuning `lambda` can lead to swing-in effects if convergence to the typical set takes a significant part of the tuning phase.

I compared all three settings (None, scaling, lambda) on a 50-dimensional MvNormal, but there's no clear winner.

To compromise, I propose to tune neither `scaling` nor `lambda` by default, but allow the user to tune either of them if they wish to.

### Changes
+ `tune` argument to `DEMetropolis` now one of `{None,scaling,lambda}`
+ support for tuning lambda (closes #3720)
+ added test to check checking of tune setting
+ both scaling and lambda are recorded in the sampler stats