### PR TITLE
Include n_tune, n_draws and t_sampling in SamplerReport

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,6 +7,7 @@
 - `DEMetropolis` can now tune both `lambda` and `scaling` parameters, but by default neither of them are tuned. See [#3743](https://github.com/pymc-devs/pymc3/pull/3743) for more info.
 - `DEMetropolisZ`, an improved variant of `DEMetropolis` brings better parallelization and higher efficiency with fewer chains with a slower initial convergence. This implementation is experimental. See [#3784](https://github.com/pymc-devs/pymc3/pull/3784) for more info.
 - Notebooks that give insight into `DEMetropolis`, `DEMetropolisZ` and the `DifferentialEquation` interface are now located in the [Tutorials/Deep Dive](https://docs.pymc.io/nb_tutorials/index.html) section.
+- `SamplerReport` (`MultiTrace.report`) now has properties `n_tune`, `n_draws`, `t_sampling` for increased convenience (see [#3827](https://github.com/pymc-devs/pymc3/pull/3827))
 
 ### Maintenance
 - Remove `sample_ppc` and `sample_ppc_w` that were deprecated in 3.6.

--- a/pymc3/backends/report.py
+++ b/pymc3/backends/report.py
@@ -175,8 +175,6 @@ class SamplerReport:
         warn_list.extend(warnings)
 
     def _log_summary(self):
-        if self._n_tune is not None and self._n_draws is not None and self._t_sampling is not None:
-            logger.info(f'Sampling {self.n_tune} tune and {self.n_draws} draw iterations took {self.t_sampling:.0f} seconds.')
         def log_warning(warn):
             level = _LEVELS[warn.level]
             logger.log(level, warn.message)

--- a/pymc3/backends/report.py
+++ b/pymc3/backends/report.py
@@ -15,6 +15,7 @@
 from collections import namedtuple
 import logging
 import enum
+import typing
 from ..util import is_transformed_name, get_untransformed_name
 
 
@@ -51,11 +52,15 @@ _LEVELS = {
 
 
 class SamplerReport:
+    """This object bundles warnings, convergence statistics and metadata of a sampling run."""
     def __init__(self):
         self._chain_warnings = {}
         self._global_warnings = []
         self._ess = None
         self._rhat = None
+        self._n_tune = None
+        self._n_draws = None
+        self._t_sampling = None
 
     @property
     def _warnings(self):
@@ -67,6 +72,25 @@ class SamplerReport:
         """Whether the automatic convergence checks found serious problems."""
         return all(_LEVELS[warn.level] < _LEVELS['warn']
                    for warn in self._warnings)
+
+    @property
+    def n_tune(self) -> typing.Optional[int]:
+        """Number of tune iterations."""
+        return self._n_tune
+
+    @property
+    def n_draws(self) -> typing.Optional[int]:
+        """Number of draw iterations."""
+        return self._n_draws
+
+    @property
+    def t_sampling(self) -> typing.Optional[float]:
+        """
+        Number of seconds that the sampling procedure took.
+        
+        (Includes parallelization overhead.)
+        """
+        return self._t_sampling
 
     def raise_ok(self, level='error'):
         errors = [warn for warn in self._warnings
@@ -151,7 +175,8 @@ class SamplerReport:
         warn_list.extend(warnings)
 
     def _log_summary(self):
-
+        if self._n_tune is not None and self._n_draws is not None and self._t_sampling is not None:
+            logger.info(f'Sampling {self.n_tune} tune and {self.n_draws} draw iterations took {self.t_sampling:.0f} seconds.')
         def log_warning(warn):
             level = _LEVELS[warn.level]
             logger.log(level, warn.message)

--- a/pymc3/backends/report.py
+++ b/pymc3/backends/report.py
@@ -75,7 +75,7 @@ class SamplerReport:
 
     @property
     def n_tune(self) -> typing.Optional[int]:
-        """Number of tune iterations."""
+        """Number of tune iterations - not necessarily kept in trace!"""
         return self._n_tune
 
     @property

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -537,14 +537,17 @@ def sample(
     n_draws = list(trace.get_sampler_stats('tune', chains=0)).count(False)
     if discard_tuned_samples:
         trace = trace[n_tune:]
-        
+
     # save metadata in SamplerReport
     trace.report._n_tune = n_tune
     trace.report._n_draws = n_draws
     trace.report._t_sampling = time.time() - t_start
+
+    n_chains = len(trace.chains)
     _log.info(
-        f'Sampling {chains} chains for {n_tune:_d} tune and {n_draws:_d} draw iterations '
-        f'({n_tune*chains:_d} + {n_draws*chains:_d} draws total) took {trace.report.t_sampling:.0f} seconds.'
+        f'Sampling {n_chains} chain{"s" if n_chains > 1 else ""} for {n_tune:_d} tune and {n_draws:_d} draw iterations '
+        f'({n_tune*n_chains:_d} + {n_draws*n_chains:_d} draws total) '
+        f'took {trace.report.t_sampling:.0f} seconds.'
     )
 
     if compute_convergence_checks:

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -535,6 +535,7 @@ def sample(
             _print_step_hierarchy(step)
             trace = _sample_many(**sample_args)
 
+    t_sampling = time.time() - t_start
     # count the number of tune/draw iterations that happened
     # ideally via the "tune" statistic, but not all samplers record it!
     if 'tune' in trace.stat_names:
@@ -556,7 +557,7 @@ def sample(
     # save metadata in SamplerReport
     trace.report._n_tune = n_tune
     trace.report._n_draws = n_draws
-    trace.report._t_sampling = time.time() - t_start
+    trace.report._t_sampling = t_sampling
 
     n_chains = len(trace.chains)
     _log.info(

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -24,6 +24,7 @@ from collections import defaultdict
 from copy import copy
 import pickle
 import logging
+import time
 import warnings
 
 import numpy as np
@@ -486,6 +487,7 @@ def sample(
     )
 
     parallel = cores > 1 and chains > 1 and not has_population_samplers
+    t_start = time.time()
     if parallel:
         _log.info("Multiprocess sampling ({} chains in {} jobs)".format(chains, cores))
         _print_step_hierarchy(step)
@@ -533,6 +535,9 @@ def sample(
 
     discard = tune if discard_tuned_samples else 0
     trace = trace[discard:]
+    trace.report._n_tune = tune
+    trace.report._n_draws = draws
+    trace.report._t_sampling = time.time() - t_start
 
     if compute_convergence_checks:
         if draws - tune < 100:

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -533,8 +533,15 @@ def sample(
             _print_step_hierarchy(step)
             trace = _sample_many(**sample_args)
 
-    n_tune = list(trace.get_sampler_stats('tune', chains=0)).count(True)
-    n_draws = list(trace.get_sampler_stats('tune', chains=0)).count(False)
+    # not all samplers record the 'tune' statistic!
+    if 'tune' in trace.stat_names:
+        n_tune = list(trace.get_sampler_stats('tune', chains=0)).count(True)
+        n_draws = list(trace.get_sampler_stats('tune', chains=0)).count(False)
+    else:
+        # these may be wrong when KeyboardInterrupt happened, but they're better than nothing
+        n_tune = tune
+        n_draws = len(trace) if discard_tuned_samples else max(0, len(trace) - n_tune)
+
     if discard_tuned_samples:
         trace = trace[n_tune:]
 

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -535,8 +535,8 @@ def sample(
 
     discard = tune if discard_tuned_samples else 0
     trace = trace[discard:]
-    trace.report._n_tune = tune
-    trace.report._n_draws = draws
+    trace.report._n_tune = tune if discard_tuned_samples else list(trace.get_sampler_stats('tune', chains=0)).count(True)
+    trace.report._n_draws = list(trace.get_sampler_stats('tune', chains=0)).count(False)
     trace.report._t_sampling = time.time() - t_start
 
     if compute_convergence_checks:

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -127,6 +127,16 @@ class TestSample(SeededTest):
             trace = pm.sample(draws=100, tune=50, cores=4)
             assert len(trace) == 100
 
+    @pytest.mark.parametrize("discard", [True, False])
+    def test_trace_report(self, discard):
+        with self.model:
+            # make sure that n_tune is correct, regardless of the discard_tuned_samples setting
+            trace = pm.sample(draws=100, tune=50, cores=1, discard_tuned_samples=discard)
+            assert trace.report.n_tune == 50
+            assert trace.report.n_draws == 100
+            assert isinstance(trace.report.t_sampling, float)
+        pass
+
     @pytest.mark.parametrize('cores', [1, 2])
     def test_sampler_stat_tune(self, cores):
         with self.model:

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -131,7 +131,25 @@ class TestSample(SeededTest):
     def test_trace_report(self, discard):
         with self.model:
             # make sure that n_tune is correct, regardless of the discard_tuned_samples setting
-            trace = pm.sample(draws=100, tune=50, cores=1, discard_tuned_samples=discard)
+            trace = pm.sample(
+                draws=100, tune=50, cores=1,
+                discard_tuned_samples=discard
+            )
+            assert trace.report.n_tune == 50
+            assert trace.report.n_draws == 100
+            assert isinstance(trace.report.t_sampling, float)
+        pass
+
+    @pytest.mark.parametrize("discard", [True, False])
+    def test_trace_report_without_tune_stat(self, discard):
+        with self.model:
+            # make sure that n_tune is correct, regardless of the discard_tuned_samples setting,
+            # even if the 'tune' stat is unavailable
+            # (inaccurate on KeyboardInterrupt)
+            trace = pm.sample(
+                draws=100, tune=50, cores=1,
+                discard_tuned_samples=discard, step=pm.Slice()
+            )
             assert trace.report.n_tune == 50
             assert trace.report.n_draws == 100
             assert isinstance(trace.report.t_sampling, float)

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -127,28 +127,16 @@ class TestSample(SeededTest):
             trace = pm.sample(draws=100, tune=50, cores=4)
             assert len(trace) == 100
 
+    @pytest.mark.parametrize("step_cls", [pm.NUTS, pm.Metropolis, pm.Slice])
     @pytest.mark.parametrize("discard", [True, False])
-    def test_trace_report(self, discard):
+    def test_trace_report(self, step_cls, discard):
         with self.model:
-            # make sure that n_tune is correct, regardless of the discard_tuned_samples setting
+            # add more variables, because stats are 2D with CompoundStep!
+            pm.Uniform('uni')
             trace = pm.sample(
                 draws=100, tune=50, cores=1,
-                discard_tuned_samples=discard
-            )
-            assert trace.report.n_tune == 50
-            assert trace.report.n_draws == 100
-            assert isinstance(trace.report.t_sampling, float)
-        pass
-
-    @pytest.mark.parametrize("discard", [True, False])
-    def test_trace_report_without_tune_stat(self, discard):
-        with self.model:
-            # make sure that n_tune is correct, regardless of the discard_tuned_samples setting,
-            # even if the 'tune' stat is unavailable
-            # (inaccurate on KeyboardInterrupt)
-            trace = pm.sample(
-                draws=100, tune=50, cores=1,
-                discard_tuned_samples=discard, step=pm.Slice()
+                discard_tuned_samples=discard,
+                step=step_cls()
             )
             assert trace.report.n_tune == 50
             assert trace.report.n_draws == 100


### PR DESCRIPTION
This PR adds three new (optional) properties to `SamplerReport`:
+ `n_tune`: Number of tune iterations.
+ `n_draws`: Number of draw iterations.
+ `t_sampling`: Number of seconds that the sampling procedure took. (Includes parallelization overhead.)

While `n_draws` may be retrieved from the trace, information about `n_tune` is lost unless `discard_tuned_samples=True`. However, ArviZ currently does not look at the `"tune"` sampler stat, making it very inconvenient to keep tuning iterations and use ArviZ at the same time.

The `t_sampling` (wall-clock) time is not kept automatically, but super useful for comparing sampler efficiency. We could also use it directly in the benchmarks..

I've included it in the `_log_summary` at `INFO` level:
![image](https://user-images.githubusercontent.com/5894642/76110106-2b2d7800-5fde-11ea-8281-eeb925ac5969.png)

What do you think?