### PR TITLE
Avoid unclear TypeError when using theano.shared variables as input to distribution parameters

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,7 @@
 
 ### Maintenance
 - `math.log1mexp_numpy` no longer raises RuntimeWarning when given very small inputs. These were commonly observed during NUTS sampling (see [#4428](https://github.com/pymc-devs/pymc3/pull/4428)).
+- `ScalarSharedVariable` can now be used as an input to other RVs directly.(see [#4445](https://github.com/pymc-devs/pymc3/pull/4445))
 
 ## PyMC3 3.11.0 (21 January 2021)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,7 +8,7 @@
 
 ### Maintenance
 - `math.log1mexp_numpy` no longer raises RuntimeWarning when given very small inputs. These were commonly observed during NUTS sampling (see [#4428](https://github.com/pymc-devs/pymc3/pull/4428)).
-- `ScalarSharedVariable` can now be used as an input to other RVs directly.(see [#4445](https://github.com/pymc-devs/pymc3/pull/4445))
+- `ScalarSharedVariable` can now be used as an input to other RVs directly (see [#4445](https://github.com/pymc-devs/pymc3/pull/4445)).
 
 ## PyMC3 3.11.0 (21 January 2021)
 

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -153,7 +153,7 @@ class Distribution:
                     if np.all(np.isfinite(attr_val)):
                         return attr_val
             raise AttributeError(
-                "%s has no finite default value to use "
+                "%s has no finite default value to use, "
                 "checked: %s. Pass testval argument or "
                 "adjust so value is finite." % (self, str(defaults))
             )

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -148,17 +148,17 @@ class Distribution:
     def get_test_val(self, val, defaults):
         if val is None:
             for v in defaults:
-                if hasattr(self, v) and np.all(np.isfinite(self.getattr_value(v))):
-                    return self.getattr_value(v)
-        else:
-            return self.getattr_value(val)
-
-        if val is None:
+                if hasattr(self, v):
+                    attr_val = self.getattr_value(v)
+                    if np.all(np.isfinite(attr_val)):
+                        return attr_val
             raise AttributeError(
-                "%s has no finite default value to use, "
+                "%s has no finite default value to use "
                 "checked: %s. Pass testval argument or "
                 "adjust so value is finite." % (self, str(defaults))
             )
+        else:
+            return self.getattr_value(val)
 
     def getattr_value(self, val):
         if isinstance(val, string_types):
@@ -167,7 +167,7 @@ class Distribution:
         if isinstance(val, tt.TensorVariable):
             return val.tag.test_value
 
-        if isinstance(val, tt.sharedvar.TensorSharedVariable):
+        if isinstance(val, tt.sharedvar.SharedVariable):
             return val.get_value()
 
         if isinstance(val, theano_constant):


### PR DESCRIPTION
Fixes #3139

As suggested by @rpgoldman over here https://github.com/pymc-devs/pymc3/issues/3139#issuecomment-522036434. This PR just makes the error message a bit clearer (I just re-arranged it a bit, the error message suggesting to add a `test_val` argument was already present).
