### PR TITLE
Pass a string to NDArray(name=...) and raise NotImplemented on named models in SMC

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,6 +36,7 @@ It also brings some dreadfully awaited fixes, so be sure to go through the chang
 - Improve numerical stability in `logp` and `logcdf` methods of `ExGaussian` (see [#4407](https://github.com/pymc-devs/pymc3/pull/4407))
 - Issue UserWarning when doing prior or posterior predictive sampling with models containing Potential factors (see [#4419](https://github.com/pymc-devs/pymc3/pull/4419))
 - Dirichlet distribution's `random` method is now optimized and gives outputs in correct shape (see [#4416](https://github.com/pymc-devs/pymc3/pull/4407))
+- Attempting to sample a named model with SMC will now raise a `NotImplementedError`. (see [#4365](https://github.com/pymc-devs/pymc3/pull/4365))
 
 ## PyMC3 3.10.0 (7 December 2020)
 

--- a/pymc3/smc/sample_smc.py
+++ b/pymc3/smc/sample_smc.py
@@ -141,6 +141,11 @@ def sample_smc(
     _log.info("Initializing SMC sampler...")
 
     model = modelcontext(model)
+    if model.name:
+        raise NotImplementedError(
+            "The SMC implementation currently does not support named models. "
+            "See https://github.com/pymc-devs/pymc3/pull/4365."
+        )
     if cores is None:
         cores = _cpu_count()
 

--- a/pymc3/smc/smc.py
+++ b/pymc3/smc/smc.py
@@ -255,7 +255,7 @@ class SMC:
         varnames = [v.name for v in self.variables]
 
         with self.model:
-            strace = NDArray(self.model)
+            strace = NDArray(self.model.name)
             strace.setup(lenght_pos, self.chain)
         for i in range(lenght_pos):
             value = []

--- a/pymc3/smc/smc.py
+++ b/pymc3/smc/smc.py
@@ -255,7 +255,7 @@ class SMC:
         varnames = [v.name for v in self.variables]
 
         with self.model:
-            strace = NDArray(self.model.name)
+            strace = NDArray(name=self.model.name)
             strace.setup(lenght_pos, self.chain)
         for i in range(lenght_pos):
             value = []


### PR DESCRIPTION
Currently, `name` is a `Model`.


**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes? → see thread & release notes
+ [x] important background, or details about the implementation → see thread
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [ ] <s>consider adding/updating relevant example notebooks</s>
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
