### PR TITLE
rewrite radon notebook using ArviZ and xarray

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,13 +1,14 @@
 # Release Notes
 
 ## PyMC3 3.9.x (on deck)
-*waiting for contributions*
+### Documentation
+- Notebook on [multilevel modeling](https://docs.pymc.io/notebooks/multilevel_modeling.html) has been rewritten to showcase ArviZ and xarray usage for inference result analysis (see [#3963](https://github.com/pymc-devs/pymc3/pull/3963))
 
 ## PyMC3 3.9.2 (24 June 2020)
 ### Maintenance
 - Warning added in GP module when `input_dim` is lower than the number of columns in `X` to compute the covariance function (see [#3974](https://github.com/pymc-devs/pymc3/pull/3974)).
 - Pass the `tune` argument from `sample` when using `advi+adapt_diag_grad` (see issue [#3965](https://github.com/pymc-devs/pymc3/issues/3965), fixed by [#3979](https://github.com/pymc-devs/pymc3/pull/3979)).
-- Add simple test case for new coords and dims feature in `pm.Model` (see [#3977](https://github.com/pymc-devs/pymc3/pull/3977)). 
+- Add simple test case for new coords and dims feature in `pm.Model` (see [#3977](https://github.com/pymc-devs/pymc3/pull/3977)).
 - Require ArviZ >= 0.9.0 (see [#3977](https://github.com/pymc-devs/pymc3/pull/3977)).
 
 _NB: The `docs/*` folder is still removed from the tarball due to an upload size limit on PyPi._


### PR DESCRIPTION
I am in the process of rewriting the notebook to exploit all ArviZ and xarray goodness. Comments are very welcome and I hope it is useful as a way to showcase xarray mostly and ArviZ capabilities inherited from xarray. Part of #3959

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] important background, or details about the implementation
  - ~Doing this I have encountered a couple bugs in ArviZ so this notebook won't even run on ArviZ master, only on PR branch. I am not sure about the timeline of the doc sprint but it will end up either running on ArviZ master or on next release (there may be a release coming in the coming weeks :thinking:). Depends on https://github.com/arviz-devs/arviz/pull/1240 and https://github.com/arviz-devs/arviz/pull/1241~ All PRs have been merged and ArviZ 0.9.0 has been released!
  - I have checked doc generation locally to make sure xarray html repr is rendered properly
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
