### PR TITLE
[WIP] Add givens argument to DensityDist

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -533,24 +533,6 @@ class DensityDist(Distribution):
             the returned array of samples. It is the user's responsibility to
             wrap the callable to make it comply with PyMC3's interpretation
             of ``size``.
-
-
-            .. code-block:: python
-
-                with pm.Model():
-                    mu = pm.Normal('mu', 0 , 1)
-                    normal_dist = pm.Normal.dist(mu, 1, shape=3)
-                    dens = pm.DensityDist(
-                        'density_dist',
-                        normal_dist.logp,
-                        observed=np.random.randn(100, 3),
-                        shape=3,
-                        random=stats.norm.rvs,
-                        pymc3_size_interpretation=False, # Is True by default
-                    )
-                    prior = pm.sample_prior_predictive(10)['density_dist']
-                assert prior.shape == (10, 100, 3)
-
         """
         if dtype is None:
             dtype = theano.config.floatX

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1109,7 +1109,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
             else:
                 self.coords[name] = coords[name]
 
-    def Var(self, name, dist, data=None, total_size=None, dims=None):
+    def Var(self, name, dist, data=None, total_size=None, dims=None, givens=None):
         """Create and add (un)observed random variable to the model with an
         appropriate prior distribution.
 
@@ -1161,6 +1161,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
                 var = MultiObservedRV(
                     name=name,
                     data=data,
+                    givens=givens,
                     distribution=dist,
                     total_size=total_size,
                     model=self,
@@ -1834,7 +1835,7 @@ class MultiObservedRV(Factor):
     Potentially partially observed.
     """
 
-    def __init__(self, name, data, distribution, total_size=None, model=None):
+    def __init__(self, name, data, distribution, total_size=None, model=None, givens=None):
         """
         Parameters
         ----------
@@ -1850,6 +1851,7 @@ class MultiObservedRV(Factor):
         self.data = {
             name: as_tensor(data, name, model, distribution) for name, data in data.items()
         }
+        self.givens = givens
 
         self.missing_values = [
             datum.missing_values for datum in self.data.values() if datum.missing_values is not None


### PR DESCRIPTION
This closes #4002 and should finish with all the DensityDist issues and complains when trying to
pass `FreeRVs` to the `observed` kwarg. This was originally possible and at some point it broke due
to ArviZ trying to store the variables passed as `observed` in the `observed_data` group. This PR
implements @rpgoldman idea of "splitting" the original unintuitive `observed` argument into
`observed` (which must be data) and `givens` which can be `FreeRVs` to maintain all the initial
flexibility of `DensityDist`.

The current proposal keeps the `data` attribute unchanged and adds a `givens` attribute which ArviZ
can use to filter all the `FreeRVs` in `data` and avoid crashing.

Note: To actually work, this PR also needs https://github.com/arviz-devs/arviz/pull/1520

Checklist
+ [x] what are the (breaking) changes that this PR makes? None
+ [x] important background, or details about the implementation: see issue #4002
+ [ ] are the changes—especially new features—covered by tests and docstrings?
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [x] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples): see https://github.com/pymc-devs/pymc-examples/pull/28
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
