### PR TITLE
Remove deprecated numpy function

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -827,7 +827,7 @@ class Wishart(Continuous):
         """
         nu, V = draw_values([self.nu, self.V], point=point, size=size)
         size = 1 if size is None else size
-        return generate_samples(stats.wishart.rvs, np.asscalar(nu), V, broadcast_shape=(size,))
+        return generate_samples(stats.wishart.rvs, nu.item(), V, broadcast_shape=(size,))
 
     def logp(self, X):
         """

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -18,7 +18,7 @@ from typing import List, Dict, Tuple, Union
 
 import xarray
 import arviz
-from numpy import asscalar, ndarray
+from numpy import ndarray
 
 from theano.tensor import TensorVariable
 
@@ -149,7 +149,7 @@ def get_repr_for_variable(variable, formatting="plain"):
                 pass
         value = variable.eval()
         if not value.shape or value.shape == (1,):
-            return asscalar(value)
+            return value.item()
         return "array"
 
     if formatting == "latex":


### PR DESCRIPTION
asscalar [was deprecated in v1.16.0](https://numpy.org/doc/stable/release/1.16.0-notes.html?highlight=asscalar)

The minimum numpy version in pymc3 is v1.13, in which `.item` works:
```
>>> import numpy as np
>>> np.array([24]).item()
24
>>> np.__version__
'1.13.0'
```