### PR TITLE
Sampling docstrings

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -135,21 +135,21 @@ def assign_step_methods(model, step=None, methods=STEP_METHODS, step_kwargs=None
 
     Parameters
     ----------
-    model : Model object
+    model: Model object
         A fully-specified model object
-    step : step function or vector of step functions
+    step: step function or vector of step functions
         One or more step functions that have been assigned to some subset of
         the model's parameters. Defaults to ``None`` (no assigned variables).
-    methods : vector of step method classes
+    methods: vector of step method classes
         The set of step methods from which the function may choose. Defaults
         to the main step methods provided by PyMC3.
-    step_kwargs : dict
+    step_kwargs: dict
         Parameters for the samplers. Keys are the lower case names of
         the step method, values a dict of arguments.
 
     Returns
     -------
-    methods : list
+    methods: list
         List of step methods associated with the model's variables.
     """
     steps = []
@@ -570,7 +570,7 @@ def _sample_many(draws, chain:int, chains:int, start:list, random_seed:list, ste
 
     Returns
     -------
-    trace : MultiTrace
+    trace: MultiTrace
         Contains samples of all chains
     """
     traces = []
@@ -614,29 +614,29 @@ def _sample_population(
 
     Parameters
     ----------
-    draws : int
+    draws: int
         The number of samples to draw
-    chain : int
+    chain: int
         The number of the first chain in the population
-    chains : int
+    chains: int
         The total number of chains in the population
-    start : list
+    start: list
         Start points for each chain
     random_seed: int or list of ints, optional
         A list is accepted if more if ``cores`` is greater than one.
-    step : function
+    step: function
         Step function (should be or contain a population step method)
     tune: int, optional
         Number of iterations to tune, if applicable (defaults to None)
     model: Model (optional if in ``with`` context)
-    progressbar : bool
+    progressbar: bool
         Show progress bars? (defaults to True)
-    parallelize : bool
+    parallelize: bool
         Setting for multiprocess parallelization
     
     Returns
     -------
-    trace : MultiTrace
+    trace: MultiTrace
         Contains samples of all chains
     """
     # create the generator that iterates all chains in parallel
@@ -680,7 +680,7 @@ def _sample(
 
     Parameters
     ----------
-    chain : int
+    chain: int
         Number of the chain that the samples will belong to.
     progressbar: bool
         Whether or not to display a progress bar in the command line. The bar shows the percentage
@@ -766,7 +766,7 @@ def iter_sample(
 
     Yields
     ------
-    trace : MultiTrace
+    trace: MultiTrace
         Contains all samples up to the current iteration
 
     Examples
@@ -810,9 +810,9 @@ def _iter_sample(
 
     Yields
     ------
-    strace : BaseTrace
+    strace: BaseTrace
         The trace object containing the samples for this chain
-    diverging : bool
+    diverging: bool
         Indicates if the draw is divergent. Only available with some samplers.
     """
     model = modelcontext(model)
@@ -964,11 +964,11 @@ class PopulationStepper:
 
         Parameters
         ----------
-        c : int
+        c: int
             number of this chain
-        stepper : BlockedStep
+        stepper: BlockedStep
             a step method such as CompoundStep
-        slave_end : multiprocessing.connection.PipeConnection
+        slave_end: multiprocessing.connection.PipeConnection
             This is our connection to the main process
         """
         # re-seed each child process to make them unique
@@ -1006,14 +1006,14 @@ class PopulationStepper:
 
         Parameters
         ----------
-        tune_stop : bool
+        tune_stop: bool
             Indicates if the condition (i == tune) is fulfilled
-        population : list
+        population: list
             Current Points of all chains
 
         Returns
         -------
-        update : list
+        update: list
             List of (Point, stats) tuples for all chains
         """
         updates = [None] * self.nchains
@@ -1046,27 +1046,27 @@ def _prepare_iter_population(
 
     Parameters
     ----------
-    draws : int
+    draws: int
         The number of samples to draw
-    chains : list
+    chains: list
         The chain numbers in the population
-    step : function
+    step: function
         Step function (should be or contain a population step method)
-    start : list
+    start: list
         Start points for each chain
-    parallelize : bool
+    parallelize: bool
         Setting for multiprocess parallelization
     tune: int, optional
         Number of iterations to tune, if applicable (defaults to None)
     model: Model (optional if in ``with`` context)
     random_seed: int or list of ints, optional
         A list is accepted if more if ``cores`` is greater than one.
-    progressbar : bool
+    progressbar: bool
         ``progressbar`` argument for the ``PopulationStepper``, (defaults to True)
     
     Returns
     -------
-    _iter_population : generator
+    _iter_population: generator
         Yields traces of all chains at the same time
     """
     # chains contains the chain numbers, but for indexing we need indices...
@@ -1133,22 +1133,22 @@ def _iter_population(draws, tune, popstep, steppers, traces, points):
 
     Parameters
     ----------
-    draws : int
+    draws: int
         number of draws per chain
-    tune : int
+    tune: int
         number of tuning steps
-    popstep : PopulationStepper
+    popstep: PopulationStepper
         the helper object for (parallelized) stepping of chains
-    steppers : list
+    steppers: list
         The step methods for each chain
-    traces : list
+    traces: list
         Traces for each chain
-    points : list
+    points: list
         population of chain states
 
     Yields
     ------
-    traces : list
+    traces: list
         List of trace objects of the individual chains
     """
     try:
@@ -1194,21 +1194,21 @@ def _choose_backend(trace, chain, shortcuts=None, **kwds):
 
     Parameters
     ----------
-    trace : backend, list, MultiTrace, or None
+    trace: backend, list, MultiTrace, or None
         This should be a BaseTrace, backend name (e.g. text, sqlite, or hdf5),
         list of variables to track, or a MultiTrace object with past values.
         If a MultiTrace object is given, it must contain samples for the chain number ``chain``.
         If None or a list of variables, the NDArray backend is used.
-    chain : int
+    chain: int
         Number of the chain of interest.
-    shortcuts : dict, optional
+    shortcuts: dict, optional
         maps backend names to a dict of backend class and name (defaults to pm.backends._shortcuts)
     **kwds
         keyword arguments to forward to the backend creation
 
     Returns 
     -------
-    trace : BaseTrace
+    trace: BaseTrace
         A trace object for the selected chain
     """
     if isinstance(trace, BaseTrace):
@@ -1259,7 +1259,7 @@ def _mp_sample(
         The number of chains to sample.
     cores: int
         The number of chains to run in parallel.
-    chain : int
+    chain: int
         Number of the first chain.
     random_seed: list of ints
         Random seeds for each chain.
@@ -1401,11 +1401,11 @@ class _DefaultTrace:
 
         Parameters
         ----------
-        k : str
+        k: str
             Name of the variable.
-        v : anything that can go into a numpy array (including a numpy array)
+        v: anything that can go into a numpy array (including a numpy array)
             The value of the `idx`th sample from variable `k`
-        ids : int
+        ids: int
             The index of the sample we are inserting into the trace.
         """
         if hasattr(v, "shape"):
@@ -1472,7 +1472,7 @@ def sample_posterior_predictive(
 
     Returns
     -------
-    samples : dict
+    samples: dict
         Dictionary with the variable names as keys, and values numpy arrays containing
         posterior predictive samples.
     """
@@ -1584,7 +1584,7 @@ def sample_posterior_predictive_w(
 
     Returns
     -------
-    samples : dict
+    samples: dict
         Dictionary with the variables as keys. The values corresponding to the
         posterior predictive samples from the weighted models.
     """
@@ -1696,16 +1696,16 @@ def sample_prior_predictive(
 
     Parameters
     ----------
-    samples : int
+    samples: int
         Number of samples from the prior predictive to generate. Defaults to 500.
-    model : Model (optional if in ``with`` context)
-    vars : Iterable[str]
+    model: Model (optional if in ``with`` context)
+    vars: Iterable[str]
         A list of names of variables for which to compute the posterior predictive
         samples.  *DEPRECATED* - Use ``var_names`` argument instead.
-    var_names : Iterable[str]
+    var_names: Iterable[str]
         A list of names of variables for which to compute the posterior predictive
         samples. Defaults to both observed and unobserved RVs.
-    random_seed : int
+    random_seed: int
         Seed for the random number generator.
 
     Returns
@@ -1770,23 +1770,23 @@ def init_nuts(
     init: str
         Initialization method to use.
 
-        * auto : Choose a default initialization method automatically.
+        * auto: Choose a default initialization method automatically.
           Currently, this is `'jitter+adapt_diag'`, but this can change in the future. If you
           depend on the exact behaviour, choose an initialization method explicitly.
-        * adapt_diag : Start with a identity mass matrix and then adapt a diagonal based on the
+        * adapt_diag: Start with a identity mass matrix and then adapt a diagonal based on the
           variance of the tuning samples. All chains use the test value (usually the prior mean)
           as starting point.
-        * jitter+adapt_diag : Same as ``adapt_diag``, but use uniform jitter in [-1, 1] as starting
+        * jitter+adapt_diag: Same as ``adapt_diag``, but use uniform jitter in [-1, 1] as starting
           point in each chain.
-        * advi+adapt_diag : Run ADVI and then adapt the resulting diagonal mass matrix based on the
+        * advi+adapt_diag: Run ADVI and then adapt the resulting diagonal mass matrix based on the
           sample variance of the tuning samples.
-        * advi+adapt_diag_grad : Run ADVI and then adapt the resulting diagonal mass matrix based
+        * advi+adapt_diag_grad: Run ADVI and then adapt the resulting diagonal mass matrix based
           on the variance of the gradients during tuning. This is **experimental** and might be
           removed in a future release.
-        * advi : Run ADVI to estimate posterior mean and diagonal mass matrix.
+        * advi: Run ADVI to estimate posterior mean and diagonal mass matrix.
         * advi_map: Initialize ADVI with MAP and use MAP as starting point.
-        * map : Use the MAP as starting point. This is discouraged.
-        * nuts : Run NUTS and estimate posterior mean and mass matrix from
+        * map: Use the MAP as starting point. This is discouraged.
+        * nuts: Run NUTS and estimate posterior mean and mass matrix from
           the trace.
     chains: int
         Number of jobs to start.

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1193,7 +1193,7 @@ def _iter_population(draws, tune, popstep, steppers, traces, points):
 
 
 def _choose_backend(trace, chain, shortcuts=None, **kwds):
-    """Selects or creates a trace for a particular chain.
+    """Selects or creates a trace backend (NDArray, Text, etc) for a particular chain.
 
     Parameters
     ----------

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1232,20 +1232,52 @@ def _choose_backend(trace, chain, shortcuts=None, **kwds):
 
 
 def _mp_sample(
-    draws,
-    tune,
+    draws:int,
+    tune:int,
     step,
-    chains,
-    cores,
-    chain,
-    random_seed,
-    start,
+    chains:int,
+    cores:int,
+    chain:int,
+    random_seed:list,
+    start:list,
     progressbar=True,
     trace=None,
     model=None,
     **kwargs
 ):
+    """Main iteration for multiprocess sampling.
 
+    Parameters
+    ----------
+    draws: int
+        The number of samples to draw
+    tune: int, optional
+        Number of iterations to tune, if applicable (defaults to None)
+    step: function
+        Step function
+    chains: int
+        The number of chains to sample.
+    cores: int
+        The number of chains to run in parallel.
+    chain : int
+        Number of the first chain.
+    random_seed: list of ints
+        Random seeds for each chain.
+    start: list
+        Starting points for each chain.
+    progressbar: bool
+        Whether or not to display a progress bar in the command line.
+    trace: backend, list, MultiTrace or None
+        This should be a backend instance, a list of variables to track, or a MultiTrace object
+        with past values. If a MultiTrace object is given, it must contain samples for the chain
+        number ``chain``. If None or a list of variables, the NDArray backend is used.
+    model: Model (optional if in ``with`` context)
+
+    Returns
+    -------
+    trace: pymc3.backends.base.MultiTrace
+        A ``MultiTrace`` object that contains the samples for all chains.
+    """
     import pymc3.parallel_sampling as ps
 
     # We did draws += tune in pm.sample

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -633,7 +633,7 @@ def _sample_population(
         Show progress bars? (defaults to True)
     parallelize : bool
         Setting for multiprocess parallelization
-
+    
     Returns
     -------
     trace : MultiTrace
@@ -718,13 +718,10 @@ def _sample(
     try:
         strace = None
         for it, (strace, diverging) in enumerate(sampling):
-            if it >= skip_first:
-                # TODO: unused variable - unnecessary creation of MultiTrace
-                trace = MultiTrace([strace])
-                if diverging:
-                    _pbar_data["divergences"] += 1
-                    if progressbar:
-                        sampling.comment = _desc.format(**_pbar_data)
+            if it >= skip_first and diverging:
+                _pbar_data["divergences"] += 1
+                if progressbar:
+                    sampling.comment = _desc.format(**_pbar_data)
     except KeyboardInterrupt:
         pass
     return strace

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -620,19 +620,19 @@ def _sample_population(
         The number of the first chain in the population
     chains : int
         The total number of chains in the population
-    step : function
-        Step function (should be or contain a population step method)
     start : list
         Start points for each chain
-    parallelize : bool
-        Setting for multiprocess parallelization
+    random_seed: int or list of ints, optional
+        A list is accepted if more if ``cores`` is greater than one.
+    step : function
+        Step function (should be or contain a population step method)
     tune: int, optional
         Number of iterations to tune, if applicable (defaults to None)
     model: Model (optional if in ``with`` context)
-    random_seed: int or list of ints, optional
-        A list is accepted if more if ``cores`` is greater than one.
     progressbar : bool
         Show progress bars? (defaults to True)
+    parallelize : bool
+        Setting for multiprocess parallelization
 
     Returns
     -------

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1016,8 +1016,8 @@ class PopulationStepper:
 
         Returns
         -------
-        update : Point
-            The new positions of the chains
+        update : list
+            List of (Point, stats) tuples for all chains
         """
         updates = [None] * self.nchains
         if self.is_parallelized:
@@ -1158,6 +1158,8 @@ def _iter_population(draws, tune, popstep, steppers, traces, points):
         with popstep:
             # iterate draws of all chains
             for i in range(draws):
+                # this call steps all chains and returns a list of (point, stats)
+                # the `popstep` may interact with subprocesses internally
                 updates = popstep.step(i == tune, points)
 
                 # apply the update to the points and record to the traces

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1044,6 +1044,27 @@ def _iter_population(draws, tune, popstep, steppers, traces, points):
 
 
 def _choose_backend(trace, chain, shortcuts=None, **kwds):
+    """Selects or creates a trace for a particular chain.
+
+    Parameters
+    ----------
+    trace : backend, list, or MultiTrace
+        This should be a BaseTrace, backend name (e.g. text, sqlite, or hdf5),
+        list of variables to track, or a MultiTrace object with past values.
+        If a MultiTrace object is given, it must contain samples for the chain number ``chain``.
+        If None or a list of variables, the NDArray backend is used.
+    chain : int
+        Number of the chain of interest.
+    shortcuts : dict, optional
+        maps backend names to a dict of backend class and name (defaults to pm.backends._shortcuts)
+    **kwds
+        keyword arguments to forward to the backend creation
+
+    Returns 
+    -------
+    trace : BaseTrace
+        A trace object for the selected chain
+    """
     if isinstance(trace, BaseTrace):
         return trace
     if isinstance(trace, MultiTrace):


### PR DESCRIPTION
Editing docstrings and type hints on internal methods to make the code easier to understand.

Based on this call tree, there are manly 3 routes through the sampling process:
![sampling](https://user-images.githubusercontent.com/5894642/72689946-6bf92c80-3b17-11ea-8b2a-c600c7ad3c1e.png)

Some arguments such as `trace` are passed down the call tree quite a lot before they are actually used. Therefore the `Parameters` sections are often very similar..

Given the Python 2 EOL we could put `, *,` in many places.

There's a TODO comment in at least one place where I think we're wasting CPU time.