### PR TITLE
Fix Triangular bounds

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,6 +14,7 @@
 - `ScalarSharedVariable` can now be used as an input to other RVs directly (see [#4445](https://github.com/pymc-devs/pymc3/pull/4445)).
 - `pm.sample` and `pm.find_MAP` no longer change the `start` argument (see [#4458](https://github.com/pymc-devs/pymc3/pull/4458)).
 - Fixed `Dirichlet.logp` method to work with unit batch or event shapes (see [#4454](https://github.com/pymc-devs/pymc3/pull/4454)).
+- Bugfix in logp and logcdf methods of `Triangular` distribution (see[#4470](https://github.com/pymc-devs/pymc3/pull/4470)).
 
 ## PyMC3 3.11.0 (21 January 2021)
 

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -802,6 +802,10 @@ class TestMatchesScipy:
             lambda value, lower, upper: sp.uniform.logcdf(value, lower, upper - lower),
             skip_paramdomain_outside_edge_test=True,
         )
+        # Custom logp / logcdf check for invalid parameters
+        invalid_dist = Uniform.dist(lower=1, upper=0)
+        assert invalid_dist.logp(0.5).tag.test_value == -np.inf
+        assert invalid_dist.logcdf(2).tag.test_value == -np.inf
 
     def test_triangular(self):
         self.check_logp(
@@ -817,6 +821,14 @@ class TestMatchesScipy:
             lambda value, c, lower, upper: sp.triang.logcdf(value, c - lower, lower, upper - lower),
             skip_paramdomain_outside_edge_test=True,
         )
+        # Custom logp check for invalid value
+        valid_dist = Triangular.dist(lower=0, upper=1, c=2.0)
+        assert np.all(valid_dist.logp(np.array([1.9, 2.0, 2.1])).tag.test_value == -np.inf)
+
+        # Custom logp / logcdf check for invalid parameters
+        invalid_dist = Triangular.dist(lower=1, upper=0, c=2.0)
+        assert invalid_dist.logp(0.5).tag.test_value == -np.inf
+        assert invalid_dist.logcdf(2).tag.test_value == -np.inf
 
     def test_bound_normal(self):
         PositiveNormal = Bound(Normal, lower=0.0)
@@ -850,6 +862,10 @@ class TestMatchesScipy:
             Rdunif,
             {"lower": -Rplusdunif, "upper": Rplusdunif},
         )
+        # Custom logp / logcdf check for invalid parameters
+        invalid_dist = DiscreteUniform.dist(lower=1, upper=0)
+        assert invalid_dist.logp(0.5).tag.test_value == -np.inf
+        assert invalid_dist.logcdf(2).tag.test_value == -np.inf
 
     def test_flat(self):
         self.check_logp(Flat, Runif, {}, lambda value: 0)


### PR DESCRIPTION
Small fix to Triangular dist logp and logcdf bounds.

Before this PR the following evaluations gave wrong results (all should evaluate to -inf):

```python
pm.Triangular.dist(lower=0, upper=1, c=2.0).logp(1.9).eval()           
array(0.64185389)

pm.Triangular.dist(lower=0, upper=1, c=-0.5).logp(-0.3).eval()          
array(0.55004634)

pm.Triangular.dist(lower=1, upper=0, c=0.5).logp(0.7).eval()
array(inf)

pm.Triangular.dist(lower=1, upper=0, c=2).logcdf(2).eval()              
array(nan)

pm.Triangular.dist(lower=1, upper=0, c=0.5).logcdf(2).eval()            
array(0.)
```


Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [ ] important background, or details about the implementation
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
