### PR TITLE
Fix interpolate random

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -4097,7 +4097,7 @@ class Interpolated(BoundedContinuous):
     def _random(self, size=None):
         return self._argcdf(np.random.uniform(size=size))
 
-    def random(self, size=None):
+    def random(self, point=None, size=None):
         """
         Draw random values from Interpolated distribution.
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -174,7 +174,7 @@ def product(domains, n_samples=-1):
     try:
         names, domains = zip(*domains.items())
     except ValueError:  # domains.items() is empty
-        return []
+        return [{}]
     all_vals = [zip(names, val) for val in itertools.product(*[d.vals for d in domains])]
     if n_samples > 0 and len(all_vals) > n_samples:
         return (all_vals[j] for j in nr.choice(len(all_vals), n_samples, replace=False))

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -19,7 +19,6 @@ import scipy.stats as st
 from scipy.special import expit
 from scipy import linalg
 import numpy.random as nr
-import theano
 
 import pymc3 as pm
 from pymc3.distributions.dist_math import clipped_beta_rvs

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -978,6 +978,7 @@ class TestScalarParameterSamples(SeededTest):
 
         pymc3_random(pm.Moyal, {"mu": R, "sigma": Rplus}, ref_rand=ref_rand)
 
+    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
     def test_interpolated(self):
         for mu in R.vals:
             for sigma in Rplus.vals:
@@ -989,9 +990,7 @@ class TestScalarParameterSamples(SeededTest):
                     def __init__(self, **kwargs):
                         x_points = np.linspace(mu - 5 * sigma, mu + 5 * sigma, 100)
                         pdf_points = st.norm.pdf(x_points, loc=mu, scale=sigma)
-                        super().__init__(
-                            x_points=pm.floatX(x_points), pdf_points=pm.floatX(pdf_points), **kwargs
-                        )
+                        super().__init__(x_points=x_points, pdf_points=pdf_points, **kwargs)
 
                 pymc3_random(TestedInterpolated, {}, ref_rand=ref_rand)
 

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -979,7 +979,6 @@ class TestScalarParameterSamples(SeededTest):
 
         pymc3_random(pm.Moyal, {"mu": R, "sigma": Rplus}, ref_rand=ref_rand)
 
-    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
     def test_interpolated(self):
         for mu in R.vals:
             for sigma in Rplus.vals:

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -19,6 +19,7 @@ import scipy.stats as st
 from scipy.special import expit
 from scipy import linalg
 import numpy.random as nr
+import theano
 
 import pymc3 as pm
 from pymc3.distributions.dist_math import clipped_beta_rvs

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -989,7 +989,8 @@ class TestScalarParameterSamples(SeededTest):
                     def __init__(self, **kwargs):
                         x_points = np.linspace(mu - 5 * sigma, mu + 5 * sigma, 100)
                         pdf_points = st.norm.pdf(x_points, loc=mu, scale=sigma)
-                        super().__init__(x_points=x_points, pdf_points=pdf_points, **kwargs)
+                        super().__init__(
+                            x_points=pm.floatX(x_points), pdf_points=pm.floatX(pdf_points), **kwargs)
 
                 pymc3_random(TestedInterpolated, {}, ref_rand=ref_rand)
 

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -990,7 +990,8 @@ class TestScalarParameterSamples(SeededTest):
                         x_points = np.linspace(mu - 5 * sigma, mu + 5 * sigma, 100)
                         pdf_points = st.norm.pdf(x_points, loc=mu, scale=sigma)
                         super().__init__(
-                            x_points=pm.floatX(x_points), pdf_points=pm.floatX(pdf_points), **kwargs)
+                            x_points=pm.floatX(x_points), pdf_points=pm.floatX(pdf_points), **kwargs
+                        )
 
                 pymc3_random(TestedInterpolated, {}, ref_rand=ref_rand)
 


### PR DESCRIPTION
Bug fix for `pm.Interpolate` random, the test were not actually run previously: the empty `paramdomains` in the test function`arg`does not trigger the for loop (main test logic)
close #4178, #4121
