### PR TITLE
CI add pre-commit, check notebook imports are sorted

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,20 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+    - name: set PY
+      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - uses: pre-commit/action@v1.1.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,12 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
-    - name: set PY
-      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.1.0
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.nbqa.ini
+++ b/.nbqa.ini
@@ -1,0 +1,4 @@
+[isort]
+config = setup.cfg
+mutate = 1
+addopts = --treat-comment-as-code '# %%%%'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+- repo: https://github.com/nbQA-dev/nbQA
+  rev: 0.1.29
+  hooks:
+    - id: nbqa
+      args: ['isort']
+      name: nbqa-isort
+      alias: nbqa-isort
+      additional_dependencies: ['isort']

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ omit =  *examples*
 [pydocstyle]
 add-ignore = D100,D104
 convention = numpy
+
+[isort]
+lines_between_types=1


### PR DESCRIPTION
closes #4077 

This allows the check to be carried out without requiring users to add pre-commit, nbqa, or isort to the dev requirements.

Also, it means that once #4083 is merged, you can easily add

```
-   repo: https://github.com/asottile/pyupgrade
    rev: v2.7.2
    hooks:
    -   id: pyupgrade
```
to `.pre-commit-config.yaml` , and similarly for any other code-quality tool (e.g. `black`, `flake8`, you name it...) you decide to add to this amazing repo