### PR TITLE
Increase unittest `check_logcdf` coverage and fix issues with some distribution methods

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -29,6 +29,7 @@ It also brings some dreadfully awaited fixes, so be sure to go through the chang
 - Fixed mathematical formulation in `MvStudentT` random method. (see [#4359](https://github.com/pymc-devs/pymc3/pull/4359))
 - Fix issue in `logp` method of `HyperGeometric`. It now returns `-inf` for invalid parameters (see [4367](https://github.com/pymc-devs/pymc3/pull/4367))
 - Fixed `MatrixNormal` random method to work with parameters as random variables. (see [#4368](https://github.com/pymc-devs/pymc3/pull/4368))
+- Fix issue in `logcdf` methods of `Uniform`, `HalfNormal`, `Gamma`  and `InverseGamma`. These functions now return correct values when evaluated with invalid parameters or values (see [4393](https://github.com/pymc-devs/pymc3/pull/4393))
 
 ## PyMC3 3.10.0 (7 December 2020)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -29,7 +29,7 @@ It also brings some dreadfully awaited fixes, so be sure to go through the chang
 - Fixed mathematical formulation in `MvStudentT` random method. (see [#4359](https://github.com/pymc-devs/pymc3/pull/4359))
 - Fix issue in `logp` method of `HyperGeometric`. It now returns `-inf` for invalid parameters (see [4367](https://github.com/pymc-devs/pymc3/pull/4367))
 - Fixed `MatrixNormal` random method to work with parameters as random variables. (see [#4368](https://github.com/pymc-devs/pymc3/pull/4368))
-- Update the `logcdf` method of several continuous distributions to return -inf for invalid parameters and values, and raise informative errors when multiple values cannot be evaluated. (see [4393](https://github.com/pymc-devs/pymc3/pull/4393))
+- Update the `logcdf` method of several continuous distributions to return -inf for invalid parameters and values, and raise an informative error when multiple values cannot be evaluated in a single call. (see [4393](https://github.com/pymc-devs/pymc3/pull/4393))
 
 ## PyMC3 3.10.0 (7 December 2020)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -29,7 +29,7 @@ It also brings some dreadfully awaited fixes, so be sure to go through the chang
 - Fixed mathematical formulation in `MvStudentT` random method. (see [#4359](https://github.com/pymc-devs/pymc3/pull/4359))
 - Fix issue in `logp` method of `HyperGeometric`. It now returns `-inf` for invalid parameters (see [4367](https://github.com/pymc-devs/pymc3/pull/4367))
 - Fixed `MatrixNormal` random method to work with parameters as random variables. (see [#4368](https://github.com/pymc-devs/pymc3/pull/4368))
-- Fix issue in `logcdf` methods of `Uniform`, `HalfNormal`, `Gamma`  and `InverseGamma`. These functions now return correct values when evaluated with invalid parameters or values (see [4393](https://github.com/pymc-devs/pymc3/pull/4393))
+- Update the `logcdf` method of several continuous distributions to return -inf for invalid parameters and values, and raise informative errors when multiple values cannot be evaluated. (see [4393](https://github.com/pymc-devs/pymc3/pull/4393))
 
 ## PyMC3 3.10.0 (7 December 2020)
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2507,7 +2507,7 @@ class Gamma(PositiveContinuous):
         """
         alpha = self.alpha
         beta = self.beta
-        # To avoid gammainc C-assertion when given invalid values (#4340)
+        # Avoid C-assertion when the gammainc function is called with invalid values (#4340)
         safe_alpha = tt.switch(tt.lt(alpha, 0), 0, alpha)
         safe_beta = tt.switch(tt.lt(beta, 0), 0, beta)
         safe_value = tt.switch(tt.lt(value, 0), 0, value)
@@ -2681,7 +2681,7 @@ class InverseGamma(PositiveContinuous):
         """
         alpha = self.alpha
         beta = self.beta
-        # To avoid gammaincc C-assertion when given invalid values (#4340)
+        # Avoid C-assertion when the gammaincc function is called with invalid values (#4340)
         safe_alpha = tt.switch(tt.lt(alpha, 0), 0, alpha)
         safe_beta = tt.switch(tt.lt(beta, 0), 0, beta)
         safe_value = tt.switch(tt.lt(value, 0), 0, value)

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -3560,7 +3560,6 @@ class Triangular(BoundedContinuous):
         l = self.lower
         u = self.upper
         c = self.c
-
         return tt.switch(
             tt.le(value, l),
             -np.inf,

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -278,7 +278,7 @@ class Uniform(BoundedContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -347,7 +347,7 @@ class Flat(Continuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -404,7 +404,7 @@ class HalfFlat(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -545,7 +545,7 @@ class Normal(Continuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -903,7 +903,7 @@ class HalfNormal(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -1109,7 +1109,7 @@ class Wald(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -1300,8 +1300,7 @@ class Beta(UnitContinuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            Value(s) for which log CDF is calculated.
 
         Returns
         -------
@@ -1322,7 +1321,7 @@ class Beta(UnitContinuous):
             tt.switch(
                 tt.lt(value, 1),
                 tt.log(incomplete_beta(a, b, value)),
-                0
+                0,
             ),
             0 <= value,
             0 < a,
@@ -1537,7 +1536,7 @@ class Exponential(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -1652,7 +1651,7 @@ class Laplace(Continuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -1808,7 +1807,7 @@ class Lognormal(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -1971,8 +1970,7 @@ class StudentT(Continuous):
         Parameters
         ----------
         value: numeric
-            Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            Value(s) for which log CDF is calculated.
 
         Returns
         -------
@@ -2121,7 +2119,7 @@ class Pareto(Continuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -2240,7 +2238,7 @@ class Cauchy(Continuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -2348,7 +2346,7 @@ class HalfCauchy(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -2499,7 +2497,7 @@ class Gamma(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -2673,7 +2671,7 @@ class InverseGamma(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -2860,7 +2858,7 @@ class Weibull(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -3160,7 +3158,7 @@ class ExGaussian(Continuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -3549,7 +3547,7 @@ class Triangular(BoundedContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -3678,7 +3676,7 @@ class Gumbel(Continuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -3960,7 +3958,7 @@ class Logistic(Continuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -4302,7 +4300,7 @@ class Moyal(Continuous):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1309,9 +1309,7 @@ class Beta(UnitContinuous):
         # incomplete_beta function can only handle scalar values (see #4342)
         if np.ndim(value):
             raise TypeError(
-                "Beta.logcdf expects a scalar value but received a {}-dimensional object.".format(
-                    np.ndim(value)
-                )
+                f"Beta.logcdf expects a scalar value but received a {np.ndim(value)}-dimensional object."
             )
 
         a = self.alpha
@@ -1979,9 +1977,7 @@ class StudentT(Continuous):
         # incomplete_beta function can only handle scalar values (see #4342)
         if np.ndim(value):
             raise TypeError(
-                "StudentT.logcdf expects a scalar value but received a {}-dimensional object.".format(
-                    np.ndim(value)
-                )
+                f"StudentT.logcdf expects a scalar value but received a {np.ndim(value)}-dimensional object."
             )
 
         nu = self.nu

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -166,9 +166,7 @@ class Binomial(Discrete):
         # incomplete_beta function can only handle scalar values (see #4342)
         if np.ndim(value):
             raise TypeError(
-                "Binomial.logcdf expects a scalar value but received a {}-dimensional object.".format(
-                    np.ndim(value)
-                )
+                f"Binomial.logcdf expects a scalar value but received a {np.ndim(value)}-dimensional object."
             )
 
         n = self.n
@@ -336,9 +334,7 @@ class BetaBinomial(Discrete):
         # logcdf can only handle scalar values at the moment
         if np.ndim(value):
             raise TypeError(
-                "BetaBinomial.logcdf expects a scalar value but received a {}-dimensional object.".format(
-                    np.ndim(value)
-                )
+                f"BetaBinomial.logcdf expects a scalar value but received a {np.ndim(value)}-dimensional object."
             )
 
         alpha = self.alpha
@@ -910,9 +906,7 @@ class NegativeBinomial(Discrete):
         # incomplete_beta function can only handle scalar values (see #4342)
         if np.ndim(value):
             raise TypeError(
-                "NegativeBinomial.logcdf expects a scalar value but received a {}-dimensional object.".format(
-                    np.ndim(value)
-                )
+                f"NegativeBinomial.logcdf expects a scalar value but received a {np.ndim(value)}-dimensional object."
             )
 
         # TODO: avoid `p` recomputation if distribution was defined in terms of `p`
@@ -1166,9 +1160,7 @@ class HyperGeometric(Discrete):
         # logcdf can only handle scalar values at the moment
         if np.ndim(value):
             raise TypeError(
-                "BetaBinomial.logcdf expects a scalar value but received a {}-dimensional object.".format(
-                    np.ndim(value)
-                )
+                f"HyperGeometric.logcdf expects a scalar value but received a {np.ndim(value)}-dimensional object."
             )
 
         # TODO: Use lower upper in locgdf for smarter logsumexp?
@@ -1743,9 +1735,7 @@ class ZeroInflatedBinomial(Discrete):
         # logcdf can only handle scalar values due to limitation in Binomial.logcdf
         if np.ndim(value):
             raise TypeError(
-                "ZeroInflatedBinomial.logcdf expects a scalar value but received a {}-dimensional object.".format(
-                    np.ndim(value)
-                )
+                f"ZeroInflatedBinomial.logcdf expects a scalar value but received a {np.ndim(value)}-dimensional object."
             )
 
         psi = self.psi
@@ -1913,9 +1903,7 @@ class ZeroInflatedNegativeBinomial(Discrete):
         # logcdf can only handle scalar values due to limitation in NegativeBinomial.logcdf
         if np.ndim(value):
             raise TypeError(
-                "ZeroInflatedNegativeBinomial.logcdf expects a scalar value but received a {}-dimensional object.".format(
-                    np.ndim(value)
-                )
+                f"ZeroInflatedNegativeBinomial.logcdf expects a scalar value but received a {np.ndim(value)}-dimensional object."
             )
         psi = self.psi
 

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -1292,7 +1292,11 @@ class DiscreteUniform(Discrete):
         lower = self.lower
 
         return bound(
-            tt.log(tt.minimum(tt.floor(value), upper) - lower + 1) - tt.log(upper - lower + 1),
+            tt.switch(
+                tt.lt(value, upper),
+                tt.log(tt.minimum(tt.floor(value), upper) - lower + 1) - tt.log(upper - lower + 1),
+                0,
+            ),
             lower <= value,
             lower <= upper,
         )

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -727,7 +727,7 @@ class Poisson(Discrete):
         """
         mu = self.mu
         value = tt.floor(value)
-        # To avoid gammaincc C-assertion when given invalid values (#4340)
+        # Avoid C-assertion when the gammaincc function is called with invalid values (#4340)
         safe_mu = tt.switch(tt.lt(mu, 0), 0, mu)
         safe_value = tt.switch(tt.lt(value, 0), 0, value)
 

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -463,7 +463,7 @@ class Bernoulli(Discrete):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -602,7 +602,7 @@ class DiscreteWeibull(Discrete):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -717,7 +717,7 @@ class Poisson(Discrete):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -1017,7 +1017,7 @@ class Geometric(Discrete):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -1288,7 +1288,7 @@ class DiscreteUniform(Discrete):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 
@@ -1601,7 +1601,7 @@ class ZeroInflatedPoisson(Discrete):
 
         Parameters
         ----------
-        value: numeric
+        value: numeric or np.ndarray or theano.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or theano tensor.
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -615,8 +615,6 @@ class TestMatchesScipy(SeededTest):
                 err_msg=str(above_domain),
             )
 
-        # TODO: Test that logcdf wih invalid parameters is always evaluated to -inf
-
         # Test that method works with multiple values or raises informative TypeError
         try:
             dist.logcdf(np.array([value, value])).tag.test_value

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -621,7 +621,9 @@ class TestMatchesScipy(SeededTest):
         try:
             dist.logcdf(np.array([value, value])).tag.test_value
         except TypeError as err:
-            if not str(err).endswith(".logcdf expects a scalar value but received a 1-dimensional object."):
+            if not str(err).endswith(
+                ".logcdf expects a scalar value but received a 1-dimensional object."
+            ):
                 raise
 
     def check_int_to_1(self, model, value, domain, paramdomains):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -615,6 +615,15 @@ class TestMatchesScipy(SeededTest):
                 err_msg=str(above_domain),
             )
 
+        # TODO: Test that logcdf wih invalid parameters is always evaluated to -inf
+
+        # Test that method works with multiple values or raises informative TypeError
+        try:
+            dist.logcdf(np.array([value, value])).tag.test_value
+        except TypeError as err:
+            if not str(err).endswith(".logcdf expects a scalar value but received a 1-dimensional object."):
+                raise
+
     def check_int_to_1(self, model, value, domain, paramdomains):
         pdf = model.fastfn(exp(model.logpt))
         for pt in product(paramdomains, n_samples=10):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -597,6 +597,24 @@ class TestMatchesScipy(SeededTest):
                 err_msg=str(pt),
             )
 
+        # Test that values below domain evaluate to -np.inf
+        if np.isfinite(domain.lower):
+            below_domain = domain.lower - 1
+            assert_equal(
+                dist.logcdf(below_domain).tag.test_value,
+                -np.inf,
+                err_msg=str(below_domain),
+            )
+
+        # Test that values above domain evaluate to 0
+        if np.isfinite(domain.upper):
+            above_domain = domain.upper + 1
+            assert_equal(
+                dist.logcdf(above_domain).tag.test_value,
+                0,
+                err_msg=str(above_domain),
+            )
+
     def check_int_to_1(self, model, value, domain, paramdomains):
         pdf = model.fastfn(exp(model.logpt))
         for pt in product(paramdomains, n_samples=10):
@@ -681,7 +699,7 @@ class TestMatchesScipy(SeededTest):
         with Model():
             x = Flat("a")
             assert_allclose(x.tag.test_value, 0)
-        self.check_logcdf(Flat, Runif, {}, lambda value: np.log(0.5))
+        self.check_logcdf(Flat, R, {}, lambda value: np.log(0.5))
         # Check infinite cases individually.
         assert 0.0 == Flat.dist().logcdf(np.inf).tag.test_value
         assert -np.inf == Flat.dist().logcdf(-np.inf).tag.test_value
@@ -692,7 +710,7 @@ class TestMatchesScipy(SeededTest):
             x = HalfFlat("a", shape=2)
             assert_allclose(x.tag.test_value, 1)
             assert x.tag.test_value.shape == (2,)
-        self.check_logcdf(HalfFlat, Runif, {}, lambda value: -np.inf)
+        self.check_logcdf(HalfFlat, Rplus, {}, lambda value: -np.inf)
         # Check infinite cases individually.
         assert 0.0 == HalfFlat.dist().logcdf(np.inf).tag.test_value
         assert -np.inf == HalfFlat.dist().logcdf(-np.inf).tag.test_value

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -575,6 +575,35 @@ class TestMatchesScipy(SeededTest):
                 err_msg=str(pt),
             )
 
+        # Test that values below domain evaluate to -np.inf
+        if np.isfinite(domain.lower):
+            below_domain = domain.lower - 1
+            assert_equal(
+                dist.logcdf(below_domain).tag.test_value,
+                -np.inf,
+                err_msg=str(below_domain),
+            )
+
+        # Test that values above domain evaluate to 0
+        # Natural domains do not have inf as the upper edge, but should also be ignored
+        not_nat_domain = domain not in (NatSmall, Nat, NatBig, PosNat)
+        if not_nat_domain and np.isfinite(domain.upper):
+            above_domain = domain.upper + 1
+            assert_equal(
+                dist.logcdf(above_domain).tag.test_value,
+                0,
+                err_msg=str(above_domain),
+            )
+
+        # Test that method works with multiple values or raises informative TypeError
+        try:
+            dist.logcdf(np.array([value, value])).tag.test_value
+        except TypeError as err:
+            if not str(err).endswith(
+                ".logcdf expects a scalar value but received a 1-dimensional object."
+            ):
+                raise
+
     def check_selfconsistency_discrete_logcdf(
         self, distribution, domain, paramdomains, decimal=None, n_samples=100
     ):
@@ -596,33 +625,6 @@ class TestMatchesScipy(SeededTest):
                 decimal=decimal,
                 err_msg=str(pt),
             )
-
-        # Test that values below domain evaluate to -np.inf
-        if np.isfinite(domain.lower):
-            below_domain = domain.lower - 1
-            assert_equal(
-                dist.logcdf(below_domain).tag.test_value,
-                -np.inf,
-                err_msg=str(below_domain),
-            )
-
-        # Test that values above domain evaluate to 0
-        if np.isfinite(domain.upper):
-            above_domain = domain.upper + 1
-            assert_equal(
-                dist.logcdf(above_domain).tag.test_value,
-                0,
-                err_msg=str(above_domain),
-            )
-
-        # Test that method works with multiple values or raises informative TypeError
-        try:
-            dist.logcdf(np.array([value, value])).tag.test_value
-        except TypeError as err:
-            if not str(err).endswith(
-                ".logcdf expects a scalar value but received a 1-dimensional object."
-            ):
-                raise
 
     def check_int_to_1(self, model, value, domain, paramdomains):
         pdf = model.fastfn(exp(model.logpt))


### PR DESCRIPTION
Changes:
This PR proposes two changes to `check_logcdf` to:
1. Test that values below or above finite domain edges are properly evaluated to `-inf` and `0`. 
2. Test that multiple values can be computed in one call, or if not, that a standard informative `TypeError` is returned.

This extended test revealed some issues with current implementations of the `logcdf` method, which are also fixed by this PR:
1. `Uniform`: Would incorrectly evaluate values above `upper` to `-inf`
2. `HalfNormal`: Would return `nan` for negative values. It was also unclear to me what the previous `logcdf` logic was doing, as it seems to me that `tt.lt(z, -1.0)` could never evaluate to `True` given valid positive values and `sigma`. As such, I simplified the code as well as correcting the invalid logcdf evaluation for negative values. Am I missing something? (pinging @domenzain)
3. `Gamma`, and `InverseGamma` were currently failing with invalid parameters due to #4340 and https://github.com/pymc-devs/Theano-PyMC/issues/224. I added a dirty hack to hide the issue for now. It can be simplified once those issues are solved.
4. `Beta` and `StudentT` logcdf now raises informative `TypeError` when asked to evaluate multiple values (#4342)

As suggested by @AlexAndorra in https://github.com/pymc-devs/pymc3/pull/4387#discussion_r549825529, the docstrings of the logcdf methods were updated to better reflect when multiple values can or cannot be evaluated.

It was necessary to change the test domains of the `Flat` and `HalfFlat` distributions to their actual domains.

This test is also relevant for the current PR #4387, were these same changes were helpful in debugging issues with the implementations of the `logcdf` methods. I thought it was best to have this as a separate PR as that one is quite large already. 

Finally, I think this does meaningfully increase the overhead of the unit tests since, at most, only three extra logp evaluations are being done for each distribution (one for each finite edge of a domain plus a (2,) array for multiple values). 