### PR TITLE
Update patsy version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ theano>=1.0.4
 numpy>=1.13.0
 scipy>=0.18.1
 pandas>=0.18.0
-patsy>=0.4.0
+patsy>=0.5.1
 fastprogress>=0.2.0
 h5py>=2.7.0


### PR DESCRIPTION
patsy < 0.5.1 is not compatible with Python > 3.7. 

Note: need to verify the tests pass before merging.