### PR TITLE
Added MLDA_introduction to the example notebooks table of contents

### DIFF
--- a/docs/source/notebooks/table_of_contents_examples.js
+++ b/docs/source/notebooks/table_of_contents_examples.js
@@ -59,6 +59,7 @@ Gallery.contents = {
     "ODE_with_manual_gradients": "Inference in ODE models",
     "ODE_API_introduction": "Inference in ODE models",
     "probabilistic_matrix_factorization": "Case Studies",
+    "MLDA_introduction": "MCMC",
     "MLDA_simple_linear_regression": "MCMC",
     "MLDA_gravity_surveying": "MCMC",
     "MLDA_variance_reduction_linear_regression": "MCMC"


### PR DESCRIPTION
This is a very minor update. We forgot to add the MLDA_introduction to the example notebooks table of contents in the previous PR: https://github.com/pymc-devs/pymc3/blob/master/docs/source/notebooks/table_of_contents_examples.js

This is fixed in https://github.com/alan-turing-institute/pymc3/commit/b543865e448b82e19eb067d387646e233fcd563d.

Sorry for the inconvenience.