### PR TITLE
Reduce number of test points in slow logcdf methods

### DIFF
--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -948,6 +948,7 @@ class TestMatchesScipy(SeededTest):
             Unit,
             {"alpha": Rplus, "beta": Rplus},
             lambda value, alpha, beta: sp.beta.logcdf(value, alpha, beta),
+            n_samples=10,
         )
 
     def test_kumaraswamy(self):
@@ -1052,17 +1053,20 @@ class TestMatchesScipy(SeededTest):
             Nat,
             {"mu": Rplus, "alpha": Rplus},
             scipy_mu_alpha_logcdf,
+            n_samples=5,
         )
         self.check_logcdf(
             NegativeBinomial,
             Nat,
             {"p": Unit, "n": Rplus},
             lambda value, p, n: sp.nbinom.logcdf(value, n, p),
+            n_samples=5,
         )
         self.check_selfconsistency_discrete_logcdf(
             NegativeBinomial,
             Nat,
             {"mu": Rplus, "alpha": Rplus},
+            n_samples=10,
         )
 
     @pytest.mark.parametrize(
@@ -1282,11 +1286,13 @@ class TestMatchesScipy(SeededTest):
             Nat,
             {"n": NatSmall, "p": Unit},
             lambda value, n, p: sp.binom.logcdf(value, n, p),
+            n_samples=10,
         )
         self.check_selfconsistency_discrete_logcdf(
             Binomial,
             Nat,
             {"n": NatSmall, "p": Unit},
+            n_samples=10,
         )
 
     # Too lazy to propagate decimal parameter through the whole chain of deps
@@ -1423,6 +1429,7 @@ class TestMatchesScipy(SeededTest):
             ZeroInflatedNegativeBinomial,
             Nat,
             {"mu": Rplusbig, "alpha": Rplusbig, "psi": Unit},
+            n_samples=10,
         )
 
     # Too lazy to propagate decimal parameter through the whole chain of deps
@@ -1437,6 +1444,7 @@ class TestMatchesScipy(SeededTest):
             ZeroInflatedBinomial,
             Nat,
             {"n": NatSmall, "p": Unit, "psi": Unit},
+            n_samples=10,
         )
 
     @pytest.mark.parametrize("n", [1, 2, 3])


### PR DESCRIPTION
CI tests for logcdf methods that make use of `dist_math.incomplete_beta::incomplete_beta` are crazy slow. This is reported in #4420 

This PR simply reduces the number of random tested points, which could save up to an hour in the CIs. Note that a similar change was already done for the logcdf method of the StudentT in https://github.com/pymc-devs/pymc3/pull/3823 for the same reasons.

Besides, these methods have passed many times now without failures, so it should be okay to reduce the number of points in each run. Objections?

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes? None
+ [x] important background, or details about the implementation. Trivial
+ [x] are the changes—especially new features—covered by tests and docstrings? Not needed.
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [x] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples) NA
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md. Not needed
