### PR TITLE
remove sample_ppc(_w)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,9 @@
 - use [fastprogress](https://github.com/fastai/fastprogress) instead of tqdm [#3693](https://github.com/pymc-devs/pymc3/pull/3693)
 - `DEMetropolis` can now tune both `lambda` and `scaling` parameters, but by default neither of them are tuned. See [#3743](https://github.com/pymc-devs/pymc3/pull/3743) for more info.
 
+### Maintenance
+- Remove `sample_ppc` and `sample_ppc_w` that where deprecated in 3.6.
+
 ## PyMC3 3.8 (November 29 2019)
 
 ### New features

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,7 +7,7 @@
 - `DEMetropolis` can now tune both `lambda` and `scaling` parameters, but by default neither of them are tuned. See [#3743](https://github.com/pymc-devs/pymc3/pull/3743) for more info.
 
 ### Maintenance
-- Remove `sample_ppc` and `sample_ppc_w` that where deprecated in 3.6.
+- Remove `sample_ppc` and `sample_ppc_w` that were deprecated in 3.6.
 
 ## PyMC3 3.8 (November 29 2019)
 

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -71,8 +71,6 @@ __all__ = [
     "sample_posterior_predictive_w",
     "init_nuts",
     "sample_prior_predictive",
-    "sample_ppc",
-    "sample_ppc_w",
 ]
 
 STEP_METHODS = (
@@ -1555,13 +1553,6 @@ def sample_posterior_predictive(
     return ppc_trace
 
 
-def sample_ppc(*args, **kwargs):
-    """Deprecated: use :func:`~sampling.sample_posterior_predictive`."""
-    message = "sample_ppc() is deprecated.  Please use sample_posterior_predictive()"
-    warnings.warn(message, DeprecationWarning, stacklevel=2)
-    return sample_posterior_predictive(*args, **kwargs)
-
-
 def sample_posterior_predictive_w(
     traces,
     samples: Optional[int] = None,
@@ -1690,13 +1681,6 @@ def sample_posterior_predictive_w(
         pass
 
     return {k: np.asarray(v) for k, v in ppc.items()}
-
-
-def sample_ppc_w(*args, **kwargs):
-    """Deprecated: use :func:`~sampling.sample_posterior_predictive_w`."""
-    message = "sample_ppc() is deprecated.  Please use sample_posterior_predictive_w()"
-    warnings.warn(message, DeprecationWarning, stacklevel=2)
-    return sample_posterior_predictive_w(*args, **kwargs)
 
 
 def sample_prior_predictive(


### PR DESCRIPTION
 sample_ppc(_w) were deprecated back in 3.6. This finally remove them.