### PR TITLE
fix regression #4273

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -511,13 +511,17 @@ class DensityDist(Distribution):
         self.logp = logp
         if type(self.logp) == types.MethodType:
             if sys.platform != "linux":
-                warnings.warn("You are passing a bound method as logp for DensityDist, this can lead to " +
-                    "errors when sampling on platforms other than Linux. Consider using a " +
-                    "plain function instead, or subclass Distribution.")
+                warnings.warn(
+                    "You are passing a bound method as logp for DensityDist, this can lead to "
+                    + "errors when sampling on platforms other than Linux. Consider using a "
+                    + "plain function instead, or subclass Distribution."
+                )
             elif type(multiprocessing.get_context()) != multiprocessing.context.ForkContext:
-                warnings.warn("You are passing a bound method as logp for DensityDist, this can lead to " +
-                    "errors when sampling when multiprocessing cannot rely on forking. Consider using a " +
-                    "plain function instead, or subclass Distribution.")
+                warnings.warn(
+                    "You are passing a bound method as logp for DensityDist, this can lead to "
+                    + "errors when sampling when multiprocessing cannot rely on forking. Consider using a "
+                    + "plain function instead, or subclass Distribution."
+                )
         self.rand = random
         self.wrap_random_with_dist_shape = wrap_random_with_dist_shape
         self.check_shape_in_random = check_shape_in_random
@@ -530,7 +534,9 @@ class DensityDist(Distribution):
             logp = dill.dumps(self.logp)
         except RecursionError as err:
             if type(self.logp) == types.MethodType:
-                raise ValueError("logp for DensityDist is a bound method, leading to RecursionError while serializing") from err
+                raise ValueError(
+                    "logp for DensityDist is a bound method, leading to RecursionError while serializing"
+                ) from err
             else:
                 raise err
         vals = self.__dict__.copy()

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -12,11 +12,15 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import multiprocessing
 import numbers
 import contextvars
 import dill
 import inspect
+import sys
+import types
 from typing import TYPE_CHECKING
+import warnings
 
 if TYPE_CHECKING:
     from typing import Optional, Callable
@@ -505,6 +509,15 @@ class DensityDist(Distribution):
             dtype = theano.config.floatX
         super().__init__(shape, dtype, testval, *args, **kwargs)
         self.logp = logp
+        if type(self.logp) == types.MethodType:
+            if sys.platform != "linux":
+                warnings.warn("You are passing a bound method as logp for DensityDist, this can lead to " +
+                    "errors when sampling on platforms other than Linux. Consider using a " +
+                    "plain function instead, or subclass Distribution.")
+            elif type(multiprocessing.get_context()) != multiprocessing.context.ForkContext:
+                warnings.warn("You are passing a bound method as logp for DensityDist, this can lead to " +
+                    "errors when sampling when multiprocessing cannot rely on forking. Consider using a " +
+                    "plain function instead, or subclass Distribution.")
         self.rand = random
         self.wrap_random_with_dist_shape = wrap_random_with_dist_shape
         self.check_shape_in_random = check_shape_in_random
@@ -513,7 +526,13 @@ class DensityDist(Distribution):
         # We use dill to serialize the logp function, as this is almost
         # always defined in the notebook and won't be pickled correctly.
         # Fix https://github.com/pymc-devs/pymc3/issues/3844
-        logp = dill.dumps(self.logp)
+        try:
+            logp = dill.dumps(self.logp)
+        except RecursionError as err:
+            if type(self.logp) == types.MethodType:
+                raise ValueError("logp for DensityDist is a bound method, leading to RecursionError while serializing") from err
+            else:
+                raise err
         vals = self.__dict__.copy()
         vals["logp"] = logp
         return vals

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -1273,7 +1273,7 @@ class TestDensityDist:
             mu = pm.Normal("mu", 0, 1)
             normal_dist = pm.Normal.dist(mu, 1)
             pm.DensityDist("density_dist", normal_dist.logp, observed=np.random.randn(100))
-            trace = pm.sample(100)
+            trace = pm.sample(100, cores=1)
 
         samples = 500
         with pytest.raises(ValueError):

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -1171,7 +1171,7 @@ class TestDensityDist:
                 shape=shape,
                 random=normal_dist.random,
             )
-            trace = pm.sample(100)
+            trace = pm.sample(100, cores=1)
 
         samples = 500
         size = 100
@@ -1194,7 +1194,7 @@ class TestDensityDist:
                 random=normal_dist.random,
                 wrap_random_with_dist_shape=False,
             )
-            trace = pm.sample(100)
+            trace = pm.sample(100, cores=1)
 
         samples = 500
         with pytest.raises(RuntimeError):
@@ -1217,7 +1217,7 @@ class TestDensityDist:
                 wrap_random_with_dist_shape=False,
                 check_shape_in_random=False,
             )
-            trace = pm.sample(100)
+            trace = pm.sample(100, cores=1)
 
         samples = 500
         ppc = pm.sample_posterior_predictive(trace, samples=samples, model=model)
@@ -1240,7 +1240,7 @@ class TestDensityDist:
                 random=rvs,
                 wrap_random_with_dist_shape=False,
             )
-            trace = pm.sample(100)
+            trace = pm.sample(100, cores=1)
 
         samples = 500
         size = 100
@@ -1260,7 +1260,7 @@ class TestDensityDist:
                 random=rvs,
                 wrap_random_with_dist_shape=False,
             )
-            trace = pm.sample(100)
+            trace = pm.sample(100, cores=1)
 
         samples = 500
         size = 100


### PR DESCRIPTION
This should fix #4273 by ensuring that our tests don't attempt parallel sampling when a bound method was used as `logp` input to `DensityDist`. Additionally, I added some informative warnings about a previously rather obscure issue.

It would be good to see whether this now allows tests to run on MacOS/Windows as well.

@rpgoldman @aseyboldt @MarcoGorelli @michaelosthege 