### PR TITLE
Use in-built hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,23 +5,11 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-toml
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 0.3.0
+  rev: 0.3.2
   hooks:
-    - id: nbqa
-      args: [black]
-      name: nbqa-black
-      alias: nbqa-black
-      additional_dependencies: [black]
-    - id: nbqa
-      args: [isort]
-      name: nbqa-isort
-      alias: nbqa-isort
-      additional_dependencies: [isort]
-    - id: nbqa
-      args: [pyupgrade]
-      name: nbqa-pyupgrade
-      alias: nbqa-pyupgrade
-      additional_dependencies: [pyupgrade]
+    - id: nbqa-black
+    - id: nbqa-isort
+    - id: nbqa-pyupgrade
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.7.2
   hooks:


### PR DESCRIPTION
We've made a new release with some in-built hooks - this cuts down on the boilerplate in `.pre-commit-config.yaml` and cuts down on the noise