### PR TITLE
Add alternative parameterization to negative binomial distribution #4126

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,6 +13,7 @@
 - `sample_posterior_predictive_w` can now feed on `xarray.Dataset` - e.g. from `InferenceData.posterior`. (see [#4042](https://github.com/pymc-devs/pymc3/pull/4042))
 - Add MLDA, a new stepper for multilevel sampling. MLDA can be used when a hierarchy of approximate posteriors of varying accuracy is available, offering improved sampling efficiency especially in high-dimensional problems and/or where gradients are not available (see [#3926](https://github.com/pymc-devs/pymc3/pull/3926))
 - Change SMC metropolis kernel to independent metropolis kernel [#4115](https://github.com/pymc-devs/pymc3/pull/3926))
+- Add alternative parametrization to NegativeBinomial distribution in terms of n and p (see [#4126](https://github.com/pymc-devs/pymc3/issues/4126))
 
 
 ## PyMC3 3.9.3 (11 August 2020)

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -635,7 +635,7 @@ class NegativeBinomial(Discrete):
                 )
         elif n is not None:
             raise ValueError(
-                "Incompatible parametrization Can't specify both alpha and n."
+                "Incompatible parametrization. Can't specify both alpha and n."
             )
 
         if mu is None:

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -598,19 +598,59 @@ class NegativeBinomial(Discrete):
     Mean      :math:`\mu`
     ========  ==========================
 
+    The negative binomial distribution can be parametrized either in terms of mu or p,
+    and either in terms of alpha or n. The link between the parametrizations is given by
+
+    .. math::
+
+        \mu &= \frac{n(1-p)}{p} \\
+        \alpha &= n
+
     Parameters
     ----------
     mu: float
         Poission distribution parameter (mu > 0).
     alpha: float
         Gamma distribution parameter (alpha > 0).
+    p: float
+        Alternative probability of success in each trial (0 < p < 1).
+    n: float
+        Alternative number of target success trials (n > 0)
     """
 
-    def __init__(self, mu, alpha, *args, **kwargs):
+    def __init__(self, mu=None, alpha=None, p=None, n=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        mu, alpha = self.get_mu_alpha(mu, alpha, p, n)
         self.mu = mu = tt.as_tensor_variable(floatX(mu))
         self.alpha = alpha = tt.as_tensor_variable(floatX(alpha))
         self.mode = intX(tt.floor(mu))
+
+    def get_mu_alpha(self, mu=None, alpha=None, p=None, n=None):
+        if alpha is None:
+            if n is not None:
+                alpha = n
+            else:
+                raise ValueError(
+                    "Incompatible parametrization. Must specify either alpha or n."
+                )
+        elif n is not None:
+            raise ValueError(
+                "Incompatible parametrization Can't specify both alpha and n."
+            )
+
+        if mu is None:
+            if p is not None:
+                mu = alpha * (1 - p) / p
+            else:
+                raise ValueError(
+                    "Incompatible parametrization. Must specify either mu or p."
+                )
+        elif p is not None:
+            raise ValueError(
+                "Incompatible parametrization. Can't specify both mu and p."
+            )
+
+        return mu, alpha
 
     def random(self, point=None, size=None):
         r"""

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -802,23 +802,25 @@ class TestMatchesScipy(SeededTest):
             lambda value, p, n: sp.nbinom.logpmf(value, n, p),
         )
 
-    def test_negative_binomial_init_fail(self):
+    @pytest.mark.parametrize(
+        "mu, p, alpha, n, expected",
+        [
+            (5, None, None, None, "Incompatible parametrization. Must specify either alpha or n."),
+            (None, .5, None, None, "Incompatible parametrization. Must specify either alpha or n."),
+            (None, None, None, None, "Incompatible parametrization. Must specify either alpha or n."),
+            (5, None, 2, 2, "Incompatible parametrization. Can't specify both alpha and n."),
+            (None, .5, 2, 2, "Incompatible parametrization. Can't specify both alpha and n."),
+            (5, .5, 2, 2, "Incompatible parametrization. Can't specify both alpha and n."),
+            (None, None, 2, None, "Incompatible parametrization. Must specify either mu or p."),
+            (None, None, None, 2, "Incompatible parametrization. Must specify either mu or p."),
+            (5, .5, 2, None, "Incompatible parametrization. Can't specify both mu and p."),
+            (5, .5, None, 2, "Incompatible parametrization. Can't specify both mu and p."),
+        ]
+    )
+    def test_negative_binomial_init_fail(self, mu, p, alpha, n, expected):
         with Model():
-            with pytest.raises(ValueError) as err:
-                x = NegativeBinomial("x", mu=5)
-            err.match("Incompatible parametrization. Must specify either alpha or n.")
-
-            with pytest.raises(ValueError) as err:
-                x = NegativeBinomial("x", n=2, alpha=2)
-            err.match("Incompatible parametrization Can't specify both alpha and n.")
-
-            with pytest.raises(ValueError) as err:
-                x = NegativeBinomial("x", n=2)
-            err.match("Incompatible parametrization. Must specify either mu or p.")
-
-            with pytest.raises(ValueError) as err:
-                x = NegativeBinomial("x", n=2, mu=2, p=.5)
-            err.match("Incompatible parametrization. Can't specify both mu and p.")
+            with pytest.raises(ValueError, match=expected):
+                NegativeBinomial("x", mu=mu, p=p, alpha=alpha, n=n)
 
     def test_laplace(self):
         self.pymc3_matches_scipy(

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -810,7 +810,7 @@ class TestMatchesScipy(SeededTest):
             (None, None, None, None, "Incompatible parametrization. Must specify either alpha or n."),
             (5, None, 2, 2, "Incompatible parametrization. Can't specify both alpha and n."),
             (None, .5, 2, 2, "Incompatible parametrization. Can't specify both alpha and n."),
-            (5, .5, 2, 2, "Incompatible parametrization. Can't specify both alpha and n."),
+            (None, None, 2, 2, "Incompatible parametrization. Can't specify both alpha and n."),
             (None, None, 2, None, "Incompatible parametrization. Must specify either mu or p."),
             (None, None, None, 2, "Incompatible parametrization. Must specify either mu or p."),
             (5, .5, 2, None, "Incompatible parametrization. Can't specify both mu and p."),

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -802,6 +802,24 @@ class TestMatchesScipy(SeededTest):
             lambda value, p, n: sp.nbinom.logpmf(value, n, p),
         )
 
+    def test_negative_binomial_init_fail(self):
+        with Model():
+            with pytest.raises(ValueError) as err:
+                x = NegativeBinomial("x", mu=5)
+            err.match("Incompatible parametrization. Must specify either alpha or n.")
+
+            with pytest.raises(ValueError) as err:
+                x = NegativeBinomial("x", n=2, alpha=2)
+            err.match("Incompatible parametrization Can't specify both alpha and n.")
+
+            with pytest.raises(ValueError) as err:
+                x = NegativeBinomial("x", n=2)
+            err.match("Incompatible parametrization. Must specify either mu or p.")
+
+            with pytest.raises(ValueError) as err:
+                x = NegativeBinomial("x", n=2, mu=2, p=.5)
+            err.match("Incompatible parametrization. Can't specify both mu and p.")
+
     def test_laplace(self):
         self.pymc3_matches_scipy(
             Laplace,

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -795,6 +795,12 @@ class TestMatchesScipy(SeededTest):
             return sp.nbinom.logpmf(value, alpha, 1 - mu / (mu + alpha))
 
         self.pymc3_matches_scipy(NegativeBinomial, Nat, {"mu": Rplus, "alpha": Rplus}, test_fun)
+        self.pymc3_matches_scipy(
+            NegativeBinomial,
+            Nat,
+            {"p": Unit, "n": Rplus},
+            lambda value, p, n: sp.nbinom.logpmf(value, n, p),
+        )
 
     def test_laplace(self):
         self.pymc3_matches_scipy(


### PR DESCRIPTION
Changes allow the specification of the NegativeBinomial distribution in terms of p (the probability of observing a success in each trial), and n (the target number of successes). This parametrization gives the likelihood for y, the number of failures observed until a target number of successes is reached.

I changed the docstrings and distribution initialization in line with other distribution that have multiple parametrizations.

I didn't figure out yet how the tests work, so I did not implement it (hence the WIP)! This should be straightforward, however, since the scipy negativebinomial distribution is implemented in terms of n and p. Any guidance in how to proceed is much appreciated!

Pinging @twiecki 

Ref #4126 