### PR TITLE
fix problem with older version of packaging

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -433,7 +433,7 @@ def sample(
 
     if return_inferencedata is None:
         v = packaging.version.parse(pm.__version__)
-        if v.major > 3 or v.minor >= 10:
+        if v.release[0] > 3 or v.release[1] >= 10:
             warnings.warn(
                 "In an upcoming release, pm.sample will return an `arviz.InferenceData` object instead of a `MultiTrace` by default. "
                 "You can pass return_inferencedata=True or return_inferencedata=False to be safe and silence this warning.",


### PR DESCRIPTION
It seems that old version of packaging can be problematic as the attributes `major` and `minor` where recently introduced, this is a quick fix.