### PR TITLE
Drop support for float128 outside of linux and mac

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,7 +28,7 @@
   pointwise log likelihood (see [#3883](https://github.com/pymc-devs/pymc3/pull/3883)).
 - The multiprocessing start method on MacOS is now set to "forkserver", to avoid crashes (see issue [#3849](https://github.com/pymc-devs/pymc3/issues/3849), solved by [#3919](https://github.com/pymc-devs/pymc3/pull/3919)).
 - Forced the `Beta` distribution's `random` method to generate samples that are in the open interval $(0, 1)$, i.e. no value can be equal to zero or equal to one (issue [#3898](https://github.com/pymc-devs/pymc3/issues/3898) fixed by [#3924](https://github.com/pymc-devs/pymc3/pull/3924)).
-- Fixed issue with clipped beta distribution rvs dtype. Removed support for `float128` on platforms that aren't Linux or Darwin (see issue [#3929](https://github.com/pymc-devs/pymc3/issues/3849) fixed by [#3930](https://github.com/pymc-devs/pymc3/pull/3930))
+- Fixed an issue that happened on Windows, that was introduced by the clipped beta distribution rvs function ([#3924](https://github.com/pymc-devs/pymc3/pull/3924)). Windows does not support the `float128` dtype, but we had assumed that it had to be available. The solution was to only support `float128` on Linux and Darwin systems (see issue [#3929](https://github.com/pymc-devs/pymc3/issues/3849) fixed by [#3930](https://github.com/pymc-devs/pymc3/pull/3930)).
 
 ### Deprecations
 - Remove `sample_ppc` and `sample_ppc_w` that were deprecated in 3.6.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,7 @@
   pointwise log likelihood (see [#3883](https://github.com/pymc-devs/pymc3/pull/3883)).
 - The multiprocessing start method on MacOS is now set to "forkserver", to avoid crashes (see issue [#3849](https://github.com/pymc-devs/pymc3/issues/3849), solved by [#3919](https://github.com/pymc-devs/pymc3/pull/3919)).
 - Forced the `Beta` distribution's `random` method to generate samples that are in the open interval $(0, 1)$, i.e. no value can be equal to zero or equal to one (issue [#3898](https://github.com/pymc-devs/pymc3/issues/3898) fixed by [#3924](https://github.com/pymc-devs/pymc3/pull/3924)).
+- Fixed issue with clipped beta distribution rvs dtype. Removed support for `float128` on platforms that aren't Linux or Darwin (see issue [#3929](https://github.com/pymc-devs/pymc3/issues/3849) fixed by [#3930](https://github.com/pymc-devs/pymc3/pull/3930))
 
 ### Deprecations
 - Remove `sample_ppc` and `sample_ppc_w` that were deprecated in 3.6.

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -17,6 +17,7 @@ Created on Mar 7, 2011
 
 @author: johnsalvatier
 '''
+import platform
 import numpy as np
 import scipy.linalg
 import scipy.stats
@@ -36,8 +37,13 @@ f = floatX
 c = - .5 * np.log(2. * np.pi)
 _beta_clip_values = {
     dtype: (np.nextafter(0, 1, dtype=dtype), np.nextafter(1, 0, dtype=dtype))
-    for dtype in ["float16", "float32", "float64", "float128"]
+    for dtype in ["float16", "float32", "float64"]
 }
+if platform.system() in ["Linux", "Darwin"]:
+    _beta_clip_values["float128"] = (
+        np.nextafter(0, 1, dtype="float128"),
+        np.nextafter(1, 0, dtype="float128")
+    )
 
 
 


### PR DESCRIPTION
Fixes #3929.

This simply drops support for `float128` outside of linux and mac platforms.

Depending on what your PR does, here are a few things you might want to address in the description:
+ [X] what are the (breaking) changes that this PR makes?
None
+ [X] important background, or details about the implementation
Windows numpy does not support `float128` dtype.
+ [X] are the changes—especially new features—covered by tests and docstrings?
No, this fixes a Windows issue and we do not test on other platforms that are not Linux.
+ [X] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
