### PR TITLE
Revert "Drop support for py3.6"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Another option is to clone the repository and install PyMC3 using
 Dependencies
 ============
 
-PyMC3 is tested on Python 3.7 and depends on Theano, NumPy,
+PyMC3 is tested on Python 3.6 and depends on Theano, NumPy,
 SciPy, and Pandas (see ``requirements.txt`` for version
 information).
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,8 +1,6 @@
 # Release Notes
 
 ## PyMC3 3.9.x (on deck)
-This release [does not support Python 3.6 anymore](https://numpy.org/neps/nep-0029-deprecation_policy.html). Use Python 3.7 or higher.
-
 ### Documentation
 - Notebook on [multilevel modeling](https://docs.pymc.io/notebooks/multilevel_modeling.html) has been rewritten to showcase ArviZ and xarray usage for inference result analysis (see [#3963](https://github.com/pymc-devs/pymc3/pull/3963))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ patsy>=0.5.1
 fastprogress>=0.2.0
 h5py>=2.7.0
 typing-extensions>=3.7.4
+dataclasses; python_version < '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ fastprogress>=0.2.0
 h5py>=2.7.0
 typing-extensions>=3.7.4
 dataclasses; python_version < '3.7'
+contextvars; python_version < '3.7' 

--- a/scripts/install_miniconda.sh
+++ b/scripts/install_miniconda.sh
@@ -7,7 +7,7 @@ if conda --version > /dev/null 2>&1; then
    exit 0
  fi
 
-PYTHON_VERSION=${PYTHON_VERSION:-3.7} # if no python specified, use 3.7
+PYTHON_VERSION=${PYTHON_VERSION:-3.6} # if no python specified, use 3.6
 
 if [ ${PYTHON_VERSION} == "2.7" ]; then
   INSTALL_FOLDER="$HOME/miniconda2"

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         # package_data={'docs': ['*']},
         include_package_data=True,
         classifiers=classifiers,
-        python_requires=">=3.7",
+        python_requires=">=3.6",
         install_requires=install_reqs,
         tests_require=test_reqs,
         test_suite="nose.collector",

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Reverts pymc-devs/pymc3#3992 and pymc-devs/pymc3#3998 

As it
~~1) breaks Travis~~
2) preventing installing pymc3 default branch (i.e., the most up-to-date) on colab

When we are ready to drop python3.6 support:
1) revert this PR
2) change https://github.com/pymc-devs/pymc3/blob/1af997623afbee7c8099e20d94c7236fb5af1332/scripts/create_testenv.sh#L23
for consistency.
