### PR TITLE
Use a more robust approach to static shape inference in Dirichlet

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -498,7 +498,7 @@ class Dirichlet(Continuous):
                 DeprecationWarning
             )
             try:
-                kwargs['shape'] = get_test_value(tt.shape(a))
+                kwargs['shape'] = np.shape(get_test_value(a))
             except AttributeError:
                 pass
 


### PR DESCRIPTION
This PR adjusts the way that static shapes are obtained in the `Dirichlet` constructor.  Previously, in some cases Theano wouldn't properly compute test values for the `tt.shape(a)` graph.  This adjustment simply uses the test value of the `a` parameter instead.

It doesn't completely finish #4060, because `pm.Dirichlet.dist(np.r_[1, 1]).random(size=2)` still returns `[1., 1.]`.
