### PR TITLE
Posterior predictive sampling was using only the first chain of InferenceData

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1721,7 +1721,7 @@ def sample_posterior_predictive(
                     param = cast(MultiTrace, _trace)._straces[chain_idx % nchain].point(point_idx)
                 # ... or a PointList
                 else:
-                    param = cast(PointList, _trace)[idx % len_trace]
+                    param = cast(PointList, _trace)[idx % (len_trace * nchain)]
             # there's only a single chain, but the index might hit it multiple times if
             # the number of indices is greater than the length of the trace.
             else:
@@ -1730,7 +1730,6 @@ def sample_posterior_predictive(
             values = draw_values(vars, point=param, size=size)
             for k, v in zip(vars, values):
                 ppc_trace_t.insert(k.name, v, idx)
-
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
This fix half of #4209. Now  Inf Data versus Trace will be the same. The speed difference is related to InfereceData not storing transformed variables.
