### PR TITLE
Bump version to 3.9.3

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # pylint: disable=wildcard-import
-__version__ = "3.9.2"
+__version__ = "3.9.3"
 
 import logging
 import multiprocessing as mp


### PR DESCRIPTION
In preparation for a new release, we need to bump the version in __init__.py (see https://github.com/pymc-devs/pymc3/wiki/PyMC3-Release-Checklist).  