### PR TITLE
Reset tuned Metropolis parameters in sequential sampling of chains

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,7 @@
 
 ### Maintenance
 - Remove `sample_ppc` and `sample_ppc_w` that were deprecated in 3.6.
+- Tuning results no longer leak into sequentially sampled `Metropolis` chains (see #3733 and #3796).
 
 ## PyMC3 3.8 (November 29 2019)
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -146,11 +146,24 @@ class Metropolis(ArrayStepShared):
         self.any_discrete = self.discrete.any()
         self.all_discrete = self.discrete.all()
 
+        # remember initial settings before tuning so they can be reset
+        self._untuned_settings = dict(
+            scaling=self.scaling,
+            steps_until_tune=tune_interval,
+            accepted=self.accepted
+        )
+
         self.mode = mode
 
         shared = pm.make_shared_replacements(vars, model)
         self.delta_logp = delta_logp(model.logpt, vars, shared)
         super().__init__(vars, shared)
+
+    def reset_tuning(self):
+        """Resets the tuned sampler parameters to their initial values."""
+        for attr, initial_value in self._untuned_settings.items():
+            setattr(self, attr, initial_value)
+        return
 
     def astep(self, q0):
         if not self.steps_until_tune and self.tune:

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -779,6 +779,27 @@ class TestPopulationSamplers:
         pass
 
 
+class TestMetropolis:
+    def test_tuning_reset(self):
+        """Re-use of the step method instance with cores=1 must not leak tuning information between chains."""
+        with Model() as pmodel:
+            D = 3
+            Normal('n', 0, 2, shape=(D,))
+            trace = sample(
+                tune=600,
+                draws=500,
+                step=Metropolis(tune=True, scaling=0.1),
+                cores=1,
+                chains=3,
+                discard_tuned_samples=False
+            )
+        for c in range(trace.nchains):
+            # check that the tuned settings changed and were reset
+            assert trace.get_sampler_stats('scaling', chains=c)[0] == 0.1
+            assert trace.get_sampler_stats('scaling', chains=c)[-1] != 0.1
+        pass
+
+
 class TestDEMetropolisZ:
     def test_tuning_lambda_sequential(self):
         with Model() as pmodel:


### PR DESCRIPTION
+ [x] add a regression test that detects the issue
+ [x] implement the fix for #3733 
+ [x] update release notes