### PR TITLE
Made sample_shape same across all contexts in draw_values

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## PyMC3 3.10.x
+## PyMC3 3.10.1 (on deck)
 
 ### Maintenance
 - Make `sample_shape` same across all contexts in `draw_values` (see [#4305](https://github.com/pymc-devs/pymc3/pull/4305)).

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## PyMC3 3.10.x
+
+### Maintenance
+- Make `sample_shape` same across all contexts in `draw_values` (see [#4305](https://github.com/pymc-devs/pymc3/pull/4305)).
+
 ## PyMC3 3.10.0 (7 December 2020)
 
 This is a major release with many exciting new features. The biggest change is that we now rely on our own fork of [Theano-PyMC](https://github.com/pymc-devs/Theano-PyMC). This is in line with our [big announcement about our commitment to PyMC3 and Theano](https://pymc-devs.medium.com/the-future-of-pymc3-or-theano-is-dead-long-live-theano-d8005f8a0e9b).

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -690,6 +690,7 @@ def draw_values(params, point=None, size=None):
     """
     # The following check intercepts and redirects calls to
     # draw_values in the context of sample_posterior_predictive
+    size = to_tuple(size)
     ppc_sampler = vectorized_ppc.get(None)
     if ppc_sampler is not None:
         # this is being done inside new, vectorized sample_posterior_predictive

--- a/pymc3/distributions/simulator.py
+++ b/pymc3/distributions/simulator.py
@@ -115,10 +115,10 @@ class Simulator(NoDistribution):
         array
         """
         params = draw_values([*self.params], point=point, size=size)
-        if size is None:
+        if not size:
             return self.function(*params)
         else:
-            return np.array([self.function(*params) for _ in range(size)])
+            return np.array([self.function(*params) for _ in range(size[0])])
 
     def _str_repr(self, name=None, dist=None, formatting="plain"):
         if dist is None:

--- a/pymc3/distributions/simulator.py
+++ b/pymc3/distributions/simulator.py
@@ -115,7 +115,7 @@ class Simulator(NoDistribution):
         array
         """
         params = draw_values([*self.params], point=point, size=size)
-        if not size:
+        if (size is None) or (len(size) == 0):
             return self.function(*params)
         else:
             return np.array([self.function(*params) for _ in range(size[0])])

--- a/pymc3/distributions/simulator.py
+++ b/pymc3/distributions/simulator.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from scipy.spatial import cKDTree
 
-from pymc3.distributions.distribution import NoDistribution, draw_values
+from pymc3.distributions.distribution import NoDistribution, draw_values, to_tuple
 
 __all__ = ["Simulator"]
 
@@ -114,8 +114,9 @@ class Simulator(NoDistribution):
         -------
         array
         """
+        size = to_tuple(size)
         params = draw_values([*self.params], point=point, size=size)
-        if (size is None) or (len(size) == 0):
+        if len(size) == 0:
             return self.function(*params)
         else:
             return np.array([self.function(*params) for _ in range(size[0])])

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -1664,6 +1664,10 @@ class TestMvNormal(SeededTest):
         for var in "abcd":
             assert not np.isnan(np.std(samples[var]))
 
+        for var in "bcd":
+            std = np.std(samples[var] - samples["a"])
+            np.testing.assert_allclose(std, 1, rtol=1e-2)
+
     def test_issue_3829(self):
         with pm.Model() as model:
             x = pm.MvNormal("x", mu=np.zeros(5), cov=np.eye(5), shape=(2, 5))


### PR DESCRIPTION
**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [X] what are the (breaking) changes that this PR makes?
Closes #3758 
+ [X] important background, or details about the implementation

There was a minor issue in this condition with respect to `size`. 
https://github.com/pymc-devs/pymc3/blob/de47253ce901ac9afac3a0fe33d3cb96f7f354db/pymc3/distributions/distribution.py#L703-L704

Coming to the code,
```python
ndim = 50
with pm.Model() as model:
    a = pm.Normal("a", sd=100, shape=ndim)
    c = pm.MvNormal("c", mu=a, chol=np.linalg.cholesky(np.eye(ndim)), shape=ndim)
    samples = pm.sample_prior_predictive(1000)
```

Variable `a` is drawn as `('a ~ Normal', 1000)` and stored in `drawn_vars`. But when looking for `MvNormal`, the condition is evaluated as `('a ~ Normal', (1000, ))` with size as tuple and there is a mismatch. So, I converted the size beforehand using `to_tuple` to ensure a common base sample_shape across contexts.

Another approach could have been the use `to_tuple` before passing size to `draw_values`. But this needs to be done for all distributions. So, I opted for the first approach.

+ [X] are the changes—especially new features—covered by tests and docstrings?
Yes. Earlier in #4207, I have written a test for first half of the issue #3758. This PR just appends that test with the second half.
+ [X] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md

