### PR TITLE
get docs for stats and plots to link to ArviZ

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,6 +16,7 @@
 - `pm.LKJCholeskyCov` now automatically computes and returns the unpacked Cholesky decomposition, the correlations and the standard deviations of the covariance matrix (see [#3881](https://github.com/pymc-devs/pymc3/pull/3881)).
 - `pm.Data` container can now be used for index variables, i.e with integer data and not only floats (issue [#3813](https://github.com/pymc-devs/pymc3/issues/3813), fixed by [#3925](https://github.com/pymc-devs/pymc3/pull/3925)).
 - `pm.Data` container can now be used as input for other random variables (issue [#3842](https://github.com/pymc-devs/pymc3/issues/3842), fixed by [#3925](https://github.com/pymc-devs/pymc3/pull/3925)).
+- Plots and Stats API sections now link to ArviZ documentation [#3927](https://github.com/pymc-devs/pymc3/pull/3927)
 
 ### Maintenance
 - Tuning results no longer leak into sequentially sampled `Metropolis` chains (see #3733 and #3796).

--- a/docs/source/api/plots.rst
+++ b/docs/source/api/plots.rst
@@ -3,7 +3,20 @@ Plots
 *****
 
 .. currentmodule:: pymc3.plots
+Plots are delegated to the
+`ArviZ <https://arviz-devs.github.io/arviz/index.html>`_.
+library, a general purpose library for
+"exploratory analysis of Bayesian models."
+For plots, ``pymc3.<function>`` are now aliases
+for ArviZ functions. Thus, the links below will redirect you to
+ArviZ docs:
 
-.. automodule:: pymc3.plots
-   :members: traceplot, plot_posterior, forestplot, compareplot, autocorrplot,
-             energyplot, kdeplot, densityplot, pairplot
+- :func:`pymc3.traceplot <arviz:arviz.plot_trace>`
+- :func:`pymc3.plot_posterior <arviz:arviz.plot_posterior>`
+- :func:`pymc3.forestplot <arviz:arviz.plot_forest>`
+- :func:`pymc3.compareplot <arviz:arviz.plot_compare>`
+- :func:`pymc3.autocorrplot <arviz:arviz.plot_autocorr>`
+- :func:`pymc3.energyplot <arviz:arviz.plot_energy>`
+- :func:`pymc3.kdeplot <arviz:arviz.plot_kde>`
+- :func:`pymc3.densityplot <arviz:arviz.plot_density>`
+- :func:`pymc3.pairplot <arviz:arviz.plot_pair>`

--- a/docs/source/api/stats.rst
+++ b/docs/source/api/stats.rst
@@ -1,8 +1,25 @@
 *****
 Stats
 *****
+Statistics and diagnostics are delegated to the
+`ArviZ <https://arviz-devs.github.io/arviz/index.html>`_.
+library, a general purpose library for
+"exploratory analysis of Bayesian models."
+For statistics and diagnostics, ``pymc3.<function>`` are now aliases
+for ArviZ functions. Thus, the links below will redirect you to
+ArviZ docs:
 
 .. currentmodule:: pymc3.stats
 
-.. automodule:: pymc3.stats
-   :members:
+
+- :func:`pymc3.bfmi <arviz:arviz.bfmi>`
+- :func:`pymc3.compare <arviz:arviz.compare>`
+- :func:`pymc3.ess <arviz:arviz.ess>`
+- :data:`pymc3.geweke <arviz:arviz.geweke>`
+- :func:`pymc3.hpd <arviz:arviz.hpd>`
+- :func:`pymc3.loo <arviz:arviz.loo>`
+- :func:`pymc3.mcse <arviz:arviz.mcse>`
+- :func:`pymc3.r2_score <arviz:arviz.r2_score>`
+- :func:`pymc3.rhat <arviz:arviz.rhat>`
+- :func:`pymc3.summary <arviz:arviz.summary>`
+- :func:`pymc3.waic <arviz:arviz.waic>`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.mathjax",
+    "sphinx.ext.intersphinx",
     "nbsphinx",
     "numpydoc",
     "IPython.sphinxext.ipython_console_highlighting",
@@ -129,6 +130,11 @@ pygments_style = "friendly"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
+
+# intersphinx configuration to ease linking arviz docs
+intersphinx_mapping = {
+    "arviz": ("https://arviz-devs.github.io/arviz/", None),
+}
 
 
 # -- Options for HTML output ----------------------------------------------


### PR DESCRIPTION
As discussed in slack, this should make stats and plots api pages to link to ArviZ counterparts, the current look is this one:

![image](https://user-images.githubusercontent.com/23738400/82248573-a9948780-9948-11ea-8c53-d0930b2ba78d.png)

Uses intersphinx whose configuration has been added to `conf.py`. 


Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes? None
+ [x] important background, or details about the implementation
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
