### PR TITLE
[WIP] Adding more detailed info to GraphViz renderings

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -238,15 +238,6 @@ class Uniform(BoundedContinuous):
         return bound(-tt.log(upper - lower),
                      value >= lower, value <= upper)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        lower = dist.lower
-        upper = dist.upper
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Uniform}}(\mathit{{lower}}={},~\mathit{{upper}}={})$'.format(
-            name, get_variable_name(lower), get_variable_name(upper))
-
     def logcdf(self, value):
         """
         Compute the log of the cumulative distribution function for Uniform distribution
@@ -314,10 +305,6 @@ class Flat(Continuous):
         """
         return tt.zeros_like(value)
 
-    def _repr_latex_(self, name=None, dist=None):
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Flat}}()$'.format(name)
-
     def logcdf(self, value):
         """
         Compute the log of the cumulative distribution function for Flat distribution
@@ -380,10 +367,6 @@ class HalfFlat(PositiveContinuous):
         TensorVariable
         """
         return bound(tt.zeros_like(value), value > 0)
-
-    def _repr_latex_(self, name=None, dist=None):
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{HalfFlat}}()$'.format(name)
 
     def logcdf(self, value):
         """
@@ -537,15 +520,8 @@ class Normal(Continuous):
         return bound((-tau * (value - mu)**2 + tt.log(tau / np.pi / 2.)) / 2.,
                      sigma > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        sigma = dist.sigma
-        mu = dist.mu
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Normal}}(\mathit{{mu}}={},~\mathit{{sigma}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(sigma))
+    def _distr_parameters_for_repr(self):
+        return ["mu", "sigma"]
 
     def logcdf(self, value):
         """
@@ -765,21 +741,8 @@ class TruncatedNormal(BoundedContinuous):
         else:
             return normal_lcdf(mu, sigma, self.upper)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        name = r'\text{%s}' % name
-        return (
-            r'${} \sim \text{{TruncatedNormal}}('
-            r'\mathit{{mu}}={},~\mathit{{sigma}}={},a={},b={})$'
-            .format(
-                name,
-                get_variable_name(self.mu),
-                get_variable_name(self.sigma),
-                get_variable_name(self.lower),
-                get_variable_name(self.upper),
-            )
-        )
+    def _distr_parameters_for_repr(self):
+        return ["mu", "sigma", "lower", "upper"]
 
 
 class HalfNormal(PositiveContinuous):
@@ -906,13 +869,8 @@ class HalfNormal(PositiveContinuous):
                      value >= 0,
                      tau > 0, sigma > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        sigma = dist.sigma
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{HalfNormal}}(\mathit{{sigma}}={})$'.format(name,
-                                                                         get_variable_name(sigma))
+    def _distr_parameters_for_repr(self):
+        return ["sigma"]
 
     def logcdf(self, value):
         """
@@ -1109,17 +1067,8 @@ class Wald(PositiveContinuous):
                      value > 0, value - alpha > 0,
                      mu > 0, lam > 0, alpha >= 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        lam = dist.lam
-        mu = dist.mu
-        alpha = dist.alpha
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Wald}}(\mathit{{mu}}={},~\mathit{{lam}}={},~\mathit{{alpha}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(lam),
-                                                                get_variable_name(alpha))
+    def _distr_parameters_for_repr(self):
+        return ["mu", "lam", "alpha"]
 
     def logcdf(self, value):
         """
@@ -1350,15 +1299,8 @@ class Beta(UnitContinuous):
             )
         )
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        alpha = dist.alpha
-        beta = dist.beta
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Beta}}(\mathit{{alpha}}={},~\mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(alpha),
-                                                                get_variable_name(beta))
+    def _distr_parameters_for_repr(self):
+        return ["alpha", "beta"]
 
 class Kumaraswamy(UnitContinuous):
     R"""
@@ -1466,16 +1408,6 @@ class Kumaraswamy(UnitContinuous):
                      value >= 0, value <= 1,
                      a > 0, b > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        a = dist.a
-        b = dist.b
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Kumaraswamy}}(\mathit{{a}}={},~\mathit{{b}}={})$'.format(name,
-                                                                                          get_variable_name(a),
-                                                                                          get_variable_name(b))
-
 
 class Exponential(PositiveContinuous):
     R"""
@@ -1563,14 +1495,6 @@ class Exponential(PositiveContinuous):
         """
         lam = self.lam
         return bound(tt.log(lam) - lam * value, value >= 0, lam > 0)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        lam = dist.lam
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Exponential}}(\mathit{{lam}}={})$'.format(name,
-                                                                get_variable_name(lam))
 
     def logcdf(self, value):
         r"""
@@ -1698,16 +1622,6 @@ class Laplace(Continuous):
         b = self.b
 
         return -tt.log(2 * b) - abs(value - mu) / b
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        b = dist.b
-        mu = dist.mu
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Laplace}}(\mathit{{mu}}={},~\mathit{{b}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(b))
 
     def logcdf(self, value):
         """
@@ -1870,15 +1784,8 @@ class Lognormal(PositiveContinuous):
                      - tt.log(value),
                      tau > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        tau = dist.tau
-        mu = dist.mu
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Lognormal}}(\mathit{{mu}}={},~\mathit{{tau}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(tau))
+    def _distr_parameters_for_repr(self):
+        return ["mu", "tau"]
 
     def logcdf(self, value):
         """
@@ -2044,17 +1951,8 @@ class StudentT(Continuous):
                      - (nu + 1.0) / 2.0 * tt.log1p(lam * (value - mu)**2 / nu),
                      lam > 0, nu > 0, sigma > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        nu = dist.nu
-        mu = dist.mu
-        lam = dist.lam
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{StudentT}}(\mathit{{nu}}={},~\mathit{{mu}}={},~\mathit{{lam}}={})$'.format(name,
-                                                                get_variable_name(nu),
-                                                                get_variable_name(mu),
-                                                                get_variable_name(lam))
+    def _distr_parameters_for_repr(self):
+        return ["nu", "mu", "lam"]
 
     def logcdf(self, value):
         """
@@ -2191,15 +2089,8 @@ class Pareto(Continuous):
                      - logpow(value, alpha + 1),
                      value >= m, alpha > 0, m > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        alpha = dist.alpha
-        m = dist.m
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Pareto}}(\mathit{{alpha}}={},~\mathit{{m}}={})$'.format(name,
-                                                                get_variable_name(alpha),
-                                                                get_variable_name(m))
+    def _distr_parameters_for_repr(self):
+        return ["alpha", "m"]
 
     def logcdf(self, value):
         """
@@ -2329,16 +2220,6 @@ class Cauchy(Continuous):
                      - tt.log1p(((value - alpha) / beta)**2),
                      beta > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        alpha = dist.alpha
-        beta = dist.beta
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Cauchy}}(\mathit{{alpha}}={},~\mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(alpha),
-                                                                get_variable_name(beta))
-
     def logcdf(self, value):
         """
         Compute the log of the cumulative distribution function for Cauchy distribution
@@ -2448,14 +2329,6 @@ class HalfCauchy(PositiveContinuous):
         return bound(tt.log(2) - tt.log(np.pi) - tt.log(beta)
                      - tt.log1p((value / beta)**2),
                      value >= 0, beta > 0)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        beta = dist.beta
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{HalfCauchy}}(\mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(beta))
 
     def logcdf(self, value):
         """
