### PR TITLE
Set start method to forkserver for MacOS

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,9 +21,10 @@
 - `pm.sample` now takes 1000 draws and 1000 tuning samples by default, instead of 500 previously (see [#3855](https://github.com/pymc-devs/pymc3/pull/3855)).
 - Moved argument division out of `NegativeBinomial` `random` method. Fixes [#3864](https://github.com/pymc-devs/pymc3/issues/3864) in the style of [#3509](https://github.com/pymc-devs/pymc3/pull/3509).
 - The Dirichlet distribution now raises a ValueError when it's initialized with <= 0 values (see [#3853](https://github.com/pymc-devs/pymc3/pull/3853)).
-- Dtype bugfix in `MvNormal` and `MvStudentT` (see [3836](https://github.com/pymc-devs/pymc3/pull/3836))
+- Dtype bugfix in `MvNormal` and `MvStudentT` (see [3836](https://github.com/pymc-devs/pymc3/pull/3836)).
 - End of sampling report now uses `arviz.InferenceData` internally and avoids storing
-  pointwise log likelihood (see [#3883](https://github.com/pymc-devs/pymc3/pull/3883))
+  pointwise log likelihood (see [#3883](https://github.com/pymc-devs/pymc3/pull/3883)).
+- The multiprocessing start method on MacOS is now set to "forkserver", to avoid crashes (see issue [#3849](https://github.com/pymc-devs/pymc3/issues/3849), solved by [#3919](https://github.com/pymc-devs/pymc3/pull/3919)).
 
 ### Deprecations
 - Remove `sample_ppc` and `sample_ppc_w` that were deprecated in 3.6.

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -16,6 +16,8 @@
 __version__ = "3.8"
 
 import logging
+import multiprocessing as mp
+import platform
 
 _log = logging.getLogger("pymc3")
 
@@ -25,10 +27,13 @@ if not logging.root.handlers:
         handler = logging.StreamHandler()
         _log.addHandler(handler)
 
+sys = platform.system()
+if sys == "Darwin":
+    _ = mp.get_context("forkserver")
+
 
 def __set_compiler_flags():
     # Workarounds for Theano compiler problems on various platforms
-    import platform
     import theano
 
     system = platform.system()

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -27,9 +27,11 @@ if not logging.root.handlers:
         handler = logging.StreamHandler()
         _log.addHandler(handler)
 
+# Set start method to forkserver for MacOS to enable multiprocessing
+# Closes issue https://github.com/pymc-devs/pymc3/issues/3849
 sys = platform.system()
 if sys == "Darwin":
-    _ = mp.get_context("forkserver")
+    new_context = mp.get_context("forkserver")
 
 
 def __set_compiler_flags():


### PR DESCRIPTION
As discussed in #3912 with @lucianopaz and @twiecki, this PR sets the start method to `forkserver` when the platform is MacOS. This is intended to solve #3849.

As this is implemented in `setup.py`, the new start method is modified each time users import PyMC3, but it does it smoothly by using `multiprocessing.get_context` instead of `multiprocessing.set_start_method`. From the [python docs](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods):

> A library which wants to use a particular start method should probably use `get_context()` to avoid interfering with the choice of the library user.

I did some raw tests locally and this does work!

+ [x] No breaking changes (that I know of)
+ [x] Added to RELEASE-NOTES.md
