### PR TITLE
[Proposal] Track Submodule pymc-examples Git Fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docs/source/pymc-examples"]
 	path = docs/source/pymc-examples
-	url = git@github.com:pymc-devs/pymc-examples.git
+	url = https://github.com/pymc-devs/pymc-examples.git
         branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "docs/source/pymc-examples"]
 	path = docs/source/pymc-examples
 	url = git@github.com:pymc-devs/pymc-examples.git
+        branch = main

--- a/build_and_deploy_docs.sh
+++ b/build_and_deploy_docs.sh
@@ -3,7 +3,7 @@
 latesttag=$(git describe --tags `git rev-list --tags --max-count=1`)
 echo checking out ${latesttag}
 git checkout ${latesttag}
-git submodule update --init --recursive
+git submodule update --remote
 pushd docs/source
 make html
 ghp-import -c docs.pymc.io -n -p _build/html/


### PR DESCRIPTION
# Overview
Proposed 🤞  fix to track submodule [pymc-examples](https://github.com/pymc-devs/pymc-examples/tree/729eb084116fad9e9b9df52eca76728f80a5c023) to the main branch. 
* Configure .gitmodules to specify branch for submodule

(potentially) closes #4357

However, there are some notes... ⬇️ 

## Notes
* I was not able to locally update (from the command below) due to permission issues. 
`git submodule update --remote`

You can see this error to align commit to `main` branch here
<img width="564" alt="Screen Shot 2020-12-23 at 2 36 38 AM" src="https://user-images.githubusercontent.com/19514362/102987871-e7055880-44c7-11eb-854d-e96629a13e2c.png">


