### PR TITLE
update report.n_draws when slicing

### DIFF
--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -29,7 +29,7 @@ import theano.tensor as tt
 from ..model import modelcontext, Model
 from .report import SamplerReport, merge_reports
 
-logger = logging.getLogger('pymc3')
+logger = logging.getLogger("pymc3")
 
 
 class BackendError(Exception):
@@ -74,10 +74,8 @@ class BaseTrace(ABC):
             test_point_.update(test_point)
             test_point = test_point_
         var_values = list(zip(self.varnames, self.fn(test_point)))
-        self.var_shapes = {var: value.shape
-                           for var, value in var_values}
-        self.var_dtypes = {var: value.dtype
-                           for var, value in var_values}
+        self.var_shapes = {var: value.shape for var, value in var_values}
+        self.var_dtypes = {var: value.dtype for var, value in var_values}
         self.chain = None
         self._is_base_setup = False
         self.sampler_vars = None
@@ -103,13 +101,12 @@ class BaseTrace(ABC):
         for stats in sampler_vars:
             for key, dtype in stats.items():
                 if dtypes.setdefault(key, dtype) != dtype:
-                    raise ValueError("Sampler statistic %s appears with "
-                                     "different types." % key)
+                    raise ValueError("Sampler statistic %s appears with " "different types." % key)
 
         self.sampler_vars = sampler_vars
 
     # pylint: disable=unused-argument
-    def setup(self, draws, chain, sampler_vars=None) -> None: 
+    def setup(self, draws, chain, sampler_vars=None) -> None:
         """Perform chain-specific setup.
 
         Parameters
@@ -154,7 +151,7 @@ class BaseTrace(ABC):
         try:
             return self.point(int(idx))
         except (ValueError, TypeError):  # Passed variable or variable name.
-            raise ValueError('Can only index with slice or integer')
+            raise ValueError("Can only index with slice or integer")
 
     def __len__(self):
         raise NotImplementedError
@@ -198,13 +195,13 @@ class BaseTrace(ABC):
         if sampler_idx is not None:
             return self._get_sampler_stats(stat_name, sampler_idx, burn, thin)
 
-        sampler_idxs = [i for i, s in enumerate(self.sampler_vars)
-                        if stat_name in s]
+        sampler_idxs = [i for i, s in enumerate(self.sampler_vars) if stat_name in s]
         if not sampler_idxs:
             raise KeyError("Unknown sampler stat %s" % stat_name)
 
-        vals = np.stack([self._get_sampler_stats(stat_name, i, burn, thin)
-                         for i in sampler_idxs], axis=-1)
+        vals = np.stack(
+            [self._get_sampler_stats(stat_name, i, burn, thin) for i in sampler_idxs], axis=-1
+        )
         if vals.shape[-1] == 1:
             return vals[..., 0]
         else:
@@ -295,13 +292,12 @@ class MultiTrace:
 
         self._report = SamplerReport()
         for strace in straces:
-            if hasattr(strace, '_warnings'):
+            if hasattr(strace, "_warnings"):
                 self._report._add_warnings(strace._warnings, strace.chain)
 
     def __repr__(self):
-        template = '<{}: {} chains, {} iterations, {} variables>'
-        return template.format(self.__class__.__name__,
-                               self.nchains, len(self), len(self.varnames))
+        template = "<{}: {} chains, {} iterations, {} variables>"
+        return template.format(self.__class__.__name__, self.nchains, len(self), len(self.varnames))
 
     @property
     def nchains(self):
@@ -338,16 +334,19 @@ class MultiTrace:
         var = str(var)
         if var in self.varnames:
             if var in self.stat_names:
-                warnings.warn("Attribute access on a trace object is ambigous. "
-                              "Sampler statistic and model variable share a name. Use "
-                              "trace.get_values or trace.get_sampler_stats.")
+                warnings.warn(
+                    "Attribute access on a trace object is ambigous. "
+                    "Sampler statistic and model variable share a name. Use "
+                    "trace.get_values or trace.get_sampler_stats."
+                )
             return self.get_values(var, burn=burn, thin=thin)
         if var in self.stat_names:
             return self.get_sampler_stats(var, burn=burn, thin=thin)
         raise KeyError("Unknown variable %s" % var)
 
-    _attrs = set(['_straces', 'varnames', 'chains', 'stat_names',
-                  'supports_sampler_stats', '_report'])
+    _attrs = set(
+        ["_straces", "varnames", "chains", "stat_names", "supports_sampler_stats", "_report"]
+    )
 
     def __getattr__(self, name):
         # Avoid infinite recursion when called before __init__
@@ -358,14 +357,15 @@ class MultiTrace:
         name = str(name)
         if name in self.varnames:
             if name in self.stat_names:
-                warnings.warn("Attribute access on a trace object is ambigous. "
-                              "Sampler statistic and model variable share a name. Use "
-                              "trace.get_values or trace.get_sampler_stats.")
+                warnings.warn(
+                    "Attribute access on a trace object is ambigous. "
+                    "Sampler statistic and model variable share a name. Use "
+                    "trace.get_values or trace.get_sampler_stats."
+                )
             return self.get_values(name)
         if name in self.stat_names:
             return self.get_sampler_stats(name)
-        raise AttributeError("'{}' object has no attribute '{}'".format(
-            type(self).__name__, name))
+        raise AttributeError("'{}' object has no attribute '{}'".format(type(self).__name__, name))
 
     def __len__(self):
         chain = self.chains[-1]
@@ -424,10 +424,12 @@ class MultiTrace:
             l_samples = len(self) * len(self.chains)
             l_v = len(v)
             if l_v != l_samples:
-                warnings.warn("The length of the values you are trying to "
-                              "add ({}) does not match the number ({}) of "
-                              "total samples in the trace "
-                              "(chains * iterations)".format(l_v, l_samples))
+                warnings.warn(
+                    "The length of the values you are trying to "
+                    "add ({}) does not match the number ({}) of "
+                    "total samples in the trace "
+                    "(chains * iterations)".format(l_v, l_samples)
+                )
 
             v = np.squeeze(v.reshape(len(chains), len(self), -1))
 
@@ -456,8 +458,7 @@ class MultiTrace:
                     chain.vars.remove(va)
                     del chain.samples[name]
 
-    def get_values(self, varname, burn=0, thin=1, combine=True, chains=None,
-                   squeeze=True):
+    def get_values(self, varname, burn=0, thin=1, combine=True, chains=None, squeeze=True):
         """Get values from traces.
 
         Parameters
