### PR TITLE
Update legibility of formula to proper Latex Format

### DIFF
--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -145,9 +145,7 @@ follows a Gaussian distribution, and
 density function <https://en.wikipedia.org/wiki/Probability_density_function>`__ that takes input :math:`x`
 
 .. math::
-    X:=f(x) = \frac{1}{\sigma \sqrt{(2 * \pi)}} * \exp^{- 0.5 * (\frac{x - \mu}{\sigma})^2} = \frac{1}{\sqrt{(2 * \pi)}} * \exp^{- 0.5 * x^2},
-    
-    \text{where }\mu = 0, \sigma = 1.
+    X:=f(x) = \frac{1}{\sigma \sqrt{(2 \pi)}} * \exp^{- 0.5 * (\frac{x - \mu}{\sigma})^2} = \frac{1}{\sqrt{(2 \pi)}} * \exp^{- 0.5 * x^2}\vert_{\mu = 0, \sigma=1}
 
 Within a model context, RVs are essentially Theano tensors (more on that
 below). This is different than TFP and pyro, where you need to be more

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -134,7 +134,7 @@ below), and x.dist() as the associated density/mass function
 (distribution in the mathematical sense). It is not perfect, and now
 after a few years learning Bayesian statistics I also realized these
 subtleties (i.e., the distinction between *random variable* and
-*distribution*). 
+*distribution*).
 
 But when I was learning probabilistic modelling as a
 beginner, I did find this approach to be the easiest and most
@@ -145,7 +145,7 @@ follows a Gaussian distribution, and
 density function <https://en.wikipedia.org/wiki/Probability_density_function>`__ that takes input :math:`x`
 
 .. math::
-    X:=f(x) = \frac{1}{\sigma \sqrt{(2 \pi)}} * \exp^{- 0.5 * (\frac{x - \mu}{\sigma})^2} = \frac{1}{\sqrt{(2 \pi)}} * \exp^{- 0.5 * x^2}\vert_{\mu = 0, \sigma=1}
+    X:=f(x) = \frac{1}{\sigma \sqrt{2 \pi}} \exp^{- 0.5 (\frac{x - \mu}{\sigma})^2}\vert_{\mu = 0, \sigma=1} = \frac{1}{\sqrt{2 \pi}} \exp^{- 0.5 x^2}
 
 Within a model context, RVs are essentially Theano tensors (more on that
 below). This is different than TFP and pyro, where you need to be more

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -134,16 +134,20 @@ below), and x.dist() as the associated density/mass function
 (distribution in the mathematical sense). It is not perfect, and now
 after a few years learning Bayesian statistics I also realized these
 subtleties (i.e., the distinction between *random variable* and
-*distribution*). But when I was learning probabilistic modelling as a
+*distribution*). 
+
+But when I was learning probabilistic modelling as a
 beginner, I did find this approach to be the easiest and most
 straightforward. In a perfect world, we should have
 :math:`x \sim \text{Normal}(0, 1)` which defines a random variable that
 follows a Gaussian distribution, and
-:math:`\chi = \text{Normal}(0, 1), x \sim \chi` which define a scalar
-density function that takes input :math:`x`
+:math:`\chi = \text{Normal}(0, 1), x \sim \chi` which define a `probability
+density function <https://en.wikipedia.org/wiki/Probability_density_function>`__ that takes input :math:`x`
 
 .. math::
-    (``X:=f(x) = 1/sqrt(2*pi) * exp(-.5*x**2)``)
+    X:=f(x) = \frac{1}{\sigma \sqrt{(2 * \pi)}} * \exp^{- 0.5 * (\frac{x - \mu}{\sigma})^2} = \frac{1}{\sqrt{(2 * \pi)}} * \exp^{- 0.5 * x^2},
+    
+    \text{where }\mu = 0, \sigma = 1.
 
 Within a model context, RVs are essentially Theano tensors (more on that
 below). This is different than TFP and pyro, where you need to be more


### PR DESCRIPTION
# Description

* Update Normal Distribution's PDF formula in the [Developer Guide](https://docs.pymc.io/developer_guide.html#reflection) section to proper latex format
* Add wiki hyperlink to PDF definition

Note: Added mid-step just to clarify why the PDF is resulted, as such.

Closes #4384

## Output

From 

```
cd docs/source
make html
make serve
```

We get
<img width="1174" alt="Example" src="https://user-images.githubusercontent.com/19514362/103210181-cff4ab00-48b9-11eb-8349-d4e27611ceae.png">
