### PR TITLE
the centering term was wrong

### DIFF
--- a/pymc3/smc/smc.py
+++ b/pymc3/smc/smc.py
@@ -191,7 +191,7 @@ class SMC:
             log_weights_un = (new_beta - old_beta) * self.likelihoods
             log_weights = log_weights_un - logsumexp(log_weights_un)
 
-        ll_max = np.max(self.likelihoods)
+        ll_max = np.max(log_weights_un)
         self.model.marginal_log_likelihood += ll_max + np.log(
             np.exp(log_weights_un - ll_max).mean()
         )


### PR DESCRIPTION
The centering term was wrong. I was getting infs for the marginal log likelihood from my model and I dug into the code and found the centering term was wrong. The original term was too large, causing overflows unnecessarily.