### PR TITLE
Cap the values that Beta.random can generate.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,7 @@
 - End of sampling report now uses `arviz.InferenceData` internally and avoids storing
   pointwise log likelihood (see [#3883](https://github.com/pymc-devs/pymc3/pull/3883)).
 - The multiprocessing start method on MacOS is now set to "forkserver", to avoid crashes (see issue [#3849](https://github.com/pymc-devs/pymc3/issues/3849), solved by [#3919](https://github.com/pymc-devs/pymc3/pull/3919)).
+- Forced the `Beta` distribution's `random` method to generate samples that are in the open interval $(0, 1)$, i.e. no value can be equal to zero or equal to one (issue [#3898](https://github.com/pymc-devs/pymc3/issues/3898) fixed by [#3922](https://github.com/pymc-devs/pymc3/pull/3919)).
 
 ### Deprecations
 - Remove `sample_ppc` and `sample_ppc_w` that were deprecated in 3.6.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,7 +25,7 @@
 - End of sampling report now uses `arviz.InferenceData` internally and avoids storing
   pointwise log likelihood (see [#3883](https://github.com/pymc-devs/pymc3/pull/3883)).
 - The multiprocessing start method on MacOS is now set to "forkserver", to avoid crashes (see issue [#3849](https://github.com/pymc-devs/pymc3/issues/3849), solved by [#3919](https://github.com/pymc-devs/pymc3/pull/3919)).
-- Forced the `Beta` distribution's `random` method to generate samples that are in the open interval $(0, 1)$, i.e. no value can be equal to zero or equal to one (issue [#3898](https://github.com/pymc-devs/pymc3/issues/3898) fixed by [#3922](https://github.com/pymc-devs/pymc3/pull/3919)).
+- Forced the `Beta` distribution's `random` method to generate samples that are in the open interval $(0, 1)$, i.e. no value can be equal to zero or equal to one (issue [#3898](https://github.com/pymc-devs/pymc3/issues/3898) fixed by [#3924](https://github.com/pymc-devs/pymc3/pull/3924)).
 
 ### Deprecations
 - Remove `sample_ppc` and `sample_ppc_w` that were deprecated in 3.6.

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -32,6 +32,7 @@ from ..math import invlogit, logit, logdiffexp
 from .dist_math import (
     alltrue_elemwise, betaln, bound, gammaln, i0e, incomplete_beta, logpow,
     normal_lccdf, normal_lcdf, SplineWrapper, std_cdf, zvalue,
+    clipped_beta_rvs,
 )
 from .distribution import (Continuous, draw_values, generate_samples)
 
@@ -1290,7 +1291,7 @@ class Beta(UnitContinuous):
         """
         alpha, beta = draw_values([self.alpha, self.beta],
                                   point=point, size=size)
-        return generate_samples(stats.beta.rvs, alpha, beta,
+        return generate_samples(clipped_beta_rvs, alpha, beta,
                                 dist_shape=self.shape,
                                 size=size)
 

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -593,6 +593,4 @@ def clipped_beta_rvs(a, b, size=None, dtype="float64"):
     """
     out = scipy.stats.beta.rvs(a, b, size=size).astype(dtype)
     lower, upper = _beta_clip_values[dtype]
-    out[out == 0] = lower
-    out[out == 1] = upper
-    return out
+    return np.maximum(np.minimum(out, upper), lower)

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -19,6 +19,7 @@ Created on Mar 7, 2011
 '''
 import numpy as np
 import scipy.linalg
+import scipy.stats
 import theano.tensor as tt
 import theano
 from theano.scalar import UnaryScalarOp, upgrade_to_float_no_complex
@@ -558,7 +559,7 @@ def incomplete_beta(a, b, value):
 def clipped_beta_rvs(a, b, size=None, dtype="float64"):
     """Draw beta distributed random samples in the open :math:`(0, 1)` interval.
 
-    The samples are generated with ``numpy.random.beta``, but any value that
+    The samples are generated with ``scipy.stats.beta.rvs``, but any value that
     is equal to 0 or 1 will be shifted towards the next floating point in the
     interval :math:`[0, 1]`, depending on the floating point precision that is
     given by ``dtype``.
@@ -566,9 +567,9 @@ def clipped_beta_rvs(a, b, size=None, dtype="float64"):
     Parameters
     ----------
     a : float or array_like of floats
-        Alpha, positive (>0).
+        Alpha, strictly positive (>0).
     b : float or array_like of floats
-        Beta, positive (>0).
+        Beta, strictly positive (>0).
     size : int or tuple of ints, optional
         Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
         ``m * n * k`` samples are drawn.  If size is ``None`` (default),
@@ -582,15 +583,15 @@ def clipped_beta_rvs(a, b, size=None, dtype="float64"):
     Returns
     -------
     out : ndarray or scalar
-        Drawn samples from the parameterized beta distribution. The numpy
+        Drawn samples from the parameterized beta distribution. The scipy
         implementation can yield values that are equal to zero or one. We
         assume the support of the Beta distribution to be in the open interval
         :math:`(0, 1)`, so we shift any sample that is equal to 0 to
         ``np.nextafter(0, 1, dtype=dtype)`` and any sample that is equal to 1
-        if shifted to ``np.nextafter(1, 0, dtype=dtype)``.
+        is shifted to ``np.nextafter(1, 0, dtype=dtype)``.
 
     """
-    out = np.random.beta(a, b, size=size).astype(dtype)
+    out = scipy.stats.beta.rvs(a, b, size=size).astype(dtype)
     lower, upper = _beta_clip_values[dtype]
     out[out == 0] = lower
     out[out == 1] = upper

--- a/pymc3/tests/test_dist_math.py
+++ b/pymc3/tests/test_dist_math.py
@@ -24,7 +24,9 @@ import pytest
 from ..theanof import floatX
 from ..distributions import Discrete
 from ..distributions.dist_math import (
-    bound, factln, alltrue_scalar, MvNormalLogp, SplineWrapper, i0e)
+    bound, factln, alltrue_scalar, MvNormalLogp, SplineWrapper, i0e,
+    clipped_beta_rvs,
+)
 
 
 def test_bound():
@@ -216,3 +218,11 @@ class TestI0e:
         utt.verify_grad(i0e, [-2.])
         utt.verify_grad(i0e, [[0.5, -2.]])
         utt.verify_grad(i0e, [[[0.5, -2.]]])
+
+
+@pytest.mark.parametrize("dtype", ["float16", "float32", "float64", "float128"])
+def test_clipped_beta_rvs(dtype):
+    # Verify that the samples drawn from the beta distribution are never
+    # equal to zero or one (issue #3898)
+    values = clipped_beta_rvs(0.01, 0.01, size=1000000, dtype=dtype)
+    assert not (np.any(values == 0) or np.any(values == 1))

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -22,6 +22,7 @@ import numpy.random as nr
 import theano
 
 import pymc3 as pm
+from pymc3.distributions.dist_math import clipped_beta_rvs
 from pymc3.distributions.distribution import (draw_values,
                                               _DrawValuesContext,
                                               _DrawValuesContextBlocker)
@@ -548,7 +549,7 @@ class TestScalarParameterSamples(SeededTest):
 
     def test_beta(self):
         def ref_rand(size, alpha, beta):
-            return st.beta.rvs(a=alpha, b=beta, size=size)
+            return clipped_beta_rvs(a=alpha, b=beta, size=size)
         pymc3_random(pm.Beta, {'alpha': Rplus, 'beta': Rplus}, ref_rand=ref_rand)
 
     def test_exponential(self):


### PR DESCRIPTION
Closes #3898.

To prevent beta random variates to be equal to 0 or 1, we cap the values to `np.nextafter(0,1, dtype)` and `np.nextafter(1,0, dtype)`, which give the next floating point nearby zero and one respectively, depending on the precision of the floating point representation.

Depending on what your PR does, here are a few things you might want to address in the description:
+ [X] what are the (breaking) changes that this PR makes?
Samples returned by `Beta.random` can never be equal to 0 or 1.

+ [x] important background, or details about the implementation

+ [X] are the changes—especially new features—covered by tests and docstrings?
Yes

+ [x] consider adding/updating relevant example notebooks
+ [X] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
