### PR TITLE
Added fenics-pymc3 to the list of Software using PyMC3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,6 +159,7 @@ Software using PyMC3
 - `NiPyMC <https://github.com/PsychoinformaticsLab/nipymc>`__: Bayesian mixed-effects modeling of fMRI data in Python.
 - `beat <https://github.com/hvasbath/beat>`__: Bayesian Earthquake Analysis Tool.
 - `pymc-learn <https://github.com/pymc-learn/pymc-learn>`__: Custom PyMC models built on top of pymc3_models/scikit-learn API
+- `fenics-pymc3 <https://github.com/IvanYashchuk/fenics-pymc3>`__: Differentiable interface to FEniCS, a library for solving partial differential equations.
 
 Please contact us if your software is not listed here.
 


### PR DESCRIPTION
@twiecki,  I added [fenics-pymc3](https://github.com/IvanYashchuk/fenics-pymc3) to the list of Software using PyMC3.
