### PR TITLE
Fixed Dirichlet.random returning output of wrong shapes 

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,6 +35,7 @@ It also brings some dreadfully awaited fixes, so be sure to go through the chang
 - Update the `logcdf` method of several continuous distributions to return -inf for invalid parameters and values, and raise an informative error when multiple values cannot be evaluated in a single call. (see [4393](https://github.com/pymc-devs/pymc3/pull/4393))
 - Improve numerical stability in `logp` and `logcdf` methods of `ExGaussian` (see [#4407](https://github.com/pymc-devs/pymc3/pull/4407))
 - Issue UserWarning when doing prior or posterior predictive sampling with models containing Potential factors (see [#4419](https://github.com/pymc-devs/pymc3/pull/4419))
+- Dirichlet distribution's `random` method is now optimized and gives outputs in correct shape (see [#4416](https://github.com/pymc-devs/pymc3/pull/4407))
 
 ## PyMC3 3.10.0 (7 December 2020)
 

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -471,32 +471,10 @@ class Dirichlet(Continuous):
 
         super().__init__(transform=transform, *args, **kwargs)
 
-        self.size_prefix = tuple(self.shape[:-1])
         self.a = a = tt.as_tensor_variable(a)
         self.mean = a / tt.sum(a)
 
         self.mode = tt.switch(tt.all(a > 1), (a - 1) / tt.sum(a - 1), np.nan)
-
-    def _random(self, a, size=None):
-        gen = stats.dirichlet.rvs
-        shape = tuple(np.atleast_1d(self.shape))
-        if size[-len(shape) :] == shape:
-            real_size = size[: -len(shape)]
-        else:
-            real_size = size
-        if self.size_prefix:
-            if real_size and real_size[0] == 1:
-                real_size = real_size[1:] + self.size_prefix
-            else:
-                real_size = real_size + self.size_prefix
-
-        if a.ndim == 1:
-            samples = gen(alpha=a, size=real_size)
-        else:
-            unrolled = a.reshape((np.prod(a.shape[:-1]), a.shape[-1]))
-            samples = np.array([gen(alpha=aa, size=1) for aa in unrolled])
-            samples = samples.reshape(a.shape)
-        return samples
 
     def random(self, point=None, size=None):
         """
@@ -516,7 +494,10 @@ class Dirichlet(Continuous):
         array
         """
         a = draw_values([self.a], point=point, size=size)[0]
-        samples = generate_samples(self._random, a=a, dist_shape=self.shape, size=size)
+        output_shape = to_tuple(size) + to_tuple(self.shape)
+        a = broadcast_dist_samples_to(to_shape=output_shape, samples=[a], size=size)[0]
+        samples = stats.gamma.rvs(a=a, size=output_shape)
+        samples = samples / samples.sum(-1, keepdims=True)
         return samples
 
     def logp(self, value):

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -542,6 +542,24 @@ class TestCategorical(BaseTestCases.BaseTestCase):
         assert pm.Categorical.dist(p=p).random(size=4).shape == (4, 3, 7)
 
 
+class TestDirichlet(SeededTest):
+    @pytest.mark.parametrize(
+        "shape, size",
+        [
+            ((2), (1)),
+            ((2), (2)),
+            ((2, 2), (2, 100)),
+            ((3, 4), (3, 4)),
+            ((3, 4), (3, 4, 100)),
+            ((3, 4), (100)),
+            ((3, 4), (1)),
+        ],
+    )
+    def test_dirichlet_random_shape(self, shape, size):
+        out_shape = to_tuple(size) + to_tuple(shape)
+        assert pm.Dirichlet.dist(a=np.ones(shape)).random(size=size).shape == out_shape
+
+
 class TestScalarParameterSamples(SeededTest):
     def test_bounded(self):
         # A bit crude...


### PR DESCRIPTION

Link to Issue: #4060 

A simple fix to the shape broadcasting logic in `generate_samples()` . The issue was mostly fixed in #4061 , leaving out a particular case when the shape tuple equals the size tuple. The issue in this case was here :

https://github.com/pymc-devs/pymc3/blob/1769258e459e8f40aa8a56e0ac911aa99e7f67de/pymc3/distributions/distribution.py#L1058-L1066

Since both the tuples were equal this particular piece of logic thought that the shape is prepended to the size tuple. Adding a simple check which necessitates that length of `dist_shape` should be greater than `size_tup` fixes the issue.

I think this fix along with #4061 completely resolves #4060 