### PR TITLE
allow pymc3.Data() to support both int and float input data

### DIFF
--- a/pymc3/data.py
+++ b/pymc3/data.py
@@ -478,10 +478,20 @@ class Data:
     For more information, take a look at this example notebook
     https://docs.pymc.io/notebooks/data_container.html
     """
-    def __new__(self, name, value):
+    def __new__(self, name, value, dtype = None):
+        if dtype is None:
+            if hasattr(value, 'dtype'):
+                # if no dtype given, but available as attr of value, use that as dtype
+                dtype = value.dtype
+            elif isinstance(value, int):
+                dtype = int
+            else:
+                # otherwise, assume float
+                dtype = float
+                
         # `pm.model.pandas_to_array` takes care of parameter `value` and
         # transforms it to something digestible for pymc3
-        shared_object = theano.shared(pm.model.pandas_to_array(value), name)
+        shared_object = theano.shared(pm.model.pandas_to_array(value, dtype = dtype), name)
 
         # To draw the node for this variable in the graphviz Digraph we need
         # its shape.

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1496,6 +1496,8 @@ def pandas_to_array(data, dtype = float):
         return pm.floatX(ret)
     elif dtype in [int, np.int32, np.int64]:
         return pm.intX(ret)
+    else:
+        raise ValueError('Unsupported type for pandas_to_array: %s' % str(dtype))
 
 def as_tensor(data, name, model, distribution):
     dtype = distribution.dtype

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1473,7 +1473,7 @@ class FreeRV(Factor, PyMC3Variable):
         return self.tag.test_value
 
 
-def pandas_to_array(data):
+def pandas_to_array(data, dtype = float):
     if hasattr(data, 'values'):  # pandas
         if data.isnull().any().any():  # missing values
             ret = np.ma.MaskedArray(data.values, data.isnull().values)
@@ -1492,8 +1492,10 @@ def pandas_to_array(data):
         ret = generator(data)
     else:
         ret = np.asarray(data)
-    return pm.floatX(ret)
-
+    if dtype in [float, np.float32, np.float64]:
+        return pm.floatX(ret)
+    elif dtype in [int, np.int32, np.int64]:
+        return pm.intX(ret)
 
 def as_tensor(data, name, model, distribution):
     dtype = distribution.dtype


### PR DESCRIPTION
Previously all input data was coerced to float when passed to pymc3.Data()

Attached changes implement this behaviour:

1. use dtype of passed array, if it has a dtype attr
2. otherwise test if input data is instance of int
3. otherwise assume float

WIP for #3813