### PR TITLE
Set different almost equal tolerance depending on floatX

### DIFF
--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -23,6 +23,7 @@ import pymc3 as pm
 from pymc3.distributions import HalfCauchy, Normal, transforms
 from pymc3 import Potential, Deterministic
 from pymc3.model import ValueGradFunction
+from .helpers import select_by_precision
 
 
 class NewModel(pm.Model):
@@ -192,17 +193,33 @@ def test_matrix_multiplication():
                               tune=0,
                               compute_convergence_checks=False,
                               progressbar=False)
+        decimal = select_by_precision(7, 5)
         for point in posterior.points():
-            npt.assert_almost_equal(point['matrix'] @ point['transformed'],
-                                    point['rv_rv'])
-            npt.assert_almost_equal(np.ones((2, 2)) @ point['transformed'],
-                                    point['np_rv'])
-            npt.assert_almost_equal(point['matrix'] @ np.ones(2),
-                                    point['rv_np'])
-            npt.assert_almost_equal(point['matrix'] @ point['rv_rv'],
-                                    point['rv_det'])
-            npt.assert_almost_equal(point['rv_rv'] @ point['transformed'],
-                                    point['det_rv'])
+            npt.assert_almost_equal(
+                point['matrix'] @ point['transformed'],
+                point['rv_rv'],
+                decimal=decimal,
+            )
+            npt.assert_almost_equal(
+                np.ones((2, 2)) @ point['transformed'],
+                point['np_rv'],
+                decimal=decimal,
+            )
+            npt.assert_almost_equal(
+                point['matrix'] @ np.ones(2),
+                point['rv_np'],
+                decimal=decimal,
+            )
+            npt.assert_almost_equal(
+                point['matrix'] @ point['rv_rv'],
+                point['rv_det'],
+                decimal=decimal,
+            )
+            npt.assert_almost_equal(
+                point['rv_rv'] @ point['transformed'],
+                point['det_rv'],
+                decimal=decimal,
+            )
 
 
 def test_duplicate_vars():


### PR DESCRIPTION
This PR fixes the broken test we are seeing in #3977, #3978 and #3979. I just changed the assertion decimal tolerance depending on theano's floatX.


Depending on what your PR does, here are a few things you might want to address in the description:
+ [X] what are the (breaking) changes that this PR makes?
None

+ [X] important background, or details about the implementation
None

+ [X] are the changes—especially new features—covered by tests and docstrings?
No

+ [X] consider adding/updating relevant example notebooks
No

+ [X] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
It's an infrastructure fix so it doesn't need to go into the release notes