### PR TITLE
Compilation error workaround

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -36,14 +36,21 @@ from .plots import *
 from .tests import test
 
 from .data import *
-import theano
-import platform
 
-system = platform.system()
-if system == "Windows":
-    theano.config.mode = "FAST_COMPILE"
-elif system == "Darwin":
-    theano.config.gcc.cxxflags = "-Wno-c++11-narrowing"
+
+def __set_compiler_flags():
+    # Workarounds for Theano compiler problems on various platforms
+    import platform
+    import theano
+
+    system = platform.system()
+    if system == "Windows":
+        theano.config.mode = "FAST_COMPILE"
+    elif system == "Darwin":
+        theano.config.gcc.cxxflags = "-Wno-c++11-narrowing"
+
+
+__set_compiler_flags()
 
 import logging
 

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -6,7 +6,15 @@ from .distributions import *
 from .distributions import transforms
 from .glm import *
 from . import gp
-from .math import logaddexp, logsumexp, logit, invlogit, expand_packed_triangular, probit, invprobit
+from .math import (
+    logaddexp,
+    logsumexp,
+    logit,
+    invlogit,
+    expand_packed_triangular,
+    probit,
+    invprobit,
+)
 from .model import *
 from .model_graph import model_to_graphviz
 from . import ode
@@ -28,9 +36,18 @@ from .plots import *
 from .tests import test
 
 from .data import *
+import theano
+import platform
+
+system = platform.system()
+if system == "Windows":
+    theano.config.mode = "FAST_COMPILE"
+elif system == "Darwin":
+    theano.config.gcc.cxxflags = "-Wno-c++11-narrowing"
 
 import logging
-_log = logging.getLogger('pymc3')
+
+_log = logging.getLogger("pymc3")
 if not logging.root.handlers:
     _log.setLevel(logging.INFO)
     if len(_log.handlers) == 0:


### PR DESCRIPTION
This applies platform-specific flags (for Mac and Windows) to circumvent compilation errors for certain models.

Closes #3695 