### PR TITLE
CI autoupdate pre-commit

### DIFF
--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -1,0 +1,33 @@
+name: "Update pre-commit config"
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # At 07:00 on each Monday.
+  workflow_dispatch:
+
+jobs:
+  update-pre-commit:
+    if: github.repository_owner == 'pymc-devs'
+    name: Autoupdate pre-commit config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Cache multiple paths
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/pre-commit
+            ~/.cache/pip
+          key: pre-commit-autoupdate-${{ runner.os }}-build
+      - name: Update pre-commit config packages
+        uses: technote-space/create-pr-action@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.ACTION_TRIGGER_TOKEN }}
+          EXECUTE_COMMANDS: |
+            pip install pre-commit
+            pre-commit autoupdate || (exit 0);
+            pre-commit run -a || (exit 0);
+          COMMIT_MESSAGE: "⬆️ UPGRADE: Autoupdate pre-commit config"
+          PR_BRANCH_NAME: "pre-commit-config-update-${PR_ID}"
+          PR_TITLE: "⬆️ UPGRADE: Autoupdate pre-commit config"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-toml
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 0.3.3
+  rev: 0.3.5
   hooks:
     - id: nbqa-black
     - id: nbqa-isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v3.3.0
   hooks:
     -   id: end-of-file-fixer
     -   id: check-toml
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 0.3.2
+  rev: 0.3.3
   hooks:
     - id: nbqa-black
     - id: nbqa-isort
     - id: nbqa-pyupgrade
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.7.2
+  rev: v2.7.3
   hooks:
     - id: pyupgrade
       args: [--py36-plus]

--- a/docs/source/notebooks/blackbox_external_likelihood.ipynb
+++ b/docs/source/notebooks/blackbox_external_likelihood.ipynb
@@ -51,7 +51,7 @@
     "import theano\n",
     "import theano.tensor as tt\n",
     "\n",
-    "print(\"Running on PyMC3 v{}\".format(pm.__version__))"
+    "print(f\"Running on PyMC3 v{pm.__version__}\")"
    ]
   },
   {
@@ -697,7 +697,7 @@
     "            color=colors[i],\n",
     "            hist_kwargs={\"density\": True},\n",
     "            **hist2dkwargs,\n",
-    "            truths=[mtrue, ctrue]\n",
+    "            truths=[mtrue, ctrue],\n",
     "        )\n",
     "    else:\n",
     "        corner.corner(\n",
@@ -729,7 +729,7 @@
     "test_grad_op_func = theano.function([var], test_grad_op(var))\n",
     "grad_vals = test_grad_op_func([mtrue, ctrue])\n",
     "\n",
-    "print('Gradient returned by \"LogLikeGrad\": {}'.format(grad_vals))\n",
+    "print(f'Gradient returned by \"LogLikeGrad\": {grad_vals}')\n",
     "\n",
     "# test the gradient called through LogLikeWithGrad\n",
     "test_gradded_op = LogLikeWithGrad(my_loglike, data, x, sigma)\n",
@@ -737,7 +737,7 @@
     "test_gradded_op_grad_func = theano.function([var], test_gradded_op_grad)\n",
     "grad_vals_2 = test_gradded_op_grad_func([mtrue, ctrue])\n",
     "\n",
-    "print('Gradient returned by \"LogLikeWithGrad\": {}'.format(grad_vals_2))\n",
+    "print(f'Gradient returned by \"LogLikeWithGrad\": {grad_vals_2}')\n",
     "\n",
     "# test the gradient that PyMC3 uses for the Normal log likelihood\n",
     "test_model = pm.Model()\n",
@@ -751,7 +751,7 @@
     "    gradfunc.set_extra_values({\"m_interval__\": mtrue, \"c_interval__\": ctrue})\n",
     "    grad_vals_pymc3 = gradfunc(np.array([mtrue, ctrue]))[1]  # get dlogp values\n",
     "\n",
-    "print('Gradient returned by PyMC3 \"Normal\" distribution: {}'.format(grad_vals_pymc3))"
+    "print(f'Gradient returned by PyMC3 \"Normal\" distribution: {grad_vals_pymc3}')"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,3 @@ pyupgrade = 1
 [tool.nbqa.addopts]
 isort = ["--treat-comment-as-code", "# %%"]
 pyupgrade = ["--py36-plus"]
-
-[tool.nbqa.ignore_cells]
-black = "%%cython"


### PR DESCRIPTION
Rather than manually updating the versions of hooks when new ones come out, you can set up a GitHub action which will automatically open up a PR each monday to do that for you.

For this to work, whoever owns the repo would need to [create an access token](https://github.com/technote-space/create-pr-action#github_token) and add it as secret `ACTION_TRIGGER_TOKEN` to the repo - see screenshot below for an example

![image](https://user-images.githubusercontent.com/33491632/96995872-c9972b00-1526-11eb-9c9f-0e38d754590c.png)