### PR TITLE
Upgrade to Theano-PyMC 1.1.2

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,7 @@
 + Automatic imputations now also work with `ndarray` data, not just `pd.Series` or `pd.DataFrame` (see[#4439](https://github.com/pymc-devs/pymc3/pull/4439)).
 
 ### Maintenance
+- We upgraded to `Theano-PyMC v1.1.2` which [includes bugfixes](https://github.com/pymc-devs/aesara/compare/rel-1.1.0...rel-1.1.2) for warning floods and compiledir locking (see [#4444](https://github.com/pymc-devs/pymc3/pull/4444))
 - `math.log1mexp_numpy` no longer raises RuntimeWarning when given very small inputs. These were commonly observed during NUTS sampling (see [#4428](https://github.com/pymc-devs/pymc3/pull/4428)).
 
 ## PyMC3 3.11.0 (21 January 2021)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ numpy>=1.15.0
 pandas>=0.24.0
 patsy>=0.5.1
 scipy>=1.2.0
-theano-pymc==1.1.0
+theano-pymc==1.1.2
 typing-extensions>=3.7.4


### PR DESCRIPTION
Preparing for `3.11.1` this upgrades our beloved backend to fix warning floods and compilelock threading problems.

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md