### PR TITLE
Show pickling issues in notebook on windows

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,10 +1,15 @@
 # Release Notes
 
 ## PyMC3 3.9.x (on deck)
+
+### Maintenance
+- Fix an error on Windows and Mac where error message from unpickling models did not show up in the notebook, or where sampling froze when a worker process crashed (see [#3991](https://github.com/pymc-devs/pymc3/pull/3991)).
+
 ### Documentation
 - Notebook on [multilevel modeling](https://docs.pymc.io/notebooks/multilevel_modeling.html) has been rewritten to showcase ArviZ and xarray usage for inference result analysis (see [#3963](https://github.com/pymc-devs/pymc3/pull/3963))
 
 ### New features
+- Introduce optional arguments to `pm.sample`: `mp_ctx` to control how the processes for parallel sampling are started, and `pickle_backend` to specify which library is used to pickle models in parallel sampling when the multiprocessing cnotext is not of type `fork`. (see [#3991](https://github.com/pymc-devs/pymc3/pull/3991))
 - Add sampler stats `process_time_diff`, `perf_counter_diff` and `perf_counter_start`, that record wall and CPU times for each NUTS and HMC sample (see [ #3986](https://github.com/pymc-devs/pymc3/pull/3986)).
 
 ## PyMC3 3.9.2 (24 June 2020)

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -27,12 +27,6 @@ if not logging.root.handlers:
         handler = logging.StreamHandler()
         _log.addHandler(handler)
 
-# Set start method to forkserver for MacOS to enable multiprocessing
-# Closes issue https://github.com/pymc-devs/pymc3/issues/3849
-sys = platform.system()
-if sys == "Darwin":
-    new_context = mp.get_context("forkserver")
-
 
 def __set_compiler_flags():
     # Workarounds for Theano compiler problems on various platforms

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -20,6 +20,7 @@ import logging
 import pickle
 from collections import namedtuple
 import traceback
+import platform
 from pymc3.exceptions import SamplingError
 
 import numpy as np
@@ -420,6 +421,9 @@ class ParallelSampler:
             raise ValueError("Number of seeds and start_points must be %s." % chains)
 
         if mp_ctx is None or isinstance(mp_ctx, str):
+            # Closes issue https://github.com/pymc-devs/pymc3/issues/3849
+            if platform.system() == 'Darwin':
+                mp_ctx = "forkserver"
             mp_ctx = multiprocessing.get_context(mp_ctx)
 
         step_method_pickled = None

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -305,6 +305,9 @@ class ProcessAdapter:
         )
         try:
             self._process.start()
+            # Close the remote pipe, so that we get notified if the other
+            # end is closed.
+            remote_conn.close()
         except IOError as e:
             # Something may have gone wrong during the fork / spawn
             if e.errno == errno.EPIPE:

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -248,7 +248,9 @@ def sample(
     callback=None,
     *,
     return_inferencedata=None,
-    idata_kwargs:dict=None,
+    idata_kwargs: dict=None,
+    mp_ctx=None,
+    pickle_backend: str = 'pickle',
     **kwargs
 ):
     """Draw samples from the posterior using the given step methods.
@@ -336,6 +338,9 @@ def sample(
         Defaults to `False`, but we'll switch to `True` in an upcoming release.
     idata_kwargs : dict, optional
         Keyword arguments for `arviz.from_pymc3`
+    mp_ctx : str
+        The name of a multiprocessing context. One of `fork`, `spawn` or `forkserver`.
+        See multiprocessing documentation for details.
 
     Returns
     -------
@@ -503,6 +508,8 @@ def sample(
         "cores": cores,
         "callback": callback,
         "discard_tuned_samples": discard_tuned_samples,
+        "mp_ctx": mp_ctx,
+        "pickle_backend": pickle_backend,
     }
 
     sample_args.update(kwargs)
@@ -1349,6 +1356,8 @@ def _mp_sample(
     model=None,
     callback=None,
     discard_tuned_samples=True,
+    mp_ctx=None,
+    pickle_backend='pickle',
     **kwargs
 ):
     """Main iteration for multiprocess sampling.
@@ -1411,7 +1420,17 @@ def _mp_sample(
         traces.append(strace)
 
     sampler = ps.ParallelSampler(
-        draws, tune, chains, cores, random_seed, start, step, chain, progressbar
+        draws,
+        tune,
+        chains,
+        cores,
+        random_seed,
+        start,
+        step,
+        chain,
+        progressbar,
+        mp_ctx=mp_ctx,
+        pickle_backend=pickle_backend,
     )
     try:
         try:

--- a/pymc3/tests/test_parallel_sampling.py
+++ b/pymc3/tests/test_parallel_sampling.py
@@ -50,13 +50,8 @@ def test_bad_unpickle():
         assert 'could not be unpickled' in str(exc_info.getrepr(style='short'))
 
 
-@theano.as_op(
-    [
-        tt.dvector if theano.config.floatX == "float64" else tt.fvector,
-        tt.iscalar,
-    ],
-    [tt.dvector if theano.config.floatX == "float64" else tt.fvector],
-)
+tt_vector = tt.TensorType(theano.config.floatX, [False])
+@theano.as_op([tt_vector, tt.iscalar], [tt_vector])
 def _crash_remote_process(a, master_pid):
     if os.getpid() != master_pid:
         os.exit(0)

--- a/pymc3/tests/test_parallel_sampling.py
+++ b/pymc3/tests/test_parallel_sampling.py
@@ -51,11 +51,19 @@ def test_bad_unpickle():
 
 
 tt_vector = tt.TensorType(theano.config.floatX, [False])
+
+
 @theano.as_op([tt_vector, tt.iscalar], [tt_vector])
 def _crash_remote_process(a, master_pid):
     if os.getpid() != master_pid:
         os.exit(0)
     return 2 * np.array(a)
+
+
+def test_dill():
+    with pm.Model():
+        pm.Normal('x')
+        pm.sample(tune=1, draws=1, chains=2, cores=2, pickle_backend="dill", mp_ctx="spawn")
 
 
 def test_remote_pipe_closed():

--- a/pymc3/tests/test_parallel_sampling.py
+++ b/pymc3/tests/test_parallel_sampling.py
@@ -12,10 +12,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import multiprocessing
+import os
 
 import pytest
 import pymc3.parallel_sampling as ps
 import pymc3 as pm
+import theano
+import theano.tensor as tt
+import numpy as np
 
 
 def test_context():
@@ -44,6 +48,31 @@ def test_bad_unpickle():
             pm.sample(tune=2, draws=2, mp_ctx='spawn', step=step,
                       cores=2, chains=2, compute_convergence_checks=False)
         assert 'could not be unpickled' in str(exc_info.getrepr(style='short'))
+
+
+@theano.as_op(
+    [
+        tt.dvector if theano.config.floatX == "float64" else tt.fvector,
+        tt.iscalar,
+    ],
+    [tt.dvector if theano.config.floatX == "float64" else tt.fvector],
+)
+def _crash_remote_process(a, master_pid):
+    if os.getpid() != master_pid:
+        os.exit(0)
+    return 2 * np.array(a)
+
+
+def test_remote_pipe_closed():
+    master_pid = os.getpid()
+    with pm.Model():
+        x = pm.Normal('x', shape=2, mu=0.1)
+        tt_pid = tt.as_tensor_variable(np.array(master_pid, dtype='int32'))
+        pm.Normal('y', mu=_crash_remote_process(x, tt_pid), shape=2)
+
+        step = pm.Metropolis()
+        with pytest.raises(RuntimeError, match="Chain [0-9] failed"):
+            pm.sample(step=step, mp_ctx='spawn', tune=2, draws=2, cores=2, chains=2)
 
 
 def test_abort():

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,3 +18,4 @@ seaborn>=0.8.1
 sphinx-autobuild==0.7.1
 sphinx>=1.5.5
 watermark
+dill


### PR DESCRIPTION
There have been issues about parallel sampling on Windows and Mac, because there the default multiprocessing backend is spawn.
Error messages end up on the console, and sometimes there seems to be a deadlock that I haven't been able to find.
This should work around those two issues: Instead of relying on multiprocessing for pickling we can simply do it ourselves, and pass the pickled objects to the remote process. If unpickling fails we send a normal error message back, that we can show in notebooks.
Also, two more arguments to `pm.sample`:
- `mp_ctx`: for explicit control over the multiprocessing context: fork, spawn or forkserver
- `pickle_backend`: one of `pickle` or `dill` (an alternative to pickle that claims that it can pickle some additional objects).

CC @lucianopaz I think that is the issue you were referring to earlier? It would be great if someone could test this on windows a bit.

An example of a model that doesn't pickle:

```python
import theano
import theano.tensor as tt
import numpy as np
import multiprocessing
import pymc3 as pm

@theano.as_op([tt.dvector], [tt.dvector])
def somefunc(a):
    return 2 * np.array(a)

with pm.Model() as model:
    x = pm.Normal('x', shape=2)
    pm.Normal('y', mu=somefunc(x), shape=2)
    #pm.Normal('y', mu=2, shape=2)

with model:
    step = pm.Metropolis()
    trace = pm.sample(step=step, mp_ctx='spawn')
```
