### PR TITLE
Change AR1 likelihood to have correct variance for first observation

### DIFF
--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -73,9 +73,12 @@ class AR1(distribution.Continuous):
 
         x_im1 = x[:-1]
         x_i = x[1:]
-        boundary = Normal.dist(0., tau=tau_e).logp
 
-        innov_like = Normal.dist(k * x_im1, tau=tau_e).logp(x_i)
+        var_ar1 = 1 / ((1-k**2)*tau_e) #the variance of an AR(1) process
+        sd_ar1 = tt.sqrt(var_ar1) #the standard deviation of an AR(1) process
+        boundary = Normal.dist(0., sigma=sd_ar1).logp #likelihood of the first observation
+
+        innov_like = Normal.dist(k * x_im1, tau=tau_e).logp(x_i) #likelihood of all adjacent pairs of observations
         return boundary(x[0]) + tt.sum(innov_like)
 
     def _repr_latex_(self, name=None, dist=None):


### PR DESCRIPTION
Addressing https://github.com/pymc-devs/pymc3/issues/3892

Assuming the AR(1) process was initiated in the infinite past, the first observation can be anywhere in the dispersion of the AR(1) process. Previously, the likelihood of the first observation was calculated using the precision (1/variance) of the innovation term, which is much smaller than the variance of the whole AR(1) process. The correct variance of an AR(1) process is:

```
variance = 1/precision = 1 / (1-k**2)   
```
where `k` is the autocorrelation parameter. 

This just changes the definition of the likelihood of the first term to have the variance of the whole AR(1) process. 
cheers


