### PR TITLE
Updating docstring of a class according to PEP 257 in a file

### DIFF
--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -133,7 +133,7 @@ class Metropolis(ArrayStepShared):
         scaling -- Initial scale factor for proposal. (default 1.0)
         tune -- Flag for tuning. (default True)
         tune_interval -- The frequency of tuning. (default 100)
-        model -- Optional model for sampling step. Defaults to None (taken from context).       (default None)
+        model -- Optional model for sampling step. Defaults to None (taken from context).(default None)
         mode -- compilation mode passed to Theano functions. (default None)
         """
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -95,28 +95,7 @@ class MultivariateNormalProposal(Proposal):
 
 
 class Metropolis(ArrayStepShared):
-    """
-    Metropolis-Hastings sampling step
-
-    Parameters
-    ----------
-    vars: list
-        List of variables for sampler
-    S: standard deviation or covariance matrix
-        Some measure of variance to parameterize proposal distribution
-    proposal_dist: function
-        Function that returns zero-mean deviates when parameterized with
-        S (and n). Defaults to normal.
-    scaling: scalar or array
-        Initial scale factor for proposal. Defaults to 1.
-    tune: bool
-        Flag for tuning. Defaults to True.
-    tune_interval: int
-        The frequency of tuning. Defaults to 100 iterations.
-    model: PyMC Model
-        Optional model for sampling step. Defaults to None (taken from context).
-    mode:  string or `Mode` instance.
-        compilation mode passed to Theano functions
+    """Metropolis-Hastings sampling step
     """
 
     name = "metropolis"
@@ -144,6 +123,19 @@ class Metropolis(ArrayStepShared):
         mode=None,
         **kwargs
     ):
+        """Metropolis-Hastings sampling step
+
+        Arguments:
+        vars -- List of variables for sampler (default None)
+        S -- Some measure of variance to parameterize proposal distribution (default None)
+        proposal_dist -- Function that returns zero-mean deviates when parameterized with
+        S (and n). Defaults to normal. (default None)
+        scaling -- Initial scale factor for proposal. (default 1.0)
+        tune -- Flag for tuning. (default True)
+        tune_interval -- The frequency of tuning. (default 100)
+        model -- Optional model for sampling step. Defaults to None (taken from context).       (default None)
+        mode -- compilation mode passed to Theano functions. (default None)
+        """
 
         model = pm.modelcontext(model)
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -133,7 +133,7 @@ class Metropolis(ArrayStepShared):
         scaling -- Initial scale factor for proposal. (default 1.0)
         tune -- Flag for tuning. (default True)
         tune_interval -- The frequency of tuning. (default 100)
-        model -- Optional model for sampling step. Defaults to None (taken from context).(default None)
+        model -- Optional model for sampling step. Defaults to None (taken from context). (default None)
         mode -- compilation mode passed to Theano functions. (default None)
         """
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -141,7 +141,7 @@ class Metropolis(ArrayStepShared):
             The frequency of tuning. Defaults to 100 iterations.
         model: PyMC Model
             Optional model for sampling step. Defaults to None (taken from context).
-        mode:  string or `Mode` instance.
+        mode: string or `Mode` instance.
             compilation mode passed to Theano functions
         """
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -96,6 +96,26 @@ class MultivariateNormalProposal(Proposal):
 
 class Metropolis(ArrayStepShared):
     """Metropolis-Hastings sampling step
+    
+    Parameters
+    ----------
+    vars: list
+        List of variables for sampler
+    S: standard deviation or covariance matrix
+        Some measure of variance to parameterize proposal distribution
+    proposal_dist: function
+        Function that returns zero-mean deviates when parameterized with
+        S (and n). Defaults to normal.
+    scaling: scalar or array
+        Initial scale factor for proposal. Defaults to 1.
+    tune: bool
+        Flag for tuning. Defaults to True.
+    tune_interval: int
+        The frequency of tuning. Defaults to 100 iterations.
+    model: PyMC Model
+        Optional model for sampling step. Defaults to None (taken from context).
+    mode:  string or `Mode` instance.
+        compilation mode passed to Theano functions
     """
 
     name = "metropolis"
@@ -123,7 +143,7 @@ class Metropolis(ArrayStepShared):
         mode=None,
         **kwargs
     ):
-        """Metropolis-Hastings sampling step
+        """Create an instance of a Metropolis stepper
 
         Arguments:
         vars -- List of variables for sampler (default None)

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -95,7 +95,28 @@ class MultivariateNormalProposal(Proposal):
 
 
 class Metropolis(ArrayStepShared):
-    """Metropolis-Hastings sampling step"""
+    """Metropolis-Hastings sampling step
+
+    Parameters
+    ----------
+    vars: list
+        List of variables for sampler
+    S: standard deviation or covariance matrix
+        Some measure of variance to parameterize proposal distribution
+    proposal_dist: function
+        Function that returns zero-mean deviates when parameterized with
+        S (and n). Defaults to normal.
+    scaling: scalar or array
+        Initial scale factor for proposal. Defaults to 1.
+    tune: bool
+        Flag for tuning. Defaults to True.
+    tune_interval: int
+        The frequency of tuning. Defaults to 100 iterations.
+    model: PyMC Model
+        Optional model for sampling step. Defaults to None (taken from context).
+    mode:  string or `Mode` instance.
+        compilation mode passed to Theano functions
+    """
 
     name = "metropolis"
 
