### PR TITLE
Fix typo in __eq__ method for MultiObservedRV.

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1555,7 +1555,9 @@ class MultiObservedRV(Factor):
         return id(self)
 
     def __eq__(self, other):
-        return self.id == other.id
+        "Use object identity for MultiObservedRV equality."
+        # This is likely a Bad Thing, but changing it would break a lot of code.
+        return self is other
 
     def __ne__(self, other):
         return not self == other

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -334,3 +334,17 @@ class TestValueGradFunction(unittest.TestCase):
         gf = m.logp_dlogp_function()
 
         assert m['x2_missing'].type == gf._extra_vars_shared['x2_missing'].type
+
+def test_multiple_observed_rv():
+    "Test previously buggy MultiObservedRV comparison code."
+    y1_data = np.random.randn(10)
+    y2_data = np.random.randn(100)
+    with pm.Model() as model:
+        mu = pm.Normal("mu")
+        x = pm.DensityDist(  # pylint: disable=unused-variable
+            "x", pm.Normal.dist(mu, 1.0).logp, observed={"value": 0.1}
+        )
+    assert not model['x'] == model['mu']
+    assert model['x'] == model['x']
+    assert  model['x'] in model.observed_RVs
+    assert not model['x'] in model.vars


### PR DESCRIPTION
The `__eq__()` method was defined in terms of `self.id` and `other.id`, which I believe to be a typo for `id(self)` and `id(other)`.

If I am not wrong about this, it should probably be merged ASAP.