### PR TITLE
Add time values as sampler stats for NUTS

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,7 +3,9 @@
 ## PyMC3 3.9.x (on deck)
 ### Documentation
 - Notebook on [multilevel modeling](https://docs.pymc.io/notebooks/multilevel_modeling.html) has been rewritten to showcase ArviZ and xarray usage for inference result analysis (see [#3963](https://github.com/pymc-devs/pymc3/pull/3963))
-- Add sampler stats `process_time_diff`, `perf_counter_diff` and `perf_counter`, that record wall and CPU time for each NUTS and HMC sample (see [ #3986](https://github.com/pymc-devs/pymc3/pull/3986)).
+
+### New features
+- Add sampler stats `process_time_diff`, `perf_counter_diff` and `perf_counter_start`, that record wall and CPU times for each NUTS and HMC sample (see [ #3986](https://github.com/pymc-devs/pymc3/pull/3986)).
 
 ## PyMC3 3.9.2 (24 June 2020)
 ### Maintenance

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,7 @@
 ## PyMC3 3.9.x (on deck)
 ### Documentation
 - Notebook on [multilevel modeling](https://docs.pymc.io/notebooks/multilevel_modeling.html) has been rewritten to showcase ArviZ and xarray usage for inference result analysis (see [#3963](https://github.com/pymc-devs/pymc3/pull/3963))
+- Add sampler stats `process_time_diff`, `perf_counter_diff` and `perf_counter`, that record wall and CPU time for each NUTS and HMC sample (see [ #3986](https://github.com/pymc-devs/pymc3/pull/3986)).
 
 ## PyMC3 3.9.2 (24 June 2020)
 ### Maintenance

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -133,8 +133,8 @@ class BaseHMC(arraystep.GradientSharedStep):
 
     def astep(self, q0):
         """Perform a single HMC iteration."""
-        perf_start = time.perf_counter_ns()
-        process_start = time.process_time_ns()
+        perf_start = time.perf_counter()
+        process_start = time.process_time()
 
         p0 = self.potential.random()
         start = self.integrator.compute_state(q0, p0)
@@ -170,8 +170,8 @@ class BaseHMC(arraystep.GradientSharedStep):
 
         hmc_step = self._hamiltonian_step(start, p0, step_size)
 
-        perf_end = time.perf_counter_ns()
-        process_end = time.process_time_ns()
+        perf_end = time.perf_counter()
+        process_end = time.process_time()
 
         self.step_adapt.update(hmc_step.accept_stat, adapt_step)
         self.potential.update(hmc_step.end.q, hmc_step.end.q_grad, self.tune)
@@ -201,9 +201,9 @@ class BaseHMC(arraystep.GradientSharedStep):
         stats = {
             "tune": self.tune,
             "diverging": bool(hmc_step.divergence_info),
-            "perf_counter_diff_ns": perf_end - perf_start,
-            "process_time_diff_ns": process_end - process_start,
-            "perf_counter_ns": perf_end,
+            "perf_counter_diff": perf_end - perf_start,
+            "process_time_diff": process_end - process_start,
+            "perf_counter_start": perf_start,
         }
 
         stats.update(hmc_step.stats)

--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -48,6 +48,9 @@ class HamiltonianMC(BaseHMC):
         'path_length': np.float64,
         'accepted': np.bool,
         'model_logp': np.float64,
+        'process_time_diff_ns': np.int64,
+        'perf_counter_diff_ns': np.int64,
+        'perf_counter_ns': np.int64,
     }]
 
     def __init__(self, vars=None, path_length=2., max_steps=1024, **kwargs):

--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -48,9 +48,9 @@ class HamiltonianMC(BaseHMC):
         'path_length': np.float64,
         'accepted': np.bool,
         'model_logp': np.float64,
-        'process_time_diff_ns': np.int64,
-        'perf_counter_diff_ns': np.int64,
-        'perf_counter_ns': np.int64,
+        'process_time_diff': np.float64,
+        'perf_counter_diff': np.float64,
+        'perf_counter_start': np.float64,
     }]
 
     def __init__(self, vars=None, path_length=2., max_steps=1024, **kwargs):

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -72,6 +72,13 @@ class NUTS(BaseHMC):
       samples, the step size is set to this value. This should converge
       during tuning.
     - `model_logp`: The model log-likelihood for this sample.
+    - `process_time_diff_ns`: The time it took to draw the sample, as defined
+      by the python standard library `time.process_time_ns`. This counts all
+      the CPU time, including worker processes in BLAS and OpenMP.
+    - `perf_counter_diff_ns`: The time it took to draw the sample, as defined
+      by the python standard library `time.perf_counter_ns` (wall time).
+    - `perf_counter_ns`: The value of the `time.perf_counter_ns` after drawing
+      the sample.
 
     References
     ----------
@@ -96,6 +103,9 @@ class NUTS(BaseHMC):
             "energy": np.float64,
             "max_energy_error": np.float64,
             "model_logp": np.float64,
+            "process_time_diff_ns": np.int64,
+            "perf_counter_diff_ns": np.int64,
+            "perf_counter_ns": np.int64,
         }
     ]
 

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -72,13 +72,13 @@ class NUTS(BaseHMC):
       samples, the step size is set to this value. This should converge
       during tuning.
     - `model_logp`: The model log-likelihood for this sample.
-    - `process_time_diff_ns`: The time it took to draw the sample, as defined
-      by the python standard library `time.process_time_ns`. This counts all
+    - `process_time_diff`: The time it took to draw the sample, as defined
+      by the python standard library `time.process_time`. This counts all
       the CPU time, including worker processes in BLAS and OpenMP.
-    - `perf_counter_diff_ns`: The time it took to draw the sample, as defined
-      by the python standard library `time.perf_counter_ns` (wall time).
-    - `perf_counter_ns`: The value of the `time.perf_counter_ns` after drawing
-      the sample.
+    - `perf_counter_diff`: The time it took to draw the sample, as defined
+      by the python standard library `time.perf_counter` (wall time).
+    - `perf_counter_start`: The value of `time.perf_counter` at the beginning
+      of the computation of the draw.
 
     References
     ----------
@@ -103,9 +103,9 @@ class NUTS(BaseHMC):
             "energy": np.float64,
             "max_energy_error": np.float64,
             "model_logp": np.float64,
-            "process_time_diff_ns": np.int64,
-            "perf_counter_diff_ns": np.int64,
-            "perf_counter_ns": np.int64,
+            "process_time_diff": np.float64,
+            "perf_counter_diff": np.float64,
+            "perf_counter_start": np.float64,
         }
     ]
 

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -979,7 +979,7 @@ class TestNutsCheckTrace:
 
     def test_sampler_stats(self):
         with Model() as model:
