### PR TITLE
fix & specify type and shapes for plot_gp_dist

### DIFF
--- a/pymc3/gp/util.py
+++ b/pymc3/gp/util.py
@@ -83,17 +83,19 @@ def conditioned_vars(varnames):
     return gp_wrapper
 
 
-def plot_gp_dist(ax, samples, x, plot_samples=True, palette="Reds", fill_alpha=0.8, samples_alpha=0.1, fill_kwargs=None, samples_kwargs=None):
+def plot_gp_dist(ax, samples:np.ndarray, x:np.ndarray, plot_samples=True, palette="Reds", fill_alpha=0.8, samples_alpha=0.1, fill_kwargs=None, samples_kwargs=None):
     """ A helper function for plotting 1D GP posteriors from trace 
     
         Parameters
     ----------
     ax: axes
         Matplotlib axes.
-    samples: trace or list of traces
-        Trace(s) or posterior predictive sample from a GP.
-    x: array
+    samples: numpy.ndarray
+        Array of S posterior predictive sample from a GP.
+        Expected shape: (S, X)
+    x: numpy.ndarray
         Grid of X values corresponding to the samples. 
+        Expected shape: (X,) or (X, 1), or (1, X)
     plot_samples: bool
         Plot the GP samples along with posterior (defaults True).
     palette: str

--- a/pymc3/gp/util.py
+++ b/pymc3/gp/util.py
@@ -15,6 +15,7 @@
 from scipy.cluster.vq import kmeans
 import numpy as np
 import theano.tensor as tt
+import warnings
 
 cholesky = tt.slinalg.cholesky
 solve_lower = tt.slinalg.Solve(A_structure='lower_triangular')
@@ -120,6 +121,12 @@ def plot_gp_dist(ax, samples:np.ndarray, x:np.ndarray, plot_samples=True, palett
         fill_kwargs = {}
     if samples_kwargs is None:
         samples_kwargs = {}
+    if np.any(np.isnan(samples)):
+        warnings.warn(
+            'There are `nan` entries in the [samples] arguments. '
+            'The plot will not contain a band!',
+            UserWarning
+        )
 
     cmap = plt.get_cmap(palette)
     percs = np.linspace(51, 99, 40)

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -247,6 +247,7 @@ class TestCovProd:
         with pytest.raises(ValueError, match=r"cannot combine"):
             cov = M + pm.gp.cov.ExpQuad(1, 1.)
 
+
 class TestCovExponentiation:
     def test_symexp_cov(self):
         X = np.linspace(0, 1, 10)[:, None]
@@ -538,6 +539,7 @@ class TestMatern12:
         npt.assert_allclose(K[0, 1], 0.32919, atol=1e-3)
         Kd = theano.function([],cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
+
 
 class TestCosine:
     def test_1d(self):
@@ -1142,3 +1144,19 @@ class TestMarginalKron:
                                      cov_funcs=self.cov_funcs)
         with pytest.raises(TypeError):
             gp1 + gp2
+
+
+class TestUtil:
+    def test_plot_gp_dist(self):
+        """Test that the plotting helper works with the stated input shapes."""
+        import matplotlib.pyplot as plt
+        X = 100
+        S = 500
+        fig, ax = plt.subplots()
+        pm.gp.util.plot_gp_dist(
+            ax,
+            x=np.linspace(0, 50, X),
+            samples=np.random.normal(np.arange(X), size=(S, X))
+        )
+        plt.close()
+        pass

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -1160,3 +1160,20 @@ class TestUtil:
         )
         plt.close()
         pass
+
+    def test_plot_gp_dist_warn_nan(self):
+        """Test that the plotting helper works with the stated input shapes."""
+        import matplotlib.pyplot as plt
+        X = 100
+        S = 500
+        samples = np.random.normal(np.arange(X), size=(S, X))
+        samples[15, 3] = np.nan
+        fig, ax = plt.subplots()
+        with pytest.warns(UserWarning):
+            pm.gp.util.plot_gp_dist(
+                ax,
+                x=np.linspace(0, 50, X),
+                samples=samples
+            )
+        plt.close()
+        pass


### PR DESCRIPTION
I got annoyed to figure tout the input shapes every time I want to use the function..

* stated shapes in the docstring
* fixed the type hints - list/multitrace wasn't actually supported, as `samples.T` and `x.flatten()` assume numpy arrays
* added a test that at least checks that it works with the stated input shape
* warn about `nan` entries in the samples that cause the band-plotting to fail

+ [x] no breaking changes
+ [x] tests
+ [x] mention the PR in the RELEASE-NOTES.md not worth the effort