### PR TITLE
Implement logcdf method for discrete distributions

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@ It also brings some dreadfully awaited fixes, so be sure to go through the chang
 - Option to set `check_bounds=False` when instantiating `pymc3.Model()`. This turns off bounds checks that ensure that input parameters of distributions are valid. For correctly specified models, this is unneccessary as all parameters get automatically transformed so that all values are valid. Turning this off should lead to faster sampling (see [#4377](https://github.com/pymc-devs/pymc3/pull/4377)).
 - `OrderedProbit` distribution added (see [#4232](https://github.com/pymc-devs/pymc3/pull/4232)).
 - `plot_posterior_predictive_glm` now works with `arviz.InferenceData` as well (see [#4234](https://github.com/pymc-devs/pymc3/pull/4234))
+- Add `logcdf` method to all univariate discrete distributions (see [#4387](https://github.com/pymc-devs/pymc3/pull/4387)).
 
 ### Maintenance
 - Fixed bug whereby partial traces returns after keyboard interrupt during parallel sampling had fewer draws than would've been available [#4318](https://github.com/pymc-devs/pymc3/pull/4318)

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -332,7 +332,9 @@ class BetaBinomial(Discrete):
             tt.lt(value, 0),
             -np.inf,
             tt.switch(
-                tt.lt(value, n), logsumexp(self.logp(tt.arange(0, value + 1)), keepdims=False), 0
+                tt.lt(value, n),
+                logsumexp(self.logp(tt.arange(0, value + 1)), keepdims=False),
+                0,
             ),
         )
 

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -1254,10 +1254,10 @@ class DiscreteUniform(Discrete):
         upper = self.upper
         lower = self.lower
 
-        return tt.switch(
-            tt.lt(upper, lower),
-            -np.inf,
+        return bound(
             tt.log(tt.minimum(tt.floor(value), upper) - lower + 1) - tt.log(upper - lower + 1),
+            lower <= value,
+            lower <= upper,
         )
 
 

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -614,7 +614,7 @@ class DiscreteWeibull(Discrete):
         beta = self.beta
 
         return bound(
-            tt.log(1 - tt.power(q, tt.power(value + 1, beta))),
+            tt.log1p(-tt.power(q, tt.power(value + 1, beta))),
             0 <= value,
             0 < q,
             q < 1,
@@ -727,7 +727,7 @@ class Poisson(Discrete):
         """
         mu = self.mu
         value = tt.floor(value)
-        # To avoid issue with #4340
+        # To avoid gammaincc C-assertion when given invalid values (#4340)
         safe_mu = tt.switch(tt.lt(mu, 0), 0, mu)
         safe_value = tt.switch(tt.lt(value, 0), 0, value)
 
@@ -1612,7 +1612,7 @@ class ZeroInflatedPoisson(Discrete):
         psi = self.psi
 
         return bound(
-            tt.log(1 - psi + psi * tt.exp(self.pois.logcdf(value))),
+            logaddexp(tt.log1p(-psi), tt.log(psi) + self.pois.logcdf(value)),
             0 <= value,
             0 <= psi,
             psi <= 1,
@@ -1751,7 +1751,7 @@ class ZeroInflatedBinomial(Discrete):
         psi = self.psi
 
         return bound(
-            tt.log(1 - psi + psi * tt.exp(self.bin.logcdf(value))),
+            logaddexp(tt.log1p(-psi), tt.log(psi) + self.bin.logcdf(value)),
             0 <= value,
             0 <= psi,
             psi <= 1,
@@ -1920,7 +1920,7 @@ class ZeroInflatedNegativeBinomial(Discrete):
         psi = self.psi
 
         return bound(
-            tt.log(1 - psi + psi * tt.exp(self.nb.logcdf(value))),
+            logaddexp(tt.log1p(-psi), tt.log(psi) + self.nb.logcdf(value)),
             0 <= value,
             0 <= psi,
             psi <= 1,

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -163,7 +163,14 @@ class Binomial(Discrete):
         -------
         TensorVariable
         """
-        # TODO: work with multiple values (see #4342)
+        # incomplete_beta function can only handle scalar values (see #4342)
+        if np.ndim(value):
+            raise TypeError(
+                "Binomial.logcdf expects a scalar value but received a {}-dimensional object.".format(
+                    np.ndim(value)
+                )
+            )
+
         n = self.n
         p = self.p
         value = tt.floor(value)
@@ -326,7 +333,14 @@ class BetaBinomial(Discrete):
         -------
         TensorVariable
         """
-        # TODO: fix for multiple values
+        # logcdf can only handle scalar values at the moment
+        if np.ndim(value):
+            raise TypeError(
+                "BetaBinomial.logcdf expects a scalar value but received a {}-dimensional object.".format(
+                    np.ndim(value)
+                )
+            )
+
         alpha = self.alpha
         beta = self.beta
         n = self.n
@@ -446,11 +460,13 @@ class Bernoulli(Discrete):
         """
         Compute the log of the cumulative distribution function for Bernoulli distribution
         at the specified value.
+
         Parameters
         ----------
         value: numeric
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
+
         Returns
         -------
         TensorVariable
@@ -583,11 +599,13 @@ class DiscreteWeibull(Discrete):
         """
         Compute the log of the cumulative distribution function for Discrete Weibull distribution
         at the specified value.
+
         Parameters
         ----------
         value: numeric
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
+
         Returns
         -------
         TensorVariable
@@ -696,11 +714,13 @@ class Poisson(Discrete):
         """
         Compute the log of the cumulative distribution function for Poisson distribution
         at the specified value.
+
         Parameters
         ----------
         value: numeric
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
+
         Returns
         -------
         TensorVariable
@@ -887,7 +907,14 @@ class NegativeBinomial(Discrete):
         -------
         TensorVariable
         """
-        # TODO: work with multiple values (see #4342)
+        # incomplete_beta function can only handle scalar values (see #4342)
+        if np.ndim(value):
+            raise TypeError(
+                "NegativeBinomial.logcdf expects a scalar value but received a {}-dimensional object.".format(
+                    np.ndim(value)
+                )
+            )
+
         # TODO: avoid `p` recomputation if distribution was defined in terms of `p`
         alpha = self.alpha
         p = alpha / (self.mu + alpha)
@@ -987,11 +1014,13 @@ class Geometric(Discrete):
         """
         Compute the log of the cumulative distribution function for Geometric distribution
         at the specified value.
+
         Parameters
         ----------
         value: numeric
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
+
         Returns
         -------
         TensorVariable
@@ -1124,15 +1153,24 @@ class HyperGeometric(Discrete):
         """
         Compute the log of the cumulative distribution function for HyperGeometric distribution
         at the specified value.
+
         Parameters
         ----------
         value: numeric
             Value for which log CDF is calculated.
+
         Returns
         -------
         TensorVariable
         """
-        # TODO: fix for multiple values
+        # logcdf can only handle scalar values at the moment
+        if np.ndim(value):
+            raise TypeError(
+                "BetaBinomial.logcdf expects a scalar value but received a {}-dimensional object.".format(
+                    np.ndim(value)
+                )
+            )
+
         # TODO: Use lower upper in locgdf for smarter logsumexp?
         N = self.N
         n = self.n
@@ -1247,11 +1285,13 @@ class DiscreteUniform(Discrete):
         """
         Compute the log of the cumulative distribution function for Discrete uniform distribution
         at the specified value.
+
         Parameters
         ----------
         value: numeric
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
+
         Returns
         -------
         TensorVariable
@@ -1558,11 +1598,13 @@ class ZeroInflatedPoisson(Discrete):
         """
         Compute the log of the cumulative distribution function for ZeroInflatedPoisson distribution
         at the specified value.
+
         Parameters
         ----------
         value: numeric
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
+
         Returns
         -------
         TensorVariable
@@ -1698,7 +1740,14 @@ class ZeroInflatedBinomial(Discrete):
         -------
         TensorVariable
         """
-        # TODO: work with multiple values (see #4342)
+        # logcdf can only handle scalar values due to limitation in Binomial.logcdf
+        if np.ndim(value):
+            raise TypeError(
+                "ZeroInflatedBinomial.logcdf expects a scalar value but received a {}-dimensional object.".format(
+                    np.ndim(value)
+                )
+            )
+
         psi = self.psi
 
         return bound(
@@ -1861,7 +1910,13 @@ class ZeroInflatedNegativeBinomial(Discrete):
         -------
         TensorVariable
         """
-        # TODO: work with multiple values (see #4342)
+        # logcdf can only handle scalar values due to limitation in NegativeBinomial.logcdf
+        if np.ndim(value):
+            raise TypeError(
+                "ZeroInflatedNegativeBinomial.logcdf expects a scalar value but received a {}-dimensional object.".format(
+                    np.ndim(value)
+                )
+            )
         psi = self.psi
 
         return bound(

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -330,11 +330,12 @@ class BetaBinomial(Discrete):
         alpha = self.alpha
         beta = self.beta
         n = self.n
+        safe_lower = tt.switch(tt.lt(value, 0), value, 0)
 
         return bound(
             tt.switch(
                 tt.lt(value, n),
-                logsumexp(self.logp(tt.arange(0, value + 1)), keepdims=False),
+                logsumexp(self.logp(tt.arange(safe_lower, value + 1)), keepdims=False),
                 0,
             ),
             0 <= value,
@@ -706,9 +707,12 @@ class Poisson(Discrete):
         """
         mu = self.mu
         value = tt.floor(value)
+        # To avoid issue with #4340
+        safe_mu = tt.switch(tt.lt(mu, 0), 0, mu)
+        safe_value = tt.switch(tt.lt(value, 0), 0, value)
 
         return bound(
-            tt.log(tt.gammaincc(value + 1, mu)),
+            tt.log(tt.gammaincc(safe_value + 1, safe_mu)),
             0 <= value,
             0 <= mu,
         )
@@ -1133,11 +1137,12 @@ class HyperGeometric(Discrete):
         N = self.N
         n = self.n
         k = self.k
+        safe_lower = tt.switch(tt.lt(value, 0), value, 0)
 
         return bound(
             tt.switch(
                 tt.lt(value, n),
-                logsumexp(self.logp(tt.arange(0, value + 1)), keepdims=False),
+                logsumexp(self.logp(tt.arange(safe_lower, value + 1)), keepdims=False),
                 0,
             ),
             0 <= value,

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -91,7 +91,7 @@ from pymc3.distributions import (
     ZeroInflatedPoisson,
     continuous,
 )
-from pymc3.math import kronecker
+from pymc3.math import kronecker, logsumexp
 from pymc3.model import Deterministic, Model, Point
 from pymc3.tests.helpers import SeededTest, select_by_precision
 from pymc3.theanof import floatX
@@ -575,6 +575,28 @@ class TestMatchesScipy(SeededTest):
                 err_msg=str(pt),
             )
 
+    def check_selfconsistency_discrete_logcdf(
+        self, distribution, domain, paramdomains, decimal=None, n_samples=100
+    ):
+        """
+        Check that logcdf of discrete distributions matches sum of logps up to value
+        """
+        domains = paramdomains.copy()
+        domains["value"] = domain
+        if decimal is None:
+            decimal = select_by_precision(float64=6, float32=3)
+        for pt in product(domains, n_samples=n_samples):
+            params = dict(pt)
+            value = params.pop("value")
+            values = np.arange(0, value + 1)
+            dist = distribution.dist(**params)
+            assert_almost_equal(
+                dist.logcdf(value).tag.test_value,
+                logsumexp(dist.logp(values), keepdims=False).tag.test_value,
+                decimal=decimal,
+                err_msg=str(pt),
+            )
+
     def check_int_to_1(self, model, value, domain, paramdomains):
         pdf = model.fastfn(exp(model.logpt))
         for pt in product(paramdomains, n_samples=10):
@@ -641,6 +663,18 @@ class TestMatchesScipy(SeededTest):
             Rdunif,
             {"lower": -Rplusdunif, "upper": Rplusdunif},
             lambda value, lower, upper: sp.randint.logpmf(value, lower, upper + 1),
+        )
+        self.check_logcdf(
+            DiscreteUniform,
+            Rdunif,
+            {"lower": -Rplusdunif, "upper": Rplusdunif},
+            lambda value, lower, upper: sp.randint.logcdf(value, lower, upper + 1),
+        )
+        self.check_selfconsistency_discrete_logcdf(
+            DiscreteUniform,
+            Rdunif,
+            # Using lower = Bool, as this unittest assumes the distribution domain starts at zero.
+            {"lower": Bool, "upper": Rplusdunif},
         )
 
     def test_flat(self):
@@ -801,31 +835,94 @@ class TestMatchesScipy(SeededTest):
 
     def test_geometric(self):
         self.pymc3_matches_scipy(
-            Geometric, Nat, {"p": Unit}, lambda value, p: np.log(sp.geom.pmf(value, p))
+            Geometric,
+            Nat,
+            {"p": Unit},
+            lambda value, p: np.log(sp.geom.pmf(value, p)),
+        )
+        self.check_logcdf(
+            Geometric,
+            Nat,
+            {"p": Unit},
+            lambda value, p: sp.geom.logcdf(value, p),
+        )
+        self.check_selfconsistency_discrete_logcdf(
+            Geometric,
+            Nat,
+            {"p": Unit},
         )
 
     def test_hypergeometric(self):
         def modified_scipy_hypergeom_logpmf(value, N, k, n):
+            # Convert nan to -np.inf
             original_res = sp.hypergeom.logpmf(value, N, k, n)
+            return original_res if not np.isnan(original_res) else -np.inf
+
+        def modified_scipy_hypergeom_logcdf(value, N, k, n):
+            # Convert nan to -np.inf
+            original_res = sp.hypergeom.logcdf(value, N, k, n)
+
+            # Correct for scipy bug in logcdf method (see https://github.com/scipy/scipy/issues/13280)
+            if not np.isnan(original_res):
+                pmfs = sp.hypergeom.logpmf(np.arange(value + 1), N, k, n)
+                if np.all(np.isnan(pmfs)):
+                    original_res = np.nan
+
             return original_res if not np.isnan(original_res) else -np.inf
 
         self.pymc3_matches_scipy(
             HyperGeometric,
             Nat,
             {"N": NatSmall, "k": NatSmall, "n": NatSmall},
-            lambda value, N, k, n: modified_scipy_hypergeom_logpmf(value, N, k, n),
+            modified_scipy_hypergeom_logpmf,
+        )
+        self.check_logcdf(
+            HyperGeometric,
+            Nat,
+            {"N": NatSmall, "k": NatSmall, "n": NatSmall},
+            modified_scipy_hypergeom_logcdf,
+        )
+        self.check_selfconsistency_discrete_logcdf(
+            HyperGeometric,
+            Nat,
+            {"N": NatSmall, "k": NatSmall, "n": NatSmall},
         )
 
     def test_negative_binomial(self):
-        def test_fun(value, mu, alpha):
+        def scipy_mu_alpha_logpmf(value, mu, alpha):
             return sp.nbinom.logpmf(value, alpha, 1 - mu / (mu + alpha))
 
-        self.pymc3_matches_scipy(NegativeBinomial, Nat, {"mu": Rplus, "alpha": Rplus}, test_fun)
+        def scipy_mu_alpha_logcdf(value, mu, alpha):
+            return sp.nbinom.logcdf(value, alpha, 1 - mu / (mu + alpha))
+
+        self.pymc3_matches_scipy(
+            NegativeBinomial,
+            Nat,
+            {"mu": Rplus, "alpha": Rplus},
+            scipy_mu_alpha_logpmf,
+        )
         self.pymc3_matches_scipy(
             NegativeBinomial,
             Nat,
             {"p": Unit, "n": Rplus},
             lambda value, p, n: sp.nbinom.logpmf(value, n, p),
+        )
+        self.check_logcdf(
+            NegativeBinomial,
+            Nat,
+            {"mu": Rplus, "alpha": Rplus},
+            scipy_mu_alpha_logcdf,
+        )
+        self.check_logcdf(
+            NegativeBinomial,
+            Nat,
+            {"p": Unit, "n": Rplus},
+            lambda value, p, n: sp.nbinom.logcdf(value, n, p),
+        )
+        self.check_selfconsistency_discrete_logcdf(
+            NegativeBinomial,
+            Nat,
+            {"mu": Rplus, "alpha": Rplus},
         )
 
     @pytest.mark.parametrize(
@@ -1024,11 +1121,43 @@ class TestMatchesScipy(SeededTest):
             {"n": NatSmall, "p": Unit},
             lambda value, n, p: sp.binom.logpmf(value, n, p),
         )
+        self.check_logcdf(
+            Binomial,
+            Nat,
+            {"n": NatSmall, "p": Unit},
+            lambda value, n, p: sp.binom.logcdf(value, n, p),
+        )
+        self.check_selfconsistency_discrete_logcdf(
+            Binomial,
+            Nat,
+            {"n": NatSmall, "p": Unit},
+        )
 
     # Too lazy to propagate decimal parameter through the whole chain of deps
     @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
     def test_beta_binomial(self):
-        self.checkd(BetaBinomial, Nat, {"alpha": Rplus, "beta": Rplus, "n": NatSmall})
+        self.checkd(
+            BetaBinomial,
+            Nat,
+            {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
+        )
+        self.pymc3_matches_scipy(
+            BetaBinomial,
+            Nat,
+            {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
+            lambda value, alpha, beta, n: sp.betabinom.logpmf(value, a=alpha, b=beta, n=n),
+        )
+        self.check_logcdf(
+            BetaBinomial,
+            Nat,
+            {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
+            lambda value, alpha, beta, n: sp.betabinom.logcdf(value, a=alpha, b=beta, n=n),
+        )
+        self.check_selfconsistency_discrete_logcdf(
+            BetaBinomial,
+            Nat,
+            {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
+        )
 
     def test_bernoulli(self):
         self.pymc3_matches_scipy(
@@ -1038,7 +1167,27 @@ class TestMatchesScipy(SeededTest):
             lambda value, logit_p: sp.bernoulli.logpmf(value, scipy.special.expit(logit_p)),
         )
         self.pymc3_matches_scipy(
-            Bernoulli, Bool, {"p": Unit}, lambda value, p: sp.bernoulli.logpmf(value, p)
+            Bernoulli,
+            Bool,
+            {"p": Unit},
+            lambda value, p: sp.bernoulli.logpmf(value, p),
+        )
+        self.check_logcdf(
+            Bernoulli,
+            Bool,
+            {"p": Unit},
+            lambda value, p: sp.bernoulli.logcdf(value, p),
+        )
+        self.check_logcdf(
+            Bernoulli,
+            Bool,
+            {"logit_p": R},
+            lambda value, logit_p: sp.bernoulli.logcdf(value, scipy.special.expit(logit_p)),
+        )
+        self.check_selfconsistency_discrete_logcdf(
+            Bernoulli,
+            Bool,
+            {"p": Unit},
         )
 
     def test_discrete_weibull(self):
@@ -1048,10 +1197,29 @@ class TestMatchesScipy(SeededTest):
             {"q": Unit, "beta": Rplusdunif},
             discrete_weibull_logpmf,
         )
+        self.check_selfconsistency_discrete_logcdf(
+            DiscreteWeibull,
+            Nat,
+            {"q": Unit, "beta": Rplusdunif},
+        )
 
     def test_poisson(self):
         self.pymc3_matches_scipy(
-            Poisson, Nat, {"mu": Rplus}, lambda value, mu: sp.poisson.logpmf(value, mu)
+            Poisson,
+            Nat,
+            {"mu": Rplus},
+            lambda value, mu: sp.poisson.logpmf(value, mu),
+        )
+        self.check_logcdf(
+            Poisson,
+            Nat,
+            {"mu": Rplus},
+            lambda value, mu: sp.poisson.logcdf(value, mu),
+        )
+        self.check_selfconsistency_discrete_logcdf(
+            Poisson,
+            Nat,
+            {"mu": Rplus},
         )
 
     def test_bound_poisson(self):
@@ -1073,7 +1241,16 @@ class TestMatchesScipy(SeededTest):
     # Too lazy to propagate decimal parameter through the whole chain of deps
     @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
     def test_zeroinflatedpoisson(self):
-        self.checkd(ZeroInflatedPoisson, Nat, {"theta": Rplus, "psi": Unit})
+        self.checkd(
+            ZeroInflatedPoisson,
+            Nat,
+            {"theta": Rplus, "psi": Unit},
+        )
+        self.check_selfconsistency_discrete_logcdf(
+            ZeroInflatedPoisson,
+            Nat,
+            {"theta": Rplus, "psi": Unit},
+        )
 
     # Too lazy to propagate decimal parameter through the whole chain of deps
     @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
@@ -1083,11 +1260,25 @@ class TestMatchesScipy(SeededTest):
             Nat,
             {"mu": Rplusbig, "alpha": Rplusbig, "psi": Unit},
         )
+        self.check_selfconsistency_discrete_logcdf(
+            ZeroInflatedNegativeBinomial,
+            Nat,
+            {"mu": Rplusbig, "alpha": Rplusbig, "psi": Unit},
+        )
 
     # Too lazy to propagate decimal parameter through the whole chain of deps
     @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
     def test_zeroinflatedbinomial(self):
-        self.checkd(ZeroInflatedBinomial, Nat, {"n": NatSmall, "p": Unit, "psi": Unit})
+        self.checkd(
+            ZeroInflatedBinomial,
+            Nat,
+            {"n": NatSmall, "p": Unit, "psi": Unit},
+        )
+        self.check_selfconsistency_discrete_logcdf(
+            ZeroInflatedBinomial,
+            Nat,
+            {"n": NatSmall, "p": Unit, "psi": Unit},
+        )
 
     @pytest.mark.parametrize("n", [1, 2, 3])
     def test_mvnormal(self, n):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -588,7 +588,7 @@ class TestMatchesScipy(SeededTest):
         for pt in product(domains, n_samples=n_samples):
             params = dict(pt)
             value = params.pop("value")
-            values = np.arange(0, value + 1)
+            values = np.arange(domain.lower, value + 1)
             dist = distribution.dist(**params)
             assert_almost_equal(
                 dist.logcdf(value).tag.test_value,
@@ -673,8 +673,7 @@ class TestMatchesScipy(SeededTest):
         self.check_selfconsistency_discrete_logcdf(
             DiscreteUniform,
             Rdunif,
-            # Using lower = Bool, as this unittest assumes the distribution domain starts at zero.
-            {"lower": Bool, "upper": Rplusdunif},
+            {"lower": -Rplusdunif, "upper": Rplusdunif},
         )
 
     def test_flat(self):


### PR DESCRIPTION
This PR adds `logcdf` methods to all univariate discrete distributions. Formulas were based in either scipy or wikipedia entries. For some distributions, I could not find specialized formulas and had to rely on summing up all the logps in `tt.arange(0, value+1)`.

Closes #4331

Unittests:
1. Using `check_logcdf` in all distributions with scipy counterpart.
2. Added a new type of unit test `check_selfconsistency_discrete_logcdf`, which tests that the logcdf is equivalent to adding all the logps starting from ~~zero~~ `domain.lower`. This provides coverage to the distributions that are not in scipy (not covered by 1.). I added it to all distributions, but maybe this is too redundant for those that are covered by 1. 

Some remaining issues / questions:
1. Should all `bound` calls in CDF methdos be replaced by `tt.switch`? Most `logcdf` methods for continous distributions seem to use `tt.switch`, except for the `Gamma` and `InverseGamma` distributions. I used `bound` whenever there were at least two conditions that needed checking leading no `-np.inf`, otherwise went with `tt.switch`. I am also not completely sure if this interferes with the recent #4377 PR.
2. Several `logcdf` methods do not work with multiple values (or even with an array containing a single value such as `np.array([1])`). In these cases, I excluded information in the docstrings about the possibility of computing the `logcdf` for multiple values, but this seems like a suboptimal solution. We should either fix it or raise a ValueError to explain the limitation to the user, as this seems to go against the expected behavior in most distributions. This occurs for two reasons:
   1. Computing logcdf by summing over the individual logps with `logsumexp(tt.arange(0, value+1), keepdims=False)` for the `BetaBinomial` and `HyperGeometric`. Any alternatives?
   2. Using the `incomplete_beta` function in the `Binomial` and `NegativeBinomial` (and `ZeroInflated` counterparts). This is also an issue in the current implementation of the `Beta` and `StudentT` distributions (see #4342). In addition, the unit tests for these functions seem to be very slow compared to those of other distributions. Is the `incomplete_beta` particularly slow?
3. Slightly different, the `logcdf` method of the `Poisson` distribution (and its `ZeroInflated` counterpart) fails with a C-assertion (exiting the python process altogether) when asked to evaluate multiple invalid values. This is also a problem in the `InverseGamma` distribution (see #4340). It will be solved once this Theano issue is fixed (see https://github.com/pymc-devs/Theano-PyMC/issues/224). **Update: I have found a temporary hack to "hide" this problem (which can be removed once those other issues are solved).**
4. Unittests: `check_logcdf` tests only for values in the output domain, ignoring the edge values, but we might want to test also for values at the edges as well as below or beyond the domain (which can be evaluated to either -np.inf or 0). For example `pm.Bernoulli(p=.1).logcdf([-1, 2]) -> [-np.inf, 0]`. Should we use more comprehensive extra-domain checks? **Update: This is now implemented in #4393.**

Other changes not directly related to this PR:
1. Added a missing `pymc3_matches_scipy` test to the `BetaBinomial`. Was there a reason why this was missing? 
2. Changed the order of the `logp` and `random` methods in the `DiscreteWeibull` distribution to be in line with the rest of the library.
3. Removed unused local variables in the init methods of `DiscreteWeibull` and `ZeroInflatedPoisson` distributions.
