### PR TITLE
Fixed error message referencing non-existent file

### DIFF
--- a/pymc3/distributions/bound.py
+++ b/pymc3/distributions/bound.py
@@ -277,8 +277,7 @@ class Bound:
                 "Observed Bound distributions are not supported. "
                 "If you want to model truncated data "
                 "you can use a pm.Potential in combination "
-                "with the cumulative probability function. See "
-                "pymc3/examples/censored_data.py for an example."
+                "with the cumulative probability function."
             )
 
         transform = kwargs.pop("transform", "infer")


### PR DESCRIPTION
Currently, attempting to use a bounded distribution as a likelihood correctly raises an error, but the error message references a file `pymc3/examples/censored_data.py` that no longer exists in the repository. This removes the reference to this file.