### PR TITLE
Fix ExGaussian logp

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,7 +4,7 @@
 
 ### Maintenance
 - Mentioned the way to do any random walk with `theano.tensor.cumsum()` in `GaussianRandomWalk` docstrings (see [#4048](https://github.com/pymc-devs/pymc3/pull/4048)).
-
+- Fixed numerical instability in ExGaussian's logp by preventing `logpow` from returning `-inf` (see [#4050](https://github.com/pymc-devs/pymc3/pull/4050)).
 
 ### Documentation
 


### PR DESCRIPTION
This is a proper version of #4049, with all the changes related to the ExGaussian's logp.
As suggested by @junpenglao in #4045, this PR adds a `tt.switch` statement in the `ExGaussian` logp to replace 0 with epsilon. That way, `std_cdf` never returns 0, and `logpow` never returns `-inf`.

The changes seem to work: `pm.ExGaussian.dist(0., .25, 1./6).logp(y).eval()` doesn't contain `-inf` anymore, and the model in Discourse doesn't raise a `BadInitialEnergy` error.

Thanks for the reviews 🖖