### PR TITLE
Improve logsumexp to work with infinite values

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,7 +13,7 @@ This is the first release to support Python3.9 and to drop Python3.6.
 - Removed `theanof.set_theano_config` because it illegally touched Theano's privates (see [#4329](https://github.com/pymc-devs/pymc3/pull/4329)).
 - In `sample_posterior_predictive` the `vars` kwarg was removed in favor of `var_names` (see [#4343](https://github.com/pymc-devs/pymc3/pull/4343)).
 - The notebook gallery has been moved to https://github.com/pymc-devs/pymc-examples (see [#4348](https://github.com/pymc-devs/pymc3/pull/4348)).
-
+- `math.logsumexp` now matches `scipy.special.logsumexp` when arrays contain infinite values (see [#4360](https://github.com/pymc-devs/pymc3/pull/4360)).
 
 ## PyMC3 3.10.0 (7 December 2020)
 

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -175,6 +175,7 @@ def tround(*args, **kwargs):
 def logsumexp(x, axis=None, keepdims=True):
     # Adapted from https://github.com/Theano/Theano/issues/1563
     x_max = tt.max(x, axis=axis, keepdims=True)
+    x_max = tt.switch(tt.isinf(x_max), 0, x_max)
     res = tt.log(tt.sum(tt.exp(x - x_max), axis=axis, keepdims=True)) + x_max
     return res if keepdims else res.squeeze()
 

--- a/pymc3/tests/test_math.py
+++ b/pymc3/tests/test_math.py
@@ -15,9 +15,10 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
-from scipy.special import logsumexp as scipy_logsumexp
 import theano
 import theano.tensor as tt
+
+from scipy.special import logsumexp as scipy_logsumexp
 
 from pymc3.math import (
     LogDet,
@@ -31,8 +32,8 @@ from pymc3.math import (
     log1mexp_numpy,
     log1pexp,
     logdet,
-    probit,
     logsumexp,
+    probit,
 )
 from pymc3.tests.helpers import SeededTest, verify_grad
 from pymc3.theanof import floatX
@@ -226,10 +227,10 @@ def test_expand_packed_triangular():
         (np.array([[-np.inf, -np.inf], [-np.inf, -np.inf]]), 0, False),
         (np.array([[-np.inf, -np.inf], [-np.inf, -np.inf]]), 1, False),
         (np.array([[-2, np.inf], [-np.inf, -np.inf]]), 0, True),
-    ]
+    ],
 )
 def test_logsumexp(values, axis, keepdims):
     npt.assert_almost_equal(
         logsumexp(values, axis=axis, keepdims=keepdims).eval(),
-        scipy_logsumexp(values, axis=axis, keepdims=keepdims)
+        scipy_logsumexp(values, axis=axis, keepdims=keepdims),
     )


### PR DESCRIPTION
Changed `math.logsumexp` to work with infinite values, in line with how `scipy.special.logsumexp` works. 

```python
pm.math.logsumexp([-np.inf, -np.inf]).eval()   # used to return array([nan]), now returns array([-inf])
```
Added new unit tests, comparing the behavior with that of the scipy function. Except for the first two tests, all tests are failing in the current version of master, and pass after the PR.