-            x = Normal("x", mu=0, sigma=1)
+            Normal("x", mu=0, sigma=1)
             trace = sample(draws=10, tune=1, chains=1)
 
         # Assert stats exist and have the correct shape.
@@ -995,6 +995,9 @@ class TestNutsCheckTrace:
             "step_size_bar",
             "tree_size",
             "tune",
+            "perf_counter_diff",
+            "perf_counter_start",
+            "process_time_diff",
         }
         assert trace.stat_names == expected_stat_names
         for varname in trace.stat_names:
@@ -1002,7 +1005,8 @@ class TestNutsCheckTrace:
 
         # Assert model logp is computed correctly: computing post-sampling
         # and tracking while sampling should give same results.
-        model_logp_ = np.array(
-            [model.logp(trace.point(i, chain=c)) for c in trace.chains for i in range(len(trace))]
-        )
+        model_logp_ = np.array([
+            model.logp(trace.point(i, chain=c))
+            for c in trace.chains for i in range(len(trace))
+        ])
         assert (trace.model_logp == model_logp_).all()


### PR DESCRIPTION
This PR adds three more sampler stats for NUTS and HMC: "process_time_diff_ns" and "perf_counter_diff_ns" and "perf_counter_ns".
During debugging it can be useful to see how long it took to compute each sample, and for issues involving blas/openmp it can also be useful to see the difference between process time and wall time.
The names are taken from the python time module: https://docs.python.org/3/library/time.html#time.perf_counter

This can be used like this:
```python
with pm.Model() as model:
    pm.Normal("a", shape=1000)
    
    tr = pm.sample(return_inferencedata=True)

stats = tr.sample_stats
for chain in stats.chain:
    sns.distplot(np.log(stats.process_time_diff_ns.sel(chain=chain)), label=chain.values)
plt.legend();
```
![image](https://user-images.githubusercontent.com/1882397/86222828-0b225580-bb87-11ea-8fd2-318cb1994cbb.png)