@@ -122,7 +143,7 @@ class Metropolis(ArrayStepShared):
         mode=None,
         **kwargs
     ):
-        """Metropolis-Hastings sampling step
+        """Create an instance of a Metropolis stepper
 
         Arguments:
         vars -- List of variables for sampler (default None)

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -95,28 +95,7 @@ class MultivariateNormalProposal(Proposal):
 
 
 class Metropolis(ArrayStepShared):
-    """Metropolis-Hastings sampling step
-
-    Parameters
-    ----------
-    vars: list
-        List of variables for sampler
-    S: standard deviation or covariance matrix
-        Some measure of variance to parameterize proposal distribution
-    proposal_dist: function
-        Function that returns zero-mean deviates when parameterized with
-        S (and n). Defaults to normal.
-    scaling: scalar or array
-        Initial scale factor for proposal. Defaults to 1.
-    tune: bool
-        Flag for tuning. Defaults to True.
-    tune_interval: int
-        The frequency of tuning. Defaults to 100 iterations.
-    model: PyMC Model
-        Optional model for sampling step. Defaults to None (taken from context).
-    mode:  string or `Mode` instance.
-        compilation mode passed to Theano functions
-    """
+    """Metropolis-Hastings sampling step"""
 
     name = "metropolis"
 
@@ -145,16 +124,25 @@ class Metropolis(ArrayStepShared):
     ):
         """Create an instance of a Metropolis stepper
 
-        Arguments:
-        vars -- List of variables for sampler (default None)
-        S -- Some measure of variance to parameterize proposal distribution (default None)
-        proposal_dist -- Function that returns zero-mean deviates when parameterized with
-        S (and n). Defaults to normal. (default None)
-        scaling -- Initial scale factor for proposal. (default 1.0)
-        tune -- Flag for tuning. (default True)
-        tune_interval -- The frequency of tuning. (default 100)
-        model -- Optional model for sampling step. Defaults to None (taken from context). (default None)
-        mode -- compilation mode passed to Theano functions. (default None)
+        Parameters
+        ----------
+        vars: list
+            List of variables for sampler
+        S: standard deviation or covariance matrix
+            Some measure of variance to parameterize proposal distribution
+        proposal_dist: function
+            Function that returns zero-mean deviates when parameterized with
+            S (and n). Defaults to normal.
+        scaling: scalar or array
+            Initial scale factor for proposal. Defaults to 1.
+        tune: bool
+            Flag for tuning. Defaults to True.
+        tune_interval: int
+            The frequency of tuning. Defaults to 100 iterations.
+        model: PyMC Model
+            Optional model for sampling step. Defaults to None (taken from context).
+        mode:  string or `Mode` instance.
+            compilation mode passed to Theano functions
         """
 
         model = pm.modelcontext(model)

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -96,6 +96,26 @@ class MultivariateNormalProposal(Proposal):
 
 class Metropolis(ArrayStepShared):
     """Metropolis-Hastings sampling step
+
+     Parameters
+    ----------
+    vars: list
+        List of variables for sampler
+    S: standard deviation or covariance matrix
+        Some measure of variance to parameterize proposal distribution
+    proposal_dist: function
+        Function that returns zero-mean deviates when parameterized with
+        S (and n). Defaults to normal.
+    scaling: scalar or array
+        Initial scale factor for proposal. Defaults to 1.
+    tune: bool
+        Flag for tuning. Defaults to True.
+    tune_interval: int
+        The frequency of tuning. Defaults to 100 iterations.
+    model: PyMC Model
+        Optional model for sampling step. Defaults to None (taken from context).
+    mode:  string or `Mode` instance.
+        compilation mode passed to Theano functions
     """
 
     name = "metropolis"
@@ -123,7 +143,7 @@ class Metropolis(ArrayStepShared):
         mode=None,
         **kwargs
     ):
-        """Metropolis-Hastings sampling step
+        """Create an instance of a Metropolis stepper
 
         Arguments:
         vars -- List of variables for sampler (default None)


### PR DESCRIPTION
link to the concerned issue #4414 

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes?
- This PR is about updating docstrings to PEP 257.
+ [x] important background, or details about the implementation
- Used PEP 257 
+ [x] are the changes—especially new features—covered by tests and docstrings?
- Used PEP 257 for docstrings instead of numpy docstrings
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
- Done style checking as mentioned in [this](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md

[link to the changed docstrings](https://github.com/pymc-devs/pymc3/blob/2d3ec8f3afcbaa9dcb8401af5fff6932ad7fd158/pymc3/step_methods/metropolis.py#L97)