### PR TITLE
Replaced ignore-installed flag by force-reinstall in create_testenv.sh

### DIFF
--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -2,52 +2,47 @@
 
 set -ex # fail on first error, print commands
 
-while test $# -gt 0
-do
-    case "$1" in
-        --global)
-            GLOBAL=1
-            ;;
-        --no-setup)
-            NO_SETUP=1
-            ;;
-    esac
-    shift
+while test $# -gt 0; do
+  case "$1" in
+  --global)
+    GLOBAL=1
+    ;;
+  --no-setup)
+    NO_SETUP=1
+    ;;
+  esac
+  shift
 done
 
 command -v conda >/dev/null 2>&1 || {
-  echo "Requires conda but it is not installed.  Run install_miniconda.sh." >&2;
-  exit 1;
+  echo "Requires conda but it is not installed.  Run install_miniconda.sh." >&2
+  exit 1
 }
 
-ENVNAME="${ENVNAME:-testenv}" # if no ENVNAME is specified, use testenv
+ENVNAME="${ENVNAME:-testenv}"         # if no ENVNAME is specified, use testenv
 PYTHON_VERSION=${PYTHON_VERSION:-3.6} # if no python specified, use 3.6
 
-if [ -z ${GLOBAL} ]
-then
-    if conda env list | grep -q ${ENVNAME}
-    then
-      echo "Environment ${ENVNAME} already exists, keeping up to date"
-    else
-      conda create -n ${ENVNAME} --yes pip python=${PYTHON_VERSION}
-    fi
-    source activate ${ENVNAME}
+if [ -z ${GLOBAL} ]; then
+  if conda env list | grep -q ${ENVNAME}; then
+    echo "Environment ${ENVNAME} already exists, keeping up to date"
+  else
+    conda create -n ${ENVNAME} --yes pip python=${PYTHON_VERSION}
+  fi
+  source activate ${ENVNAME}
 fi
 pip install --upgrade pip
 
 conda install --yes mkl-service
 conda install --yes -c conda-forge python-graphviz
 
-
-#  Install editable using the setup.py
-
 # Travis env is unable to import cached mpl sometimes https://github.com/pymc-devs/pymc3/issues/3423
-pip install --no-cache-dir --ignore-installed -e .
-pip install --no-cache-dir --ignore-installed -r requirements-dev.txt
+pip install --no-cache-dir --force-reinstall -e .
+pip install --no-cache-dir --force-reinstall -r requirements-dev.txt
 
 # Install untested, non-required code (linter fails without them)
 pip install ipython ipywidgets
 
+#  Install editable using the setup.py
 if [ -z ${NO_SETUP} ]; then
-    python setup.py build_ext --inplace
+  python setup.py build_ext --inplace
 fi


### PR DESCRIPTION
Very simple PR that replaces the `ignore-installed` flag by `force-reinstall` in `create_testenv.sh`. 
As discussed in #3912, this is safer as it will uninstall previous versions of packaging before installing new ones, therefore avoiding having multiple versions of the same package in the test suite's virtual env.
In passing, I reformatted the file appropriately.

+ [x] No breaking changes
+ [x] Too trivial for RELEASE-NOTES.md
