### PR TITLE
Fix tarball generation as 3.9.1 release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include pymc3/examples/data *
 recursive-include source *
-recursive-include docs *
+# because of an upload-size limit by PyPI, we're temporarily removing docs from the tarball:
+recursive-exclude docs *
 include requirements.txt
 include *.md *.rst
 include scripts/*.sh

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,13 @@
 # Release Notes
 
-## PyMC3 3.9 (On deck)
+## PyMC3 3.9.x (on deck)
+*waiting for contributions*
+
+## PyMC3 3.9.1 (16 June 2020)
+The `v3.9.0` upload to PyPI didn't include a tarball, which is fixed in this release.
+Though we had to temporarily remove the `docs/*` folder from the tarball due to a size limit.
+
+## PyMC3 3.9.0 (16 June 2020)
 
 ### New features
 - Use [fastprogress](https://github.com/fastai/fastprogress) instead of tqdm [#3693](https://github.com/pymc-devs/pymc3/pull/3693).

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # pylint: disable=wildcard-import
-__version__ = "3.9.0"
+__version__ = "3.9.1"
 
 import logging
 import multiprocessing as mp

--- a/setup.py
+++ b/setup.py
@@ -18,63 +18,71 @@ from os.path import realpath, dirname, join
 from setuptools import setup, find_packages
 import re
 
-DISTNAME = 'pymc3'
+DISTNAME = "pymc3"
 DESCRIPTION = "Probabilistic Programming in Python: Bayesian Modeling and Probabilistic Machine Learning with Theano"
-AUTHOR = 'PyMC Developers'
-AUTHOR_EMAIL = 'pymc.devs@gmail.com'
+AUTHOR = "PyMC Developers"
+AUTHOR_EMAIL = "pymc.devs@gmail.com"
 URL = "http://github.com/pymc-devs/pymc3"
 LICENSE = "Apache License, Version 2.0"
 
-classifiers = ['Development Status :: 5 - Production/Stable',
-               'Programming Language :: Python',
-               'Programming Language :: Python :: 3',
-               'Programming Language :: Python :: 3.6',
-               'Programming Language :: Python :: 3.7',
-               'Programming Language :: Python :: 3.8',
-               'License :: OSI Approved :: Apache Software License',
-               'Intended Audience :: Science/Research',
-               'Topic :: Scientific/Engineering',
-               'Topic :: Scientific/Engineering :: Mathematics',
-               'Operating System :: OS Independent']
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "License :: OSI Approved :: Apache Software License",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Operating System :: OS Independent",
+]
 
 PROJECT_ROOT = dirname(realpath(__file__))
 
 # Get the long description from the README file
-with open(join(PROJECT_ROOT, 'README.rst'), encoding='utf-8') as buff:
+with open(join(PROJECT_ROOT, "README.rst"), encoding="utf-8") as buff:
     LONG_DESCRIPTION = buff.read()
 
-REQUIREMENTS_FILE = join(PROJECT_ROOT, 'requirements.txt')
+REQUIREMENTS_FILE = join(PROJECT_ROOT, "requirements.txt")
 
 with open(REQUIREMENTS_FILE) as f:
     install_reqs = f.read().splitlines()
 
-test_reqs = ['pytest', 'pytest-cov']
+test_reqs = ["pytest", "pytest-cov"]
+
 
 def get_version():
-    VERSIONFILE = join('pymc3', '__init__.py')
-    lines = open(VERSIONFILE, 'rt').readlines()
+    VERSIONFILE = join("pymc3", "__init__.py")
+    lines = open(VERSIONFILE, "rt").readlines()
     version_regex = r"^__version__ = ['\"]([^'\"]*)['\"]"
     for line in lines:
         mo = re.search(version_regex, line, re.M)
         if mo:
             return mo.group(1)
-    raise RuntimeError('Unable to find version in %s.' % (VERSIONFILE,))
+    raise RuntimeError("Unable to find version in %s." % (VERSIONFILE,))
+
 
 if __name__ == "__main__":
-    setup(name=DISTNAME,
-          version=get_version(),
-          maintainer=AUTHOR,
-          maintainer_email=AUTHOR_EMAIL,
-          description=DESCRIPTION,
-          license=LICENSE,
-          url=URL,
-          long_description=LONG_DESCRIPTION,
-          long_description_content_type='text/x-rst',
-          packages=find_packages(),
-          package_data={'docs': ['*']},
-          include_package_data=True,
-          classifiers=classifiers,
-          python_requires=">=3.6",
-          install_requires=install_reqs,
-          tests_require=test_reqs,
-          test_suite='nose.collector')
+    setup(
+        name=DISTNAME,
+        version=get_version(),
+        maintainer=AUTHOR,
+        maintainer_email=AUTHOR_EMAIL,
+        description=DESCRIPTION,
+        license=LICENSE,
+        url=URL,
+        long_description=LONG_DESCRIPTION,
+        long_description_content_type="text/x-rst",
+        packages=find_packages(),
+        # because of an upload-size limit by PyPI, we're temporarily removing docs from the tarball.
+        # Also see MANIFEST.in
+        # package_data={'docs': ['*']},
+        include_package_data=True,
+        classifiers=classifiers,
+        python_requires=">=3.6",
+        install_requires=install_reqs,
+        tests_require=test_reqs,
+        test_suite="nose.collector",
+    )


### PR DESCRIPTION
The 3.9.0 release did not include a tarball, because it was bigger than the 60 MB upload limit by PyPI.

PyPI unfortunately did accept the Wheel and published it as a release.
As a result `pip install --no-binary pymc3 pymc3` still installs 3.8.

With these changes, the tarball reduces to <2 MB and the version is bumped to `3.9.1` so we can release the "complete" package right away.
+ removes docs/* from the tarball to fix PyPI size limits (setup.py and MANIFEST.in)
+ updates the release notes with 3.9.0/3.9.1 sections
+ black applied to setup.py
