### PR TITLE
Closes #3051 - logp numpy array input- fixed

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -327,7 +327,7 @@ class MvNormal(_QuadFormBase):
         TensorVariable
         """
         quaddist, logdet, ok = self._quaddist(value)
-        k = value.shape[-1].astype(theano.config.floatX)
+        k = theano.shared(value).shape[-1].astype(theano.config.floatX)
         norm = - 0.5 * k * pm.floatX(np.log(2 * np.pi))
         return bound(norm - 0.5 * quaddist - logdet, ok)
 
@@ -441,7 +441,7 @@ class MvStudentT(_QuadFormBase):
         TensorVariable
         """
         quaddist, logdet, ok = self._quaddist(value)
-        k = value.shape[-1].astype(theano.config.floatX)
+        k = theano.shared(value).shape[-1].astype(theano.config.floatX)
 
         norm = (gammaln((self.nu + k) / 2.)
                 - gammaln(self.nu / 2.)


### PR DESCRIPTION
Converts 'int' type to <TensorType(int64,Scalar)> to parse value to `astype` and allows arguments to `logp(self,value)` when called with numpy array.