### PR TITLE
Fixup all non-theano non-notebook docs warnings, replace dead link

### DIFF
--- a/docs/source/Advanced_usage_of_Theano_in_PyMC3.rst
+++ b/docs/source/Advanced_usage_of_Theano_in_PyMC3.rst
@@ -1,3 +1,8 @@
+:orphan:
+
+..
+    _referenced in docs/source/notebooks/table_of_contents_tutorials.js
+
 =================================
 Advanced usage of Theano in PyMC3
 =================================

--- a/docs/source/Gaussian_Processes.rst
+++ b/docs/source/Gaussian_Processes.rst
@@ -1,3 +1,8 @@
+:orphan:
+
+..
+    _href from docs/source/index.rst
+
 ******************
 Gaussian Processes
 ******************

--- a/docs/source/Probability_Distributions.rst
+++ b/docs/source/Probability_Distributions.rst
@@ -1,3 +1,8 @@
+:orphan:
+
+..
+    _href from docs/source/index.rst
+
 .. _prob_dists:
 
 **********************************

--- a/docs/source/PyMC3_and_Theano.rst
+++ b/docs/source/PyMC3_and_Theano.rst
@@ -1,3 +1,8 @@
+:orphan:
+
+..
+    _href from docs/source/index.rst
+
 ================
 PyMC3 and Theano
 ================

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -1,3 +1,8 @@
+:orphan:
+
+..
+    _href from docs/source/index.rst
+
 .. _about:
 
 ***********

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,3 +1,8 @@
+:orphan:
+
+..
+    _"api" is referenced in html_theme_options docs/source/conf.py
+
 .. _api:
 
 ***************

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -1,3 +1,8 @@
+:orphan:
+
+..
+    _referenced in html_theme_options docs/source/conf.py
+
 =====================
 PyMC3 Developer Guide
 =====================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,12 +23,14 @@
 
     X, y = linear_training_data()
     with pm.Model() as linear_model:
-        weights = pm.Normal('weights', mu=0, sigma=1)
-        noise = pm.Gamma('noise', alpha=2, beta=1)
-        y_observed = pm.Normal('y_observed',
-                    mu=X @ weights,
-                    sigma=noise,
-                    observed=y)
+        weights = pm.Normal("weights", mu=0, sigma=1)
+        noise = pm.Gamma("noise", alpha=2, beta=1)
+        y_observed = pm.Normal(
+            "y_observed",
+            mu=X @ weights,
+            sigma=noise,
+            observed=y,
+        )
 
         prior = pm.sample_prior_predictive()
         posterior = pm.sample()

--- a/docs/source/learn.rst
+++ b/docs/source/learn.rst
@@ -1,3 +1,8 @@
+:orphan:
+
+..
+    _"learn" is referenced in html_theme_options docs/source/conf.py
+
 .. title:: Learning Resources
 
 .. raw:: html
@@ -99,7 +104,7 @@
 
         <div class="card">
             <div class="image">
-                <img src="https://lh5.googleusercontent.com/R1T8ZXbMi4vSO0JlnLQMkEQNvd2ncBb23OmHOsmw-t_oEOF6jJlfWuJoOK0MMmECSDymhUdfTS2yoMgkR2TY-xIiBTHCpeuYjzXqD3xhZ-MuIhs2ARcJ=w1280">
+                <img src="https://lh5.googleusercontent.com/Ms2ssellxl7cM6OEL_kpiKRojcj2E4ZaUWDXOa8zEwi-v9orJGYuhjczbwFSDJNsEb_ruiwtCJONNjoo7T1c7qorZm3LsAnroMAm4S5WzNT_PVqWz9aE=w1280">
             </div>
             <div class="content">
                 <div class="header">Doing Bayesian Data Analysis</div>

--- a/docs/source/sphinxext/gallery_generator.py
+++ b/docs/source/sphinxext/gallery_generator.py
@@ -22,6 +22,11 @@ DEFAULT_IMG_LOC = os.path.join(os.path.dirname(DOC_SRC), "logos", "PyMC3.png")
 TABLE_OF_CONTENTS_FILENAME = "table_of_contents_{}.js"
 
 INDEX_TEMPLATE = """
+:orphan:
+
+..
+    _href from docs/source/conf.py
+
 .. _{sphinx_tag}:
 
 .. title:: {gallery}_notebooks


### PR DESCRIPTION
There are still some warnings coming from using automodule on theano functions, and from the notebooks' docstrings, but this at least fixes those given from PyMC3's own rst files.

Also, the old link to "Doing Bayesian Analysis" seems like it was down