### PR TITLE
Fix pymc3 to work with latest theano-pymc master

### DIFF
--- a/pymc3/sampling_jax.py
+++ b/pymc3/sampling_jax.py
@@ -12,8 +12,8 @@ import jax
 import numpy as np
 import pandas as pd
 import theano
-import theano.sandbox.jax_linker
-import theano.sandbox.jaxify
+
+from theano.link.jax.jax_dispatch import jax_funcify
 
 import pymc3 as pm
 
@@ -46,7 +46,7 @@ def sample_tfp_nuts(
     seed = jax.random.PRNGKey(random_seed)
 
     fgraph = theano.gof.FunctionGraph(model.free_RVs, [model.logpt])
-    fns = theano.sandbox.jaxify.jax_funcify(fgraph)
+    fns = jax_funcify(fgraph)
     logp_fn_jax = fns[0]
 
     rv_names = [rv.name for rv in model.free_RVs]
@@ -131,7 +131,7 @@ def sample_numpyro_nuts(
     seed = jax.random.PRNGKey(random_seed)
 
     fgraph = theano.gof.FunctionGraph(model.free_RVs, [model.logpt])
-    fns = theano.sandbox.jaxify.jax_funcify(fgraph)
+    fns = jax_funcify(fgraph)
     logp_fn_jax = fns[0]
 
     rv_names = [rv.name for rv in model.free_RVs]

--- a/pymc3/tests/helpers.py
+++ b/pymc3/tests/helpers.py
@@ -20,7 +20,7 @@ import numpy.random as nr
 import theano
 
 from theano.gradient import verify_grad as tt_verify_grad
-from theano.sandbox.rng_mrg import MRG_RandomStreams
+from theano.sandbox.rng_mrg import MRG_RandomStream as RandomStream
 
 from pymc3.theanof import set_tt_rng, tt_rng
 
@@ -35,7 +35,7 @@ class SeededTest:
     def setup_method(self):
         nr.seed(self.random_seed)
         self.old_tt_rng = tt_rng()
-        set_tt_rng(MRG_RandomStreams(self.random_seed))
+        set_tt_rng(RandomStream(self.random_seed))
 
     def teardown_method(self):
         set_tt_rng(self.old_tt_rng)

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -19,7 +19,7 @@ from theano import change_flags, scalar
 from theano import tensor as tt
 from theano.gof import Op
 from theano.gof.graph import inputs
-from theano.sandbox.rng_mrg import MRG_RandomStreams
+from theano.sandbox.rng_mrg import MRG_RandomStream as RandomStream
 
 from pymc3.blocking import ArrayOrdering
 from pymc3.data import GeneratorAdapter
@@ -394,7 +394,7 @@ def generator(gen, default=None):
     return GeneratorOp(gen, default)()
 
 
-_tt_rng = MRG_RandomStreams()
+_tt_rng = RandomStream()
 
 
 def tt_rng(random_seed=None):
@@ -409,14 +409,14 @@ def tt_rng(random_seed=None):
 
     Returns
     -------
-    `theano.sandbox.rng_mrg.MRG_RandomStreams` instance
-        `theano.sandbox.rng_mrg.MRG_RandomStreams`
+    `theano.tensor.random.utils.RandomStream` instance
+        `theano.tensor.random.utils.RandomStream`
         instance passed to the most recent call of `set_tt_rng`
     """
     if random_seed is None:
         return _tt_rng
     else:
-        ret = MRG_RandomStreams(random_seed)
+        ret = RandomStream(random_seed)
         return ret
 
 
@@ -426,14 +426,14 @@ def set_tt_rng(new_rng):
 
     Parameters
     ----------
-    new_rng: `theano.sandbox.rng_mrg.MRG_RandomStreams` instance
+    new_rng: `theano.tensor.random.utils.RandomStream` instance
         The random number generator to use.
     """
     # pylint: disable=global-statement
     global _tt_rng
     # pylint: enable=global-statement
     if isinstance(new_rng, int):
-        new_rng = MRG_RandomStreams(new_rng)
+        new_rng = RandomStream(new_rng)
     _tt_rng = new_rng
 
 

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -1078,9 +1078,9 @@ class Group(WithMemoization):
             if deterministic:
                 return tt.ones(shape, dtype) * dist_map
             else:
-                return getattr(self._rng, dist_name)(shape)
+                return getattr(self._rng, dist_name)(size=shape)
         else:
-            sample = getattr(self._rng, dist_name)(shape)
+            sample = getattr(self._rng, dist_name)(size=shape)
             initial = tt.switch(deterministic, tt.ones(shape, dtype) * dist_map, sample)
             return initial
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ numpy>=1.13.0
 pandas>=0.18.0
 patsy>=0.5.1
 scipy>=0.18.1
-theano-pymc==1.0.12
+theano-pymc==1.0.14
 typing-extensions>=3.7.4


### PR DESCRIPTION
The current pymc master branch is pinned to the latest theano release, but there have been some breaking changes since that release (e.g., Random and jax_dispatch changes).  This PR fixes these compatibility issues.  Note this is not expected to pass initially until we sort out the version bump for theano.