### PR TITLE
add docs for interpretation of length scales in periodic kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,3 @@ benchmarks/results/
 pytestdebug.log
 .dir-locals.el
 .pycheckers
-env/

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ benchmarks/results/
 pytestdebug.log
 .dir-locals.el
 .pycheckers
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ benchmarks/results/
 pytestdebug.log
 .dir-locals.el
 .pycheckers
+

--- a/pymc3/gp/cov.py
+++ b/pymc3/gp/cov.py
@@ -352,11 +352,11 @@ class Periodic(Stationary):
     The Periodic kernel.
 
     .. math::
-       k(x, x') = \mathrm{exp}\left( -\frac{\mathrm{sin}^2(2 \pi |x-x'| \frac{1}{T})}{\ell^2} \right)
+       k(x, x') = \mathrm{exp}\left( -\frac{\mathrm{sin}^2(\pi |x-x'| \frac{1}{T})}{2\ell^2} \right)
 
-    .. versionchanged:: 3.9.3
-        Use the standard expression, as presented in [1]_, of the Periodic kernel
-        to evaluate the covariance matrix.
+    The interpretation of length-scale for this kernel is different than the
+    one used normally (see [1]_). Priors on length scale must be put keeping
+    this in mind.
 
     References
     ----------
@@ -376,7 +376,7 @@ class Periodic(Stationary):
         f2 = Xs.dimshuffle("x", 0, 1)
         r = np.pi * (f1 - f2) / self.period
         r = tt.sum(tt.square(tt.sin(r) / self.ls), 2)
-        return tt.exp(-2.0 * r)
+        return tt.exp(-0.5 * r)
 
 
 class ExpQuad(Stationary):

--- a/pymc3/gp/cov.py
+++ b/pymc3/gp/cov.py
@@ -352,7 +352,16 @@ class Periodic(Stationary):
     The Periodic kernel.
 
     .. math::
-       k(x, x') = \mathrm{exp}\left( -\frac{\mathrm{sin}^2(\pi |x-x'| \frac{1}{T})}{2\ell^2} \right)
+       k(x, x') = \mathrm{exp}\left( -\frac{\mathrm{sin}^2(2 \pi |x-x'| \frac{1}{T})}{\ell^2} \right)
+
+    .. versionchanged:: 3.9.3
+        Use the standard expression, as presented in [1]_, of the Periodic kernel
+        to evaluate the covariance matrix.
+
+    References
+    ----------
+    .. [1] David Duvenaud, "The Kernel Cookbook"
+       https://www.cs.toronto.edu/~duvenaud/cookbook/
     """
 
     def __init__(self, input_dim, period, ls=None, ls_inv=None, active_dims=None):
@@ -367,7 +376,7 @@ class Periodic(Stationary):
         f2 = Xs.dimshuffle("x", 0, 1)
         r = np.pi * (f1 - f2) / self.period
         r = tt.sum(tt.square(tt.sin(r) / self.ls), 2)
-        return tt.exp(-0.5 * r)
+        return tt.exp(-2.0 * r)
 
 
 class ExpQuad(Stationary):

--- a/pymc3/gp/cov.py
+++ b/pymc3/gp/cov.py
@@ -354,9 +354,11 @@ class Periodic(Stationary):
     .. math::
        k(x, x') = \mathrm{exp}\left( -\frac{\mathrm{sin}^2(\pi |x-x'| \frac{1}{T})}{2\ell^2} \right)
 
-    The interpretation of length-scale for this kernel is different than the
-    one used normally (see [1]_). Priors on length scale must be put keeping
-    this in mind.
+    Notes
+    -----
+    Note that the scaling factor for this kernel is different compared to the more common
+    definition (see [1]_). Here, 0.5 is in the exponent instead of the more common value, 2.
+    Divide the length-scale by 2 when initializing the kernel to recover the standard definition.
 
     References
     ----------

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -559,11 +559,11 @@ class TestPeriodic:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
-            cov = pm.gp.cov.Periodic(1, 0.1, 0.1)
+            cov = pm.gp.cov.Periodic(1, 1., 1.)
         K = theano.function([], cov(X))()
-        npt.assert_allclose(K[0, 1], 0.00288, atol=1e-3)
+        npt.assert_allclose(K[3, 4], 0.791397, atol=1e-3)
         K = theano.function([], cov(X, X))()
-        npt.assert_allclose(K[0, 1], 0.00288, atol=1e-3)
+        npt.assert_allclose(K[3, 4], 0.791397, atol=1e-3)
         # check diagonal
         Kd = theano.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -559,11 +559,11 @@ class TestPeriodic:
     def test_1d(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
-            cov = pm.gp.cov.Periodic(1, 1., 1.)
+            cov = pm.gp.cov.Periodic(1, 0.1, 0.1)
         K = theano.function([], cov(X))()
-        npt.assert_allclose(K[3, 4], 0.791397, atol=1e-3)
+        npt.assert_allclose(K[0, 1], 0.00288, atol=1e-3)
         K = theano.function([], cov(X, X))()
-        npt.assert_allclose(K[3, 4], 0.791397, atol=1e-3)
+        npt.assert_allclose(K[0, 1], 0.00288, atol=1e-3)
         # check diagonal
         Kd = theano.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)


### PR DESCRIPTION
Fixes #3987.

I have added a `versionchanged` just so that the documentation warns the user when the next version is released. Changed the tests accordingly.

cc @bwengals 
