### PR TITLE
add distribution details to GraphViz output

### DIFF
--- a/pymc3/model_graph.py
+++ b/pymc3/model_graph.py
@@ -143,7 +143,7 @@ class ModelGraph:
         if v in self.model.potentials:
             label = f'{var_name}\n~\nPotential'
         elif isinstance(v, SharedVariable):
-            label = f'{var_name}\n~\Data'
+            label = f'{var_name}\n~\nData'
         else:
             label = str(v).replace(' ~ ', '\n~\n')
 

--- a/pymc3/model_graph.py
+++ b/pymc3/model_graph.py
@@ -133,22 +133,21 @@ class ModelGraph:
         if isinstance(v, SharedVariable):
             attrs['style'] = 'rounded, filled'
 
-        # Get name for node
+        # determine the shape for this node (default (Distribution) is ellipse)
         if v in self.model.potentials:
-            distribution = 'Potential'
             attrs['shape'] = 'octagon'
-        elif hasattr(v, 'distribution'):
-            distribution = v.distribution.__class__.__name__
-        elif isinstance(v, SharedVariable):
-            distribution = 'Data'
-            attrs['shape'] = 'box'
-        else:
-            distribution = 'Deterministic'
+        elif isinstance(v, SharedVariable) or not hasattr(v, 'distribution'):
+            # shared variables and Deterministic represented by a box
             attrs['shape'] = 'box'
 
-        graph.node(var_name.replace(':', '&'),
-                f'{var_name}\n~\n{distribution}',
-                **attrs)
+        if v in self.model.potentials:
+            label = f'{var_name}\n~\nPotential'
+        elif isinstance(v, SharedVariable):
+            label = f'{var_name}\n~\Data'
+        else:
+            label = str(v).replace(' ~ ', '\n~\n')
+
+        graph.node(var_name.replace(':', '&'), label, **attrs)
 
     def get_plates(self):
         """ Rough but surprisingly accurate plate detection.

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -174,12 +174,11 @@ class TestData(SeededTest):
             x = pm.Data("x", [1.0, 2.0, 3.0])
             y = pm.Data("y", [1.0, 2.0, 3.0])
             beta = pm.Normal("beta", 0, 10.0)
-            pm.Normal("obs", beta * x, np.sqrt(1e-2), observed=y)
+            pm.Normal("obs", beta * x, 0.1, observed=y)
             pm.sample(1000, init=None, tune=1000, chains=1)
 
         g = pm.model_to_graphviz(model)
 
-        print(g.source)
         # Data node rendered correctly?
         text = 'x [label="x\n~\nData" shape=box style="rounded, filled"]'
         assert text in g.source

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -179,6 +179,7 @@ class TestData(SeededTest):
 
         g = pm.model_to_graphviz(model)
 
+        print(g.source)
         # Data node rendered correctly?
         text = 'x [label="x\n~\nData" shape=box style="rounded, filled"]'
         assert text in g.source

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -174,18 +174,20 @@ class TestData(SeededTest):
             x = pm.Data("x", [1.0, 2.0, 3.0])
             y = pm.Data("y", [1.0, 2.0, 3.0])
             beta = pm.Normal("beta", 0, 10.0)
-            pm.Normal("obs", beta * x, 0.1, observed=y)
+            obs_sigma = np.sqrt(1e-2)
+            pm.Normal("obs", beta * x, obs_sigma, observed=y)
             pm.sample(1000, init=None, tune=1000, chains=1)
 
         g = pm.model_to_graphviz(model)
 
+        print(g.source)
         # Data node rendered correctly?
         text = 'x [label="x\n~\nData" shape=box style="rounded, filled"]'
         assert text in g.source
         # Didn't break ordinary variables?
         text = 'beta [label="beta\n~\nNormal(mu=0.0, sigma=10.0)"]'
         assert text in g.source
-        text = 'obs [label="obs\n~\nNormal(mu=f(f(beta), x), sigma=0.1)" style=filled]'
+        text = f'obs [label="obs\n~\nNormal(mu=f(f(beta), x), sigma={obs_sigma})" style=filled]'
         assert text in g.source
 
     def test_explicit_coords(self):

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -183,9 +183,9 @@ class TestData(SeededTest):
         text = 'x [label="x\n~\nData" shape=box style="rounded, filled"]'
         assert text in g.source
         # Didn't break ordinary variables?
-        text = 'beta [label="beta\n~\nNormal"]'
+        text = 'beta [label="beta\n~\nNormal(mu=0.0, sigma=10.0)"]'
         assert text in g.source
-        text = 'obs [label="obs\n~\nNormal" style=filled]'
+        text = 'obs [label="obs\n~\nNormal(mu=f(f(beta), x), sigma=0.1)" style=filled]'
         assert text in g.source
 
     def test_explicit_coords(self):

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 import pymc3 as pm
+from ..theanof import floatX
 from .helpers import SeededTest
 import numpy as np
 import pandas as pd
@@ -174,13 +175,12 @@ class TestData(SeededTest):
             x = pm.Data("x", [1.0, 2.0, 3.0])
             y = pm.Data("y", [1.0, 2.0, 3.0])
             beta = pm.Normal("beta", 0, 10.0)
-            obs_sigma = np.sqrt(1e-2)
+            obs_sigma = floatX(np.sqrt(1e-2))
             pm.Normal("obs", beta * x, obs_sigma, observed=y)
             pm.sample(1000, init=None, tune=1000, chains=1)
 
         g = pm.model_to_graphviz(model)
 
-        print(g.source)
         # Data node rendered correctly?
         text = 'x [label="x\n~\nData" shape=box style="rounded, filled"]'
         assert text in g.source


### PR DESCRIPTION
As originally discussed in https://github.com/pymc-devs/pymc3/pull/3956, since the new `str` functionality has now been merged into master (https://github.com/pymc-devs/pymc3/pull/4076), we can use it in GraphViz renderings.
