### PR TITLE
add regression test for issue 3965

### DIFF
--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -307,7 +307,7 @@ class QuadPotentialDiagAdaptGrad(QuadPotentialDiagAdapt):
         self._ngrads2 += 1
 
         if self._n_samples <= 150:
-            super().update(sample, grad)
+            super().update(sample, grad, tune)
         else:
             self._update((self._ngrads1 / self._grads1) ** 2)
 

--- a/pymc3/tests/test_quadpotential.py
+++ b/pymc3/tests/test_quadpotential.py
@@ -283,3 +283,9 @@ def test_full_adapt_sampling(seed=289586):
         pymc3.sample(
             draws=10, tune=1000, random_seed=seed, step=step, cores=1, chains=1
         )
+
+        
+def test_issue_3965():
+    with pymc3.Model():
+        pymc3.Normal('n')
+        pymc3.sample(100, tune=300, chains=1, init='advi+adapt_diag_grad')


### PR DESCRIPTION
This PR is supposed to fix #3965.

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] no breaking changes, just bugfix
+ [x] in `quadpotential.py`, the `tune` argument wasn't passed to the `update(point, grad, tune)` method
+ [x] added a regression test (supposed to fail the first CI run)
+ [x] <s>right before it's ready to merge, mention the PR in the RELEASE-NOTES.md</s> will mention in follow-up PR
