### PR TITLE
Update Contributing guide to reflect the current workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,10 +145,11 @@ docker exec -it pymc3 jupyter notebook list
 
 ## Style guide
 
-Follow [TensorFlow's style guide](https://www.tensorflow.org/community/contribute/code_style) or the [Google style guide](https://google.github.io/styleguide/pyguide.html) for writing code, which more or less follows PEP 8.
+We have configured a pre-commit hook that checks for `black`-compliant code style.
+We encourage you to configure the pre-commit hook as described in the [PyMC3 Python Code Style Wiki Page](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style), because it will automatically enforce the code style on your commits.
+
+Similarly, consult the [PyMC's Jupyter Notebook Style](https://github.com/pymc-devs/pymc3/wiki/PyMC's-Jupyter-Notebook-Style) guides for notebooks.
 
 For documentation strings, we *prefer* [numpy style](https://numpydoc.readthedocs.io/en/latest/format.html) to comply with the style that predominates in our upstream dependencies.
-
-Finally, see the [PyMC3 Python Code Style](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style) and the [PyMC's Jupyter Notebook Style](https://github.com/pymc-devs/pymc3/wiki/PyMC's-Jupyter-Notebook-Style) guides.
 
 #### This guide was derived from the [scikit-learn guide to contributing](https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
The contributing guide was outdated on the section about the code style.

We no longer give contributors the freedom about the code style 🔥.

+ [x] ~what are the (breaking) changes that this PR makes?~ None
+ [x] ~important background, or details about the implementation~ Trivial
+ [x] ~are the changes—especially new features—covered by tests and docstrings?~ does not apply
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [x] ~[consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)~ Nope
+ [x] ~right before it's ready to merge, mention the PR in the RELEASE-NOTES.md~ no need
