### PR TITLE
Add MixtureSameFamily distribution

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,6 +18,7 @@
 - Add MLDA, a new stepper for multilevel sampling. MLDA can be used when a hierarchy of approximate posteriors of varying accuracy is available, offering improved sampling efficiency especially in high-dimensional problems and/or where gradients are not available (see [#3926](https://github.com/pymc-devs/pymc3/pull/3926))
 - Change SMC metropolis kernel to independent metropolis kernel [#4115](https://github.com/pymc-devs/pymc3/pull/3926))
 - Add alternative parametrization to NegativeBinomial distribution in terms of n and p (see [#4126](https://github.com/pymc-devs/pymc3/issues/4126))
+- Added a new `MixtureSameFamily` distribution to handle mixtures of arbitrary dimensions in vectorized form (see [#4185](https://github.com/pymc-devs/pymc3/issues/4185)).
 
 
 ## PyMC3 3.9.3 (11 August 2020)

--- a/docs/source/api/distributions/mixture.rst
+++ b/docs/source/api/distributions/mixture.rst
@@ -6,6 +6,7 @@ Mixture
 .. autosummary::
    Mixture
    NormalMixture
+   MixtureSameFamily
 
 .. automodule:: pymc3.distributions.mixture
    :members:

--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -79,6 +79,7 @@ from .simulator import Simulator
 
 from .mixture import Mixture
 from .mixture import NormalMixture
+from .mixture import MixtureSameFamily
 
 from .multivariate import MvNormal
 from .multivariate import MatrixNormal
@@ -164,6 +165,7 @@ __all__ = [
     "SkewNormal",
     "Mixture",
     "NormalMixture",
+    "MixtureSameFamily",
     "Triangular",
     "DiscreteWeibull",
     "Gumbel",

--- a/pymc3/tests/test_mixture.py
+++ b/pymc3/tests/test_mixture.py
@@ -490,3 +490,47 @@ class TestMixtureVsLatent(SeededTest):
             logps.append(z_logp + latent_mix.logp(test_point))
         latent_mix_logp = logsumexp(np.array(logps), axis=0)
         assert_allclose(mix_logp, latent_mix_logp, rtol=rtol)
+
+
+class TestMixtureSameFamily(SeededTest):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.size = 50
+        cls.n_samples = 1000
+        cls.mixture_comps = 10
+
+    @pytest.mark.parametrize("batch_shape", [(3, 4), (20,)], ids=str)
+    def test_with_multinomial(self, batch_shape):
+        p = np.random.uniform(size=(*batch_shape, self.mixture_comps, 3))
+        n = 100 * np.ones((*batch_shape, 1))
+        w = np.ones((self.mixture_comps)) / self.mixture_comps
+        mixture_axis = len(batch_shape)
+        with pm.Model() as model:
+            comp_dists = pm.Multinomial.dist(p=p, n=n, shape=(*batch_shape, self.mixture_comps, 3))
+            mixture = pm.MixtureSameFamily(
+                "mixture",
+                w=w,
+                comp_dists=comp_dists,
+                mixture_axis=mixture_axis,
+                shape=(*batch_shape, 3),
+            )
+            prior = pm.sample_prior_predictive(samples=self.n_samples)
+
+        assert prior["mixture"].shape == (self.n_samples, *batch_shape, 3)
+        assert mixture.random(size=self.size).shape == (self.size, *batch_shape, 3)
+
+        if theano.config.floatX == "float32":
+            rtol = 1e-4
+        else:
+            rtol = 1e-7
+
+        comp_logp = comp_dists.logp(model.test_point["mixture"].reshape(*batch_shape, 1, 3))
+        log_sum_exp = logsumexp(
+            comp_logp.eval() + np.log(w)[..., None], axis=mixture_axis, keepdims=True
+        ).sum()
+        assert_allclose(
+            model.logp(model.test_point),
+            log_sum_exp,
+            rtol,
+        )

--- a/pymc3/tests/test_mixture.py
+++ b/pymc3/tests/test_mixture.py
@@ -504,7 +504,7 @@ class TestMixtureSameFamily(SeededTest):
     def test_with_multinomial(self, batch_shape):
         p = np.random.uniform(size=(*batch_shape, self.mixture_comps, 3))
         n = 100 * np.ones((*batch_shape, 1))
-        w = np.ones((self.mixture_comps)) / self.mixture_comps
+        w = np.ones(self.mixture_comps) / self.mixture_comps
         mixture_axis = len(batch_shape)
         with pm.Model() as model:
             comp_dists = pm.Multinomial.dist(p=p, n=n, shape=(*batch_shape, self.mixture_comps, 3))


### PR DESCRIPTION
Co-authored-by: lucianopaz <luciano.paz.neuro@gmail.com>


**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [X] what are the (breaking) changes that this PR makes?
The PyMC3's Mixture distribution considers the mixture components over the last dimension. This makes it difficult to handle mixtures over multivariate distributions because the last dimension is event_shape and thus, cannot represent mixture components. This PR adds a new MixtureSameFamily distribution, making it easy to specify mixtures for multivariate distributions along a specified `mixture_axis`. All vectorized calculations for `logp` and `random` methods, thereby making it much faster.

+ [X] important background, or details about the implementation
Multivariate distribution is passed as an argument and has a shape (batch_shape, mixture_axis, event_shape). For computing `logp` and `random` samples, the `mixture_axis` is reduced / marginalised away. This is similar to `MixtureSameFamily` distribution in TFP.

+ [X] are the changes—especially new features—covered by tests and docstrings?
Yes. I have added a few tests with mixture of Multinomial distribution. I have been trying to add mixture over MvNormal distribution as tests. But I could not do so because it is difficult to form a vectorized MvNormal distribution with a given `batch_shape`. I need help writing them.

+ [X] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
Once tests pass, I will give a mention in the RELEASE-NOTES.md