### PR TITLE
TST Cover sample_posterior_predictive_w

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1869,8 +1869,8 @@ def sample_posterior_predictive_w(
 
     except KeyboardInterrupt:
         pass
-
-    return {k: np.asarray(v) for k, v in ppc.items()}
+    else:
+        return {k: np.asarray(v) for k, v in ppc.items()}
 
 
 def sample_prior_predictive(


### PR DESCRIPTION
Adding test cases for uncovered lines in sample_posterior_predictive_w

I haven't covered lines 1838-1850, because AFAIKT it currently only works for a single observed random variable - if that's so, then maybe handling multiple observed RVs should be handled separately