@@ -2640,15 +2513,8 @@ class Gamma(PositiveContinuous):
             alpha > 0,
             beta > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        beta = dist.beta
-        alpha = dist.alpha
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Gamma}}(\mathit{{alpha}}={},~\mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(alpha),
-                                                                get_variable_name(beta))
+    def _distr_parameters_for_repr(self):
+        return ["alpha", "beta"]
 
 
 class InverseGamma(PositiveContinuous):
@@ -2790,15 +2656,8 @@ class InverseGamma(PositiveContinuous):
                      + logpow(value, -alpha - 1),
                      value > 0, alpha > 0, beta > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        beta = dist.beta
-        alpha = dist.alpha
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{InverseGamma}}(\mathit{{alpha}}={},~\mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(alpha),
-                                                                get_variable_name(beta))
+    def _distr_parameters_for_repr(self):
+        return ["alpha", "beta"]
 
 
 class ChiSquared(Gamma):
@@ -2842,14 +2701,6 @@ class ChiSquared(Gamma):
     def __init__(self, nu, *args, **kwargs):
         self.nu = nu = tt.as_tensor_variable(floatX(nu))
         super().__init__(alpha=nu / 2., beta=0.5, *args, **kwargs)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        nu = dist.nu
-        name = r'\text{%s}' % name
-        return r'${} \sim \Chi^2(\mathit{{nu}}={})$'.format(name,
-                                                            get_variable_name(nu))
 
 
 class Weibull(PositiveContinuous):
@@ -2957,16 +2808,6 @@ class Weibull(PositiveContinuous):
                      + (alpha - 1) * tt.log(value / beta)
                      - (value / beta)**alpha,
                      value >= 0, alpha > 0, beta > 0)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        beta = dist.beta
-        alpha = dist.alpha
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Weibull}}(\mathit{{alpha}}={},~\mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(alpha),
-                                                                get_variable_name(beta))
 
     def logcdf(self, value):
         r"""
@@ -3126,15 +2967,8 @@ class HalfStudentT(PositiveContinuous):
                      - (nu + 1.0) / 2.0 * tt.log1p(value ** 2 / (nu * sigma**2)),
                      sigma > 0, lam > 0, nu > 0, value >= 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        nu = dist.nu
-        sigma = dist.sigma
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{HalfStudentT}}(\mathit{{nu}}={},~\mathit{{sigma}}={})$'.format(name,
-                                                                get_variable_name(nu),
-                                                                get_variable_name(sigma))
+    def _distr_parameters_for_repr(self):
+        return ["nu", "lam"]
 
 
 class ExGaussian(Continuous):
@@ -3276,17 +3110,8 @@ class ExGaussian(Continuous):
                        - 0.5 * ((value - mu) / sigma)**2)
         return bound(lp, sigma > 0., nu > 0.)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        sigma = dist.sigma
-        mu = dist.mu
-        nu = dist.nu
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{ExGaussian}}(\mathit{{mu}}={},~\mathit{{sigma}}={},~\mathit{{nu}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(sigma),
-                                                                get_variable_name(nu))
+    def _distr_parameters_for_repr(self):
+        return ["mu", "sigma", "nu"]
 
     def logcdf(self, value):
         """
@@ -3420,16 +3245,8 @@ class VonMises(Continuous):
         return bound(kappa * tt.cos(mu - value) - (tt.log(2 * np.pi) + log_i0(kappa)),
                      kappa > 0, value >= -np.pi, value <= np.pi)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        kappa = dist.kappa
-        mu = dist.mu
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{VonMises}}(\mathit{{mu}}={},~\mathit{{kappa}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(kappa))
-
+    def _distr_parameters_for_repr(self):
+        return ["mu", "kappa"]
 
 
 class SkewNormal(Continuous):
@@ -3563,17 +3380,8 @@ class SkewNormal(Continuous):
                + tt.log(tau / np.pi / 2.)) / 2.,
             tau > 0, sigma > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        sigma = dist.sigma
-        mu = dist.mu
-        alpha = dist.alpha
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Skew-Normal}}(\mathit{{mu}}={},~\mathit{{sigma}}={},~\mathit{{alpha}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(sigma),
-                                                                get_variable_name(alpha))
+    def _distr_parameters_for_repr(self):
+        return ["mu", "sigma", "alpha"]
 
 
 class Triangular(BoundedContinuous):
@@ -3698,18 +3506,6 @@ class Triangular(BoundedContinuous):
                                    tt.switch(alltrue_elemwise([c < value, value <= upper]),
                                              tt.log(2 * (upper - value) / ((upper - lower) * (upper - c))),
                                              np.inf)))
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        lower = dist.lower
-        upper = dist.upper
-        c = dist.c
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Triangular}}(\mathit{{c}}={},~\mathit{{lower}}={},~\mathit{{upper}}={})$'.format(name,
-                                                                get_variable_name(c),
-                                                                get_variable_name(lower),
-                                                                get_variable_name(upper))
 
     def logcdf(self, value):
         """
@@ -3843,16 +3639,6 @@ class Gumbel(Continuous):
         """
         scaled = (value - self.mu) / self.beta
         return bound(-scaled - tt.exp(-scaled) - tt.log(self.beta), self.beta > 0)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        beta = dist.beta
-        mu = dist.mu
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Gumbel}}(\mathit{{mu}}={},~\mathit{{beta}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(beta))
 
     def logcdf(self, value):
         """
@@ -4022,6 +3808,9 @@ class Rice(PositiveContinuous):
                      value > 0,
                      )
 
+    def _distr_parameters_for_repr(self):
+        return ["nu", "sigma"]
+
 
 class Logistic(Continuous):
     R"""
@@ -4119,16 +3908,6 @@ class Logistic(Continuous):
             loc=mu, scale=s,
             dist_shape=self.shape,
             size=size)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        mu = dist.mu
