### PR TITLE
Documentation sample plot for Rice distribution docs

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3884,6 +3884,23 @@ class Rice(PositiveContinuous):
        {\frac  {x}{\sigma ^{2}}}\exp
        \left({\frac  {-(x^{2}+\nu ^{2})}{2\sigma ^{2}}}\right)I_{0}\left({\frac  {x\nu }{\sigma ^{2}}}\right),
 
+    .. plot::
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import scipy.stats as st
+        plt.style.use('seaborn-darkgrid')
+        x = np.linspace(0, 8, 500)
+        nus = [0., 0., 2., 4.]
+        sigmas = [1., 2., 2., 1.]
+        for nu, sigma in  zip(nus, sigmas):
+            pdf = st.rice.pdf(x, nu, scale=sigma)
+            plt.plot(x, pdf, label=r'$\nu$ = {}, $\sigma$ = {}'.format(nu, sigma))
+        plt.xlabel('x', fontsize=12)
+        plt.ylabel('f(x)', fontsize=12)
+        plt.legend(loc=1)
+        plt.show()
+
     ========  ==============================================================
     Support   :math:`x \in (0, \infty)`
     Mean      :math:`\sigma {\sqrt  {\pi /2}}\,\,L_{{1/2}}(-\nu ^{2}/2\sigma ^{2})`

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3891,10 +3891,10 @@ class Rice(PositiveContinuous):
         import scipy.stats as st
         plt.style.use('seaborn-darkgrid')
         x = np.linspace(0, 8, 500)
-        nus = [0., 0., 2., 4.]
+        nus = [0., 0., 4., 4.]
         sigmas = [1., 2., 2., 1.]
         for nu, sigma in  zip(nus, sigmas):
-            pdf = st.rice.pdf(x, nu, scale=sigma)
+            pdf = st.rice.pdf(x, nu / sigma, scale=sigma)
             plt.plot(x, pdf, label=r'$\nu$ = {}, $\sigma$ = {}'.format(nu, sigma))
         plt.xlabel('x', fontsize=12)
         plt.ylabel('f(x)', fontsize=12)

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3892,7 +3892,7 @@ class Rice(PositiveContinuous):
         plt.style.use('seaborn-darkgrid')
         x = np.linspace(0, 8, 500)
         nus = [0., 0., 4., 4.]
-        sigmas = [1., 2., 2., 1.]
+        sigmas = [1., 2., 1., 2.]
         for nu, sigma in  zip(nus, sigmas):
             pdf = st.rice.pdf(x, nu / sigma, scale=sigma)
             plt.plot(x, pdf, label=r'$\nu$ = {}, $\sigma$ = {}'.format(nu, sigma))


### PR DESCRIPTION
Per issue #3860 I added a sample plot (image below) to the Rice distribution docstring. Hopefully the parameter values seem reasonable.

![rice-continuous](https://user-images.githubusercontent.com/15817526/77905855-e1534d00-727e-11ea-8d92-b683b5cf2768.png)


