### PR TITLE
Disable FAST_COMPILE on windows again

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -31,12 +31,8 @@ if not logging.root.handlers:
 def __set_compiler_flags():
     # Workarounds for Theano compiler problems on various platforms
     import theano
-
-    system = platform.system()
-    if system == "Windows":
-        theano.config.mode = "FAST_COMPILE"
-    elif system == "Darwin":
-        theano.config.gcc.cxxflags = "-Wno-c++11-narrowing"
+    current = theano.config.gcc.cxxflags
+    theano.config.gcc.cxxflags = f"{current} -Wno-c++11-narrowing"
 
 
 __set_compiler_flags()


### PR DESCRIPTION
Revert the workaround to use FAST_COMPILE on Windows. This has unacceptable performance implications, and setting no-c++11-narrowing should be enough.
A better solution would be to fix the code that is generated by theano.