-        s = dist.s
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Logistic}}(\mathit{{mu}}={},~\mathit{{s}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(s))
 
     def logcdf(self, value):
         r"""
@@ -4271,15 +4050,8 @@ class LogitNormal(UnitContinuous):
                      + 0.5 * tt.log(tau / (2. * np.pi))
                      - tt.log(value * (1 - value)), value > 0, value < 1, tau > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        sigma = dist.sigma
-        mu = dist.mu
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{LogitNormal}}(\mathit{{mu}}={},~\mathit{{sigma}}={})$'.format(name,
-                                                                get_variable_name(mu),
-                                                                get_variable_name(sigma))
+    def _distr_parameters_for_repr(self):
+        return ["mu", "sigma"]
 
 
 class Interpolated(BoundedContinuous):
@@ -4383,6 +4155,9 @@ class Interpolated(BoundedContinuous):
         """
         return tt.log(self.interp_op(value) / self.Z)
 
+    def _distr_parameters_for_repr(self):
+        return []
+
 
 class Moyal(Continuous):
     R"""
@@ -4484,16 +4259,6 @@ class Moyal(Continuous):
         return bound((-(1 / 2) * (scaled + tt.exp(-scaled))
                       - tt.log(self.sigma)
                       - (1 / 2) * tt.log(2 * np.pi)), self.sigma > 0)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        sigma = dist.sigma
-        mu = dist.mu
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Moyal}}(\mathit{{mu}}={},~\mathit{{sigma}}={})$'.format(name,
-                                                                                         get_variable_name(mu),
-                                                                                         get_variable_name(sigma))
 
     def logcdf(self, value):
         """

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -26,7 +26,6 @@ import warnings
 
 from pymc3.theanof import floatX
 from . import transforms
-from pymc3.util import get_variable_name
 from .special import log_i0
 from ..math import invlogit, logit, logdiffexp
 from .dist_math import (

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -123,15 +123,6 @@ class Binomial(Discrete):
             0 <= value, value <= n,
             0 <= p, p <= 1)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        n = dist.n
-        p = dist.p
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Binomial}}(\mathit{{n}}={},~\mathit{{p}}={})$'.format(name,
-                                                get_variable_name(n),
-                                                get_variable_name(p))
 
 class BetaBinomial(Discrete):
     R"""
@@ -259,16 +250,6 @@ class BetaBinomial(Discrete):
                      value >= 0, value <= self.n,
                      alpha > 0, beta > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        alpha = dist.alpha
-        beta = dist.beta
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{BetaBinomial}}(\mathit{{alpha}}={},~\mathit{{beta}}={})$'.format(name,
-                                                get_variable_name(alpha),
-                                                get_variable_name(beta))
-
 
 class Bernoulli(Discrete):
     R"""Bernoulli log-likelihood
@@ -371,13 +352,8 @@ class Bernoulli(Discrete):
                 value >= 0, value <= 1,
                 p >= 0, p <= 1)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        p = dist.p
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Bernoulli}}(\mathit{{p}}={})$'.format(name,
-                                                get_variable_name(p))
+    def _distr_parameters_for_repr(self):
+        return ["p"]
 
 
 class DiscreteWeibull(Discrete):
@@ -486,16 +462,6 @@ class DiscreteWeibull(Discrete):
                                 dist_shape=self.shape,
                                 size=size)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        q = dist.q
-        beta = dist.beta
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{DiscreteWeibull}}(\mathit{{q}}={},~\mathit{{beta}}={})$'.format(name,
-                                                get_variable_name(q),
-                                                get_variable_name(beta))
-
 
 class Poisson(Discrete):
     R"""
@@ -589,14 +555,6 @@ class Poisson(Discrete):
         # Return zero when mu and value are both zero
         return tt.switch(tt.eq(mu, 0) * tt.eq(value, 0),
                          0, log_prob)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        mu = dist.mu
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Poisson}}(\mathit{{mu}}={})$'.format(name,
-                                                get_variable_name(mu))
 
 
 class NegativeBinomial(Discrete):
@@ -717,16 +675,6 @@ class NegativeBinomial(Discrete):
                          Poisson.dist(self.mu).logp(value),
                          negbinom)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        mu = dist.mu
-        alpha = dist.alpha
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{NegativeBinomial}}(\mathit{{mu}}={},~\mathit{{alpha}}={})$'.format(name,
-                                                get_variable_name(mu),
-                                                get_variable_name(alpha))
-
 
 class Geometric(Discrete):
     R"""
@@ -809,14 +757,6 @@ class Geometric(Discrete):
         p = self.p
         return bound(tt.log(p) + logpow(1 - p, value - 1),
                      0 <= p, p <= 1, value >= 1)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        p = dist.p
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Geometric}}(\mathit{{p}}={})$'.format(name,
-                                                get_variable_name(p))
 
 
 class DiscreteUniform(Discrete):
@@ -912,16 +852,6 @@ class DiscreteUniform(Discrete):
         lower = self.lower
         return bound(-tt.log(upper - lower + 1),
                      lower <= value, value <= upper)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        lower = dist.lower
-        upper = dist.upper
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{DiscreteUniform}}(\mathit{{lower}}={},~\mathit{{upper}}={})$'.format(name,
-                                                get_variable_name(lower),
-                                                get_variable_name(upper))
 
 
 class Categorical(Discrete):
@@ -1044,14 +974,6 @@ class Categorical(Discrete):
         return bound(a, value >= 0, value <= (k - 1),
                      tt.all(p_ >= 0, axis=-1), tt.all(p <= 1, axis=-1))
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        p = dist.p
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Categorical}}(\mathit{{p}}={})$'.format(name,
-                                                get_variable_name(p))
-
 
 class Constant(Discrete):
     r"""
@@ -1111,12 +1033,6 @@ class Constant(Discrete):
         """
         c = self.c
         return bound(0, tt.eq(value, c))
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{Constant}}()$'.format(name)
 
 
 ConstantDist = Constant
@@ -1231,16 +1147,6 @@ class ZeroInflatedPoisson(Discrete):
             0 <= psi, psi <= 1,
             0 <= theta)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        theta = dist.theta
-        psi = dist.psi
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{ZeroInflatedPoisson}}(\mathit{{theta}}={},~\mathit{{psi}}={})$'.format(name,
-                                                get_variable_name(theta),
-                                                get_variable_name(psi))
-
 
 class ZeroInflatedBinomial(Discrete):
     R"""
@@ -1353,22 +1259,6 @@ class ZeroInflatedBinomial(Discrete):
             0 <= value, value <= n,
             0 <= psi, psi <= 1,
             0 <= p, p <= 1)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        n = dist.n
-        p = dist.p
-        psi = dist.psi
-
-        name_n = get_variable_name(n)
-        name_p = get_variable_name(p)
-        name_psi = get_variable_name(psi)
-        name = r'\text{%s}' % name
-        return (r'${} \sim \text{{ZeroInflatedBinomial}}'
-                r'(\mathit{{n}}={},~\mathit{{p}}={},~'
-                r'\mathit{{psi}}={})$'
-                .format(name, name_n, name_p, name_psi))
 
 
 class ZeroInflatedNegativeBinomial(Discrete):
@@ -1523,22 +1413,6 @@ class ZeroInflatedNegativeBinomial(Discrete):
             0 <= psi, psi <= 1,
             mu > 0, alpha > 0)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        mu = dist.mu
-        alpha = dist.alpha
-        psi = dist.psi
-
-        name_mu = get_variable_name(mu)
-        name_alpha = get_variable_name(alpha)
-        name_psi = get_variable_name(psi)
-        name = r'\text{%s}' % name
-        return (r'${} \sim \text{{ZeroInflatedNegativeBinomial}}'
-                r'(\mathit{{mu}}={},~\mathit{{alpha}}={},~'
-                r'\mathit{{psi}}={})$'
-                .format(name, name_mu, name_alpha, name_psi))
-
 
 class OrderedLogistic(Categorical):
     R"""
@@ -1619,12 +1493,3 @@ class OrderedLogistic(Categorical):
         p = p_cum[..., 1:] - p_cum[..., :-1]
 
         super().__init__(p=p, *args, **kwargs)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        name_eta = get_variable_name(dist.eta)
-        name_cutpoints = get_variable_name(dist.cutpoints)
-        return (r'${} \sim \text{{OrderedLogistic}}'
-                r'(\mathit{{eta}}={}, \mathit{{cutpoints}}={}$'
-                .format(name, name_eta, name_cutpoints))

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -17,7 +17,6 @@ import theano.tensor as tt
 from scipy import stats
 import warnings
 
