### PR TITLE
uncomment test from #4297

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -54,6 +54,8 @@ vectorized_ppc = contextvars.ContextVar(
     "vectorized_ppc", default=None
 )  # type: contextvars.ContextVar[Optional[Callable]]
 
+PLATFORM = sys.platform
+
 
 class _Unpickling:
     pass
@@ -510,17 +512,17 @@ class DensityDist(Distribution):
         super().__init__(shape, dtype, testval, *args, **kwargs)
         self.logp = logp
         if type(self.logp) == types.MethodType:
-            if sys.platform != "linux":
+            if PLATFORM != "linux":
                 warnings.warn(
                     "You are passing a bound method as logp for DensityDist, this can lead to "
-                    + "errors when sampling on platforms other than Linux. Consider using a "
-                    + "plain function instead, or subclass Distribution."
+                    "errors when sampling on platforms other than Linux. Consider using a "
+                    "plain function instead, or subclass Distribution."
                 )
             elif type(multiprocessing.get_context()) != multiprocessing.context.ForkContext:
                 warnings.warn(
                     "You are passing a bound method as logp for DensityDist, this can lead to "
-                    + "errors when sampling when multiprocessing cannot rely on forking. Consider using a "
-                    + "plain function instead, or subclass Distribution."
+                    "errors when sampling when multiprocessing cannot rely on forking. Consider using a "
+                    "plain function instead, or subclass Distribution."
                 )
         self.rand = random
         self.wrap_random_with_dist_shape = wrap_random_with_dist_shape

--- a/pymc3/tests/test_parallel_sampling.py
+++ b/pymc3/tests/test_parallel_sampling.py
@@ -177,10 +177,8 @@ def test_spawn_densitydist_bound_method():
         mu = pm.Normal("mu", 0, 1)
         normal_dist = pm.Normal.dist(mu, 1)
         obs = pm.DensityDist("density_dist", normal_dist.logp, observed=np.random.randn(100))
-        with pytest.raises(
-            ValueError,
-            match="logp for DensityDist is a bound method, leading to RecursionError while serializing",
-        ):
+        msg = "logp for DensityDist is a bound method, leading to RecursionError while serializing"
+        with pytest.raises(ValueError, match=msg):
             trace = pm.sample(draws=10, tune=10, step=pm.Metropolis(), cores=2, mp_ctx="spawn")
 
 


### PR DESCRIPTION
#4297 had a commented-out test, so here's a little PR to uncomment it

If we set a global variable `PLATFORM` in `pymc3/distributions/distribution.py` then we can patch it during testing without affecting `sys.platform` and hence not affecting `theano`