### PR TITLE
Fix reparameterized gp.TP `chi2` variable name

### DIFF
--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -266,7 +266,7 @@ class TP(Latent):
         cov = stabilize(self.cov_func(X))
         shape = infer_shape(X, kwargs.pop("shape", None))
         if reparameterize:
-            chi2 = pm.ChiSquared("chi2_", self.nu)
+            chi2 = pm.ChiSquared(name + "_chi2_", self.nu)
             v = pm.Normal(name + "_rotated_", mu=0.0, sigma=1.0, shape=shape, **kwargs)
             f = pm.Deterministic(name, (tt.sqrt(self.nu) / chi2) * (mu + cholesky(cov).dot(v)))
         else:

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -1,4 +1,4 @@
-#   Copyright 2020 The PyMC Developers
+/Users/bill/packages/pymc3/pymc3/tests #   Copyright 2020 The PyMC Developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -1015,8 +1015,8 @@ class TestTP:
             p = tp.conditional("p", self.Xnew)
         chol = np.linalg.cholesky(cov_func(self.X).eval())
         y_rotated = np.linalg.solve(chol, self.y)
-        # testing full model logp unreliable due to introduction of chi2__log__
-        plogp = p.logp({"f_rotated_": y_rotated, "p": self.pnew, "chi2__log__": np.log(1e20)})
+        # testing full model logp unreliable due to introduction of f_chi2__log__
+        plogp = p.logp({"f_rotated_": y_rotated, "p": self.pnew, "f_chi2__log__": np.log(1e20)})
         npt.assert_allclose(self.plogp, plogp, atol=0, rtol=1e-2)
 
     def testAdditiveTPRaises(self):

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -1,4 +1,4 @@
-/Users/bill/packages/pymc3/pymc3/tests #   Copyright 2020 The PyMC Developers
+#   Copyright 2020 The PyMC Developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.


### PR DESCRIPTION
Small fix, in `gp.TP`, a parameter called `chi2_` is automatically added to the model.  It didn't have a unique name though, so there's an error if more than one Student's t process is in the model.  This PR fixes this by changing the name to `tp_name` + `_chi2_`.  Does this need a test?