-from pymc3.util import get_variable_name
 from .dist_math import bound, factln, binomln, betaln, logpow, random_choice
 from .distribution import Discrete, draw_values, generate_samples
 from .shape_utils import broadcast_distribution_samples

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 import numpy as np
 import theano.tensor as tt
 from theano import function
-from ..util import get_variable_name
+from ..util import get_repr_for_variable
 import theano
 from ..memoize import memoize
 from ..model import (
@@ -158,7 +158,8 @@ class Distribution:
             name = '[unnamed]'
 
         param_names = self._distr_parameters_for_repr()
-        param_values = [get_variable_name(getattr(dist, x)) for x in param_names]
+        param_values = [get_repr_for_variable(getattr(dist, x), formatting=formatting)
+            for x in param_names]
 
         if formatting == "latex":
             param_string = ",~".join([r"\mathit{{{name}}}={value}".format(name=name,

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -173,11 +173,11 @@ class Distribution:
                 distr_name=dist._distr_name(), params=param_string)
 
     def __str__(self, **kwargs):
-        return self._str_repr(formatting='plain', **kwargs)
+        return self._str_repr(formatting="plain", **kwargs)
 
     def _repr_latex_(self, **kwargs):
         """Magic method name for IPython to use for LaTeX formatting."""
-        return self._str_repr(formatting='latex', **kwargs)
+        return self._str_repr(formatting="latex", **kwargs)
 
     def logp_nojac(self, *args, **kwargs):
         """Return the logp, but do not include a jacobian term for transforms.

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 import numpy as np
 import theano.tensor as tt
 from theano import function
-from .util import get_variable_name
+from ..util import get_variable_name
 import theano
 from ..memoize import memoize
 from ..model import (

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 import numpy as np
 import theano.tensor as tt
 from theano import function
-from pymc3.util import get_variable_name
+from .util import get_variable_name
 import theano
 from ..memoize import memoize
 from ..model import (

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -528,6 +528,9 @@ class DensityDist(Distribution):
                 "Define a custom random method and pass it as kwarg random"
             )
 
+    def _distr_parameters_for_repr(self):
+        return []
+
 
 class _DrawValuesContext(metaclass=ContextMeta, context_class='_DrawValuesContext'):
     """ A context manager class used while drawing values with draw_values

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -14,6 +14,7 @@
 
 import numbers
 import contextvars
+import inspect
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Optional, Callable
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
 import numpy as np
 import theano.tensor as tt
 from theano import function
+from pymc3.util import get_variable_name
 import theano
 from ..memoize import memoize
 from ..model import (
@@ -134,9 +136,48 @@ class Distribution:
 
         return val
 
-    def _repr_latex_(self, name=None, dist=None):
+    def _distr_parameters(self):
+        """Return the names of the parameters for this distribution (e.g. "mu"
+        and "sigma" for Normal). Used in generating string (and LaTeX etc.)
+        representations of Distribution objects. By default based on inspection
+        of __init__, but can be overwritten if necessary (e.g. to avoid including
+        "sd" and "tau").
+        """
+        return inspect.getfullargspec(self.__init__).args[1:]
+
+    def _distr_name(self):
+        return self.__class__.__name__
+
+    def _str_repr(self, name=None, dist=None, formatting='plain'):
+        """Generate string representation for this distribution, optionally
+        including LaTeX markup (formatting='latex').
+        """
+        if dist is None:
+            dist = self
+        if name is None:
+            name = '[unnamed]'
+
+        param_names = self._distr_parameters()
+        param_values = [get_variable_name(getattr(dist, x)) for x in param_names]
+
+        if formatting == "latex":
+            param_string = ",~".join([r"\mathit{{{name}}}={value}".format(name=name,
+                value=value) for name, value in zip(param_names, param_values)])
+            return r"$\text{{{var_name}}} \sim \text{{{distr_name}}}({params})$".format(var_name=name,
+                distr_name=dist._distr_name(), params=param_string)
+        else:
+            # 'plain' is default option
+            param_string = ", ".join(["{name}={value}".format(name=name,
+                value=value) for name, value in zip(param_names, param_values)])
+            return "{var_name} ~ {distr_name}({params})".format(var_name=name,
+                distr_name=dist._distr_name(), params=param_string)
+
+    def __str__(self, **kwargs):
+        return self._str_repr(formatting='plain', **kwargs)
+
+    def _repr_latex_(self, **kwargs):
         """Magic method name for IPython to use for LaTeX formatting."""
-        return None
+        return self._str_repr(formatting='latex', **kwargs)
 
     def logp_nojac(self, *args, **kwargs):
         """Return the logp, but do not include a jacobian term for transforms.

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -136,7 +136,7 @@ class Distribution:
 
         return val
 
-    def _distr_parameters(self):
+    def _distr_parameters_for_repr(self):
         """Return the names of the parameters for this distribution (e.g. "mu"
         and "sigma" for Normal). Used in generating string (and LaTeX etc.)
         representations of Distribution objects. By default based on inspection
@@ -145,7 +145,7 @@ class Distribution:
         """
         return inspect.getfullargspec(self.__init__).args[1:]
 
-    def _distr_name(self):
+    def _distr_name_for_repr(self):
         return self.__class__.__name__
 
     def _str_repr(self, name=None, dist=None, formatting='plain'):
@@ -157,20 +157,20 @@ class Distribution:
         if name is None:
             name = '[unnamed]'
 
-        param_names = self._distr_parameters()
+        param_names = self._distr_parameters_for_repr()
         param_values = [get_variable_name(getattr(dist, x)) for x in param_names]
 
         if formatting == "latex":
             param_string = ",~".join([r"\mathit{{{name}}}={value}".format(name=name,
                 value=value) for name, value in zip(param_names, param_values)])
             return r"$\text{{{var_name}}} \sim \text{{{distr_name}}}({params})$".format(var_name=name,
-                distr_name=dist._distr_name(), params=param_string)
+                distr_name=dist._distr_name_for_repr(), params=param_string)
         else:
             # 'plain' is default option
             param_string = ", ".join(["{name}={value}".format(name=name,
                 value=value) for name, value in zip(param_names, param_values)])
             return "{var_name} ~ {distr_name}({params})".format(var_name=name,
-                distr_name=dist._distr_name(), params=param_string)
+                distr_name=dist._distr_name_for_repr(), params=param_string)
 
     def __str__(self, **kwargs):
         return self._str_repr(formatting="plain", **kwargs)

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -18,7 +18,6 @@ import theano
 import theano.tensor as tt
 import warnings
 
-from pymc3.util import get_variable_name
 from ..math import logsumexp
 from .dist_math import bound, random_choice
 from .distribution import (Discrete, Distribution, draw_values,

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -578,6 +578,8 @@ class Mixture(Distribution):
             samples = np.reshape(samples, size + dist_shape)
         return samples
 
+    def _distr_parameters_for_repr(self):
+        return []
 
 class NormalMixture(Mixture):
     R"""
@@ -627,14 +629,5 @@ class NormalMixture(Mixture):
         super().__init__(w, Normal.dist(mu, sigma=sigma, shape=comp_shape),
                                             *args, **kwargs)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        mu = dist.mu
-        w = dist.w
-        sigma = dist.sigma
-        name = r'\text{%s}' % name
-        return r'${} \sim \text{{NormalMixture}}(\mathit{{w}}={},~\mathit{{mu}}={},~\mathit{{sigma}}={})$'.format(name,
-                                                get_variable_name(w),
-                                                get_variable_name(mu),
-                                                get_variable_name(sigma))
+    def _distr_parameters_for_repr(self):
+        return ["w", "mu", "sigma"]

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -151,18 +151,11 @@ class _QuadFormBase(Continuous):
         logdet = -tt.sum(tt.log(diag))
         return quaddist, logdet, ok
 
-    def _repr_cov_params(self, dist=None):
-        if dist is None:
-            dist = self
-        if self._cov_type == 'chol':
-            chol = get_variable_name(self.chol_cov)
-            return r'\mathit{{chol}}={}'.format(chol)
-        elif self._cov_type == 'cov':
-            cov = get_variable_name(self.cov)
-            return r'\mathit{{cov}}={}'.format(cov)
-        elif self._cov_type == 'tau':
-            tau = get_variable_name(self.tau)
-            return r'\mathit{{tau}}={}'.format(tau)
+    def _cov_param_for_repr(self):
+        if self._cov_type == "chol":
+            return "chol_cov"
+        else:
+            return self._cov_type
 
 
 class MvNormal(_QuadFormBase):
@@ -330,14 +323,8 @@ class MvNormal(_QuadFormBase):
         norm = - 0.5 * k * pm.floatX(np.log(2 * np.pi))
         return bound(norm - 0.5 * quaddist - logdet, ok)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        mu = dist.mu
-        name_mu = get_variable_name(mu)
-        return (r'${} \sim \text{{MvNormal}}'
-                r'(\mathit{{mu}}={}, {})$'
-                .format(name, name_mu, self._repr_cov_params(dist)))
+    def _distr_parameters_for_repr(self):
+        return ["mu", self._cov_param_for_repr()]
 
 
 class MvStudentT(_QuadFormBase):
@@ -448,17 +435,8 @@ class MvStudentT(_QuadFormBase):
         inner = - (self.nu + k) / 2. * tt.log1p(quaddist / self.nu)
         return bound(norm + inner - logdet, ok)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        mu = dist.mu
-        nu = dist.nu
-        name_nu = get_variable_name(nu)
-        name_mu = get_variable_name(mu)
-        return (r'${} \sim \text{{MvStudentT}}'
-                r'(\mathit{{nu}}={}, \mathit{{mu}}={}, '
-                r'{})$'
-                .format(name, name_nu, name_mu, self._repr_cov_params(dist)))
+    def _distr_parameters_for_repr(self):
+        return ["mu", "nu", self._cov_param_for_repr()]
 
 
 class Dirichlet(Continuous):
@@ -580,12 +558,8 @@ class Dirichlet(Continuous):
                      np.logical_not(a.broadcastable), tt.all(a > 0),
                      broadcast_conditions=False)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        a = dist.a
-        return r'${} \sim \text{{Dirichlet}}(\mathit{{a}}={})$'.format(name,
-                                                get_variable_name(a))
+    def _distr_parameters_for_repr(self):
+        return ["a"]
 
 
 class Multinomial(Discrete):
@@ -734,15 +708,6 @@ class Multinomial(Discrete):
             tt.all(tt.ge(n, 0)),
             broadcast_conditions=False
         )
-
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        n = dist.n
-        p = dist.p
-        return r'${} \sim \text{{Multinomial}}(\mathit{{n}}={}, \mathit{{p}}={})$'.format(name,
-                                                get_variable_name(n),
-                                                get_variable_name(p))
 
 
 def posdef(AA):
@@ -901,14 +866,6 @@ class Wishart(Continuous):
                      broadcast_conditions=False
         )
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        nu = dist.nu
-        V = dist.V
-        return r'${} \sim \text{{Wishart}}(\mathit{{nu}}={}, \mathit{{V}}={})$'.format(name,
-                                                get_variable_name(nu),
-                                                get_variable_name(V))
 
 def WishartBartlett(name, S, nu, is_cholesky=False, return_cholesky=False, testval=None):
     R"""

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -30,7 +30,6 @@ import pymc3 as pm
 
 from pymc3.theanof import floatX
 from . import transforms
-from pymc3.util import get_variable_name
 from .distribution import (Continuous, Discrete, draw_values, generate_samples,
                            _DrawValuesContext)
 from ..model import Deterministic

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -19,7 +19,6 @@ import theano.tensor as tt
 from theano import scan
 import numpy as np
 
-from pymc3.util import get_variable_name
 from .continuous import get_tau_sigma, Normal, Flat
 from .shape_utils import to_tuple
 from . import multivariate

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -80,16 +80,6 @@ class AR1(distribution.Continuous):
         innov_like = Normal.dist(k * x_im1, tau=tau_e).logp(x_i)
         return boundary(x[0]) + tt.sum(innov_like)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        k = dist.k
-        tau_e = dist.tau_e
-        name = r"\text{%s}" % name
-        return r"${} \sim \text{{AR1}}(\mathit{{k}}={},~\mathit{{tau_e}}={})$".format(
-            name, get_variable_name(k), get_variable_name(tau_e)
-        )
-
 
 class AR(distribution.Continuous):
     r"""
@@ -323,15 +313,8 @@ class GaussianRandomWalk(distribution.Continuous):
             data = data - data[0]
         return data
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        mu = dist.mu
-        sigma = dist.sigma
-        name = r"\text{%s}" % name
-        return r"${} \sim \text{{GaussianRandomWalk}}(\mathit{{mu}}={},~\mathit{{sigma}}={})$".format(
-            name, get_variable_name(mu), get_variable_name(sigma)
-        )
+    def _distr_parameters_for_repr(self):
+        return ["mu", "sigma"]
 
 
 class GARCH11(distribution.Continuous):
@@ -397,19 +380,8 @@ class GARCH11(distribution.Continuous):
         vol = self.get_volatility(x)
         return tt.sum(Normal.dist(0.0, sigma=vol).logp(x))
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        omega = dist.omega
-        alpha_1 = dist.alpha_1
-        beta_1 = dist.beta_1
-        name = r"\text{%s}" % name
-        return r"${} \sim \text{GARCH}(1,~1,~\mathit{{omega}}={},~\mathit{{alpha_1}}={},~\mathit{{beta_1}}={})$".format(
-            name,
-            get_variable_name(omega),
-            get_variable_name(alpha_1),
-            get_variable_name(beta_1),
-        )
+    def _distr_parameters_for_repr(self):
+        return ["omega", "alpha_1", "beta_1"]
 
 
 class EulerMaruyama(distribution.Continuous):
@@ -451,14 +423,8 @@ class EulerMaruyama(distribution.Continuous):
         sd = tt.sqrt(self.dt) * g
         return tt.sum(Normal.dist(mu=mu, sigma=sd).logp(x[1:]))
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        dt = dist.dt
-        name = r"\text{%s}" % name
-        return r"${} \sim \text{EulerMaruyama}(\mathit{{dt}}={})$".format(
-            name, get_variable_name(dt)
-        )
+    def _distr_parameters_for_repr(self):
+        return ["dt"]
 
 
 class MvGaussianRandomWalk(distribution.Continuous):
@@ -521,15 +487,8 @@ class MvGaussianRandomWalk(distribution.Continuous):
 
         return self.init.logp_sum(x[0]) + self.innov.logp_sum(x_i - x_im1)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        mu = dist.innov.mu
-        cov = dist.innov.cov
-        name = r"\text{%s}" % name
-        return r"${} \sim \text{MvGaussianRandomWalk}(\mathit{{mu}}={},~\mathit{{cov}}={})$".format(
-            name, get_variable_name(mu), get_variable_name(cov)
-        )
+    def _distr_parameters_for_repr(self):
+        return ["mu", "cov"]
 
 
 class MvStudentTRandomWalk(MvGaussianRandomWalk):
@@ -556,13 +515,5 @@ class MvStudentTRandomWalk(MvGaussianRandomWalk):
         self.nu = tt.as_tensor_variable(nu)
         self.innov = multivariate.MvStudentT.dist(self.nu, None, *self.innovArgs)
 
-    def _repr_latex_(self, name=None, dist=None):
-        if dist is None:
-            dist = self
-        nu = dist.innov.nu
-        mu = dist.innov.mu
-        cov = dist.innov.cov
-        name = r"\text{%s}" % name
-        return r"${} \sim \text{MvStudentTRandomWalk}(\mathit{{nu}}={},~\mathit{{mu}}={},~\mathit{{cov}}={})$".format(
-            name, get_variable_name(nu), get_variable_name(mu), get_variable_name(cov)
-        )
+    def _distr_parameters_for_repr(self):
+        return ["nu", "mu", "cov"]

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -196,6 +196,11 @@ class TransformedDistribution(distribution.Distribution):
         """
         return self.dist.logp(self.transform_used.backward(x))
 
+    def _repr_latex_(self, **kwargs):
+        # prevent TransformedDistributions from ending up in LaTeX representations
+        # of models
+        return None
+
 
 transform = Transform
 

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -201,6 +201,9 @@ class TransformedDistribution(distribution.Distribution):
         # of models
         return None
 
+    def _distr_parameters_for_repr(self):
+        return []
+
 
 transform = Transform
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1346,20 +1346,36 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
             name="Log-probability of test_point",
         )
 
-    def _repr_latex_(self, name=None, dist=None):
-        tex_vars = []
-        for rv in itertools.chain(self.unobserved_RVs, self.observed_RVs):
-            rv_tex = rv.__latex__()
-            if rv_tex is not None:
-                array_rv = rv_tex.replace(r"\sim", r"&\sim &").strip("$")
-                tex_vars.append(array_rv)
-        return r"""$$
-            \begin{{array}}{{rcl}}
-            {}
-            \end{{array}}
-            $$""".format(
-            "\\\\".join(tex_vars)
-        )
+    def _str_repr(self, formatting="plain", **kwargs):
+        all_rv = itertools.chain(self.unobserved_RVs, self.observed_RVs)
+
+        if formatting == "latex":
+            rv_reprs = [rv.__latex__() for rv in all_rv]
+            rv_reprs = [rv_repr.replace(r"\sim", r"&\sim &").strip("$")
+                for rv_repr in rv_reprs if rv_repr is not None]
+            return r"""$$
+                \begin{{array}}{{rcl}}
+                {}
+                \end{{array}}
+                $$""".format(
+                "\\\\".join(rv_reprs))
+        else:
+            rv_reprs = [rv.__str__() for rv in all_rv]
+            rv_reprs = [rv_repr for rv_repr in rv_reprs if not 'TransformedDistribution()' in rv_repr]
+            # align vars on their ~
+            names = [s[:s.index('~')-1] for s in rv_reprs]
+            distrs = [s[s.index('~')+2:] for s in rv_reprs]
+            maxlen = str(max(len(x) for x in names))
+            rv_reprs = [('{name:>' + maxlen + '} ~ {distr}').format(name=n, distr=d)
+                for n, d in zip(names, distrs)]
+            return "\n".join(rv_reprs)
+
+
+    def __str__(self, **kwargs):
+        return self._str_repr(**kwargs)
+
+    def _repr_latex_(self, **kwargs):
+        return self._str_repr(formatting="latex", **kwargs)
 
     __latex__ = _repr_latex_
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -63,6 +63,27 @@ class PyMC3Variable(TensorVariable):
     def __rmatmul__(self, other):
         return tt.dot(other, self)
 
+    def _str_repr(self, name=None, dist=None, formatting="plain"):
+        if getattr(self, "distribution", None) is None:
+            if formatting == "latex":
+                return None
+            else:
+                return super().__str__()
+
+        if name is None and hasattr(self, 'name'):
+            name = self.name
+        if dist is None and hasattr(self, 'distribution'):
+            dist = self.distribution
+        return self.distribution._str_repr(name=name, dist=dist, formatting=formatting)
+
+    def __str__(self, **kwargs):
+        return self._str_repr(**kwargs)
+
+    def _repr_latex_(self, **kwargs):
+        return self._str_repr(formatting="latex", **kwargs)
+
+    __latex__ = _repr_latex_
+
 
 class InstanceMethod:
     """Class for hiding references to instance methods so they can be pickled.
@@ -1606,17 +1627,6 @@ class FreeRV(Factor, PyMC3Variable):
                 wrapper=InstanceMethod,
             )
 
