### PR TITLE
Evaluate only desired branch in log1mexp_numpy

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## PyMC3 vNext (on deck)
+
+### Breaking Changes
+
+### New Features
+
+### Maintenance
+- `math.log1mexp_numpy` no longer raises RuntimeWarning when given very small inputs. These were commonly observed during NUTS sampling (see [#4428](https://github.com/pymc-devs/pymc3/pull/4428)).
+
 ## PyMC3 3.11.0 (21 January 2021)
 
 This release breaks some APIs w.r.t. `3.10.0`. It also brings some dreadfully awaited fixes, so be sure to go through the (breaking) changes below.

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -244,11 +244,12 @@ def log1mexp_numpy(x):
     https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
     """
     x = np.asarray(x)
-    mask = x < 0.6931471805599453
-    x[mask] = np.log(-np.expm1(-x[mask]))
+    out = np.empty_like(x)
+    mask = x < 0.6931471805599453  # log(2)
+    out[mask] = np.log(-np.expm1(-x[mask]))
     mask = ~mask
-    x[mask] = np.log1p(-np.exp(-x[mask]))
-    return x
+    out[mask] = np.log1p(-np.exp(-x[mask]))
+    return out
 
 
 def flatten_list(tensors):

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -243,7 +243,12 @@ def log1mexp_numpy(x):
     For details, see
     https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
     """
-    return np.where(x < 0.6931471805599453, np.log(-np.expm1(-x)), np.log1p(-np.exp(-x)))
+    x = np.asarray(x)
+    mask = x < 0.6931471805599453
+    x[mask] = np.log(-np.expm1(-x[mask]))
+    mask = ~mask
+    x[mask] = np.log1p(-np.exp(-x[mask]))
+    return x
 
 
 def flatten_list(tensors):

--- a/pymc3/tests/test_math.py
+++ b/pymc3/tests/test_math.py
@@ -133,6 +133,7 @@ def test_log1pexp():
 
 def test_log1mexp():
     vals = np.array([-1, 0, 1e-20, 1e-4, 10, 100, 1e20])
+    vals_ = vals.copy()
     # import mpmath
     # mpmath.mp.dps = 1000
     # [float(mpmath.log(1 - mpmath.exp(-x))) for x in vals]
@@ -151,6 +152,8 @@ def test_log1mexp():
     npt.assert_allclose(actual, expected)
     actual_ = log1mexp_numpy(vals)
     npt.assert_allclose(actual_, expected)
+    # Check that input was not changed in place
+    npt.assert_allclose(vals, vals_)
 
 
 def test_log1mexp_numpy_no_warning():

--- a/pymc3/tests/test_math.py
+++ b/pymc3/tests/test_math.py
@@ -153,6 +153,13 @@ def test_log1mexp():
     npt.assert_allclose(actual_, expected)
 
 
+def test_log1mexp_numpy_no_warning():
+    """Assert RuntimeWarning is not raised for very small numbers"""
+    with pytest.warns(None) as record:
+        log1mexp_numpy(1e-25)
+    assert not record
+
+
 class TestLogDet(SeededTest):
     def setup_method(self):
         super().setup_method()


### PR DESCRIPTION
This PR changes `log1mexp_numpy` in the math module to only apply one of the two operations to the inputs. This avoids the non-important but common RuntimeWarning during NUTS sampling when `logdiffexp_numpy` is called in the `stats` method:

```
RuntimeWarning: divide by zero encountered in log1p
return np.where(x < 0.6931471805599453, np.log(-np.expm1(-x)), np.log1p(-np.exp(-x)))
```
The RuntimeWarning occurred because both operations were applied to `x` before selecting the desired (more numerical stable) output with `np.where`.

I added a test that fails in Master but passes in this PR.
