### PR TITLE
Always define the `diverging` variable in sampling generator

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -912,6 +912,7 @@ def _iter_sample(
             step.reset_tuning()
         for i in range(draws):
             stats = None
+            diverging = False
 
             if i == 0 and hasattr(step, "iter_count"):
                 step.iter_count = 0
@@ -927,7 +928,6 @@ def _iter_sample(
             else:
                 point = step.step(point)
                 strace.record(point)
-                diverging = False
             if callback is not None:
                 warns = getattr(step, "warnings", None)
                 callback(trace=strace, draw=Draw(chain, i == draws, i, i < tune, stats, point, warns))

--- a/pymc3/tests/test_text_backend.py
+++ b/pymc3/tests/test_text_backend.py
@@ -28,6 +28,11 @@ class TestTextSampling:
             db = text.Text(self.name)
             pm.sample(20, tune=10, init=None, trace=db, cores=2)
 
+    def test_supports_sampler_stats_diverging(self):
+        with pm.Model():
+            pm.Normal("mu", mu=0, sigma=1, shape=2)
+            pm.sample(20, tune=10, init=None, trace='text', cores=1)
+
     def teardown_method(self):
         bf.remove_file_or_directory(self.name)
 


### PR DESCRIPTION
The sampler generator has an unbound variable error when it uses a backend that doesn't support sampler statistics (e.g. the text backend).  This PR makes sure that the `diverging` variable is defined where it previously wasn't.