-    def _repr_latex_(self, name=None, dist=None):
-        if self.distribution is None:
-            return None
-        if name is None:
-            name = self.name
-        if dist is None:
-            dist = self.distribution
-        return self.distribution._repr_latex_(name=name, dist=dist)
-
-    __latex__ = _repr_latex_
-
     @property
     def init_value(self):
         """Convenience attribute to return tag.test_value"""
@@ -1750,17 +1760,6 @@ class ObservedRV(Factor, PyMC3Variable):
             theano.gof.Apply(theano.compile.view_op, inputs=[data], outputs=[self])
             self.tag.test_value = theano.compile.view_op(data).tag.test_value
             self.scaling = _get_scaling(total_size, data.shape, data.ndim)
-
-    def _repr_latex_(self, name=None, dist=None):
-        if self.distribution is None:
-            return None
-        if name is None:
-            name = self.name
-        if dist is None:
-            dist = self.distribution
-        return self.distribution._repr_latex_(name=name, dist=dist)
-
-    __latex__ = _repr_latex_
 
     @property
     def init_value(self):
@@ -1940,17 +1939,6 @@ class TransformedRV(PyMC3Variable):
                 methods=["random"],
                 wrapper=InstanceMethod,
             )
-
-    def _repr_latex_(self, name=None, dist=None):
-        if self.distribution is None:
-            return None
-        if name is None:
-            name = self.name
-        if dist is None:
-            dist = self.distribution
-        return self.distribution._repr_latex_(name=name, dist=dist)
-
-    __latex__ = _repr_latex_
 
     @property
     def init_value(self):

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1485,8 +1485,14 @@ def Point(*args, **kwargs):
         d = dict(*args, **kwargs)
     except Exception as e:
         raise TypeError("can't turn {} and {} into a dict. {}".format(args, kwargs, e))
