### PR TITLE
Omit test files from coverage calculation

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit =
+    # exclude tests files from coverage calculation
+    pymc3/tests/test_*.py


### PR DESCRIPTION
Our coverage job in PRs often fails, because coveralls messes up.

The fact that we include test files in the coverage calculation may contribute to these failures.

By adding a `.coveragerc` configuration file, we can omit `test_*` files from the coverage report.

**Do we want this?** Does it help?

+ [x] changes: a huge change in our coverage percentage
+ [x] background: `pytest-cov` takes just very few CLI arguments, hence the configuration file
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
