### PR TITLE
Update CI badge to GitHub Actions badge in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -212,8 +212,8 @@ Sponsors
 
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/pymc-devs/pymc3/master?filepath=%2Fdocs%2Fsource%2Fnotebooks
-.. |Build Status| image:: https://travis-ci.org/pymc-devs/pymc3.svg?branch=master
-   :target: https://travis-ci.org/pymc-devs/pymc3
+.. |Build Status| image:: https://github.com/pymc-devs/pymc3/workflows/pytest/badge.svg
+   :target: https://github.com/pymc-devs/pymc3/actions
 .. |Coverage| image:: https://codecov.io/gh/pymc-devs/pymc3/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/pymc-devs/pymc3
 .. |Dockerhub| image:: https://img.shields.io/docker/automated/pymc/pymc3.svg

--- a/docs/source/semantic_sphinx/layout.html
+++ b/docs/source/semantic_sphinx/layout.html
@@ -86,8 +86,8 @@ such as on Chrome for documents on localhost #}
 <div class="ui container" role="main">
     {% if pagename == 'index' %}
     <div class="ui vertical segment">
-        <a class="ui image" href="https://travis-ci.org/pymc-devs/pymc3">
-            <img src="https://travis-ci.org/pymc-devs/pymc3.svg?branch=master">
+        <a class="ui image" href="https://github.com/pymc-devs/pymc3/actions">
+            <img src="https://github.com/pymc-devs/pymc3/workflows/pytest/badge.svg">
         </a>
         <a class="ui image" href="https://coveralls.io/github/pymc-devs/pymc3?branch=master">
             <img src="https://coveralls.io/repos/github/pymc-devs/pymc3/badge.svg?branch=master">


### PR DESCRIPTION
closes #4350

This PR changes the TravisCI badge to the GitHub Actions in docs such as README & Sphinx.

This was requested in Issue #4350

Sphinx Example w/`make html` & `make build` ⬇️ 
<img width="531" alt="Sphinx build" src="https://user-images.githubusercontent.com/19514362/102683696-a59f4100-4187-11eb-8c02-b0e16922b783.png">
