### PR TITLE
Add tests for tt.switch related bugs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,7 @@
 
 ### Maintenance
 - We upgraded to `Theano-PyMC v1.1.2` which [includes bugfixes](https://github.com/pymc-devs/aesara/compare/rel-1.1.0...rel-1.1.2) for warning floods and compiledir locking (see [#4444](https://github.com/pymc-devs/pymc3/pull/4444))
+- `Theano-PyMC v1.1.2` also fixed an important issue in `tt.switch` that affected the behavior of several PyMC distributions, including at least the `Bernoulli` and `TruncatedNormal` (see[#4448](https://github.com/pymc-devs/pymc3/pull/4448))
 - `math.log1mexp_numpy` no longer raises RuntimeWarning when given very small inputs. These were commonly observed during NUTS sampling (see [#4428](https://github.com/pymc-devs/pymc3/pull/4428)).
 
 ## PyMC3 3.11.0 (21 January 2021)


### PR DESCRIPTION
This PR adds two tests for subtle issues related to this bug in `tt.switch`: https://github.com/pymc-devs/aesara/issues/270

The tests are being added because these two bugs (https://github.com/pymc-devs/pymc3/issues/4389 and https://github.com/pymc-devs/pymc3/issues/4417) were rather surprising and difficult to debug. The tests fail before #4444 and pass afterwards.

I have included them in `test_model::TestValueGradFunction` because it seemed to be the most conceptually close block. For e.g.: https://github.com/pymc-devs/pymc3/blob/03d7af5b6dd5ad99ab2f3bd8ca7987a744dbef46/pymc3/tests/test_model.py#L338

Closes #4417 