+    def _mystr(k):
+        # make sure to use "plain" string representations (i.e. names) of variables
+        if isinstance(k, TensorVariable):
+            return super(TensorVariable, k).__str__()
+        else:
+            return str(k)
     return dict(
-        (str(k), np.array(v)) for k, v in d.items() if str(k) in map(str, model.vars)
+        (_mystr(k), np.array(v)) for k, v in d.items() if _mystr(k) in map(_mystr, model.vars)
     )
 
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1821,27 +1821,28 @@ class MultiObservedRV(Factor):
         return not self == other
 
 
-def _walk_up_rv(rv):
+def _walk_up_rv(rv, formatting='plain'):
     """Walk up theano graph to get inputs for deterministic RV."""
     all_rvs = []
     parents = list(itertools.chain(*[j.inputs for j in rv.get_parents()]))
     if parents:
         for parent in parents:
-            all_rvs.extend(_walk_up_rv(parent))
+            all_rvs.extend(_walk_up_rv(parent, formatting=formatting))
     else:
-        if rv.name:
-            all_rvs.append(r"\text{%s}" % rv.name)
-        else:
-            all_rvs.append(r"\text{Constant}")
+        name = rv.name if rv.name else "Constant"
+        fmt = r"\text{{{name}}}" if formatting == "latex" else "{name}"
+        all_rvs.append(fmt.format(name=name))
     return all_rvs
 
 
