### PR TITLE
Add more info to divergence warnings

### DIFF
--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -154,7 +154,8 @@ class BaseHMC(arraystep.GradientSharedStep):
             self.potential.raise_ok(self._logp_dlogp_func._ordering.vmap)
             message_energy = (
                 "Bad initial energy, check any log probabilities that "
-                "are inf or -inf, nan or very small:\n{}".format(error_logp.to_string())
+                "are inf or -inf, nan or very small:\n{}"
+                .format(error_logp.to_string())
             )
             warning = SamplerWarning(
                 WarningType.BAD_ENERGY,
@@ -190,11 +191,13 @@ class BaseHMC(arraystep.GradientSharedStep):
                 kind = WarningType.DIVERGENCE
                 self._num_divs_sample += 1
                 # We don't want to fill up all memory with divergence info
-                if self._num_divs_sample < 100:
+                if self._num_divs_sample < 100 and info.state is not None:
                     point = self._logp_dlogp_func.array_to_dict(info.state.q)
+                if self._num_divs_sample < 100 and info.state_div is not None:
                     point_dest = self._logp_dlogp_func.array_to_dict(
                         info.state_div.q
                     )
+                if self._num_divs_sample < 100:
                     info_store = info
             warning = SamplerWarning(
                 kind,

--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -116,23 +116,25 @@ class HamiltonianMC(BaseHMC):
 
         energy_change = -np.inf
         state = start
+        last = state
         div_info = None
         try:
             for _ in range(n_steps):
+                last = state
                 state = self.integrator.step(step_size, state)
         except IntegrationError as e:
-            div_info = DivergenceInfo('Divergence encountered.', e, state)
+            div_info = DivergenceInfo('Integration failed.', e, last, None)
         else:
             if not np.isfinite(state.energy):
                 div_info = DivergenceInfo(
-                    'Divergence encountered, bad energy.', None, state)
+                    'Divergence encountered, bad energy.', None, last, state)
             energy_change = start.energy - state.energy
             if np.isnan(energy_change):
                 energy_change = -np.inf
             if np.abs(energy_change) > self.Emax:
                 div_info = DivergenceInfo(
                     'Divergence encountered, large integration error.',
-                    None, state)
+                    None, last, state)
 
         accept_stat = min(1, np.exp(energy_change))
 

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -210,7 +210,7 @@ class NUTS(BaseHMC):
                 "The chain reached the maximum tree depth. Increase "
                 "max_treedepth, increase target_accept or reparameterize."
             )
-            warn = SamplerWarning(WarningType.TREEDEPTH, msg, "warn", None, None, None)
+            warn = SamplerWarning(WarningType.TREEDEPTH, msg, 'warn')
             warnings.append(warn)
         return warnings
 
@@ -331,6 +331,7 @@ class _Tree:
         except IntegrationError as err:
             error_msg = str(err)
             error = err
+            right = None
         else:
             # h - H0
             energy_change = right.energy - self.start_energy
@@ -363,7 +364,7 @@ class _Tree:
                 )
                 error = None
         tree = Subtree(None, None, None, None, -np.inf, -np.inf, 1)
-        divergance_info = DivergenceInfo(error_msg, error, left)
+        divergance_info = DivergenceInfo(error_msg, error, left, right)
         return tree, divergance_info, False
 
     def _build_subtree(self, left, depth, epsilon):

--- a/pymc3/step_methods/step_sizes.py
+++ b/pymc3/step_methods/step_sizes.py
@@ -77,7 +77,7 @@ class DualAverageAdaptation:
                    % (mean_accept, target_accept))
             info = {'target': target_accept, 'actual': mean_accept}
             warning = SamplerWarning(
-                WarningType.BAD_ACCEPTANCE, msg, 'warn', None, None, info)
+                WarningType.BAD_ACCEPTANCE, msg, 'warn', extra=info)
             return [warning]
         else:
             return []

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ patsy>=0.5.1
 fastprogress>=0.2.0
 h5py>=2.7.0
 typing-extensions>=3.7.4
+dataclasses
 contextvars; python_version < '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,3 @@ patsy>=0.5.1
 fastprogress>=0.2.0
 h5py>=2.7.0
 typing-extensions>=3.7.4
-dataclasses
-contextvars; python_version < '3.7'


### PR DESCRIPTION
This is a patch to store some additional information in the internal warnings about divergences. I used this a couple of times for debugging, and I think it might be of some use for other people as well.
Before, we only stored where the step that diverged _started_. This patch also adds what the energy, logp, gradient and velocity were where it started, _and_ where it ended up.
I also converted the `report.SamplerWarning` to a dataclass to make it easier to extend. This requires >=py3.7.

This makes it possible to make interesting plots of where divergences happend:
```python
import pymc3 as pm
import matplotlib.pyplot as plt
import numpy as np

with pm.Model() as model:
    sd = pm.HalfNormal('sd')
    pm.Normal('x', sd=sd)
    
    trace = pm.sample(Emax=1000)

x = 'sd_log__'
y = 'x'
plt.scatter(trace[x], trace[y], marker='.')
for warn in trace.report._warnings:
    if warn.divergence_point_dest is not None:
        source = warn.divergence_point_source
        dest = warn.divergence_point_dest
        source = np.array([source[x], source[y]])
        dest = np.array([dest[x], dest[y]])
        plt.arrow(*source, *(dest - source) / 100)
```
![image](https://user-images.githubusercontent.com/1882397/86277536-23ba5c00-bbd7-11ea-9c1e-a8ba87d786b1.png)

(Maybe `Emax=1000` is a bit high as a default by the way?)