### PR TITLE
Resave notebooks to fix doc compilation error

### DIFF
--- a/docs/source/notebooks/GLM-hierarchical.ipynb
+++ b/docs/source/notebooks/GLM-hierarchical.ipynb
@@ -583,5 +583,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/docs/source/notebooks/GLM-model-selection.ipynb
+++ b/docs/source/notebooks/GLM-model-selection.ipynb
@@ -1583,5 +1583,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/docs/source/notebooks/GLM-robust-with-outlier-detection.ipynb
+++ b/docs/source/notebooks/GLM-robust-with-outlier-detection.ipynb
@@ -804,5 +804,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/docs/source/notebooks/GLM-robust.ipynb
+++ b/docs/source/notebooks/GLM-robust.ipynb
@@ -334,5 +334,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/docs/source/notebooks/GLM-rolling-regression.ipynb
+++ b/docs/source/notebooks/GLM-rolling-regression.ipynb
@@ -471,5 +471,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/docs/source/notebooks/GLM.ipynb
+++ b/docs/source/notebooks/GLM.ipynb
@@ -718,5 +718,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/docs/source/notebooks/GP-Kron.ipynb
+++ b/docs/source/notebooks/GP-Kron.ipynb
@@ -488,9 +488,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pymc33.6",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "pymc33_6"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -502,7 +502,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/GP-Latent.ipynb
+++ b/docs/source/notebooks/GP-Latent.ipynb
@@ -634,9 +634,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "pymc33.6",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "pymc33_6"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -648,7 +648,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The deployed docs have this annoying condition where the method name and argument type don't have a space making copying hard.

https://docs.pymc.io/api/inference.html?highlight=sample_ppc

Tried fixing locally and ran into another issue where the docs wouldn't build because some notebooks were out of date. After that I compiled the docs and the local version didn't have the issue:

So long story short this PR fixes the notebook issue and I'm hoping when the docs recompile in CI they'll redeploy and include the space making copying and pasting easy

https://docs.pymc.io/api/inference.html?highlight=sample_ppc
![image](https://user-images.githubusercontent.com/7213793/74906659-7dc42e80-5366-11ea-9f1a-5730ac144e84.png)