@@ -484,14 +485,12 @@ class MultiTrace:
             chains = self.chains
         varname = str(varname)
         try:
-            results = [self._straces[chain].get_values(varname, burn, thin)
-                       for chain in chains]
+            results = [self._straces[chain].get_values(varname, burn, thin) for chain in chains]
         except TypeError:  # Single chain passed.
             results = [self._straces[chains].get_values(varname, burn, thin)]
         return _squeeze_cat(results, combine, squeeze)
 
-    def get_sampler_stats(self, stat_name, burn=0, thin=1, combine=True,
-                          chains=None, squeeze=True):
+    def get_sampler_stats(self, stat_name, burn=0, thin=1, combine=True, chains=None, squeeze=True):
         """Get sampler statistics from the trace.
 
         Parameters
@@ -519,8 +518,9 @@ class MultiTrace:
         except TypeError:
             chains = [chains]
 
-        results = [self._straces[chain].get_sampler_stats(stat_name, None, burn, thin)
-                   for chain in chains]
+        results = [
+            self._straces[chain].get_sampler_stats(stat_name, None, burn, thin) for chain in chains
+        ]
         return _squeeze_cat(results, combine, squeeze)
 
     def _slice(self, slice):
@@ -528,7 +528,7 @@ class MultiTrace:
         new_traces = [trace._slice(slice) for trace in self._straces.values()]
         trace = MultiTrace(new_traces)
         idxs = slice.indices(len(self))
-        trace._report = self._report._slice(*idxs)
+        trace.report._n_draws = len(trace)
         return trace
 
     def point(self, idx, chain=None):
@@ -581,7 +581,9 @@ def merge_traces(mtraces: List[MultiTrace]) -> MultiTrace:
     base_mtrace = mtraces[0]
     chain_len = len(base_mtrace)
     # check base trace
-    if any(len(st) != chain_len for _, st in base_mtrace._straces.items()):  # pylint: disable=line-too-long
+    if any(
+        len(st) != chain_len for _, st in base_mtrace._straces.items()
+    ):  # pylint: disable=line-too-long
         raise ValueError("Chains are of different lengths.")
     for new_mtrace in mtraces[1:]:
         for new_chain, strace in new_mtrace._straces.items():

--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -528,6 +528,7 @@ class MultiTrace:
         new_traces = [trace._slice(slice) for trace in self._straces.values()]
         trace = MultiTrace(new_traces)
         idxs = slice.indices(len(self))
+        trace.report._chain_warnings = self.report._chain_warnings
         trace.report._n_draws = len(trace)
         return trace
 

--- a/pymc3/backends/ndarray.py
+++ b/pymc3/backends/ndarray.py
@@ -26,11 +26,12 @@ import warnings
 import numpy as np
 from pymc3.backends import base
 from pymc3.backends.base import MultiTrace
+from pymc3.backends.report import SamplerReport
 from pymc3.model import Model, modelcontext
 from pymc3.exceptions import TraceDirectoryError
 
 
-def save_trace(trace: MultiTrace, directory: Optional[str]=None, overwrite=False) -> str:
+def save_trace(trace: MultiTrace, directory: Optional[str] = None, overwrite=False) -> str:
     """Save multitrace to file.
 
     TODO: Also save warnings.
