### PR TITLE
Fixed log posterior of bounded variables when the value lies near the boundary

### DIFF
--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -278,7 +278,8 @@ class Interval(ElemwiseTransform):
 
     def backward(self, x):
         a, b = self.a, self.b
-        r = (b - a) * tt.nnet.sigmoid(x) + a
+        sigmoid_x = tt.nnet.sigmoid(x)
+        r = sigmoid_x * b + (1 - sigmoid_x) * a
         return r
 
     def forward(self, x):

--- a/pymc3/tests/test_transforms.py
+++ b/pymc3/tests/test_transforms.py
@@ -196,6 +196,19 @@ def test_interval():
         close_to_logical(vals < b, True, tol)
 
 
+@pytest.mark.skipif(theano.config.floatX == "float32", reason="Test fails on 32 bit")
+def test_interval_near_boundary():
+    lb = -1.0
+    ub = 1e-7
+    x0 = np.nextafter(ub, lb)
+
+    with pm.Model() as model:
+        pm.Uniform("x", testval=x0, lower=lb, upper=ub)
+
+    log_prob = model.check_test_point()
+    np.testing.assert_allclose(log_prob.values, np.array([-52.68]))
+
+
 def test_circular():
     trans = tr.circular
     check_transform(trans, Circ)


### PR DESCRIPTION
Fix for #3938 

Fix sugested by @lcontento over here https://github.com/pymc-devs/pymc3/issues/3938#issue-627991010

The following code : 

```
import numpy as np
import pymc3 as pm

lb = -1.0
ub = 1e-7
x0 = np.nextafter(ub, lb)

with pm.Model() as model:
    pm.Uniform('x', testval=x0, lower=lb, upper=ub)

model.check_test_point()
```

Now returns : 
```
x_interval__   -52.68
Name: Log-probability of test_point, dtype: float64
```
Instead of `-inf`.