### PR TITLE
Close main process copy of pipe when sampling in parallel

### DIFF
--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -257,6 +257,9 @@ class ProcessAdapter:
         )
         try:
             self._process.start()
+            # Close the remote pipe, so that we get notified if the other
+            # end is closed.
+            remote_conn.close()
         except IOError as e:
             # Something may have gone wrong during the fork / spawn
             if e.errno == errno.EPIPE:
@@ -285,7 +288,10 @@ class ProcessAdapter:
         self._msg_pipe.send(("write_next",))
 
     def abort(self):
-        self._msg_pipe.send(("abort",))
+        try:
+            self._msg_pipe.send(("abort",))
+        except BrokenPipeError:
+            pass
 
     def join(self, timeout=None):
         self._process.join(timeout)

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -980,5 +980,6 @@ class TestIssues:
                 pm.sample(
                     step=pm.Metropolis(),
                     cores=2, chains=2,
-                    tune=100, draws=300
+                    tune=100, draws=300,
+                    compute_convergence_checks=False
                 )

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -956,7 +956,10 @@ class TestSamplePosteriorPredictive:
             )
 
 
-@theano.as_op([tt.dvector], [tt.dvector])
+@theano.as_op(
+    [tt.dvector if theano.config.floatX == "float64" else tt.fvector],
+    [tt.dvector if theano.config.floatX == "float64" else tt.fvector]
+)
 def segfault_on_negative(a):
     if np.any(a < 0):
         # Segfault

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -956,10 +956,8 @@ class TestSamplePosteriorPredictive:
             )
 
 
-@theano.as_op(
-    [tt.dvector if theano.config.floatX == "float64" else tt.fvector],
-    [tt.dvector if theano.config.floatX == "float64" else tt.fvector]
-)
+tt_vector = tt.TensorType(theano.config.floatX, [False])
+@theano.as_op([tt_vector], [tt_vector])
 def segfault_on_negative(a):
     if np.any(a < 0):
         # Segfault


### PR DESCRIPTION
When starting parallel sampling, we first create a pipe for communication. We pass one end to the new worker thread, but we should still close our own local copy, so that the pipe breaks when the remote process dies for some reason.
If we don't, then when a worker dies the main process will wait for new samples, but since there is still an open end of the queue it will not exit with a `ConnectionResetError`, but wait indefinitely.
Closing the connection will prevent this. So when a worker dies, sampling stops and errors out.
We can test this behaviour by producing a segfault on purpose:
```python
import pymc3 as pm
import theano
import theano.tensor as tt
import random
import ctypes
import numpy as np

@theano.as_op([tt.dvector], [tt.dvector])
def somefunc(a):
    if random.random() < 0.01:
        # Segfault
        ctypes.string_at(0)
    return 2 * np.array(a)

with pm.Model() as model:
    x = pm.Normal('x', shape=2)
    pm.Normal('y', mu=somefunc(x), shape=2)
    
    step = pm.Metropolis()
    trace = pm.sample(step=step)
```

Unfortunately there is a small probability that this will also segfault the main process, so I don't really know how to create a proper test out of this.