### PR TITLE
Fix BEST notebook credible difference of means conclusion

### DIFF
--- a/docs/source/notebooks/BEST.ipynb
+++ b/docs/source/notebooks/BEST.ipynb
@@ -303,9 +303,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Looking at the group differences, we can conclude that there are meaningful differences between the two groups for all three measures. For these comparisons, it is useful to use zero as a reference value (`ref_val`); providing this reference value yields cumulative probabilities for the posterior distribution on either side of the value. Thus, for the difference in means, 99.4% of the posterior probability is greater than zero, which suggests the group means are credibly different. The effect size and differences in standard deviation are similarly positive.\n",
+    "Looking at the group differences below, we can conclude that there are meaningful differences between the two groups for all three measures. For these comparisons, it is useful to use zero as a reference value (`ref_val`); providing this reference value yields cumulative probabilities for the posterior distribution on either side of the value. Thus, for the difference of means, at least 97% of the posterior probability are greater than zero, which suggests the group means are credibly different. The effect size and differences in standard deviation are similarly positive.\n",
     "\n",
-    "These estimates suggest that the \"smart drug\" increased both the expected scores, but also the  variability in scores across the sample. So, this does not rule out the possibility that some recipients may be adversely affected by the drug at the same time others benefit."
+    "These estimates suggest that the \"smart drug\" increased both the expected scores, but also the variability in scores across the sample. So, this does not rule out the possibility that some recipients may be adversely affected by the drug at the same time others benefit."
    ]
   },
   {
@@ -515,7 +515,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.3"
   },
   "latex_envs": {
    "bibliofile": "biblio.bib",


### PR DESCRIPTION
This commit fixes the conclusion made in the BEST notebook about the credible difference of means. Originally, it was said that 99.4% of the posterior probability would be greater than zero, referencing the plot below the text which stated 98.4% as a value:

<img width="1015" alt="bug_or_not_BEST_notebook_pymc3" src="https://user-images.githubusercontent.com/9593883/73140646-100b3800-4030-11ea-912f-a9694acdd70d.png">

The issue is that, given the stochastic estimation, this value may vary as the notebook is re-run. This fix replaces "99.4%" with "at least 97%". It also clarifies that the text references the plot below it.

This issue was discussed on [PyMC's discourse](https://discourse.pymc.io/t/bug-or-not-best-notebook-difference-of-means-of-posterior-probability-in-plot-vs-text/4411) with @junpenglao.