### PR TITLE
Fix Matplotlib type error for tests

### DIFF
--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -20,12 +20,13 @@ import theano.tensor as tt
 import pytest
 import theano
 from pymc3.theanof import floatX
+from packaging import version
 
 from .helpers import SeededTest
 
-try:
+if version.parse(matplotlib.__version__) < version.parse('3.3'):
     matplotlib.use('Agg', warn=False)
-except TypeError:
+else:
     matplotlib.use('Agg')
 
 

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -23,7 +23,10 @@ from pymc3.theanof import floatX
 
 from .helpers import SeededTest
 
-matplotlib.use('Agg', warn=False)
+try:
+    matplotlib.use('Agg', warn=False)
+except TypeError:
+    matplotlib.use('Agg')
 
 
 def get_city_data():


### PR DESCRIPTION
Check for support for `warn` argument in `matplotlib.use()` call. Drop it if it causes an error.

Attempted fix for #4022

I don't have the same version of matplotlib, so I am debugging through Travis!