### PR TITLE
Use absolute imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,3 +54,8 @@ repos:
       language: python
       name: Check no tests are ignored
       pass_filenames: false
+    - id: no-relative-imports
+      name: No relative imports
+      entry: from \.[\.\w]* import
+      types: [python]
+      language: pygrep

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -38,16 +38,16 @@ def __set_compiler_flags():
 
 __set_compiler_flags()
 
-from . import gp, ode, sampling
-from .backends import load_trace, save_trace
-from .backends.tracetab import *
-from .blocking import *
-from .data import *
-from .distributions import *
-from .distributions import transforms
-from .exceptions import *
-from .glm import *
-from .math import (
+from pymc3 import gp, ode, sampling
+from pymc3.backends import load_trace, save_trace
+from pymc3.backends.tracetab import *
+from pymc3.blocking import *
+from pymc3.data import *
+from pymc3.distributions import *
+from pymc3.distributions import transforms
+from pymc3.exceptions import *
+from pymc3.glm import *
+from pymc3.math import (
     expand_packed_triangular,
     invlogit,
     invprobit,
@@ -56,15 +56,15 @@ from .math import (
     logsumexp,
     probit,
 )
-from .model import *
-from .model_graph import model_to_graphviz
-from .plots import *
-from .sampling import *
-from .smc import *
-from .stats import *
-from .step_methods import *
-from .tests import test
-from .theanof import *
-from .tuning import *
-from .variational import *
-from .vartypes import *
+from pymc3.model import *
+from pymc3.model_graph import model_to_graphviz
+from pymc3.plots import *
+from pymc3.sampling import *
+from pymc3.smc import *
+from pymc3.stats import *
+from pymc3.step_methods import *
+from pymc3.tests import test
+from pymc3.theanof import *
+from pymc3.tuning import *
+from pymc3.variational import *
+from pymc3.vartypes import *

--- a/pymc3/backends/__init__.py
+++ b/pymc3/backends/__init__.py
@@ -60,4 +60,9 @@ Loading a saved backend
 Saved backends can be loaded using `arviz.from_netcdf`
 
 """
-from ..backends.ndarray import NDArray, load_trace, point_list_to_multitrace, save_trace
+from pymc3.backends.ndarray import (
+    NDArray,
+    load_trace,
+    point_list_to_multitrace,
+    save_trace,
+)

--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -26,9 +26,9 @@ from typing import List
 import numpy as np
 import theano.tensor as tt
 
-from ..model import modelcontext
-from ..util import get_var_name
-from .report import SamplerReport, merge_reports
+from pymc3.backends.report import SamplerReport, merge_reports
+from pymc3.model import modelcontext
+from pymc3.util import get_var_name
 
 logger = logging.getLogger("pymc3")
 

--- a/pymc3/backends/report.py
+++ b/pymc3/backends/report.py
@@ -20,7 +20,7 @@ from typing import Any, Optional
 
 import arviz
 
-from ..util import get_untransformed_name, is_transformed_name
+from pymc3.util import get_untransformed_name, is_transformed_name
 
 logger = logging.getLogger("pymc3")
 

--- a/pymc3/backends/tracetab.py
+++ b/pymc3/backends/tracetab.py
@@ -20,7 +20,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from ..util import get_default_varnames
+from pymc3.util import get_default_varnames
 
 __all__ = ["trace_to_dataframe"]
 

--- a/pymc3/blocking.py
+++ b/pymc3/blocking.py
@@ -22,7 +22,7 @@ import copy
 
 import numpy as np
 
-from .util import get_var_name
+from pymc3.util import get_var_name
 
 __all__ = ["ArrayOrdering", "DictToArrayBijection", "DictToVarBijection"]
 

--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -12,10 +12,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from . import shape_utils, timeseries, transforms
-from .bart import BART
-from .bound import Bound
-from .continuous import (
+from pymc3.distributions import shape_utils, timeseries, transforms
+from pymc3.distributions.bart import BART
+from pymc3.distributions.bound import Bound
+from pymc3.distributions.continuous import (
     Beta,
     Cauchy,
     ChiSquared,
@@ -48,7 +48,7 @@ from .continuous import (
     Wald,
     Weibull,
 )
-from .discrete import (
+from pymc3.distributions.discrete import (
     Bernoulli,
     BetaBinomial,
     Binomial,
@@ -66,7 +66,7 @@ from .discrete import (
     ZeroInflatedNegativeBinomial,
     ZeroInflatedPoisson,
 )
-from .distribution import (
+from pymc3.distributions.distribution import (
     Continuous,
     DensityDist,
     Discrete,
@@ -76,8 +76,8 @@ from .distribution import (
     draw_values,
     generate_samples,
 )
-from .mixture import Mixture, MixtureSameFamily, NormalMixture
-from .multivariate import (
+from pymc3.distributions.mixture import Mixture, MixtureSameFamily, NormalMixture
+from pymc3.distributions.multivariate import (
     Dirichlet,
     KroneckerNormal,
     LKJCholeskyCov,
@@ -89,9 +89,9 @@ from .multivariate import (
     Wishart,
     WishartBartlett,
 )
-from .posterior_predictive import fast_sample_posterior_predictive
-from .simulator import Simulator
-from .timeseries import (
+from pymc3.distributions.posterior_predictive import fast_sample_posterior_predictive
+from pymc3.distributions.simulator import Simulator
+from pymc3.distributions.timeseries import (
     AR,
     AR1,
     GARCH11,

--- a/pymc3/distributions/bart.py
+++ b/pymc3/distributions/bart.py
@@ -14,8 +14,8 @@
 
 import numpy as np
 
-from .distribution import NoDistribution
-from .tree import LeafNode, SplitNode, Tree
+from pymc3.distributions.distribution import NoDistribution
+from pymc3.distributions.tree import LeafNode, SplitNode, Tree
 
 __all__ = ["BART"]
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -27,11 +27,8 @@ from scipy import stats
 from scipy.interpolate import InterpolatedUnivariateSpline
 from scipy.special import expit
 
-from pymc3.theanof import floatX
-
-from ..math import invlogit, logdiffexp, logit
-from . import transforms
-from .dist_math import (
+from pymc3.distributions import transforms
+from pymc3.distributions.dist_math import (
     SplineWrapper,
     alltrue_elemwise,
     betaln,
@@ -46,8 +43,10 @@ from .dist_math import (
     std_cdf,
     zvalue,
 )
-from .distribution import Continuous, draw_values, generate_samples
-from .special import log_i0
+from pymc3.distributions.distribution import Continuous, draw_values, generate_samples
+from pymc3.distributions.special import log_i0
+from pymc3.math import invlogit, logdiffexp, logit
+from pymc3.theanof import floatX
 
 __all__ = [
     "Uniform",

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -19,12 +19,18 @@ import theano.tensor as tt
 
 from scipy import stats
 
+from pymc3.distributions.dist_math import (
+    betaln,
+    binomln,
+    bound,
+    factln,
+    logpow,
+    random_choice,
+)
+from pymc3.distributions.distribution import Discrete, draw_values, generate_samples
+from pymc3.distributions.shape_utils import broadcast_distribution_samples
 from pymc3.math import log1pexp, logaddexp, logit, sigmoid, tround
-
-from ..theanof import floatX, intX, take_along_axis
-from .dist_math import betaln, binomln, bound, factln, logpow, random_choice
-from .distribution import Discrete, draw_values, generate_samples
-from .shape_utils import broadcast_distribution_samples
+from pymc3.theanof import floatX, intX, take_along_axis
 
 __all__ = [
     "Binomial",

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -31,10 +31,9 @@ from theano.scalar import UnaryScalarOp, upgrade_to_float_no_complex
 from theano.scan import until
 from theano.tensor.slinalg import Cholesky
 
+from pymc3.distributions.shape_utils import to_tuple
+from pymc3.distributions.special import gammaln
 from pymc3.theanof import floatX
-
-from .shape_utils import to_tuple
-from .special import gammaln
 
 f = floatX
 c = -0.5 * np.log(2.0 * np.pi)

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -33,8 +33,13 @@ import theano.tensor as tt
 
 from theano import function
 
-from ..memoize import memoize
-from ..model import (
+from pymc3.distributions.shape_utils import (
+    broadcast_dist_samples_shape,
+    get_broadcastable_dist_samples,
+    to_tuple,
+)
+from pymc3.memoize import memoize
+from pymc3.model import (
     ContextMeta,
     FreeRV,
     Model,
@@ -42,13 +47,8 @@ from ..model import (
     ObservedRV,
     build_named_node_tree,
 )
-from ..util import get_repr_for_variable, get_var_name
-from ..vartypes import string_types, theano_constant
-from .shape_utils import (
-    broadcast_dist_samples_shape,
-    get_broadcastable_dist_samples,
-    to_tuple,
-)
+from pymc3.util import get_repr_for_variable, get_var_name
+from pymc3.vartypes import string_types, theano_constant
 
 __all__ = [
     "DensityDist",

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -20,11 +20,9 @@ import numpy as np
 import theano
 import theano.tensor as tt
 
-from ..math import logsumexp
-from ..theanof import _conversion_map, take_along_axis
-from .continuous import Normal, get_tau_sigma
-from .dist_math import bound, random_choice
-from .distribution import (
+from pymc3.distributions.continuous import Normal, get_tau_sigma
+from pymc3.distributions.dist_math import bound, random_choice
+from pymc3.distributions.distribution import (
     Discrete,
     Distribution,
     _DrawValuesContext,
@@ -32,11 +30,13 @@ from .distribution import (
     draw_values,
     generate_samples,
 )
-from .shape_utils import (
+from pymc3.distributions.shape_utils import (
     broadcast_distribution_samples,
     get_broadcastable_dist_samples,
     to_tuple,
 )
+from pymc3.math import logsumexp
+from pymc3.theanof import _conversion_map, take_along_axis
 
 __all__ = ["Mixture", "NormalMixture", "MixtureSameFamily"]
 

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -30,22 +30,21 @@ from theano.tensor.slinalg import Cholesky
 
 import pymc3 as pm
 
-from pymc3.theanof import floatX
-
-from ..math import kron_diag, kron_dot, kron_solve_lower, kronecker
-from ..model import Deterministic
-from . import transforms
-from .continuous import ChiSquared, Normal
-from .dist_math import bound, factln, logpow
-from .distribution import (
+from pymc3.distributions import transforms
+from pymc3.distributions.continuous import ChiSquared, Normal
+from pymc3.distributions.dist_math import bound, factln, logpow
+from pymc3.distributions.distribution import (
     Continuous,
     Discrete,
     _DrawValuesContext,
     draw_values,
     generate_samples,
 )
-from .shape_utils import broadcast_dist_samples_to, to_tuple
-from .special import gammaln, multigammaln
+from pymc3.distributions.shape_utils import broadcast_dist_samples_to, to_tuple
+from pymc3.distributions.special import gammaln, multigammaln
+from pymc3.math import kron_diag, kron_dot, kron_solve_lower, kronecker
+from pymc3.model import Deterministic
+from pymc3.theanof import floatX
 
 __all__ = [
     "MvNormal",

--- a/pymc3/distributions/posterior_predictive.py
+++ b/pymc3/distributions/posterior_predictive.py
@@ -27,24 +27,24 @@ from arviz import InferenceData
 from typing_extensions import Literal, Protocol
 from xarray import Dataset
 
-from ..backends.base import MultiTrace
-from ..exceptions import IncorrectArgumentsError
-from ..model import (
-    Model,
-    MultiObservedRV,
-    ObservedRV,
-    get_named_nodes_and_relations,
-    modelcontext,
-)
-from ..util import chains_and_samples, dataset_to_point_list, get_var_name
-from ..vartypes import theano_constant
-from .distribution import (
+from pymc3.backends.base import MultiTrace
+from pymc3.distributions.distribution import (
     _compile_theano_function,
     _DrawValuesContext,
     _DrawValuesContextBlocker,
     is_fast_drawable,
     vectorized_ppc,
 )
+from pymc3.exceptions import IncorrectArgumentsError
+from pymc3.model import (
+    Model,
+    MultiObservedRV,
+    ObservedRV,
+    get_named_nodes_and_relations,
+    modelcontext,
+)
+from pymc3.util import chains_and_samples, dataset_to_point_list, get_var_name
+from pymc3.vartypes import theano_constant
 
 # Failing tests:
 #    test_mixture_random_shape::test_mixture_random_shape

--- a/pymc3/distributions/simulator.py
+++ b/pymc3/distributions/simulator.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from scipy.spatial import cKDTree
 
-from .distribution import NoDistribution, draw_values
+from pymc3.distributions.distribution import NoDistribution, draw_values
 
 __all__ = ["Simulator"]
 

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -20,9 +20,9 @@ import theano.tensor as tt
 from scipy import stats
 from theano import scan
 
-from . import distribution, multivariate
-from .continuous import Flat, Normal, get_tau_sigma
-from .shape_utils import to_tuple
+from pymc3.distributions import distribution, multivariate
+from pymc3.distributions.continuous import Flat, Normal, get_tau_sigma
+from pymc3.distributions.shape_utils import to_tuple
 
 __all__ = [
     "AR1",

--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -19,11 +19,11 @@ import theano.tensor as tt
 
 from scipy.special import logit as nplogit
 
-from ..math import invlogit, logit, logsumexp
-from ..model import FreeRV
-from ..theanof import floatX, gradient
-from . import distribution
-from .distribution import draw_values
+from pymc3.distributions import distribution
+from pymc3.distributions.distribution import draw_values
+from pymc3.math import invlogit, logit, logsumexp
+from pymc3.model import FreeRV
+from pymc3.theanof import floatX, gradient
 
 __all__ = [
     "Transform",

--- a/pymc3/glm/__init__.py
+++ b/pymc3/glm/__init__.py
@@ -12,5 +12,5 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from . import families
-from .linear import GLM, LinearComponent
+from pymc3.glm import families
+from pymc3.glm.linear import GLM, LinearComponent

--- a/pymc3/glm/families.py
+++ b/pymc3/glm/families.py
@@ -19,8 +19,8 @@ from copy import copy
 import numpy as np
 import theano.tensor as tt
 
-from .. import distributions as pm_dists
-from ..model import modelcontext
+from pymc3 import distributions as pm_dists
+from pymc3.model import modelcontext
 
 __all__ = ["Normal", "StudentT", "Binomial", "Poisson", "NegativeBinomial"]
 

--- a/pymc3/glm/linear.py
+++ b/pymc3/glm/linear.py
@@ -15,10 +15,10 @@
 import numpy as np
 import theano.tensor as tt
 
-from ..distributions import Flat, Normal
-from ..model import Deterministic, Model
-from . import families
-from .utils import any_to_tensor_and_labels
+from pymc3.distributions import Flat, Normal
+from pymc3.glm import families
+from pymc3.glm.utils import any_to_tensor_and_labels
+from pymc3.model import Deterministic, Model
 
 __all__ = ["LinearComponent", "GLM"]
 

--- a/pymc3/gp/__init__.py
+++ b/pymc3/gp/__init__.py
@@ -12,5 +12,5 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from . import cov, mean, util
-from .gp import TP, Latent, LatentKron, Marginal, MarginalKron, MarginalSparse
+from pymc3.gp import cov, mean, util
+from pymc3.gp.gp import TP, Latent, LatentKron, Marginal, MarginalKron, MarginalSparse

--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -33,8 +33,13 @@ from pymc3.gp.util import (
     solve_upper,
     stabilize,
 )
-
-from ..math import cartesian, kron_diag, kron_dot, kron_solve_lower, kron_solve_upper
+from pymc3.math import (
+    cartesian,
+    kron_diag,
+    kron_dot,
+    kron_solve_lower,
+    kron_solve_upper,
+)
 
 __all__ = ["Latent", "Marginal", "TP", "MarginalSparse", "LatentKron", "MarginalKron"]
 

--- a/pymc3/memoize.py
+++ b/pymc3/memoize.py
@@ -17,7 +17,7 @@ import functools
 
 import dill
 
-from .util import biwrap
+from pymc3.util import biwrap
 
 CACHE_REGISTRY = []
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -32,15 +32,20 @@ from theano.tensor.var import TensorVariable
 
 import pymc3 as pm
 
+from pymc3.blocking import ArrayOrdering, DictToArrayBijection
+from pymc3.exceptions import ImputationWarning
 from pymc3.math import flatten_list
-from pymc3.theanof import floatX, set_theano_conf
-
-from .blocking import ArrayOrdering, DictToArrayBijection
-from .exceptions import ImputationWarning
-from .memoize import WithMemoization, memoize
-from .theanof import generator, gradient, hessian, inputvars
-from .util import get_transformed_name, get_var_name
-from .vartypes import continuous_types, discrete_types, isgenerator, typefilter
+from pymc3.memoize import WithMemoization, memoize
+from pymc3.theanof import (
+    floatX,
+    generator,
+    gradient,
+    hessian,
+    inputvars,
+    set_theano_conf,
+)
+from pymc3.util import get_transformed_name, get_var_name
+from pymc3.vartypes import continuous_types, discrete_types, isgenerator, typefilter
 
 __all__ = [
     "Model",
@@ -622,7 +627,7 @@ class ValueGradFunction:
         compute_grads=True,
         **kwargs,
     ):
-        from .distributions import TensorType
+        from pymc3.distributions import TensorType
 
         if extra_vars is None:
             extra_vars = []
@@ -1729,7 +1734,7 @@ def as_tensor(data, name, model, distribution):
             " sampling distribution.".format(name=name)
         )
         warnings.warn(impute_message, ImputationWarning)
-        from .distributions import NoDistribution
+        from pymc3.distributions import NoDistribution
 
         testval = np.broadcast_to(distribution.default(), data.shape)[data.mask]
         fakedist = NoDistribution.dist(
@@ -1781,7 +1786,7 @@ class ObservedRV(Factor, PyMC3Variable):
         total_size: scalar Tensor (optional)
             needed for upscaling logp
         """
-        from .distributions import TensorType
+        from pymc3.distributions import TensorType
 
         if hasattr(data, "type") and isinstance(data.type, tt.TensorType):
             type = data.type

--- a/pymc3/model_graph.py
+++ b/pymc3/model_graph.py
@@ -23,8 +23,8 @@ from theano.tensor import Tensor
 
 import pymc3 as pm
 
-from .model import ObservedRV
-from .util import get_default_varnames, get_var_name
+from pymc3.model import ObservedRV
+from pymc3.util import get_default_varnames, get_var_name
 
 
 class ModelGraph:

--- a/pymc3/ode/__init__.py
+++ b/pymc3/ode/__init__.py
@@ -12,5 +12,5 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from . import utils
-from .ode import DifferentialEquation
+from pymc3.ode import utils
+from pymc3.ode.ode import DifferentialEquation

--- a/pymc3/ode/ode.py
+++ b/pymc3/ode/ode.py
@@ -21,8 +21,8 @@ import theano.tensor as tt
 
 from theano.gof.op import get_test_value
 
-from ..exceptions import DtypeError, ShapeError
-from ..ode import utils
+from pymc3.exceptions import DtypeError, ShapeError
+from pymc3.ode import utils
 
 _log = logging.getLogger("pymc3")
 floatX = theano.config.floatX

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -27,9 +27,8 @@ import numpy as np
 
 from fastprogress.fastprogress import progress_bar
 
+from pymc3 import theanof
 from pymc3.exceptions import SamplingError
-
-from . import theanof
 
 logger = logging.getLogger("pymc3")
 

--- a/pymc3/plots/__init__.py
+++ b/pymc3/plots/__init__.py
@@ -101,7 +101,7 @@ def compareplot(*args, **kwargs):
     return az.plot_compare(*args, **kwargs)
 
 
-from .posteriorplot import plot_posterior_predictive_glm
+from pymc3.plots.posteriorplot import plot_posterior_predictive_glm
 
 # Access to arviz plots: base plots provided by arviz
 for plot in az.plots.__all__:

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -39,16 +39,14 @@ from theano.tensor import Tensor
 
 import pymc3 as pm
 
-from pymc3.step_methods.hmc import quadpotential
-
-from .backends.base import BaseTrace, MultiTrace
-from .backends.ndarray import NDArray
-from .distributions.distribution import draw_values
-from .distributions.posterior_predictive import fast_sample_posterior_predictive
-from .exceptions import IncorrectArgumentsError, SamplingError
-from .model import Model, Point, all_continuous, modelcontext
-from .parallel_sampling import Draw, _cpu_count
-from .step_methods import (
+from pymc3.backends.base import BaseTrace, MultiTrace
+from pymc3.backends.ndarray import NDArray
+from pymc3.distributions.distribution import draw_values
+from pymc3.distributions.posterior_predictive import fast_sample_posterior_predictive
+from pymc3.exceptions import IncorrectArgumentsError, SamplingError
+from pymc3.model import Model, Point, all_continuous, modelcontext
+from pymc3.parallel_sampling import Draw, _cpu_count
+from pymc3.step_methods import (
     NUTS,
     PGBART,
     BinaryGibbsMetropolis,
@@ -61,7 +59,8 @@ from .step_methods import (
     Slice,
     arraystep,
 )
-from .util import (
+from pymc3.step_methods.hmc import quadpotential
+from pymc3.util import (
     chains_and_samples,
     check_start_vals,
     dataset_to_point_list,
@@ -70,7 +69,7 @@ from .util import (
     is_transformed_name,
     update_start_vals,
 )
-from .vartypes import discrete_types
+from pymc3.vartypes import discrete_types
 
 sys.setrecursionlimit(10000)
 

--- a/pymc3/smc/__init__.py
+++ b/pymc3/smc/__init__.py
@@ -12,4 +12,4 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from .sample_smc import sample_smc
+from pymc3.smc.sample_smc import sample_smc

--- a/pymc3/smc/sample_smc.py
+++ b/pymc3/smc/sample_smc.py
@@ -21,10 +21,10 @@ from collections.abc import Iterable
 
 import numpy as np
 
-from ..backends.base import MultiTrace
-from ..model import modelcontext
-from ..parallel_sampling import _cpu_count
-from .smc import SMC
+from pymc3.backends.base import MultiTrace
+from pymc3.model import modelcontext
+from pymc3.parallel_sampling import _cpu_count
+from pymc3.smc.smc import SMC
 
 
 def sample_smc(

--- a/pymc3/smc/smc.py
+++ b/pymc3/smc/smc.py
@@ -21,10 +21,15 @@ from scipy.special import logsumexp
 from scipy.stats import multivariate_normal
 from theano import function as theano_function
 
-from ..backends.ndarray import NDArray
-from ..model import Point, modelcontext
-from ..sampling import sample_prior_predictive
-from ..theanof import floatX, inputvars, join_nonshared_inputs, make_shared_replacements
+from pymc3.backends.ndarray import NDArray
+from pymc3.model import Point, modelcontext
+from pymc3.sampling import sample_prior_predictive
+from pymc3.theanof import (
+    floatX,
+    inputvars,
+    join_nonshared_inputs,
+    make_shared_replacements,
+)
 
 
 class SMC:

--- a/pymc3/step_methods/__init__.py
+++ b/pymc3/step_methods/__init__.py
@@ -12,11 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from .compound import CompoundStep
-from .elliptical_slice import EllipticalSlice
-from .gibbs import ElemwiseCategorical
-from .hmc import NUTS, HamiltonianMC
-from .metropolis import (
+from pymc3.step_methods.compound import CompoundStep
+from pymc3.step_methods.elliptical_slice import EllipticalSlice
+from pymc3.step_methods.gibbs import ElemwiseCategorical
+from pymc3.step_methods.hmc import NUTS, HamiltonianMC
+from pymc3.step_methods.metropolis import (
     BinaryGibbsMetropolis,
     BinaryMetropolis,
     CategoricalGibbsMetropolis,
@@ -30,6 +30,11 @@ from .metropolis import (
     PoissonProposal,
     UniformProposal,
 )
-from .mlda import MLDA, DEMetropolisZMLDA, MetropolisMLDA, RecursiveDAProposal
-from .pgbart import PGBART
-from .slicer import Slice
+from pymc3.step_methods.mlda import (
+    MLDA,
+    DEMetropolisZMLDA,
+    MetropolisMLDA,
+    RecursiveDAProposal,
+)
+from pymc3.step_methods.pgbart import PGBART
+from pymc3.step_methods.slicer import Slice

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -18,11 +18,11 @@ import numpy as np
 
 from numpy.random import uniform
 
-from ..blocking import ArrayOrdering, DictToArrayBijection
-from ..model import modelcontext
-from ..theanof import inputvars
-from ..util import get_var_name
-from .compound import CompoundStep
+from pymc3.blocking import ArrayOrdering, DictToArrayBijection
+from pymc3.model import modelcontext
+from pymc3.step_methods.compound import CompoundStep
+from pymc3.theanof import inputvars
+from pymc3.util import get_var_name
 
 __all__ = ["ArrayStep", "ArrayStepShared", "metrop_select", "Competence"]
 

--- a/pymc3/step_methods/elliptical_slice.py
+++ b/pymc3/step_methods/elliptical_slice.py
@@ -16,10 +16,10 @@ import numpy as np
 import numpy.random as nr
 import theano.tensor as tt
 
-from ..distributions import draw_values
-from ..model import modelcontext
-from ..theanof import inputvars
-from .arraystep import ArrayStep, Competence
+from pymc3.distributions import draw_values
+from pymc3.model import modelcontext
+from pymc3.step_methods.arraystep import ArrayStep, Competence
+from pymc3.theanof import inputvars
 
 __all__ = ["EllipticalSlice"]
 

--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -34,9 +34,9 @@ from numpy.random import uniform
 from theano.gof.graph import inputs
 from theano.tensor import add
 
-from ..distributions.discrete import Categorical
-from ..model import modelcontext
-from .arraystep import ArrayStep, Competence
+from pymc3.distributions.discrete import Categorical
+from pymc3.model import modelcontext
+from pymc3.step_methods.arraystep import ArrayStep, Competence
 
 __all__ = ["ElemwiseCategorical"]
 

--- a/pymc3/step_methods/hmc/__init__.py
+++ b/pymc3/step_methods/hmc/__init__.py
@@ -12,5 +12,5 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from .hmc import HamiltonianMC
-from .nuts import NUTS
+from pymc3.step_methods.hmc.hmc import HamiltonianMC
+from pymc3.step_methods.hmc.nuts import NUTS

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -24,10 +24,9 @@ from pymc3.exceptions import SamplingError
 from pymc3.model import Point, modelcontext
 from pymc3.step_methods import arraystep, step_sizes
 from pymc3.step_methods.hmc import integration
+from pymc3.step_methods.hmc.quadpotential import QuadPotentialDiagAdapt, quad_potential
 from pymc3.theanof import floatX, inputvars
 from pymc3.tuning import guess_scaling
-
-from .quadpotential import QuadPotentialDiagAdapt, quad_potential
 
 logger = logging.getLogger("pymc3")
 

--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -14,11 +14,10 @@
 
 import numpy as np
 
+from pymc3.step_methods.arraystep import Competence
 from pymc3.step_methods.hmc.base_hmc import BaseHMC, DivergenceInfo, HMCStepData
 from pymc3.step_methods.hmc.integration import IntegrationError
 from pymc3.vartypes import discrete_types
-
-from ..arraystep import Competence
 
 __all__ = ["HamiltonianMC"]
 

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -17,14 +17,13 @@ from collections import namedtuple
 import numpy as np
 
 from pymc3.backends.report import SamplerWarning, WarningType
+from pymc3.distributions import BART
 from pymc3.math import logbern, logdiffexp_numpy
+from pymc3.step_methods.arraystep import Competence
+from pymc3.step_methods.hmc.base_hmc import BaseHMC, DivergenceInfo, HMCStepData
+from pymc3.step_methods.hmc.integration import IntegrationError
 from pymc3.theanof import floatX
 from pymc3.vartypes import continuous_types
-
-from ...distributions import BART
-from ..arraystep import Competence
-from .base_hmc import BaseHMC, DivergenceInfo, HMCStepData
-from .integration import IntegrationError
 
 __all__ = ["NUTS"]
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -19,16 +19,15 @@ import theano
 
 import pymc3 as pm
 
-from pymc3.theanof import floatX
-
-from ..distributions import draw_values
-from .arraystep import (
+from pymc3.distributions import draw_values
+from pymc3.step_methods.arraystep import (
     ArrayStep,
     ArrayStepShared,
     Competence,
     PopulationArrayStepShared,
     metrop_select,
 )
+from pymc3.theanof import floatX
 
 __all__ = [
     "Metropolis",

--- a/pymc3/step_methods/mlda.py
+++ b/pymc3/step_methods/mlda.py
@@ -24,10 +24,15 @@ import theano.tensor as tt
 
 import pymc3 as pm
 
-from ..model import Model
-from .arraystep import ArrayStepShared, Competence, metrop_select
-from .compound import CompoundStep
-from .metropolis import DEMetropolisZ, Metropolis, Proposal, delta_logp
+from pymc3.model import Model
+from pymc3.step_methods.arraystep import ArrayStepShared, Competence, metrop_select
+from pymc3.step_methods.compound import CompoundStep
+from pymc3.step_methods.metropolis import (
+    DEMetropolisZ,
+    Metropolis,
+    Proposal,
+    delta_logp,
+)
 
 __all__ = [
     "MetropolisMLDA",

--- a/pymc3/step_methods/pgbart.py
+++ b/pymc3/step_methods/pgbart.py
@@ -18,11 +18,11 @@ import numpy as np
 
 from theano import function as theano_function
 
-from ..distributions import BART
-from ..distributions.tree import Tree
-from ..model import modelcontext
-from ..theanof import inputvars, join_nonshared_inputs, make_shared_replacements
-from .arraystep import ArrayStepShared, Competence
+from pymc3.distributions import BART
+from pymc3.distributions.tree import Tree
+from pymc3.model import modelcontext
+from pymc3.step_methods.arraystep import ArrayStepShared, Competence
+from pymc3.theanof import inputvars, join_nonshared_inputs, make_shared_replacements
 
 _log = logging.getLogger("pymc3")
 

--- a/pymc3/step_methods/sgmcmc.py
+++ b/pymc3/step_methods/sgmcmc.py
@@ -19,9 +19,9 @@ from collections import OrderedDict
 import theano
 import theano.tensor as tt
 
-from ..model import inputvars, modelcontext
-from ..theanof import make_shared_replacements, tt_rng
-from .arraystep import ArrayStepShared
+from pymc3.model import inputvars, modelcontext
+from pymc3.step_methods.arraystep import ArrayStepShared
+from pymc3.theanof import make_shared_replacements, tt_rng
 
 __all__ = []
 

--- a/pymc3/step_methods/slicer.py
+++ b/pymc3/step_methods/slicer.py
@@ -17,10 +17,10 @@
 import numpy as np
 import numpy.random as nr
 
-from ..model import modelcontext
-from ..theanof import inputvars
-from ..vartypes import continuous_types
-from .arraystep import ArrayStep, Competence
+from pymc3.model import modelcontext
+from pymc3.step_methods.arraystep import ArrayStep, Competence
+from pymc3.theanof import inputvars
+from pymc3.vartypes import continuous_types
 
 __all__ = ["Slice"]
 

--- a/pymc3/tests/helpers.py
+++ b/pymc3/tests/helpers.py
@@ -22,7 +22,7 @@ import theano
 from theano.gradient import verify_grad as tt_verify_grad
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 
-from ..theanof import set_tt_rng, tt_rng
+from pymc3.theanof import set_tt_rng, tt_rng
 
 
 class SeededTest:

--- a/pymc3/tests/sampler_fixtures.py
+++ b/pymc3/tests/sampler_fixtures.py
@@ -20,9 +20,8 @@ from scipy import stats
 
 import pymc3 as pm
 
+from pymc3.tests.helpers import SeededTest
 from pymc3.util import get_var_name
-
-from .helpers import SeededTest
 
 
 class KnownMean:

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -18,8 +18,8 @@ import pytest
 
 import pymc3 as pm
 
-from ..theanof import floatX
-from .helpers import SeededTest
+from pymc3.tests.helpers import SeededTest
+from pymc3.theanof import floatX
 
 
 class TestData(SeededTest):

--- a/pymc3/tests/test_dist_math.py
+++ b/pymc3/tests/test_dist_math.py
@@ -22,8 +22,8 @@ from scipy import interpolate, stats
 
 import pymc3 as pm
 
-from ..distributions import Discrete
-from ..distributions.dist_math import (
+from pymc3.distributions import Discrete
+from pymc3.distributions.dist_math import (
     MvNormalLogp,
     SplineWrapper,
     alltrue_scalar,
@@ -32,8 +32,8 @@ from ..distributions.dist_math import (
     factln,
     i0e,
 )
-from ..theanof import floatX
-from .helpers import verify_grad
+from pymc3.tests.helpers import verify_grad
+from pymc3.theanof import floatX
 
 
 def test_bound():

--- a/pymc3/tests/test_distribution_defaults.py
+++ b/pymc3/tests/test_distribution_defaults.py
@@ -15,8 +15,8 @@
 import numpy as np
 import pytest
 
-from ..distributions import Categorical, Continuous, DiscreteUniform
-from ..model import Model
+from pymc3.distributions import Categorical, Continuous, DiscreteUniform
+from pymc3.model import Model
 
 
 class DistTest(Continuous):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -30,10 +30,8 @@ from scipy.special import logit
 
 import pymc3 as pm
 
-from pymc3.theanof import floatX
-
-from ..blocking import DictToVarBijection
-from ..distributions import (
+from pymc3.blocking import DictToVarBijection
+from pymc3.distributions import (
     AR1,
     Bernoulli,
     Beta,
@@ -92,10 +90,11 @@ from ..distributions import (
     ZeroInflatedPoisson,
     continuous,
 )
-from ..math import kronecker
-from ..model import Deterministic, Model, Point
-from ..vartypes import continuous_types
-from .helpers import SeededTest, select_by_precision
+from pymc3.math import kronecker
+from pymc3.model import Deterministic, Model, Point
+from pymc3.tests.helpers import SeededTest, select_by_precision
+from pymc3.theanof import floatX
+from pymc3.vartypes import continuous_types
 
 
 def get_lkj_cases():

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -34,9 +34,8 @@ from pymc3.distributions.distribution import (
     draw_values,
     to_tuple,
 )
-
-from .helpers import SeededTest
-from .test_distributions import (
+from pymc3.tests.helpers import SeededTest
+from pymc3.tests.test_distributions import (
     Domain,
     I,
     Nat,

--- a/pymc3/tests/test_distributions_timeseries.py
+++ b/pymc3/tests/test_distributions_timeseries.py
@@ -15,16 +15,16 @@
 import numpy as np
 import pytest
 
-from ..distributions.continuous import Flat, Normal
-from ..distributions.timeseries import AR, AR1, GARCH11, EulerMaruyama
-from ..model import Model
-from ..sampling import (
+from pymc3.distributions.continuous import Flat, Normal
+from pymc3.distributions.timeseries import AR, AR1, GARCH11, EulerMaruyama
+from pymc3.model import Model
+from pymc3.sampling import (
     fast_sample_posterior_predictive,
     sample,
     sample_posterior_predictive,
 )
-from ..theanof import floatX
-from .helpers import select_by_precision
+from pymc3.tests.helpers import select_by_precision
+from pymc3.theanof import floatX
 
 pytestmark = pytest.mark.usefixtures("seeded_test")
 

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -23,9 +23,8 @@ from packaging import version
 
 import pymc3 as pm
 
+from pymc3.tests.helpers import SeededTest
 from pymc3.theanof import floatX
-
-from .helpers import SeededTest
 
 if version.parse(matplotlib.__version__) < version.parse("3.3"):
     matplotlib.use("Agg", warn=False)

--- a/pymc3/tests/test_glm.py
+++ b/pymc3/tests/test_glm.py
@@ -30,8 +30,7 @@ from pymc3 import (
     find_MAP,
     sample,
 )
-
-from .helpers import SeededTest
+from pymc3.tests.helpers import SeededTest
 
 
 # Generate data

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -24,7 +24,7 @@ import theano.tensor as tt
 
 import pymc3 as pm
 
-from ..math import cartesian, kronecker
+from pymc3.math import cartesian, kronecker
 
 np.random.seed(101)
 

--- a/pymc3/tests/test_hmc.py
+++ b/pymc3/tests/test_hmc.py
@@ -20,9 +20,8 @@ import numpy.testing as npt
 import pymc3
 
 from pymc3.step_methods.hmc.base_hmc import BaseHMC
+from pymc3.tests import models
 from pymc3.theanof import floatX
-
-from . import models
 
 logger = logging.getLogger("pymc3")
 

--- a/pymc3/tests/test_math.py
+++ b/pymc3/tests/test_math.py
@@ -32,9 +32,8 @@ from pymc3.math import (
     logdet,
     probit,
 )
+from pymc3.tests.helpers import SeededTest, verify_grad
 from pymc3.theanof import floatX
-
-from .helpers import SeededTest, verify_grad
 
 
 def test_kronecker():

--- a/pymc3/tests/test_mixture.py
+++ b/pymc3/tests/test_mixture.py
@@ -38,9 +38,8 @@ from pymc3 import (
     sample,
 )
 from pymc3.distributions.shape_utils import to_tuple
+from pymc3.tests.helpers import SeededTest
 from pymc3.theanof import floatX
-
-from .helpers import SeededTest
 
 
 # Generate data

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -27,8 +27,7 @@ import pymc3 as pm
 from pymc3 import Deterministic, Potential
 from pymc3.distributions import HalfCauchy, Normal, transforms
 from pymc3.model import ValueGradFunction
-
-from .helpers import select_by_precision
+from pymc3.tests.helpers import select_by_precision
 
 
 class NewModel(pm.Model):

--- a/pymc3/tests/test_model_func.py
+++ b/pymc3/tests/test_model_func.py
@@ -17,8 +17,8 @@ import scipy.stats as sp
 
 import pymc3 as pm
 
-from .checks import close_to
-from .models import mv_simple, simple_model
+from pymc3.tests.checks import close_to
+from pymc3.tests.models import mv_simple, simple_model
 
 tol = 2.0 ** -11
 

--- a/pymc3/tests/test_model_graph.py
+++ b/pymc3/tests/test_model_graph.py
@@ -18,8 +18,7 @@ import theano as th
 import pymc3 as pm
 
 from pymc3.model_graph import ModelGraph, model_to_graphviz
-
-from .helpers import SeededTest
+from pymc3.tests.helpers import SeededTest
 
 
 def radon_model():

--- a/pymc3/tests/test_models_linear.py
+++ b/pymc3/tests/test_models_linear.py
@@ -17,8 +17,7 @@ import pytest
 
 from pymc3 import Model, Normal, Slice, Uniform, find_MAP, sample
 from pymc3.glm import GLM, LinearComponent
-
-from .helpers import SeededTest
+from pymc3.tests.helpers import SeededTest
 
 
 # Generate data

--- a/pymc3/tests/test_ode.py
+++ b/pymc3/tests/test_ode.py
@@ -21,8 +21,8 @@ from scipy.stats import norm
 
 import pymc3 as pm
 
-from ..ode import DifferentialEquation
-from ..ode.utils import augment_system
+from pymc3.ode import DifferentialEquation
+from pymc3.ode.utils import augment_system
 
 
 def test_gradients():

--- a/pymc3/tests/test_pickling.py
+++ b/pymc3/tests/test_pickling.py
@@ -15,7 +15,7 @@
 import pickle
 import traceback
 
-from .models import simple_model
+from pymc3.tests.models import simple_model
 
 
 class TestPickling:

--- a/pymc3/tests/test_posteriors.py
+++ b/pymc3/tests/test_posteriors.py
@@ -15,7 +15,7 @@
 import pytest
 import theano
 
-from . import sampler_fixtures as sf
+from pymc3.tests import sampler_fixtures as sf
 
 
 @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")

--- a/pymc3/tests/test_profile.py
+++ b/pymc3/tests/test_profile.py
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from .models import simple_model
+from pymc3.tests.models import simple_model
 
 
 class TestProfile:

--- a/pymc3/tests/test_random.py
+++ b/pymc3/tests/test_random.py
@@ -23,8 +23,7 @@ from numpy import random as nr
 import pymc3 as pm
 
 from pymc3.distributions.distribution import _draw_value, draw_values
-
-from .helpers import SeededTest
+from pymc3.tests.helpers import SeededTest
 
 
 def test_draw_value():

--- a/pymc3/tests/test_shared.py
+++ b/pymc3/tests/test_shared.py
@@ -17,7 +17,7 @@ import theano
 
 import pymc3 as pm
 
-from .helpers import SeededTest
+from pymc3.tests.helpers import SeededTest
 
 
 class TestShared(SeededTest):

--- a/pymc3/tests/test_smc.py
+++ b/pymc3/tests/test_smc.py
@@ -17,7 +17,7 @@ import theano.tensor as tt
 
 import pymc3 as pm
 
-from .helpers import SeededTest
+from pymc3.tests.helpers import SeededTest
 
 
 class TestSMC(SeededTest):

--- a/pymc3/tests/test_special_functions.py
+++ b/pymc3/tests/test_special_functions.py
@@ -20,7 +20,7 @@ from theano import function
 
 import pymc3.distributions.special as ps
 
-from .checks import close_to
+from pymc3.tests.checks import close_to
 
 
 def test_functions():

--- a/pymc3/tests/test_starting.py
+++ b/pymc3/tests/test_starting.py
@@ -17,11 +17,10 @@ import numpy as np
 from pytest import raises
 
 from pymc3 import Beta, Binomial, Model, Normal, Point, Uniform, find_MAP
+from pymc3.tests.checks import close_to
+from pymc3.tests.helpers import select_by_precision
+from pymc3.tests.models import non_normal, simple_arbitrary_det, simple_model
 from pymc3.tuning import starting
-
-from .checks import close_to
-from .helpers import select_by_precision
-from .models import non_normal, simple_arbitrary_det, simple_model
 
 
 def test_accuracy_normal():

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -58,11 +58,9 @@ from pymc3.step_methods import (
     UniformProposal,
 )
 from pymc3.step_methods.mlda import extract_Q_estimate
-from pymc3.theanof import floatX
-
-from .checks import close_to
-from .helpers import select_by_precision
-from .models import (
+from pymc3.tests.checks import close_to
+from pymc3.tests.helpers import select_by_precision
+from pymc3.tests.models import (
     mv_prior_simple,
     mv_simple,
     mv_simple_coarse,
@@ -71,6 +69,7 @@ from .models import (
     simple_2model_continuous,
     simple_categorical,
 )
+from pymc3.theanof import floatX
 
 
 class TestStepMethods:  # yield test doesn't work subclassing object

--- a/pymc3/tests/test_transforms.py
+++ b/pymc3/tests/test_transforms.py
@@ -20,10 +20,9 @@ import theano.tensor as tt
 import pymc3 as pm
 import pymc3.distributions.transforms as tr
 
-from ..theanof import jacobian
-from .checks import close_to, close_to_logical
-from .helpers import SeededTest
-from .test_distributions import (
+from pymc3.tests.checks import close_to, close_to_logical
+from pymc3.tests.helpers import SeededTest
+from pymc3.tests.test_distributions import (
     Circ,
     MultiSimplex,
     R,
@@ -35,6 +34,7 @@ from .test_distributions import (
     UnitSortedVector,
     Vector,
 )
+from pymc3.theanof import jacobian
 
 # some transforms (stick breaking) require additon of small slack in order to be numerically
 # stable. The minimal addable slack for float32 is higher thus we need to be less strict

--- a/pymc3/tests/test_tuning.py
+++ b/pymc3/tests/test_tuning.py
@@ -17,9 +17,8 @@ import numpy as np
 from numpy import inf
 
 from pymc3.step_methods.metropolis import tune
+from pymc3.tests import models
 from pymc3.tuning import find_MAP, scaling
-
-from . import models
 
 
 def test_adjust_precision():

--- a/pymc3/tests/test_util.py
+++ b/pymc3/tests/test_util.py
@@ -20,8 +20,7 @@ from numpy.testing import assert_almost_equal
 import pymc3 as pm
 
 from pymc3.distributions.transforms import Transform
-
-from .helpers import SeededTest
+from pymc3.tests.helpers import SeededTest
 
 
 class TestTransformName:

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -25,6 +25,8 @@ import pymc3 as pm
 import pymc3.memoize
 import pymc3.util
 
+from pymc3.tests import models
+from pymc3.tests.helpers import not_raises
 from pymc3.theanof import change_flags, intX
 from pymc3.variational import flows, opvi
 from pymc3.variational.approximations import (
@@ -39,9 +41,6 @@ from pymc3.variational.approximations import (
 )
 from pymc3.variational.inference import ADVI, ASVGD, NFVI, SVGD, FullRankADVI, fit
 from pymc3.variational.opvi import Approximation, Group
-
-from . import models
-from .helpers import not_raises
 
 pytestmark = pytest.mark.usefixtures("strict_float32", "seeded_test")
 

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -22,9 +22,9 @@ from theano.gof import Op
 from theano.gof.graph import inputs
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 
-from .blocking import ArrayOrdering
-from .data import GeneratorAdapter
-from .vartypes import continuous_types, int_types, typefilter
+from pymc3.blocking import ArrayOrdering
+from pymc3.data import GeneratorAdapter
+from pymc3.vartypes import continuous_types, int_types, typefilter
 
 __all__ = [
     "gradient",

--- a/pymc3/tuning/__init__.py
+++ b/pymc3/tuning/__init__.py
@@ -12,5 +12,5 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from .scaling import find_hessian, guess_scaling, trace_cov
-from .starting import find_MAP
+from pymc3.tuning.scaling import find_hessian, guess_scaling, trace_cov
+from pymc3.tuning.starting import find_MAP

--- a/pymc3/tuning/scaling.py
+++ b/pymc3/tuning/scaling.py
@@ -16,10 +16,10 @@ import numpy as np
 
 from numpy import exp, log, sqrt
 
-from ..blocking import ArrayOrdering, DictToArrayBijection
-from ..model import Point, modelcontext
-from ..theanof import hessian_diag, inputvars
-from ..util import get_var_name
+from pymc3.blocking import ArrayOrdering, DictToArrayBijection
+from pymc3.model import Point, modelcontext
+from pymc3.theanof import hessian_diag, inputvars
+from pymc3.util import get_var_name
 
 __all__ = ["find_hessian", "trace_cov", "guess_scaling"]
 

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -30,16 +30,16 @@ from scipy.optimize import minimize
 
 import pymc3 as pm
 
-from ..blocking import ArrayOrdering, DictToArrayBijection
-from ..model import Point, modelcontext
-from ..theanof import inputvars
-from ..util import (
+from pymc3.blocking import ArrayOrdering, DictToArrayBijection
+from pymc3.model import Point, modelcontext
+from pymc3.theanof import inputvars
+from pymc3.util import (
     check_start_vals,
     get_default_varnames,
     get_var_name,
     update_start_vals,
 )
-from ..vartypes import discrete_types, typefilter
+from pymc3.vartypes import discrete_types, typefilter
 
 __all__ = ["find_MAP"]
 

--- a/pymc3/variational/__init__.py
+++ b/pymc3/variational/__init__.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # commonly used
-from . import (
+from pymc3.variational import (
     approximations,
     callbacks,
     flows,
@@ -23,14 +23,14 @@ from . import (
     test_functions,
     updates,
 )
-from .approximations import (
+from pymc3.variational.approximations import (
     Empirical,
     FullRank,
     MeanField,
     NormalizingFlow,
     sample_approx,
 )
-from .inference import (
+from pymc3.variational.inference import (
     ADVI,
     ASVGD,
     NFVI,
@@ -41,11 +41,11 @@ from .inference import (
     KLqp,
     fit,
 )
-from .opvi import Approximation, Group
+from pymc3.variational.opvi import Approximation, Group
 
 # special
-from .stein import Stein
-from .updates import (
+from pymc3.variational.stein import Stein
+from pymc3.variational.updates import (
     adadelta,
     adagrad,
     adagrad_window,

--- a/pymc3/variational/approximations.py
+++ b/pymc3/variational/approximations.py
@@ -23,10 +23,8 @@ from pymc3.distributions.dist_math import rho2sigma
 from pymc3.math import batched_diag
 from pymc3.theanof import change_flags
 from pymc3.util import update_start_vals
-from pymc3.variational import flows
+from pymc3.variational import flows, opvi
 from pymc3.variational.opvi import Approximation, Group, node_property
-
-from . import opvi
 
 __all__ = ["MeanField", "FullRank", "Empirical", "NormalizingFlow", "sample_approx"]
 

--- a/pymc3/variational/flows.py
+++ b/pymc3/variational/flows.py
@@ -17,11 +17,11 @@ import theano
 
 from theano import tensor as tt
 
-from ..distributions.dist_math import rho2sigma
-from ..memoize import WithMemoization
-from ..theanof import change_flags
-from . import opvi
-from .opvi import collect_shared_to_list, node_property
+from pymc3.distributions.dist_math import rho2sigma
+from pymc3.memoize import WithMemoization
+from pymc3.theanof import change_flags
+from pymc3.variational import opvi
+from pymc3.variational.opvi import collect_shared_to_list, node_property
 
 __all__ = ["Formula", "PlanarFlow", "HouseholderFlow", "RadialFlow", "LocFlow", "ScaleFlow"]
 

--- a/pymc3/variational/inference.py
+++ b/pymc3/variational/inference.py
@@ -22,7 +22,7 @@ from fastprogress.fastprogress import progress_bar
 
 import pymc3 as pm
 
-from pymc3.variational import test_functions
+from pymc3.variational import opvi, test_functions
 from pymc3.variational.approximations import (
     Empirical,
     FullRank,
@@ -30,8 +30,6 @@ from pymc3.variational.approximations import (
     NormalizingFlow,
 )
 from pymc3.variational.operators import KL, KSD
-
-from . import opvi
 
 logger = logging.getLogger(__name__)
 

--- a/pymc3/variational/operators.py
+++ b/pymc3/variational/operators.py
@@ -17,10 +17,9 @@ from theano import tensor as tt
 import pymc3 as pm
 
 from pymc3.theanof import change_flags
+from pymc3.variational import opvi
 from pymc3.variational.opvi import ObjectiveFunction, Operator
 from pymc3.variational.stein import Stein
-
-from . import opvi
 
 __all__ = ["KL", "KSD"]
 

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -55,15 +55,13 @@ import theano.tensor as tt
 
 import pymc3 as pm
 
-from pymc3.util import get_transformed
-
-from ..backends import NDArray
-from ..blocking import ArrayOrdering, DictToArrayBijection, VarMap
-from ..memoize import WithMemoization, memoize
-from ..model import modelcontext
-from ..theanof import change_flags, identity, tt_rng
-from ..util import get_default_varnames
-from .updates import adagrad_window
+from pymc3.backends import NDArray
+from pymc3.blocking import ArrayOrdering, DictToArrayBijection, VarMap
+from pymc3.memoize import WithMemoization, memoize
+from pymc3.model import modelcontext
+from pymc3.theanof import change_flags, identity, tt_rng
+from pymc3.util import get_default_varnames, get_transformed
+from pymc3.variational.updates import adagrad_window
 
 __all__ = ["ObjectiveFunction", "Operator", "TestFunction", "Group", "Approximation"]
 

--- a/pymc3/variational/test_functions.py
+++ b/pymc3/variational/test_functions.py
@@ -15,8 +15,7 @@
 from theano import tensor as tt
 
 from pymc3.theanof import floatX
-
-from .opvi import TestFunction
+from pymc3.variational.opvi import TestFunction
 
 __all__ = ["rbf"]
 


### PR DESCRIPTION
This was discussed but not implemented, and it was pretty easy to write a script to do this so I figured I'd submit a PR

---

I have no strong opinion on whether relative or absolute imports are better (though PEP8 suggests absolute), but I do think that in a large codebase such as PyMC3's then there is a benefit to consistency