### PR TITLE
Remove unreachable lines of sampling code

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -130,8 +130,6 @@ def instantiate_steppers(_model, steps, selected_steps, step_kwargs=None):
 
     used_keys = set()
     for step_class, vars in selected_steps.items():
-        if len(vars) == 0:
-            continue
         args = step_kwargs.get(step_class.name, {})
         used_keys.add(step_class.name)
         step = step_class(vars=vars, **args)

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -113,27 +113,29 @@ def instantiate_steppers(_model, steps, selected_steps, step_kwargs=None):
         A fully-specified model object; legacy argument -- ignored
     steps : step function or vector of step functions
         One or more step functions that have been assigned to some subset of
-        the model's parameters. Defaults to None (no assigned variables).
+        the model's parameters.
     selected_steps : dictionary of step methods and variables
-        The step methods and the variables that have were assigned to them.
+        The step methods and the (possibly zero) variables that have were assigned to them.
     step_kwargs : dict
         Parameters for the samplers. Keys are the lower case names of
-        the step method, values a dict of arguments.
+        the step method, values a dict of arguments. Defaults to None.
 
     Returns
     -------
-    methods : list
-        List of step methods associated with the model's variables.
+    methods : list or step
+        List of step methods associated with the model's variables, or step method
+        if there is only one.
     """
     if step_kwargs is None:
         step_kwargs = {}
 
     used_keys = set()
     for step_class, vars in selected_steps.items():
-        args = step_kwargs.get(step_class.name, {})
-        used_keys.add(step_class.name)
-        step = step_class(vars=vars, **args)
-        steps.append(step)
+        if vars:
+            args = step_kwargs.get(step_class.name, {})
+            used_keys.add(step_class.name)
+            step = step_class(vars=vars, **args)
+            steps.append(step)
 
     unused_args = set(step_kwargs).difference(used_keys)
     if unused_args:

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -111,11 +111,11 @@ def instantiate_steppers(_model, steps, selected_steps, step_kwargs=None):
     ----------
     model : Model object
         A fully-specified model object; legacy argument -- ignored
-    steps : sequence of step functions
-        One or more step functions that have been assigned to some subset of
+    steps : list
+        A list of zero or more step function instances that have been assigned to some subset of
         the model's parameters.
-    selected_steps : dictionary of step methods and variables
-        The step methods and the (possibly zero) variables that have were assigned to them.
+    selected_steps : dict
+        A dictionary that maps a step method class to a list of zero or more model variables.
     step_kwargs : dict
         Parameters for the samplers. Keys are the lower case names of
         the step method, values a dict of arguments. Defaults to None.

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -111,7 +111,7 @@ def instantiate_steppers(_model, steps, selected_steps, step_kwargs=None):
     ----------
     model : Model object
         A fully-specified model object; legacy argument -- ignored
-    steps : step function or vector of step functions
+    steps : sequence of step functions
         One or more step functions that have been assigned to some subset of
         the model's parameters.
     selected_steps : dictionary of step methods and variables


### PR DESCRIPTION
I may be wrong here, but I think these lines are unreachable. I was trying to write a sensible test which covers them, but I think that might not be possible.

The function `instantiate_steppers` is only ever called from `assign_step_methods`.

In `assign_step_methods`, there is
```python
    selected_steps = defaultdict(list)
    for var in model.free_RVs:
        if var not in assigned_vars:
            # determine if a gradient can be computed
            has_gradient = var.dtype not in discrete_types
            if has_gradient:
                try:
                    tg.grad(model.logpt, var)
                except (AttributeError, NotImplementedError, tg.NullTypeGradError):
                    has_gradient = False
            # select the best method
            selected = max(
                methods,
                key=lambda method, var=var, has_gradient=has_gradient: method._competence(
                    var, has_gradient
                ),
            )
            selected_steps[selected].append(var)
```

We have two cases:

- If `model` has no unnassigned free random variables, then `selected_steps` will be empty and so the loop `    for step_class, vars in selected_steps.items():` in `instantiate_steppers` will never be reached.

- if `model` has unnasigned free random variables, then `selected_steps[selected]` will be a list with `var` in it, and so `if len(vars) == 0` will never be True.

In both cases, the `continue` in
```python
        if len(vars) == 0:
            continue
```
won't be reached.

----

cc @michaelosthege - does this look right to you, or am I missing something?