### PR TITLE
Update `log1mexp` and remove redundant local reimplementations in the library

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -45,7 +45,7 @@ from pymc3.distributions.dist_math import (
 )
 from pymc3.distributions.distribution import Continuous, draw_values, generate_samples
 from pymc3.distributions.special import log_i0
-from pymc3.math import invlogit, logdiffexp, logit
+from pymc3.math import invlogit, log1mexp, logdiffexp, logit
 from pymc3.theanof import floatX
 
 __all__ = [
@@ -1513,12 +1513,6 @@ class Exponential(PositiveContinuous):
         Compute the log of cumulative distribution function for the Exponential distribution
         at the specified value.
 
-        References
-        ----------
-        .. [Machler2012] Martin Mächler (2012).
-            "Accurately computing :math:`\log(1-\exp(-\mid a \mid))` Assessed by the Rmpfr
-            package"
-
         Parameters
         ----------
         value: numeric
@@ -1533,9 +1527,9 @@ class Exponential(PositiveContinuous):
         lam = self.lam
         a = lam * value
         return tt.switch(
-            tt.le(value, 0.0),
+            tt.or_(tt.le(value, 0.0), tt.le(lam, 0)),
             -np.inf,
-            tt.switch(tt.le(a, tt.log(2.0)), tt.log(-tt.expm1(-a)), tt.log1p(-tt.exp(-a))),
+            log1mexp(a),
         )
 
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1527,7 +1527,7 @@ class Exponential(PositiveContinuous):
         lam = self.lam
         a = lam * value
         return tt.switch(
-            tt.or_(tt.le(value, 0.0), tt.le(lam, 0)),
+            tt.le(value, 0.0) | tt.le(lam, 0),
             -np.inf,
             log1mexp(a),
         )
@@ -3896,7 +3896,7 @@ class Logistic(Continuous):
 
         References
         ----------
-        .. [Machler2012] c.
+        .. [Machler2012] Martin Mächler (2012).
             "Accurately computing :math:  `\log(1-\exp(- \mid a \mid<))` Assessed by the Rmpfr
             package"
 
@@ -3910,7 +3910,6 @@ class Logistic(Continuous):
         -------
         TensorVariable
         """
-        # TODO: Check possible redundant (or improved) reimplementation of log1pexp
         mu = self.mu
         s = self.s
         a = -(value - mu) / s

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2800,12 +2800,6 @@ class Weibull(PositiveContinuous):
         Compute the log of the cumulative distribution function for Weibull distribution
         at the specified value.
 
-        References
-        ----------
-        .. [Machler2012] Martin Mächler (2012).
-            "Accurately computing `\log(1-\exp(- \mid a \mid))` Assessed by the Rmpfr
-            package"
-
         Parameters
         ----------
         value: numeric
@@ -2822,7 +2816,7 @@ class Weibull(PositiveContinuous):
         return tt.switch(
             tt.le(value, 0.0),
             -np.inf,
-            tt.switch(tt.le(a, tt.log(2.0)), tt.log(-tt.expm1(-a)), tt.log1p(-tt.exp(-a))),
+            log1mexp(a),
         )
 
 
@@ -3902,7 +3896,7 @@ class Logistic(Continuous):
 
         References
         ----------
-        .. [Machler2012] Martin Mächler (2012).
+        .. [Machler2012] c.
             "Accurately computing :math:  `\log(1-\exp(- \mid a \mid<))` Assessed by the Rmpfr
             package"
 
@@ -3916,6 +3910,7 @@ class Logistic(Continuous):
         -------
         TensorVariable
         """
+        # TODO: Check possible redundant (or improved) reimplementation of log1pexp
         mu = self.mu
         s = self.s
         a = -(value - mu) / s

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -219,12 +219,19 @@ def log1pexp(x):
 
 
 def log1mexp(x):
-    """Return log(1 - exp(-x)).
+    r"""Return log(1 - exp(-x)).
 
     This function is numerically more stable than the naive approach.
 
     For details, see
     https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
+
+    References
+        ----------
+        .. [Machler2012] Martin Mächler (2012).
+            "Accurately computing `\log(1-\exp(- \mid a \mid))` Assessed by the Rmpfr
+            package"
+
     """
     return tt.switch(tt.lt(x, 0.6931471805599453), tt.log(-tt.expm1(-x)), tt.log1p(-tt.exp(-x)))
 

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -226,7 +226,7 @@ def log1mexp(x):
     For details, see
     https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
     """
-    return tt.switch(tt.lt(x, 0.683), tt.log(-tt.expm1(-x)), tt.log1p(-tt.exp(-x)))
+    return tt.switch(tt.lt(x, 0.693147), tt.log(-tt.expm1(-x)), tt.log1p(-tt.exp(-x)))
 
 
 def log1mexp_numpy(x):
@@ -235,7 +235,7 @@ def log1mexp_numpy(x):
     For details, see
     https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
     """
-    return np.where(x < 0.683, np.log(-np.expm1(-x)), np.log1p(-np.exp(-x)))
+    return np.where(x < 0.693147, np.log(-np.expm1(-x)), np.log1p(-np.exp(-x)))
 
 
 def flatten_list(tensors):

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -226,7 +226,7 @@ def log1mexp(x):
     For details, see
     https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
     """
-    return tt.switch(tt.lt(x, 0.693147), tt.log(-tt.expm1(-x)), tt.log1p(-tt.exp(-x)))
+    return tt.switch(tt.lt(x, 0.6931471805599453), tt.log(-tt.expm1(-x)), tt.log1p(-tt.exp(-x)))
 
 
 def log1mexp_numpy(x):
@@ -235,7 +235,7 @@ def log1mexp_numpy(x):
     For details, see
     https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
     """
-    return np.where(x < 0.693147, np.log(-np.expm1(-x)), np.log1p(-np.exp(-x)))
+    return np.where(x < 0.6931471805599453, np.log(-np.expm1(-x)), np.log1p(-np.exp(-x)))
 
 
 def flatten_list(tensors):


### PR DESCRIPTION
The cutoff in `log1mexp` (and its numpy counterpart) is supposed to be `log(2) = 0.693`. There was probably a small typo when writing the function as the cutoff was set to `0.683`. Pinging @aseyboldt 

Original source of this algorithm: https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
Example R implementation: https://github.com/cran/Rmpfr/blob/7f15be8d124a7517719012107c132b5d828284f9/inst/doc/log1mexp-note.R#L96
TensorFlow implementation: https://github.com/tensorflow/probability/blob/v0.11.1/tensorflow_probability/python/math/generic.py#L495-L519
Haskell implementation: https://gitlab.haskell.org/ghc/ghc/-/blob/master/libraries/base/GHC/Float.hs#L159-161

I also removed a redundant re-implementation of this function in the `logcdf` method of the `Exponential` and `Weibull` distribution.

***

I would further suggest that the `log1mexp` method be changed to expect negative values (such as logarithms of probabilities) instead of positive values. This is what the Haskell implementation does directly and what the TensorFlow does less directly by first taking the absolute of the input and then negating it. The function would change from `log(1 - exp(-x))` to `log(1 - exp(x))` (as in Haskell). This is equivalent to `log(1 - exp(-|x|))` (as in TFP), but I like the formula with the absolute less because it seems to just hide mistakes such as asking `log(1 - exp(log(1.1))`. I don't see why one would ever want values larger than 1 after exponentiation to be negated before exponentiation.

I have actually implemented this change and it did not seem to have large ramifications. There seem to be only 2 places (3 after #4387) in the library where the function is used directly, and the only thing needed is to negate the input (e.g., the function `logdiffexp` needs to be changed from `a + log1mexp(a - b)` to `a + log1mexp(b - a)`). I also checked that current unittests would detect all the spotted sections if they were not corrected.

The least nice part is that it would probably require a `UserWarning` about the change when the function is called directly by the user. What do you think?

**Update: This change was rejected to avoid backwards incompatibility**