### PR TITLE
Fix keep_size for arviz structures.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,6 +11,7 @@
 ### New features
 - Introduce optional arguments to `pm.sample`: `mp_ctx` to control how the processes for parallel sampling are started, and `pickle_backend` to specify which library is used to pickle models in parallel sampling when the multiprocessing cnotext is not of type `fork`. (see [#3991](https://github.com/pymc-devs/pymc3/pull/3991))
 - Add sampler stats `process_time_diff`, `perf_counter_diff` and `perf_counter_start`, that record wall and CPU times for each NUTS and HMC sample (see [ #3986](https://github.com/pymc-devs/pymc3/pull/3986)).
+- Extend `keep_size` argument handling for `sample_posterior_predictive` and `fast_sample_posterior_predictive`, to work on arviz InferenceData and xarray Dataset input values. (see [PR #4006](https://github.com/pymc-devs/pymc3/pull/4006) and [Issue #4004](https://github.com/pymc-devs/pymc3/issues/4004).
 
 ## PyMC3 3.9.2 (24 June 2020)
 ### Maintenance

--- a/pymc3/distributions/posterior_predictive.py
+++ b/pymc3/distributions/posterior_predictive.py
@@ -1,26 +1,45 @@
 import numbers
-from typing import List, Dict, Any, Optional, Tuple, Union, cast, TYPE_CHECKING, Callable, overload
+from typing import (
+    List,
+    Dict,
+    Any,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+    TYPE_CHECKING,
+    Callable,
+    overload,
+    Set,
+)
 import warnings
 import logging
 from collections import UserDict
 from contextlib import AbstractContextManager
-
-if TYPE_CHECKING:
-    import contextvars          # noqa: F401
-    from typing import Set
+import contextvars
 from typing_extensions import Protocol, Literal
 
 import numpy as np
 import theano
 import theano.tensor as tt
 from xarray import Dataset
-
-from ..backends.base import MultiTrace #, TraceLike, TraceDict
-from .distribution import _DrawValuesContext, _DrawValuesContextBlocker, is_fast_drawable, _compile_theano_function, vectorized_ppc
-from ..model import Model, get_named_nodes_and_relations, ObservedRV, MultiObservedRV, modelcontext
 from arviz import InferenceData
 
-from ..backends.base import MultiTrace  # , TraceLike, TraceDict
+from ..backends.base import MultiTrace
+from .distribution import (
+    _DrawValuesContext,
+    _DrawValuesContextBlocker,
+    is_fast_drawable,
+    _compile_theano_function,
+    vectorized_ppc,
+)
+from ..model import (
+    Model,
+    get_named_nodes_and_relations,
+    ObservedRV,
+    MultiObservedRV,
+    modelcontext,
+)
 from ..exceptions import IncorrectArgumentsError
 from ..vartypes import theano_constant
 from ..util import dataset_to_point_dict, chains_and_samples
@@ -32,13 +51,16 @@ from ..util import dataset_to_point_dict, chains_and_samples
 PosteriorPredictiveTrace = Dict[str, np.ndarray]
 Point = Dict[str, np.ndarray]
 
+
 class HasName(Protocol):
-    name = None                 # type: str
+    name: str
+
 
 if TYPE_CHECKING:
     _TraceDictParent = UserDict[str, np.ndarray]
 else:
     _TraceDictParent = UserDict
+
 
 class _TraceDict(_TraceDictParent):
     """This class extends the standard trace-based representation
@@ -49,30 +71,35 @@ class _TraceDict(_TraceDictParent):
     ~~~~~~~~~~
         varnames: list of strings"""
 
-    varnames = None             # type: List[str]
-    _len = None                 # type: int
-    data = None                 # type: Dict[str, np.ndarray]
-    
+    varnames: List[str]
+    _len: int
+    data: Dict[str, np.ndarray]
 
-    def __init__(self, point_list: Optional[List[Dict[str, np.ndarray]]] = None, \
-                 multi_trace: Optional[MultiTrace] = None,
-                 dict: Optional[Dict[str, np.ndarray]] = None):
+    def __init__(
+        self,
+        point_list: Optional[List[Dict[str, np.ndarray]]] = None,
+        multi_trace: Optional[MultiTrace] = None,
+        dict: Optional[Dict[str, np.ndarray]] = None,
+    ):
         """
 
         """
         if multi_trace:
             assert point_list is None and dict is None
-            self.data = {}      # Dict[str, np.ndarray]
-            self._len = sum((len(multi_trace._straces[chain]) for chain in multi_trace.chains))
+            self.data = {}  # Dict[str, np.ndarray]
+            self._len = sum(
+                (len(multi_trace._straces[chain]) for chain in multi_trace.chains)
+            )
             self.varnames = multi_trace.varnames
             for vn in multi_trace.varnames:
                 self.data[vn] = multi_trace.get_values(vn)
         if point_list is not None:
             assert multi_trace is None and dict is None
             self.varnames = varnames = list(point_list[0].keys())
-            rep_values = [point_list[0][varname ]for varname in varnames]
+            rep_values = [point_list[0][varname] for varname in varnames]
             # translate the point list.
             self._len = num_points = len(point_list)
+
             def arr_for(val):
                 if np.isscalar(val):
                     return np.ndarray(shape=(num_points,))
@@ -80,7 +107,11 @@ class _TraceDict(_TraceDictParent):
                     shp = (num_points,) + val.shape
                     return np.ndarray(shape=shp)
                 else:
-                    raise TypeError("Illegal object %s of type %s as value of variable in point list."%(val, type(val)))
+                    raise TypeError(
+                        "Illegal object %s of type %s as value of variable in point list."
+                        % (val, type(val))
+                    )
+
             self.data = {name: arr_for(val) for name, val in zip(varnames, rep_values)}
             for i, point in enumerate(point_list):
                 for var, value in point.items():
@@ -90,27 +121,35 @@ class _TraceDict(_TraceDictParent):
             self.data = dict
             self.varnames = list(dict.keys())
             self._len = dict[self.varnames[0]].shape[0]
-        assert self.varnames is not None and self._len is not None and self.data is not None
+        assert (
+            self.varnames is not None
+            and self._len is not None
+            and self.data is not None
+        )
 
     def __len__(self) -> int:
         return self._len
 
-    def _extract_slice(self, slc: slice) -> '_TraceDict':
-        sliced_dict = {}        # type: Dict[str, np.ndarray]
+    def _extract_slice(self, slc: slice) -> "_TraceDict":
+        sliced_dict: Dict[str, np.ndarray] = {}
+
         def apply_slice(arr: np.ndarray) -> np.ndarray:
             if len(arr.shape) == 1:
                 return arr[slc]
             else:
-                return arr[slc,:]
+                return arr[slc, :]
+
         for vn, arr in self.data.items():
             sliced_dict[vn] = apply_slice(arr)
         return _TraceDict(dict=sliced_dict)
 
     @overload
-    def __getitem__(self, item: Union[str, HasName]) -> np.ndarray: ...
+    def __getitem__(self, item: Union[str, HasName]) -> np.ndarray:
+        ...
 
     @overload
-    def __getitem__(self, item: Union[slice, int]) -> '_TraceDict': ...
+    def __getitem__(self, item: Union[slice, int]) -> "_TraceDict":
+        ...
 
     def __getitem__(self, item):
         if isinstance(item, str):
@@ -118,12 +157,13 @@ class _TraceDict(_TraceDictParent):
         elif isinstance(item, slice):
             return self._extract_slice(item)
         elif isinstance(item, int):
-            return _TraceDict(dict={k: np.atleast_1d(v[item]) for k, v in self.data.items()})
-        elif hasattr(item, 'name'):
+            return _TraceDict(
+                dict={k: np.atleast_1d(v[item]) for k, v in self.data.items()}
+            )
+        elif hasattr(item, "name"):
             return super(_TraceDict, self).__getitem__(item.name)
         else:
-            raise IndexError("Illegal index %s for _TraceDict"%str(item))
-
+            raise IndexError("Illegal index %s for _TraceDict" % str(item))
 
 
 def fast_sample_posterior_predictive(
@@ -207,21 +247,26 @@ def fast_sample_posterior_predictive(
         elif isinstance(trace, MultiTrace):
             _trace = _TraceDict(multi_trace=trace)
         else:
-            raise TypeError("Unable to generate posterior predictive samples from argument of type %s"%type(trace))
+            raise TypeError(
+                "Unable to generate posterior predictive samples from argument of type %s"
+                % type(trace)
+            )
 
         len_trace = len(_trace)
 
         assert isinstance(_trace, _TraceDict)
 
-        _samples = [] # type: List[int]
+        _samples: List[int] = []
         # temporary replacement for more complicated logic.
         max_samples: int = len_trace
         if samples is None or samples == max_samples:
             _samples = [max_samples]
         elif samples < max_samples:
-            warnings.warn("samples parameter is smaller than nchains times ndraws, some draws "
-                          "and/or chains may not be represented in the returned posterior "
-                          "predictive sample")
+            warnings.warn(
+                "samples parameter is smaller than nchains times ndraws, some draws "
+                "and/or chains may not be represented in the returned posterior "
+                "predictive sample"
+            )
             # if this is less than the number of samples in the trace, take a slice and
             # work with that.
             _trace = _trace[slice(samples)]
@@ -230,7 +275,10 @@ def fast_sample_posterior_predictive(
             full, rem = divmod(samples, max_samples)
             _samples = (full * [max_samples]) + ([rem] if rem != 0 else [])
         else:
-            raise IncorrectArgumentsError("Unexpected combination of samples (%s) and max_samples (%d)"%(samples, max_samples))
+            raise IncorrectArgumentsError(
+                "Unexpected combination of samples (%s) and max_samples (%d)"
+                % (samples, max_samples)
+            )
 
         if var_names is None:
             vars = model.observed_RVs
@@ -243,7 +291,8 @@ def fast_sample_posterior_predictive(
         if TYPE_CHECKING:
             _ETPParent = UserDict[str, np.ndarray]  # this is only processed by mypy
         else:
-            _ETPParent = UserDict  # this is not seen by mypy but will be executed at runtime.
+            # this is not seen by mypy but will be executed at runtime.
+            _ETPParent = UserDict
 
         class _ExtendableTrace(_ETPParent):
             def extend_trace(self, trace: Dict[str, np.ndarray]) -> None:
@@ -253,36 +302,44 @@ def fast_sample_posterior_predictive(
                     else:
                         self.data[k] = v
 
-
         ppc_trace = _ExtendableTrace()
         for s in _samples:
             strace = _trace if s == len_trace else _trace[slice(0, s)]
             try:
-                values = posterior_predictive_draw_values(cast(List[Any], vars), strace, s)
-                new_trace = {k.name: v for (k, v) in zip(vars, values)}  # type: Dict[str, np.ndarray]
+                values = posterior_predictive_draw_values(
+                    cast(List[Any], vars), strace, s
+                )
+                new_trace: Dict[str, np.ndarray] = {
+                    k.name: v for (k, v) in zip(vars, values)
+                }
                 ppc_trace.extend_trace(new_trace)
             except KeyboardInterrupt:
                 pass
 
         if keep_size:
-            assert isinstance(trace, MultiTrace)
-            return {k: ary.reshape((trace.nchains, len(trace), *ary.shape[1:])) for k, ary in ppc_trace.items() }
-        else:
-            return ppc_trace.data # this gets us a Dict[str, np.ndarray] instead of my wrapped equiv.
+            return {
+                k: ary.reshape((nchains, ndraws, *ary.shape[1:]))
+                for k, ary in ppc_trace.items()
+            }
+        # this gets us a Dict[str, np.ndarray] instead of my wrapped equiv.
+        return ppc_trace.data
 
 
-def posterior_predictive_draw_values(vars: List[Any], trace: _TraceDict, samples: int) -> List[np.ndarray]:
+def posterior_predictive_draw_values(
+    vars: List[Any], trace: _TraceDict, samples: int
+) -> List[np.ndarray]:
     with _PosteriorPredictiveSampler(vars, trace, samples, None) as sampler:
         return sampler.draw_values()
 
+
 class _PosteriorPredictiveSampler(AbstractContextManager):
-    '''The process of posterior predictive sampling is quite complicated so this provides a central data store.'''
+    """The process of posterior predictive sampling is quite complicated so this provides a central data store."""
 
     # inputs
     vars: List[Any]
     trace: _TraceDict
     samples: int
-    size: Optional[int] # not supported!
+    size: Optional[int]  # not supported!
 
     # other slots
     logger: logging.Logger
@@ -295,26 +352,30 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
     leaf_nodes: Dict[str, Any]
     named_nodes_parents: Dict[str, Any]
     named_nodes_children: Dict[str, Any]
-    _tok = None                  # type: contextvars.Token
-    
-    def __init__(self, vars, trace: _TraceDict, samples, model: Optional[Model], size=None):
+    _tok: contextvars.Token
+
+    def __init__(
+        self, vars, trace: _TraceDict, samples, model: Optional[Model], size=None
+    ):
         if size is not None:
-            raise NotImplementedError("sample_posterior_predictive does not support the size argument at this time.")
+            raise NotImplementedError(
+                "sample_posterior_predictive does not support the size argument at this time."
+            )
         assert vars is not None
         self.vars = vars
         self.trace = trace
         self.samples = samples
         self.size = size
-        self.logger = logging.getLogger('posterior_predictive')
+        self.logger = logging.getLogger("posterior_predictive")
 
-    def __enter__(self) -> '_PosteriorPredictiveSampler':
+    def __enter__(self) -> "_PosteriorPredictiveSampler":
         self._tok = vectorized_ppc.set(posterior_predictive_draw_values)
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+    def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
         vectorized_ppc.reset(self._tok)
         return False
-        
+
     def draw_values(self) -> List[np.ndarray]:
         vars = self.vars
         trace = self.trace
@@ -329,8 +390,11 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
             drawn = context.drawn_vars
 
             # Init givens and the stack of nodes to try to `_draw_value` from
-            givens = {p.name: (p, v) for (p, samples), v in drawn.items()
-                      if getattr(p, 'name', None) is not None}
+            givens = {
+                p.name: (p, v)
+                for (p, samples), v in drawn.items()
+                if getattr(p, "name", None) is not None
+            }
             stack = list(self.leaf_nodes.values())  # A queue would be more appropriate
 
             while stack:
@@ -338,8 +402,7 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
                 if (next_, samples) in drawn:
                     # If the node already has a givens value, skip it
                     continue
-                elif isinstance(next_, (theano_constant,
-                                        tt.sharedvar.SharedVariable)):
+                elif isinstance(next_, (theano_constant, tt.sharedvar.SharedVariable)):
                     # If the node is a theano.tensor.TensorConstant or a
                     # theano.tensor.sharedvar.SharedVariable, its value will be
                     # available automatically in _compile_theano_function so
@@ -353,10 +416,14 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
                     # of TensorConstants or SharedVariables, we must add them
                     # to the stack or risk evaluating deterministics with the
                     # wrong values (issue #3354)
-                    stack.extend([node for node in self.named_nodes_parents[next_]
-                                  if isinstance(node, (ObservedRV,
-                                                       MultiObservedRV))
-                                  and (node, samples) not in drawn])
+                    stack.extend(
+                        [
+                            node
+                            for node in self.named_nodes_parents[next_]
+                            if isinstance(node, (ObservedRV, MultiObservedRV))
+                            and (node, samples) not in drawn
+                        ]
+                    )
                     continue
                 else:
                     # If the node does not have a givens value, try to draw it.
@@ -367,9 +434,7 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
                     try:
                         # This may fail for autotransformed RVs, which don't
                         # have the random method
-                        value = self.draw_value(next_,
-                                                trace=trace,
-                                                givens=temp_givens)
+                        value = self.draw_value(next_, trace=trace, givens=temp_givens)
                         assert isinstance(value, np.ndarray)
                         givens[next_.name] = (next_, value)
                         drawn[(next_, samples)] = value
@@ -377,20 +442,27 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
                         # The node failed, so we must add the node's parents to
                         # the stack of nodes to try to draw from. We exclude the
                         # nodes in the `params` list.
-                        stack.extend([node for node in self.named_nodes_parents[next_]
-                                      if node is not None and
-                                      (node, samples) not in drawn])
-
+                        stack.extend(
+                            [
+                                node
+                                for node in self.named_nodes_parents[next_]
+                                if node is not None and (node, samples) not in drawn
+                            ]
+                        )
 
             # the below makes sure the graph is evaluated in order
             # test_distributions_random::TestDrawValues::test_draw_order fails without it
             # The remaining params that must be drawn are all hashable
-            to_eval = set() # type: Set[int]
-            missing_inputs = set([j for j, p in self.symbolic_params]) # type: Set[int]
+            to_eval: Set[int] = set()
+            missing_inputs: Set[int] = set([j for j, p in self.symbolic_params])
 
             while to_eval or missing_inputs:
                 if to_eval == missing_inputs:
-                    raise ValueError('Cannot resolve inputs for {}'.format([str(trace.varnames[j]) for j in to_eval]))
+                    raise ValueError(
+                        "Cannot resolve inputs for {}".format(
+                            [str(trace.varnames[j]) for j in to_eval]
+                        )
+                    )
                 to_eval = set(missing_inputs)
                 missing_inputs = set()
                 for param_idx in to_eval:
@@ -403,16 +475,16 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
                             if param in self.named_nodes_children:
                                 for node in self.named_nodes_children[param]:
                                     if (
-                                        node.name not in givens and
-                                        (node, samples) in drawn
+                                        node.name not in givens
+                                        and (node, samples) in drawn
                                     ):
                                         givens[node.name] = (
                                             node,
-                                            drawn[(node, samples)]
+                                            drawn[(node, samples)],
                                         )
-                            value = self.draw_value(param,
-                                                    trace=self.trace,
-                                                    givens=givens.values())
+                            value = self.draw_value(
+                                param, trace=self.trace, givens=givens.values()
+                            )
                             assert isinstance(value, np.ndarray)
                             self.evaluated[param_idx] = drawn[(param, samples)] = value
                             givens[param.name] = (param, value)
@@ -420,32 +492,38 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
                             missing_inputs.add(param_idx)
         return [self.evaluated[j] for j in params]
 
-
     def init(self) -> None:
-        '''This method carries out the initialization phase of sampling 
+        """This method carries out the initialization phase of sampling 
     from the posterior predictive distribution.  Notably it initializes the
     ``_DrawValuesContext`` bookkeeping object and evaluates the "fast drawable"
-    parts of the model.'''
+    parts of the model."""
         vars: List[Any] = self.vars
         trace: _TraceDict = self.trace
         samples: int = self.samples
+        leaf_nodes: Dict[str, Any]
+        named_nodes_parents: Dict[str, Any]
+        named_nodes_children: Dict[str, Any]
 
         # initialization phase
         context = _DrawValuesContext.get_context()
         assert isinstance(context, _DrawValuesContext)
         with context:
             drawn = context.drawn_vars
-            evaluated = {} # type: Dict[int, Any]
+            evaluated: Dict[int, Any] = {}
             symbolic_params = []
             for i, var in enumerate(vars):
                 if is_fast_drawable(var):
                     evaluated[i] = self.draw_value(var)
                     continue
-                name = getattr(var, 'name', None)
+                name = getattr(var, "name", None)
                 if (var, samples) in drawn:
                     evaluated[i] = drawn[(var, samples)]
-                                # We filter out Deterministics by checking for `model` attribute
-                elif name is not None and hasattr(var, 'model') and name in trace.varnames:
+                    # We filter out Deterministics by checking for `model` attribute
+                elif (
+                    name is not None
+                    and hasattr(var, "model")
+                    and name in trace.varnames
+                ):
                     # param.name is in the trace.  Record it as drawn and evaluated
                     drawn[(var, samples)] = evaluated[i] = trace[cast(str, name)]
                 else:
@@ -454,18 +532,16 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
         self.evaluated = evaluated
         self.symbolic_params = symbolic_params
 
-
-
     def make_graph(self) -> None:
         # Distribution parameters may be nodes which have named node-inputs
         # specified in the point. Need to find the node-inputs, their
         # parents and children to replace them.
         symbolic_params = self.symbolic_params
-        self.leaf_nodes = {} # type: Dict[str, Any]
-        self.named_nodes_parents = {} # type: Dict[str, Any]
-        self.named_nodes_children = {} # type: Dict[str, Any]
+        self.leaf_nodes = {}
+        self.named_nodes_parents = {}
+        self.named_nodes_children = {}
         for _, param in symbolic_params:
-            if hasattr(param, 'name'):
+            if hasattr(param, "name"):
                 # Get the named nodes under the `param` node
                 nn, nnp, nnc = get_named_nodes_and_relations(param)
                 self.leaf_nodes.update(nn)
@@ -482,7 +558,7 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
                     else:
                         self.named_nodes_children[k].update(nnc[k])
 
-    def draw_value(self, param, trace: Optional[_TraceDict]=None, givens=None):
+    def draw_value(self, param, trace: Optional[_TraceDict] = None, givens=None):
         """Draw a set of random values from a distribution or return a constant.
 
         Parameters
@@ -502,20 +578,31 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
         """
         samples = self.samples
 
-        def random_sample(meth: Callable[..., np.ndarray], param, point: _TraceDict, size: int, shape: Tuple[int, ...]) -> np.ndarray:
+        def random_sample(
+            meth: Callable[..., np.ndarray],
+            param,
+            point: _TraceDict,
+            size: int,
+            shape: Tuple[int, ...],
+        ) -> np.ndarray:
             val = meth(point=point, size=size)
             if size == 1:
                 val = np.expand_dims(val, axis=0)
             try:
-                assert val.shape == (size, ) + shape, "Sampling from random of %s yields wrong shape"%param
+                assert val.shape == (size,) + shape, (
+                    "Sampling from random of %s yields wrong shape" % param
+                )
             # error-quashing here is *extremely* ugly, but it seems to be what the logic in DensityDist wants.
             except AssertionError as e:
-                if hasattr(param, 'distribution') and hasattr(param.distribution, 'wrap_random_with_dist_shape') \
-                   and not param.distribution.wrap_random_with_dist_shape:
+                if (
+                    hasattr(param, "distribution")
+                    and hasattr(param.distribution, "wrap_random_with_dist_shape")
+                    and not param.distribution.wrap_random_with_dist_shape
+                ):
                     pass
                 else:
                     raise e
-                
+
             return val
 
         if isinstance(param, (numbers.Number, np.ndarray)):
@@ -525,27 +612,39 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
         elif isinstance(param, tt.sharedvar.SharedVariable):
             return param.get_value()
         elif isinstance(param, (tt.TensorVariable, MultiObservedRV)):
-            if hasattr(param, 'model') and trace and param.name in trace.varnames:
+            if hasattr(param, "model") and trace and param.name in trace.varnames:
                 return trace[param.name]
-            elif hasattr(param, 'random') and param.random is not None:
+            elif hasattr(param, "random") and param.random is not None:
                 model = modelcontext(None)
                 assert isinstance(model, Model)
-                shape = tuple(_param_shape(param, model)) # type: Tuple[int, ...]
-                return random_sample(param.random, param, point=trace, size=samples, shape=shape)
-            elif (hasattr(param, 'distribution') and
-                    hasattr(param.distribution, 'random') and
-                    param.distribution.random is not None):
-                if hasattr(param, 'observations'):
+                shape: Tuple[int, ...] = tuple(_param_shape(param, model))
+                return random_sample(
+                    param.random, param, point=trace, size=samples, shape=shape
+                )
+            elif (
+                hasattr(param, "distribution")
+                and hasattr(param.distribution, "random")
+                and param.distribution.random is not None
+            ):
+                if hasattr(param, "observations"):
                     # shape inspection for ObservedRV
                     dist_tmp = param.distribution
                     try:
-                        distshape = tuple(param.observations.shape.eval()) # type: Tuple[int, ...]
+                        distshape: Tuple[int, ...] = tuple(
+                            param.observations.shape.eval()
+                        )
                     except AttributeError:
                         distshape = tuple(param.observations.shape)
 
                     dist_tmp.shape = distshape
                     try:
-                        return random_sample(dist_tmp.random, param, point=trace, size=samples, shape=distshape)
+                        return random_sample(
+                            dist_tmp.random,
+                            param,
+                            point=trace,
+                            size=samples,
+                            shape=distshape,
+                        )
                     except (ValueError, TypeError):
                         # reset shape to account for shape changes
                         # with theano.shared inputs
@@ -554,40 +653,55 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
                         # we don't want to store these drawn values to the context
                         with _DrawValuesContextBlocker():
                             point = trace[0] if trace else None
-                            temp_val = np.atleast_1d(dist_tmp.random(point=point, size=None))
+                            temp_val = np.atleast_1d(
+                                dist_tmp.random(point=point, size=None)
+                            )
                         # if hasattr(param, 'name') and param.name == 'obs':
                         #     import pdb; pdb.set_trace()
                         # Sometimes point may change the size of val but not the
                         # distribution's shape
                         if point and samples is not None:
                             temp_size = np.atleast_1d(samples)
-                            if all(temp_val.shape[:len(temp_size)] == temp_size):
-                                dist_tmp.shape = tuple(temp_val.shape[len(temp_size):])
+                            if all(temp_val.shape[: len(temp_size)] == temp_size):
+                                dist_tmp.shape = tuple(temp_val.shape[len(temp_size) :])
                             else:
                                 dist_tmp.shape = tuple(temp_val.shape)
                         # I am not sure why I need to do this, but I do in order to trim off a
                         # degenerate dimension [2019/09/05:rpg]
                         if dist_tmp.shape[0] == 1 and len(dist_tmp.shape) > 1:
                             dist_tmp.shape = dist_tmp.shape[1:]
-                        return random_sample(dist_tmp.random, point=trace, size=samples, param=param, shape=tuple(dist_tmp.shape))
-                else: # has a distribution, but no observations
+                        return random_sample(
+                            dist_tmp.random,
+                            point=trace,
+                            size=samples,
+                            param=param,
+                            shape=tuple(dist_tmp.shape),
+                        )
+                else:  # has a distribution, but no observations
                     distshape = tuple(param.distribution.shape)
-                    return random_sample(meth=param.distribution.random, param=param, point=trace, size=samples, shape=distshape)
+                    return random_sample(
+                        meth=param.distribution.random,
+                        param=param,
+                        point=trace,
+                        size=samples,
+                        shape=distshape,
+                    )
             # NOTE: I think the following is already vectorized.
-            else: 
+            else:
                 if givens:
                     variables, values = list(zip(*givens))
                 else:
                     variables = values = []
                 # We only truly care if the ancestors of param that were given
                 # value have the matching dshape and val.shape
-                param_ancestors = \
-                    set(theano.gof.graph.ancestors([param],
-                                                   blockers=list(variables))
-                        )
-                inputs = [(var, val) for var, val in
-                          zip(variables, values)
-                          if var in param_ancestors]
+                param_ancestors = set(
+                    theano.gof.graph.ancestors([param], blockers=list(variables))
+                )
+                inputs = [
+                    (var, val)
+                    for var, val in zip(variables, values)
+                    if var in param_ancestors
+                ]
                 if inputs:
                     input_vars, input_vals = list(zip(*inputs))
                 else:
@@ -595,9 +709,11 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
                     input_vals = []
                 func = _compile_theano_function(param, input_vars)
                 if not input_vars:
-                    assert input_vals == []  # AFAICT if there are now vars, there can't be vals
+                    assert (
+                        input_vals == []
+                    )  # AFAICT if there are now vars, there can't be vals
                     output = func(*input_vals)
-                    if hasattr(output, 'shape'):
+                    if hasattr(output, "shape"):
                         val = np.repeat(np.expand_dims(output, 0), samples, axis=0)
                     else:
                         val = np.full(samples, output)
@@ -606,22 +722,22 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
                     val = func(*input_vals)
                     # np.ndarray([func(*input_vals) for inp in zip(*input_vals)])
                 return val
-        raise ValueError('Unexpected type in draw_value: %s' % type(param))
+        raise ValueError("Unexpected type in draw_value: %s" % type(param))
 
 
 def _param_shape(var_desig, model: Model) -> Tuple[int, ...]:
     if isinstance(var_desig, str):
         v = model[var_desig]
     else:
-        v = var_desig                                                                          
-    if hasattr(v, 'observations'):
+        v = var_desig
+    if hasattr(v, "observations"):
         try:
             # To get shape of _observed_ data container `pm.Data`
             # (wrapper for theano.SharedVariable) we evaluate it.
             shape = tuple(v.observations.shape.eval())
         except AttributeError:
             shape = v.observations.shape
-    elif hasattr(v, 'dshape'):
+    elif hasattr(v, "dshape"):
         shape = v.dshape
     else:
         shape = v.tag.test_value.shape

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -99,7 +99,7 @@ PointList = List[PointType]
 _log = logging.getLogger("pymc3")
 
 
-def instantiate_steppers(model, steps, selected_steps, step_kwargs=None):
+def instantiate_steppers(_model, steps, selected_steps, step_kwargs=None):
     """Instantiate steppers assigned to the model variables.
 
     This function is intended to be called automatically from ``sample()``, but
@@ -108,7 +108,7 @@ def instantiate_steppers(model, steps, selected_steps, step_kwargs=None):
     Parameters
     ----------
     model : Model object
-        A fully-specified model object
+        A fully-specified model object; legacy argument -- ignored
     steps : step function or vector of step functions
         One or more step functions that have been assigned to some subset of
         the model's parameters. Defaults to None (no assigned variables).
@@ -226,7 +226,9 @@ def _print_step_hierarchy(s, level=0):
     else:
         varnames = ", ".join(
             [
-                get_untransformed_name(v.name) if is_transformed_name(v.name) else v.name
+                get_untransformed_name(v.name)
+                if is_transformed_name(v.name)
+                else v.name
                 for v in s.vars
             ]
         )
@@ -441,7 +443,7 @@ def sample(
             "Tuning samples will be included in the returned `MultiTrace` object, which can lead to"
             " complications in your downstream analysis. Please consider to switch to `InferenceData`:\n"
             "`pm.sample(..., return_inferencedata=True)`",
-            UserWarning
+            UserWarning,
         )
 
     if return_inferencedata is None:
@@ -450,7 +452,7 @@ def sample(
             warnings.warn(
                 "In an upcoming release, pm.sample will return an `arviz.InferenceData` object instead of a `MultiTrace` by default. "
                 "You can pass return_inferencedata=True or return_inferencedata=False to be safe and silence this warning.",
-                FutureWarning
+                FutureWarning,
             )
         # set the default
         return_inferencedata = False
@@ -483,13 +485,16 @@ def sample(
                 model=model,
                 random_seed=random_seed,
                 progressbar=progressbar,
-                **kwargs
+                **kwargs,
             )
             if start is None:
                 start = start_
         except (AttributeError, NotImplementedError, tg.NullTypeGradError):
             # gradient computation failed
-            _log.info("Initializing NUTS failed. " "Falling back to elementwise auto-assignment.")
+            _log.info(
+                "Initializing NUTS failed. "
+                "Falling back to elementwise auto-assignment."
+            )
             _log.debug("Exception in init nuts", exec_info=True)
             step = assign_step_methods(model, step, step_kwargs=kwargs)
     else:
@@ -554,7 +559,9 @@ def sample(
             has_demcmc = np.any(
                 [
                     isinstance(m, DEMetropolis)
-                    for m in (step.methods if isinstance(step, CompoundStep) else [step])
+                    for m in (
+                        step.methods if isinstance(step, CompoundStep) else [step]
+                    )
                 ]
             )
             _log.info("Population sampling ({} chains)".format(chains))
@@ -581,11 +588,11 @@ def sample(
     t_sampling = time.time() - t_start
     # count the number of tune/draw iterations that happened
     # ideally via the "tune" statistic, but not all samplers record it!
-    if 'tune' in trace.stat_names:
-        stat = trace.get_sampler_stats('tune', chains=0)
+    if "tune" in trace.stat_names:
+        stat = trace.get_sampler_stats("tune", chains=0)
         # when CompoundStep is used, the stat is 2 dimensional!
         if len(stat.shape) == 2:
-            stat = stat[:,0]
+            stat = stat[:, 0]
         stat = tuple(stat)
         n_tune = stat.count(True)
         n_draws = stat.count(False)
@@ -605,8 +612,8 @@ def sample(
     n_chains = len(trace.chains)
     _log.info(
         f'Sampling {n_chains} chain{"s" if n_chains > 1 else ""} for {n_tune:_d} tune and {n_draws:_d} draw iterations '
-        f'({n_tune*n_chains:_d} + {n_draws*n_chains:_d} draws total) '
-        f'took {trace.report.t_sampling:.0f} seconds.'
+        f"({n_tune*n_chains:_d} + {n_draws*n_chains:_d} draws total) "
+        f"took {trace.report.t_sampling:.0f} seconds."
     )
 
     idata = None
@@ -618,7 +625,9 @@ def sample(
 
     if compute_convergence_checks:
         if draws - tune < 100:
-            warnings.warn("The number of samples is too small to check convergence reliably.")
+            warnings.warn(
+                "The number of samples is too small to check convergence reliably."
+            )
         else:
             trace.report._run_convergence_checks(idata, model)
     trace.report._log_summary()
@@ -654,7 +663,16 @@ def _check_start_shape(model, start):
         raise ValueError("Bad shape for start argument:{}".format(e))
 
 
-def _sample_many(draws, chain:int, chains:int, start:list, random_seed:list, step, callback=None, **kwargs):
+def _sample_many(
+    draws,
+    chain: int,
+    chains: int,
+    start: list,
+    random_seed: list,
+    step,
+    callback=None,
+    **kwargs,
+):
     """Samples all chains sequentially.
 
     Parameters
@@ -686,7 +704,7 @@ def _sample_many(draws, chain:int, chains:int, start:list, random_seed:list, ste
             step=step,
             random_seed=random_seed[i],
             callback=callback,
-            **kwargs
+            **kwargs,
         )
         if trace is None:
             if len(traces) == 0:
@@ -703,9 +721,9 @@ def _sample_many(draws, chain:int, chains:int, start:list, random_seed:list, ste
 
 
 def _sample_population(
-    draws:int,
-    chain:int,
-    chains:int,
+    draws: int,
+    chain: int,
+    chains: int,
     start,
     random_seed,
     step,
@@ -713,7 +731,7 @@ def _sample_population(
     model,
     progressbar: bool = True,
     parallelize=False,
-    **kwargs
+    **kwargs,
 ):
     """Performs sampling of a population of chains using the ``PopulationStepper``.
 
@@ -778,7 +796,7 @@ def _sample(
     tune=None,
     model: Optional[Model] = None,
     callback=None,
-    **kwargs
+    **kwargs,
 ):
     """Main iteration for singleprocess sampling.
 
@@ -815,7 +833,9 @@ def _sample(
     """
     skip_first = kwargs.get("skip_first", 0)
 
-    sampling = _iter_sample(draws, step, start, trace, chain, tune, model, random_seed, callback)
+    sampling = _iter_sample(
+        draws, step, start, trace, chain, tune, model, random_seed, callback
+    )
     _pbar_data = {"chain": chain, "divergences": 0}
     _desc = "Sampling chain {chain:d}, {divergences:,d} divergences"
     if progressbar:
@@ -889,13 +909,23 @@ def iter_sample(
         for trace in iter_sample(500, step):
             ...
     """
-    sampling = _iter_sample(draws, step, start, trace, chain, tune, model, random_seed, callback)
+    sampling = _iter_sample(
+        draws, step, start, trace, chain, tune, model, random_seed, callback
+    )
     for i, (strace, _) in enumerate(sampling):
         yield MultiTrace([strace[: i + 1]])
 
 
 def _iter_sample(
-    draws, step, start=None, trace=None, chain=0, tune=None, model=None, random_seed=None, callback=None
+    draws,
+    step,
+    start=None,
+    trace=None,
+    chain=0,
+    tune=None,
+    model=None,
+    random_seed=None,
+    callback=None,
 ):
     """Generator for sampling one chain. (Used in singleprocess sampling.)
 
@@ -959,7 +989,7 @@ def _iter_sample(
 
     try:
         step.tune = bool(tune)
-        if hasattr(step, 'reset_tuning'):
+        if hasattr(step, "reset_tuning"):
             step.reset_tuning()
         for i in range(draws):
             stats = None
@@ -981,7 +1011,10 @@ def _iter_sample(
                 strace.record(point)
             if callback is not None:
                 warns = getattr(step, "warnings", None)
-                callback(trace=strace, draw=Draw(chain, i == draws, i, i < tune, stats, point, warns))
+                callback(
+                    trace=strace,
+                    draw=Draw(chain, i == draws, i, i < tune, stats, point, warns),
+                )
 
             yield strace, diverging
     except KeyboardInterrupt:
@@ -1002,6 +1035,7 @@ def _iter_sample(
 
 class PopulationStepper:
     """Wraps population of step methods to step them in parallel with single or multiprocessing."""
+
     def __init__(self, steppers, parallelize, progressbar=True):
         """Use multiprocessing to parallelize chains.
 
@@ -1033,7 +1067,9 @@ class PopulationStepper:
                 import multiprocessing
 
                 for c, stepper in (
-                    enumerate(progress_bar(steppers)) if progressbar else enumerate(steppers)
+                    enumerate(progress_bar(steppers))
+                    if progressbar
+                    else enumerate(steppers)
                 ):
                     secondary_end, primary_end = multiprocessing.Pipe()
                     stepper_dumps = pickle.dumps(stepper, protocol=4)
@@ -1100,7 +1136,9 @@ class PopulationStepper:
             # but rather a CompoundStep. PopulationArrayStepShared.population
             # has to be updated, therefore we identify the substeppers first.
             population_steppers = []
-            for sm in stepper.methods if isinstance(stepper, CompoundStep) else [stepper]:
+            for sm in (
+                stepper.methods if isinstance(stepper, CompoundStep) else [stepper]
+            ):
                 if isinstance(sm, arraystep.PopulationArrayStepShared):
                     population_steppers.append(sm)
             while True:
@@ -1157,7 +1195,7 @@ def _prepare_iter_population(
     chains: list,
     step,
     start: list,
-    parallelize:bool,
+    parallelize: bool,
     tune=None,
     model=None,
     random_seed=None,
@@ -1367,8 +1405,8 @@ def _mp_sample(
     callback=None,
     discard_tuned_samples=True,
     mp_ctx=None,
-    pickle_backend='pickle',
-    **kwargs
+    pickle_backend="pickle",
+    **kwargs,
 ):
     """Main iteration for multiprocess sampling.
 
@@ -1676,12 +1714,15 @@ def sample_posterior_predictive(
 
     if var_names is not None:
         if vars is not None:
-            raise IncorrectArgumentsError("Should not specify both vars and var_names arguments.")
+            raise IncorrectArgumentsError(
+                "Should not specify both vars and var_names arguments."
+            )
         else:
             vars = [model[x] for x in var_names]
-    elif vars is not None: # var_names is None, and vars is not.
-        warnings.warn("vars argument is deprecated in favor of var_names.",
-                      DeprecationWarning)
+    elif vars is not None:  # var_names is None, and vars is not.
+        warnings.warn(
+            "vars argument is deprecated in favor of var_names.", DeprecationWarning
+        )
     if vars is None:
         vars = model.observed_RVs
 
@@ -1892,7 +1933,8 @@ def sample_prior_predictive(
     if vars is None and var_names is None:
         prior_pred_vars = model.observed_RVs
         prior_vars = (
-            get_default_varnames(model.unobserved_RVs, include_transformed=True) + model.potentials
+            get_default_varnames(model.unobserved_RVs, include_transformed=True)
+            + model.potentials
         )
         vars_ = [var.name for var in prior_vars + prior_pred_vars]
         vars = set(vars_)
@@ -1900,7 +1942,9 @@ def sample_prior_predictive(
         vars = var_names
         vars_ = vars
     elif vars is not None:
-        warnings.warn("vars argument is deprecated in favor of var_names.", DeprecationWarning)
+        warnings.warn(
+            "vars argument is deprecated in favor of var_names.", DeprecationWarning
+        )
         vars_ = vars
     else:
         raise ValueError("Cannot supply both vars and var_names arguments.")
@@ -1930,7 +1974,13 @@ def sample_prior_predictive(
 
 
 def init_nuts(
-    init="auto", chains=1, n_init=500000, model=None, random_seed=None, progressbar=True, **kwargs
+    init="auto",
+    chains=1,
+    n_init=500000,
+    model=None,
+    random_seed=None,
+    progressbar=True,
+    **kwargs,
 ):
     """Set up the mass matrix initialization for NUTS.
 
@@ -1986,7 +2036,9 @@ def init_nuts(
     if set(vars) != set(model.vars):
         raise ValueError("Must use init_nuts on all variables of a model.")
     if not all_continuous(vars):
-        raise ValueError("init_nuts can only be used for models with only " "continuous variables.")
+        raise ValueError(
+            "init_nuts can only be used for models with only " "continuous variables."
+        )
 
     if not isinstance(init, str):
         raise TypeError("init must be a string.")
@@ -2040,7 +2092,9 @@ def init_nuts(
         mean = approx.bij.rmap(approx.mean.get_value())
         mean = model.dict_to_array(mean)
         weight = 50
-        potential = quadpotential.QuadPotentialDiagAdaptGrad(model.ndim, mean, cov, weight)
+        potential = quadpotential.QuadPotentialDiagAdaptGrad(
+            model.ndim, mean, cov, weight
+        )
     elif init == "advi+adapt_diag":
         approx = pm.fit(
             random_seed=random_seed,
@@ -2100,7 +2154,7 @@ def init_nuts(
         mean = np.mean([model.dict_to_array(vals) for vals in start], axis=0)
         cov = np.eye(model.ndim)
         potential = quadpotential.QuadPotentialFullAdapt(model.ndim, mean, cov, 10)
-    elif init == 'jitter+adapt_full':
+    elif init == "jitter+adapt_full":
         start = []
         for _ in range(chains):
             mean = {var: val.copy() for var, val in model.test_point.items()}

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1697,7 +1697,7 @@ def sample_posterior_predictive(
             # this is a list of points
             samples = len(_trace)
         else:
-            raise ValueError(
+            raise TypeError(
                 "Do not know how to compute number of samples for trace argument of type %s"
                 % type(_trace)
             )

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -578,9 +578,7 @@ class TestSamplePPC(SeededTest):
 
         samples = 100
         with model:
-            post_pred = pm.sample_posterior_predictive(
-                trace, samples=samples, var_names=["p", "obs"]
-            )
+            post_pred = pm.sample_posterior_predictive(trace, samples=samples, var_names=["p", "obs"])
 
         expected_p = np.array(
             [logistic.eval({coeff: val}) for val in trace["x"][:samples]]

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -381,6 +381,13 @@ class TestSamplePPC(SeededTest):
             ppc = pm.fast_sample_posterior_predictive(trace, keep_size=True)
             assert ppc["a"].shape == (nchains, ndraws)
 
+            # test keep_size parameter and idata input
+            idata = az.from_pymc3(trace)
+            ppc = pm.sample_posterior_predictive(idata, keep_size=True)
+            assert ppc["a"].shape == (nchains, ndraws)
+            ppc = pm.fast_sample_posterior_predictive(trace, keep_size=True)
+            assert ppc["a"].shape == (nchains, ndraws)
+
             # test default case
             ppc = pm.sample_posterior_predictive(trace, var_names=["a"])
             assert "a" in ppc
@@ -428,8 +435,25 @@ class TestSamplePPC(SeededTest):
             assert "a" in ppc
             assert ppc["a"].shape == (12, 2)
 
+            # test keep_size parameter with inference data as input...
+            idata = az.from_pymc3(trace)
+            ppc = pm.sample_posterior_predictive(idata, keep_size=True)
+            assert ppc["a"].shape == (trace.nchains, len(trace), 2)
+            with pytest.warns(UserWarning):
+                ppc = pm.sample_posterior_predictive(trace, samples=12, var_names=["a"])
+            assert "a" in ppc
+            assert ppc["a"].shape == (12, 2)
+
             # test keep_size parameter
             ppc = pm.fast_sample_posterior_predictive(trace, keep_size=True)
+            assert ppc["a"].shape == (trace.nchains, len(trace), 2)
+            with pytest.warns(UserWarning):
+                ppc = pm.fast_sample_posterior_predictive(trace, samples=12, var_names=["a"])
+            assert "a" in ppc
+            assert ppc["a"].shape == (12, 2)
+
+            # test keep_size parameter with inference data as input
+            ppc = pm.fast_sample_posterior_predictive(idata, keep_size=True)
             assert ppc["a"].shape == (trace.nchains, len(trace), 2)
             with pytest.warns(UserWarning):
                 ppc = pm.fast_sample_posterior_predictive(trace, samples=12, var_names=["a"])

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -483,6 +483,12 @@ class TestSamplePPC(SeededTest):
                 ppc = pm.sample_posterior_predictive(trace, size=4, keep_size=True)
             with pytest.raises(IncorrectArgumentsError):
                 ppc = pm.sample_posterior_predictive(trace, vars=[a], var_names=["a"])
+            # test wrong type argument
+            bad_trace = {'mu': stats.norm.rvs(size=1000)}
+            with pytest.raises(TypeError):
+                ppc = pm.sample_posterior_predictive(bad_trace)
+            with pytest.raises(TypeError):
+                ppc = pm.fast_sample_posterior_predictive(bad_trace)
 
     def test_vector_observed(self):
         with pm.Model() as model:

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -14,9 +14,10 @@
 
 import re
 import functools
-from typing import List, Dict
+from typing import List, Dict, Tuple, Union
 
 import xarray
+import arviz
 from numpy import asscalar, ndarray
 
 
@@ -182,22 +183,42 @@ def biwrap(wrapper):
         else:
             newwrapper = functools.partial(wrapper, *args, **kwargs)
             return newwrapper
+
     return enhanced
 
+
+# FIXME: this function is poorly named, because it returns a LIST of
+# points, not a dictionary of points.
 def dataset_to_point_dict(ds: xarray.Dataset) -> List[Dict[str, ndarray]]:
     # grab posterior samples for each variable
-    _samples = {
-        vn : ds[vn].values
-        for vn in ds.keys()
-    }
+    _samples: Dict[str, ndarray] = {vn: ds[vn].values for vn in ds.keys()}
     # make dicts
-    points = []
+    points: List[Dict[str, ndarray]] = []
+    vn: str
+    s: ndarray
     for c in ds.chain:
         for d in ds.draw:
-            points.append({
-                vn : s[c, d]
-                for vn, s in _samples.items()
-            })
+            points.append({vn: s[c, d] for vn, s in _samples.items()})
     # use the list of points
-    ds = points
-    return ds
+    return points
+
+
+def chains_and_samples(
+    data: Union[xarray.Dataset, arviz.InferenceData]
+) -> Tuple[int, int]:
+    """Extract and return number of chains and samples in xarray or arviz traces."""
+    dataset: xarray.Dataset
+    if isinstance(data, xarray.Dataset):
+        dataset = data
+    elif isinstance(data, arviz.InferenceData):
+        dataset = data.posterior
+    else:
+        raise ValueError(
+            "Argument must be xarray Dataset or arviz InferenceData. Got %s",
+            data.__class__,
+        )
+
+    coords = dataset.coords
+    nchains = coords["chain"].sizes["chain"]
+    nsamples = coords["draw"].sizes["draw"]
+    return nchains, nsamples

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -21,7 +21,7 @@ import arviz
 from numpy import asscalar, ndarray
 
 
-LATEX_ESCAPE_RE = re.compile(r'(%|_|\$|#|&)', re.MULTILINE)
+LATEX_ESCAPE_RE = re.compile(r"(%|_|\$|#|&)", re.MULTILINE)
 
 
 def escape_latex(strng):
@@ -44,8 +44,8 @@ def escape_latex(strng):
         A string with LaTeX escaped
     """
     if strng is None:
-        return 'None'
-    return LATEX_ESCAPE_RE.sub(r'\\\1', strng)
+        return "None"
+    return LATEX_ESCAPE_RE.sub(r"\\\1", strng)
 
 
 def get_transformed_name(name, transform):
@@ -81,7 +81,7 @@ def is_transformed_name(name):
     bool
         Boolean, whether the string could have been produced by `get_transformed_name`
     """
-    return name.endswith('__') and name.count('_') >= 3
+    return name.endswith("__") and name.count("_") >= 3
 
 
 def get_untransformed_name(name):
@@ -99,8 +99,8 @@ def get_untransformed_name(name):
         String with untransformed version of the name.
     """
     if not is_transformed_name(name):
-        raise ValueError('{} does not appear to be a transformed name'.format(name))
-    return '_'.join(name.split('_')[:-3])
+        raise ValueError("{} does not appear to be a transformed name".format(name))
+    return "_".join(name.split("_")[:-3])
 
 
 def get_default_varnames(var_iterator, include_transformed):
@@ -130,19 +130,20 @@ def get_variable_name(variable):
     """
     name = variable.name
     if name is None:
-        if hasattr(variable, 'get_parents'):
+        if hasattr(variable, "get_parents"):
             try:
-                names = [get_variable_name(item)
-                         for item in variable.get_parents()[0].inputs]
+                names = [
+                    get_variable_name(item) for item in variable.get_parents()[0].inputs
+                ]
                 # do not escape_latex these, since it is not idempotent
-                return 'f(%s)' % ',~'.join([n for n in names if isinstance(n, str)])
+                return "f(%s)" % ",~".join([n for n in names if isinstance(n, str)])
             except IndexError:
                 pass
         value = variable.eval()
         if not value.shape:
             return asscalar(value)
-        return 'array'
-    return r'\text{%s}' % name
+        return "array"
+    return r"\text{%s}" % name
 
 
 def update_start_vals(a, b, model):
@@ -155,16 +156,16 @@ def update_start_vals(a, b, model):
             for name in a:
                 if is_transformed_name(tname) and get_untransformed_name(tname) == name:
                     transform_func = [
-                        d.transformation for d in model.deterministics if d.name == name]
+                        d.transformation for d in model.deterministics if d.name == name
+                    ]
                     if transform_func:
-                        b[tname] = transform_func[0].forward_val(
-                            a[name], point=b)
+                        b[tname] = transform_func[0].forward_val(a[name], point=b)
 
     a.update({k: v for k, v in b.items() if k not in a})
 
 
 def get_transformed(z):
-    if hasattr(z, 'transformed'):
+    if hasattr(z, "transformed"):
         z = z.transformed
     return z
 


### PR DESCRIPTION
The `keep_size` kwarg for `sample_posterior_predictive` and `fast_sample_posterior_predictive` didn't handle `arviz.InferenceData` or `xarray.Dataset` arguments correctly when the `keep_size` option is chosen.

Addresses !4004