### PR TITLE
Tempered nuts2

### DIFF
--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -236,13 +236,16 @@ class PopulationArrayStepShared(ArrayStepShared):
 
 class GradientSharedStep(BlockedStep):
     def __init__(self, vars, model=None, blocked=True,
-                 dtype=None, **theano_kwargs):
+                 dtype=None, logp_dlogp_func=None, **theano_kwargs):
         model = modelcontext(model)
         self.vars = vars
         self.blocked = blocked
 
-        func = model.logp_dlogp_function(
-            vars, dtype=dtype, **theano_kwargs)
+        if logp_dlogp_func is None:
+            func = model.logp_dlogp_function(
+                vars, dtype=dtype, **theano_kwargs)
+        else:
+            func = logp_dlogp_func
 
         # handle edge case discovered in #2948
         try:
@@ -250,6 +253,8 @@ class GradientSharedStep(BlockedStep):
             q = func.dict_to_array(model.test_point)
             logp, dlogp = func(q)
         except ValueError:
+            if logp_dlogp_func is not None:
+                raise
             theano_kwargs.update(mode='FAST_COMPILE')
             func = model.logp_dlogp_function(
                 vars, dtype=dtype, **theano_kwargs)

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -393,8 +393,18 @@ def test_tempered_logp_dlogp():
     func_temp = model.logp_dlogp_function(tempered=True)
     func_temp.set_extra_values({})
 
+    func_nograd = model.logp_dlogp_function(compute_grads=False)
+    func_nograd.set_extra_values({})
+
+    func_temp_nograd = model.logp_dlogp_function(
+        tempered=True, compute_grads=False
+    )
+    func_temp_nograd.set_extra_values({})
+
     x = np.ones(func.size, dtype=func.dtype)
     assert func(x) == func_temp(x)
+    assert func_nograd(x) == func(x)[0]
+    assert func_temp_nograd(x) == func(x)[0]
 
     func_temp.set_weights(np.array([0.], dtype=func.dtype))
     func_temp_nograd.set_weights(np.array([0.], dtype=func.dtype))
@@ -408,3 +418,6 @@ def test_tempered_logp_dlogp():
     func_temp_nograd.set_weights(np.array([0.5], dtype=func.dtype))
     npt.assert_allclose(func(x)[0], 4 / 3 * func_temp(x)[0])
     npt.assert_allclose(func(x)[1], func_temp(x)[1])
+
+    npt.assert_allclose(func_nograd(x), func(x)[0])
+    npt.assert_allclose(func_temp_nograd(x), func_temp(x)[0])

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -380,3 +380,26 @@ def test_multiple_observed_rv():
     assert model['x'] == model['x']
     assert  model['x'] in model.observed_RVs
     assert not model['x'] in model.vars
+
+
+def test_tempered_logp_dlogp():
+    with pm.Model() as model:
+        pm.Normal('x')
+        pm.Normal('y', observed=1)
+
+    func = model.logp_dlogp_function()
+    func.set_extra_values({})
+
+    func_temp = model.logp_dlogp_function(tempered=True)
+    func_temp.set_extra_values({})
+
+    x = np.ones(func.size, dtype=func.dtype)
+    assert func(x) == func_temp(x)
+
+    func_temp.set_weights(np.array([0.]))
+    npt.assert_allclose(func(x)[0], 2 * func_temp(x)[0])
+    npt.assert_allclose(func(x)[1], func_temp(x)[1])
+
+    func_temp.set_weights(np.array([0.5]))
+    npt.assert_allclose(func(x)[0], 4 / 3 * func_temp(x)[0])
+    npt.assert_allclose(func(x)[1], func_temp(x)[1])

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -265,7 +265,7 @@ class TestValueGradFunction(unittest.TestCase):
         a.tag.test_value = np.zeros(3, dtype=a.dtype)
         a.dshape = (3,)
         a.dsize = 3
-        f_grad = ValueGradFunction(a.sum(), [a], [], mode='FAST_COMPILE')
+        f_grad = ValueGradFunction([a.sum()], [a], [], mode='FAST_COMPILE')
         assert f_grad.size == 3
 
     def test_invalid_type(self):
@@ -274,7 +274,7 @@ class TestValueGradFunction(unittest.TestCase):
         a.dshape = (3,)
         a.dsize = 3
         with pytest.raises(TypeError) as err:
-            ValueGradFunction(a.sum(), [a], [], mode='FAST_COMPILE')
+            ValueGradFunction([a.sum()], [a], [], mode='FAST_COMPILE')
         err.match('Invalid dtype')
 
     def setUp(self):
@@ -303,7 +303,7 @@ class TestValueGradFunction(unittest.TestCase):
         self.cost = extra1 * val1.sum() + val2.sum()
 
         self.f_grad = ValueGradFunction(
-            self.cost, [val1, val2], [extra1], mode='FAST_COMPILE')
+            [self.cost], [val1, val2], [extra1], mode='FAST_COMPILE')
 
     def test_extra_not_set(self):
         with pytest.raises(ValueError) as err:
@@ -396,10 +396,15 @@ def test_tempered_logp_dlogp():
     x = np.ones(func.size, dtype=func.dtype)
     assert func(x) == func_temp(x)
 
-    func_temp.set_weights(np.array([0.]))
+    func_temp.set_weights(np.array([0.], dtype=func.dtype))
+    func_temp_nograd.set_weights(np.array([0.], dtype=func.dtype))
     npt.assert_allclose(func(x)[0], 2 * func_temp(x)[0])
     npt.assert_allclose(func(x)[1], func_temp(x)[1])
 
-    func_temp.set_weights(np.array([0.5]))
+    npt.assert_allclose(func_nograd(x), func(x)[0])
+    npt.assert_allclose(func_temp_nograd(x), func_temp(x)[0])
+
+    func_temp.set_weights(np.array([0.5], dtype=func.dtype))
+    func_temp_nograd.set_weights(np.array([0.5], dtype=func.dtype))
     npt.assert_allclose(func(x)[0], 4 / 3 * func_temp(x)[0])
     npt.assert_allclose(func(x)[1], func_temp(x)[1])


### PR DESCRIPTION
This adds an argument `tempered` to `model.logp_dlogp_function`, so that the function will compute tempered logp values `prior_logp + beta * observed_logp` for values of `beta != 1`.
I'm not sure if this should be a PR on its own, since it is not used in pymc3 anywhere at the moment. (I've got a slower but more robust nuts tuning method pending that would use this). I've used this a number of times while trying out different initialization schemes, and found it to be useful, and I'm guessing other people might as well.