### PR TITLE
Make Multinomial robust against batches

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,7 @@
 - Fixed numerical instability in ExGaussian's logp by preventing `logpow` from returning `-inf` (see [#4050](https://github.com/pymc-devs/pymc3/pull/4050)).
 - Use dill to serialize user defined logp functions in `DensityDist`. The previous serialization code fails if it is used in notebooks on Windows and Mac. `dill` is now a required dependency. (see [#3844](https://github.com/pymc-devs/pymc3/issues/3844)).
 - Numerically improved stickbreaking transformation - e.g. for the `Dirichlet` distribution. [#4129](https://github.com/pymc-devs/pymc3/pull/4129)
+- Enabled the `Multinomial` distribution to handle batch sizes that have more than 2 dimensions. [#4169](https://github.com/pymc-devs/pymc3/pull/4169)
 
 ### Documentation
 

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -597,12 +597,8 @@ class Multinomial(Discrete):
         super().__init__(*args, **kwargs)
 
         p = p / tt.sum(p, axis=-1, keepdims=True)
-        n = np.squeeze(n)  # works also if n is a tensor
 
-        if len(self.shape) > 1:
-            self.n = tt.shape_padright(n)
-            self.p = p if p.ndim > 1 else tt.shape_padleft(p)
-        elif n.ndim == 1:
+        if len(self.shape) >= 1:
             self.n = tt.shape_padright(n)
             self.p = p if p.ndim > 1 else tt.shape_padleft(p)
         else:
@@ -611,10 +607,9 @@ class Multinomial(Discrete):
             self.p = tt.as_tensor_variable(p)
 
         self.mean = self.n * self.p
-        mode = tt.cast(tt.round(self.mean), "int32")
-        diff = self.n - tt.sum(mode, axis=-1, keepdims=True)
-        inc_bool_arr = tt.abs_(diff) > 0
-        mode = tt.inc_subtensor(mode[inc_bool_arr.nonzero()], diff[inc_bool_arr.nonzero()])
+        mode_ind = tt.argmax(self.p, axis=-1, keepdims=True)
+        mode = tt.zeros_like(self.mean, dtype=self.dtype)
+        mode = tt.inc_subtensor(mode[..., mode_ind], 1)
         self.mode = mode
 
     def _random(self, n, p, size=None, raw_size=None):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1449,15 +1449,15 @@ class TestMatchesScipy(SeededTest):
 
     def test_batch_multinomial(self):
         n = 10
-        vals = np.zeros((4, 5, 3))
-        p = np.zeros_like(vals)
+        vals = np.zeros((4, 5, 3), dtype="int32")
+        p = np.zeros_like(vals, dtype=theano.config.floatX)
         inds = np.random.randint(vals.shape[-1], size=vals.shape[:-1])[..., None]
         np.put_along_axis(vals, inds, n, axis=-1)
         np.put_along_axis(p, inds, 1, axis=-1)
 
         dist = Multinomial.dist(n=n, p=p, shape=vals.shape)
-        value = tt.tensor3()
-        value.tag.test_value = np.zeros_like(vals)
+        value = tt.tensor3(dtype="int32")
+        value.tag.test_value = np.zeros_like(vals, dtype="int32")
         logp = tt.exp(dist.logp(value))
         f = theano.function(inputs=[value], outputs=logp)
         assert_almost_equal(


### PR DESCRIPTION
At the moment, our `Multinomial` distribution mangles the `n` parameter's shape. This makes it very difficult to work with batches that have more than 2 dimensions. This PR addresses the problem and adds a test for it.


**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [ ] important background, or details about the implementation
+ [X] are the changes—especially new features—covered by tests and docstrings?
+ [ ] consider adding/updating relevant example notebooks
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
