### PR TITLE
Add bound to HyperGeometric logp (resolves #4366)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,7 @@ It also brings some dreadfully awaited fixes, so be sure to go through the chang
 - The notebook gallery has been moved to https://github.com/pymc-devs/pymc-examples (see [#4348](https://github.com/pymc-devs/pymc3/pull/4348)).
 - `math.logsumexp` now matches `scipy.special.logsumexp` when arrays contain infinite values (see [#4360](https://github.com/pymc-devs/pymc3/pull/4360)).
 - Fixed mathematical formulation in `MvStudentT` random method. (see [#4359](https://github.com/pymc-devs/pymc3/pull/4359))
+- Fix issue in `logp` method of `HyperGeometric`. It now returns `-inf` for invalid parameters (see [4367](https://github.com/pymc-devs/pymc3/pull/4367))
 
 ## PyMC3 3.10.0 (7 December 2020)
 

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -930,8 +930,9 @@ class HyperGeometric(Discrete):
             - betaln(n - value + 1, bad - n + value + 1)
             - betaln(tot + 1, 1)
         )
-        lower = tt.max([0, n - N + k])
-        upper = tt.min([k, n])
+        # value in [max(0, n - N + k), min(k, n)]
+        lower = tt.switch(tt.gt(n - N + k, 0), n - N + k, 0)
+        upper = tt.switch(tt.lt(k, n), k, n)
         return bound(result, lower <= value, value <= upper)
 
 

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -930,7 +930,9 @@ class HyperGeometric(Discrete):
             - betaln(n - value + 1, bad - n + value + 1)
             - betaln(tot + 1, 1)
         )
-        return result
+        lower = tt.max([0, n - N + k])
+        upper = tt.min([k, n])
+        return bound(result, lower <= value, value <= upper)
 
 
 class DiscreteUniform(Discrete):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -805,11 +805,15 @@ class TestMatchesScipy(SeededTest):
         )
 
     def test_hypergeometric(self):
+        def modified_scipy_hypergeom_logpmf(value, N, k, n):
+            original_res = sp.hypergeom.logpmf(value, N, k, n)
+            return original_res if not np.isnan(original_res) else -np.inf
+
         self.pymc3_matches_scipy(
             HyperGeometric,
             Nat,
             {"N": NatSmall, "k": NatSmall, "n": NatSmall},
-            lambda value, N, k, n: sp.hypergeom.logpmf(value, N, k, n),
+            lambda value, N, k, n: modified_scipy_hypergeom_logpmf(value, N, k, n),
         )
 
     def test_negative_binomial(self):


### PR DESCRIPTION
This PR adds a bound to the `HyperGeometric logp`, in order to return `-inf` when given invalid parameters, instead of `nan` or sometimes wrong results (see #4366).

I am using the bounds suggested by @tirthasheshpatel in [here](https://github.com/pymc-devs/pymc3/pull/4108#discussion_r509542356), which seem to be the support bounds described in the [Wikipedia entry](https://en.wikipedia.org/wiki/Hypergeometric_distribution). ~~I am not sure whether the current `tt.max` and `tt.min` has any disadvantages compared to the `tt.switch` that was suggsted before.~~ It seems `tt.switch` deals better with weird parameter shapes...

To pass the unit tests, it was necessary to replace the `nan` output of the scipy.hypergeom to `-inf`. I decided to simply wrap the original scipy function in the helper `modified_scipy_hypergeom_logpmf` function.