### PR TITLE
Improve ExGaussian logcdf and refactor logp

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -32,6 +32,7 @@ It also brings some dreadfully awaited fixes, so be sure to go through the chang
 - Fix issue in `logp` method of `HyperGeometric`. It now returns `-inf` for invalid parameters (see [4367](https://github.com/pymc-devs/pymc3/pull/4367))
 - Fixed `MatrixNormal` random method to work with parameters as random variables. (see [#4368](https://github.com/pymc-devs/pymc3/pull/4368))
 - Update the `logcdf` method of several continuous distributions to return -inf for invalid parameters and values, and raise an informative error when multiple values cannot be evaluated in a single call. (see [4393](https://github.com/pymc-devs/pymc3/pull/4393))
+- Improve numerical stability in `logp` and `logcdf` methods of `ExGaussian` (see [#4407](https://github.com/pymc-devs/pymc3/pull/4407))
 
 ## PyMC3 3.10.0 (7 December 2020)
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -37,6 +37,7 @@ from pymc3.distributions.dist_math import (
     gammaln,
     i0e,
     incomplete_beta,
+    log_normal,
     logpow,
     normal_lccdf,
     normal_lcdf,
@@ -3214,21 +3215,21 @@ class ExGaussian(Continuous):
         sigma = self.sigma
         nu = self.nu
 
-        standardized_val = (value - mu) / sigma
-        cdf_val = std_cdf(standardized_val - sigma / nu)
-        cdf_val_safe = tt.switch(tt.eq(cdf_val, 0), np.finfo(theano.config.floatX).eps, cdf_val)
-
-        # This condition is suggested by exGAUS.R from gamlss
-        lp = tt.switch(
-            tt.gt(nu, 0.05 * sigma),
-            -tt.log(nu) + (mu - value) / nu + 0.5 * (sigma / nu) ** 2 + logpow(cdf_val_safe, 1.0),
-            -tt.log(sigma * tt.sqrt(2 * np.pi)) - 0.5 * standardized_val ** 2,
+        # Alogithm is adapted from dexGAUS.R from gamlss
+        return bound(
+            tt.switch(
+                tt.gt(nu, 0.05 * sigma),
+                (
+                    -tt.log(nu)
+                    + (mu - value) / nu
+                    + 0.5 * (sigma / nu) ** 2
+                    + normal_lcdf(mu + (sigma ** 2) / nu, sigma, value)
+                ),
+                log_normal(value, mean=mu, sigma=sigma),
+            ),
+            0 < sigma,
+            0 < nu,
         )
-
-        return bound(lp, sigma > 0.0, nu > 0.0)
-
-    def _distr_parameters_for_repr(self):
-        return ["mu", "sigma", "nu"]
 
     def logcdf(self, value):
         """
@@ -3253,21 +3254,24 @@ class ExGaussian(Continuous):
         """
         mu = self.mu
         sigma = self.sigma
-        sigma_2 = sigma ** 2
         nu = self.nu
-        z = value - mu - sigma_2 / nu
+
+        # Alogithm is adapted from pexGAUS.R from gamlss
         return tt.switch(
             tt.gt(nu, 0.05 * sigma),
-            tt.log(
-                std_cdf((value - mu) / sigma)
-                - std_cdf(z / sigma)
-                * tt.exp(
-                    ((mu + (sigma_2 / nu)) ** 2 - (mu ** 2) - 2 * value * ((sigma_2) / nu))
-                    / (2 * sigma_2)
-                )
+            logdiffexp(
+                normal_lcdf(mu, sigma, value),
+                (
+                    (mu - value) / nu
+                    + 0.5 * (sigma / nu) ** 2
+                    + normal_lcdf(mu + (sigma ** 2) / nu, sigma, value)
+                ),
             ),
             normal_lcdf(mu, sigma, value),
         )
+
+    def _distr_parameters_for_repr(self):
+        return ["mu", "sigma", "nu"]
 
 
 class VonMises(Continuous):

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -41,7 +41,6 @@ from pymc3.distributions.dist_math import (
     logpow,
     normal_lccdf,
     normal_lcdf,
-    std_cdf,
     zvalue,
 )
 from pymc3.distributions.distribution import Continuous, draw_values, generate_samples

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -20,7 +20,6 @@ nodes in PyMC.
 import warnings
 
 import numpy as np
-import theano
 import theano.tensor as tt
 
 from scipy import stats

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -559,7 +559,6 @@ class TestMatchesScipy(SeededTest):
         logp = model.fastlogp
         for pt in product(domains, n_samples=100):
             pt = Point(pt, model=model)
-            print(pt)
             if decimal is None:
                 decimal = select_by_precision(float64=6, float32=3)
             assert_almost_equal(logp(pt), logp_reference(pt), decimal=decimal, err_msg=str(pt))
@@ -579,7 +578,6 @@ class TestMatchesScipy(SeededTest):
             decimal = select_by_precision(float64=6, float32=3)
         for pt in product(domains, n_samples=n_samples):
             params = dict(pt)
-            print(params)
             scipy_cdf = scipy_logcdf(**params)
             value = params.pop("value")
             dist = pymc3_dist.dist(**params)

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -559,6 +559,7 @@ class TestMatchesScipy(SeededTest):
         logp = model.fastlogp
         for pt in product(domains, n_samples=100):
             pt = Point(pt, model=model)
+            print(pt)
             if decimal is None:
                 decimal = select_by_precision(float64=6, float32=3)
             assert_almost_equal(logp(pt), logp_reference(pt), decimal=decimal, err_msg=str(pt))
@@ -578,6 +579,7 @@ class TestMatchesScipy(SeededTest):
             decimal = select_by_precision(float64=6, float32=3)
         for pt in product(domains, n_samples=n_samples):
             params = dict(pt)
+            print(params)
             scipy_cdf = scipy_logcdf(**params)
             value = params.pop("value")
             dist = pymc3_dist.dist(**params)
@@ -1825,6 +1827,9 @@ class TestMatchesScipy(SeededTest):
             (15.0, 5.000, 7.500, 7.500, -3.3093854),
             (50.0, 50.000, 10.000, 10.000, -3.6436067),
             (1000.0, 500.000, 10.000, 20.000, -27.8707323),
+            (-1.0, 1.0, 20.0, 0.9, -3.91967108),  # Fails in scipy version
+            (0.01, 0.01, 100.0, 0.01, -5.5241087),  # Fails in scipy version
+            (-1.0, 0.0, 0.1, 0.1, -51.022349),  # Fails in previous pymc3 version
         ],
     )
     def test_ex_gaussian(self, value, mu, sigma, nu, logp):
@@ -1851,6 +1856,9 @@ class TestMatchesScipy(SeededTest):
             (15.0, 5.000, 7.500, 7.500, -0.4545255),
             (50.0, 50.000, 10.000, 10.000, -1.433714),
             (1000.0, 500.000, 10.000, 20.000, -1.573708e-11),
+            (0.01, 0.01, 100.0, 0.01, -0.69314718),  # Fails in scipy version
+            (-0.43402407, 0.0, 0.1, 0.1, -13.59615423),  # Previous 32-bit version failed here
+            (-0.72402009, 0.0, 0.1, 0.1, -31.26571842),  # Previous 64-bit version failed here
         ],
     )
     def test_ex_gaussian_cdf(self, value, mu, sigma, nu, logcdf):


### PR DESCRIPTION
This PR fixes #4295 

**logcdf**
The logcdf method was reliably returning nan for some configurations due to numerical inaccuracies in the `std_cdf` method. By replacing it with the more numerical stable `normal_lcdf` the problems seem to vanish. 

In addition the method was originally written in the natural scale and only at the end converted to log, but it was straightforward to rewrite it in log terms, which simplifies things quite a bit, and further allows for the use of `logdiffexp`, which should provide further numerical stability. 

I added unit tests on values that were systematically failing in the 32- and 64-bit implementations. I also added one test that fails with the scipy `exponnorm` implementation, which is numerically unstable in different ways.

**logp**
I thought it would be nice to also add the `normal_lcdf` to the logp method. This seems to not only solve the issues that were addressed by #4050 (method would wrongly return `-inf` for several configurations), but it is also more numerically accurate (using the R implementation as the benchmark).

I added a unittest based on the output of the `gamlss::exGAUS` R function that fails on master but not in this PR. I also added two tests that fail with the scipy `exponnorm` implementation, which is numerically unstable in different ways.

The only downside, is that the `normal_lcdf` relies on `tt.erfcx` which does not have `c_code` support (as mentioned by warnings in the tests). However, since the same function is being used in the logp of the `TruncatedNormal`, I thought it would be okay to use it here as well. Maybe we can add `c_code` support for `tt.erfcx` in the future?

*** 
**Indirect benefit**
The code for the logp and logcdf methods look much more clean now, and it is much easier to see the similarities and differences between them!

