### PR TITLE
WIP: Add tt.nnet.softmax to math (#4226)

### DIFF
--- a/docs/source/api/math.rst
+++ b/docs/source/api/math.rst
@@ -58,6 +58,7 @@ expressions rather than NumPy or Python code.
    logsumexp
    invlogit
    logit
+   softmax
 
 .. automodule:: pymc3.math
    :members:

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -194,6 +194,9 @@ def invlogit(x, eps=sys.float_info.epsilon):
     """The inverse of the logit function, 1 / (1 + exp(-x))."""
     return (1.0 - 2.0 * eps) / (1.0 + tt.exp(-x)) + eps
 
+def softmax(x):
+    """Generalization of the inverse logit function to multiple dimensions."""   
+    return tt.nnet.softmax(x)
 
 def logbern(log_p):
     if np.isnan(log_p):

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -194,9 +194,11 @@ def invlogit(x, eps=sys.float_info.epsilon):
     """The inverse of the logit function, 1 / (1 + exp(-x))."""
     return (1.0 - 2.0 * eps) / (1.0 + tt.exp(-x)) + eps
 
+
 def softmax(x):
-    """Generalization of the inverse logit function to multiple dimensions."""   
+    """Generalization of the inverse logit function to multiple dimensions."""
     return tt.nnet.softmax(x)
+
 
 def logbern(log_p):
     if np.isnan(log_p):


### PR DESCRIPTION
This PR is a straightforward proposal to give access to the tt.nnet.softmax via the pm.math module. 

This PR does not address the current deprecation warning when using the softmax function. Perhaps this should be solved before adding it?

I assumed that no new tests would be needed, since this is just a wrapper to the theano function. Is there anything else that should be done?
