### PR TITLE
Use new TestValueError when available

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -38,6 +38,12 @@ from .dist_math import bound, logpow, factln
 from .shape_utils import to_tuple
 from ..math import kron_dot, kron_diag, kron_solve_lower, kronecker
 
+# TODO: Remove this once the theano-pymc dependency is above 1.0.9
+try:
+    from theano.gof.utils import TestValueError
+except ImportError:
+    TestValueError = AttributeError
+
 
 __all__ = [
     "MvNormal",
@@ -477,7 +483,7 @@ class Dirichlet(Continuous):
             )
             try:
                 kwargs["shape"] = np.shape(get_test_value(a))
-            except AttributeError:
+            except TestValueError:
                 pass
 
         super().__init__(transform=transform, *args, **kwargs)


### PR DESCRIPTION
Recently, Theano-PyMC introduced a new `TestValueError` that's raised when an attempt is made to obtain a test value for a `Variable` that doesn't have one.  This PR changes a `try` statement so that it catches the appropriate exception for all versions of Theano.