### PR TITLE
Add str/repr formatting options and change defaults accordingly

### DIFF
--- a/pymc3/distributions/bart.py
+++ b/pymc3/distributions/bart.py
@@ -246,7 +246,7 @@ class BART(BaseBART):
         alpha = self.alpha
         m = self.m
 
-        if formatting == "latex":
+        if "latex" in formatting:
             return f"$\\text{{{name}}} \\sim  \\text{{BART}}(\\text{{alpha = }}\\text{{{alpha}}}, \\text{{m = }}\\text{{{m}}})$"
         else:
             return f"{name} ~ BART(alpha = {alpha}, m = {m})"

--- a/pymc3/distributions/bound.py
+++ b/pymc3/distributions/bound.py
@@ -157,13 +157,13 @@ class _Bounded(Distribution):
 
     def _str_repr(self, **kwargs):
         distr_repr = self._wrapped._str_repr(**{**kwargs, "dist": self._wrapped})
-        if "formatting" in kwargs and kwargs["formatting"] == "latex":
+        if "formatting" in kwargs and "latex" in kwargs["formatting"]:
             distr_repr = distr_repr[distr_repr.index(r" \sim") + 6 :]
         else:
             distr_repr = distr_repr[distr_repr.index(" ~") + 3 :]
         self_repr = super()._str_repr(**kwargs)
 
-        if "formatting" in kwargs and kwargs["formatting"] == "latex":
+        if "formatting" in kwargs and "latex" in kwargs["formatting"]:
             return self_repr + " -- " + distr_repr
         else:
             return self_repr + "-" + distr_repr

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -164,34 +164,51 @@ class Distribution:
         return self.__class__.__name__
 
     def _str_repr(self, name=None, dist=None, formatting="plain"):
-        """Generate string representation for this distribution, optionally
+        """
+        Generate string representation for this distribution, optionally
         including LaTeX markup (formatting='latex').
+
+        Parameters
+        ----------
+        name : str
+            name of the distribution
+        dist : Distribution
+            the distribution object
+        formatting : str
+            one of { "latex", "plain", "latex_with_params", "plain_with_params" }
         """
         if dist is None:
             dist = self
         if name is None:
             name = "[unnamed]"
+        supported_formattings = {"latex", "plain", "latex_with_params", "plain_with_params"}
+        if not formatting in supported_formattings:
+            raise ValueError(f"Unsupported formatting ''. Choose one of {supported_formattings}.")
 
         param_names = self._distr_parameters_for_repr()
         param_values = [
             get_repr_for_variable(getattr(dist, x), formatting=formatting) for x in param_names
         ]
 
-        if formatting == "latex":
+        if "latex" in formatting:
             param_string = ",~".join(
                 [fr"\mathit{{{name}}}={value}" for name, value in zip(param_names, param_values)]
             )
-            return r"$\text{{{var_name}}} \sim \text{{{distr_name}}}({params})$".format(
-                var_name=name, distr_name=dist._distr_name_for_repr(), params=param_string
+            if formatting == "latex_with_params":
+                return r"$\text{{{var_name}}} \sim \text{{{distr_name}}}({params})$".format(
+                    var_name=name, distr_name=dist._distr_name_for_repr(), params=param_string
+                )
+            return r"$\text{{{var_name}}} \sim \text{{{distr_name}}}$".format(
+                var_name=name, distr_name=dist._distr_name_for_repr()
             )
         else:
-            # 'plain' is default option
+            # one of the plain formattings
             param_string = ", ".join(
                 [f"{name}={value}" for name, value in zip(param_names, param_values)]
             )
-            return "{var_name} ~ {distr_name}({params})".format(
-                var_name=name, distr_name=dist._distr_name_for_repr(), params=param_string
-            )
+            if formatting == "plain_with_params":
+                return f"{name} ~ {dist._distr_name_for_repr()}({param_string})"
+            return f"{name} ~ {dist._distr_name_for_repr()}"
 
     def __str__(self, **kwargs):
         try:
@@ -201,7 +218,7 @@ class Distribution:
 
     def _repr_latex_(self, **kwargs):
         """Magic method name for IPython to use for LaTeX formatting."""
-        return self._str_repr(formatting="latex", **kwargs)
+        return self._str_repr(formatting="latex_with_params", **kwargs)
 
     def logp_nojac(self, *args, **kwargs):
         """Return the logp, but do not include a jacobian term for transforms.

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -216,9 +216,9 @@ class Distribution:
         except:
             return super().__str__()
 
