### PR TITLE
Add QuadPotentialFullAdapt in pm.sample init

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,7 @@
 - Add `fast_sample_posterior_predictive`, a vectorized alternative to `sample_posterior_predictive`.  This alternative is substantially faster for large models.
 - `sample_posterior_predictive` can now feed on `xarray.Dataset` - e.g. from `InferenceData.posterior`. (see [#3846](https://github.com/pymc-devs/pymc3/pull/3846))
 - `SamplerReport` (`MultiTrace.report`) now has properties `n_tune`, `n_draws`, `t_sampling` for increased convenience (see [#3827](https://github.com/pymc-devs/pymc3/pull/3827))
+- `pm.sample` now has support for adapting dense mass matrix using `QuadPotentialFullAdapt` (see [#3596](https://github.com/pymc-devs/pymc3/pull/3596), [#3705](https://github.com/pymc-devs/pymc3/pull/3705) and [#3858](https://github.com/pymc-devs/pymc3/pull/3858))
 
 ### Maintenance
 - Remove `sample_ppc` and `sample_ppc_w` that were deprecated in 3.6.

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -275,6 +275,7 @@ def sample(
         * advi_map: Initialize ADVI with MAP and use MAP as starting point.
         * map: Use the MAP as starting point. This is discouraged.
         * nuts: Run NUTS and estimate posterior mean and mass matrix from the trace.
+        * adapt_full: Adapt a dense mass matrix using the sample covariances
     step: function or iterable of functions
         A step function or collection of functions. If there are variables without step methods,
         step methods for those variables will be assigned automatically.  By default the NUTS step
@@ -1866,6 +1867,7 @@ def init_nuts(
         * map: Use the MAP as starting point. This is discouraged.
         * nuts: Run NUTS and estimate posterior mean and mass matrix from
           the trace.
+        * adapt_full: Adapt a dense mass matrix using the sample covariances
     chains: int
         Number of jobs to start.
     n_init: int
@@ -2006,6 +2008,11 @@ def init_nuts(
         cov = np.atleast_1d(pm.trace_cov(init_trace))
         start = list(np.random.choice(init_trace, chains))
         potential = quadpotential.QuadPotentialFull(cov)
+    elif init == "adapt_full":
+        start = [model.test_point] * chains
+        mean = np.mean([model.dict_to_array(vals) for vals in start], axis=0)
+        cov = np.ones((model.ndim, model.ndim))
+        potential = quadpotential.QuadPotentialFullAdapt(model.ndim, mean, cov, 10)
     else:
         raise ValueError("Unknown initializer: {}.".format(init))
 


### PR DESCRIPTION
Fixes #3845 
@ColCarroll @twiecki @eigenfoo  I have tried to add `QuadPotentialFullAdapt` to the `pm.sample`. Since I have no experience with this type of sampling, I am not sure whether the initialized mean and covariance are correct. It would be great if you could guide me a little, I'll update the PR with correct initializations. 
Do I also need to add tests for this?