### PR TITLE
distribution on new line in GraphViz node

### DIFF
--- a/pymc3/model_graph.py
+++ b/pymc3/model_graph.py
@@ -147,7 +147,7 @@ class ModelGraph:
             attrs['shape'] = 'box'
 
         graph.node(var_name.replace(':', '&'),
-                '{var_name} ~ {distribution}'.format(var_name=var_name, distribution=distribution),
+                '{var_name}\n~\n{distribution}'.format(var_name=var_name, distribution=distribution),
                 **attrs)
 
     def get_plates(self):

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -188,12 +188,12 @@ class TestData(SeededTest):
         g = pm.model_to_graphviz(model)
 
         # Data node rendered correctly?
-        text = 'x [label="x ~ Data" shape=box style="rounded, filled"]'
+        text = 'x [label="x\n~\nData" shape=box style="rounded, filled"]'
         assert text in g.source
         # Didn't break ordinary variables?
-        text = 'beta [label="beta ~ Normal"]'
+        text = 'beta [label="beta\n~\nNormal"]'
         assert text in g.source
-        text = 'obs [label="obs ~ Normal" style=filled]'
+        text = 'obs [label="obs\n~\nNormal" style=filled]'
         assert text in g.source
 
     def test_explicit_coords(self):


### PR DESCRIPTION
This makes nodes in GraphViz rendering skinnier, as the distribution is placed on a new line, after the variable name (rather than all on the same line). Originally part of larger PR #3956, but filing as separate PR, as suggested by @ColCarroll.
