### PR TITLE
use inference data in end of sampling report

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,8 @@
 - Dropped the outdated 'nuts' initialization method for `pm.sample` (see [#3863](https://github.com/pymc-devs/pymc3/pull/3863)).
 - Moved argument division out of `NegativeBinomial` `random` method. Fixes [#3864](https://github.com/pymc-devs/pymc3/issues/3864) in the style of [#3509](https://github.com/pymc-devs/pymc3/pull/3509).
 - The Dirichlet distribution now raises a ValueError when it's initialized with <= 0 values (see [#3853](https://github.com/pymc-devs/pymc3/pull/3853)).
+- End of sampling report now uses `arviz.InferenceData` internally and avoids storing
+  pointwise log likelihood (see [#3883](https://github.com/pymc-devs/pymc3/pull/3883))
 
 ## PyMC3 3.8 (November 29 2019)
 

--- a/pymc3/backends/report.py
+++ b/pymc3/backends/report.py
@@ -87,7 +87,7 @@ class SamplerReport:
     def t_sampling(self) -> typing.Optional[float]:
         """
         Number of seconds that the sampling procedure took.
-        
+
         (Includes parallelization overhead.)
         """
         return self._t_sampling
@@ -108,6 +108,7 @@ class SamplerReport:
             return
 
         from pymc3 import rhat, ess
+        from arviz import from_pymc3
 
         valid_name = [rv.name for rv in model.free_RVs + model.deterministics]
         varnames = []
@@ -119,8 +120,9 @@ class SamplerReport:
             if rv_name in trace.varnames:
                 varnames.append(rv_name)
 
-        self._ess = ess = ess(trace, var_names=varnames)
-        self._rhat = rhat = rhat(trace, var_names=varnames)
+        idata = from_pymc3(trace, log_likelihood=False)
+        self._ess = ess = ess(idata, var_names=varnames)
+        self._rhat = rhat = rhat(idata, var_names=varnames)
 
         warnings = []
         rhat_max = max(val.max() for val in rhat.values())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arviz>=0.4.1
+arviz>=0.7.0
 theano>=1.0.4
 numpy>=1.13.0
 scipy>=0.18.1
@@ -7,4 +7,4 @@ patsy>=0.5.1
 fastprogress>=0.2.0
 h5py>=2.7.0
 typing-extensions>=3.7.4
-contextvars; python_version < '3.7' 
+contextvars; python_version < '3.7'


### PR DESCRIPTION
Current code calls `az.ess` and `az.rhat` using trace objects instead of inference data objects. ArviZ therefore converts the trace to inferencedata object twice. This is generally not an issue and it is barely noticeable unless the number of observations is large, in which case the conversion (and consequent retrieving of pointwise log likelihood data) can be quite memory expensive. Below there is memory usage in an example (courtesy of @nitishp25) where the effect is quite noticeable:

![image](https://user-images.githubusercontent.com/23738400/79503494-8a48c880-8031-11ea-8a7d-5a4d000dc250.png)

This PR explicits the conversion to inferencedata so it only happens once, and if possible, skips retrieving the pointwise log likelihood data (which is not needed for ess nor rhat calculation).

