### PR TITLE
Pandas 1.0 compatibility: to_numpy() instead of as_matrix()

### DIFF
--- a/pymc3/glm/utils.py
+++ b/pymc3/glm/utils.py
@@ -48,7 +48,7 @@ def any_to_tensor_and_labels(x, labels=None):
     if isinstance(x, pd.DataFrame):
         if not labels:
             labels = x.columns
-        x = x.as_matrix()
+        x = x.to_numpy()
 
     # pandas.Series
     # there can still be a label
@@ -56,7 +56,7 @@ def any_to_tensor_and_labels(x, labels=None):
     elif isinstance(x, pd.Series):
         if not labels:
             labels = [x.name]
-        x = x.as_matrix()[:, None]
+        x = x.to_numpy()[:, None]
 
     # dict
     # labels are keys,
@@ -66,7 +66,7 @@ def any_to_tensor_and_labels(x, labels=None):
         try:
             x = pd.DataFrame.from_dict(x)
             labels = x.columns
-            x = x.as_matrix()
+            x = x.to_numpy()
         # some types fail there
         # another approach is to construct
         # variable by hand

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -72,11 +72,11 @@ class TestARM12_6(SeededTest):
     def build_model(self):
         data = get_city_data()
 
-        self.obs_means = data.groupby('fips').lradon.mean().as_matrix()
+        self.obs_means = data.groupby('fips').lradon.mean().to_numpy()
 
-        lradon = data.lradon.as_matrix()
-        floor = data.floor.as_matrix()
-        group = data.group.as_matrix()
+        lradon = data.lradon.to_numpy()
+        floor = data.floor.to_numpy()
+        group = data.group.to_numpy()
 
         with pm.Model() as model:
             groupmean = pm.Normal('groupmean', 0, 10. ** -2.)
@@ -107,10 +107,10 @@ class TestARM12_6Uranium(SeededTest):
         data = get_city_data()
         self.obs_means = data.groupby('fips').lradon.mean()
 
-        lradon = data.lradon.as_matrix()
-        floor = data.floor.as_matrix()
-        group = data.group.as_matrix()
-        ufull = data.Uppm.as_matrix()
+        lradon = data.lradon.to_numpy()
+        floor = data.floor.to_numpy()
+        group = data.group.to_numpy()
+        ufull = data.Uppm.to_numpy()
 
         with pm.Model() as model:
             groupmean = pm.Normal('groupmean', 0, 10. ** -2.)


### PR DESCRIPTION
Over in #3784 my pipeline broke because of the pandas 1.0 release.

This PR fixes the incompatibilities that caused the tests to fail.