### PR TITLE
Fixing HMC et al. tuning schedule to reset at the beginning of a chain even on 1 core

### DIFF
--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -198,6 +198,10 @@ class BaseHMC(arraystep.GradientSharedStep):
 
         return hmc_step.end.q, [stats]
 
+    def reset_tuning(self, start=None):
+        self.step_adapt.reset()
+        self.reset(start=None)
+
     def reset(self, start=None):
         self.tune = True
         self.potential.reset()

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -534,6 +534,8 @@ class QuadPotentialFullAdapt(QuadPotentialFull):
         self.adaptation_window_multiplier = float(adaptation_window_multiplier)
         self._update_window = int(update_window)
 
+        self.reset()
+
     def reset(self):
         self._previous_update = 0
         self._cov = np.array(self._initial_cov, dtype=self.dtype, copy=True)

--- a/pymc3/step_methods/step_sizes.py
+++ b/pymc3/step_methods/step_sizes.py
@@ -20,15 +20,19 @@ from pymc3.backends.report import SamplerWarning, WarningType
 
 class DualAverageAdaptation:
     def __init__(self, initial_step, target, gamma, k, t0):
-        self._log_step = np.log(initial_step)
-        self._log_bar = self._log_step
+        self._initial_step = initial_step
         self._target = target
-        self._hbar = 0.
         self._k = k
         self._t0 = t0
-        self._count = 1
-        self._mu = np.log(10 * initial_step)
         self._gamma = gamma
+        self.reset()
+
+    def reset(self):
+        self._log_step = np.log(self._initial_step)
+        self._log_bar = self._log_step
+        self._hbar = 0.
+        self._count = 1
+        self._mu = np.log(10 * self._initial_step)
         self._tuned_stats = []
 
     def current(self, tune):

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -145,6 +145,15 @@ class TestSample(SeededTest):
             trace = pm.sample(draws=100, tune=50, cores=4)
             assert len(trace) == 100
 
+    def test_reset_tuning(self):
+        with self.model:
+            tune = 50
+            chains = 2
+            start, step = pm.sampling.init_nuts(chains=chains)
+            pm.sample(draws=2, tune=tune, chains=chains, step=step, start=start, cores=1)
+            assert step.potential._n_samples == tune
+            assert step.step_adapt._count == tune + 1
+
     @pytest.mark.parametrize("step_cls", [pm.NUTS, pm.Metropolis, pm.Slice])
     @pytest.mark.parametrize("discard", [True, False])
     def test_trace_report(self, step_cls, discard):


### PR DESCRIPTION
This pull request fixes #3939.

This should be completely backwards compatible in terms of interface, but sampling results (when using just a single core or when running more chains than cores) could change as a result of this patch.