### PR TITLE
Add release pipeline GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,9 @@
 name: release-pipeline
 
-#on:
-#  release:
-#    types:
-#      - created
-# !!!!!!!!!!!! TODO: uncomment the block above & remove the next line !!!!!!!!!!!!
-on: [push, pull_request]
+on:
+  release:
+    types:
+      - created
 
 jobs:
   release-job:
@@ -34,8 +32,6 @@ jobs:
         python setup.py sdist bdist_wheel
     - name: Check version number match
       run: |
-# TODO: take out the next line, which simulates the tag
-        export GITHUB_REF="refs/tags/v3.9.0"
         echo "GITHUB_REF: ${GITHUB_REF}"
         # The GITHUB_REF should be something like "refs/tags/v3.x.x"
         # Make sure the package version is the same as the tag
@@ -43,7 +39,7 @@ jobs:
     - name: Publish to PyPI
       run: |
         twine check dist/*
-# TODO: twine upload --repository pypi --username __token__ --password ${PYPI_TOKEN} dist/*
+        twine upload --repository pypi --username __token__ --password ${PYPI_TOKEN} dist/*
   test-install-job:
     needs: release-job
     runs-on: ubuntu-latest
@@ -55,5 +51,4 @@ jobs:
       run: sleep 240
     - name: Install from PyPI
       run: |
-        pip install pymc3
-# TODO: pip install pymc3==${GITHUB_REF:11}
+        pip install pymc3==${GITHUB_REF:11}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: release-pipeline
+
+#on:
+#  release:
+#    types:
+#      - created
+# !!!!!!!!!!!! TODO: uncomment the block above & remove the next line !!!!!!!!!!!!
+on: [push, pull_request]
+
+jobs:
+  release-job:
+    runs-on: ubuntu-latest
+    env:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    # TODO: ideally, this pipeline should run parallelized tests in upstream jobs..
+    #- name: Install test tooling
+    #  run: |
+    #    pip install pytest pytest-cov nose nose-parameterized
+    #    pip install -r requirements.txt
+    #- name: Run tests
+    #  run: |
+    #    pytest --cov=./pymc3 --cov-report term-missing pymc3/
+    - name: Install release tooling
+      run: |
+        pip install twine wheel
+    - name: Build package
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Check version number match
+      run: |
+# TODO: take out the next line, which simulates the tag
+        export GITHUB_REF="refs/tags/v3.9.0"
+        echo "GITHUB_REF: ${GITHUB_REF}"
+        # The GITHUB_REF should be something like "refs/tags/v3.x.x"
+        # Make sure the package version is the same as the tag
+        grep -Rq "^Version: ${GITHUB_REF:11}$" pymc3.egg-info/PKG-INFO
+    - name: Publish to PyPI
+      run: |
+        twine check dist/*
+# TODO: twine upload --repository pypi --username __token__ --password ${PYPI_TOKEN} dist/*
+  test-install-job:
+    needs: release-job
+    runs-on: ubuntu-latest
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Give PyPI a chance to update the index
+      run: sleep 120
+    - name: Install from PyPI
+      run: |
+        pip install pymc3
+# TODO: pip install pymc3==${GITHUB_REF:11}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Give PyPI a chance to update the index
-      run: sleep 120
+      run: sleep 240
     - name: Install from PyPI
       run: |
         pip install pymc3

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # pylint: disable=wildcard-import
-__version__ = "3.8"
+__version__ = "3.9.0"
 
 import logging
 import multiprocessing as mp

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
           license=LICENSE,
           url=URL,
           long_description=LONG_DESCRIPTION,
+          long_description_content_type='text/x-rst',
           packages=find_packages(),
           package_data={'docs': ['*']},
           include_package_data=True,


### PR DESCRIPTION
## Description
This PR adds a GitHub Action with a release pipeline.

I commented out a few blocks/lines to make the pipeline run on this PR. _Which it doesn't, because the GitHub action does not activate before it's on master._

***Before merging, the TODO lines (except the tests) MUST be addressed.***

Also, a GitHub Action Secret must be created in the Settings of the GitHub repository:

![image](https://user-images.githubusercontent.com/5894642/84435090-77b5ce80-ac31-11ea-9cf0-45a26d0b99f0.png)

The pipeline currently does not run tests. For now, **we must not create release tags if the pipeline failed on master**.

## TODO
+ [x] switch the `on` condition (will skip the pipeline from the last PR commit before merging, but run it when the release is created)
+ [x] remove the `export GITHUB_REF` which is just there to simulate the creation of the release tag
+ [ ] add the `PYPI_TOKEN` secret as described above
+ [x] enable the `twine upload` line
+ [x] switch the `pip install pymc3` line to the one that uses the released version


## References
+ https://github.com/pymc-devs/pymc3/wiki/PyMC3-Release-Checklist
+ https://github.com/michaelosthege/pyrff/blob/master/.github/workflows/release.yml
