### PR TITLE
add a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+
+## Description
+
+**Please provide a short abstract motivating your pull request.**
+
+
+## Breaking changes
++ *list all breaking changes that this PR introduces*
+
+## Backwards-compatible changes
++ *list all backwards-compatible changes that this PR introduces*
+
+## Details
+
+**For non-trivial PRs, please explain the background and implementation details.**
+
+## PR checklist
++ [ ] are the changes covered by tests?
++ [ ] re-run example notebooks if they are effected in a relevant way
++ [ ] **mention the PR in the RELEASE-NOTES.md**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 
 Depending on what your PR does, here are a few things you might want to address in the description:
 + [ ] what are the (breaking) changes that this PR makes?
-+ [ ] important background, or a details about the implementation
++ [ ] background about the implementation: what, why, how?
 + [ ] are the changes covered by tests? 
 + [ ] are example-notebooks affected in a relevant way?
 + [ ] describe the change and link to the PR in the RELEASE-NOTES.md

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,9 @@
 
-## Description
+**Thank your for opening a PR!**
 
-**Please provide a short abstract motivating your pull request.**
-
-
-## Breaking changes
-+ *list all breaking changes that this PR introduces*
-
-## Backwards-compatible changes
-+ *list all backwards-compatible changes that this PR introduces*
-
-## Details
-
-**For non-trivial PRs, please explain the background and implementation details.**
-
-## PR checklist
-+ [ ] are the changes covered by tests?
-+ [ ] re-run example notebooks if they are effected in a relevant way
-+ [ ] **mention the PR in the RELEASE-NOTES.md**
+Depending on what your PR does, here are a few things you might want to address in the description:
++ [ ] what are the (breaking) changes that this PR makes?
++ [ ] important background, or a details about the implementation
++ [ ] are the changes covered by tests? 
++ [ ] are example-notebooks affected in a relevant way?
++ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,4 @@ Depending on what your PR does, here are a few things you might want to address 
 + [ ] important background, or a details about the implementation
 + [ ] are the changes covered by tests? 
 + [ ] are example-notebooks affected in a relevant way?
-+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
++ [ ] describe the change and link to the PR in the RELEASE-NOTES.md


### PR DESCRIPTION
It looks like there are many ways to set up PR templates, even with the possibility of having different templates for the user to choose from (bugfix template, feature template...).

Read more in the documentation: https://help.github.com/en/github/building-a-strong-community/using-templates-to-encourage-useful-issues-and-pull-requests

To to begin, I just added one template for all.

+ [x] what are the (breaking) changes that this PR makes? -- does not apply
+ [x] important background, or a details about the implementation
+ [x] are the changes covered by tests? -- does not apply
+ [x] are example-notebooks affected in a relevant way? -- does not apply
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md -- we don't usually mention repository maintenance in the release notes