### PR TITLE
Run some CI tests with arviz master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,8 @@ stages:
 
 jobs:
   include:
-  - stage: test
+  - name: ArviZ compatibility
+    stage: test
     install:
       - . ./scripts/create_testenv.sh
       - pip uninstall arviz -y
@@ -56,8 +57,8 @@ jobs:
     script:
       - . ./scripts/test.sh --durations=10 --cov-append pymc3/tests/test_sampling.py
     after_success: skip
-  include:
-  - stage: binder
+  - name: binder
+    stage: binder
     before_install: skip
     install: skip
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,19 @@ stages:
 
 jobs:
   include:
+  - stage: test
+    install:
+      - . ./scripts/create_testenv.sh
+      - pip uninstall arviz -y
+      # replace ArviZ with the lastest master
+      - pip install git+git://github.com/arviz-devs/arviz.git
+      - pip install codecov
+      - conda list && pip freeze
+      - export FLOATX='float64'
+    script:
+      - . ./scripts/test.sh --durations=10 --cov-append pymc3/tests/test_sampling.py
+    after_success: skip
+  include:
   - stage: binder
     before_install: skip
     install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
     script:
       - . ./scripts/test.sh --durations=10 --cov-append pymc3/tests/test_sampling.py
     after_success: skip
-  - name: binder
+  - name: Update Binder
     stage: binder
     before_install: skip
     install: skip


### PR DESCRIPTION
Some PRs lately broke ArviZ compatibility. By testing against the latest ArviZ master in the CI, we can notice and fix bugs before they are merged.

+ [x] no (breaking) changes
+ [x] a new job is added to the Travis CI config. It uninstalls ArviZ and replaces it with the latest master before running a selection of tests,
+ [x] <s>mention the PR in the RELEASE-NOTES.md</s> no API changes
