### PR TITLE
[WIP] Introduced pm.TidyData class

### DIFF
--- a/pymc3/data.py
+++ b/pymc3/data.py
@@ -36,6 +36,7 @@ __all__ = [
     "Minibatch",
     "align_minibatches",
     "Data",
+    "TidyData",
 ]
 BASE_URL = "https://raw.githubusercontent.com/pymc-devs/pymc-examples/main/examples/data/{filename}"
 
@@ -594,3 +595,78 @@ class Data:
                     coords[dim] = pd.RangeIndex(size, name=dim)
 
         return coords
+
+
+class _IndexAccessor:
+    def __init__(self, data):
+        self._data = data
+
+    def __getitem__(self, key):
+        category = self._data._col_as_category(key)
+        vals = self._data.data.reset_index().loc[:, key]
+        return pd.Categorical(vals, dtype=category).codes
+
+
+class TidyData:
+    def __init__(self, data, copy_data=True, import_dims=None, model=None):
+        self.data = data
+        self._shared_vars = {}
+        self._category_cols = {}
+        self._index_dict = _IndexAccessor(self)
+
+        if import_dims is not None:
+            model = pm.model.modelcontext(model)
+            coords = self._extract_coords(import_dims)
+            model.add_coords(coords)
+
+    @property
+    def idxs(self):
+        return self._index_dict
+
+    def _col_as_category(self, key):
+        if key in self._category_cols:
+            return self._category_cols[key]
+        data = self.data.reset_index()
+        values = data.loc[:, key]
+        if values.dtype.name != 'category':
+            values = values.astype('category')
+        self._category_cols[key] = values.dtype
+        return values.dtype
+
+    def __getitem__(self, key):
+        if key not in self.data.columns:
+            raise KeyError('Unknown column %s' % key)
+        if key in self._shared_vars:
+            return self._shared_vars[key]
+
+        shared_var = theano.shared(self.data.loc[:, key].values)
+        self._shared_vars[key] = shared_var
+        return shared_var
+
+    def _extract_coords(self, dims):
+        data = self.data
+        dims = set(dims)
+        coords = {}
+
+        if data.index.name is not None and data.index.name in dims:
+            dims.remove(data.index.name)
+            coords[data.index.name] = data.index
+
+        # We want to iterate over index columns of a multi index as well
+        data = data.reset_index()
+        for col in data.columns:
+            if col not in dims:
+                continue
+            dims.remove(col)
+            category = self._col_as_category(col)
+            cat = pd.Categorical(category.categories, dtype=category)
+            coords[col] = pd.CategoricalIndex(cat, name=col)
+
+        if dims:
+            raise KeyError('Unknown columns: %s' % dims)
+
+        return coords
+
+    @property
+    def columns(self):
+        return self.data.columns


### PR DESCRIPTION
Link to Issue: #3953

As mentioned in the issue, added a `pm.TidyData` class for automatically translating strings from a `xarray` DataSet into integer arrays for indexing in models. The input (currently) is expected to be a `xarray.Dataset`.

This is just a basic implementation to see if it's going in the right direction. New feature suggestions are welcome. The expected usage is as follows : 

```
import pandas as pd
import pymc3 as pm
import numpy as np
import arviz as az
import theano 
from pymc3.data import TidyData
df = pd.DataFrame({
    'treatment':['Carboplatin']*3 + ['Adriamycin']*4 + ['Fluorouracil']*3,
    'age':np.random.randint(40,80,size=10),
    'location':['Berlin']*6 + ['London']*4,
    'outcome':np.random.randn(10),
})
df.index.name = 'patient'

xdf = df.to_xarray()

with pm.Model() as model:
    data = TidyData(xdf,import_dims=['treatment','location','patient','outcome'])

    intercept = pm.Flat('intercept')
    treatment = pm.Normal('b_treat',sd=0.2,mu=0,dims='treatment')
    location = pm.Normal('b_location',sd=0.2,mu=0,dims='location')
    age = pm.Normal('b_age',sd=0.2,mu=0)
    mu = (intercept
        + treatment[data.get_indexed('treatment')]
        + location[data.get_indexed('location')]
        + age*data['age']
        )
    pm.Normal('y',mu=mu,sd=1,dims='patient',observed=data['outcome'])
    trace = pm.sample()
    tr = az.from_pymc3(trace=trace,model=model)
```