### PR TITLE
MAINT: omit examples from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,3 @@ omit =
     # exclude tests files from coverage calculation
     pymc3/tests/test_*.py
     pymc3/examples/*
-    pymc3/tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,5 @@
 omit =
     # exclude tests files from coverage calculation
     pymc3/tests/test_*.py
+    pymc3/examples/*
+    pymc3/tests/*


### PR DESCRIPTION
I don't think we should be testing examples or tests for coverage.