-    def _repr_latex_(self, **kwargs):
+    def _repr_latex_(self, *, formatting="latex_with_params", **kwargs):
         """Magic method name for IPython to use for LaTeX formatting."""
-        return self._str_repr(formatting="latex_with_params", **kwargs)
+        return self._str_repr(formatting=formatting, **kwargs)
 
     def logp_nojac(self, *args, **kwargs):
         """Return the logp, but do not include a jacobian term for transforms.

--- a/pymc3/distributions/simulator.py
+++ b/pymc3/distributions/simulator.py
@@ -126,7 +126,7 @@ class Simulator(NoDistribution):
         sum_stat = self.sum_stat.__name__ if hasattr(self.sum_stat, "__call__") else self.sum_stat
         distance = getattr(self.distance, "__name__", self.distance.__class__.__name__)
 
-        if formatting == "latex":
+        if "latex" in formatting:
             return f"$\\text{{{name}}} \\sim  \\text{{Simulator}}(\\text{{{function}}}({params}), \\text{{{distance}}}, \\text{{{sum_stat}}})$"
         else:
             return f"{name} ~ Simulator({function}({params}), {distance}, {sum_stat})"

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1874,24 +1874,27 @@ def _walk_up_rv(rv, formatting="plain"):
             all_rvs.extend(_walk_up_rv(parent, formatting=formatting))
     else:
         name = rv.name if rv.name else "Constant"
-        fmt = r"\text{{{name}}}" if formatting == "latex" else "{name}"
+        fmt = r"\text{{{name}}}" if "latex" in formatting else "{name}"
         all_rvs.append(fmt.format(name=name))
     return all_rvs
 
 
 class DeterministicWrapper(tt.TensorVariable):
     def _str_repr(self, formatting="plain"):
-        if formatting == "latex":
-            return r"$\text{{{name}}} \sim \text{{Deterministic}}({args})$".format(
-                name=self.name, args=r",~".join(_walk_up_rv(self, formatting=formatting))
-            )
+        if "latex" in formatting:
+            if formatting == "latex_with_params":
+                return r"$\text{{{name}}} \sim \text{{Deterministic}}({args})$".format(
+                    name=self.name, args=r",~".join(_walk_up_rv(self, formatting=formatting))
+                )
+            return fr"$\text{{{self.name}}} \sim \text{{Deterministic}}$"
         else:
-            return "{name} ~ Deterministic({args})".format(
-                name=self.name, args=", ".join(_walk_up_rv(self, formatting=formatting))
-            )
+            if formatting == "plain_with_params":
+                args = ", ".join(_walk_up_rv(self, formatting=formatting))
+                return f"{self.name} ~ Deterministic({args})"
+            return f"{self.name} ~ Deterministic"
 
     def _repr_latex_(self):
-        return self._str_repr(formatting="latex")
+        return self._str_repr(formatting="latex_with_params")
 
     __latex__ = _repr_latex_
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -65,7 +65,7 @@ class PyMC3Variable(TensorVariable):
 
     def _str_repr(self, name=None, dist=None, formatting="plain"):
         if getattr(self, "distribution", None) is None:
-            if formatting == "latex":
+            if "latex" in formatting:
                 return None
             else:
                 return super().__str__()
@@ -76,8 +76,8 @@ class PyMC3Variable(TensorVariable):
             dist = self.distribution
         return self.distribution._str_repr(name=name, dist=dist, formatting=formatting)
 
-    def _repr_latex_(self, **kwargs):
-        return self._str_repr(formatting="latex", **kwargs)
+    def _repr_latex_(self, *, formatting="latex_with_params", **kwargs):
+        return self._str_repr(formatting=formatting, **kwargs)
 
     def __str__(self, **kwargs):
         try:
@@ -1375,8 +1375,8 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
     def _str_repr(self, formatting="plain", **kwargs):
         all_rv = itertools.chain(self.unobserved_RVs, self.observed_RVs)
 
-        if formatting == "latex":
-            rv_reprs = [rv.__latex__() for rv in all_rv]
+        if "latex" in formatting:
+            rv_reprs = [rv.__latex__(formatting=formatting) for rv in all_rv]
             rv_reprs = [
                 rv_repr.replace(r"\sim", r"&\sim &").strip("$")
                 for rv_repr in rv_reprs
@@ -1407,8 +1407,8 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
     def __str__(self, **kwargs):
         return self._str_repr(formatting="plain", **kwargs)
 
-    def _repr_latex_(self, **kwargs):
-        return self._str_repr(formatting="latex", **kwargs)
+    def _repr_latex_(self, *, formatting="latex", **kwargs):
+        return self._str_repr(formatting=formatting, **kwargs)
 
     __latex__ = _repr_latex_
 
@@ -1893,8 +1893,8 @@ class DeterministicWrapper(tt.TensorVariable):
                 return f"{self.name} ~ Deterministic({args})"
             return f"{self.name} ~ Deterministic"
 
-    def _repr_latex_(self):
-        return self._str_repr(formatting="latex_with_params")
+    def _repr_latex_(self, *, formatting="latex_with_params", **kwargs):
+        return self._str_repr(formatting=formatting)
 
     __latex__ = _repr_latex_
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1800,58 +1800,83 @@ class TestStrAndLatexRepr:
             Y_obs = Normal("Y_obs", mu=mu, sigma=sigma, observed=Y)
 
         self.distributions = [alpha, sigma, mu, b, Z, Y_obs, bound_var]
-        self.expected_latex = (
-            r"$\text{alpha} \sim \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$",
-            r"$\text{sigma} \sim \text{HalfNormal}(\mathit{sigma}=1.0)$",
-            r"$\text{mu} \sim \text{Deterministic}(\text{alpha},~\text{Constant},~\text{beta})$",
-            r"$\text{beta} \sim \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$",
-            r"$\text{Z} \sim \text{MvNormal}(\mathit{mu}=array,~\mathit{chol_cov}=array)$",
-            r"$\text{Y_obs} \sim \text{Normal}(\mathit{mu}=\text{mu},~\mathit{sigma}=f(\text{sigma}))$",
-            r"$\text{bound_var} \sim \text{Bound}(\mathit{lower}=1.0,~\mathit{upper}=\text{None})$ -- \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$",
-            r"$\text{kron_normal} \sim \text{KroneckerNormal}(\mathit{mu}=array)$",
-            r"$\text{mat_normal} \sim \text{MatrixNormal}(\mathit{mu}=array,~\mathit{rowcov}=array,~\mathit{colchol_cov}=array)$",
-        )
-        self.expected_str = (
-            r"alpha ~ Normal(mu=0.0, sigma=10.0)",
-            r"sigma ~ HalfNormal(sigma=1.0)",
-            r"mu ~ Deterministic(alpha, Constant, beta)",
-            r"beta ~ Normal(mu=0.0, sigma=10.0)",
-            r"Z ~ MvNormal(mu=array, chol_cov=array)",
-            r"Y_obs ~ Normal(mu=mu, sigma=f(sigma))",
-            r"bound_var ~ Bound(lower=1.0, upper=None)-Normal(mu=0.0, sigma=10.0)",
-            r"kron_normal ~ KroneckerNormal(mu=array)",
-            r"mat_normal ~ MatrixNormal(mu=array, rowcov=array, colchol_cov=array)",
-        )
+        self.expected = {
+            "latex": (
+                r"$\text{alpha} \sim \text{Normal}$",
+                r"$\text{sigma} \sim \text{HalfNormal}$",
+                r"$\text{mu} \sim \text{Deterministic}$",
+                r"$\text{beta} \sim \text{Normal}$",
+                r"$\text{Z} \sim \text{MvNormal}$",
+                r"$\text{Y_obs} \sim \text{Normal}$",
+                r"$\text{bound_var} \sim \text{Bound}$ -- \text{Normal}$",
+                r"$\text{kron_normal} \sim \text{KroneckerNormal}$",
+                r"$\text{mat_normal} \sim \text{MatrixNormal}$",
+            ),
+            "plain": (
+                r"alpha ~ Normal",
+                r"sigma ~ HalfNormal",
+                r"mu ~ Deterministic",
+                r"beta ~ Normal",
+                r"Z ~ MvNormal",
+                r"Y_obs ~ Normal",
+                r"bound_var ~ Bound-Normal",
+                r"kron_normal ~ KroneckerNormal",
+                r"mat_normal ~ MatrixNormal",
+            ),
+            "latex_with_params": (
+                r"$\text{alpha} \sim \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$",
+                r"$\text{sigma} \sim \text{HalfNormal}(\mathit{sigma}=1.0)$",
+                r"$\text{mu} \sim \text{Deterministic}(\text{alpha},~\text{Constant},~\text{beta})$",
+                r"$\text{beta} \sim \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$",
+                r"$\text{Z} \sim \text{MvNormal}(\mathit{mu}=array,~\mathit{chol_cov}=array)$",
+                r"$\text{Y_obs} \sim \text{Normal}(\mathit{mu}=\text{mu},~\mathit{sigma}=f(\text{sigma}))$",
+                r"$\text{bound_var} \sim \text{Bound}(\mathit{lower}=1.0,~\mathit{upper}=\text{None})$ -- \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$",
+                r"$\text{kron_normal} \sim \text{KroneckerNormal}(\mathit{mu}=array)$",
+                r"$\text{mat_normal} \sim \text{MatrixNormal}(\mathit{mu}=array,~\mathit{rowcov}=array,~\mathit{colchol_cov}=array)$",
+            ),
+            "plain_with_params": (
+                r"alpha ~ Normal(mu=0.0, sigma=10.0)",
+                r"sigma ~ HalfNormal(sigma=1.0)",
+                r"mu ~ Deterministic(alpha, Constant, beta)",
+                r"beta ~ Normal(mu=0.0, sigma=10.0)",
+                r"Z ~ MvNormal(mu=array, chol_cov=array)",
+                r"Y_obs ~ Normal(mu=mu, sigma=f(sigma))",
+                r"bound_var ~ Bound(lower=1.0, upper=None)-Normal(mu=0.0, sigma=10.0)",
+                r"kron_normal ~ KroneckerNormal(mu=array)",
+                r"mat_normal ~ MatrixNormal(mu=array, rowcov=array, colchol_cov=array)",
+            ),
+        }
 
     def test__repr_latex_(self):
-        for distribution, tex in zip(self.distributions, self.expected_latex):
+        for distribution, tex in zip(self.distributions, self.expected["latex_with_params"]):
             assert distribution._repr_latex_() == tex
 
         model_tex = self.model._repr_latex_()
 
-        for tex in self.expected_latex:  # make sure each variable is in the model
+        # make sure each variable is in the model
+        for tex in self.expected["latex"]:
             for segment in tex.strip("$").split(r"\sim"):
                 assert segment in model_tex
 
     def test___latex__(self):
-        for distribution, tex in zip(self.distributions, self.expected_latex):
+        for distribution, tex in zip(self.distributions, self.expected["latex_with_params"]):
             assert distribution._repr_latex_() == distribution.__latex__()
         assert self.model._repr_latex_() == self.model.__latex__()
 
     def test___str__(self):
-        for distribution, str_repr in zip(self.distributions, self.expected_str):
+        for distribution, str_repr in zip(self.distributions, self.expected["plain"]):
             assert distribution.__str__() == str_repr
 
         model_str = self.model.__str__()
-        for str_repr in self.expected_str:
+        for str_repr in self.expected["plain"]:
             assert str_repr in model_str
 
     def test_str(self):
-        for distribution, str_repr in zip(self.distributions, self.expected_str):
+        for distribution, str_repr in zip(self.distributions, self.expected["plain"]):
             assert str(distribution) == str_repr
 
         model_str = str(self.model)
-        for str_repr in self.expected_str:
+        for str_repr in self.expected["plain"]:
             assert str_repr in model_str
 
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1776,6 +1776,12 @@ class TestStrAndLatexRepr:
             # Test Cholesky parameterization
             Z = MvNormal("Z", mu=np.zeros(2), chol=np.eye(2), shape=(2,))
 
+            # NegativeBinomial representations to test issue 4186
+            nb1 = pm.NegativeBinomial(
+                "nb_with_mu_alpha", mu=pm.Normal("nbmu"), alpha=pm.Gamma("nbalpha", mu=6, sigma=1)
+            )
+            nb2 = pm.NegativeBinomial("nb_with_p_n", p=pm.Uniform("nbp"), n=10)
+
             # Expected value of outcome
             mu = Deterministic("mu", floatX(alpha + tt.dot(X, b)))
 
@@ -1799,7 +1805,7 @@ class TestStrAndLatexRepr:
             # Likelihood (sampling distribution) of observations
             Y_obs = Normal("Y_obs", mu=mu, sigma=sigma, observed=Y)
 
-        self.distributions = [alpha, sigma, mu, b, Z, Y_obs, bound_var]
+        self.distributions = [alpha, sigma, mu, b, Z, nb1, nb2, Y_obs, bound_var]
         self.expected = {
             "latex": (
                 r"$\text{alpha} \sim \text{Normal}$",
@@ -1807,6 +1813,8 @@ class TestStrAndLatexRepr:
                 r"$\text{mu} \sim \text{Deterministic}$",
                 r"$\text{beta} \sim \text{Normal}$",
                 r"$\text{Z} \sim \text{MvNormal}$",
+                r"$\text{nb_with_mu_alpha} \sim \text{NegativeBinomial}$",
+                r"$\text{nb_with_p_n} \sim \text{NegativeBinomial}$",
                 r"$\text{Y_obs} \sim \text{Normal}$",
                 r"$\text{bound_var} \sim \text{Bound}$ -- \text{Normal}$",
                 r"$\text{kron_normal} \sim \text{KroneckerNormal}$",
@@ -1818,6 +1826,8 @@ class TestStrAndLatexRepr:
                 r"mu ~ Deterministic",
                 r"beta ~ Normal",
                 r"Z ~ MvNormal",
+                r"nb_with_mu_alpha ~ NegativeBinomial",
+                r"nb_with_p_n ~ NegativeBinomial",
                 r"Y_obs ~ Normal",
                 r"bound_var ~ Bound-Normal",
                 r"kron_normal ~ KroneckerNormal",
@@ -1829,6 +1839,8 @@ class TestStrAndLatexRepr:
                 r"$\text{mu} \sim \text{Deterministic}(\text{alpha},~\text{Constant},~\text{beta})$",
                 r"$\text{beta} \sim \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$",
                 r"$\text{Z} \sim \text{MvNormal}(\mathit{mu}=array,~\mathit{chol_cov}=array)$",
+                r"$\text{nb_with_mu_alpha} \sim \text{NegativeBinomial}(\mathit{mu}=\text{nbmu},~\mathit{alpha}=\text{nbalpha})$",
+                r"$\text{nb_with_p_n} \sim \text{NegativeBinomial}(\mathit{p}=\text{nbp},~\mathit{n}=10)$",
                 r"$\text{Y_obs} \sim \text{Normal}(\mathit{mu}=\text{mu},~\mathit{sigma}=f(\text{sigma}))$",
                 r"$\text{bound_var} \sim \text{Bound}(\mathit{lower}=1.0,~\mathit{upper}=\text{None})$ -- \text{Normal}(\mathit{mu}=0.0,~\mathit{sigma}=10.0)$",
                 r"$\text{kron_normal} \sim \text{KroneckerNormal}(\mathit{mu}=array)$",
@@ -1840,6 +1852,8 @@ class TestStrAndLatexRepr:
                 r"mu ~ Deterministic(alpha, Constant, beta)",
                 r"beta ~ Normal(mu=0.0, sigma=10.0)",
                 r"Z ~ MvNormal(mu=array, chol_cov=array)",
+                r"nb_with_mu_alpha ~ NegativeBinomial(mu=nbmu, alpha=nbalpha)",
+                r"nb_with_p_n ~ NegativeBinomial(p=nbp, n=10)",
                 r"Y_obs ~ Normal(mu=mu, sigma=f(sigma))",
                 r"bound_var ~ Bound(lower=1.0, upper=None)-Normal(mu=0.0, sigma=10.0)",
                 r"kron_normal ~ KroneckerNormal(mu=array)",
@@ -1928,17 +1942,6 @@ class TestBugfixes:
         assert isinstance(actual_a, np.ndarray)
         assert actual_a.shape == (X.shape[0],)
         pass
-
-    def test_issue_4186(self):
-        with pm.Model():
-            nb = pm.NegativeBinomial(
-                "nb", mu=pm.Normal("mu"), alpha=pm.Gamma("alpha", mu=6, sigma=1)
-            )
-        assert str(nb) == "nb ~ NegativeBinomial(mu=mu, alpha=alpha)"
-
-        with pm.Model():
-            nb = pm.NegativeBinomial("nb", p=pm.Uniform("p"), n=10)
-        assert str(nb) == "nb ~ NegativeBinomial(p=p, n=10)"
 
 
 def test_serialize_density_dist():

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -137,7 +137,7 @@ def get_repr_for_variable(variable, formatting="plain"):
                     for item in variable.get_parents()[0].inputs
                 ]
                 # do not escape_latex these, since it is not idempotent
-                if formatting == "latex":
+                if "latex" in formatting:
                     return "f({args})".format(
                         args=",~".join([n for n in names if isinstance(n, str)])
                     )
@@ -152,7 +152,7 @@ def get_repr_for_variable(variable, formatting="plain"):
             return value.item()
         return "array"
 
-    if formatting == "latex":
+    if "latex" in formatting:
         return fr"\text{{{name}}}"
     else:
         return name


### PR DESCRIPTION
+ new options "latex_with_params" and "plain_with_params" replace the current default behavior of including input parameters (going back to default behaviour of the 3.9.3 release)
+ `__latex__` and `_repr_latex` default to "latex_with_params"
+ `__str__` and `_str_repr` default to "plain"
+ `__latex__` repr __of a model__ defaults to "latex" (without params)
+ new formatting kwarg for `model_to_graphviz` enables switching between "plain" (default) and "plain_with_params"

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] ~~what are the (breaking) changes that this PR makes?~~ - None
+ [x] important background, or details about the implementation
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [x] ~~consider adding/updating relevant example notebooks~~
+ [x] ~~right before it's ready to merge, mention the PR in the RELEASE-NOTES.md~~
