### PR TITLE
update pre-commit hooks versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,16 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-toml
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 0.3.5
+  rev: 0.4.1
   hooks:
     - id: nbqa-black
+      additional_dependencies: [black==20.8b1]
     - id: nbqa-isort
+      additional_dependencies: [isort==5.6.4]
     - id: nbqa-pyupgrade
+      additional_dependencies: [pyupgrade==2.7.4]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.7.3
+  rev: v2.7.4
   hooks:
     - id: pyupgrade
       args: [--py36-plus]

--- a/docs/source/notebooks/lda-advi-aevb.ipynb
+++ b/docs/source/notebooks/lda-advi-aevb.ipynb
@@ -718,7 +718,9 @@
     }
    ],
    "source": [
-    "%time result_pymc3 = eval_lda(transform_pymc3, beta_pymc3, docs_te.toarray(), np.arange(100))\n",
+    "%time result_pymc3 = eval_lda(\\\n",
+    "          transform_pymc3, beta_pymc3, docs_te.toarray(), np.arange(100)\\\n",
+    "      )\n",
     "print(\"Predictive log prob (pm3) = {}\".format(result_pymc3[\"lp\"]))"
    ]
   },
@@ -750,7 +752,9 @@
     "    return thetas / thetas.sum(axis=1)[:, np.newaxis]\n",
     "\n",
     "\n",
-    "%time result_sklearn = eval_lda(transform_sklearn, beta_sklearn, docs_te.toarray(), np.arange(100))\n",
+    "%time result_sklearn = eval_lda(\\\n",
+    "          transform_sklearn, beta_sklearn, docs_te.toarray(), np.arange(100)\\\n",
+    "      )\n",
     "print(\"Predictive log prob (sklearn) = {}\".format(result_sklearn[\"lp\"]))"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,10 @@
 [tool.black]
 line-length = 100
 
-[tool.nbqa.config]
-isort = "setup.cfg"
-black = "pyproject.toml"
-
 [tool.nbqa.mutate]
 isort = 1
 black = 1
 pyupgrade = 1
 
 [tool.nbqa.addopts]
-isort = ["--treat-comment-as-code", "# %%"]
 pyupgrade = ["--py36-plus"]


### PR DESCRIPTION
Update pre-commit hook versions numbers

nbqa 0.4.1 has handles code inside of in-line magics - this only affects one file here - and simplifies configuration a bit

the new pyupgrade version 2.7.4 doesn't seem to affect any code here, but it's still probably better to stay up-to-date