### PR TITLE
Fix ExGaussian logp

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,7 @@
 
 ### Maintenance
 - Mentioned the way to do any random walk with `theano.tensor.cumsum()` in `GaussianRandomWalk` docstrings (see [#4048](https://github.com/pymc-devs/pymc3/pull/4048)).
+- Fixed numerical instability in ExGaussian's logp by preventing `logpow` from returning `-inf` (see [#4049](https://github.com/pymc-devs/pymc3/pull/4049)).
 
 ### Documentation
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3341,7 +3341,7 @@ class ExGaussian(Continuous):
 
         standardized_val = (value - mu) / sigma
         cdf_val = std_cdf(standardized_val - sigma / nu)
-        cdf_val_safe = tt.switch(tt.eq(cdf_val, 0), np.finfo(floatX).eps, cdf_val)
+        cdf_val_safe = tt.switch(tt.eq(cdf_val, 0), np.finfo(float).eps, cdf_val)
 
         # This condition is suggested by exGAUS.R from gamlss
         lp = tt.switch(

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -18,6 +18,7 @@ A collection of common probability distributions for stochastic
 nodes in PyMC.
 """
 import numpy as np
+import theano
 import theano.tensor as tt
 from scipy import stats
 from scipy.special import expit
@@ -3341,7 +3342,7 @@ class ExGaussian(Continuous):
 
         standardized_val = (value - mu) / sigma
         cdf_val = std_cdf(standardized_val - sigma / nu)
-        cdf_val_safe = tt.switch(tt.eq(cdf_val, 0), np.finfo(float).eps, cdf_val)
+        cdf_val_safe = tt.switch(tt.eq(cdf_val, 0), np.finfo(theano.config.floatX).eps, cdf_val)
 
         # This condition is suggested by exGAUS.R from gamlss
         lp = tt.switch(

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3268,21 +3268,16 @@ class ExGaussian(Continuous):
         sigma = self.sigma
         nu = self.nu
 
+        standardized_val = (value - mu) / sigma
+        cdf_val = std_cdf(standardized_val - sigma / nu)
+        cdf_val_safe = tt.switch(tt.eq(cdf_val, 0), np.finfo(floatX).eps, cdf_val)
+
         # This condition is suggested by exGAUS.R from gamlss
         lp = tt.switch(
             tt.gt(nu, 0.05 * sigma),
-            -tt.log(nu)
-            + (mu - value) / nu
-            + 0.5 * (sigma / nu) ** 2
-            + logpow(
-                tt.switch(
-                    tt.eq(std_cdf((value - mu) / sigma - sigma / nu), 0),
-                    np.finfo(float).eps,
-                    std_cdf((value - mu) / sigma - sigma / nu)
-                ),
-                1.0
-            ),
-            -tt.log(sigma * tt.sqrt(2 * np.pi)) - 0.5 * ((value - mu) / sigma) ** 2,
+            -tt.log(nu) + (mu - value) / nu + 0.5 * (sigma / nu) ** 2 + logpow(
+                cdf_val_safe, 1.0),
+            -tt.log(sigma * tt.sqrt(2 * np.pi)) - 0.5 * standardized_val ** 2,
         )
 
         return bound(lp, sigma > 0., nu > 0.)

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -17,17 +17,13 @@
 A collection of common probability distributions for stochastic
 nodes in PyMC.
 """
+import warnings
+
 import numpy as np
 import theano
 import theano.tensor as tt
-from scipy import stats
-from scipy.special import expit
-from scipy.interpolate import InterpolatedUnivariateSpline
-import warnings
 
-from pymc3.theanof import floatX
 from . import transforms
-from pymc3.util import get_variable_name
 from .special import log_i0
 from ..math import invlogit, logit, logdiffexp
 from .dist_math import (
@@ -46,6 +42,11 @@ from .dist_math import (
     clipped_beta_rvs,
 )
 from .distribution import Continuous, draw_values, generate_samples
+from pymc3.theanof import floatX
+from pymc3.util import get_variable_name
+from scipy import stats
+from scipy.special import expit
+from scipy.interpolate import InterpolatedUnivariateSpline
 
 __all__ = [
     "Uniform",


### PR DESCRIPTION
As suggested by @junpenglao in #4045, this PR adds a `tt.switch` statement in the `ExGaussian` logp to replace 0 with epsilon. That way, `std_cdf` never returns 0, and `logpow` never returns -inf.

I'm not sure what I did is very pythonic/theanoesque, so feel free to comment and suggest improvements! It does seem to work though: `pm.ExGaussian.dist(0., .25, 1./6).logp(y).eval()` doesn't contain -inf anymore, and the model in Discourse doesn't raise a `BadInitialEnergy` error.

Once these changes are validated, I'll blackify the file for better readibility and update the release notes.
Thanks for the reviews 🖖 