-def _latex_repr_rv(rv):
+def _repr_deterministic_rv(rv, formatting='plain'):
     """Make latex string for a Deterministic variable"""
-    return r"$\text{%s} \sim \text{Deterministic}(%s)$" % (
-        rv.name,
-        r",~".join(_walk_up_rv(rv)),
-    )
+    if formatting == 'latex':
+        return r"$\text{{{name}}} \sim \text{{Deterministic}}({args})$".format(
+            name=rv.name, args=r",~".join(_walk_up_rv(rv, formatting=formatting)))
+    else:
+        return "{name} ~ Deterministic({args})".format(
+            name=rv.name, args=", ".join(_walk_up_rv(rv, formatting=formatting)))
 
 
 def Deterministic(name, var, model=None, dims=None):
@@ -1860,8 +1861,9 @@ def Deterministic(name, var, model=None, dims=None):
     var = var.copy(model.name_for(name))
     model.deterministics.append(var)
     model.add_random_variable(var, dims)
-    var._repr_latex_ = functools.partial(_latex_repr_rv, var)
+    var._repr_latex_ = functools.partial(_repr_deterministic_rv, var, formatting='latex')
     var.__latex__ = var._repr_latex_
+    var.__str__ = functools.partial(_repr_deterministic_rv, var, formatting='plain')
     return var
 
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -35,7 +35,7 @@ from .memoize import memoize, WithMemoization
 from .theanof import gradient, hessian, inputvars, generator
 from .vartypes import typefilter, discrete_types, continuous_types, isgenerator
 from .blocking import DictToArrayBijection, ArrayOrdering
-from .util import get_transformed_name
+from .util import get_transformed_name, plain_str
 from .exceptions import ImputationWarning
 
 __all__ = [
@@ -1485,14 +1485,8 @@ def Point(*args, **kwargs):
         d = dict(*args, **kwargs)
     except Exception as e:
         raise TypeError("can't turn {} and {} into a dict. {}".format(args, kwargs, e))
-    def _mystr(k):
-        # make sure to use "plain" string representations (i.e. names) of variables
-        if isinstance(k, TensorVariable):
-            return super(TensorVariable, k).__str__()
-        else:
-            return str(k)
     return dict(
-        (_mystr(k), np.array(v)) for k, v in d.items() if _mystr(k) in map(_mystr, model.vars)
+        (plain_str(k), np.array(v)) for k, v in d.items() if plain_str(k) in map(plain_str, model.vars)
     )
 
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1850,14 +1850,16 @@ def _walk_up_rv(rv, formatting='plain'):
     return all_rvs
 
 
-def _repr_deterministic_rv(rv, formatting='plain'):
+def _repr_deterministic_rv(rv, name=None, formatting='plain'):
     """Make latex string for a Deterministic variable"""
+    if name is None:
+        name = rv.name
     if formatting == 'latex':
         return r"$\text{{{name}}} \sim \text{{Deterministic}}({args})$".format(
-            name=rv.name, args=r",~".join(_walk_up_rv(rv, formatting=formatting)))
+            name=name, args=r",~".join(_walk_up_rv(rv, formatting=formatting)))
     else:
         return "{name} ~ Deterministic({args})".format(
-            name=rv.name, args=", ".join(_walk_up_rv(rv, formatting=formatting)))
+            name=name, args=", ".join(_walk_up_rv(rv, formatting=formatting)))
 
 
 def Deterministic(name, var, model=None, dims=None):

--- a/pymc3/model_graph.py
+++ b/pymc3/model_graph.py
@@ -24,7 +24,7 @@ from theano.tensor import Tensor
 from .util import get_default_varnames
 from .model import ObservedRV
 import pymc3 as pm
-from pymc3.util import get_variable_name
+from pymc3.util import get_repr_for_variable
 
 
 class ModelGraph:
@@ -155,7 +155,7 @@ class ModelGraph:
         if include_prior_params and distribution in self._distr_params:
             param_strings = []
             for param in self._distr_params[distribution]:
-                val = get_variable_name(getattr(v.distribution, param))
+                val = get_repr_for_variable(getattr(v.distribution, param))
                 if type(val) is str and len(val) > 100:
                     val = '<long expression>'
                 try:

--- a/pymc3/model_graph.py
+++ b/pymc3/model_graph.py
@@ -24,7 +24,6 @@ from theano.tensor import Tensor
 from .util import get_default_varnames
 from .model import ObservedRV
 import pymc3 as pm
-from pymc3.util import get_repr_for_variable
 
 
 class ModelGraph:

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -15,6 +15,7 @@
 from .compound import CompoundStep
 from ..model import modelcontext
 from ..theanof import inputvars
+from ..util import plain_str
 from ..blocking import ArrayOrdering, DictToArrayBijection
 import numpy as np
 from numpy.random import uniform
