### PR TITLE
CI: add slash workflow

### DIFF
--- a/.github/workflows/dispatched_pre-commit.yml
+++ b/.github/workflows/dispatched_pre-commit.yml
@@ -1,0 +1,33 @@
+name: run pre-commit
+
+on:
+  repository_dispatch:
+    types: [pre-commit-run-command]
+jobs:
+  runPreCommit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{github.event.client_payload.pull_request.head.repo.full_name}}
+          ref: ${{github.event.client_payload.pull_request.head.ref}}
+          token: ${{ secrets.ACTION_TRIGGER_TOKEN }}
+      - name: Cache multiple paths
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/pre-commit
+            ~/.cache/pip
+          key: pre-commit-dispatched-${{ runner.os }}-build
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: install-pre-commit
+        run: python -m pip install --upgrade pre-commit
+      - name: Slash Command Dispatch
+        run: pre-commit run --all-files || (exit 0)
+      - run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Run pre-commit" -a
+          git push

--- a/.github/workflows/slash_dispatch.yml
+++ b/.github/workflows/slash_dispatch.yml
@@ -1,0 +1,15 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.ACTION_TRIGGER_TOKEN }}
+          issue-type: pull-request
+          commands: |
+            pre-commit-run


### PR DESCRIPTION
This would be an on-demand bot to run pre-commit checks on a PR, which can be triggered by commenting

```
/pre-commit-run
```

on a pull request (see [here](https://github.com/nbQA-dev/nbQA/pull/518) for a demo).

Use case: if a PR is submitted and is good-to-go except for some linting error, we can just comment `/pre-commit-run` and have the bot fixup the errors