### PR TITLE
Add black_nbconvert and watermark to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+black_nbconvert
 bokeh>=0.12.13
 coverage<5.0
 graphviz>=0.8.3
@@ -16,3 +17,4 @@ recommonmark>=0.4.0
 seaborn>=0.8.1
 sphinx-autobuild==0.7.1
 sphinx>=1.5.5
+watermark


### PR DESCRIPTION
Very simple PR to add [black_nbconvert](https://github.com/dfm/black_nbconvert) and [watermark](https://github.com/rasbt/watermark) to our dev requirements.

This goes with the goal of standardizing and giving a common feel to our notebook gallery. I wrote a short [NB style page](https://github.com/pymc-devs/pymc3/wiki/PyMC's-Jupyter-Notebook-Style) in our Wiki to facilitate reaching this goal gradually, when we update or create NBs. If this is fine with you, I'll open an issue about that if beginners want to help us update our NBs in small batches.

Thanks and PyMCheers 🖖 
