### PR TITLE
Removed redundant bound in Wald distribution

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -1053,8 +1053,6 @@ class Wald(PositiveContinuous):
             logpow(lam / (2.0 * np.pi), 0.5)
             - logpow(centered_value, 1.5)
             - (0.5 * lam / centered_value * ((centered_value - mu) / mu) ** 2),
-            # XXX these two are redundant. Please, check.
-            value > 0,
             centered_value > 0,
             mu > 0,
             lam > 0,


### PR DESCRIPTION
Bound was checked for the value and the centered value in the Wald distribution. This removes the former.

