### PR TITLE
- Fix regression caused by #4211

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -491,8 +491,8 @@ def sample(
                 **kwargs,
             )
             if start is None:
-                check_start_vals(start_, model)
                 start = start_
+                check_start_vals(start, model)
         except (AttributeError, NotImplementedError, tg.NullTypeGradError):
             # gradient computation failed
             _log.info("Initializing NUTS failed. " "Falling back to elementwise auto-assignment.")

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -414,15 +414,15 @@ def sample(
     """
     model = modelcontext(model)
     if start is None:
-        start = model.test_point
+        check_start_vals(model.test_point, model)
     else:
         if isinstance(start, dict):
             update_start_vals(start, model.test_point, model)
         else:
             for chain_start_vals in start:
                 update_start_vals(chain_start_vals, model.test_point, model)
+        check_start_vals(start, model)
 
-    check_start_vals(start, model)
     if cores is None:
         cores = min(4, _cpu_count())
 

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -490,8 +490,8 @@ def sample(
                 progressbar=progressbar,
                 **kwargs,
             )
-            check_start_vals(start_, model)
             if start is None:
+                check_start_vals(start_, model)
                 start = start_
         except (AttributeError, NotImplementedError, tg.NullTypeGradError):
             # gradient computation failed

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -777,13 +777,14 @@ def test_default_sample_nuts_jitter(init, start, expectation, monkeypatch):
     # being used when pm.sample() is called without specifying an explicit start point (see
     # https://github.com/pymc-devs/pymc3/pull/4285).
     def _mocked_init_nuts(*args, **kwargs):
-        if init == 'adapt_diag':
-            start_ = [{'x': np.array(0.79788456)}]
+        if init == "adapt_diag":
+            start_ = [{"x": np.array(0.79788456)}]
         else:
-            start_ = [{'x': np.array(-0.04949886)}]
+            start_ = [{"x": np.array(-0.04949886)}]
         _, step = pm.init_nuts(*args, **kwargs)
         return start_, step
-    monkeypatch.setattr('pymc3.sampling.init_nuts', _mocked_init_nuts)
+
+    monkeypatch.setattr("pymc3.sampling.init_nuts", _mocked_init_nuts)
     with pm.Model() as m:
         x = pm.HalfNormal("x", transform=None)
         with expectation:

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -769,11 +769,15 @@ def test_exec_nuts_init(method):
         ("jitter+adapt_diag", None, pytest.raises(SamplingError)),
         ("auto", {"x": 0}, does_not_raise()),
         ("jitter+adapt_diag", {"x": 0}, does_not_raise()),
+        ("adapt_diag", None, does_not_raise()),
     ],
 )
 def test_default_sample_nuts_jitter(init, start, expectation):
-    # Random seed was selected to make sure initialization with "jitter+adapt_diag" would fail.
-    # This will need to be changed in the future if initialization or randomization method changes
+    # This test tries to check whether the starting points returned by init_nuts are actually being
+    # used when pm.sample() is called without specifying an explicit start point (see
+    # https://github.com/pymc-devs/pymc3/pull/4285).
+    # A random seed was selected to make sure the initialization with "jitter+adapt_diag" would fail.
+    # This will need to be changed in the future if the initialization or randomization method changes
     # or if default initialization is made more robust.
     with pm.Model() as m:
         x = pm.HalfNormal("x", transform=None)

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -768,7 +768,7 @@ def test_exec_nuts_init(method):
         ("auto", None, pytest.raises(SamplingError)),
         ("jitter+adapt_diag", None, pytest.raises(SamplingError)),
         ("auto", {"x": 0}, does_not_raise()),
-        ("jitter+adapt_diag", {'x': 0}, does_not_raise()),
+        ("jitter+adapt_diag", {"x": 0}, does_not_raise()),
     ],
 )
 def test_default_sample_nuts_jitter(init, start, expectation):
@@ -776,10 +776,9 @@ def test_default_sample_nuts_jitter(init, start, expectation):
     # This will need to be changed in the future if initialization or randomization method changes
     # or if default initialization is made more robust.
     with pm.Model() as m:
-        x = pm.HalfNormal('x', transform=None)
+        x = pm.HalfNormal("x", transform=None)
         with expectation:
-            pm.sample(tune=1, draws=0, chains=1, random_seed=7,
-                      init=init, start=start)
+            pm.sample(tune=1, draws=0, chains=1, random_seed=7, init=init, start=start)
 
 
 @pytest.fixture(scope="class")

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from contextlib import nullcontext as does_not_raise
+from contextlib import ExitStack as does_not_raise
 from itertools import combinations
 from typing import Tuple
 import numpy as np
@@ -778,7 +778,7 @@ def test_default_sample_nuts_jitter(init, start, expectation):
     with pm.Model() as m:
         x = pm.HalfNormal('x', transform=None)
         with expectation:
-            pm.sample(tune=1, draws=0, chains=4, random_seed=7,
+            pm.sample(tune=1, draws=0, chains=1, random_seed=7,
                       init=init, start=start)
 
 


### PR DESCRIPTION
PR #4211 caused a subtle regression. Default sampling no longer applies the `jitter+adapt_diag` because `start` is set to `model.test_point` by default, in order to test if the model likelihood is finite with `pm.util.check_start_vals`.

https://github.com/pymc-devs/pymc3/blob/988ab9dd54e83dbd336fb4463aa16c8c8ce7ccfd/pymc3/sampling.py#L417

This conflicts with this line further down the road, where the undefined `start` values would be given those from the auto-assigned NUTS sampler
https://github.com/pymc-devs/pymc3/blob/988ab9dd54e83dbd336fb4463aa16c8c8ce7ccfd/pymc3/sampling.py#L494

I altered the code so that the `model.test_point` is still tested, without overriding the sample `start` variable.

I found this issue when working in #4107 