### PR TITLE
documented the default value of BinaryGibbsMetropolis' transit_p

### DIFF
--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -364,7 +364,7 @@ class BinaryGibbsMetropolis(ArrayStep):
         e.g., [0, 2, 1, ...]. Default is random
     transit_p: float
         The diagonal of the transition kernel. A value > .5 gives anticorrelated proposals,
-        which resulting in more efficient antithetical sampling.
+        which resulting in more efficient antithetical sampling. Default is 0.8
     model: PyMC Model
         Optional model for sampling step. Defaults to None (taken from context).
 


### PR DESCRIPTION
Added the default value of BinaryGibbsMetropolis' transit_p to the function's docstring.

I needed to go to the source code to find this out and I think this information should be right in the documentation.