### PR TITLE
add potentials to priors when running abc

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,6 +13,7 @@
 - Add sampler stats `process_time_diff`, `perf_counter_diff` and `perf_counter_start`, that record wall and CPU times for each NUTS and HMC sample (see [ #3986](https://github.com/pymc-devs/pymc3/pull/3986)).
 - Extend `keep_size` argument handling for `sample_posterior_predictive` and `fast_sample_posterior_predictive`, to work on arviz InferenceData and xarray Dataset input values. (see [PR #4006](https://github.com/pymc-devs/pymc3/pull/4006) and [Issue #4004](https://github.com/pymc-devs/pymc3/issues/4004).
 - SMC-ABC: add the wasserstein and energy distance functions. Refactor API, the distance, sum_stats and epsilon arguments are now passed `pm.Simulator` instead of `pm.sample_smc`. Add random method to `pm.Simulator`. Add option to save the simulated data. Improves LaTeX representation [#3996](https://github.com/pymc-devs/pymc3/pull/3996)
+- SMC-ABC: Allow use of potentials by adding them to the prior term. [#4016](https://github.com/pymc-devs/pymc3/pull/4016)
 
 ## PyMC3 3.9.2 (24 June 2020)
 ### Maintenance

--- a/pymc3/smc/sample_smc.py
+++ b/pymc3/smc/sample_smc.py
@@ -137,6 +137,7 @@ def sample_smc(
     _log = logging.getLogger("pymc3")
     _log.info("Initializing SMC sampler...")
 
+    model = modelcontext(model)
     if cores is None:
         cores = _cpu_count()
 
@@ -165,8 +166,10 @@ def sample_smc(
 
     if kernel.lower() == "abc":
         warnings.warn(EXPERIMENTAL_WARNING)
-        if len(modelcontext(model).observed_RVs) != 1:
+        if len(model.observed_RVs) != 1:
             warnings.warn("SMC-ABC only works properly with models with one observed variable")
+        if model.potentials:
+            _log.info("Potentials will be added to the prior term")
 
     params = (
         draws,


### PR DESCRIPTION
Because potentials are applied to the likelihood term they are invisible to ABC models. This change it (only for ABC).
Sampling from the prior still is still unaware of potentials, this not fix that as it should be solved in the sampling_prior_predictive function. Unless we decide not to provide a general solution (in that case I will solve it for SMC and SMC/ABC)