@@ -54,13 +55,12 @@ def save_trace(trace: MultiTrace, directory: Optional[str]=None, overwrite=False
     str, path to the directory where the trace was saved
     """
     warnings.warn(
-        'The `save_trace` function will soon be removed.'
-        'Instead, use ArviZ to save/load traces.',
+        "The `save_trace` function will soon be removed." "Instead, use ArviZ to save/load traces.",
         DeprecationWarning,
     )
 
     if directory is None:
-        directory = '.pymc_{}.trace'
+        directory = ".pymc_{}.trace"
         idx = 1
         while os.path.exists(directory.format(idx)):
             idx += 1
@@ -70,8 +70,10 @@ def save_trace(trace: MultiTrace, directory: Optional[str]=None, overwrite=False
         if overwrite:
             shutil.rmtree(directory)
         else:
-            raise OSError('Cautiously refusing to overwrite the already existing {}! Please supply '
-                          'a different directory, or set `overwrite=True`'.format(directory))
+            raise OSError(
+                "Cautiously refusing to overwrite the already existing {}! Please supply "
+                "a different directory, or set `overwrite=True`".format(directory)
+            )
     os.makedirs(directory)
 
     for chain, ndarray in trace._straces.items():
@@ -97,12 +99,11 @@ def load_trace(directory: str, model=None) -> MultiTrace:
     pm.Multitrace that was saved in the directory
     """
     warnings.warn(
-        'The `load_trace` function will soon be removed.'
-        'Instead, use ArviZ to save/load traces.',
+        "The `load_trace` function will soon be removed." "Instead, use ArviZ to save/load traces.",
         DeprecationWarning,
     )
     straces = []
-    for subdir in glob.glob(os.path.join(directory, '*')):
+    for subdir in glob.glob(os.path.join(directory, "*")):
         if os.path.isdir(subdir):
             straces.append(SerializeNDArray(subdir).load(model))
     if not straces:
@@ -111,16 +112,16 @@ def load_trace(directory: str, model=None) -> MultiTrace:
 
 
 class SerializeNDArray:
-    metadata_file = 'metadata.json'
-    samples_file = 'samples.npz'
-    metadata_path = None # type: str
-    samples_path = None # type: str
+    metadata_file = "metadata.json"
+    samples_file = "samples.npz"
+    metadata_path = None  # type: str
+    samples_path = None  # type: str
 
     def __init__(self, directory: str):
         """Helper to save and load NDArray objects"""
         warnings.warn(
-            'The `SerializeNDArray` class will soon be removed. '
-            'Instead, use ArviZ to save/load traces.',
+            "The `SerializeNDArray` class will soon be removed. "
+            "Instead, use ArviZ to save/load traces.",
             DeprecationWarning,
         )
         self.directory = directory
@@ -140,13 +141,12 @@ class SerializeNDArray:
                 stats.append({key: value.tolist() for key, value in stat.items()})
                 sampler_vars.append({key: str(value.dtype) for key, value in stat.items()})
 
-
         metadata = {
-            'draw_idx': ndarray.draw_idx,
-            'draws': ndarray.draws,
-            '_stats': stats,
-            'chain': ndarray.chain,
-            'sampler_vars': sampler_vars
+            "draw_idx": ndarray.draw_idx,
+            "draws": ndarray.draws,
+            "_stats": stats,
+            "chain": ndarray.chain,
+            "sampler_vars": sampler_vars,
         }
         return metadata
 
@@ -158,32 +158,34 @@ class SerializeNDArray:
         to reload the multitrace.
         """
         if not isinstance(ndarray, NDArray):
-            raise TypeError('Can only save NDArray')
+            raise TypeError("Can only save NDArray")
 
         if os.path.isdir(self.directory):
             shutil.rmtree(self.directory)
 
         os.mkdir(self.directory)
 
-        with open(self.metadata_path, 'w') as buff:
+        with open(self.metadata_path, "w") as buff:
             json.dump(SerializeNDArray.to_metadata(ndarray), buff)
 
         np.savez_compressed(self.samples_path, **ndarray.samples)
 
-    def load(self, model: Model) -> 'NDArray':
+    def load(self, model: Model) -> "NDArray":
         """Load the saved ndarray from file"""
         if not os.path.exists(self.samples_path) or not os.path.exists(self.metadata_path):
             raise TraceDirectoryError("%s is not a trace directory" % self.directory)
 
         new_trace = NDArray(model=model)
-        with open(self.metadata_path, 'r') as buff:
+        with open(self.metadata_path, "r") as buff:
             metadata = json.load(buff)
 
-        metadata['_stats'] = [{k: np.array(v) for k, v in stat.items()} for stat in metadata['_stats']]
+        metadata["_stats"] = [
+            {k: np.array(v) for k, v in stat.items()} for stat in metadata["_stats"]
+        ]
 
         # it seems like at least some old traces don't have 'sampler_vars'
         try:
-            sampler_vars = metadata.pop('sampler_vars')
+            sampler_vars = metadata.pop("sampler_vars")
             new_trace._set_sampler_vars(sampler_vars)
         except KeyError:
             pass
@@ -241,16 +243,12 @@ class NDArray(base.BaseTrace):
             self.draw_idx = old_draws
             for varname, shape in self.var_shapes.items():
                 old_var_samples = self.samples[varname]
-                new_var_samples = np.zeros((draws, ) + shape,
-                                           self.var_dtypes[varname])
-                self.samples[varname] = np.concatenate((old_var_samples,
-                                                        new_var_samples),
-                                                       axis=0)
+                new_var_samples = np.zeros((draws,) + shape, self.var_dtypes[varname])
+                self.samples[varname] = np.concatenate((old_var_samples, new_var_samples), axis=0)
         else:  # Otherwise, make array of zeros for each variable.
             self.draws = draws
             for varname, shape in self.var_shapes.items():
-                self.samples[varname] = np.zeros((draws, ) + shape,
-                                                 dtype=self.var_dtypes[varname])
+                self.samples[varname] = np.zeros((draws,) + shape, dtype=self.var_dtypes[varname])
 
         if sampler_vars is None:
             return
@@ -258,7 +256,7 @@ class NDArray(base.BaseTrace):
         if self._stats is None:
             self._stats = []
             for sampler in sampler_vars:
-                data = dict() # type: Dict[str, np.ndarray]
+                data = dict()  # type: Dict[str, np.ndarray]
                 self._stats.append(data)
                 for varname, dtype in sampler.items():
                     data[varname] = np.zeros(draws, dtype=dtype)
@@ -301,12 +299,12 @@ class NDArray(base.BaseTrace):
             return
         # Remove trailing zeros if interrupted before completed all
         # draws.
-        self.samples = {var: vtrace[:self.draw_idx]
-                        for var, vtrace in self.samples.items()}
+        self.samples = {var: vtrace[: self.draw_idx] for var, vtrace in self.samples.items()}
         if self._stats is not None:
             self._stats = [
-                {var: trace[:self.draw_idx] for var, trace in stats.items()}
-                for stats in self._stats]
+                {var: trace[: self.draw_idx] for var, trace in stats.items()}
+                for stats in self._stats
+            ]
 
     # Selection methods
 
@@ -340,19 +338,20 @@ class NDArray(base.BaseTrace):
 
         sliced = NDArray(model=self.model, vars=self.vars)
         sliced.chain = self.chain
-        sliced.samples = {varname: values[idx]
-                          for varname, values in self.samples.items()}
+        sliced.samples = {varname: values[idx] for varname, values in self.samples.items()}
         sliced.sampler_vars = self.sampler_vars
         sliced.draw_idx = (idx.stop - idx.start) // idx.step
 
-        if self._stats is None:
-            return sliced
-        sliced._stats = []
-        for vars in self._stats:
-            var_sliced = {}
-            sliced._stats.append(var_sliced)
-            for key, vals in vars.items():
-                var_sliced[key] = vals[idx]
+        sliced.report = SamplerReport()
+        sliced.report._n_draws = len(sliced)
+
+        if self._stats is not None:
+            sliced._stats = []
+            for vars in self._stats:
+                var_sliced = {}
+                sliced._stats.append(var_sliced)
+                for key, vals in vars.items():
+                    var_sliced[key] = vals[idx]
 
         return sliced
 
@@ -361,8 +360,7 @@ class NDArray(base.BaseTrace):
         with variable names as keys.
         """
         idx = int(idx)
-        return {varname: values[idx]
-                for varname, values in self.samples.items()}
+        return {varname: values[idx] for varname, values in self.samples.items()}
 
 
 def _slice_as_ndarray(strace, idx):
@@ -370,23 +368,24 @@ def _slice_as_ndarray(strace, idx):
     sliced.chain = strace.chain
 
     # Happy path where we do not need to load everything from the trace
-    if ((idx.step is None or idx.step >= 1) and
-            (idx.stop is None or idx.stop == len(strace))):
+    if (idx.step is None or idx.step >= 1) and (idx.stop is None or idx.stop == len(strace)):
         start, stop, step = idx.indices(len(strace))
-        sliced.samples = {v: strace.get_values(v, burn=idx.start, thin=idx.step)
-                          for v in strace.varnames}
+        sliced.samples = {
+            v: strace.get_values(v, burn=idx.start, thin=idx.step) for v in strace.varnames
+        }
         sliced.draw_idx = (stop - start) // step
     else:
         start, stop, step = idx.indices(len(strace))
-        sliced.samples = {v: strace.get_values(v)[start:stop:step]
-                          for v in strace.varnames}
+        sliced.samples = {v: strace.get_values(v)[start:stop:step] for v in strace.varnames}
         sliced.draw_idx = (stop - start) // step
 
     return sliced
 
 
-def point_list_to_multitrace(point_list: List[Dict[str, np.ndarray]], model: Optional[Model]=None) -> MultiTrace:
-    '''transform point list into MultiTrace'''
+def point_list_to_multitrace(
+    point_list: List[Dict[str, np.ndarray]], model: Optional[Model] = None
+) -> MultiTrace:
+    """transform point list into MultiTrace"""
     _model = modelcontext(model)
     varnames = list(point_list[0].keys())
     with _model:
@@ -396,6 +395,7 @@ def point_list_to_multitrace(point_list: List[Dict[str, np.ndarray]], model: Opt
         # chain.record() to use. This crushes the default.
         def point_fun(point):
             return [point[vn] for vn in varnames]
+
         chain.fn = point_fun
         for point in point_list:
             chain.record(point)

--- a/pymc3/backends/ndarray.py
+++ b/pymc3/backends/ndarray.py
@@ -54,7 +54,7 @@ def save_trace(trace: MultiTrace, directory: Optional[str] = None, overwrite=Fal
     str, path to the directory where the trace was saved
     """
     warnings.warn(
-        "The `save_trace` function will soon be removed." "Instead, use ArviZ to save/load traces.",
+        "The `save_trace` function will soon be removed. Instead, use ArviZ to save/load traces.",
         DeprecationWarning,
     )
 
@@ -98,7 +98,7 @@ def load_trace(directory: str, model=None) -> MultiTrace:
     pm.Multitrace that was saved in the directory
     """
     warnings.warn(
-        "The `load_trace` function will soon be removed." "Instead, use ArviZ to save/load traces.",
+        "The `load_trace` function will soon be removed. Instead, use ArviZ to save/load traces.",
         DeprecationWarning,
     )
     straces = []

--- a/pymc3/backends/ndarray.py
+++ b/pymc3/backends/ndarray.py
@@ -26,7 +26,6 @@ import warnings
 import numpy as np
 from pymc3.backends import base
 from pymc3.backends.base import MultiTrace
-from pymc3.backends.report import SamplerReport
 from pymc3.model import Model, modelcontext
 from pymc3.exceptions import TraceDirectoryError
 

--- a/pymc3/backends/ndarray.py
+++ b/pymc3/backends/ndarray.py
@@ -342,9 +342,6 @@ class NDArray(base.BaseTrace):
         sliced.sampler_vars = self.sampler_vars
         sliced.draw_idx = (idx.stop - idx.start) // idx.step
 
-        sliced.report = SamplerReport()
-        sliced.report._n_draws = len(sliced)
-
         if self._stats is not None:
             sliced._stats = []
             for vars in self._stats:


### PR DESCRIPTION
When slicing a trace the report property is lost, this add it back. With this fix all the properties will set to 
`None`. The `n_draws` values will be updated to the length of the slice. We could update the other values too, but most of them, if not all of them, are related to the entire trace and not the slice so probably it is better to leave them as `None`.