### PR TITLE
Add Normal mixture example, fixup check_toc script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,6 @@ repos:
       entry: python scripts/check_toc_is_complete.py
       language: python
       name: Check all notebooks appear in table of contents
-      pass_filenames: false
       types: [jupyter]
     - id: check-no-tests-are-ignored
       entry: python scripts/check_all_tests_are_covered.py

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -602,7 +602,29 @@ class NormalMixture(Mixture):
         of the mixture distribution, with one axis being
         the number of components.
 
-    Note: You only have to pass in sigma or tau, but not both.
+    Notes
+    -----
+    You only have to pass in sigma or tau, but not both.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        n_components = 3
+
+        with pm.Model() as gauss_mix:
+            μ = pm.Normal(
+                "μ",
+                data.mean(),
+                10,
+                shape=n_components,
+                transform=pm.transforms.ordered,
+                testval=[1, 2, 3],
+            )
+            σ = pm.HalfNormal("σ", 10, shape=n_components)
+            weights = pm.Dirichlet("w", np.ones(n_components))
+
+            pm.NormalMixture("y", w=weights, mu=μ, sigma=σ, observed=data)
     """
 
     def __init__(self, w, mu, sigma=None, tau=None, sd=None, comp_shape=(), *args, **kwargs):

--- a/scripts/check_toc_is_complete.py
+++ b/scripts/check_toc_is_complete.py
@@ -5,16 +5,16 @@ This is intended to be used as a pre-commit hook, see `.pre-commit-config.yaml`.
 You can run it manually with `pre-commit run check-toc --all`.
 """
 
-import json
 from pathlib import Path
 import argparse
+import ast
 
 if __name__ == "__main__":
     toc_examples = (Path("docs") / "source/notebooks/table_of_contents_examples.js").read_text()
     toc_tutorials = (Path("docs") / "source/notebooks/table_of_contents_tutorials.js").read_text()
     toc_keys = {
-        **json.loads(toc_examples[toc_examples.find("{") :]),
-        **json.loads(toc_tutorials[toc_tutorials.find("{") :]),
+        **ast.literal_eval(toc_examples[toc_examples.find("{") :]),
+        **ast.literal_eval(toc_tutorials[toc_tutorials.find("{") :]),
     }.keys()
     parser = argparse.ArgumentParser()
     parser.add_argument("filenames", nargs="*")


### PR DESCRIPTION
> [people understand concepts better by example than through accurate explanations](https://pandas.pydata.org/pandas-docs/stable/development/contributing_docstring.html#section-7-examples)

The mixture examples aren't the most straightforward, so here's a simple Gaussian mixture example:

![image](https://user-images.githubusercontent.com/33491632/101199770-4573af80-365d-11eb-94e2-06baea19861d.png)

While I'm here, am also fixing up the check_toc script to use `ast.literval_eval` instead of `json.loads`, as the docs build fine with trailing commas in the js dicts and this way we won't get mysterious errors like [this one](https://github.com/pymc-devs/pymc3/pull/4247#discussion_r528588294) @twiecki got when adding a trailing comma