### PR TITLE
Reducing the running time of tests

### DIFF
--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -463,12 +463,12 @@ class TestMatchesScipy(SeededTest):
                 decimal = select_by_precision(float64=6, float32=3)
             assert_almost_equal(logp(pt), logp_reference(pt), decimal=decimal, err_msg=str(pt))
 
-    def check_logcdf(self, pymc3_dist, domain, paramdomains, scipy_logcdf, decimal=None):
+    def check_logcdf(self, pymc3_dist, domain, paramdomains, scipy_logcdf, decimal=None, n_samples=100):
         domains = paramdomains.copy()
         domains['value'] = domain
         if decimal is None:
             decimal = select_by_precision(float64=6, float32=3)
-        for pt in product(domains, n_samples=100):
+        for pt in product(domains, n_samples=n_samples):
             params = dict(pt)
             scipy_cdf = scipy_logcdf(**params)
             value = params.pop('value')
@@ -656,7 +656,7 @@ class TestMatchesScipy(SeededTest):
         self.pymc3_matches_scipy(StudentT, R, {'nu': Rplus, 'mu': R, 'lam': Rplus},
                                  lambda value, nu, mu, lam: sp.t.logpdf(value, nu, mu, lam**-0.5))
         self.check_logcdf(StudentT, R, {'nu': Rplus, 'mu': R, 'lam': Rplus},
-                          lambda value, nu, mu, lam: sp.t.logcdf(value, nu, mu, lam**-0.5))
+                          lambda value, nu, mu, lam: sp.t.logcdf(value, nu, mu, lam**-0.5), n_samples=10)
 
     def test_cauchy(self):
         self.pymc3_matches_scipy(Cauchy, R, {'alpha': R, 'beta': Rplusbig},


### PR DESCRIPTION
Hi,

I updated the number of samples in `test_t` in `test_distributions.py` which reduces the running time of the test from ~59s to ~19s on my local machine. I also verified that the test passes on multiple seeds.

Would you guys be interested in such optimizations? If yes, I can help contribute more and look at how to optimize other expensive tests in the test suite. Please let me know if you have any other suggestions or any necessary checks that I should do on these tests.

Thanks!