@@ -175,7 +176,7 @@ class ArrayStepShared(BlockedStep):
         """
         self.vars = vars
         self.ordering = ArrayOrdering(vars)
-        self.shared = {str(var): shared for var, shared in shared.items()}
+        self.shared = {plain_str(var): shared for var, shared in shared.items()}
         self.blocked = blocked
         self.bij = None
 

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -191,9 +191,9 @@ class TestData(SeededTest):
         text = 'x [label="x\n~\nData" shape=box style="rounded, filled"]'
         assert text in g.source
         # Didn't break ordinary variables?
-        text = 'beta [label="beta\n~\nNormal"]'
+        text = 'beta [label="beta\n~\nNormal(mu=0.0, sigma=10.0)"]'
         assert text in g.source
-        text = 'obs [label="obs\n~\nNormal" style=filled]'
+        text = 'obs [label="obs\n~\nNormal(mu=f(f(beta), x), sigma=0.1)" style=filled]'
         assert text in g.source
 
     def test_explicit_coords(self):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1770,7 +1770,7 @@ def test_bound():
         BoundPoissonPositionalArgs = Bound(Poisson, upper=6)("x", 2.0)
 
 
-class TestLatex:
+class TestStrAndLatexRepr:
     def setup_class(self):
         # True parameter values
         alpha, sigma = 1, 1
@@ -1799,7 +1799,7 @@ class TestLatex:
             # Likelihood (sampling distribution) of observations
             Y_obs = Normal("Y_obs", mu=mu, sigma=sigma, observed=Y)
         self.distributions = [alpha, sigma, mu, b, Z, Y_obs]
-        self.expected = (
+        self.expected_latex = (
             r"$\text{alpha} \sim \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$",
             r"$\text{sigma} \sim \text{HalfNormal}(\mathit{sigma}=1.0)$",
             r"$\text{mu} \sim \text{Deterministic}(\text{alpha},~\text{Constant},~\text{beta})$",
@@ -1807,21 +1807,37 @@ class TestLatex:
             r"$\text{Z} \sim \text{MvNormal}(\mathit{mu}=array,~\mathit{chol_cov}=array)$",
             r"$\text{Y_obs} \sim \text{Normal}(\mathit{mu}=\text{mu},~\mathit{sigma}=f(\text{sigma}))$",
         )
+        self.expected_str = (
+            r"alpha ~ Normal(mu=0.0, sigma=10.0)",
+            r"sigma ~ HalfNormal(sigma=1.0)",
+            r"mu ~ Deterministic(alpha, Constant, beta)",
+            r"beta ~ Normal(mu=0.0, sigma=10.0)",
+            r"Z ~ MvNormal(mu=array, chol_cov=array)",
+            r"Y_obs ~ Normal(mu=mu, sigma=f(sigma))",
+        )
 
     def test__repr_latex_(self):
-        for distribution, tex in zip(self.distributions, self.expected):
+        for distribution, tex in zip(self.distributions, self.expected_latex):
             assert distribution._repr_latex_() == tex
 
         model_tex = self.model._repr_latex_()
 
-        for tex in self.expected:  # make sure each variable is in the model
+        for tex in self.expected_latex:  # make sure each variable is in the model
             for segment in tex.strip("$").split(r"\sim"):
                 assert segment in model_tex
 
     def test___latex__(self):
-        for distribution, tex in zip(self.distributions, self.expected):
+        for distribution, tex in zip(self.distributions, self.expected_latex):
             assert distribution._repr_latex_() == distribution.__latex__()
         assert self.model._repr_latex_() == self.model.__latex__()
+
+    def test___str__(self):
+        for distribution, str_repr in zip(self.distributions, self.expected_str):
+            assert distribution.__str__() == str_repr
+
+        model_str = self.model.__str__()
+        for str_repr in self.expected_str:
+            assert str_repr in model_str
 
 
 def test_discrete_trafo():

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1804,7 +1804,7 @@ class TestLatex:
             r"$\text{sigma} \sim \text{HalfNormal}(\mathit{sigma}=1.0)$",
             r"$\text{mu} \sim \text{Deterministic}(\text{alpha},~\text{Constant},~\text{beta})$",
             r"$\text{beta} \sim \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$",
-            r"$Z \sim \text{MvNormal}(\mathit{mu}=array, \mathit{chol}=array)$",
+            r"$\text{Z} \sim \text{MvNormal}(\mathit{mu}=array,~\mathit{chol_cov}=array)$",
             r"$\text{Y_obs} \sim \text{Normal}(\mathit{mu}=\text{mu},~\mathit{sigma}=f(\text{sigma}))$",
         )
 

--- a/pymc3/tuning/scaling.py
+++ b/pymc3/tuning/scaling.py
@@ -17,6 +17,7 @@ from numpy import exp, log, sqrt
 from ..model import modelcontext, Point
 from ..theanof import hessian_diag, inputvars
 from ..blocking import DictToArrayBijection, ArrayOrdering
+from ..util import plain_str
 
 __all__ = ['find_hessian', 'trace_cov', 'guess_scaling']
 
@@ -135,7 +136,7 @@ def trace_cov(trace, vars=None, model=None):
         vars = trace.varnames
 
     def flat_t(var):
-        x = trace[str(var)]
+        x = trace[plain_str(var)]
         return x.reshape((x.shape[0], np.prod(x.shape[1:], dtype=int)))
 
     return np.cov(np.concatenate(list(map(flat_t, vars)), 1).T)

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -20,6 +20,7 @@ import xarray
 import arviz
 from numpy import asscalar, ndarray
 
+from theano.tensor import TensorVariable
 
 LATEX_ESCAPE_RE = re.compile(r"(%|_|\$|#|&)", re.MULTILINE)
 
@@ -230,3 +231,11 @@ def chains_and_samples(
     nchains = coords["chain"].sizes["chain"]
     nsamples = coords["draw"].sizes["draw"]
     return nchains, nsamples
+
+
+def plain_str(k):
+    # make sure to use "plain" string representations (i.e. names) of variables
+    if isinstance(k, TensorVariable):
+        return super(TensorVariable, k).__str__()
+    else:
+        return str(k)

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -140,7 +140,7 @@ def get_variable_name(variable):
             except IndexError:
                 pass
         value = variable.eval()
-        if not value.shape:
+        if not value.shape or value.shape == (1,):
             return asscalar(value)
         return "array"
     return r"\text{%s}" % name


### PR DESCRIPTION
Note: this PR is a work in progress, and some brief feedback would be welcome before I add some more commits to finalize the functionality (if it's desirable at all, of course).

I very much like the GraphViz rendering functionality, but have noticed that complex/bigger models often result in extremely wide graphs with very wide, horizontally elongated, nodes. The first very simple thing that this PR does is it places the distribution a new line in the node text ("MyVar ~ Normal" --> "MyVar\n~\nNormal"), which results in more evenly distributed graphs (nodes considerably less wide).

The second, more elaborate thing, this PR does is it adds a `include_prior_params` option to the `model_to_graphviz` functionality. The idea is that this would enable display of not just e.g. "MyVar ~ Normal", but "MyVar ~ Normal(mu=1, sigma=0)" in the graph nodes. To me at least this would be useful functionality. See this simple rendering:

![image](https://user-images.githubusercontent.com/3042751/84512667-987d3300-acc8-11ea-9d54-58b58e29aa84.png)

As of now, the functionality supports `Normal` and `Uniform`, but others are trivial to add (and I'll add before this PR should be merged). But before I do that, I had two questions:

1. I couldn't find any unified mechanism by which `Distribution` subclasses advertise their parameters. Many distributions have a `_repr_latex()` method which I had a look at, and saw that each subclass hard-codes its parameters of interest there. I didn't want to introduce a general mechanism by which distributions advertise their parameters (as this seems a somewhat major overhaul), so instead I opted to add a `dict` to `ModelGraph` that maps distributions to their parameters of interest. For now I just added `Normal` and `Uniform`, but if you agree this is the way to go I'll add the rest (just a bit of monkey work--happy to do it but won't if this is inappropriate of course ;) ).

2. I noticed (and am using) the `util.get_variable_name` function, which is somewhat strangely named since it actually returns a variable's value, or a description of that value. I think the general logic of the function is highly relevant to what this PR is trying to do, but it has some LaTeX hardcoded in it (only `'\text{%s}'` at the end). Perhaps that's OK to remove?

