### PR TITLE
Honor discard_tuned_samples during KeyboardInterrupt

### DIFF
--- a/pymc3/backends/report.py
+++ b/pymc3/backends/report.py
@@ -99,7 +99,14 @@ class SamplerReport:
         if errors:
             raise ValueError('Serious convergence issues during sampling.')
 
-    def _run_convergence_checks(self, idata:arviz.InferenceData, model):
+    def _run_convergence_checks(self, idata: arviz.InferenceData, model):
+        if not hasattr(idata, 'posterior'):
+            msg = "No posterior samples. Unable to run convergence checks"
+            warn = SamplerWarning(WarningType.BAD_PARAMS, msg, 'info',
+                                  None, None, None)
+            self._add_warnings([warn])
+            return
+
         if idata.posterior.sizes['chain'] == 1:
             msg = ("Only one chain was sampled, this makes it impossible to "
                    "run some convergence checks")

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -502,6 +502,7 @@ def sample(
         "random_seed": random_seed,
         "cores": cores,
         "callback": callback,
+        "discard_tuned_samples": discard_tuned_samples,
     }
 
     sample_args.update(kwargs)
@@ -1347,6 +1348,7 @@ def _mp_sample(
     trace=None,
     model=None,
     callback=None,
+    discard_tuned_samples=True,
     **kwargs
 ):
     """Main iteration for multiprocess sampling.
@@ -1439,7 +1441,10 @@ def _mp_sample(
             raise
         return MultiTrace(traces)
     except KeyboardInterrupt:
-        traces, length = _choose_chains(traces, tune)
+        if discard_tuned_samples:
+            traces, length = _choose_chains(traces, tune)
+        else:
+            traces, length = _choose_chains(traces, 0)
         return MultiTrace(traces)[:length]
     finally:
         for trace in traces:


### PR DESCRIPTION
We used to ignore the `discard_tuned_samples` setting when deciding which samples to keep when we interrupt sampling with Ctrl-C, so that pymc3 would not give us any trace if there were no non-tuning samples yet.