### PR TITLE
Update ppc test

### DIFF
--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -587,7 +587,7 @@ class TestSamplePPC(SeededTest):
 
         expected_p = np.array([logistic.eval({coeff: val}) for val in trace["x"][:samples]])
         assert post_pred["obs"].shape == (samples, 3)
-        assert np.allclose(post_pred["p"], expected_p)
+        npt.assert_allclose(post_pred["p"], expected_p)
 
         # fast version
         samples = 100
@@ -598,11 +598,12 @@ class TestSamplePPC(SeededTest):
 
         expected_p = np.array([logistic.eval({coeff: val}) for val in trace["x"][:samples]])
         assert post_pred["obs"].shape == (samples, 3)
-        assert np.allclose(post_pred["p"], expected_p)
+        npt.assert_allclose(post_pred["p"], expected_p)
 
     def test_deterministic_of_observed(self):
-        meas_in_1 = pm.theanof.floatX(2 + 4 * np.random.randn(100))
-        meas_in_2 = pm.theanof.floatX(5 + 4 * np.random.randn(100))
+        meas_in_1 = pm.theanof.floatX(2 + 4 * np.random.randn(10))
+        meas_in_2 = pm.theanof.floatX(5 + 4 * np.random.randn(10))
+        nchains = 2
         with pm.Model() as model:
             mu_in_1 = pm.Normal("mu_in_1", 0, 1)
             sigma_in_1 = pm.HalfNormal("sd_in_1", 1)
@@ -614,40 +615,38 @@ class TestSamplePPC(SeededTest):
             out_diff = in_1 + in_2
             pm.Deterministic("out", out_diff)
 
-            trace = pm.sample(100)
-            ppc_trace = pm.trace_to_dataframe(
-                trace, varnames=[n for n in trace.varnames if n != "out"]
-            ).to_dict("records")
+            trace = pm.sample(100, chains=nchains)
+            np.random.seed(0)
             with pytest.warns(DeprecationWarning):
                 ppc = pm.sample_posterior_predictive(
                     model=model,
-                    trace=ppc_trace,
-                    samples=len(ppc_trace),
+                    trace=trace,
+                    samples=len(trace) * nchains,
                     vars=(model.deterministics + model.basic_RVs),
                 )
 
-            rtol = 1e-5 if theano.config.floatX == "float64" else 1e-3
-            assert np.allclose(ppc["in_1"] + ppc["in_2"], ppc["out"], rtol=rtol)
+            rtol = 1e-5 if theano.config.floatX == "float64" else 1e-4
+            npt.assert_allclose(ppc["in_1"] + ppc["in_2"], ppc["out"], rtol=rtol)
 
+            np.random.seed(0)
             ppc = pm.sample_posterior_predictive(
                 model=model,
-                trace=ppc_trace,
-                samples=len(ppc_trace),
+                trace=trace,
+                samples=len(trace) * nchains,
                 var_names=[var.name for var in (model.deterministics + model.basic_RVs)],
             )
 
-            rtol = 1e-5 if theano.config.floatX == "float64" else 1e-3
-            assert np.allclose(ppc["in_1"] + ppc["in_2"], ppc["out"], rtol=rtol)
+            npt.assert_allclose(ppc["in_1"] + ppc["in_2"], ppc["out"], rtol=rtol)
 
+            np.random.seed(0)
             ppc = pm.fast_sample_posterior_predictive(
                 model=model,
-                trace=ppc_trace,
-                samples=len(ppc_trace),
+                trace=trace,
+                samples=len(trace) * nchains,
                 var_names=[var.name for var in (model.deterministics + model.basic_RVs)],
             )
 
-            rtol = 1e-5 if theano.config.floatX == "float64" else 1e-3
-            assert np.allclose(ppc["in_1"] + ppc["in_2"], ppc["out"], rtol=rtol)
+            npt.assert_allclose(ppc["in_1"] + ppc["in_2"], ppc["out"], rtol=rtol)
 
     def test_deterministic_of_observed_modified_interface(self):
         meas_in_1 = pm.theanof.floatX(2 + 4 * np.random.randn(100))
@@ -675,7 +674,7 @@ class TestSamplePPC(SeededTest):
             )
 
             rtol = 1e-5 if theano.config.floatX == "float64" else 1e-3
-            assert np.allclose(ppc["in_1"] + ppc["in_2"], ppc["out"], rtol=rtol)
+            npt.assert_allclose(ppc["in_1"] + ppc["in_2"], ppc["out"], rtol=rtol)
 
             ppc = pm.fast_sample_posterior_predictive(
                 model=model,
@@ -685,7 +684,7 @@ class TestSamplePPC(SeededTest):
             )
 
             rtol = 1e-5 if theano.config.floatX == "float64" else 1e-3
-            assert np.allclose(ppc["in_1"] + ppc["in_2"], ppc["out"], rtol=rtol)
+            npt.assert_allclose(ppc["in_1"] + ppc["in_2"], ppc["out"], rtol=rtol)
 
     def test_variable_type(self):
         with pm.Model() as model:


### PR DESCRIPTION
I think this will unstick @StephenHogg in #4211. 

My working theory is that this was asserting that 2 arrays of 20,000 floats were equal, after going through a couple arithmetic operations, and so it was essentially fuzzing theano's math library. I can't prove that, but this 
- makes the fuzzing less thorough (2,000 floats now), and 
- lowers the number of operations (I don't go through a pandas dataframe in the middle, since I feel like that might do wild things to the floats). 
- Added an extra seed before each ppc sampling, since two of the asserts should give the exact same results.

Also, I changed `assert np.allclose` to `npt.assert_allclose`, since it gives more pleasant stack traces.