### PR TITLE
Name quadpotential adaptation windows consistently

### DIFF
--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -513,8 +513,8 @@ class QuadPotentialFullAdapt(QuadPotentialFull):
         self._background_cov = _WeightedCovariance(self._n, dtype=self.dtype)
         self._n_samples = 0
 
-        self._adaptation_window = int(adaptation_window)
-        self._adaptation_window_multiplier = float(adaptation_window_multiplier)
+        self.adaptation_window = int(adaptation_window)
+        self.adaptation_window_multiplier = float(adaptation_window_multiplier)
         self._update_window = int(update_window)
         self._previous_update = 0
 
@@ -542,14 +542,14 @@ class QuadPotentialFullAdapt(QuadPotentialFull):
 
         # Reset the background covariance if we are at the end of the adaptation
         # window.
-        if delta >= self._adaptation_window:
+        if delta >= self.adaptation_window:
             self._foreground_cov = self._background_cov
             self._background_cov = _WeightedCovariance(
                 self._n, dtype=self.dtype
             )
 
             self._previous_update = self._n_samples
-            self._adaptation_window = int(self._adaptation_window * self._adaptation_window_multiplier)
+            self.adaptation_window = int(self.adaptation_window * self.adaptation_window_multiplier)
 
         self._n_samples += 1
 

--- a/pymc3/tests/test_quadpotential.py
+++ b/pymc3/tests/test_quadpotential.py
@@ -225,7 +225,7 @@ def test_full_adapt_adaptation_window(seed=8978):
     for i in range(window + 1):
         pot.update(np.random.randn(2), None, True)
     assert pot._previous_update == window
-    assert pot._adaptation_window == window * pot._adaptation_window_multiplier
+    assert pot.adaptation_window == window * pot.adaptation_window_multiplier
 
     pot = quadpotential.QuadPotentialFullAdapt(
         2, np.zeros(2), np.eye(2), 1, adaptation_window=window
@@ -233,7 +233,7 @@ def test_full_adapt_adaptation_window(seed=8978):
     for i in range(window + 1):
         pot.update(np.random.randn(2), None, True)
     assert pot._previous_update == window
-    assert pot._adaptation_window == window * pot._adaptation_window_multiplier
+    assert pot.adaptation_window == window * pot.adaptation_window_multiplier
 
 
 def test_full_adapt_not_invertible():


### PR DESCRIPTION
Small change `_adaptation_window` to `adaptation_window` to make `QuadPotentialFullAdapt` and `QuadPotentialDiagAdapt` have attributes named similarly.

It does not seem necessary for this attribute to be private.