### PR TITLE
Make all MLDA tests deterministic

### DIFF
--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -1133,7 +1133,7 @@ class TestMLDA:
             Normal("x", 0, 1)
             for stepper in TestMLDA.steppers:
                 step = stepper(coarse_models=[coarse_model])
-                trace = sample(chains=2, cores=1, draws=20, tune=0, step=step)
+                trace = sample(chains=2, cores=1, draws=20, tune=0, step=step, random_seed=1)
                 samples = np.array(trace.get_values("x", combine=False))[:, 5]
                 assert (
                     len(set(samples)) == 2
@@ -1150,7 +1150,7 @@ class TestMLDA:
             Normal("x", 0, 1)
             for stepper in TestMLDA.steppers:
                 step = stepper(coarse_models=[coarse_model])
-                trace = sample(chains=2, cores=2, draws=20, tune=0, step=step)
+                trace = sample(chains=2, cores=2, draws=20, tune=0, step=step, random_seed=1)
                 samples = np.array(trace.get_values("x", combine=False))[:, 5]
                 assert len(set(samples)) == 2, "Parallelized {} " "chains are identical.".format(
                     stepper
@@ -1176,7 +1176,7 @@ class TestMLDA:
             Normal("x", 5.0, 1.0)
             for coarse_model in possible_coarse_models:
                 step = MLDA(coarse_models=[coarse_model], subsampling_rates=3)
-                trace = sample(chains=1, draws=500, tune=100, step=step)
+                trace = sample(chains=1, draws=500, tune=100, step=step, random_seed=1)
                 acc.append(trace.get_sampler_stats("accepted").mean())
             assert acc[0] > acc[1] > acc[2], (
                 "Acceptance rate is not "


### PR DESCRIPTION
I have added `random_seed` arguments to the sampler in three different MLDA tests in `test_step.py`, where they were missing. `test_nonparallelized_chains_are_random`, `test_parallelized_chains_are_random` and `test_acceptance_rate_against_coarseness`.

This is a response to https://github.com/pymc-devs/pymc3/issues/4267

@MarcoGorelli mentioned that the issue seemed to be resolved after removing parallel testing, but here is a PR anyway, in case you want to merge these changes.