### PR TITLE
Increase logcdf coverage for invalid parameter values

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -32,7 +32,7 @@ It also brings some dreadfully awaited fixes, so be sure to go through the chang
 - Fixed mathematical formulation in `MvStudentT` random method. (see [#4359](https://github.com/pymc-devs/pymc3/pull/4359))
 - Fix issue in `logp` method of `HyperGeometric`. It now returns `-inf` for invalid parameters (see [4367](https://github.com/pymc-devs/pymc3/pull/4367))
 - Fixed `MatrixNormal` random method to work with parameters as random variables. (see [#4368](https://github.com/pymc-devs/pymc3/pull/4368))
-- Update the `logcdf` method of several continuous distributions to return -inf for invalid parameters and values, and raise an informative error when multiple values cannot be evaluated in a single call. (see [4393](https://github.com/pymc-devs/pymc3/pull/4393))
+- Update the `logcdf` method of several continuous distributions to return -inf for invalid parameters and values, and raise an informative error when multiple values cannot be evaluated in a single call. (see [4393](https://github.com/pymc-devs/pymc3/pull/4393) and [#4421](https://github.com/pymc-devs/pymc3/pull/4421))
 - Improve numerical stability in `logp` and `logcdf` methods of `ExGaussian` (see [#4407](https://github.com/pymc-devs/pymc3/pull/4407))
 - Issue UserWarning when doing prior or posterior predictive sampling with models containing Potential factors (see [#4419](https://github.com/pymc-devs/pymc3/pull/4419))
 - Dirichlet distribution's `random` method is now optimized and gives outputs in correct shape (see [#4416](https://github.com/pymc-devs/pymc3/pull/4407))

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -349,6 +349,7 @@ class BetaBinomial(Discrete):
                 0,
             ),
             0 <= value,
+            0 <= n,
             0 < alpha,
             0 < beta,
         )

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -595,7 +595,9 @@ class TestMatchesScipy(SeededTest):
 
         The following tests are performed by default:
             1. Test PyMC3 logcdf and equivalent scipy logcdf methods give similar
-            results for valid values and parameters within the supported edges.
+            results for valid values and parameters inside the supported edges.
+            Edges are excluded by default, but can be artificially included by
+            creating a domain with repeated values (e.g., `Domain([0, 0, .5, 1, 1]`)
             Can be skipped via skip_paramdomain_inside_edge_test
             2. Test PyMC3 logcdf method returns -inf for invalid parameter values
             outside the supported edges. Can be skipped via skip_paramdomain_outside_edge_test
@@ -609,24 +611,24 @@ class TestMatchesScipy(SeededTest):
         pymc3_dist: PyMC3 distribution
         domain : Domain
             Supported domain of distribution values
-        paramdomains : Dictionary of Pamameter : Domain pairs
+        paramdomains : Dictionary of Parameter : Domain pairs
             Supported domains of distribution parameters
         scipy_logcdf : Scipy logcdf method
             Scipy logcdf method of equivalent pymc3_dist distribution
         decimal : Int
-            Level of precision with which pymc3_dist and scipy_logcdf are
-            compared. Defaults to 6 for float64 and 3 for float32
+            Level of precision with which pymc3_dist and scipy_logcdf are compared.
+            Defaults to 6 for float64 and 3 for float32
         n_samples : Int
             Upper limit on the number of valid domain and value combinations that
-            are compared between pymc3 and scipy methods. If n_samples is below
-            the total number of combinations, a random subset is evaluated.
+            are compared between pymc3 and scipy methods. If n_samples is below the
+            total number of combinations, a random subset is evaluated.
             Defaults to 100
         skip_paramdomain_inside_edge_test : Bool
-            Whether to compare pymc3 and scipy distributions match for valid values
-            and parameters within the respective domain edges (excluding edges)
+            Whether to run test 1., which checks that pymc3 and scipy distributions
+            match for valid values and parameters inside the respective domain edges
         skip_paramdomain_outside_edge_test : Bool
-            Whether to test pymc3 distribution logcdf returns -inf for invalid
-            parameter values that lie beyond the supported edge (excluding edges)
+            Whether to run test 2., which checks that pymc3 distribution logcdf
+            returns -inf for invalid parameter values outside the supported domain edge
 
         Returns
         -------

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -587,46 +587,121 @@ class TestMatchesScipy(SeededTest):
         scipy_logcdf,
         decimal=None,
         n_samples=100,
+        skip_paramdomain_inside_edge_test=False,
+        skip_paramdomain_outside_edge_test=False,
     ):
-        domains = paramdomains.copy()
-        domains["value"] = domain
-        if decimal is None:
-            decimal = select_by_precision(float64=6, float32=3)
-        for pt in product(domains, n_samples=n_samples):
-            params = dict(pt)
-            scipy_cdf = scipy_logcdf(**params)
-            value = params.pop("value")
-            dist = pymc3_dist.dist(**params)
-            assert_almost_equal(
-                dist.logcdf(value).tag.test_value,
-                scipy_cdf,
-                decimal=decimal,
-                err_msg=str(pt),
-            )
+        """
+        Generic test for PyMC3 logcdf methods
 
-        # Test that values below domain evaluate to -np.inf
+        The following tests are performed by default:
+            1. Test PyMC3 logcdf and equivalent scipy logcdf methods give similar
+            results for valid values and parameters within the supported edges.
+            Can be skipped via skip_paramdomain_inside_edge_test
+            2. Test PyMC3 logcdf method returns -inf for invalid parameter values
+            outside the supported edges. Can be skipped via skip_paramdomain_outside_edge_test
+            3. Test PyMC3 logcdf method returns -inf and 0 for values below and
+            above the supported edge, respectively, when using valid parameters.
+            4. Test PyMC3 logcdf methods works with multiple value or returns
+            default informative TypeError
+
+        Parameters
+        ----------
+        pymc3_dist: PyMC3 distribution
+        domain : Domain
+            Supported domain of distribution values
+        paramdomains : Dictionary of Pamameter : Domain pairs
+            Supported domains of distribution parameters
+        scipy_logcdf : Scipy logcdf method
+            Scipy logcdf method of equivalent pymc3_dist distribution
+        decimal : Int
+            Level of precision with which pymc3_dist and scipy_logcdf are
+            compared. Defaults to 6 for float64 and 3 for float32
+        n_samples : Int
+            Upper limit on the number of valid domain and value combinations that
+            are compared between pymc3 and scipy methods. If n_samples is below
+            the total number of combinations, a random subset is evaluated.
+            Defaults to 100
+        skip_paramdomain_inside_edge_test : Bool
+            Whether to compare pymc3 and scipy distributions match for valid values
+            and parameters within the respective domain edges (excluding edges)
+        skip_paramdomain_outside_edge_test : Bool
+            Whether to test pymc3 distribution logcdf returns -inf for invalid
+            parameter values that lie beyond the supported edge (excluding edges)
+
+        Returns
+        -------
+
+        """
+        # Test pymc3 and scipy distributions match for values and parameters
+        # within the supported domain edges (excluding edges)
+        if not skip_paramdomain_inside_edge_test:
+            domains = paramdomains.copy()
+            domains["value"] = domain
+            if decimal is None:
+                decimal = select_by_precision(float64=6, float32=3)
+            for pt in product(domains, n_samples=n_samples):
+                params = dict(pt)
+                scipy_cdf = scipy_logcdf(**params)
+                value = params.pop("value")
+                dist = pymc3_dist.dist(**params)
+                assert_almost_equal(
+                    dist.logcdf(value).tag.test_value,
+                    scipy_cdf,
+                    decimal=decimal,
+                    err_msg=str(pt),
+                )
+
+        valid_value = domain.vals[0]
+        valid_params = {param: paramdomain.vals[0] for param, paramdomain in paramdomains.items()}
+        valid_dist = pymc3_dist.dist(**valid_params)
+
+        # Natural domains do not have inf as the upper edge, but should also be ignored
+        nat_domains = (NatSmall, Nat, NatBig, PosNat)
+
+        # Test pymc3 distribution gives -inf for parameters outside the
+        # supported domain edges (excluding edgse)
+        if not skip_paramdomain_outside_edge_test:
+            # Step1: collect potential invalid parameters
+            invalid_params = {param: [None, None] for param in paramdomains}
+            for param, paramdomain in paramdomains.items():
+                if np.isfinite(paramdomain.lower):
+                    invalid_params[param][0] = paramdomain.lower - 1
+                if np.isfinite(paramdomain.upper) and paramdomain not in nat_domains:
+                    invalid_params[param][1] = paramdomain.upper + 1
+            # Step2: test invalid parameters, one a time
+            for invalid_param, invalid_edges in invalid_params.items():
+                for invalid_edge in invalid_edges:
+                    if invalid_edge is not None:
+                        test_params = valid_params.copy()  # Shallow copy should be okay
+                        test_params[invalid_param] = invalid_edge
+                        invalid_dist = pymc3_dist.dist(**test_params)
+                        assert_equal(
+                            invalid_dist.logcdf(valid_value).tag.test_value,
+                            -np.inf,
+                            err_msg=str(test_params),
+                        )
+
+        # Test that values below domain edge evaluate to -np.inf
         if np.isfinite(domain.lower):
             below_domain = domain.lower - 1
             assert_equal(
-                dist.logcdf(below_domain).tag.test_value,
+                valid_dist.logcdf(below_domain).tag.test_value,
                 -np.inf,
                 err_msg=str(below_domain),
             )
 
-        # Test that values above domain evaluate to 0
-        # Natural domains do not have inf as the upper edge, but should also be ignored
-        not_nat_domain = domain not in (NatSmall, Nat, NatBig, PosNat)
-        if not_nat_domain and np.isfinite(domain.upper):
+        # Test that values above domain edge evaluate to 0
+        if domain not in nat_domains and np.isfinite(domain.upper):
             above_domain = domain.upper + 1
             assert_equal(
-                dist.logcdf(above_domain).tag.test_value,
+                valid_dist.logcdf(above_domain).tag.test_value,
                 0,
                 err_msg=str(above_domain),
             )
 
         # Test that method works with multiple values or raises informative TypeError
         try:
-            dist.logcdf(np.array([value, value])).tag.test_value
+            valid_dist.logcdf(np.array([valid_value, valid_value])).tag.test_value
         except TypeError as err:
             if not str(err).endswith(
                 ".logcdf expects a scalar value but received a 1-dimensional object."
@@ -686,6 +761,7 @@ class TestMatchesScipy(SeededTest):
             Runif,
             {"lower": -Rplusunif, "upper": Rplusunif},
             lambda value, lower, upper: sp.uniform.logcdf(value, lower, upper - lower),
+            skip_paramdomain_outside_edge_test=True,
         )
 
     def test_triangular(self):
@@ -700,6 +776,7 @@ class TestMatchesScipy(SeededTest):
             Runif,
             {"lower": -Rplusunif, "c": Runif, "upper": Rplusunif},
             lambda value, c, lower, upper: sp.triang.logcdf(value, c - lower, lower, upper - lower),
+            skip_paramdomain_outside_edge_test=True,
         )
 
     def test_bound_normal(self):
@@ -727,6 +804,7 @@ class TestMatchesScipy(SeededTest):
             Rdunif,
             {"lower": -Rplusdunif, "upper": Rplusdunif},
             lambda value, lower, upper: sp.randint.logcdf(value, lower, upper + 1),
+            skip_paramdomain_outside_edge_test=True,
         )
         self.check_selfconsistency_discrete_logcdf(
             DiscreteUniform,
@@ -807,7 +885,8 @@ class TestMatchesScipy(SeededTest):
             lambda value, nu: sp.chi2.logpdf(value, df=nu),
         )
 
-    @pytest.mark.xfail(reason="Poor CDF in SciPy. See scipy/scipy#869 for details.")
+    # TODO: Is this still needed? It passes locally.
+    # @pytest.mark.xfail(reason="Poor CDF in SciPy. See scipy/scipy#869 for details.")
     def test_wald_scipy(self):
         self.pymc3_matches_scipy(
             Wald,
@@ -1099,6 +1178,7 @@ class TestMatchesScipy(SeededTest):
             Rplus,
             {"alpha": Rplusbig, "beta": Rplusbig},
             lambda value, alpha, beta: sp.gamma.logcdf(value, alpha, scale=1.0 / beta),
+            skip_paramdomain_outside_edge_test=False,  # TODO: This is failing mysteriously
         )
 
     @pytest.mark.xfail(
@@ -1117,6 +1197,7 @@ class TestMatchesScipy(SeededTest):
             Rplus,
             {"alpha": Rplus, "beta": Rplus},
             lambda value, alpha, beta: sp.invgamma.logcdf(value, alpha, scale=beta),
+            skip_paramdomain_outside_edge_test=False,  # TODO: This is failing mysteriously
         )
 
     @pytest.mark.xfail(
@@ -2022,6 +2103,15 @@ class TestMatchesScipy(SeededTest):
             logcdf,
             decimal=select_by_precision(float64=6, float32=2),
             err_msg=str((value, mu, sigma, nu, logcdf)),
+        )
+
+    def test_ex_gaussian_cdf_outside_edges(self):
+        self.check_logcdf(
+            ExGaussian,
+            R,
+            {"mu": R, "sigma": Rplus, "nu": Rplus},
+            None,
+            skip_paramdomain_inside_edge_test=True,  # Valid values are tested above
         )
 
     @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -885,8 +885,10 @@ class TestMatchesScipy(SeededTest):
             lambda value, nu: sp.chi2.logpdf(value, df=nu),
         )
 
-    # TODO: Is this still needed? It passes locally.
-    # @pytest.mark.xfail(reason="Poor CDF in SciPy. See scipy/scipy#869 for details.")
+    @pytest.mark.xfail(
+        condition=(theano.config.floatX == "float32"),
+        reason="Poor CDF in SciPy. See scipy/scipy#869 for details.",
+    )
     def test_wald_scipy(self):
         self.pymc3_matches_scipy(
             Wald,
@@ -1178,7 +1180,7 @@ class TestMatchesScipy(SeededTest):
             Rplus,
             {"alpha": Rplusbig, "beta": Rplusbig},
             lambda value, alpha, beta: sp.gamma.logcdf(value, alpha, scale=1.0 / beta),
-            skip_paramdomain_outside_edge_test=True,  # TODO: This is failing mysteriously
+            skip_paramdomain_outside_edge_test=True,  # TODO: When True, Python crashes
         )
 
     @pytest.mark.xfail(
@@ -1197,7 +1199,7 @@ class TestMatchesScipy(SeededTest):
             Rplus,
             {"alpha": Rplus, "beta": Rplus},
             lambda value, alpha, beta: sp.invgamma.logcdf(value, alpha, scale=beta),
-            skip_paramdomain_outside_edge_test=True,  # TODO: This is failing mysteriously
+            skip_paramdomain_outside_edge_test=True,  # TODO: When True, Python crashes
         )
 
     @pytest.mark.xfail(

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1178,7 +1178,7 @@ class TestMatchesScipy(SeededTest):
             Rplus,
             {"alpha": Rplusbig, "beta": Rplusbig},
             lambda value, alpha, beta: sp.gamma.logcdf(value, alpha, scale=1.0 / beta),
-            skip_paramdomain_outside_edge_test=False,  # TODO: This is failing mysteriously
+            skip_paramdomain_outside_edge_test=True,  # TODO: This is failing mysteriously
         )
 
     @pytest.mark.xfail(
@@ -1197,7 +1197,7 @@ class TestMatchesScipy(SeededTest):
             Rplus,
             {"alpha": Rplus, "beta": Rplus},
             lambda value, alpha, beta: sp.invgamma.logcdf(value, alpha, scale=beta),
-            skip_paramdomain_outside_edge_test=False,  # TODO: This is failing mysteriously
+            skip_paramdomain_outside_edge_test=True,  # TODO: This is failing mysteriously
         )
 
     @pytest.mark.xfail(

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1177,12 +1177,15 @@ class TestMatchesScipy(SeededTest):
 
         self.pymc3_matches_scipy(Gamma, Rplus, {"mu": Rplusbig, "sigma": Rplusbig}, test_fun)
 
+        # pymc-devs/Theano-PyMC#224: skip_paramdomain_outside_edge_test has to be set
+        # True to avoid triggering a C-level assertion in the Theano GammaQ function
+        # in gamma.c file. Can be set back to False (defalut) once that issue is solved
         self.check_logcdf(
             Gamma,
             Rplus,
             {"alpha": Rplusbig, "beta": Rplusbig},
             lambda value, alpha, beta: sp.gamma.logcdf(value, alpha, scale=1.0 / beta),
-            skip_paramdomain_outside_edge_test=True,  # TODO: When True, Python crashes
+            skip_paramdomain_outside_edge_test=True,
         )
 
     @pytest.mark.xfail(
@@ -1196,12 +1199,15 @@ class TestMatchesScipy(SeededTest):
             {"alpha": Rplus, "beta": Rplus},
             lambda value, alpha, beta: sp.invgamma.logpdf(value, alpha, scale=beta),
         )
+        # pymc-devs/Theano-PyMC#224: skip_paramdomain_outside_edge_test has to be set
+        # True to avoid triggering a C-level assertion in the Theano GammaQ function
+        # in gamma.c file. Can be set back to False (defalut) once that issue is solved
         self.check_logcdf(
             InverseGamma,
             Rplus,
             {"alpha": Rplus, "beta": Rplus},
             lambda value, alpha, beta: sp.invgamma.logcdf(value, alpha, scale=beta),
-            skip_paramdomain_outside_edge_test=True,  # TODO: When True, Python crashes
+            skip_paramdomain_outside_edge_test=True,
         )
 
     @pytest.mark.xfail(


### PR DESCRIPTION
This PR extends the work started in the https://github.com/pymc-devs/pymc3/pull/4393 PR, and addresses the issue that most logcdf methods for continuous distributions were not checking for invalid parameteres (closes https://github.com/pymc-devs/pymc3/issues/4399 issue).

The main change is that `test_distributions.py::check_logcdf` method now tests that distributions return `-inf` when given invalid parameters (i.e., one unit below or above a finite domain edge). This is done for one invalid parameter at a time.

This extended test detected failures in all the continuous distribution logcdf methods mentioned in https://github.com/pymc-devs/pymc3/issues/4399 (and some more), as well as an issue in the discrete `BetaBinomial` distribution that I had missed before. The solution to most cases was to simply wrap the returned result in a `Bound`.

For the `Uniform`, `Triangular` and `DiscreteUniform` distributions it does not make sense to test values outside of the "Domain edges" since these are set arbitrarily (so that the upper and lower parameters do not clash). I added an optional argument `skip_paramdomain_outside_edge_test` that skips this step for these distributions.

The `ExGaussian` distribution was not being tested with `check_logcdf` probably because there is no Scipy implementation. To have it covered in the new tests I added the optional argument `skip_paramdomain_inside_edge_test` which skips the pymc3 vs scipy comparison for valid parameters / values (i.e., the default behavior of `check_logcdf`).

Since this PR and https://github.com/pymc-devs/pymc3/pull/4393 added considerable complexity to the `check_logcdf` method, I went ahead and documented it as best as I could. This will hopefully make it easier to maintain in the future.

**Two issues remain:**
- [x] `Gamma` and `InverseGamma` fail mysteriously with a `Fatal Python error: Aborted` unless I skip the new added tests with `skip_paramdomain_outside_edge_test=True`. ~~I could not understand why this is the case, since the functions seem to work fine when I test them with the exact same values in iPython. Maybe it's something to do with using the `.tag.test_value` vs `.eval()` that I am missing? I set it to False so that someone can look at the failing logs and maybe figure it out. I am also pasting the complete unhelpful traceback I get in PyCharm below. Possibly related to https://github.com/pymc-devs/pymc3/issues/4340 which was "hacked" away in https://github.com/pymc-devs/pymc3/pull/4393.~~ **Update**: Issue is explained below and it should go away once pymc-devs/Theano-PyMC#224 is closed
- [x] `test_wald_scipy` has a 4 year old `@pytest.mark.xfail` referring to a rather old scipy issue. It is passing locally on my machine, so maybe it can be removed? I commented it out to see if it passes here on Github. https://github.com/pymc-devs/pymc3/blame/master/pymc3/tests/test_distributions.py#L810 **Update**: Seems to be a float32 specific xfail. Added the specific condition.

<details>
<summary>Gamma / InverseGamma traceback</summary>

```python
test_distributions.py::TestMatchesScipy::test_gamma Fatal Python error: Aborted

Current thread 0x00007f54df052740 (most recent call first):
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/theano/link/c/basic.py", line 1829 in __call__
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/theano/gof/op.py", line 883 in rval
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/theano/gof/op.py", line 109 in compute_test_value
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/theano/gof/op.py", line 640 in __call__
  File "/home/ricardo/Documents/Projects/pymc3/pymc3/distributions/continuous.py", line 2625 in logcdf
  File "/home/ricardo/Documents/Projects/pymc3/pymc3/tests/test_distributions.py", line 663 in check_logcdf
  File "/home/ricardo/Documents/Projects/pymc3/pymc3/tests/test_distributions.py", line 1155 in test_gamma
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/python.py", line 184 in pytest_pyfunc_call
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/manager.py", line 84 in <lambda>
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/python.py", line 1627 in runtest
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/runner.py", line 163 in pytest_runtest_call
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/manager.py", line 84 in <lambda>
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/runner.py", line 256 in <lambda>
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/runner.py", line 310 in from_call
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/runner.py", line 255 in call_runtest_hook
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/runner.py", line 216 in call_and_report
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/runner.py", line 127 in runtestprotocol
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/runner.py", line 110 in pytest_runtest_protocol
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/manager.py", line 84 in <lambda>
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/main.py", line 338 in pytest_runtestloop
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/manager.py", line 84 in <lambda>
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/main.py", line 313 in _main
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/main.py", line 257 in wrap_session
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/main.py", line 306 in pytest_cmdline_main
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/manager.py", line 84 in <lambda>
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/ricardo/Documents/Projects/pymc3-venv/lib/python3.8/site-packages/_pytest/config/__init__.py", line 164 in main
  File "/opt/pycharm-2020.2.3/plugins/python/helpers/pycharm/_jb_pytest_runner.py", line 43 in <module>

Process finished with exit code 134 (interrupted by signal 6: SIGABRT)
```
</details>

***
**Follow-up question:** Do you think it would be helpful to add these new checks to `pymc3_matches_scipy` (the equivalent test for logp methods)? 