### PR TITLE
Import warnings module in timeseries.py.

### DIFF
--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import warnings
+
 from scipy import stats
 import theano.tensor as tt
 from theano import scan


### PR DESCRIPTION
Not sure why this worked before, does warnings need an import only on certain python versions? Anyway, got an error without that line trying to use RandomWalk.