### PR TITLE
Implement more robust jitter init (resolves #4107)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -48,6 +48,7 @@ This new version of `Theano-PyMC` comes with an experimental JAX backend which, 
 - Fix bug in `model.check_test_point` that caused the `test_point` argument to be ignored. (see [PR #4211](https://github.com/pymc-devs/pymc3/pull/4211#issuecomment-727142721))
 - Refactored MvNormal.random method with better handling of sample, batch and event shapes. [#4207](https://github.com/pymc-devs/pymc3/pull/4207)
 - The `InverseGamma` distribution now implements a `logcdf`. [#3944](https://github.com/pymc-devs/pymc3/pull/3944)
+- Make starting jitter methods for nuts sampling more robust by resampling values that lead to non-finite probabilities. A new optional argument `jitter-max-retries` can be passed to `pm.sample()` and `pm.init_nuts()` to control the maximum number of retries per chain. [4298](https://github.com/pymc-devs/pymc3/pull/4298)
 
 ### Documentation
 - Added a new notebook demonstrating how to incorporate sampling from a conjugate Dirichlet-multinomial posterior density in conjunction with other step methods (see [#4199](https://github.com/pymc-devs/pymc3/pull/4199)).

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -332,7 +332,7 @@ def sample(
         the ``draw.chain`` argument can be used to determine which of the active chains the sample
         is drawn from.
         Sampling can be interrupted by throwing a ``KeyboardInterrupt`` in the callback.
-    jitter_max_retries: int
+    jitter_max_retries : int
         Maximum number of repeated attempts (per chain) at creating an initial matrix with uniform jitter
         that yields a finite probability. This applies to ``jitter+adapt_diag`` and ``jitter+adapt_full``
         init methods.
@@ -1957,13 +1957,13 @@ def _init_jitter(model, chains, jitter_max_retries):
 
     pymc3.util.check_start_vals is used to test whether the jittered starting values produce
     a finite log probability. Invalid values are resampled unless `jitter_max_retries` is achieved,
-    in which case the last sampled values are returned
+    in which case the last sampled values are returned.
 
     Parameters
     ----------
     model : Model
     chains : int
-    jitter_max_retries: int
+    jitter_max_retries : int
         Maximum number of repeated attempts at initializing values (per chain).
 
     Returns
@@ -2039,7 +2039,7 @@ def init_nuts(
     model : Model (optional if in ``with`` context)
     progressbar : bool
         Whether or not to display a progressbar for advi sampling.
-    jitter_max_retries: int
+    jitter_max_retries : int
         Maximum number of repeated attempts (per chain) at creating an initial matrix with uniform jitter
         that yields a finite probability. This applies to ``jitter+adapt_diag`` and ``jitter+adapt_full``
         init methods.

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1961,7 +1961,7 @@ def _init_jitter(model, chains, jitter_max_retries):
 
     Parameters
     ----------
-    model : Model
+    model : pymc3.Model
     chains : int
     jitter_max_retries : int
         Maximum number of repeated attempts at initializing values (per chain).


### PR DESCRIPTION
This PR addresses issue #4107, by allowing the starting jitter to be resampled when the sampled values generate an invalid probability for the model. There is a new optional argument `jitter_max_retries` in `sample()` and `init_nuts()` that controls the maximum number of times that a value can be resampled (per chain) before it gives up and returns whatever was last sampled. I arbitrarily set it to 10, but we can choose another default.

I further refactored the code that applies jitter to the starting point of each chain into a helper function `_init_jitter()`, to avoid duplicated code between the two init methods where this is used `init="jitter+adapt_diag"` and `init="jitter+adapt_diag"`. I added a unit_test for this function.

Here is an example that (almost deterministically) shows an improvement following this PR:

```python3
import pymc3 as pm

with pm.Model() as m:
    x = pm.HalfNormal('x', transform=None)

try:
    with m:
        trace = pm.sample(tune=1, draws=1, chains=100, jitter_max_retries=0,
                          compute_convergence_checks=False, progressbar=False)
except pm.exceptions.SamplingError:
    print('Exception raised as expected')


with m:
    trace = pm.sample(tune=1, draws=1, chains=100, jitter_max_retries=10,
                      compute_convergence_checks=False, progressbar=False)
print('Exception not raised as expected')
```

If you happen to know other examples of models that have fragile starting points when jitter is applied it would be great to test it out.

Any thoughts?