### PR TITLE
Fix energy change of nan in HamiltonianMC

### DIFF
--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -37,7 +37,7 @@ class HamiltonianMC(BaseHMC):
         'model_logp': np.float64,
     }]
 
-    def __init__(self, vars=None, path_length=2., **kwargs):
+    def __init__(self, vars=None, path_length=2., max_steps=1024, **kwargs):
         """Set up the Hamiltonian Monte Carlo sampler.
 
         Parameters
@@ -82,6 +82,8 @@ class HamiltonianMC(BaseHMC):
         adapt_step_size : bool, default=True
             Whether step size adaptation should be enabled. If this is
             disabled, `k`, `t0`, `gamma` and `target_accept` are ignored.
+        max_steps : int
+            The maximum number of leapfrog steps.
         model : pymc3.Model
             The model
         **kwargs : passed to BaseHMC
@@ -90,9 +92,11 @@ class HamiltonianMC(BaseHMC):
         kwargs.setdefault('target_accept', 0.65)
         super().__init__(vars, **kwargs)
         self.path_length = path_length
+        self.max_steps = max_steps
 
     def _hamiltonian_step(self, start, p0, step_size):
         n_steps = max(1, int(self.path_length / step_size))
+        n_steps = min(self.max_steps, n_steps)
 
         energy_change = -np.inf
         state = start

--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -107,6 +107,8 @@ class HamiltonianMC(BaseHMC):
                 div_info = DivergenceInfo(
                     'Divergence encountered, bad energy.', None, state)
             energy_change = start.energy - state.energy
+            if np.isnan(energy_change):
+                energy_change = -np.inf
             if np.abs(energy_change) > self.Emax:
                 div_info = DivergenceInfo(
                     'Divergence encountered, large integration error.',


### PR DESCRIPTION
* Check if the energy change in a hamiltonian MCMC step is nan and set it to -inf if so. This prevents steps size adaptation from misbehaving.
* Introduce an argument to limit the maximum number of leapfrog steps, otherwise it can get arbitrarily large especially during tuning if the step size is very small.
fixes #3777