### PR TITLE
Change draws and tune defaults to 1000 in pm.sample

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,7 +3,6 @@
 ## PyMC3 3.9 (On deck)
 
 ### New features
-- `pm.sample` now takes 1000 draws and 1000 tuning samples by default, instead of 500 previously (see [#3855](https://github.com/pymc-devs/pymc3/pull/3855)).
 - use [fastprogress](https://github.com/fastai/fastprogress) instead of tqdm [#3693](https://github.com/pymc-devs/pymc3/pull/3693)
 - `DEMetropolis` can now tune both `lambda` and `scaling` parameters, but by default neither of them are tuned. See [#3743](https://github.com/pymc-devs/pymc3/pull/3743) for more info.
 - `DEMetropolisZ`, an improved variant of `DEMetropolis` brings better parallelization and higher efficiency with fewer chains with a slower initial convergence. This implementation is experimental. See [#3784](https://github.com/pymc-devs/pymc3/pull/3784) for more info.
@@ -16,7 +15,8 @@
 - Remove `sample_ppc` and `sample_ppc_w` that were deprecated in 3.6.
 - Tuning results no longer leak into sequentially sampled `Metropolis` chains (see #3733 and #3796).
 - Deprecated `sd` in version 3.7 has been replaced by `sigma` now raises `DepreciationWarning` on using `sd` in continuous, mixed and timeseries distributions. (see #3837 and #3688).
-- In named models, `pm.Data` objects now get model-relative names (see [#3843](https://github.com/pymc-devs/pymc3/pull/3843))
+- In named models, `pm.Data` objects now get model-relative names (see [#3843](https://github.com/pymc-devs/pymc3/pull/3843)).
+- `pm.sample` now takes 1000 draws and 1000 tuning samples by default, instead of 500 previously (see [#3855](https://github.com/pymc-devs/pymc3/pull/3855)).
 
 ## PyMC3 3.8 (November 29 2019)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,7 @@
 ## PyMC3 3.9 (On deck)
 
 ### New features
+- `pm.sample` now takes 1000 draws and 1000 tuning samples by default, instead of 500 previously (see [#3855](https://github.com/pymc-devs/pymc3/pull/3855)).
 - use [fastprogress](https://github.com/fastai/fastprogress) instead of tqdm [#3693](https://github.com/pymc-devs/pymc3/pull/3693)
 - `DEMetropolis` can now tune both `lambda` and `scaling` parameters, but by default neither of them are tuned. See [#3743](https://github.com/pymc-devs/pymc3/pull/3743) for more info.
 - `DEMetropolisZ`, an improved variant of `DEMetropolis` brings better parallelization and higher efficiency with fewer chains with a slower initial convergence. This implementation is experimental. See [#3784](https://github.com/pymc-devs/pymc3/pull/3784) for more info.

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -237,7 +237,7 @@ def sample(
     chain_idx=0,
     chains=None,
     cores=None,
-    tune=2000,
+    tune=1000,
     progressbar=True,
     model=None,
     random_seed=None,
@@ -305,7 +305,7 @@ def sample(
         The number of chains to run in parallel. If ``None``, set to the number of CPUs in the
         system, but at most 4.
     tune: int
-        Number of iterations to tune, defaults to 2000. Samplers adjust the step sizes, scalings or
+        Number of iterations to tune, defaults to 1000. Samplers adjust the step sizes, scalings or
         similar during tuning. Tuning samples will be drawn in addition to the number specified in
         the ``draws`` argument, and will be discarded unless ``discard_tuned_samples`` is set to
         False.

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -228,7 +228,7 @@ def _print_step_hierarchy(s, level=0):
 
 
 def sample(
-    draws=500,
+    draws=1000,
     step=None,
     init="auto",
     n_init=200000,
@@ -237,7 +237,7 @@ def sample(
     chain_idx=0,
     chains=None,
     cores=None,
-    tune=500,
+    tune=2000,
     progressbar=True,
     model=None,
     random_seed=None,
@@ -253,7 +253,7 @@ def sample(
     Parameters
     ----------
     draws: int
-        The number of samples to draw. Defaults to 500. The number of tuned samples are discarded
+        The number of samples to draw. Defaults to 1000. The number of tuned samples are discarded
         by default. See ``discard_tuned_samples``.
     init: str
         Initialization method to use for auto-assigned NUTS samplers.
@@ -305,7 +305,7 @@ def sample(
         The number of chains to run in parallel. If ``None``, set to the number of CPUs in the
         system, but at most 4.
     tune: int
-        Number of iterations to tune, defaults to 500. Samplers adjust the step sizes, scalings or
+        Number of iterations to tune, defaults to 2000. Samplers adjust the step sizes, scalings or
         similar during tuning. Tuning samples will be drawn in addition to the number specified in
         the ``draws`` argument, and will be discarded unless ``discard_tuned_samples`` is set to
         False.
@@ -362,7 +362,7 @@ def sample(
         >>> with pm.Model() as model: # context management
         ...     p = pm.Beta('p', alpha=alpha, beta=beta)
         ...     y = pm.Binomial('y', n=n, p=p, observed=h)
-        ...     trace = pm.sample(2000, tune=1000, cores=4)
+        ...     trace = pm.sample()
         >>> pm.summary(trace)
                mean        sd  mc_error   hpd_2.5  hpd_97.5
         p  0.604625  0.047086   0.00078  0.510498  0.694774
@@ -1103,10 +1103,10 @@ class PopulationStepper:
 
 
 def _prepare_iter_population(
-    draws:int,
-    chains:list,
+    draws: int,
+    chains: list,
     step,
-    start:list,
+    start: list,
     parallelize:bool,
     tune=None,
     model=None,
@@ -1303,14 +1303,14 @@ def _choose_backend(trace, chain, shortcuts=None, **kwds):
 
 
 def _mp_sample(
-    draws:int,
-    tune:int,
+    draws: int,
+    tune: int,
     step,
-    chains:int,
-    cores:int,
-    chain:int,
-    random_seed:list,
-    start:list,
+    chains: int,
+    cores: int,
+    chain: int,
+    random_seed: list,
+    start: list,
     progressbar=True,
     trace=None,
     model=None,


### PR DESCRIPTION
As discussed in #3854, this PR proposes to change defaults values of `draws` and `tune` in `pm.sample` to 1000 and 2000 respectively -- both are currently at 500.
I also cleaned some PEP8 typos in sampling.py.
Happy to make deeper changes if needed, and thanks in advance for the reviews ✌️ 