### PR TITLE
Small compatibility fix for master of Theano-PyMc

### DIFF
--- a/.github/workflows/arviz_compat.yml
+++ b/.github/workflows/arviz_compat.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      THEANO_FLAGS: floatX=${{ matrix.floatx }},gcc.cxxflags='-march=native'
+      THEANO_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=native'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      THEANO_FLAGS: floatX=${{ matrix.floatx }},gcc.cxxflags='-march=native'
+      THEANO_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=native'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      THEANO_FLAGS: floatX=${{ matrix.floatx }},gcc.cxxflags='-march=core2'
+      THEANO_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=core2'
     defaults:
       run:
         shell: bash -l {0}

--- a/conda-envs/environment-dev-py36.yml
+++ b/conda-envs/environment-dev-py36.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.6
   - arviz>=0.9
-  - theano-pymc==1.0.11
+  - theano-pymc==1.0.12
   - numpy>=1.13
   - scipy>=0.18
   - pandas>=0.18

--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.7
   - arviz>=0.9
-  - theano-pymc==1.0.11
+  - theano-pymc==1.0.12
   - numpy>=1.13
   - scipy>=0.18
   - pandas>=0.18

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.8
   - arviz>=0.9
-  - theano-pymc==1.0.11
+  - theano-pymc==1.0.12
   - numpy>=1.13
   - scipy>=0.18
   - pandas>=0.18

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -32,8 +32,8 @@ def __set_compiler_flags():
     # Workarounds for Theano compiler problems on various platforms
     import theano
 
-    current = theano.config.gcc.cxxflags
-    theano.config.gcc.cxxflags = f"{current} -Wno-c++11-narrowing"
+    current = theano.config.gcc__cxxflags
+    theano.config.gcc__cxxflags = f"{current} -Wno-c++11-narrowing"
 
 
 __set_compiler_flags()

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -724,7 +724,7 @@ class PosDefMatrix(theano.Op):
             pm._log.exception("Failed to check if %s positive definite", x)
             raise
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [[]]
 
     def grad(self, inp, grads):

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -363,7 +363,7 @@ class BatchedDiag(tt.Op):
         idx = tt.arange(gz.shape[-1])
         return [gz[..., idx, idx]]
 
-    def infer_shape(self, nodes, shapes):
+    def infer_shape(self, fgraph, nodes, shapes):
         return [(shapes[0][0],) + (shapes[0][1],) * 2]
 
 
@@ -422,7 +422,7 @@ class BlockDiagonalMatrix(Op):
         ]
         return [gout[0][slc] for slc in slices]
 
-    def infer_shape(self, nodes, shapes):
+    def infer_shape(self, fgraph, nodes, shapes):
         first, second = zip(*shapes)
         return [(tt.add(*first), tt.add(*second))]
 

--- a/pymc3/ode/ode.py
+++ b/pymc3/ode/ode.py
@@ -213,7 +213,7 @@ class DifferentialEquation(theano.Op):
         # simulate states and sensitivities in one forward pass
         output_storage[0][0], output_storage[1][0] = self._simulate(y0, theta)
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         s_y0, s_theta = input_shapes
         output_shapes = [(self.n_times, self.n_states), (self.n_times, self.n_states, self.n_p)]
         return output_shapes

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ numpy>=1.13.0
 pandas>=0.18.0
 patsy>=0.5.1
 scipy>=0.18.1
-theano-pymc==1.0.11
+theano-pymc==1.0.12
 typing-extensions>=3.7.4

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,4 +3,4 @@
 set -e
 
 _FLOATX=${FLOATX:=float64}
-THEANO_FLAGS="floatX=${_FLOATX},gcc.cxxflags='-march=core2'" pytest -v --cov=pymc3 --cov-report=xml "$@" --cov-report term
+THEANO_FLAGS="floatX=${_FLOATX},gcc__cxxflags='-march=core2'" pytest -v --cov=pymc3 --cov-report=xml "$@" --cov-report term


### PR DESCRIPTION

+ Import of pymc3 failed with the most recent master branch of Theano-PyMC 
+ I could nail down the problem to [this commit ](https://github.com/pymc-devs/Theano-PyMC/commit/f1016f7fec226f521f588936574dc59971fbf18a) on the Theano-PyMC GitHub
+ Changed the `__init__.py` to use the new config style