### PR TITLE
Remove max_energy_error sampling stat from HMC

### DIFF
--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -31,7 +31,6 @@ class HamiltonianMC(BaseHMC):
         'diverging': np.bool,
         'energy_error': np.float64,
         'energy': np.float64,
-        'max_energy_error': np.float64,
         'path_length': np.float64,
         'accepted': np.bool,
         'model_logp': np.float64,


### PR DESCRIPTION
Something I came across while working on [LittleMCMC](https://github.com/eigenfoo/littlemcmc).

Currently it looks like we define [the `max_energy_error` dtype in HMC](https://github.com/pymc-devs/pymc3/blob/master/pymc3/step_methods/hmc/hmc.py#L34), but we don't seem to [actually have a `max_energy_error` sampler stat for HMC](https://github.com/pymc-devs/pymc3/blob/master/pymc3/step_methods/hmc/hmc.py#L130) (although I should note that NUTS does). This PR just removes the `max_energy_error` dtype.