### PR TITLE
Remove unused import to fix pylint CI job

### DIFF
--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -16,7 +16,6 @@ import numpy as np
 import numpy.random as nr
 import theano
 import scipy.linalg
-import warnings
 
 from ..distributions import draw_values
 from .arraystep import ArrayStepShared, PopulationArrayStepShared, ArrayStep, metrop_select, Competence


### PR DESCRIPTION
The pylint CI job failed on master because #3949 was merged even though the lint job failed.

This fixes it by taking out an unused import.