### PR TITLE
Drop support for py3.6

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,8 @@
 # Release Notes
 
 ## PyMC3 3.9.x (on deck)
+This release does not support python 3.6 anymore. Use python 3.7 or higher.
+
 ### Documentation
 - Notebook on [multilevel modeling](https://docs.pymc.io/notebooks/multilevel_modeling.html) has been rewritten to showcase ArviZ and xarray usage for inference result analysis (see [#3963](https://github.com/pymc-devs/pymc3/pull/3963))
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## PyMC3 3.9.x (on deck)
-This release does not support python 3.6 anymore. Use python 3.7 or higher.
+This release [does not support Python 3.6 anymore](https://numpy.org/neps/nep-0029-deprecation_policy.html). Use Python 3.7 or higher.
 
 ### Documentation
 - Notebook on [multilevel modeling](https://docs.pymc.io/notebooks/multilevel_modeling.html) has been rewritten to showcase ArviZ and xarray usage for inference result analysis (see [#3963](https://github.com/pymc-devs/pymc3/pull/3963))

--- a/scripts/install_miniconda.sh
+++ b/scripts/install_miniconda.sh
@@ -7,7 +7,7 @@ if conda --version > /dev/null 2>&1; then
    exit 0
  fi
 
-PYTHON_VERSION=${PYTHON_VERSION:-3.6} # if no python specified, use 3.6
+PYTHON_VERSION=${PYTHON_VERSION:-3.7} # if no python specified, use 3.7
 
 if [ ${PYTHON_VERSION} == "2.7" ]; then
   INSTALL_FOLDER="$HOME/miniconda2"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
We can merge this PR whenever we would like to drop support for python 3.6.
This was briefly mentioned in #3986, with some support to do this sooner rather then later.