### PR TITLE
Pin Matplotlib < 3.1.1 to avoid mutiprocessing MacOS error

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -27,7 +27,8 @@
 - Moved argument division out of `NegativeBinomial` `random` method. Fixes [#3864](https://github.com/pymc-devs/pymc3/issues/3864) in the style of [#3509](https://github.com/pymc-devs/pymc3/pull/3509).
 - The Dirichlet distribution now raises a ValueError when it's initialized with <= 0 values (see [#3853](https://github.com/pymc-devs/pymc3/pull/3853)).
 - End of sampling report now uses `arviz.InferenceData` internally and avoids storing
-  pointwise log likelihood (see [#3883](https://github.com/pymc-devs/pymc3/pull/3883))
+  pointwise log likelihood (see [#3883](https://github.com/pymc-devs/pymc3/pull/3883)).
+- To avoid crashing multiprocessing on MacOS, matplotlib dependency is pinned to versions < 3.1.1 until [the issue](https://github.com/matplotlib/matplotlib/issues/15410) is resolved (see [#3849](https://github.com/pymc-devs/pymc3/issues/3849)).
 
 ## PyMC3 3.8 (November 29 2019)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ coverage<5.0
 graphviz>=0.8.3
 ipython
 Keras>=2.0.8
-matplotlib<=3.1.0
 nbsphinx>=0.4.2
 nose>=1.3.7
 nose-parameterized==0.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ coverage<5.0
 graphviz>=0.8.3
 ipython
 Keras>=2.0.8
+matplotlib<=3.1.0
 nbsphinx>=0.4.2
 nose>=1.3.7
 nose-parameterized==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 arviz>=0.7.0
 fastprogress>=0.2.0
 h5py>=2.7.0
+matplotlib==3.1.0
 numpy>=1.13.0
 pandas>=0.18.0
 patsy>=0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 arviz>=0.7.0
 fastprogress>=0.2.0
 h5py>=2.7.0
-matplotlib<=3.1.0
 numpy>=1.13.0
 pandas>=0.18.0
 patsy>=0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 arviz>=0.7.0
-theano>=1.0.4
-numpy>=1.13.0
-scipy>=0.18.1
-pandas>=0.18.0
-patsy>=0.5.1
 fastprogress>=0.2.0
 h5py>=2.7.0
+matplotlib<=3.1.0
+numpy>=1.13.0
+pandas>=0.18.0
+patsy>=0.5.1
+scipy>=0.18.1
+theano>=1.0.4
 typing-extensions>=3.7.4
 contextvars; python_version < '3.7'

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -37,6 +37,7 @@ conda install --yes -c conda-forge python-graphviz
 
 # Uninstall then pin Matplotlib until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
 pip uninstall matplotlib --yes
+conda uninstall matplotlib --yes
 
 # Travis env is unable to import cached mpl sometimes https://github.com/pymc-devs/pymc3/issues/3423
 pip install --no-cache-dir --ignore-installed -e .

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -36,7 +36,7 @@ conda install --yes mkl-service
 conda install --yes -c conda-forge python-graphviz
 
 # Pin MPL until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
-pip uninstall matplotlib
+pip uninstall matplotlib --yes
 pip install "matplotlib==3.1.0"
 
 # Travis env is unable to import cached mpl sometimes https://github.com/pymc-devs/pymc3/issues/3423

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -35,10 +35,12 @@ pip install --upgrade pip
 conda install --yes mkl-service
 conda install --yes -c conda-forge python-graphviz
 
-# Uninstall then pin matplotlib until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
+# Uninstall the three matplotlibs present on conda env
 pip uninstall matplotlib --yes
-# Uninstall second matplotlib present on conda venv
 pip uninstall matplotlib --yes
+pip uninstall matplotlib --yes
+# Pin matplotlib until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
+pip install --force-reinstall "matplotlib==3.1.0"
 
 # Travis env is unable to import cached mpl sometimes https://github.com/pymc-devs/pymc3/issues/3423
 pip install --no-cache-dir --ignore-installed -e .

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -35,18 +35,17 @@ pip install --upgrade pip
 conda install --yes mkl-service
 conda install --yes -c conda-forge python-graphviz
 
-#  Install editable using the setup.py
+# Pin MPL until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
+pip install --no-cache-dir --force-reinstall "matplotlib<3.1.1"
 
 # Travis env is unable to import cached mpl sometimes https://github.com/pymc-devs/pymc3/issues/3423
 pip install --no-cache-dir --ignore-installed -e .
 pip install --no-cache-dir --ignore-installed -r requirements-dev.txt
 
-# Pin MPL until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
-pip install --no-cache-dir --force-reinstall "matplotlib<3.1.1"
-
 # Install untested, non-required code (linter fails without them)
 pip install ipython ipywidgets
 
+#  Install editable using the setup.py
 if [ -z ${NO_SETUP} ]; then
   python setup.py build_ext --inplace
 fi

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -35,9 +35,8 @@ pip install --upgrade pip
 conda install --yes mkl-service
 conda install --yes -c conda-forge python-graphviz
 
-# Pin MPL until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
+# Uninstall then pin Matplotlib until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
 pip uninstall matplotlib --yes
-pip install "matplotlib==3.1.0"
 
 # Travis env is unable to import cached mpl sometimes https://github.com/pymc-devs/pymc3/issues/3423
 pip install --no-cache-dir --ignore-installed -e .

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -35,7 +35,9 @@ pip install --upgrade pip
 conda install --yes mkl-service
 conda install --yes -c conda-forge python-graphviz
 
-# Uninstall then pin Matplotlib until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
+# Uninstall then pin matplotlib until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
+pip uninstall matplotlib --yes
+# Uninstall second matplotlib present on conda venv
 pip uninstall matplotlib --yes
 
 # Travis env is unable to import cached mpl sometimes https://github.com/pymc-devs/pymc3/issues/3423

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -36,7 +36,8 @@ conda install --yes mkl-service
 conda install --yes -c conda-forge python-graphviz
 
 # Pin MPL until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
-pip install --no-cache-dir --force-reinstall matplotlib==3.1.0
+pip uninstall matplotlib
+pip install "matplotlib==3.1.0"
 
 # Travis env is unable to import cached mpl sometimes https://github.com/pymc-devs/pymc3/issues/3423
 pip install --no-cache-dir --ignore-installed -e .

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -37,7 +37,6 @@ conda install --yes -c conda-forge python-graphviz
 
 # Uninstall then pin Matplotlib until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
 pip uninstall matplotlib --yes
-conda uninstall matplotlib --yes
 
 # Travis env is unable to import cached mpl sometimes https://github.com/pymc-devs/pymc3/issues/3423
 pip install --no-cache-dir --ignore-installed -e .

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -2,42 +2,38 @@
 
 set -ex # fail on first error, print commands
 
-while test $# -gt 0
-do
-    case "$1" in
-        --global)
-            GLOBAL=1
-            ;;
-        --no-setup)
-            NO_SETUP=1
-            ;;
-    esac
-    shift
+while test $# -gt 0; do
+  case "$1" in
+  --global)
+    GLOBAL=1
+    ;;
+  --no-setup)
+    NO_SETUP=1
+    ;;
+  esac
+  shift
 done
 
 command -v conda >/dev/null 2>&1 || {
-  echo "Requires conda but it is not installed.  Run install_miniconda.sh." >&2;
-  exit 1;
+  echo "Requires conda but it is not installed.  Run install_miniconda.sh." >&2
+  exit 1
 }
 
-ENVNAME="${ENVNAME:-testenv}" # if no ENVNAME is specified, use testenv
+ENVNAME="${ENVNAME:-testenv}"         # if no ENVNAME is specified, use testenv
 PYTHON_VERSION=${PYTHON_VERSION:-3.6} # if no python specified, use 3.6
 
-if [ -z ${GLOBAL} ]
-then
-    if conda env list | grep -q ${ENVNAME}
-    then
-      echo "Environment ${ENVNAME} already exists, keeping up to date"
-    else
-      conda create -n ${ENVNAME} --yes pip python=${PYTHON_VERSION}
-    fi
-    source activate ${ENVNAME}
+if [ -z ${GLOBAL} ]; then
+  if conda env list | grep -q ${ENVNAME}; then
+    echo "Environment ${ENVNAME} already exists, keeping up to date"
+  else
+    conda create -n ${ENVNAME} --yes pip python=${PYTHON_VERSION}
+  fi
+  source activate ${ENVNAME}
 fi
 pip install --upgrade pip
 
 conda install --yes mkl-service
 conda install --yes -c conda-forge python-graphviz
-
 
 #  Install editable using the setup.py
 
@@ -45,9 +41,12 @@ conda install --yes -c conda-forge python-graphviz
 pip install --no-cache-dir --ignore-installed -e .
 pip install --no-cache-dir --ignore-installed -r requirements-dev.txt
 
+# Pin MPL until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
+pip install --no-cache-dir --force-reinstall "matplotlib<3.1.1"
+
 # Install untested, non-required code (linter fails without them)
 pip install ipython ipywidgets
 
 if [ -z ${NO_SETUP} ]; then
-    python setup.py build_ext --inplace
+  python setup.py build_ext --inplace
 fi

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -36,7 +36,7 @@ conda install --yes mkl-service
 conda install --yes -c conda-forge python-graphviz
 
 # Pin MPL until https://github.com/matplotlib/matplotlib/issues/15410 is resolved
-pip install --no-cache-dir --force-reinstall "matplotlib<3.1.1"
+pip install --no-cache-dir --force-reinstall matplotlib==3.1.0
 
 # Travis env is unable to import cached mpl sometimes https://github.com/pymc-devs/pymc3/issues/3423
 pip install --no-cache-dir --ignore-installed -e .


### PR DESCRIPTION
This PR adresses #3849 by pinning Matplotlib to versions < 3.1.1. 
This avoids an issue that appeared in MPL 3.1.1, where multiprocessing crashes on MacOS when plotting code is executed before code using multiprocessing -- see [this issue](https://github.com/matplotlib/matplotlib/issues/15410) on MPL repo.

The pin should be removed only when the issue is resolved on MPL side.
Should we keep #3849 open though, as a reminder?

In passing, I reordered requirements.txt alphabetically, to mirror requirements-dev.txt

+ [x] No breaking changes
+ [x] Added to RELEASE-NOTES.md
