### PR TITLE
Rename Theano to Aesara

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -18,7 +18,7 @@ If you have questions about a specific use case, or you are not sure whether thi
 ## Versions and main components
 
 * PyMC3 Version:
-* Theano Version:
+* Aesara Version:
 * Python Version:
 * Operating system:
 * How did you install PyMC3: (conda/pip)

--- a/.github/workflows/arviz_compat.yml
+++ b/.github/workflows/arviz_compat.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      THEANO_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=native'
+      AESARA_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=native'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/jaxtests.yml
+++ b/.github/workflows/jaxtests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      THEANO_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=native'
+      AESARA_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=native'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      THEANO_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=native'
+      AESARA_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=native'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      THEANO_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=core2'
+      AESARA_FLAGS: floatX=${{ matrix.floatx }},gcc__cxxflags='-march=core2'
     defaults:
       run:
         shell: bash -l {0}

--- a/README.rst
+++ b/README.rst
@@ -15,18 +15,6 @@ Check out the `getting started guide <http://docs.pymc.io/notebooks/getting_star
 using Binder!
 For questions on PyMC3, head on over to our `PyMC Discourse <https://discourse.pymc.io/>`__ forum.
 
-The future of PyMC3 & Theano
-============================
-
-There have been many questions and uncertainty around the future of PyMC3 since Theano
-stopped getting developed by the original authors, and we started experiments with PyMC4.
-
-We are happy to announce that PyMC3 on Theano (which we are `developing further <https://github.com/pymc-devs/Theano-PyMC>`__)
-with a new JAX backend is the future. PyMC4 will not be developed further.
-
-See the `full announcement <https://pymc-devs.medium.com/the-future-of-pymc3-or-theano-is-dead-long-live-theano-d8005f8a0e9b>`__
-for more details.
-
 Features
 ========
 
@@ -39,7 +27,7 @@ Features
 -  **Variational inference**: `ADVI <http://www.jmlr.org/papers/v18/16-107.html>`__
    for fast approximate posterior estimation as well as mini-batch ADVI
    for large data sets.
--  Relies on `Theano-PyMC <https://theano-pymc.readthedocs.io/en/latest/>`__ which provides:
+-  Relies on `Aesara <https://aesara.readthedocs.io/en/latest/>`__ which provides:
     *  Computation optimization and dynamic C or JAX compilation
     *  Numpy broadcasting and advanced indexing
     *  Linear algebra operators

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,7 +2,7 @@
 
 ## PyMC3 vNext (TBD)
 ### Breaking Changes
-+ ...
+- ⚠ Theano-PyMC has been replaced with Aesara, so all external references to `theano`, `tt`, and `pymc3.theanof` need to be replaced with `aesara`, `aet`, and `pymc3.aesaraf` (see [4471](https://github.com/pymc-devs/pymc3/pull/4471)).
 
 ### New Features
 + ...

--- a/benchmarks/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks/benchmarks.py
@@ -14,11 +14,11 @@
 import time
 import timeit
 
+import aesara
+import aesara.tensor as aet
 import arviz as az
 import numpy as np
 import pandas as pd
-import theano
-import theano.tensor as tt
 
 import pymc3 as pm
 
@@ -27,7 +27,7 @@ def glm_hierarchical_model(random_seed=123):
     """Sample glm hierarchical model to use in benchmarks"""
     np.random.seed(random_seed)
     data = pd.read_csv(pm.get_data("radon.csv"))
-    data["log_radon"] = data["log_radon"].astype(theano.config.floatX)
+    data["log_radon"] = data["log_radon"].astype(aesara.config.floatX)
     county_idx = data.county_code.values
 
     n_counties = len(data.county.unique())
@@ -61,8 +61,8 @@ def mixture_model(random_seed=1234):
         mu = pm.Normal("mu", mu=0.0, sd=10.0, shape=w_true.shape)
         enforce_order = pm.Potential(
             "enforce_order",
-            tt.switch(mu[0] - mu[1] <= 0, 0.0, -np.inf)
-            + tt.switch(mu[1] - mu[2] <= 0, 0.0, -np.inf),
+            aet.switch(mu[0] - mu[1] <= 0, 0.0, -np.inf)
+            + aet.switch(mu[1] - mu[2] <= 0, 0.0, -np.inf),
         )
         tau = pm.Gamma("tau", alpha=1.0, beta=1.0, shape=w_true.shape)
         pm.NormalMixture("x_obs", w=w, mu=mu, tau=tau, observed=x)

--- a/docs/source/Gaussian_Processes.rst
+++ b/docs/source/Gaussian_Processes.rst
@@ -113,7 +113,7 @@ which allows users to combine covariance functions into new ones, for example:
 
 After the covariance function is defined, it is now a function that is
 evaluated by calling :code:`cov_func(x, x)` (or :code:`mean_func(x)`).  Since
-PyMC3 is built on top of Theano, it is relatively easy to define and experiment
+PyMC3 is built on top of Aesara, it is relatively easy to define and experiment
 with non-standard covariance and mean functons.  For more information check out
 the tutorial on covariance functions.
 
@@ -158,7 +158,7 @@ other type of random variable.  The first argument is the name of the random
 variable representing the function we are placing the prior over.
 The second argument is the inputs to the function that the prior is over,
 :code:`X`.  The inputs are usually known and present in the data, but they can
-also be PyMC3 random variables.  If the inputs are a Theano tensor or a
+also be PyMC3 random variables.  If the inputs are a Aesara tensor or a
 PyMC3 random variable, the :code:`shape` needs to be given.
 
 Usually at this point, inference is performed on the model.  The

--- a/docs/source/Probability_Distributions.rst
+++ b/docs/source/Probability_Distributions.rst
@@ -27,7 +27,7 @@ A variable requires at least a ``name`` argument, and zero or more model paramet
 
         p = pm.Beta('p', 1, 1, shape=(3, 3))
 
-Probability distributions are all subclasses of ``Distribution``, which in turn has two major subclasses: ``Discrete`` and ``Continuous``. In terms of data types, a ``Continuous`` random variable is given whichever floating point type is defined by ``theano.config.floatX``, while ``Discrete`` variables are given ``int16`` types when ``theano.config.floatX`` is ``float32``, and ``int64`` otherwise.
+Probability distributions are all subclasses of ``Distribution``, which in turn has two major subclasses: ``Discrete`` and ``Continuous``. In terms of data types, a ``Continuous`` random variable is given whichever floating point type is defined by ``aesara.config.floatX``, while ``Discrete`` variables are given ``int16`` types when ``aesara.config.floatX`` is ``float32``, and ``int64`` otherwise.
 
 All distributions in ``pm.distributions`` will have two important methods: ``random()`` and ``logp()`` with the following signatures:
 

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -27,7 +27,7 @@ PyMC3 strives to make Bayesian modeling as simple and painless as possible,  all
 
 * Includes a large suite of well-documented statistical distributions.
 
-* Uses Theano as the computational backend, allowing for fast expression evaluation, automatic gradient calculation, and GPU computing.
+* Uses Aesara as the computational backend, allowing for fast expression evaluation, automatic gradient calculation, and GPU computing.
 
 * Built-in support for Gaussian process modeling.
 
@@ -45,7 +45,7 @@ PyMC3 strives to make Bayesian modeling as simple and painless as possible,  all
 What's new in version 3
 =======================
 
-The third major version of PyMC has benefitted from being re-written from scratch. Substantial improvements in the user interface and performance have resulted from this. While PyMC2 relied on Fortran extensions (via f2py) for most of the computational heavy-lifting, PyMC3 leverages Theano, a library from the Montréal Institute for Learning Algorithms (MILA), for array-based expression evaluation, to perform its computation. What this provides, above all else, is fast automatic differentiation, which is at the heart of the gradient-based sampling and optimization methods currently providing inference for probabilistic programming.
+The third major version of PyMC has benefitted from being re-written from scratch. Substantial improvements in the user interface and performance have resulted from this. While PyMC2 relied on Fortran extensions (via f2py) for most of the computational heavy-lifting, PyMC3 leverages Aesara, a fork of the Theano library from the Montréal Institute for Learning Algorithms (MILA), for array-based expression evaluation, to perform its computation. What this provides, above all else, is fast automatic differentiation, which is at the heart of the gradient-based sampling and optimization methods currently providing inference for probabilistic programming.
 
 Major changes from previous versions:
 
@@ -65,7 +65,7 @@ Major changes from previous versions:
 
 * Much more!
 
-While the addition of Theano adds a level of complexity to the development of PyMC, fundamentally altering how the underlying computation is performed, we have worked hard to maintain the elegant simplicity of the original PyMC model specification syntax.
+While the addition of Aesara adds a level of complexity to the development of PyMC, fundamentally altering how the underlying computation is performed, we have worked hard to maintain the elegant simplicity of the original PyMC model specification syntax.
 
 
 History
@@ -90,7 +90,7 @@ plotting, csv table output, improved imputation syntax, and posterior
 predictive check plots. PyMC 2.3 was released on October 31, 2013. It included
 Python 3 compatibility, improved summary plots, and some important bug fixes.
 
-In 2011, John Salvatier began thinking about implementing gradient-based MCMC samplers, and developed the ``mcex`` package to experiment with his ideas. The following year, John was invited by the team to re-engineer PyMC to accomodate Hamiltonian Monte Carlo sampling. This led to the adoption of Theano as the computational back end, and marked the beginning of PyMC3's development. The first alpha version of PyMC3 was released in June 2015. Over the following 2 years, the core development team grew to 12 members, and the first release, PyMC3 3.0, was launched in January 2017.
+In 2011, John Salvatier began thinking about implementing gradient-based MCMC samplers, and developed the ``mcex`` package to experiment with his ideas. The following year, John was invited by the team to re-engineer PyMC to accomodate Hamiltonian Monte Carlo sampling. This led to the adoption of Theano as the computational back end, and marked the beginning of PyMC3's development. The first alpha version of PyMC3 was released in June 2015. Over the following 2 years, the core development team grew to 12 members, and the first release, PyMC3 3.0, was launched in January 2017.  In 2020 the PyMC developers forked Theano and in 2021 renamed the forked project to Aesara.
 
 .. _support:
 

--- a/docs/source/api/math.rst
+++ b/docs/source/api/math.rst
@@ -3,8 +3,8 @@ Math
 ====
 
 This submodule contains various mathematical functions. Most of them are imported directly
-from theano.tensor (see there for more details). Doing any kind of math with PyMC3 random
-variables, or defining custom likelihoods or priors requires you to use these theano
+from aesara.tensor (see there for more details). Doing any kind of math with PyMC3 random
+variables, or defining custom likelihoods or priors requires you to use these aesara
 expressions rather than NumPy or Python code.
 
 .. currentmodule:: pymc3.math

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -158,7 +158,7 @@ html_theme_options = {
         ("About PyMC3", "about"),
     ],
     #     "fixed_sidebar": "false",
-    #     "description": "Probabilistic Programming in Python: Bayesian Modeling and Probabilistic Machine Learning with Theano"
+    #     "description": "Probabilistic Programming in Python: Bayesian Modeling and Probabilistic Machine Learning with Aesara"
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -97,10 +97,10 @@
                     </div>
                 </a>
 
-                <a class="ui link card" href="/PyMC3_and_Theano.html">
+                <a class="ui link card" href="/PyMC3_and_Aesara.html">
                     <div class="content">
-                        <div class="header">PyMC3 and Theano</div>
-                        <div class="description">Theano is the deep-learning library PyMC3 uses to construct probability distributions and then access the gradient in order to implement cutting edge inference algorithms. More advanced models may be built by understanding this layer.
+                        <div class="header">PyMC3 and Aesara</div>
+                        <div class="description">Aesara is the library PyMC3 uses to construct probability distributions and then access the gradient in order to implement cutting edge inference algorithms. More advanced models may be built by understanding this layer.
                         </div>
                     </div>
                 </a>

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -29,16 +29,17 @@ if not logging.root.handlers:
 
 
 def __set_compiler_flags():
-    # Workarounds for Theano compiler problems on various platforms
-    import theano
+    # Workarounds for Aesara compiler problems on various platforms
+    import aesara
 
-    current = theano.config.gcc__cxxflags
-    theano.config.gcc__cxxflags = f"{current} -Wno-c++11-narrowing"
+    current = aesara.config.gcc__cxxflags
+    aesara.config.gcc__cxxflags = f"{current} -Wno-c++11-narrowing"
 
 
 __set_compiler_flags()
 
 from pymc3 import gp, ode, sampling
+from pymc3.aesaraf import *
 from pymc3.backends import load_trace, save_trace
 from pymc3.backends.tracetab import *
 from pymc3.blocking import *
@@ -63,7 +64,6 @@ from pymc3.sampling import *
 from pymc3.smc import *
 from pymc3.step_methods import *
 from pymc3.tests import test
-from pymc3.theanof import *
 from pymc3.tuning import *
 from pymc3.variational import *
 from pymc3.vartypes import *

--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -23,8 +23,8 @@ import warnings
 from abc import ABC
 from typing import List
 
+import aesara.tensor as aet
 import numpy as np
-import theano.tensor as tt
 
 from pymc3.backends.report import SamplerReport, merge_reports
 from pymc3.model import modelcontext
@@ -434,7 +434,7 @@ class MultiTrace:
 
             for idx, chain in enumerate(chains.values()):
                 if new_var:
-                    dummy = tt.as_tensor_variable([], k)
+                    dummy = aet.as_tensor_variable([], k)
                     chain.vars.append(dummy)
                 chain.samples[k] = v[idx]
 

--- a/pymc3/blocking.py
+++ b/pymc3/blocking.py
@@ -125,13 +125,13 @@ class DictToArrayBijection:
 
 class ListArrayOrdering:
     """
-    An ordering for a list to an array space. Takes also non theano.tensors.
+    An ordering for a list to an array space. Takes also non aesara.tensors.
     Modified from pymc3 blocking.
 
     Parameters
     ----------
     list_arrays: list
-        :class:`numpy.ndarray` or :class:`theano.tensor.Tensor`
+        :class:`numpy.ndarray` or :class:`aesara.tensor.Tensor`
     intype: str
         defining the input type 'tensor' or 'numpy'
     """

--- a/pymc3/data.py
+++ b/pymc3/data.py
@@ -21,12 +21,14 @@ import urllib.request
 from copy import copy
 from typing import Any, Dict, List
 
+import aesara
+import aesara.tensor as aet
 import numpy as np
 import pandas as pd
-import theano
-import theano.tensor as tt
 
-from theano.graph.basic import Apply
+from aesara.graph.basic import Apply
+from aesara.tensor.type import TensorType
+from aesara.tensor.var import TensorVariable
 
 import pymc3 as pm
 
@@ -61,7 +63,7 @@ def get_data(filename):
     return io.BytesIO(content)
 
 
-class GenTensorVariable(tt.TensorVariable):
+class GenTensorVariable(TensorVariable):
     def __init__(self, op, type, name=None):
         super().__init__(type=type, name=name)
         self.op = op
@@ -96,7 +98,7 @@ class GeneratorAdapter:
         # make pickling potentially possible
         self._yielded_test_value = False
         self.gen = generator
-        self.tensortype = tt.TensorType(self.test_value.dtype, ((False,) * self.test_value.ndim))
+        self.tensortype = TensorType(self.test_value.dtype, ((False,) * self.test_value.ndim))
 
     # python3 generator
     def __next__(self):
@@ -119,7 +121,7 @@ class GeneratorAdapter:
         return hash(id(self))
 
 
-class Minibatch(tt.TensorVariable):
+class Minibatch(TensorVariable):
     """Multidimensional minibatch that is pure TensorVariable
 
     Parameters
@@ -143,7 +145,7 @@ class Minibatch(tt.TensorVariable):
         you can use it to change source of
         minibatches programmatically
     in_memory_size: ``int`` or ``List[int|slice|Ellipsis]``
-        data size for storing in ``theano.shared``
+        data size for storing in ``aesara.shared``
 
     Attributes
     ----------
@@ -231,11 +233,11 @@ class Minibatch(tt.TensorVariable):
     To be more concrete about how we create a minibatch, here is a demo:
     1. create a shared variable
 
-        >>> shared = theano.shared(data)
+        >>> shared = aesara.shared(data)
 
     2. take a random slice of size 10:
 
-        >>> ridx = pm.tt_rng().uniform(size=(10,), low=0, high=data.shape[0]-1e-10).astype('int64')
+        >>> ridx = pm.aet_rng().uniform(size=(10,), low=0, high=data.shape[0]-1e-10).astype('int64')
 
     3) take the resulting slice:
 
@@ -255,7 +257,7 @@ class Minibatch(tt.TensorVariable):
     Then you should create a `dict` with replacements:
 
     >>> replacements = {x: testdata}
-    >>> rnode = theano.clone(node, replacements)
+    >>> rnode = aesara.clone_replace(node, replacements)
     >>> assert (testdata ** 2 == rnode.eval()).all()
 
     *FIXME: In the following, what is the **reason** to replace the Minibatch variable with
@@ -266,7 +268,7 @@ class Minibatch(tt.TensorVariable):
     For example
 
     >>> replacements = {x.minibatch: x.shared}
-    >>> rnode = theano.clone(node, replacements)
+    >>> rnode = aesara.clone_replace(node, replacements)
 
     For more complex slices some more code is needed that can seem not so clear
 
@@ -296,7 +298,7 @@ class Minibatch(tt.TensorVariable):
 
     RNG = collections.defaultdict(list)  # type: Dict[str, List[Any]]
 
-    @theano.config.change_flags(compute_test_value="raise")
+    @aesara.config.change_flags(compute_test_value="raise")
     def __init__(
         self,
         data,
@@ -313,23 +315,23 @@ class Minibatch(tt.TensorVariable):
         else:
             data = np.asarray(data, dtype)
         in_memory_slc = self.make_static_slices(in_memory_size)
-        self.shared = theano.shared(data[in_memory_slc])
+        self.shared = aesara.shared(data[in_memory_slc])
         self.update_shared_f = update_shared_f
         self.random_slc = self.make_random_slices(self.shared.shape, batch_size, random_seed)
         minibatch = self.shared[self.random_slc]
         if broadcastable is None:
             broadcastable = (False,) * minibatch.ndim
-        minibatch = tt.patternbroadcast(minibatch, broadcastable)
+        minibatch = aet.patternbroadcast(minibatch, broadcastable)
         self.minibatch = minibatch
         super().__init__(self.minibatch.type, None, None, name=name)
-        Apply(theano.compile.view_op, inputs=[self.minibatch], outputs=[self])
+        Apply(aesara.compile.view_op, inputs=[self.minibatch], outputs=[self])
         self.tag.test_value = copy(self.minibatch.tag.test_value)
 
     def rslice(self, total, size, seed):
         if size is None:
             return slice(None)
         elif isinstance(size, int):
-            rng = pm.tt_rng(seed)
+            rng = pm.aet_rng(seed)
             Minibatch.RNG[id(self)].append(rng)
             return rng.uniform(size=(size,), low=0.0, high=pm.floatX(total) - 1e-16).astype("int64")
         else:
@@ -401,7 +403,7 @@ class Minibatch(tt.TensorVariable):
                     )
                 if len(end) > 0:
                     shp_mid = shape[sep : -len(end)]
-                    mid = [tt.arange(s) for s in shp_mid]
+                    mid = [aet.arange(s) for s in shp_mid]
                 else:
                     mid = []
             else:
@@ -419,17 +421,17 @@ class Minibatch(tt.TensorVariable):
                 shp_end = np.asarray([])
             shp_begin = shape[: len(begin)]
             slc_begin = [
-                self.rslice(shp_begin[i], t[0], t[1]) if t is not None else tt.arange(shp_begin[i])
+                self.rslice(shp_begin[i], t[0], t[1]) if t is not None else aet.arange(shp_begin[i])
                 for i, t in enumerate(begin)
             ]
             slc_end = [
-                self.rslice(shp_end[i], t[0], t[1]) if t is not None else tt.arange(shp_end[i])
+                self.rslice(shp_end[i], t[0], t[1]) if t is not None else aet.arange(shp_end[i])
                 for i, t in enumerate(end)
             ]
             slc = slc_begin + mid + slc_end
         else:
             raise TypeError("Unrecognized size type, %r" % batch_size)
-        return pm.theanof.ix_(*slc)
+        return pm.aesaraf.ix_(*slc)
 
     def update_shared(self):
         if self.update_shared_f is None:
@@ -460,7 +462,7 @@ def align_minibatches(batches=None):
 
 
 class Data:
-    """Data container class that wraps the theano ``SharedVariable`` class
+    """Data container class that wraps the aesara ``SharedVariable`` class
     and lets the model be aware of its inputs and outputs.
 
     Parameters
@@ -524,7 +526,7 @@ class Data:
 
         # `pm.model.pandas_to_array` takes care of parameter `value` and
         # transforms it to something digestible for pymc3
-        shared_object = theano.shared(pm.model.pandas_to_array(value), name)
+        shared_object = aesara.shared(pm.model.pandas_to_array(value), name)
 
         if isinstance(dims, str):
             dims = (dims,)

--- a/pymc3/distributions/bound.py
+++ b/pymc3/distributions/bound.py
@@ -14,9 +14,10 @@
 
 from numbers import Real
 
+import aesara.tensor as aet
 import numpy as np
-import theano.tensor as tt
 
+from pymc3.aesaraf import floatX
 from pymc3.distributions import transforms
 from pymc3.distributions.dist_math import bound
 from pymc3.distributions.distribution import (
@@ -26,7 +27,6 @@ from pymc3.distributions.distribution import (
     draw_values,
     generate_samples,
 )
-from pymc3.theanof import floatX
 
 __all__ = ["Bound"]
 
@@ -207,9 +207,9 @@ class _ContinuousBounded(_Bounded, Continuous):
 
     def __init__(self, distribution, lower, upper, transform="infer", *args, **kwargs):
         if lower is not None:
-            lower = tt.as_tensor_variable(floatX(lower))
+            lower = aet.as_tensor_variable(floatX(lower))
         if upper is not None:
-            upper = tt.as_tensor_variable(floatX(upper))
+            upper = aet.as_tensor_variable(floatX(upper))
 
         if transform == "infer":
             if lower is None and upper is None:

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -19,13 +19,14 @@ nodes in PyMC.
 """
 import warnings
 
+import aesara.tensor as aet
 import numpy as np
-import theano.tensor as tt
 
 from scipy import stats
 from scipy.interpolate import InterpolatedUnivariateSpline
 from scipy.special import expit
 
+from pymc3.aesaraf import floatX
 from pymc3.distributions import transforms
 from pymc3.distributions.dist_math import (
     SplineWrapper,
@@ -44,7 +45,6 @@ from pymc3.distributions.dist_math import (
 from pymc3.distributions.distribution import Continuous, draw_values, generate_samples
 from pymc3.distributions.special import log_i0
 from pymc3.math import invlogit, log1mexp, log1pexp, logdiffexp, logit
-from pymc3.theanof import floatX
 
 __all__ = [
     "Uniform",
@@ -101,8 +101,8 @@ class BoundedContinuous(Continuous):
 
     def __init__(self, transform="auto", lower=None, upper=None, *args, **kwargs):
 
-        lower = tt.as_tensor_variable(lower) if lower is not None else None
-        upper = tt.as_tensor_variable(upper) if upper is not None else None
+        lower = aet.as_tensor_variable(lower) if lower is not None else None
+        upper = aet.as_tensor_variable(upper) if upper is not None else None
 
         if transform == "auto":
             if lower is None and upper is None:
@@ -223,8 +223,8 @@ class Uniform(BoundedContinuous):
     """
 
     def __init__(self, lower=0, upper=1, *args, **kwargs):
-        self.lower = lower = tt.as_tensor_variable(floatX(lower))
-        self.upper = upper = tt.as_tensor_variable(floatX(upper))
+        self.lower = lower = aet.as_tensor_variable(floatX(lower))
+        self.upper = upper = aet.as_tensor_variable(floatX(upper))
         self.mean = (upper + lower) / 2.0
         self.median = self.mean
 
@@ -268,7 +268,7 @@ class Uniform(BoundedContinuous):
         """
         lower = self.lower
         upper = self.upper
-        return bound(-tt.log(upper - lower), value >= lower, value <= upper)
+        return bound(-aet.log(upper - lower), value >= lower, value <= upper)
 
     def logcdf(self, value):
         """
@@ -277,9 +277,9 @@ class Uniform(BoundedContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -288,12 +288,12 @@ class Uniform(BoundedContinuous):
         lower = self.lower
         upper = self.upper
 
-        return tt.switch(
-            tt.lt(value, lower) | tt.lt(upper, lower),
+        return aet.switch(
+            aet.lt(value, lower) | aet.lt(upper, lower),
             -np.inf,
-            tt.switch(
-                tt.lt(value, upper),
-                tt.log(value - lower) - tt.log(upper - lower),
+            aet.switch(
+                aet.lt(value, upper),
+                aet.log(value - lower) - aet.log(upper - lower),
                 0,
             ),
         )
@@ -331,13 +331,13 @@ class Flat(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
         TensorVariable
         """
-        return tt.zeros_like(value)
+        return aet.zeros_like(value)
 
     def logcdf(self, value):
         """
@@ -346,16 +346,16 @@ class Flat(Continuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
         TensorVariable
         """
-        return tt.switch(
-            tt.eq(value, -np.inf), -np.inf, tt.switch(tt.eq(value, np.inf), 0, tt.log(0.5))
+        return aet.switch(
+            aet.eq(value, -np.inf), -np.inf, aet.switch(aet.eq(value, np.inf), 0, aet.log(0.5))
         )
 
 
@@ -388,13 +388,13 @@ class HalfFlat(PositiveContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
         TensorVariable
         """
-        return bound(tt.zeros_like(value), value > 0)
+        return bound(aet.zeros_like(value), value > 0)
 
     def logcdf(self, value):
         """
@@ -403,15 +403,17 @@ class HalfFlat(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
         TensorVariable
         """
-        return tt.switch(tt.lt(value, np.inf), -np.inf, tt.switch(tt.eq(value, np.inf), 0, -np.inf))
+        return aet.switch(
+            aet.lt(value, np.inf), -np.inf, aet.switch(aet.eq(value, np.inf), 0, -np.inf)
+        )
 
 
 class Normal(Continuous):
@@ -481,10 +483,10 @@ class Normal(Continuous):
         if sd is not None:
             sigma = sd
         tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
-        self.sigma = self.sd = tt.as_tensor_variable(sigma)
-        self.tau = tt.as_tensor_variable(tau)
+        self.sigma = self.sd = aet.as_tensor_variable(sigma)
+        self.tau = aet.as_tensor_variable(tau)
 
-        self.mean = self.median = self.mode = self.mu = mu = tt.as_tensor_variable(floatX(mu))
+        self.mean = self.median = self.mode = self.mu = mu = aet.as_tensor_variable(floatX(mu))
         self.variance = 1.0 / self.tau
 
         assert_negative_support(sigma, "sigma", "Normal")
@@ -522,7 +524,7 @@ class Normal(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -532,7 +534,7 @@ class Normal(Continuous):
         tau = self.tau
         mu = self.mu
 
-        return bound((-tau * (value - mu) ** 2 + tt.log(tau / np.pi / 2.0)) / 2.0, sigma > 0)
+        return bound((-tau * (value - mu) ** 2 + aet.log(tau / np.pi / 2.0)) / 2.0, sigma > 0)
 
     def _distr_parameters_for_repr(self):
         return ["mu", "sigma"]
@@ -544,9 +546,9 @@ class Normal(Continuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -647,21 +649,21 @@ class TruncatedNormal(BoundedContinuous):
         if sd is not None:
             sigma = sd
         tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
-        self.sigma = self.sd = tt.as_tensor_variable(sigma)
-        self.tau = tt.as_tensor_variable(tau)
-        self.lower_check = tt.as_tensor_variable(floatX(lower)) if lower is not None else lower
-        self.upper_check = tt.as_tensor_variable(floatX(upper)) if upper is not None else upper
+        self.sigma = self.sd = aet.as_tensor_variable(sigma)
+        self.tau = aet.as_tensor_variable(tau)
+        self.lower_check = aet.as_tensor_variable(floatX(lower)) if lower is not None else lower
+        self.upper_check = aet.as_tensor_variable(floatX(upper)) if upper is not None else upper
         self.lower = (
-            tt.as_tensor_variable(floatX(lower))
+            aet.as_tensor_variable(floatX(lower))
             if lower is not None
-            else tt.as_tensor_variable(-np.inf)
+            else aet.as_tensor_variable(-np.inf)
         )
         self.upper = (
-            tt.as_tensor_variable(floatX(upper))
+            aet.as_tensor_variable(floatX(upper))
             if upper is not None
-            else tt.as_tensor_variable(np.inf)
+            else aet.as_tensor_variable(np.inf)
         )
-        self.mu = tt.as_tensor_variable(floatX(mu))
+        self.mu = aet.as_tensor_variable(floatX(mu))
 
         if self.lower_check is None and self.upper_check is None:
             self._defaultval = mu
@@ -732,7 +734,7 @@ class TruncatedNormal(BoundedContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -763,7 +765,7 @@ class TruncatedNormal(BoundedContinuous):
             lsf_a = normal_lccdf(mu, sigma, self.lower)
             lsf_b = normal_lccdf(mu, sigma, self.upper)
 
-            return tt.switch(self.lower > 0, logdiffexp(lsf_a, lsf_b), logdiffexp(lcdf_b, lcdf_a))
+            return aet.switch(self.lower > 0, logdiffexp(lsf_a, lsf_b), logdiffexp(lcdf_b, lcdf_a))
 
         if self.lower_check is not None:
             return normal_lccdf(mu, sigma, self.lower)
@@ -843,10 +845,10 @@ class HalfNormal(PositiveContinuous):
         super().__init__(*args, **kwargs)
         tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
 
-        self.sigma = self.sd = sigma = tt.as_tensor_variable(sigma)
-        self.tau = tau = tt.as_tensor_variable(tau)
+        self.sigma = self.sd = sigma = aet.as_tensor_variable(sigma)
+        self.tau = tau = aet.as_tensor_variable(tau)
 
-        self.mean = tt.sqrt(2 / (np.pi * self.tau))
+        self.mean = aet.sqrt(2 / (np.pi * self.tau))
         self.variance = (1.0 - 2 / np.pi) / self.tau
 
         assert_negative_support(tau, "tau", "HalfNormal")
@@ -882,7 +884,7 @@ class HalfNormal(PositiveContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -891,7 +893,7 @@ class HalfNormal(PositiveContinuous):
         tau = self.tau
         sigma = self.sigma
         return bound(
-            -0.5 * tau * value ** 2 + 0.5 * tt.log(tau * 2.0 / np.pi),
+            -0.5 * tau * value ** 2 + 0.5 * aet.log(tau * 2.0 / np.pi),
             value >= 0,
             tau > 0,
             sigma > 0,
@@ -907,9 +909,9 @@ class HalfNormal(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -918,7 +920,7 @@ class HalfNormal(PositiveContinuous):
         sigma = self.sigma
         z = zvalue(value, mu=0, sigma=sigma)
         return bound(
-            tt.log1p(-tt.erfc(z / tt.sqrt(2.0))),
+            aet.log1p(-aet.erfc(z / aet.sqrt(2.0))),
             0 <= value,
             0 < sigma,
         )
@@ -1005,14 +1007,14 @@ class Wald(PositiveContinuous):
     def __init__(self, mu=None, lam=None, phi=None, alpha=0.0, *args, **kwargs):
         super().__init__(*args, **kwargs)
         mu, lam, phi = self.get_mu_lam_phi(mu, lam, phi)
-        self.alpha = alpha = tt.as_tensor_variable(floatX(alpha))
-        self.mu = mu = tt.as_tensor_variable(floatX(mu))
-        self.lam = lam = tt.as_tensor_variable(floatX(lam))
-        self.phi = phi = tt.as_tensor_variable(floatX(phi))
+        self.alpha = alpha = aet.as_tensor_variable(floatX(alpha))
+        self.mu = mu = aet.as_tensor_variable(floatX(mu))
+        self.lam = lam = aet.as_tensor_variable(floatX(lam))
+        self.phi = phi = aet.as_tensor_variable(floatX(phi))
 
         self.mean = self.mu + self.alpha
         self.mode = (
-            self.mu * (tt.sqrt(1.0 + (1.5 * self.mu / self.lam) ** 2) - 1.5 * self.mu / self.lam)
+            self.mu * (aet.sqrt(1.0 + (1.5 * self.mu / self.lam) ** 2) - 1.5 * self.mu / self.lam)
             + self.alpha
         )
         self.variance = (self.mu ** 3) / self.lam
@@ -1080,7 +1082,7 @@ class Wald(PositiveContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -1113,9 +1115,9 @@ class Wald(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -1129,29 +1131,29 @@ class Wald(PositiveContinuous):
         value -= alpha
         q = value / mu
         l = lam * mu
-        r = tt.sqrt(value * lam)
+        r = aet.sqrt(value * lam)
 
         a = normal_lcdf(0, 1, (q - 1.0) / r)
         b = 2.0 / l + normal_lcdf(0, 1, -(q + 1.0) / r)
 
         left_limit = (
-            tt.lt(value, 0)
-            | (tt.eq(value, 0) & tt.gt(mu, 0) & tt.lt(lam, np.inf))
-            | (tt.lt(value, mu) & tt.eq(lam, 0))
+            aet.lt(value, 0)
+            | (aet.eq(value, 0) & aet.gt(mu, 0) & aet.lt(lam, np.inf))
+            | (aet.lt(value, mu) & aet.eq(lam, 0))
         )
         right_limit = (
-            tt.eq(value, np.inf)
-            | (tt.eq(lam, 0) & tt.gt(value, mu))
-            | (tt.gt(value, 0) & tt.eq(lam, np.inf))
+            aet.eq(value, np.inf)
+            | (aet.eq(lam, 0) & aet.gt(value, mu))
+            | (aet.gt(value, 0) & aet.eq(lam, np.inf))
         )
-        degenerate_dist = (tt.lt(mu, np.inf) & tt.eq(mu, value) & tt.eq(lam, 0)) | (
-            tt.eq(value, 0) & tt.eq(lam, np.inf)
+        degenerate_dist = (aet.lt(mu, np.inf) & aet.eq(mu, value) & aet.eq(lam, 0)) | (
+            aet.eq(value, 0) & aet.eq(lam, np.inf)
         )
 
         return bound(
-            tt.switch(
+            aet.switch(
                 ~(right_limit | degenerate_dist),
-                a + tt.log1p(tt.exp(b - a)),
+                a + aet.log1p(aet.exp(b - a)),
                 0,
             ),
             ~left_limit,
@@ -1229,8 +1231,8 @@ class Beta(UnitContinuous):
         if sd is not None:
             sigma = sd
         alpha, beta = self.get_alpha_beta(alpha, beta, mu, sigma)
-        self.alpha = alpha = tt.as_tensor_variable(floatX(alpha))
-        self.beta = beta = tt.as_tensor_variable(floatX(beta))
+        self.alpha = alpha = aet.as_tensor_variable(floatX(alpha))
+        self.beta = beta = aet.as_tensor_variable(floatX(beta))
 
         self.mean = self.alpha / (self.alpha + self.beta)
         self.variance = (
@@ -1283,7 +1285,7 @@ class Beta(UnitContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -1292,11 +1294,11 @@ class Beta(UnitContinuous):
         alpha = self.alpha
         beta = self.beta
 
-        logval = tt.log(value)
-        log1pval = tt.log1p(-value)
+        logval = aet.log(value)
+        log1pval = aet.log1p(-value)
         logp = (
-            tt.switch(tt.eq(alpha, 1), 0, (alpha - 1) * logval)
-            + tt.switch(tt.eq(beta, 1), 0, (beta - 1) * log1pval)
+            aet.switch(aet.eq(alpha, 1), 0, (alpha - 1) * logval)
+            + aet.switch(aet.eq(beta, 1), 0, (beta - 1) * log1pval)
             - betaln(alpha, beta)
         )
 
@@ -1326,9 +1328,9 @@ class Beta(UnitContinuous):
         b = self.beta
 
         return bound(
-            tt.switch(
-                tt.lt(value, 1),
-                tt.log(incomplete_beta(a, b, value)),
+            aet.switch(
+                aet.lt(value, 1),
+                aet.log(incomplete_beta(a, b, value)),
                 0,
             ),
             0 <= value,
@@ -1385,15 +1387,15 @@ class Kumaraswamy(UnitContinuous):
     def __init__(self, a, b, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.a = a = tt.as_tensor_variable(floatX(a))
-        self.b = b = tt.as_tensor_variable(floatX(b))
+        self.a = a = aet.as_tensor_variable(floatX(a))
+        self.b = b = aet.as_tensor_variable(floatX(b))
 
-        ln_mean = tt.log(b) + tt.gammaln(1 + 1 / a) + tt.gammaln(b) - tt.gammaln(1 + 1 / a + b)
-        self.mean = tt.exp(ln_mean)
+        ln_mean = aet.log(b) + aet.gammaln(1 + 1 / a) + aet.gammaln(b) - aet.gammaln(1 + 1 / a + b)
+        self.mean = aet.exp(ln_mean)
         ln_2nd_raw_moment = (
-            tt.log(b) + tt.gammaln(1 + 2 / a) + tt.gammaln(b) - tt.gammaln(1 + 2 / a + b)
+            aet.log(b) + aet.gammaln(1 + 2 / a) + aet.gammaln(b) - aet.gammaln(1 + 2 / a + b)
         )
-        self.variance = tt.exp(ln_2nd_raw_moment) - self.mean ** 2
+        self.variance = aet.exp(ln_2nd_raw_moment) - self.mean ** 2
 
         assert_negative_support(a, "a", "Kumaraswamy")
         assert_negative_support(b, "b", "Kumaraswamy")
@@ -1430,7 +1432,7 @@ class Kumaraswamy(UnitContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -1439,7 +1441,9 @@ class Kumaraswamy(UnitContinuous):
         a = self.a
         b = self.b
 
-        logp = tt.log(a) + tt.log(b) + (a - 1) * tt.log(value) + (b - 1) * tt.log(1 - value ** a)
+        logp = (
+            aet.log(a) + aet.log(b) + (a - 1) * aet.log(value) + (b - 1) * aet.log(1 - value ** a)
+        )
 
         return bound(logp, value >= 0, value <= 1, a > 0, b > 0)
 
@@ -1483,10 +1487,10 @@ class Exponential(PositiveContinuous):
 
     def __init__(self, lam, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.lam = lam = tt.as_tensor_variable(floatX(lam))
+        self.lam = lam = aet.as_tensor_variable(floatX(lam))
         self.mean = 1.0 / self.lam
-        self.median = self.mean * tt.log(2)
-        self.mode = tt.zeros_like(self.lam)
+        self.median = self.mean * aet.log(2)
+        self.mode = aet.zeros_like(self.lam)
 
         self.variance = self.lam ** -2
 
@@ -1522,14 +1526,14 @@ class Exponential(PositiveContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
         TensorVariable
         """
         lam = self.lam
-        return bound(tt.log(lam) - lam * value, value >= 0, lam > 0)
+        return bound(aet.log(lam) - lam * value, value >= 0, lam > 0)
 
     def logcdf(self, value):
         r"""
@@ -1538,15 +1542,15 @@ class Exponential(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
         TensorVariable
         """
-        value = floatX(tt.as_tensor(value))
+        value = floatX(aet.as_tensor(value))
         lam = self.lam
         a = lam * value
         return bound(
@@ -1600,8 +1604,8 @@ class Laplace(Continuous):
 
     def __init__(self, mu, b, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.b = b = tt.as_tensor_variable(floatX(b))
-        self.mean = self.median = self.mode = self.mu = mu = tt.as_tensor_variable(floatX(mu))
+        self.b = b = aet.as_tensor_variable(floatX(b))
+        self.mean = self.median = self.mode = self.mu = mu = aet.as_tensor_variable(floatX(mu))
 
         self.variance = 2 * self.b ** 2
 
@@ -1635,7 +1639,7 @@ class Laplace(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -1644,7 +1648,7 @@ class Laplace(Continuous):
         mu = self.mu
         b = self.b
 
-        return -tt.log(2 * b) - abs(value - mu) / b
+        return -aet.log(2 * b) - abs(value - mu) / b
 
     def logcdf(self, value):
         """
@@ -1653,9 +1657,9 @@ class Laplace(Continuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -1665,13 +1669,13 @@ class Laplace(Continuous):
         b = self.b
         y = (value - a) / b
         return bound(
-            tt.switch(
-                tt.le(value, a),
-                tt.log(0.5) + y,
-                tt.switch(
-                    tt.gt(y, 1),
-                    tt.log1p(-0.5 * tt.exp(-y)),
-                    tt.log(1 - 0.5 * tt.exp(-y)),
+            aet.switch(
+                aet.le(value, a),
+                aet.log(0.5) + y,
+                aet.switch(
+                    aet.gt(y, 1),
+                    aet.log1p(-0.5 * aet.exp(-y)),
+                    aet.log(1 - 0.5 * aet.exp(-y)),
                 ),
             ),
             0 < b,
@@ -1715,9 +1719,9 @@ class AsymmetricLaplace(Continuous):
     """
 
     def __init__(self, b, kappa, mu=0, *args, **kwargs):
-        self.b = tt.as_tensor_variable(floatX(b))
-        self.kappa = tt.as_tensor_variable(floatX(kappa))
-        self.mu = mu = tt.as_tensor_variable(floatX(mu))
+        self.b = aet.as_tensor_variable(floatX(b))
+        self.kappa = aet.as_tensor_variable(floatX(kappa))
+        self.mu = mu = aet.as_tensor_variable(floatX(mu))
 
         self.mean = self.mu - (self.kappa - 1 / self.kappa) / b
         self.variance = (1 + self.kappa ** 4) / (self.kappa ** 2 * self.b ** 2)
@@ -1763,7 +1767,7 @@ class AsymmetricLaplace(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -1771,8 +1775,8 @@ class AsymmetricLaplace(Continuous):
         """
         value = value - self.mu
         return bound(
-            tt.log(self.b / (self.kappa + (self.kappa ** -1)))
-            + (-value * self.b * tt.sgn(value) * (self.kappa ** tt.sgn(value))),
+            aet.log(self.b / (self.kappa + (self.kappa ** -1)))
+            + (-value * self.b * aet.sgn(value) * (self.kappa ** aet.sgn(value))),
             0 < self.b,
             0 < self.kappa,
         )
@@ -1847,14 +1851,14 @@ class Lognormal(PositiveContinuous):
 
         tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
 
-        self.mu = mu = tt.as_tensor_variable(floatX(mu))
-        self.tau = tau = tt.as_tensor_variable(tau)
-        self.sigma = self.sd = sigma = tt.as_tensor_variable(sigma)
+        self.mu = mu = aet.as_tensor_variable(floatX(mu))
+        self.tau = tau = aet.as_tensor_variable(tau)
+        self.sigma = self.sd = sigma = aet.as_tensor_variable(sigma)
 
-        self.mean = tt.exp(self.mu + 1.0 / (2 * self.tau))
-        self.median = tt.exp(self.mu)
-        self.mode = tt.exp(self.mu - 1.0 / self.tau)
-        self.variance = (tt.exp(1.0 / self.tau) - 1) * tt.exp(2 * self.mu + 1.0 / self.tau)
+        self.mean = aet.exp(self.mu + 1.0 / (2 * self.tau))
+        self.median = aet.exp(self.mu)
+        self.mode = aet.exp(self.mu - 1.0 / self.tau)
+        self.variance = (aet.exp(1.0 / self.tau) - 1) * aet.exp(2 * self.mu + 1.0 / self.tau)
 
         assert_negative_support(tau, "tau", "Lognormal")
         assert_negative_support(sigma, "sigma", "Lognormal")
@@ -1891,7 +1895,7 @@ class Lognormal(PositiveContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -1900,9 +1904,9 @@ class Lognormal(PositiveContinuous):
         mu = self.mu
         tau = self.tau
         return bound(
-            -0.5 * tau * (tt.log(value) - mu) ** 2
-            + 0.5 * tt.log(tau / (2.0 * np.pi))
-            - tt.log(value),
+            -0.5 * tau * (aet.log(value) - mu) ** 2
+            + 0.5 * aet.log(tau / (2.0 * np.pi))
+            - aet.log(value),
             tau > 0,
         )
 
@@ -1916,9 +1920,9 @@ class Lognormal(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -1929,7 +1933,7 @@ class Lognormal(PositiveContinuous):
         tau = self.tau
 
         return bound(
-            normal_lcdf(mu, sigma, tt.log(value)),
+            normal_lcdf(mu, sigma, aet.log(value)),
             0 < value,
             0 < tau,
         )
@@ -2002,13 +2006,13 @@ class StudentT(Continuous):
         super().__init__(*args, **kwargs)
         if sd is not None:
             sigma = sd
-        self.nu = nu = tt.as_tensor_variable(floatX(nu))
+        self.nu = nu = aet.as_tensor_variable(floatX(nu))
         lam, sigma = get_tau_sigma(tau=lam, sigma=sigma)
-        self.lam = lam = tt.as_tensor_variable(lam)
-        self.sigma = self.sd = sigma = tt.as_tensor_variable(sigma)
-        self.mean = self.median = self.mode = self.mu = mu = tt.as_tensor_variable(mu)
+        self.lam = lam = aet.as_tensor_variable(lam)
+        self.sigma = self.sd = sigma = aet.as_tensor_variable(sigma)
+        self.mean = self.median = self.mode = self.mu = mu = aet.as_tensor_variable(mu)
 
-        self.variance = tt.switch((nu > 2) * 1, (1 / self.lam) * (nu / (nu - 2)), np.inf)
+        self.variance = aet.switch((nu > 2) * 1, (1 / self.lam) * (nu / (nu - 2)), np.inf)
 
         assert_negative_support(lam, "lam (sigma)", "StudentT")
         assert_negative_support(nu, "nu", "StudentT")
@@ -2043,7 +2047,7 @@ class StudentT(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -2056,9 +2060,9 @@ class StudentT(Continuous):
 
         return bound(
             gammaln((nu + 1.0) / 2.0)
-            + 0.5 * tt.log(lam / (nu * np.pi))
+            + 0.5 * aet.log(lam / (nu * np.pi))
             - gammaln(nu / 2.0)
-            - (nu + 1.0) / 2.0 * tt.log1p(lam * (value - mu) ** 2 / nu),
+            - (nu + 1.0) / 2.0 * aet.log1p(lam * (value - mu) ** 2 / nu),
             lam > 0,
             nu > 0,
             sigma > 0,
@@ -2092,11 +2096,11 @@ class StudentT(Continuous):
         sigma = self.sigma
         lam = self.lam
         t = (value - mu) / sigma
-        sqrt_t2_nu = tt.sqrt(t ** 2 + nu)
+        sqrt_t2_nu = aet.sqrt(t ** 2 + nu)
         x = (t + sqrt_t2_nu) / (2.0 * sqrt_t2_nu)
 
         return bound(
-            tt.log(incomplete_beta(nu / 2.0, nu / 2.0, x)),
+            aet.log(incomplete_beta(nu / 2.0, nu / 2.0, x)),
             0 < nu,
             0 < sigma,
             0 < lam,
@@ -2149,13 +2153,13 @@ class Pareto(Continuous):
     """
 
     def __init__(self, alpha, m, transform="lowerbound", *args, **kwargs):
-        self.alpha = alpha = tt.as_tensor_variable(floatX(alpha))
-        self.m = m = tt.as_tensor_variable(floatX(m))
+        self.alpha = alpha = aet.as_tensor_variable(floatX(alpha))
+        self.m = m = aet.as_tensor_variable(floatX(m))
 
-        self.mean = tt.switch(tt.gt(alpha, 1), alpha * m / (alpha - 1.0), np.inf)
+        self.mean = aet.switch(aet.gt(alpha, 1), alpha * m / (alpha - 1.0), np.inf)
         self.median = m * 2.0 ** (1.0 / alpha)
-        self.variance = tt.switch(
-            tt.gt(alpha, 2), (alpha * m ** 2) / ((alpha - 2.0) * (alpha - 1.0) ** 2), np.inf
+        self.variance = aet.switch(
+            aet.gt(alpha, 2), (alpha * m ** 2) / ((alpha - 2.0) * (alpha - 1.0) ** 2), np.inf
         )
 
         assert_negative_support(alpha, "alpha", "Pareto")
@@ -2197,7 +2201,7 @@ class Pareto(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -2206,7 +2210,7 @@ class Pareto(Continuous):
         alpha = self.alpha
         m = self.m
         return bound(
-            tt.log(alpha) + logpow(m, alpha) - logpow(value, alpha + 1),
+            aet.log(alpha) + logpow(m, alpha) - logpow(value, alpha + 1),
             value >= m,
             alpha > 0,
             m > 0,
@@ -2222,9 +2226,9 @@ class Pareto(Continuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -2234,10 +2238,10 @@ class Pareto(Continuous):
         alpha = self.alpha
         arg = (m / value) ** alpha
         return bound(
-            tt.switch(
-                tt.le(arg, 1e-5),
-                tt.log1p(-arg),
-                tt.log(1 - arg),
+            aet.switch(
+                aet.le(arg, 1e-5),
+                aet.log1p(-arg),
+                aet.log(1 - arg),
             ),
             m <= value,
             0 < alpha,
@@ -2292,8 +2296,8 @@ class Cauchy(Continuous):
 
     def __init__(self, alpha, beta, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.median = self.mode = self.alpha = tt.as_tensor_variable(floatX(alpha))
-        self.beta = tt.as_tensor_variable(floatX(beta))
+        self.median = self.mode = self.alpha = aet.as_tensor_variable(floatX(alpha))
+        self.beta = aet.as_tensor_variable(floatX(beta))
 
         assert_negative_support(beta, "beta", "Cauchy")
 
@@ -2329,7 +2333,7 @@ class Cauchy(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -2338,7 +2342,7 @@ class Cauchy(Continuous):
         alpha = self.alpha
         beta = self.beta
         return bound(
-            -tt.log(np.pi) - tt.log(beta) - tt.log1p(((value - alpha) / beta) ** 2), beta > 0
+            -aet.log(np.pi) - aet.log(beta) - aet.log1p(((value - alpha) / beta) ** 2), beta > 0
         )
 
     def logcdf(self, value):
@@ -2348,9 +2352,9 @@ class Cauchy(Continuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -2359,7 +2363,7 @@ class Cauchy(Continuous):
         alpha = self.alpha
         beta = self.beta
         return bound(
-            tt.log(0.5 + tt.arctan((value - alpha) / beta) / np.pi),
+            aet.log(0.5 + aet.arctan((value - alpha) / beta) / np.pi),
             0 < beta,
         )
 
@@ -2404,8 +2408,8 @@ class HalfCauchy(PositiveContinuous):
 
     def __init__(self, beta, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.mode = tt.as_tensor_variable(0)
-        self.median = self.beta = tt.as_tensor_variable(floatX(beta))
+        self.mode = aet.as_tensor_variable(0)
+        self.median = self.beta = aet.as_tensor_variable(floatX(beta))
 
         assert_negative_support(beta, "beta", "HalfCauchy")
 
@@ -2441,7 +2445,7 @@ class HalfCauchy(PositiveContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -2449,7 +2453,7 @@ class HalfCauchy(PositiveContinuous):
         """
         beta = self.beta
         return bound(
-            tt.log(2) - tt.log(np.pi) - tt.log(beta) - tt.log1p((value / beta) ** 2),
+            aet.log(2) - aet.log(np.pi) - aet.log(beta) - aet.log1p((value / beta) ** 2),
             value >= 0,
             beta > 0,
         )
@@ -2461,9 +2465,9 @@ class HalfCauchy(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -2471,7 +2475,7 @@ class HalfCauchy(PositiveContinuous):
         """
         beta = self.beta
         return bound(
-            tt.log(2 * tt.arctan(value / beta) / np.pi),
+            aet.log(2 * aet.arctan(value / beta) / np.pi),
             0 <= value,
             0 < beta,
         )
@@ -2541,10 +2545,10 @@ class Gamma(PositiveContinuous):
             sigma = sd
 
         alpha, beta = self.get_alpha_beta(alpha, beta, mu, sigma)
-        self.alpha = alpha = tt.as_tensor_variable(floatX(alpha))
-        self.beta = beta = tt.as_tensor_variable(floatX(beta))
+        self.alpha = alpha = aet.as_tensor_variable(floatX(alpha))
+        self.beta = beta = aet.as_tensor_variable(floatX(beta))
         self.mean = alpha / beta
-        self.mode = tt.maximum((alpha - 1) / beta, 0)
+        self.mode = aet.maximum((alpha - 1) / beta, 0)
         self.variance = alpha / beta ** 2
 
         assert_negative_support(alpha, "alpha", "Gamma")
@@ -2595,7 +2599,7 @@ class Gamma(PositiveContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -2617,9 +2621,9 @@ class Gamma(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -2628,12 +2632,12 @@ class Gamma(PositiveContinuous):
         alpha = self.alpha
         beta = self.beta
         # Avoid C-assertion when the gammainc function is called with invalid values (#4340)
-        safe_alpha = tt.switch(tt.lt(alpha, 0), 0, alpha)
-        safe_beta = tt.switch(tt.lt(beta, 0), 0, beta)
-        safe_value = tt.switch(tt.lt(value, 0), 0, value)
+        safe_alpha = aet.switch(aet.lt(alpha, 0), 0, alpha)
+        safe_beta = aet.switch(aet.lt(beta, 0), 0, beta)
+        safe_value = aet.switch(aet.lt(value, 0), 0, value)
 
         return bound(
-            tt.log(tt.gammainc(safe_alpha, safe_beta * safe_value)),
+            aet.log(aet.gammainc(safe_alpha, safe_beta * safe_value)),
             0 <= value,
             0 < alpha,
             0 < beta,
@@ -2698,13 +2702,13 @@ class InverseGamma(PositiveContinuous):
             sigma = sd
 
         alpha, beta = InverseGamma._get_alpha_beta(alpha, beta, mu, sigma)
-        self.alpha = alpha = tt.as_tensor_variable(floatX(alpha))
-        self.beta = beta = tt.as_tensor_variable(floatX(beta))
+        self.alpha = alpha = aet.as_tensor_variable(floatX(alpha))
+        self.beta = beta = aet.as_tensor_variable(floatX(beta))
 
         self.mean = self._calculate_mean()
         self.mode = beta / (alpha + 1.0)
-        self.variance = tt.switch(
-            tt.gt(alpha, 2), (beta ** 2) / ((alpha - 2) * (alpha - 1.0) ** 2), np.inf
+        self.variance = aet.switch(
+            aet.gt(alpha, 2), (beta ** 2) / ((alpha - 2) * (alpha - 1.0) ** 2), np.inf
         )
         assert_negative_support(alpha, "alpha", "InverseGamma")
         assert_negative_support(beta, "beta", "InverseGamma")
@@ -2766,7 +2770,7 @@ class InverseGamma(PositiveContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -2791,9 +2795,9 @@ class InverseGamma(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -2802,12 +2806,12 @@ class InverseGamma(PositiveContinuous):
         alpha = self.alpha
         beta = self.beta
         # Avoid C-assertion when the gammaincc function is called with invalid values (#4340)
-        safe_alpha = tt.switch(tt.lt(alpha, 0), 0, alpha)
-        safe_beta = tt.switch(tt.lt(beta, 0), 0, beta)
-        safe_value = tt.switch(tt.lt(value, 0), 0, value)
+        safe_alpha = aet.switch(aet.lt(alpha, 0), 0, alpha)
+        safe_beta = aet.switch(aet.lt(beta, 0), 0, beta)
+        safe_value = aet.switch(aet.lt(value, 0), 0, value)
 
         return bound(
-            tt.log(tt.gammaincc(safe_alpha, safe_beta / safe_value)),
+            aet.log(aet.gammaincc(safe_alpha, safe_beta / safe_value)),
             0 <= value,
             0 < alpha,
             0 < beta,
@@ -2853,7 +2857,7 @@ class ChiSquared(Gamma):
     """
 
     def __init__(self, nu, *args, **kwargs):
-        self.nu = nu = tt.as_tensor_variable(floatX(nu))
+        self.nu = nu = aet.as_tensor_variable(floatX(nu))
         super().__init__(alpha=nu / 2.0, beta=0.5, *args, **kwargs)
 
 
@@ -2903,12 +2907,12 @@ class Weibull(PositiveContinuous):
 
     def __init__(self, alpha, beta, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.alpha = alpha = tt.as_tensor_variable(floatX(alpha))
-        self.beta = beta = tt.as_tensor_variable(floatX(beta))
-        self.mean = beta * tt.exp(gammaln(1 + 1.0 / alpha))
-        self.median = beta * tt.exp(gammaln(tt.log(2))) ** (1.0 / alpha)
-        self.variance = beta ** 2 * tt.exp(gammaln(1 + 2.0 / alpha)) - self.mean ** 2
-        self.mode = tt.switch(
+        self.alpha = alpha = aet.as_tensor_variable(floatX(alpha))
+        self.beta = beta = aet.as_tensor_variable(floatX(beta))
+        self.mean = beta * aet.exp(gammaln(1 + 1.0 / alpha))
+        self.median = beta * aet.exp(gammaln(aet.log(2))) ** (1.0 / alpha)
+        self.variance = beta ** 2 * aet.exp(gammaln(1 + 2.0 / alpha)) - self.mean ** 2
+        self.mode = aet.switch(
             alpha >= 1, beta * ((alpha - 1) / alpha) ** (1 / alpha), 0
         )  # Reference: https://en.wikipedia.org/wiki/Weibull_distribution
 
@@ -2947,7 +2951,7 @@ class Weibull(PositiveContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -2956,9 +2960,9 @@ class Weibull(PositiveContinuous):
         alpha = self.alpha
         beta = self.beta
         return bound(
-            tt.log(alpha)
-            - tt.log(beta)
-            + (alpha - 1) * tt.log(value / beta)
+            aet.log(alpha)
+            - aet.log(beta)
+            + (alpha - 1) * aet.log(value / beta)
             - (value / beta) ** alpha,
             value >= 0,
             alpha > 0,
@@ -2972,9 +2976,9 @@ class Weibull(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -3053,12 +3057,12 @@ class HalfStudentT(PositiveContinuous):
         if sd is not None:
             sigma = sd
 
-        self.mode = tt.as_tensor_variable(0)
+        self.mode = aet.as_tensor_variable(0)
         lam, sigma = get_tau_sigma(lam, sigma)
-        self.median = tt.as_tensor_variable(sigma)
-        self.sigma = self.sd = tt.as_tensor_variable(sigma)
-        self.lam = tt.as_tensor_variable(lam)
-        self.nu = nu = tt.as_tensor_variable(floatX(nu))
+        self.median = aet.as_tensor_variable(sigma)
+        self.sigma = self.sd = aet.as_tensor_variable(sigma)
+        self.lam = aet.as_tensor_variable(lam)
+        self.nu = nu = aet.as_tensor_variable(floatX(nu))
 
         assert_negative_support(sigma, "sigma", "HalfStudentT")
         assert_negative_support(lam, "lam", "HalfStudentT")
@@ -3094,7 +3098,7 @@ class HalfStudentT(PositiveContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -3105,11 +3109,11 @@ class HalfStudentT(PositiveContinuous):
         lam = self.lam
 
         return bound(
-            tt.log(2)
+            aet.log(2)
             + gammaln((nu + 1.0) / 2.0)
             - gammaln(nu / 2.0)
-            - 0.5 * tt.log(nu * np.pi * sigma ** 2)
-            - (nu + 1.0) / 2.0 * tt.log1p(value ** 2 / (nu * sigma ** 2)),
+            - 0.5 * aet.log(nu * np.pi * sigma ** 2)
+            - (nu + 1.0) / 2.0 * aet.log1p(value ** 2 / (nu * sigma ** 2)),
             sigma > 0,
             lam > 0,
             nu > 0,
@@ -3191,9 +3195,9 @@ class ExGaussian(Continuous):
         if sd is not None:
             sigma = sd
 
-        self.mu = mu = tt.as_tensor_variable(floatX(mu))
-        self.sigma = self.sd = sigma = tt.as_tensor_variable(floatX(sigma))
-        self.nu = nu = tt.as_tensor_variable(floatX(nu))
+        self.mu = mu = aet.as_tensor_variable(floatX(mu))
+        self.sigma = self.sd = sigma = aet.as_tensor_variable(floatX(sigma))
+        self.nu = nu = aet.as_tensor_variable(floatX(nu))
         self.mean = mu + nu
         self.variance = (sigma ** 2) + (nu ** 2)
 
@@ -3234,7 +3238,7 @@ class ExGaussian(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -3246,10 +3250,10 @@ class ExGaussian(Continuous):
 
         # Alogithm is adapted from dexGAUS.R from gamlss
         return bound(
-            tt.switch(
-                tt.gt(nu, 0.05 * sigma),
+            aet.switch(
+                aet.gt(nu, 0.05 * sigma),
                 (
-                    -tt.log(nu)
+                    -aet.log(nu)
                     + (mu - value) / nu
                     + 0.5 * (sigma / nu) ** 2
                     + normal_lcdf(mu + (sigma ** 2) / nu, sigma, value)
@@ -3273,9 +3277,9 @@ class ExGaussian(Continuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -3287,8 +3291,8 @@ class ExGaussian(Continuous):
 
         # Alogithm is adapted from pexGAUS.R from gamlss
         return bound(
-            tt.switch(
-                tt.gt(nu, 0.05 * sigma),
+            aet.switch(
+                aet.gt(nu, 0.05 * sigma),
                 logdiffexp(
                     normal_lcdf(mu, sigma, value),
                     (
@@ -3355,8 +3359,8 @@ class VonMises(Continuous):
         if transform == "circular":
             transform = transforms.Circular()
         super().__init__(transform=transform, *args, **kwargs)
-        self.mean = self.median = self.mode = self.mu = mu = tt.as_tensor_variable(floatX(mu))
-        self.kappa = kappa = tt.as_tensor_variable(floatX(kappa))
+        self.mean = self.median = self.mode = self.mu = mu = aet.as_tensor_variable(floatX(mu))
+        self.kappa = kappa = aet.as_tensor_variable(floatX(kappa))
 
         assert_negative_support(kappa, "kappa", "VonMises")
 
@@ -3390,7 +3394,7 @@ class VonMises(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -3399,7 +3403,7 @@ class VonMises(Continuous):
         mu = self.mu
         kappa = self.kappa
         return bound(
-            kappa * tt.cos(mu - value) - (tt.log(2 * np.pi) + log_i0(kappa)),
+            kappa * aet.cos(mu - value) - (aet.log(2 * np.pi) + log_i0(kappa)),
             kappa > 0,
             value >= -np.pi,
             value <= np.pi,
@@ -3474,11 +3478,11 @@ class SkewNormal(Continuous):
             sigma = sd
 
         tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
-        self.mu = mu = tt.as_tensor_variable(floatX(mu))
-        self.tau = tt.as_tensor_variable(tau)
-        self.sigma = self.sd = tt.as_tensor_variable(sigma)
+        self.mu = mu = aet.as_tensor_variable(floatX(mu))
+        self.tau = aet.as_tensor_variable(tau)
+        self.sigma = self.sd = aet.as_tensor_variable(sigma)
 
-        self.alpha = alpha = tt.as_tensor_variable(floatX(alpha))
+        self.alpha = alpha = aet.as_tensor_variable(floatX(alpha))
 
         self.mean = mu + self.sigma * (2 / np.pi) ** 0.5 * alpha / (1 + alpha ** 2) ** 0.5
         self.variance = self.sigma ** 2 * (1 - (2 * alpha ** 2) / ((1 + alpha ** 2) * np.pi))
@@ -3518,7 +3522,7 @@ class SkewNormal(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -3529,8 +3533,8 @@ class SkewNormal(Continuous):
         mu = self.mu
         alpha = self.alpha
         return bound(
-            tt.log(1 + tt.erf(((value - mu) * tt.sqrt(tau) * alpha) / tt.sqrt(2)))
-            + (-tau * (value - mu) ** 2 + tt.log(tau / np.pi / 2.0)) / 2.0,
+            aet.log(1 + aet.erf(((value - mu) * aet.sqrt(tau) * alpha) / aet.sqrt(2)))
+            + (-tau * (value - mu) ** 2 + aet.log(tau / np.pi / 2.0)) / 2.0,
             tau > 0,
             sigma > 0,
         )
@@ -3594,9 +3598,9 @@ class Triangular(BoundedContinuous):
     """
 
     def __init__(self, lower=0, upper=1, c=0.5, *args, **kwargs):
-        self.median = self.mean = self.c = c = tt.as_tensor_variable(floatX(c))
-        self.lower = lower = tt.as_tensor_variable(floatX(lower))
-        self.upper = upper = tt.as_tensor_variable(floatX(upper))
+        self.median = self.mean = self.c = c = aet.as_tensor_variable(floatX(c))
+        self.lower = lower = aet.as_tensor_variable(floatX(lower))
+        self.upper = upper = aet.as_tensor_variable(floatX(upper))
 
         super().__init__(lower=lower, upper=upper, *args, **kwargs)
 
@@ -3639,7 +3643,7 @@ class Triangular(BoundedContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -3649,10 +3653,10 @@ class Triangular(BoundedContinuous):
         lower = self.lower
         upper = self.upper
         return bound(
-            tt.switch(
-                tt.lt(value, c),
-                tt.log(2 * (value - lower) / ((upper - lower) * (c - lower))),
-                tt.log(2 * (upper - value) / ((upper - lower) * (upper - c))),
+            aet.switch(
+                aet.lt(value, c),
+                aet.log(2 * (value - lower) / ((upper - lower) * (c - lower))),
+                aet.log(2 * (upper - value) / ((upper - lower) * (upper - c))),
             ),
             lower <= value,
             value <= upper,
@@ -3665,9 +3669,9 @@ class Triangular(BoundedContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -3677,15 +3681,15 @@ class Triangular(BoundedContinuous):
         lower = self.lower
         upper = self.upper
         return bound(
-            tt.switch(
-                tt.le(value, lower),
+            aet.switch(
+                aet.le(value, lower),
                 -np.inf,
-                tt.switch(
-                    tt.le(value, c),
-                    tt.log(((value - lower) ** 2) / ((upper - lower) * (c - lower))),
-                    tt.switch(
-                        tt.lt(value, upper),
-                        tt.log1p(-((upper - value) ** 2) / ((upper - lower) * (upper - c))),
+                aet.switch(
+                    aet.le(value, c),
+                    aet.log(((value - lower) ** 2) / ((upper - lower) * (c - lower))),
+                    aet.switch(
+                        aet.lt(value, upper),
+                        aet.log1p(-((upper - value) ** 2) / ((upper - lower) * (upper - c))),
                         0,
                     ),
                 ),
@@ -3743,13 +3747,13 @@ class Gumbel(Continuous):
     """
 
     def __init__(self, mu=0, beta=1.0, **kwargs):
-        self.mu = tt.as_tensor_variable(floatX(mu))
-        self.beta = tt.as_tensor_variable(floatX(beta))
+        self.mu = aet.as_tensor_variable(floatX(mu))
+        self.beta = aet.as_tensor_variable(floatX(beta))
 
         assert_negative_support(beta, "beta", "Gumbel")
 
         self.mean = self.mu + self.beta * np.euler_gamma
-        self.median = self.mu - self.beta * tt.log(tt.log(2))
+        self.median = self.mu - self.beta * aet.log(aet.log(2))
         self.mode = self.mu
         self.variance = (np.pi ** 2 / 6.0) * self.beta ** 2
 
@@ -3785,7 +3789,7 @@ class Gumbel(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -3795,7 +3799,7 @@ class Gumbel(Continuous):
         beta = self.beta
         scaled = (value - mu) / beta
         return bound(
-            -scaled - tt.exp(-scaled) - tt.log(self.beta),
+            -scaled - aet.exp(-scaled) - aet.log(self.beta),
             0 < beta,
         )
 
@@ -3806,9 +3810,9 @@ class Gumbel(Continuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -3818,7 +3822,7 @@ class Gumbel(Continuous):
         mu = self.mu
 
         return bound(
-            -tt.exp(-(value - mu) / beta),
+            -aet.exp(-(value - mu) / beta),
             0 < beta,
         )
 
@@ -3888,18 +3892,18 @@ class Rice(PositiveContinuous):
             sigma = sd
 
         nu, b, sigma = self.get_nu_b(nu, b, sigma)
-        self.nu = nu = tt.as_tensor_variable(floatX(nu))
-        self.sigma = self.sd = sigma = tt.as_tensor_variable(floatX(sigma))
-        self.b = b = tt.as_tensor_variable(floatX(b))
+        self.nu = nu = aet.as_tensor_variable(floatX(nu))
+        self.sigma = self.sd = sigma = aet.as_tensor_variable(floatX(sigma))
+        self.b = b = aet.as_tensor_variable(floatX(b))
 
         nu_sigma_ratio = -(nu ** 2) / (2 * sigma ** 2)
         self.mean = (
             sigma
             * np.sqrt(np.pi / 2)
-            * tt.exp(nu_sigma_ratio / 2)
+            * aet.exp(nu_sigma_ratio / 2)
             * (
-                (1 - nu_sigma_ratio) * tt.i0(-nu_sigma_ratio / 2)
-                - nu_sigma_ratio * tt.i1(-nu_sigma_ratio / 2)
+                (1 - nu_sigma_ratio) * aet.i0(-nu_sigma_ratio / 2)
+                - nu_sigma_ratio * aet.i1(-nu_sigma_ratio / 2)
             )
         )
         self.variance = (
@@ -3907,10 +3911,10 @@ class Rice(PositiveContinuous):
             + nu ** 2
             - (np.pi * sigma ** 2 / 2)
             * (
-                tt.exp(nu_sigma_ratio / 2)
+                aet.exp(nu_sigma_ratio / 2)
                 * (
-                    (1 - nu_sigma_ratio) * tt.i0(-nu_sigma_ratio / 2)
-                    - nu_sigma_ratio * tt.i1(-nu_sigma_ratio / 2)
+                    (1 - nu_sigma_ratio) * aet.i0(-nu_sigma_ratio / 2)
+                    - nu_sigma_ratio * aet.i1(-nu_sigma_ratio / 2)
                 )
             )
             ** 2
@@ -3963,7 +3967,7 @@ class Rice(PositiveContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -3974,7 +3978,7 @@ class Rice(PositiveContinuous):
         b = self.b
         x = value / sigma
         return bound(
-            tt.log(x * tt.exp((-(x - b) * (x - b)) / 2) * i0e(x * b) / sigma),
+            aet.log(x * aet.exp((-(x - b) * (x - b)) / 2) * i0e(x * b) / sigma),
             sigma >= 0,
             nu >= 0,
             value > 0,
@@ -4030,8 +4034,8 @@ class Logistic(Continuous):
     def __init__(self, mu=0.0, s=1.0, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.mu = tt.as_tensor_variable(floatX(mu))
-        self.s = tt.as_tensor_variable(floatX(s))
+        self.mu = aet.as_tensor_variable(floatX(mu))
+        self.s = aet.as_tensor_variable(floatX(s))
 
         self.mean = self.mode = mu
         self.variance = s ** 2 * np.pi ** 2 / 3.0
@@ -4067,7 +4071,7 @@ class Logistic(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -4077,7 +4081,7 @@ class Logistic(Continuous):
         s = self.s
 
         return bound(
-            -(value - mu) / s - tt.log(s) - 2 * tt.log1p(tt.exp(-(value - mu) / s)),
+            -(value - mu) / s - aet.log(s) - 2 * aet.log1p(aet.exp(-(value - mu) / s)),
             s > 0,
         )
 
@@ -4088,9 +4092,9 @@ class Logistic(Continuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -4151,10 +4155,10 @@ class LogitNormal(UnitContinuous):
     def __init__(self, mu=0, sigma=None, tau=None, sd=None, **kwargs):
         if sd is not None:
             sigma = sd
-        self.mu = mu = tt.as_tensor_variable(floatX(mu))
+        self.mu = mu = aet.as_tensor_variable(floatX(mu))
         tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
-        self.sigma = self.sd = tt.as_tensor_variable(sigma)
-        self.tau = tau = tt.as_tensor_variable(tau)
+        self.sigma = self.sd = aet.as_tensor_variable(sigma)
+        self.tau = tau = aet.as_tensor_variable(tau)
 
         self.median = invlogit(mu)
         assert_negative_support(sigma, "sigma", "LogitNormal")
@@ -4192,7 +4196,7 @@ class LogitNormal(UnitContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -4202,8 +4206,8 @@ class LogitNormal(UnitContinuous):
         tau = self.tau
         return bound(
             -0.5 * tau * (logit(value) - mu) ** 2
-            + 0.5 * tt.log(tau / (2.0 * np.pi))
-            - tt.log(value * (1 - value)),
+            + 0.5 * aet.log(tau / (2.0 * np.pi))
+            - aet.log(value * (1 - value)),
             value > 0,
             value < 1,
             tau > 0,
@@ -4242,15 +4246,15 @@ class Interpolated(BoundedContinuous):
     """
 
     def __init__(self, x_points, pdf_points, *args, **kwargs):
-        self.lower = lower = tt.as_tensor_variable(x_points[0])
-        self.upper = upper = tt.as_tensor_variable(x_points[-1])
+        self.lower = lower = aet.as_tensor_variable(x_points[0])
+        self.upper = upper = aet.as_tensor_variable(x_points[-1])
 
         super().__init__(lower=lower, upper=upper, *args, **kwargs)
 
         interp = InterpolatedUnivariateSpline(x_points, pdf_points, k=1, ext="zeros")
         Z = interp.integral(x_points[0], x_points[-1])
 
-        self.Z = tt.as_tensor_variable(Z)
+        self.Z = aet.as_tensor_variable(Z)
         self.interp_op = SplineWrapper(interp)
         self.x_points = x_points
         self.pdf_points = pdf_points / Z
@@ -4301,13 +4305,13 @@ class Interpolated(BoundedContinuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
         TensorVariable
         """
-        return tt.log(self.interp_op(value) / self.Z)
+        return aet.log(self.interp_op(value) / self.Z)
 
     def _distr_parameters_for_repr(self):
         return []
@@ -4361,13 +4365,13 @@ class Moyal(Continuous):
     """
 
     def __init__(self, mu=0, sigma=1.0, *args, **kwargs):
-        self.mu = tt.as_tensor_variable(floatX(mu))
-        self.sigma = tt.as_tensor_variable(floatX(sigma))
+        self.mu = aet.as_tensor_variable(floatX(mu))
+        self.sigma = aet.as_tensor_variable(floatX(sigma))
 
         assert_negative_support(sigma, "sigma", "Moyal")
 
-        self.mean = self.mu + self.sigma * (np.euler_gamma + tt.log(2))
-        self.median = self.mu - self.sigma * tt.log(2 * tt.erfcinv(1 / 2) ** 2)
+        self.mean = self.mu + self.sigma * (np.euler_gamma + aet.log(2))
+        self.median = self.mu - self.sigma * aet.log(2 * aet.erfcinv(1 / 2) ** 2)
         self.mode = self.mu
         self.variance = (np.pi ** 2 / 2.0) * self.sigma ** 2
 
@@ -4403,7 +4407,7 @@ class Moyal(Continuous):
         ----------
         value: numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or theano tensor
+            values are desired the values must be provided in a numpy array or aesara tensor
 
         Returns
         -------
@@ -4413,7 +4417,11 @@ class Moyal(Continuous):
         sigma = self.sigma
         scaled = (value - mu) / sigma
         return bound(
-            (-(1 / 2) * (scaled + tt.exp(-scaled)) - tt.log(sigma) - (1 / 2) * tt.log(2 * np.pi)),
+            (
+                -(1 / 2) * (scaled + aet.exp(-scaled))
+                - aet.log(sigma)
+                - (1 / 2) * aet.log(2 * np.pi)
+            ),
             0 < sigma,
         )
 
@@ -4424,9 +4432,9 @@ class Moyal(Continuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or theano.tensor
+        value: numeric or np.ndarray or aesara.tensor
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or theano tensor.
+            values are desired the values must be provided in a numpy array or aesara tensor.
 
         Returns
         -------
@@ -4437,6 +4445,6 @@ class Moyal(Continuous):
 
         scaled = (value - mu) / sigma
         return bound(
-            tt.log(tt.erfc(tt.exp(-scaled / 2) * (2 ** -0.5))),
+            aet.log(aet.erfc(aet.exp(-scaled / 2) * (2 ** -0.5))),
             0 < sigma,
         )

--- a/pymc3/distributions/special.py
+++ b/pymc3/distributions/special.py
@@ -12,16 +12,17 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara.tensor as aet
 import numpy as np
-import theano.tensor as tt
 
-from theano import scalar
-from theano.scalar.basic_scipy import GammaLn, Psi
+from aesara import scalar
+from aesara.scalar.basic_scipy import GammaLn, Psi
+from aesara.tensor.elemwise import Elemwise
 
 __all__ = ["gammaln", "multigammaln", "psi", "log_i0"]
 
 scalar_gammaln = GammaLn(scalar.upgrade_to_float, name="scalar_gammaln")
-gammaln = tt.Elemwise(scalar_gammaln, name="gammaln")
+gammaln = Elemwise(scalar_gammaln, name="gammaln")
 
 
 def multigammaln(a, p):
@@ -33,17 +34,17 @@ def multigammaln(a, p):
     p: int
        degrees of freedom. p > 0
     """
-    i = tt.arange(1, p + 1)
-    return p * (p - 1) * tt.log(np.pi) / 4.0 + tt.sum(gammaln(a + (1.0 - i) / 2.0), axis=0)
+    i = aet.arange(1, p + 1)
+    return p * (p - 1) * aet.log(np.pi) / 4.0 + aet.sum(gammaln(a + (1.0 - i) / 2.0), axis=0)
 
 
 def log_i0(x):
     """
     Calculates the logarithm of the 0 order modified Bessel function of the first kind""
     """
-    return tt.switch(
-        tt.lt(x, 5),
-        tt.log1p(
+    return aet.switch(
+        aet.lt(x, 5),
+        aet.log1p(
             x ** 2.0 / 4.0
             + x ** 4.0 / 64.0
             + x ** 6.0 / 2304.0
@@ -52,8 +53,8 @@ def log_i0(x):
             + x ** 12.0 / 2123366400.0
         ),
         x
-        - 0.5 * tt.log(2.0 * np.pi * x)
-        + tt.log1p(
+        - 0.5 * aet.log(2.0 * np.pi * x)
+        + aet.log1p(
             1.0 / (8.0 * x)
             + 9.0 / (128.0 * x ** 2.0)
             + 225.0 / (3072.0 * x ** 3.0)
@@ -63,4 +64,4 @@ def log_i0(x):
 
 
 scalar_psi = Psi(scalar.upgrade_to_float, name="scalar_psi")
-psi = tt.Elemwise(scalar_psi, name="psi")
+psi = Elemwise(scalar_psi, name="psi")

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -12,11 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara.tensor as aet
 import numpy as np
-import theano.tensor as tt
 
+from aesara import scan
 from scipy import stats
-from theano import scan
 
 from pymc3.distributions import distribution, multivariate
 from pymc3.distributions.continuous import Flat, Normal, get_tau_sigma
@@ -47,10 +47,10 @@ class AR1(distribution.Continuous):
 
     def __init__(self, k, tau_e, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.k = k = tt.as_tensor_variable(k)
-        self.tau_e = tau_e = tt.as_tensor_variable(tau_e)
+        self.k = k = aet.as_tensor_variable(k)
+        self.tau_e = tau_e = aet.as_tensor_variable(tau_e)
         self.tau = tau_e * (1 - k ** 2)
-        self.mode = tt.as_tensor_variable(0.0)
+        self.mode = aet.as_tensor_variable(0.0)
 
     def logp(self, x):
         """
@@ -74,7 +74,7 @@ class AR1(distribution.Continuous):
         boundary = Normal.dist(0.0, tau=tau).logp
 
         innov_like = Normal.dist(k * x_im1, tau=tau_e).logp(x_i)
-        return boundary(x[0]) + tt.sum(innov_like)
+        return boundary(x[0]) + aet.sum(innov_like)
 
 
 class AR(distribution.Continuous):
@@ -116,10 +116,10 @@ class AR(distribution.Continuous):
             sigma = sd
 
         tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
-        self.sigma = self.sd = tt.as_tensor_variable(sigma)
-        self.tau = tt.as_tensor_variable(tau)
+        self.sigma = self.sd = aet.as_tensor_variable(sigma)
+        self.tau = aet.as_tensor_variable(tau)
 
-        self.mean = tt.as_tensor_variable(0.0)
+        self.mean = aet.as_tensor_variable(0.0)
 
         if isinstance(rho, list):
             p = len(rho)
@@ -140,7 +140,7 @@ class AR(distribution.Continuous):
             self.p = p
 
         self.constant = constant
-        self.rho = rho = tt.as_tensor_variable(rho)
+        self.rho = rho = aet.as_tensor_variable(rho)
         self.init = init
 
     def logp(self, value):
@@ -157,7 +157,7 @@ class AR(distribution.Continuous):
         TensorVariable
         """
         if self.constant:
-            x = tt.add(
+            x = aet.add(
                 *[self.rho[i + 1] * value[self.p - (i + 1) : -(i + 1)] for i in range(self.p)]
             )
             eps = value[self.p :] - self.rho[0] - x
@@ -165,7 +165,7 @@ class AR(distribution.Continuous):
             if self.p == 1:
                 x = self.rho * value[:-1]
             else:
-                x = tt.add(
+                x = aet.add(
                     *[self.rho[i] * value[self.p - (i + 1) : -(i + 1)] for i in range(self.p)]
                 )
             eps = value[self.p :] - x
@@ -173,7 +173,7 @@ class AR(distribution.Continuous):
         innov_like = Normal.dist(mu=0.0, tau=self.tau).logp(eps)
         init_like = self.init.logp(value[: self.p])
 
-        return tt.sum(innov_like) + tt.sum(init_like)
+        return aet.sum(innov_like) + aet.sum(init_like)
 
 
 class GaussianRandomWalk(distribution.Continuous):
@@ -181,7 +181,7 @@ class GaussianRandomWalk(distribution.Continuous):
 
     Note that this is mainly a user-friendly wrapper to enable an easier specification
     of GRW. You are not restricted to use only Normal innovations but can use any
-    distribution: just use `theano.tensor.cumsum()` to create the random walk behavior.
+    distribution: just use `aesara.tensor.cumsum()` to create the random walk behavior.
 
     Parameters
     ----------
@@ -209,12 +209,12 @@ class GaussianRandomWalk(distribution.Continuous):
         if sd is not None:
             sigma = sd
         tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
-        self.tau = tt.as_tensor_variable(tau)
-        sigma = tt.as_tensor_variable(sigma)
+        self.tau = aet.as_tensor_variable(tau)
+        sigma = aet.as_tensor_variable(sigma)
         self.sigma = self.sd = sigma
-        self.mu = tt.as_tensor_variable(mu)
+        self.mu = aet.as_tensor_variable(mu)
         self.init = init
-        self.mean = tt.as_tensor_variable(0.0)
+        self.mean = aet.as_tensor_variable(0.0)
 
     def _mu_and_sigma(self, mu, sigma):
         """Helper to get mu and sigma if they are high dimensional."""
@@ -242,7 +242,7 @@ class GaussianRandomWalk(distribution.Continuous):
             x_i = x[1:]
             mu, sigma = self._mu_and_sigma(self.mu, self.sigma)
             innov_like = Normal.dist(mu=x_im1 + mu, sigma=sigma).logp(x_i)
-            return self.init.logp(x[0]) + tt.sum(innov_like)
+            return self.init.logp(x[0]) + aet.sum(innov_like)
         return self.init.logp(x)
 
     def random(self, point=None, size=None):
@@ -323,17 +323,17 @@ class GARCH11(distribution.Continuous):
     def __init__(self, omega, alpha_1, beta_1, initial_vol, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.omega = omega = tt.as_tensor_variable(omega)
-        self.alpha_1 = alpha_1 = tt.as_tensor_variable(alpha_1)
-        self.beta_1 = beta_1 = tt.as_tensor_variable(beta_1)
-        self.initial_vol = tt.as_tensor_variable(initial_vol)
-        self.mean = tt.as_tensor_variable(0.0)
+        self.omega = omega = aet.as_tensor_variable(omega)
+        self.alpha_1 = alpha_1 = aet.as_tensor_variable(alpha_1)
+        self.beta_1 = beta_1 = aet.as_tensor_variable(beta_1)
+        self.initial_vol = aet.as_tensor_variable(initial_vol)
+        self.mean = aet.as_tensor_variable(0.0)
 
     def get_volatility(self, x):
         x = x[:-1]
 
         def volatility_update(x, vol, w, a, b):
-            return tt.sqrt(w + a * tt.square(x) + b * tt.square(vol))
+            return aet.sqrt(w + a * aet.square(x) + b * aet.square(vol))
 
         vol, _ = scan(
             fn=volatility_update,
@@ -341,7 +341,7 @@ class GARCH11(distribution.Continuous):
             outputs_info=[self.initial_vol],
             non_sequences=[self.omega, self.alpha_1, self.beta_1],
         )
-        return tt.concatenate([[self.initial_vol], vol])
+        return aet.concatenate([[self.initial_vol], vol])
 
     def logp(self, x):
         """
@@ -357,7 +357,7 @@ class GARCH11(distribution.Continuous):
         TensorVariable
         """
         vol = self.get_volatility(x)
-        return tt.sum(Normal.dist(0.0, sigma=vol).logp(x))
+        return aet.sum(Normal.dist(0.0, sigma=vol).logp(x))
 
     def _distr_parameters_for_repr(self):
         return ["omega", "alpha_1", "beta_1"]
@@ -379,7 +379,7 @@ class EulerMaruyama(distribution.Continuous):
 
     def __init__(self, dt, sde_fn, sde_pars, *args, **kwds):
         super().__init__(*args, **kwds)
-        self.dt = dt = tt.as_tensor_variable(dt)
+        self.dt = dt = aet.as_tensor_variable(dt)
         self.sde_fn = sde_fn
         self.sde_pars = sde_pars
 
@@ -399,8 +399,8 @@ class EulerMaruyama(distribution.Continuous):
         xt = x[:-1]
         f, g = self.sde_fn(x[:-1], *self.sde_pars)
         mu = xt + self.dt * f
-        sd = tt.sqrt(self.dt) * g
-        return tt.sum(Normal.dist(mu=mu, sigma=sd).logp(x[1:]))
+        sd = aet.sqrt(self.dt) * g
+        return aet.sum(Normal.dist(mu=mu, sigma=sd).logp(x[1:]))
 
     def _distr_parameters_for_repr(self):
         return ["dt"]
@@ -437,7 +437,7 @@ class MvGaussianRandomWalk(distribution.Continuous):
         self.init = init
         self.innovArgs = (mu, cov, tau, chol, lower)
         self.innov = multivariate.MvNormal.dist(*self.innovArgs, shape=self.shape)
-        self.mean = tt.as_tensor_variable(0.0)
+        self.mean = aet.as_tensor_variable(0.0)
 
     def logp(self, x):
         """
@@ -551,7 +551,7 @@ class MvStudentTRandomWalk(MvGaussianRandomWalk):
 
     def __init__(self, nu, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.nu = tt.as_tensor_variable(nu)
+        self.nu = aet.as_tensor_variable(nu)
         self.innov = multivariate.MvStudentT.dist(self.nu, None, *self.innovArgs)
 
     def _distr_parameters_for_repr(self):

--- a/pymc3/glm/families.py
+++ b/pymc3/glm/families.py
@@ -16,8 +16,8 @@ import numbers
 
 from copy import copy
 
+import aesara.tensor as aet
 import numpy as np
-import theano.tensor as tt
 
 from pymc3 import distributions as pm_dists
 from pymc3.model import modelcontext
@@ -36,9 +36,9 @@ class Identity:
 
 
 identity = Identity()
-logit = tt.nnet.sigmoid
-inverse = tt.inv
-exp = tt.exp
+logit = aet.nnet.sigmoid
+inverse = aet.inv
+exp = aet.exp
 
 
 class Family:
@@ -80,7 +80,7 @@ class Family:
 
         Parameters
         ----------
-        y_est: theano.tensor
+        y_est: aesara.tensor
             Estimate of dependent variable
         y_data: array
             Observed dependent variable

--- a/pymc3/glm/linear.py
+++ b/pymc3/glm/linear.py
@@ -12,8 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara.tensor as aet
 import numpy as np
-import theano.tensor as tt
 
 from pymc3.distributions import Flat, Normal
 from pymc3.glm import families
@@ -39,7 +39,7 @@ class LinearComponent(Model):
         use `Regressor` key for defining default prior for all regressors
             defaults to Normal.dist(mu=0, tau=1.0E-6)
     vars: dict - random variables instead of creating new ones
-    offset: scalar, or numpy/theano array with the same shape as y
+    offset: scalar, or numpy/aesara array with the same shape as y
         this can be used to specify an a priori known component to be
         included in the linear predictor during fitting.
     """
@@ -73,7 +73,7 @@ class LinearComponent(Model):
         x, labels = any_to_tensor_and_labels(x, labels)
         # now we have x, shape and labels
         if intercept:
-            x = tt.concatenate([tt.ones((x.shape[0], 1), x.dtype), x], axis=1)
+            x = aet.concatenate([aet.ones((x.shape[0], 1), x.dtype), x], axis=1)
             labels = ["Intercept"] + labels
         coeffs = list()
         for name in labels:
@@ -94,7 +94,7 @@ class LinearComponent(Model):
                         ),
                     )
                 coeffs.append(v)
-        self.coeffs = tt.stack(coeffs, axis=0)
+        self.coeffs = aet.stack(coeffs, axis=0)
         self.y_est = x.dot(self.coeffs) + offset
 
     @classmethod
@@ -149,7 +149,7 @@ class GLM(LinearComponent):
     init: dict - test_vals for coefficients
     vars: dict - random variables instead of creating new ones
     family: pymc3..families object
-    offset: scalar, or numpy/theano array with the same shape as y
+    offset: scalar, or numpy/aesara array with the same shape as y
         this can be used to specify an a priori known component to be
         included in the linear predictor during fitting.
     """

--- a/pymc3/glm/utils.py
+++ b/pymc3/glm/utils.py
@@ -12,9 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara.tensor as aet
 import numpy as np
 import pandas as pd
-import theano.tensor as tt
+
+from aesara.graph.basic import Variable
 
 
 def any_to_tensor_and_labels(x, labels=None):
@@ -33,7 +35,7 @@ def any_to_tensor_and_labels(x, labels=None):
 
     Parameters
     ----------
-    x: np.ndarray | pd.DataFrame | tt.Variable | dict | list
+    x: np.ndarray | pd.DataFrame | Variable | dict | list
     labels: list - names for columns of output tensor
 
     Returns
@@ -76,13 +78,13 @@ def any_to_tensor_and_labels(x, labels=None):
             for k, v in x.items():
                 res.append(v)
                 labels.append(k)
-            x = tt.stack(res, axis=1)
+            x = aet.stack(res, axis=1)
             if x.ndim == 1:
                 x = x[:, None]
     # case when it can appear to be some
     # array like value like lists of lists
     # numpy deals with it
-    elif not isinstance(x, tt.Variable):
+    elif not isinstance(x, Variable):
         x = np.asarray(x)
         if x.ndim == 0:
             raise ValueError("Cannot use scalars")
@@ -92,7 +94,7 @@ def any_to_tensor_and_labels(x, labels=None):
     # but user passes labels trusting seems
     # to be a good option
     elif labels is not None:
-        x = tt.as_tensor_variable(x)
+        x = aet.as_tensor_variable(x)
         if x.ndim == 0:
             raise ValueError("Cannot use scalars")
         elif x.ndim == 1:
@@ -100,15 +102,15 @@ def any_to_tensor_and_labels(x, labels=None):
     else:  # trust input
         pass
     # we should check that we can extract labels
-    if labels is None and not isinstance(x, tt.Variable):
+    if labels is None and not isinstance(x, Variable):
         labels = ["x%d" % i for i in range(x.shape[1])]
-    # for theano variables we should have labels from user
+    # for aesara variables we should have labels from user
     elif labels is None:
         raise ValueError("Please provide labels as " "we cannot infer shape of input")
     else:  # trust labels, user knows what he is doing
         pass
     # it's time to check shapes if we can
-    if not isinstance(x, tt.Variable):
+    if not isinstance(x, Variable):
         if not len(labels) == x.shape[1]:
             raise ValueError(
                 "Please provide full list "
@@ -126,8 +128,8 @@ def any_to_tensor_and_labels(x, labels=None):
     elif not isinstance(labels, list):
         labels = list(labels)
     # as output we need tensor
-    if not isinstance(x, tt.Variable):
-        x = tt.as_tensor_variable(x)
+    if not isinstance(x, Variable):
+        x = aet.as_tensor_variable(x)
         # finally check dimensions
         if x.ndim == 0:
             raise ValueError("Cannot use scalars")

--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -15,10 +15,10 @@
 import functools
 import warnings
 
+import aesara.tensor as aet
 import numpy as np
-import theano.tensor as tt
 
-from theano.tensor.nlinalg import eigh
+from aesara.tensor.nlinalg import eigh
 
 import pymc3 as pm
 
@@ -195,9 +195,9 @@ class Latent(Base):
         L = cholesky(stabilize(Kxx))
         A = solve_lower(L, Kxs)
         v = solve_lower(L, f - mean_total(X))
-        mu = self.mean_func(Xnew) + tt.dot(tt.transpose(A), v)
+        mu = self.mean_func(Xnew) + aet.dot(aet.transpose(A), v)
         Kss = self.cov_func(Xnew)
-        cov = Kss - tt.dot(tt.transpose(A), A)
+        cov = Kss - aet.dot(aet.transpose(A), A)
         return mu, cov
 
     def conditional(self, name, Xnew, given=None, **kwargs):
@@ -281,7 +281,7 @@ class TP(Latent):
         if reparameterize:
             chi2 = pm.ChiSquared(name + "_chi2_", self.nu)
             v = pm.Normal(name + "_rotated_", mu=0.0, sigma=1.0, shape=shape, **kwargs)
-            f = pm.Deterministic(name, (tt.sqrt(self.nu) / chi2) * (mu + cholesky(cov).dot(v)))
+            f = pm.Deterministic(name, (aet.sqrt(self.nu) / chi2) * (mu + cholesky(cov).dot(v)))
         else:
             f = pm.MvStudentT(name, nu=self.nu, mu=mu, cov=cov, shape=shape, **kwargs)
         return f
@@ -318,10 +318,10 @@ class TP(Latent):
         Kss = self.cov_func(Xnew)
         L = cholesky(stabilize(Kxx))
         A = solve_lower(L, Kxs)
-        cov = Kss - tt.dot(tt.transpose(A), A)
+        cov = Kss - aet.dot(aet.transpose(A), A)
         v = solve_lower(L, f - self.mean_func(X))
-        mu = self.mean_func(Xnew) + tt.dot(tt.transpose(A), v)
-        beta = tt.dot(v, v)
+        mu = self.mean_func(Xnew) + aet.dot(aet.transpose(A), v)
+        beta = aet.dot(v, v)
         nu2 = self.nu + X.shape[0]
         covT = (self.nu + beta - 2) / (nu2 - 2) * cov
         return nu2, mu, covT
@@ -476,16 +476,16 @@ class Marginal(Base):
         L = cholesky(stabilize(Kxx) + Knx)
         A = solve_lower(L, Kxs)
         v = solve_lower(L, rxx)
-        mu = self.mean_func(Xnew) + tt.dot(tt.transpose(A), v)
+        mu = self.mean_func(Xnew) + aet.dot(aet.transpose(A), v)
         if diag:
             Kss = self.cov_func(Xnew, diag=True)
-            var = Kss - tt.sum(tt.square(A), 0)
+            var = Kss - aet.sum(aet.square(A), 0)
             if pred_noise:
                 var += noise(Xnew, diag=True)
             return mu, var
         else:
             Kss = self.cov_func(Xnew)
-            cov = Kss - tt.dot(tt.transpose(A), A)
+            cov = Kss - aet.dot(aet.transpose(A), A)
             if pred_noise:
                 cov += noise(Xnew)
             return mu, cov if pred_noise else stabilize(cov)
@@ -664,32 +664,32 @@ class MarginalSparse(Marginal):
     # in marginal_likelihood instead of lambda. This makes pickling
     # possible.
     def _build_marginal_likelihood_logp(self, y, X, Xu, sigma):
-        sigma2 = tt.square(sigma)
+        sigma2 = aet.square(sigma)
         Kuu = self.cov_func(Xu)
         Kuf = self.cov_func(Xu, X)
         Luu = cholesky(stabilize(Kuu))
         A = solve_lower(Luu, Kuf)
-        Qffd = tt.sum(A * A, 0)
+        Qffd = aet.sum(A * A, 0)
         if self.approx == "FITC":
             Kffd = self.cov_func(X, diag=True)
-            Lamd = tt.clip(Kffd - Qffd, 0.0, np.inf) + sigma2
+            Lamd = aet.clip(Kffd - Qffd, 0.0, np.inf) + sigma2
             trace = 0.0
         elif self.approx == "VFE":
-            Lamd = tt.ones_like(Qffd) * sigma2
+            Lamd = aet.ones_like(Qffd) * sigma2
             trace = (1.0 / (2.0 * sigma2)) * (
-                tt.sum(self.cov_func(X, diag=True)) - tt.sum(tt.sum(A * A, 0))
+                aet.sum(self.cov_func(X, diag=True)) - aet.sum(aet.sum(A * A, 0))
             )
         else:  # DTC
-            Lamd = tt.ones_like(Qffd) * sigma2
+            Lamd = aet.ones_like(Qffd) * sigma2
             trace = 0.0
         A_l = A / Lamd
-        L_B = cholesky(tt.eye(Xu.shape[0]) + tt.dot(A_l, tt.transpose(A)))
+        L_B = cholesky(aet.eye(Xu.shape[0]) + aet.dot(A_l, aet.transpose(A)))
         r = y - self.mean_func(X)
         r_l = r / Lamd
-        c = solve_lower(L_B, tt.dot(A, r_l))
-        constant = 0.5 * X.shape[0] * tt.log(2.0 * np.pi)
-        logdet = 0.5 * tt.sum(tt.log(Lamd)) + tt.sum(tt.log(tt.diag(L_B)))
-        quadratic = 0.5 * (tt.dot(r, r_l) - tt.dot(c, c))
+        c = solve_lower(L_B, aet.dot(A, r_l))
+        constant = 0.5 * X.shape[0] * aet.log(2.0 * np.pi)
+        logdet = 0.5 * aet.sum(aet.log(Lamd)) + aet.sum(aet.log(aet.diag(L_B)))
+        quadratic = 0.5 * (aet.dot(r, r_l) - aet.dot(c, c))
         return -1.0 * (constant + logdet + quadratic + trace)
 
     def marginal_likelihood(self, name, X, Xu, y, noise=None, is_observed=True, **kwargs):
@@ -743,36 +743,38 @@ class MarginalSparse(Marginal):
             return pm.DensityDist(name, logp, shape=shape, **kwargs)
 
     def _build_conditional(self, Xnew, pred_noise, diag, X, Xu, y, sigma, cov_total, mean_total):
-        sigma2 = tt.square(sigma)
+        sigma2 = aet.square(sigma)
         Kuu = cov_total(Xu)
         Kuf = cov_total(Xu, X)
         Luu = cholesky(stabilize(Kuu))
         A = solve_lower(Luu, Kuf)
-        Qffd = tt.sum(A * A, 0)
+        Qffd = aet.sum(A * A, 0)
         if self.approx == "FITC":
             Kffd = cov_total(X, diag=True)
-            Lamd = tt.clip(Kffd - Qffd, 0.0, np.inf) + sigma2
+            Lamd = aet.clip(Kffd - Qffd, 0.0, np.inf) + sigma2
         else:  # VFE or DTC
-            Lamd = tt.ones_like(Qffd) * sigma2
+            Lamd = aet.ones_like(Qffd) * sigma2
         A_l = A / Lamd
-        L_B = cholesky(tt.eye(Xu.shape[0]) + tt.dot(A_l, tt.transpose(A)))
+        L_B = cholesky(aet.eye(Xu.shape[0]) + aet.dot(A_l, aet.transpose(A)))
         r = y - mean_total(X)
         r_l = r / Lamd
-        c = solve_lower(L_B, tt.dot(A, r_l))
+        c = solve_lower(L_B, aet.dot(A, r_l))
         Kus = self.cov_func(Xu, Xnew)
         As = solve_lower(Luu, Kus)
-        mu = self.mean_func(Xnew) + tt.dot(tt.transpose(As), solve_upper(tt.transpose(L_B), c))
+        mu = self.mean_func(Xnew) + aet.dot(aet.transpose(As), solve_upper(aet.transpose(L_B), c))
         C = solve_lower(L_B, As)
         if diag:
             Kss = self.cov_func(Xnew, diag=True)
-            var = Kss - tt.sum(tt.square(As), 0) + tt.sum(tt.square(C), 0)
+            var = Kss - aet.sum(aet.square(As), 0) + aet.sum(aet.square(C), 0)
             if pred_noise:
                 var += sigma2
             return mu, var
         else:
-            cov = self.cov_func(Xnew) - tt.dot(tt.transpose(As), As) + tt.dot(tt.transpose(C), C)
+            cov = (
+                self.cov_func(Xnew) - aet.dot(aet.transpose(As), As) + aet.dot(aet.transpose(C), C)
+            )
             if pred_noise:
-                cov += sigma2 * tt.identity_like(cov)
+                cov += sigma2 * aet.identity_like(cov)
             return mu, cov if pred_noise else stabilize(cov)
 
     def _get_given_vals(self, given):
@@ -891,7 +893,7 @@ class LatentKron(Base):
         chols = [cholesky(stabilize(cov(X))) for cov, X in zip(self.cov_funcs, Xs)]
         # remove reparameterization option
         v = pm.Normal(name + "_rotated_", mu=0.0, sigma=1.0, shape=self.N, **kwargs)
-        f = pm.Deterministic(name, mu + tt.flatten(kron_dot(chols, v)))
+        f = pm.Deterministic(name, mu + aet.flatten(kron_dot(chols, v)))
         return f
 
     def prior(self, name, Xs, **kwargs):
@@ -925,15 +927,15 @@ class LatentKron(Base):
         delta = f - self.mean_func(X)
         covs = [stabilize(cov(Xi)) for cov, Xi in zip(self.cov_funcs, Xs)]
         chols = [cholesky(cov) for cov in covs]
-        cholTs = [tt.transpose(chol) for chol in chols]
+        cholTs = [aet.transpose(chol) for chol in chols]
         Kss = self.cov_func(Xnew)
         Kxs = self.cov_func(X, Xnew)
-        Ksx = tt.transpose(Kxs)
+        Ksx = aet.transpose(Kxs)
         alpha = kron_solve_lower(chols, delta)
         alpha = kron_solve_upper(cholTs, alpha)
-        mu = tt.dot(Ksx, alpha).ravel() + self.mean_func(Xnew)
+        mu = aet.dot(Ksx, alpha).ravel() + self.mean_func(Xnew)
         A = kron_solve_lower(chols, Kxs)
-        cov = stabilize(Kss - tt.dot(tt.transpose(A), A))
+        cov = stabilize(Kss - aet.dot(aet.transpose(A), A))
         return mu, cov
 
     def conditional(self, name, Xnew, **kwargs):
@@ -1103,7 +1105,7 @@ class MarginalKron(Base):
         delta = y - self.mean_func(X)
         Kns = [f(x) for f, x in zip(self.cov_funcs, Xs)]
         eigs_sep, Qs = zip(*map(eigh, Kns))  # Unzip
-        QTs = list(map(tt.transpose, Qs))
+        QTs = list(map(aet.transpose, Qs))
         eigs = kron_diag(*eigs_sep)  # Combine separate eigs
         if sigma is not None:
             eigs += sigma ** 2
@@ -1117,21 +1119,21 @@ class MarginalKron(Base):
         alpha = kron_dot(QTs, delta)
         alpha = alpha / eigs[:, None]
         alpha = kron_dot(Qs, alpha)
-        mu = tt.dot(Kmn, alpha).ravel() + self.mean_func(Xnew)
+        mu = aet.dot(Kmn, alpha).ravel() + self.mean_func(Xnew)
 
         # Build conditional cov
         A = kron_dot(QTs, Knm)
-        A = A / tt.sqrt(eigs[:, None])
+        A = A / aet.sqrt(eigs[:, None])
         if diag:
-            Asq = tt.sum(tt.square(A), 0)
+            Asq = aet.sum(aet.square(A), 0)
             cov = Km - Asq
             if pred_noise:
                 cov += sigma
         else:
-            Asq = tt.dot(A.T, A)
+            Asq = aet.dot(A.T, A)
             cov = Km - Asq
             if pred_noise:
-                cov += sigma * tt.identity_like(cov)
+                cov += sigma * aet.identity_like(cov)
         return mu, cov
 
     def conditional(self, name, Xnew, pred_noise=False, **kwargs):

--- a/pymc3/gp/mean.py
+++ b/pymc3/gp/mean.py
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import theano.tensor as tt
+import aesara.tensor as aet
 
 __all__ = ["Zero", "Constant", "Linear"]
 
@@ -46,7 +46,7 @@ class Zero(Mean):
     """
 
     def __call__(self, X):
-        return tt.alloc(0.0, X.shape[0])
+        return aet.alloc(0.0, X.shape[0])
 
 
 class Constant(Mean):
@@ -64,7 +64,7 @@ class Constant(Mean):
         self.c = c
 
     def __call__(self, X):
-        return tt.alloc(1.0, X.shape[0]) * self.c
+        return aet.alloc(1.0, X.shape[0]) * self.c
 
 
 class Linear(Mean):
@@ -85,7 +85,7 @@ class Linear(Mean):
         self.A = coeffs
 
     def __call__(self, X):
-        return tt.squeeze(tt.dot(X, self.A) + self.b)
+        return aet.squeeze(aet.dot(X, self.A) + self.b)
 
 
 class Add(Mean):
@@ -95,7 +95,7 @@ class Add(Mean):
         self.m2 = second_mean
 
     def __call__(self, X):
-        return tt.add(self.m1(X), self.m2(X))
+        return aet.add(self.m1(X), self.m2(X))
 
 
 class Prod(Mean):
@@ -105,4 +105,4 @@ class Prod(Mean):
         self.m2 = second_mean
 
     def __call__(self, X):
-        return tt.mul(self.m1(X), self.m2(X))
+        return aet.mul(self.m1(X), self.m2(X))

--- a/pymc3/gp/util.py
+++ b/pymc3/gp/util.py
@@ -14,16 +14,16 @@
 
 import warnings
 
+import aesara.tensor as aet
 import numpy as np
-import theano.tensor as tt
-import theano.tensor.slinalg  # pylint: disable=unused-import
 
+from aesara.tensor.slinalg import Solve, cholesky  # pylint: disable=unused-import
+from aesara.tensor.var import TensorConstant
 from scipy.cluster.vq import kmeans
 
-cholesky = tt.slinalg.cholesky
-solve_lower = tt.slinalg.Solve(A_structure="lower_triangular")
-solve_upper = tt.slinalg.Solve(A_structure="upper_triangular")
-solve = tt.slinalg.Solve(A_structure="general")
+solve_lower = Solve(A_structure="lower_triangular")
+solve_upper = Solve(A_structure="upper_triangular")
+solve = Solve(A_structure="general")
 
 
 def infer_shape(X, n_points=None):
@@ -37,12 +37,12 @@ def infer_shape(X, n_points=None):
 
 def stabilize(K):
     """ adds small diagonal to a covariance matrix """
-    return K + 1e-6 * tt.identity_like(K)
+    return K + 1e-6 * aet.identity_like(K)
 
 
 def kmeans_inducing_points(n_inducing, X):
     # first whiten X
-    if isinstance(X, tt.TensorConstant):
+    if isinstance(X, TensorConstant):
         X = X.value
     elif isinstance(X, (np.ndarray, tuple, list)):
         X = np.asarray(X)

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -16,20 +16,19 @@ import sys
 
 from functools import partial, reduce
 
+import aesara
+import aesara.sparse
+import aesara.tensor as aet
+import aesara.tensor.slinalg  # pylint: disable=unused-import
 import numpy as np
 import scipy as sp
 import scipy.sparse  # pylint: disable=unused-import
-import theano
-import theano.sparse
-import theano.tensor as tt
-import theano.tensor.slinalg  # pylint: disable=unused-import
 
-from scipy.linalg import block_diag as scipy_block_diag
-from theano.graph.basic import Apply
-from theano.graph.op import Op
+from aesara.graph.basic import Apply
+from aesara.graph.op import Op
 
 # pylint: disable=unused-import
-from theano.tensor import (
+from aesara.tensor import (
     abs_,
     and_,
     ceil,
@@ -71,10 +70,11 @@ from theano.tensor import (
     where,
     zeros_like,
 )
-from theano.tensor.nlinalg import det, extract_diag, matrix_dot, matrix_inverse, trace
-from theano.tensor.nnet import sigmoid
+from aesara.tensor.nlinalg import det, extract_diag, matrix_dot, matrix_inverse, trace
+from aesara.tensor.nnet import sigmoid
+from scipy.linalg import block_diag as scipy_block_diag
 
-from pymc3.theanof import floatX, ix_, largest_common_dtype
+from pymc3.aesaraf import floatX, ix_, largest_common_dtype
 
 # pylint: enable=unused-import
 
@@ -93,7 +93,7 @@ def kronecker(*Ks):
     np.ndarray :
         Block matrix Kroncker product of the argument matrices.
     """
-    return reduce(tt.slinalg.kron, Ks)
+    return reduce(aet.slinalg.kron, Ks)
 
 
 def cartesian(*arrays):
@@ -140,17 +140,17 @@ def kron_matrix_op(krons, m, op):
         raise ValueError(f"m must have ndim <= 2, not {m.ndim}")
     res = kron_vector_op(m)
     res_shape = res.shape
-    return tt.reshape(res, (res_shape[1], res_shape[0])).T
+    return aet.reshape(res, (res_shape[1], res_shape[0])).T
 
 
 # Define kronecker functions that work on 1D and 2D arrays
-kron_dot = partial(kron_matrix_op, op=tt.dot)
-kron_solve_lower = partial(kron_matrix_op, op=tt.slinalg.solve_lower_triangular)
-kron_solve_upper = partial(kron_matrix_op, op=tt.slinalg.solve_upper_triangular)
+kron_dot = partial(kron_matrix_op, op=aet.dot)
+kron_solve_lower = partial(kron_matrix_op, op=aet.slinalg.solve_lower_triangular)
+kron_solve_upper = partial(kron_matrix_op, op=aet.slinalg.solve_upper_triangular)
 
 
 def flat_outer(a, b):
-    return tt.outer(a, b).ravel()
+    return aet.outer(a, b).ravel()
 
 
 def kron_diag(*diags):
@@ -166,24 +166,24 @@ def kron_diag(*diags):
 
 def tround(*args, **kwargs):
     """
-    Temporary function to silence round warning in Theano. Please remove
+    Temporary function to silence round warning in Aesara. Please remove
     when the warning disappears.
     """
     kwargs["mode"] = "half_to_even"
-    return tt.round(*args, **kwargs)
+    return aet.round(*args, **kwargs)
 
 
 def logsumexp(x, axis=None, keepdims=True):
     # Adapted from https://github.com/Theano/Theano/issues/1563
-    x_max = tt.max(x, axis=axis, keepdims=True)
-    x_max = tt.switch(tt.isinf(x_max), 0, x_max)
-    res = tt.log(tt.sum(tt.exp(x - x_max), axis=axis, keepdims=True)) + x_max
+    x_max = aet.max(x, axis=axis, keepdims=True)
+    x_max = aet.switch(aet.isinf(x_max), 0, x_max)
+    res = aet.log(aet.sum(aet.exp(x - x_max), axis=axis, keepdims=True)) + x_max
     return res if keepdims else res.squeeze()
 
 
 def logaddexp(a, b):
     diff = b - a
-    return tt.switch(diff > 0, b + tt.log1p(tt.exp(-diff)), a + tt.log1p(tt.exp(diff)))
+    return aet.switch(diff > 0, b + aet.log1p(aet.exp(-diff)), a + aet.log1p(aet.exp(diff)))
 
 
 def logdiffexp(a, b):
@@ -198,7 +198,7 @@ def logdiffexp_numpy(a, b):
 
 def invlogit(x, eps=sys.float_info.epsilon):
     """The inverse of the logit function, 1 / (1 + exp(-x))."""
-    return (1.0 - 2.0 * eps) / (1.0 + tt.exp(-x)) + eps
+    return (1.0 - 2.0 * eps) / (1.0 + aet.exp(-x)) + eps
 
 
 def logbern(log_p):
@@ -208,7 +208,7 @@ def logbern(log_p):
 
 
 def logit(p):
-    return tt.log(p / (floatX(1) - p))
+    return aet.log(p / (floatX(1) - p))
 
 
 def log1pexp(x):
@@ -216,7 +216,7 @@ def log1pexp(x):
 
     This function is numerically more stable than the naive approach.
     """
-    return tt.nnet.softplus(x)
+    return aet.nnet.softplus(x)
 
 
 def log1mexp(x):
@@ -234,7 +234,9 @@ def log1mexp(x):
             package"
 
     """
-    return tt.switch(tt.lt(x, 0.6931471805599453), tt.log(-tt.expm1(-x)), tt.log1p(-tt.exp(-x)))
+    return aet.switch(
+        aet.lt(x, 0.6931471805599453), aet.log(-aet.expm1(-x)), aet.log1p(-aet.exp(-x))
+    )
 
 
 def log1mexp_numpy(x):
@@ -253,7 +255,7 @@ def log1mexp_numpy(x):
 
 
 def flatten_list(tensors):
-    return tt.concatenate([var.ravel() for var in tensors])
+    return aet.concatenate([var.ravel() for var in tensors])
 
 
 class LogDet(Op):
@@ -268,8 +270,8 @@ class LogDet(Op):
     """
 
     def make_node(self, x):
-        x = theano.tensor.as_tensor_variable(x)
-        o = theano.tensor.scalar(dtype=x.dtype)
+        x = aesara.tensor.as_tensor_variable(x)
+        o = aesara.tensor.scalar(dtype=x.dtype)
         return Apply(self, [x], [o])
 
     def perform(self, node, inputs, outputs, params=None):
@@ -319,7 +321,7 @@ def expand_packed_triangular(n, packed, lower=True, diagonal_only=False):
     ----------
     n: int
         The number of rows of the triangular matrix.
-    packed: theano.vector
+    packed: aesara.vector
         The matrix in packed format.
     lower: bool, default=True
         If true, assume that the matrix is lower triangular.
@@ -338,13 +340,13 @@ def expand_packed_triangular(n, packed, lower=True, diagonal_only=False):
         diag_idxs = np.arange(2, n + 2)[::-1].cumsum() - n - 1
         return packed[diag_idxs]
     elif lower:
-        out = tt.zeros((n, n), dtype=theano.config.floatX)
+        out = aet.zeros((n, n), dtype=aesara.config.floatX)
         idxs = np.tril_indices(n)
-        return tt.set_subtensor(out[idxs], packed)
+        return aet.set_subtensor(out[idxs], packed)
     elif not lower:
-        out = tt.zeros((n, n), dtype=theano.config.floatX)
+        out = aet.zeros((n, n), dtype=aesara.config.floatX)
         idxs = np.triu_indices(n)
-        return tt.set_subtensor(out[idxs], packed)
+        return aet.set_subtensor(out[idxs], packed)
 
 
 class BatchedDiag(Op):
@@ -355,11 +357,11 @@ class BatchedDiag(Op):
     __props__ = ()
 
     def make_node(self, diag):
-        diag = tt.as_tensor_variable(diag)
+        diag = aet.as_tensor_variable(diag)
         if diag.type.ndim != 2:
             raise TypeError("data argument must be a matrix", diag.type)
 
-        return Apply(self, [diag], [tt.tensor3(dtype=diag.dtype)])
+        return Apply(self, [diag], [aet.tensor3(dtype=diag.dtype)])
 
     def perform(self, node, ins, outs, params=None):
         (C,) = ins
@@ -375,7 +377,7 @@ class BatchedDiag(Op):
 
     def grad(self, inputs, gout):
         (gz,) = gout
-        idx = tt.arange(gz.shape[-1])
+        idx = aet.arange(gz.shape[-1])
         return [gz[..., idx, idx]]
 
     def infer_shape(self, fgraph, nodes, shapes):
@@ -383,14 +385,14 @@ class BatchedDiag(Op):
 
 
 def batched_diag(C):
-    C = tt.as_tensor(C)
+    C = aet.as_tensor(C)
     dim = C.shape[-1]
     if C.ndim == 2:
         # diag -> matrices
         return BatchedDiag()(C)
     elif C.ndim == 3:
         # matrices -> diag
-        idx = tt.arange(dim)
+        idx = aet.arange(dim)
         return C[..., idx, idx]
     else:
         raise ValueError("Input should be 2 or 3 dimensional")
@@ -408,13 +410,13 @@ class BlockDiagonalMatrix(Op):
     def make_node(self, *matrices):
         if not matrices:
             raise ValueError("no matrices to allocate")
-        matrices = list(map(tt.as_tensor, matrices))
+        matrices = list(map(aet.as_tensor, matrices))
         if any(mat.type.ndim != 2 for mat in matrices):
             raise TypeError("all data arguments must be matrices")
         if self.sparse:
-            out_type = theano.sparse.matrix(self.format, dtype=largest_common_dtype(matrices))
+            out_type = aesara.sparse.matrix(self.format, dtype=largest_common_dtype(matrices))
         else:
-            out_type = theano.tensor.matrix(dtype=largest_common_dtype(matrices))
+            out_type = aesara.tensor.matrix(dtype=largest_common_dtype(matrices))
         return Apply(self, matrices, [out_type])
 
     def perform(self, node, inputs, output_storage, params=None):
@@ -425,13 +427,13 @@ class BlockDiagonalMatrix(Op):
             output_storage[0][0] = scipy_block_diag(*inputs).astype(dtype)
 
     def grad(self, inputs, gout):
-        shapes = tt.stack([i.shape for i in inputs])
+        shapes = aet.stack([i.shape for i in inputs])
         index_end = shapes.cumsum(0)
         index_begin = index_end - shapes
         slices = [
             ix_(
-                tt.arange(index_begin[i, 0], index_end[i, 0]),
-                tt.arange(index_begin[i, 1], index_end[i, 1]),
+                aet.arange(index_begin[i, 0], index_end[i, 0]),
+                aet.arange(index_begin[i, 1], index_end[i, 1]),
             )
             for i in range(len(inputs))
         ]
@@ -439,7 +441,7 @@ class BlockDiagonalMatrix(Op):
 
     def infer_shape(self, fgraph, nodes, shapes):
         first, second = zip(*shapes)
-        return [(tt.add(*first), tt.add(*second))]
+        return [(aet.add(*first), aet.add(*second))]
 
 
 def block_diagonal(matrices, sparse=False, format="csr"):

--- a/pymc3/model_graph.py
+++ b/pymc3/model_graph.py
@@ -13,18 +13,18 @@
 #   limitations under the License.
 
 from collections import deque
-from typing import Dict, Iterator, Optional, Set
+from typing import Dict, Iterator, NewType, Optional, Set
 
-VarName = str
-
-from theano.compile import SharedVariable
-from theano.graph.basic import walk
-from theano.tensor import Tensor
+from aesara.compile import SharedVariable
+from aesara.graph.basic import walk
+from aesara.tensor.var import TensorVariable
 
 import pymc3 as pm
 
 from pymc3.model import ObservedRV
 from pymc3.util import get_default_varnames, get_var_name
+
+VarName = NewType("VarName", str)
 
 
 class ModelGraph:
@@ -46,17 +46,17 @@ class ModelGraph:
                 deterministics.append(v)
         return deterministics
 
-    def _get_ancestors(self, var: Tensor, func) -> Set[Tensor]:
+    def _get_ancestors(self, var: TensorVariable, func) -> Set[TensorVariable]:
         """Get all ancestors of a function, doing some accounting for deterministics."""
 
         # this contains all of the variables in the model EXCEPT var...
         vars = set(self.var_list)
         vars.remove(var)
 
-        blockers = set()  # type: Set[Tensor]
-        retval = set()  # type: Set[Tensor]
+        blockers = set()  # type: Set[TensorVariable]
+        retval = set()  # type: Set[TensorVariable]
 
-        def _expand(node) -> Optional[Iterator[Tensor]]:
+        def _expand(node) -> Optional[Iterator[TensorVariable]]:
             if node in blockers:
                 return None
             elif node in vars:
@@ -87,7 +87,7 @@ class ModelGraph:
                 raise AssertionError("Do not know what to do with {}".format(get_var_name(p)))
         return keep
 
-    def get_parents(self, var: Tensor) -> Set[VarName]:
+    def get_parents(self, var: TensorVariable) -> Set[VarName]:
         """Get the named nodes that are direct inputs to the var"""
         if hasattr(var, "transformed"):
             func = var.transformed.logpt
@@ -167,7 +167,7 @@ class ModelGraph:
             if hasattr(v, "observations"):
                 try:
                     # To get shape of _observed_ data container `pm.Data`
-                    # (wrapper for theano.SharedVariable) we evaluate it.
+                    # (wrapper for aesara.SharedVariable) we evaluate it.
                     shape = tuple(v.observations.shape.eval())
                 except AttributeError:
                     shape = v.observations.shape

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -27,7 +27,7 @@ import numpy as np
 
 from fastprogress.fastprogress import progress_bar
 
-from pymc3 import theanof
+from pymc3 import aesaraf
 from pymc3.exceptions import SamplingError
 
 logger = logging.getLogger("pymc3")
@@ -99,7 +99,7 @@ class _Process:
         self._step_method_is_pickled = step_method_is_pickled
         self._shared_point = shared_point
         self._seed = seed
-        self._tt_seed = seed + 1
+        self._aet_seed = seed + 1
         self._draws = draws
         self._tune = tune
         self._pickle_backend = pickle_backend
@@ -170,7 +170,7 @@ class _Process:
 
     def _start_loop(self):
         np.random.seed(self._seed)
-        theanof.set_tt_rng(self._tt_seed)
+        aesaraf.set_aet_rng(self._aet_seed)
 
         draw = 0
         tuning = True

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -25,10 +25,10 @@ from collections import defaultdict
 from copy import copy, deepcopy
 from typing import Any, Dict, Iterable, List, Optional, Set, Union, cast
 
+import aesara.gradient as tg
 import arviz
 import numpy as np
 import packaging
-import theano.gradient as tg
 import xarray
 
 from arviz import InferenceData

--- a/pymc3/sampling_jax.py
+++ b/pymc3/sampling_jax.py
@@ -9,13 +9,13 @@ xla_flags = os.getenv("XLA_FLAGS", "").lstrip("--")
 xla_flags = re.sub(r"xla_force_host_platform_device_count=.+\s", "", xla_flags).split()
 os.environ["XLA_FLAGS"] = " ".join(["--xla_force_host_platform_device_count={}".format(100)])
 
+import aesara.graph.fg
 import arviz as az
 import jax
 import numpy as np
 import pandas as pd
-import theano.graph.fg
 
-from theano.link.jax.jax_dispatch import jax_funcify
+from aesara.link.jax.jax_dispatch import jax_funcify
 
 import pymc3 as pm
 
@@ -24,9 +24,9 @@ from pymc3 import modelcontext
 warnings.warn("This module is experimental.")
 
 # Disable C compilation by default
-# theano.config.cxx = ""
+# aesara.config.cxx = ""
 # This will make the JAX Linker the default
-# theano.config.mode = "JAX"
+# aesara.config.mode = "JAX"
 
 
 def sample_tfp_nuts(
@@ -47,7 +47,7 @@ def sample_tfp_nuts(
 
     seed = jax.random.PRNGKey(random_seed)
 
-    fgraph = theano.graph.fg.FunctionGraph(model.free_RVs, [model.logpt])
+    fgraph = aesara.graph.fg.FunctionGraph(model.free_RVs, [model.logpt])
     fns = jax_funcify(fgraph)
     logp_fn_jax = fns[0]
 
@@ -133,7 +133,7 @@ def sample_numpyro_nuts(
 
     seed = jax.random.PRNGKey(random_seed)
 
-    fgraph = theano.graph.fg.FunctionGraph(model.free_RVs, [model.logpt])
+    fgraph = aesara.graph.fg.FunctionGraph(model.free_RVs, [model.logpt])
     fns = jax_funcify(fgraph)
     logp_fn_jax = fns[0]
 
@@ -199,7 +199,7 @@ def _transform_samples(samples, model, keep_untransformed=False):
     ops_to_compute = [x for x in model.unobserved_RVs if x.name in names_to_compute]
 
     # Create function graph for these:
-    fgraph = theano.graph.fg.FunctionGraph(model.free_RVs, ops_to_compute)
+    fgraph = aesara.graph.fg.FunctionGraph(model.free_RVs, ops_to_compute)
 
     # Jaxify, which returns a list of functions, one for each op
     jax_fns = jax_funcify(fgraph)

--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -19,10 +19,10 @@ import numpy as np
 
 from numpy.random import uniform
 
+from pymc3.aesaraf import inputvars
 from pymc3.blocking import ArrayOrdering, DictToArrayBijection
 from pymc3.model import PyMC3Variable, modelcontext
 from pymc3.step_methods.compound import CompoundStep
-from pymc3.theanof import inputvars
 from pymc3.util import get_var_name
 
 __all__ = ["ArrayStep", "ArrayStepShared", "metrop_select", "Competence"]
@@ -137,7 +137,7 @@ class ArrayStep(BlockedStep):
     ----------
     vars: list
         List of variables for sampler.
-    fs: list of logp theano functions
+    fs: list of logp aesara functions
     allvars: Boolean (default False)
     blocked: Boolean (default True)
     """
@@ -177,7 +177,7 @@ class ArrayStepShared(BlockedStep):
         Parameters
         ----------
         vars: list of sampling variables
-        shared: dict of theano variable -> shared variable
+        shared: dict of aesara variable -> shared variable
         blocked: Boolean (default True)
         """
         self.vars = vars
@@ -212,7 +212,7 @@ class PopulationArrayStepShared(ArrayStepShared):
         Parameters
         ----------
         vars: list of sampling variables
-        shared: dict of theano variable -> shared variable
+        shared: dict of aesara variable -> shared variable
         blocked: Boolean (default True)
         """
         self.population = None
@@ -244,14 +244,14 @@ class PopulationArrayStepShared(ArrayStepShared):
 
 class GradientSharedStep(BlockedStep):
     def __init__(
-        self, vars, model=None, blocked=True, dtype=None, logp_dlogp_func=None, **theano_kwargs
+        self, vars, model=None, blocked=True, dtype=None, logp_dlogp_func=None, **aesara_kwargs
     ):
         model = modelcontext(model)
         self.vars = vars
         self.blocked = blocked
 
         if logp_dlogp_func is None:
-            func = model.logp_dlogp_function(vars, dtype=dtype, **theano_kwargs)
+            func = model.logp_dlogp_function(vars, dtype=dtype, **aesara_kwargs)
         else:
             func = logp_dlogp_func
 
@@ -263,8 +263,8 @@ class GradientSharedStep(BlockedStep):
         except ValueError:
             if logp_dlogp_func is not None:
                 raise
-            theano_kwargs.update(mode="FAST_COMPILE")
-            func = model.logp_dlogp_function(vars, dtype=dtype, **theano_kwargs)
+            aesara_kwargs.update(mode="FAST_COMPILE")
+            func = model.logp_dlogp_function(vars, dtype=dtype, **aesara_kwargs)
 
         self._logp_dlogp_func = func
 

--- a/pymc3/step_methods/elliptical_slice.py
+++ b/pymc3/step_methods/elliptical_slice.py
@@ -12,14 +12,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara.tensor as aet
 import numpy as np
 import numpy.random as nr
-import theano.tensor as tt
 
+from pymc3.aesaraf import inputvars
 from pymc3.distributions import draw_values
 from pymc3.model import modelcontext
 from pymc3.step_methods.arraystep import ArrayStep, Competence
-from pymc3.theanof import inputvars
 
 __all__ = ["EllipticalSlice"]
 
@@ -44,7 +44,7 @@ def get_chol(cov, chol):
         raise ValueError("Must pass exactly one of cov or chol")
 
     if cov is not None:
-        chol = tt.slinalg.cholesky(cov)
+        chol = aet.slinalg.cholesky(cov)
     return chol
 
 
@@ -86,7 +86,7 @@ class EllipticalSlice(ArrayStep):
     def __init__(self, vars=None, prior_cov=None, prior_chol=None, model=None, **kwargs):
         self.model = modelcontext(model)
         chol = get_chol(prior_cov, prior_chol)
-        self.prior_chol = tt.as_tensor_variable(chol)
+        self.prior_chol = aet.as_tensor_variable(chol)
 
         if vars is None:
             vars = self.model.cont_vars

--- a/pymc3/step_methods/gibbs.py
+++ b/pymc3/step_methods/gibbs.py
@@ -19,6 +19,8 @@ Created on May 12, 2012
 """
 from warnings import warn
 
+from aesara.graph.basic import graph_inputs
+from aesara.tensor import add
 from numpy import (
     arange,
     array,
@@ -31,8 +33,6 @@ from numpy import (
     searchsorted,
 )
 from numpy.random import uniform
-from theano.graph.basic import graph_inputs
-from theano.tensor import add
 
 from pymc3.distributions.discrete import Categorical
 from pymc3.model import modelcontext

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -19,13 +19,13 @@ from collections import namedtuple
 
 import numpy as np
 
+from pymc3.aesaraf import floatX, inputvars
 from pymc3.backends.report import SamplerWarning, WarningType
 from pymc3.exceptions import SamplingError
 from pymc3.model import Point, modelcontext
 from pymc3.step_methods import arraystep, step_sizes
 from pymc3.step_methods.hmc import integration
 from pymc3.step_methods.hmc.quadpotential import QuadPotentialDiagAdapt, quad_potential
-from pymc3.theanof import floatX, inputvars
 from pymc3.tuning import guess_scaling
 
 logger = logging.getLogger("pymc3")
@@ -57,13 +57,13 @@ class BaseHMC(arraystep.GradientSharedStep):
         t0=10,
         adapt_step_size=True,
         step_rand=None,
-        **theano_kwargs
+        **aesara_kwargs
     ):
         """Set up Hamiltonian samplers with common structures.
 
         Parameters
         ----------
-        vars: list of theano variables
+        vars: list of aesara variables
         scaling: array_like, ndim = {1,2}
             Scaling for momentum distribution. 1d arrays interpreted matrix
             diagonal.
@@ -77,7 +77,7 @@ class BaseHMC(arraystep.GradientSharedStep):
         potential: Potential, optional
             An object that represents the Hamiltonian with methods `velocity`,
             `energy`, and `random` methods.
-        **theano_kwargs: passed to theano functions
+        **aesara_kwargs: passed to aesara functions
         """
         self._model = modelcontext(model)
 
@@ -85,7 +85,7 @@ class BaseHMC(arraystep.GradientSharedStep):
             vars = self._model.cont_vars
         vars = inputvars(vars)
 
-        super().__init__(vars, blocked=blocked, model=model, dtype=dtype, **theano_kwargs)
+        super().__init__(vars, blocked=blocked, model=model, dtype=dtype, **aesara_kwargs)
 
         self.adapt_step_size = adapt_step_size
         self.Emax = Emax

--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -59,7 +59,7 @@ class HamiltonianMC(BaseHMC):
 
         Parameters
         ----------
-        vars: list of theano variables
+        vars: list of aesara variables
         path_length: float, default=2
             total length to travel
         step_rand: function float -> float, default=unif

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -16,13 +16,13 @@ from collections import namedtuple
 
 import numpy as np
 
+from pymc3.aesaraf import floatX
 from pymc3.backends.report import SamplerWarning, WarningType
 from pymc3.distributions import BART
 from pymc3.math import logbern, logdiffexp_numpy
 from pymc3.step_methods.arraystep import Competence
 from pymc3.step_methods.hmc.base_hmc import BaseHMC, DivergenceInfo, HMCStepData
 from pymc3.step_methods.hmc.integration import IntegrationError
-from pymc3.theanof import floatX
 from pymc3.vartypes import continuous_types
 
 __all__ = ["NUTS"]
@@ -114,7 +114,7 @@ class NUTS(BaseHMC):
 
         Parameters
         ----------
-        vars: list of Theano variables, default all continuous vars
+        vars: list of Aesara variables, default all continuous vars
         Emax: float, default 1000
             Maximum energy change allowed during leapfrog steps. Larger
             deviations will abort the integration.

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -14,14 +14,14 @@
 
 import warnings
 
+import aesara
 import numpy as np
 import scipy.linalg
-import theano
 
 from numpy.random import normal
 from scipy.sparse import issparse
 
-from pymc3.theanof import floatX
+from pymc3.aesaraf import floatX
 
 __all__ = [
     "quad_potential",
@@ -170,7 +170,7 @@ class QuadPotentialDiagAdapt(QuadPotential):
             )
 
         if dtype is None:
-            dtype = theano.config.floatX
+            dtype = aesara.config.floatX
 
         if initial_diag is None:
             initial_diag = np.ones(n, dtype=dtype)
@@ -189,7 +189,7 @@ class QuadPotentialDiagAdapt(QuadPotential):
 
     def reset(self):
         self._var = np.array(self._initial_diag, dtype=self.dtype, copy=True)
-        self._var_theano = theano.shared(self._var)
+        self._var_aesara = aesara.shared(self._var)
         self._stds = np.sqrt(self._initial_diag)
         self._inv_stds = floatX(1.0) / self._stds
         self._foreground_var = _WeightedVariance(
@@ -222,7 +222,7 @@ class QuadPotentialDiagAdapt(QuadPotential):
         weightvar.current_variance(out=self._var)
         np.sqrt(self._var, out=self._stds)
         np.divide(1, self._stds, out=self._inv_stds)
-        self._var_theano.set_value(self._var)
+        self._var_aesara.set_value(self._var)
 
     def update(self, sample, grad, tune):
         """Inform the potential about a new sample during tuning."""
@@ -304,7 +304,7 @@ class QuadPotentialDiagAdaptGrad(QuadPotentialDiagAdapt):
         self._var[:] = var
         np.sqrt(self._var, out=self._stds)
         np.divide(1, self._stds, out=self._inv_stds)
-        self._var_theano.set_value(self._var)
+        self._var_aesara.set_value(self._var)
 
     def update(self, sample, grad, tune):
         """Inform the potential about a new sample during tuning."""
@@ -384,7 +384,7 @@ class QuadPotentialDiag(QuadPotential):
            Diagonal of covariance matrix for the potential vector
         """
         if dtype is None:
-            dtype = theano.config.floatX
+            dtype = aesara.config.floatX
         self.dtype = dtype
         v = v.astype(self.dtype)
         s = v ** 0.5
@@ -428,7 +428,7 @@ class QuadPotentialFullInv(QuadPotential):
            Inverse of covariance matrix for the potential vector
         """
         if dtype is None:
-            dtype = theano.config.floatX
+            dtype = aesara.config.floatX
         self.dtype = dtype
         self.L = floatX(scipy.linalg.cholesky(A, lower=True))
 
@@ -468,7 +468,7 @@ class QuadPotentialFull(QuadPotential):
             scaling matrix for the potential vector
         """
         if dtype is None:
-            dtype = theano.config.floatX
+            dtype = aesara.config.floatX
         self.dtype = dtype
         self._cov = np.array(cov, dtype=self.dtype, copy=True)
         self._chol = scipy.linalg.cholesky(self._cov, lower=True)
@@ -525,7 +525,7 @@ class QuadPotentialFullAdapt(QuadPotentialFull):
             )
 
         if dtype is None:
-            dtype = theano.config.floatX
+            dtype = aesara.config.floatX
 
         if initial_cov is None:
             initial_cov = np.eye(n, dtype=dtype)
@@ -658,7 +658,7 @@ except ImportError:
 if chol_available:
     __all__ += ["QuadPotentialSparse"]
 
-    import theano.sparse
+    import aesara.sparse
 
     class QuadPotentialSparse(QuadPotential):
         def __init__(self, A):
@@ -676,8 +676,8 @@ if chol_available:
 
         def velocity(self, x):
             """Compute the current velocity at a position in parameter space."""
-            A = theano.sparse.as_sparse(self.A)
-            return theano.sparse.dot(A, x)
+            A = aesara.sparse.as_sparse(self.A)
+            return aesara.sparse.dot(A, x)
 
         def random(self):
             """Draw random value from QuadPotential."""

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -12,13 +12,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara
 import numpy as np
 import numpy.random as nr
 import scipy.linalg
-import theano
 
 import pymc3 as pm
 
+from pymc3.aesaraf import floatX
 from pymc3.distributions import draw_values
 from pymc3.step_methods.arraystep import (
     ArrayStep,
@@ -27,7 +28,6 @@ from pymc3.step_methods.arraystep import (
     PopulationArrayStepShared,
     metrop_select,
 )
-from pymc3.theanof import floatX
 
 __all__ = [
     "Metropolis",
@@ -142,7 +142,7 @@ class Metropolis(ArrayStepShared):
         model: PyMC Model
             Optional model for sampling step. Defaults to None (taken from context).
         mode: string or `Mode` instance.
-            compilation mode passed to Theano functions
+            compilation mode passed to Aesara functions
         """
 
         model = pm.modelcontext(model)
@@ -571,7 +571,7 @@ class DEMetropolis(PopulationArrayStepShared):
     model: PyMC Model
         Optional model for sampling step. Defaults to None (taken from context).
     mode:  string or `Mode` instance.
-        compilation mode passed to Theano functions
+        compilation mode passed to Aesara functions
 
     References
     ----------
@@ -713,7 +713,7 @@ class DEMetropolisZ(ArrayStepShared):
     model: PyMC Model
         Optional model for sampling step. Defaults to None (taken from context).
     mode:  string or `Mode` instance.
-        compilation mode passed to Theano functions
+        compilation mode passed to Aesara functions
 
     References
     ----------
@@ -887,6 +887,6 @@ def delta_logp(logp, vars, shared):
 
     logp1 = pm.CallableTensor(logp0)(inarray1)
 
-    f = theano.function([inarray1, inarray0], logp1 - logp0)
+    f = aesara.function([inarray1, inarray0], logp1 - logp0)
     f.trust_input = True
     return f

--- a/pymc3/step_methods/pgbart.py
+++ b/pymc3/step_methods/pgbart.py
@@ -16,13 +16,13 @@ import logging
 
 import numpy as np
 
-from theano import function as theano_function
+from aesara import function as aesara_function
 
+from pymc3.aesaraf import inputvars, join_nonshared_inputs, make_shared_replacements
 from pymc3.distributions import BART
 from pymc3.distributions.tree import Tree
 from pymc3.model import modelcontext
 from pymc3.step_methods.arraystep import ArrayStepShared, Competence
-from pymc3.theanof import inputvars, join_nonshared_inputs, make_shared_replacements
 
 _log = logging.getLogger("pymc3")
 
@@ -274,7 +274,7 @@ class ParticleTree:
 
 
 def logp(out_vars, vars, shared):
-    """Compile Theano function of the model and the input and output variables.
+    """Compile Aesara function of the model and the input and output variables.
 
     Parameters
     ----------
@@ -283,9 +283,9 @@ def logp(out_vars, vars, shared):
     vars: List
         containing :class:`pymc3.Distribution` for the input variables
     shared: List
-        containing :class:`theano.tensor.Tensor` for depended shared data
+        containing :class:`aesara.tensor.Tensor` for depended shared data
     """
     out_list, inarray0 = join_nonshared_inputs(out_vars, vars, shared)
-    f = theano_function([inarray0], out_list[0])
+    f = aesara_function([inarray0], out_list[0])
     f.trust_input = True
     return f

--- a/pymc3/step_methods/slicer.py
+++ b/pymc3/step_methods/slicer.py
@@ -17,9 +17,9 @@
 import numpy as np
 import numpy.random as nr
 
+from pymc3.aesaraf import inputvars
 from pymc3.model import modelcontext
 from pymc3.step_methods.arraystep import ArrayStep, Competence
-from pymc3.theanof import inputvars
 from pymc3.vartypes import continuous_types
 
 __all__ = ["Slice"]

--- a/pymc3/tests/backend_fixtures.py
+++ b/pymc3/tests/backend_fixtures.py
@@ -16,10 +16,10 @@ import collections
 import os
 import shutil
 
+import aesara
 import numpy as np
 import numpy.testing as npt
 import pytest
-import theano
 
 from pymc3.backends import base
 from pymc3.tests import models
@@ -250,7 +250,7 @@ class SamplingTestCase(ModelBackendSetupTestCase):
         else:
             self.strace.record(point=point)
 
-    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_standard_close(self):
         for idx in range(self.draws):
             self.record_point(idx)
@@ -293,14 +293,14 @@ class SelectionTestCase(ModelBackendSampledTestCase):
     - shape
     """
 
-    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_get_values_default(self):
         for varname in self.test_point.keys():
             expected = np.concatenate([self.expected[chain][varname] for chain in [0, 1]])
             result = self.mtrace.get_values(varname)
             npt.assert_equal(result, expected)
 
-    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_get_values_nocombine_burn_keyword(self):
         burn = 2
         for varname in self.test_point.keys():
@@ -311,7 +311,7 @@ class SelectionTestCase(ModelBackendSampledTestCase):
     def test_len(self):
         assert len(self.mtrace) == self.draws
 
-    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_dtypes(self):
         for varname in self.test_point.keys():
             assert (
@@ -515,7 +515,7 @@ class BackendEqualityTestCase(ModelBackendSampledTestCase):
         assert self.mtrace0.nchains == self.mtrace1.nchains
         assert len(self.mtrace0) == len(self.mtrace1)
 
-    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_dtype(self):
         for varname in self.test_point.keys():
             assert (

--- a/pymc3/tests/conftest.py
+++ b/pymc3/tests/conftest.py
@@ -12,31 +12,31 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara
 import numpy as np
 import pytest
-import theano
 
 import pymc3 as pm
 
 
 @pytest.fixture(scope="function", autouse=True)
-def theano_config():
-    config = theano.config.change_flags(compute_test_value="raise")
+def aesara_config():
+    config = aesara.config.change_flags(compute_test_value="raise")
     with config:
         yield
 
 
 @pytest.fixture(scope="function", autouse=True)
 def exception_verbosity():
-    config = theano.config.change_flags(exception_verbosity="high")
+    config = aesara.config.change_flags(exception_verbosity="high")
     with config:
         yield
 
 
 @pytest.fixture(scope="function", autouse=False)
 def strict_float32():
-    if theano.config.floatX == "float32":
-        config = theano.config.change_flags(warn_float64="raise")
+    if aesara.config.floatX == "float32":
+        config = aesara.config.change_flags(warn_float64="raise")
         with config:
             yield
     else:
@@ -47,4 +47,4 @@ def strict_float32():
 def seeded_test():
     # TODO: use this instead of SeededTest
     np.random.seed(42)
-    pm.set_tt_rng(42)
+    pm.set_aet_rng(42)

--- a/pymc3/tests/helpers.py
+++ b/pymc3/tests/helpers.py
@@ -16,13 +16,13 @@ import contextlib
 
 from logging.handlers import BufferingHandler
 
+import aesara
 import numpy.random as nr
-import theano
 
-from theano.gradient import verify_grad as tt_verify_grad
-from theano.sandbox.rng_mrg import MRG_RandomStream as RandomStream
+from aesara.gradient import verify_grad as aet_verify_grad
+from aesara.sandbox.rng_mrg import MRG_RandomStream as RandomStream
 
-from pymc3.theanof import set_tt_rng, tt_rng
+from pymc3.aesaraf import aet_rng, set_aet_rng
 
 
 class SeededTest:
@@ -34,11 +34,11 @@ class SeededTest:
 
     def setup_method(self):
         nr.seed(self.random_seed)
-        self.old_tt_rng = tt_rng()
-        set_tt_rng(RandomStream(self.random_seed))
+        self.old_aet_rng = aet_rng()
+        set_aet_rng(RandomStream(self.random_seed))
 
     def teardown_method(self):
-        set_tt_rng(self.old_tt_rng)
+        set_aet_rng(self.old_aet_rng)
 
 
 class LoggingHandler(BufferingHandler):
@@ -104,7 +104,7 @@ class Matcher:
 
 def select_by_precision(float64, float32):
     """Helper function to choose reasonable decimal cutoffs for different floatX modes."""
-    decimal = float64 if theano.config.floatX == "float64" else float32
+    decimal = float64 if aesara.config.floatX == "float64" else float32
     return decimal
 
 
@@ -116,4 +116,4 @@ def not_raises():
 def verify_grad(op, pt, n_tests=2, rng=None, *args, **kwargs):
     if rng is None:
         rng = nr.RandomState(411342)
-    tt_verify_grad(op, pt, n_tests, rng, *args, **kwargs)
+    aet_verify_grad(op, pt, n_tests, rng, *args, **kwargs)

--- a/pymc3/tests/models.py
+++ b/pymc3/tests/models.py
@@ -14,23 +14,23 @@
 
 from itertools import product
 
+import aesara
+import aesara.tensor as aet
 import numpy as np
-import theano
-import theano.tensor as tt
 
-from theano.compile.ops import as_op
+from aesara.compile.ops import as_op
 
 import pymc3 as pm
 
 from pymc3 import Categorical, Metropolis, Model, Normal
-from pymc3.theanof import floatX_array
+from pymc3.aesaraf import floatX_array
 
 
 def simple_model():
     mu = -2.1
     tau = 1.3
     with Model() as model:
-        Normal("x", mu, tau=tau, shape=2, testval=tt.ones(2) * 0.1)
+        Normal("x", mu, tau=tau, shape=2, testval=aet.ones(2) * 0.1)
 
     return model.test_point, model, (mu, tau ** -0.5)
 
@@ -50,13 +50,13 @@ def multidimensional_model():
     mu = -2.1
     tau = 1.3
     with Model() as model:
-        Normal("x", mu, tau=tau, shape=(3, 2), testval=0.1 * tt.ones((3, 2)))
+        Normal("x", mu, tau=tau, shape=(3, 2), testval=0.1 * aet.ones((3, 2)))
 
     return model.test_point, model, (mu, tau ** -0.5)
 
 
 def simple_arbitrary_det():
-    scalar_type = tt.dscalar if theano.config.floatX == "float64" else tt.fscalar
+    scalar_type = aet.dscalar if aesara.config.floatX == "float64" else aet.fscalar
 
     @as_op(itypes=[scalar_type], otypes=[scalar_type])
     def arbitrary_det(value):
@@ -82,7 +82,7 @@ def simple_2model():
     p = 0.4
     with Model() as model:
         x = pm.Normal("x", mu, tau=tau, testval=0.1)
-        pm.Deterministic("logx", tt.log(x))
+        pm.Deterministic("logx", aet.log(x))
         pm.Bernoulli("y", p)
     return model.test_point, model
 
@@ -92,7 +92,7 @@ def simple_2model_continuous():
     tau = 1.3
     with Model() as model:
         x = pm.Normal("x", mu, tau=tau, testval=0.1)
-        pm.Deterministic("logx", tt.log(x))
+        pm.Deterministic("logx", aet.log(x))
         pm.Beta("y", alpha=1, beta=1, shape=2)
     return model.test_point, model
 
@@ -104,8 +104,8 @@ def mv_simple():
     with pm.Model() as model:
         pm.MvNormal(
             "x",
-            tt.constant(mu),
-            tau=tt.constant(tau),
+            aet.constant(mu),
+            tau=aet.constant(tau),
             shape=3,
             testval=floatX_array([0.1, 1.0, 0.8]),
         )
@@ -121,8 +121,8 @@ def mv_simple_coarse():
     with pm.Model() as model:
         pm.MvNormal(
             "x",
-            tt.constant(mu),
-            tau=tt.constant(tau),
+            aet.constant(mu),
+            tau=aet.constant(tau),
             shape=3,
             testval=floatX_array([0.1, 1.0, 0.8]),
         )
@@ -138,8 +138,8 @@ def mv_simple_very_coarse():
     with pm.Model() as model:
         pm.MvNormal(
             "x",
-            tt.constant(mu),
-            tau=tt.constant(tau),
+            aet.constant(mu),
+            tau=aet.constant(tau),
             shape=3,
             testval=floatX_array([0.1, 1.0, 0.8]),
         )
@@ -153,7 +153,7 @@ def mv_simple_discrete():
     n = 5
     p = floatX_array([0.15, 0.85])
     with pm.Model() as model:
-        pm.Multinomial("x", n, tt.constant(p), shape=d, testval=np.array([1, 4]))
+        pm.Multinomial("x", n, aet.constant(p), shape=d, testval=np.array([1, 4]))
         mu = n * p
         # covariance matrix
         C = np.zeros((d, d))

--- a/pymc3/tests/sampler_fixtures.py
+++ b/pymc3/tests/sampler_fixtures.py
@@ -12,10 +12,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara.tensor as aet
 import arviz as az
 import numpy as np
 import numpy.testing as npt
-import theano.tensor as tt
 
 from scipy import stats
 
@@ -124,9 +124,9 @@ class LKJCholeskyCovFixture(KnownCDF):
             sd_dist = pm.Lognormal.dist(mu=sd_mu, sigma=sd_mu / 10.0, shape=5)
             chol_packed = pm.LKJCholeskyCov("chol_packed", eta=3, n=5, sd_dist=sd_dist)
             chol = pm.expand_packed_triangular(5, chol_packed, lower=True)
-            cov = tt.dot(chol, chol.T)
-            stds = tt.sqrt(tt.diag(cov))
-            pm.Deterministic("log_stds", tt.log(stds))
+            cov = aet.dot(chol, chol.T)
+            stds = aet.sqrt(aet.diag(cov))
+            pm.Deterministic("log_stds", aet.log(stds))
             corr = cov / stds[None, :] / stds[:, None]
             corr_entries_unit = (corr[np.tril_indices(5, -1)] + 1) / 2
             pm.Deterministic("corr_entries_unit", corr_entries_unit)

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -16,12 +16,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from theano import shared
+from aesara import shared
 
 import pymc3 as pm
 
+from pymc3.aesaraf import floatX
 from pymc3.tests.helpers import SeededTest
-from pymc3.theanof import floatX
 
 
 class TestData(SeededTest):

--- a/pymc3/tests/test_dist_math.py
+++ b/pymc3/tests/test_dist_math.py
@@ -13,16 +13,17 @@
 #   limitations under the License.
 import sys
 
+import aesara
+import aesara.tensor as aet
 import numpy as np
 import numpy.testing as npt
 import pytest
-import theano
-import theano.tensor as tt
 
 from scipy import interpolate, stats
 
 import pymc3 as pm
 
+from pymc3.aesaraf import floatX
 from pymc3.distributions import Discrete
 from pymc3.distributions.dist_math import (
     MvNormalLogp,
@@ -34,28 +35,27 @@ from pymc3.distributions.dist_math import (
     i0e,
 )
 from pymc3.tests.helpers import verify_grad
-from pymc3.theanof import floatX
 
 
 def test_bound():
-    logp = tt.ones((10, 10))
-    cond = tt.ones((10, 10))
+    logp = aet.ones((10, 10))
+    cond = aet.ones((10, 10))
     assert np.all(bound(logp, cond).eval() == logp.eval())
 
-    logp = tt.ones((10, 10))
-    cond = tt.zeros((10, 10))
+    logp = aet.ones((10, 10))
+    cond = aet.zeros((10, 10))
     assert np.all(bound(logp, cond).eval() == (-np.inf * logp).eval())
 
-    logp = tt.ones((10, 10))
+    logp = aet.ones((10, 10))
     cond = True
     assert np.all(bound(logp, cond).eval() == logp.eval())
 
-    logp = tt.ones(3)
+    logp = aet.ones(3)
     cond = np.array([1, 0, 1])
     assert not np.all(bound(logp, cond).eval() == 1)
     assert np.prod(bound(logp, cond).eval()) == -np.inf
 
-    logp = tt.ones((2, 3))
+    logp = aet.ones((2, 3))
     cond = np.array([[1, 1, 1], [1, 0, 1]])
     assert not np.all(bound(logp, cond).eval() == 1)
     assert np.prod(bound(logp, cond).eval()) == -np.inf
@@ -63,7 +63,7 @@ def test_bound():
 
 def test_check_bounds_false():
     with pm.Model(check_bounds=False):
-        logp = tt.ones(3)
+        logp = aet.ones(3)
         cond = np.array([1, 0, 1])
         assert np.all(bound(logp, cond).eval() == logp.eval())
 
@@ -71,21 +71,21 @@ def test_check_bounds_false():
 def test_alltrue_scalar():
     assert alltrue_scalar([]).eval()
     assert alltrue_scalar([True]).eval()
-    assert alltrue_scalar([tt.ones(10)]).eval()
-    assert alltrue_scalar([tt.ones(10), 5 * tt.ones(101)]).eval()
-    assert alltrue_scalar([np.ones(10), 5 * tt.ones(101)]).eval()
-    assert alltrue_scalar([np.ones(10), True, 5 * tt.ones(101)]).eval()
-    assert alltrue_scalar([np.array([1, 2, 3]), True, 5 * tt.ones(101)]).eval()
+    assert alltrue_scalar([aet.ones(10)]).eval()
+    assert alltrue_scalar([aet.ones(10), 5 * aet.ones(101)]).eval()
+    assert alltrue_scalar([np.ones(10), 5 * aet.ones(101)]).eval()
+    assert alltrue_scalar([np.ones(10), True, 5 * aet.ones(101)]).eval()
+    assert alltrue_scalar([np.array([1, 2, 3]), True, 5 * aet.ones(101)]).eval()
 
     assert not alltrue_scalar([False]).eval()
-    assert not alltrue_scalar([tt.zeros(10)]).eval()
+    assert not alltrue_scalar([aet.zeros(10)]).eval()
     assert not alltrue_scalar([True, False]).eval()
-    assert not alltrue_scalar([np.array([0, -1]), tt.ones(60)]).eval()
-    assert not alltrue_scalar([np.ones(10), False, 5 * tt.ones(101)]).eval()
+    assert not alltrue_scalar([np.array([0, -1]), aet.ones(60)]).eval()
+    assert not alltrue_scalar([np.ones(10), False, 5 * aet.ones(101)]).eval()
 
 
 def test_alltrue_shape():
-    vals = [True, tt.ones(10), tt.zeros(5)]
+    vals = [True, aet.ones(10), aet.zeros(5)]
 
     assert alltrue_scalar(vals).eval().shape == ()
 
@@ -102,11 +102,11 @@ class MultinomialA(Discrete):
         p = self.p
 
         return bound(
-            factln(n) - factln(value).sum() + (value * tt.log(p)).sum(),
+            factln(n) - factln(value).sum() + (value * aet.log(p)).sum(),
             value >= 0,
             0 <= p,
             p <= 1,
-            tt.isclose(p.sum(), 1),
+            aet.isclose(p.sum(), 1),
             broadcast_conditions=False,
         )
 
@@ -123,11 +123,11 @@ class MultinomialB(Discrete):
         p = self.p
 
         return bound(
-            factln(n) - factln(value).sum() + (value * tt.log(p)).sum(),
-            tt.all(value >= 0),
-            tt.all(0 <= p),
-            tt.all(p <= 1),
-            tt.isclose(p.sum(), 1),
+            factln(n) - factln(value).sum() + (value * aet.log(p)).sum(),
+            aet.all(value >= 0),
+            aet.all(0 <= p),
+            aet.all(p <= 1),
+            aet.isclose(p.sum(), 1),
             broadcast_conditions=False,
         )
 
@@ -156,30 +156,30 @@ class TestMvNormalLogp:
 
         chol_val = floatX(np.array([[1, 0.9], [0, 2]]))
         cov_val = floatX(np.dot(chol_val, chol_val.T))
-        cov = tt.matrix("cov")
+        cov = aet.matrix("cov")
         cov.tag.test_value = cov_val
         delta_val = floatX(np.random.randn(5, 2))
-        delta = tt.matrix("delta")
+        delta = aet.matrix("delta")
         delta.tag.test_value = delta_val
         expect = stats.multivariate_normal(mean=np.zeros(2), cov=cov_val)
         expect = expect.logpdf(delta_val).sum()
         logp = MvNormalLogp()(cov, delta)
-        logp_f = theano.function([cov, delta], logp)
+        logp_f = aesara.function([cov, delta], logp)
         logp = logp_f(cov_val, delta_val)
         npt.assert_allclose(logp, expect)
 
-    @theano.config.change_flags(compute_test_value="ignore")
+    @aesara.config.change_flags(compute_test_value="ignore")
     def test_grad(self):
         np.random.seed(42)
 
         def func(chol_vec, delta):
-            chol = tt.stack(
+            chol = aet.stack(
                 [
-                    tt.stack([tt.exp(0.1 * chol_vec[0]), 0]),
-                    tt.stack([chol_vec[1], 2 * tt.exp(chol_vec[2])]),
+                    aet.stack([aet.exp(0.1 * chol_vec[0]), 0]),
+                    aet.stack([chol_vec[1], 2 * aet.exp(chol_vec[2])]),
                 ]
             )
-            cov = tt.dot(chol, chol.T)
+            cov = aet.dot(chol, chol.T)
             return MvNormalLogp()(cov, delta)
 
         chol_vec_val = floatX(np.array([0.5, 1.0, -0.1]))
@@ -190,46 +190,46 @@ class TestMvNormalLogp:
         delta_val = floatX(np.random.randn(5, 2))
         verify_grad(func, [chol_vec_val, delta_val])
 
-    @pytest.mark.skip(reason="Fix in theano not released yet: Theano#5908")
-    @theano.config.change_flags(compute_test_value="ignore")
+    @pytest.mark.skip(reason="Fix in aesara not released yet: Theano#5908")
+    @aesara.config.change_flags(compute_test_value="ignore")
     def test_hessian(self):
-        chol_vec = tt.vector("chol_vec")
+        chol_vec = aet.vector("chol_vec")
         chol_vec.tag.test_value = np.array([0.1, 2, 3])
-        chol = tt.stack(
+        chol = aet.stack(
             [
-                tt.stack([tt.exp(0.1 * chol_vec[0]), 0]),
-                tt.stack([chol_vec[1], 2 * tt.exp(chol_vec[2])]),
+                aet.stack([aet.exp(0.1 * chol_vec[0]), 0]),
+                aet.stack([chol_vec[1], 2 * aet.exp(chol_vec[2])]),
             ]
         )
-        cov = tt.dot(chol, chol.T)
-        delta = tt.matrix("delta")
+        cov = aet.dot(chol, chol.T)
+        delta = aet.matrix("delta")
         delta.tag.test_value = np.ones((5, 2))
         logp = MvNormalLogp()(cov, delta)
-        g_cov, g_delta = tt.grad(logp, [cov, delta])
-        tt.grad(g_delta.sum() + g_cov.sum(), [delta, cov])
+        g_cov, g_delta = aet.grad(logp, [cov, delta])
+        aet.grad(g_delta.sum() + g_cov.sum(), [delta, cov])
 
 
 class TestSplineWrapper:
-    @theano.config.change_flags(compute_test_value="ignore")
+    @aesara.config.change_flags(compute_test_value="ignore")
     def test_grad(self):
         x = np.linspace(0, 1, 100)
         y = x * x
         spline = SplineWrapper(interpolate.InterpolatedUnivariateSpline(x, y, k=1))
         verify_grad(spline, [0.5])
 
-    @theano.config.change_flags(compute_test_value="ignore")
+    @aesara.config.change_flags(compute_test_value="ignore")
     def test_hessian(self):
         x = np.linspace(0, 1, 100)
         y = x * x
         spline = SplineWrapper(interpolate.InterpolatedUnivariateSpline(x, y, k=1))
-        x_var = tt.dscalar("x")
-        (g_x,) = tt.grad(spline(x_var), [x_var])
+        x_var = aet.dscalar("x")
+        (g_x,) = aet.grad(spline(x_var), [x_var])
         with pytest.raises(NotImplementedError):
-            tt.grad(g_x, [x_var])
+            aet.grad(g_x, [x_var])
 
 
 class TestI0e:
-    @theano.config.change_flags(compute_test_value="ignore")
+    @aesara.config.change_flags(compute_test_value="ignore")
     def test_grad(self):
         verify_grad(i0e, [0.5])
         verify_grad(i0e, [-2.0])

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -17,12 +17,12 @@ import sys
 
 from contextlib import ExitStack as does_not_raise
 
+import aesara
 import numpy as np
 import numpy.random as nr
 import numpy.testing as npt
 import pytest
 import scipy.stats as st
-import theano
 
 from scipy import linalg
 from scipy.special import expit
@@ -1127,7 +1127,7 @@ class TestScalarParameterSamples(SeededTest):
 
         pymc3_random(pm.Moyal, {"mu": R, "sigma": Rplus}, ref_rand=ref_rand)
 
-    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_interpolated(self):
         for mu in R.vals:
             for sigma in Rplus.vals:

--- a/pymc3/tests/test_distributions_timeseries.py
+++ b/pymc3/tests/test_distributions_timeseries.py
@@ -15,6 +15,7 @@
 import numpy as np
 import pytest
 
+from pymc3.aesaraf import floatX
 from pymc3.distributions.continuous import Flat, Normal
 from pymc3.distributions.timeseries import AR, AR1, GARCH11, EulerMaruyama
 from pymc3.model import Model
@@ -24,7 +25,6 @@ from pymc3.sampling import (
     sample_posterior_predictive,
 )
 from pymc3.tests.helpers import select_by_precision
-from pymc3.theanof import floatX
 
 pytestmark = pytest.mark.usefixtures("seeded_test")
 

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -12,20 +12,20 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara
+import aesara.tensor as aet
 import arviz as az
 import matplotlib
 import numpy as np
 import pandas as pd
 import pytest
-import theano
-import theano.tensor as tt
 
 from packaging import version
 
 import pymc3 as pm
 
+from pymc3.aesaraf import floatX
 from pymc3.tests.helpers import SeededTest
-from pymc3.theanof import floatX
 
 if version.parse(matplotlib.__version__) < version.parse("3.3"):
     matplotlib.use("Agg", warn=False)
@@ -68,7 +68,7 @@ class TestARM5_4(SeededTest):
 
         with pm.Model() as model:
             effects = pm.Normal("effects", mu=0, sigma=100, shape=len(P.columns))
-            logit_p = tt.dot(floatX(np.array(P)), effects)
+            logit_p = aet.dot(floatX(np.array(P)), effects)
             pm.Bernoulli("s", logit_p=logit_p, observed=floatX(data.switch.values))
         return model
 
@@ -186,13 +186,13 @@ def build_disaster_model(masked=False):
         # Allocate appropriate Poisson rates to years before and after current
         # switchpoint location
         idx = np.arange(years)
-        rate = tt.switch(switchpoint >= idx, early_mean, late_mean)
+        rate = aet.switch(switchpoint >= idx, early_mean, late_mean)
         # Data likelihood
         pm.Poisson("disasters", rate, observed=disasters_data)
     return model
 
 
-@pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+@pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
 class TestDisasterModel(SeededTest):
     # Time series of recorded coal mining disasters in the UK from 1851 to 1962
     def test_disaster_model(self):
@@ -294,7 +294,7 @@ class TestLatentOccupancy(SeededTest):
 
 
 @pytest.mark.xfail(
-    condition=(theano.config.floatX == "float32"),
+    condition=(aesara.config.floatX == "float32"),
     reason="Fails on float32 due to starting inf at starting logP",
 )
 class TestRSV(SeededTest):

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -16,11 +16,11 @@
 from functools import reduce
 from operator import add
 
+import aesara
+import aesara.tensor as aet
 import numpy as np
 import numpy.testing as npt
 import pytest
-import theano
-import theano.tensor as tt
 
 import pymc3 as pm
 
@@ -34,7 +34,7 @@ class TestZeroMean:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             zero_mean = pm.gp.mean.Zero()
-        M = theano.function([], zero_mean(X))()
+        M = aesara.function([], zero_mean(X))()
         assert np.all(M == 0)
         assert M.shape == (10,)
 
@@ -44,7 +44,7 @@ class TestConstantMean:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             const_mean = pm.gp.mean.Constant(6)
-        M = theano.function([], const_mean(X))()
+        M = aesara.function([], const_mean(X))()
         assert np.all(M == 6)
         assert M.shape == (10,)
 
@@ -54,7 +54,7 @@ class TestLinearMean:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             linear_mean = pm.gp.mean.Linear(2, 0.5)
-        M = theano.function([], linear_mean(X))()
+        M = aesara.function([], linear_mean(X))()
         npt.assert_allclose(M[1], 0.7222, atol=1e-3)
         assert M.shape == (10,)
 
@@ -66,7 +66,7 @@ class TestAddProdMean:
             mean1 = pm.gp.mean.Linear(coeffs=2, intercept=0.5)
             mean2 = pm.gp.mean.Constant(2)
             mean = mean1 + mean2 + mean2
-        M = theano.function([], mean(X))()
+        M = aesara.function([], mean(X))()
         npt.assert_allclose(M[1], 0.7222 + 2 + 2, atol=1e-3)
 
     def test_prod(self):
@@ -75,7 +75,7 @@ class TestAddProdMean:
             mean1 = pm.gp.mean.Linear(coeffs=2, intercept=0.5)
             mean2 = pm.gp.mean.Constant(2)
             mean = mean1 * mean2 * mean2
-        M = theano.function([], mean(X))()
+        M = aesara.function([], mean(X))()
         npt.assert_allclose(M[1], 0.7222 * 2 * 2, atol=1e-3)
 
     def test_add_multid(self):
@@ -86,7 +86,7 @@ class TestAddProdMean:
             mean1 = pm.gp.mean.Linear(coeffs=A, intercept=b)
             mean2 = pm.gp.mean.Constant(2)
             mean = mean1 + mean2 + mean2
-        M = theano.function([], mean(X))()
+        M = aesara.function([], mean(X))()
         npt.assert_allclose(M[1], 10.8965 + 2 + 2, atol=1e-3)
 
     def test_prod_multid(self):
@@ -97,7 +97,7 @@ class TestAddProdMean:
             mean1 = pm.gp.mean.Linear(coeffs=A, intercept=b)
             mean2 = pm.gp.mean.Constant(2)
             mean = mean1 * mean2 * mean2
-        M = theano.function([], mean(X))()
+        M = aesara.function([], mean(X))()
         npt.assert_allclose(M[1], 10.8965 * 2 * 2, atol=1e-3)
 
 
@@ -108,10 +108,10 @@ class TestCovAdd:
             cov1 = pm.gp.cov.ExpQuad(1, 0.1)
             cov2 = pm.gp.cov.ExpQuad(1, 0.1)
             cov = cov1 + cov2
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_rightadd_scalar(self):
@@ -119,10 +119,10 @@ class TestCovAdd:
         with pm.Model() as model:
             a = 1
             cov = pm.gp.cov.ExpQuad(1, 0.1) + a
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 1.53940, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_leftadd_scalar(self):
@@ -130,10 +130,10 @@ class TestCovAdd:
         with pm.Model() as model:
             a = 1
             cov = a + pm.gp.cov.ExpQuad(1, 0.1)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 1.53940, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_rightadd_matrix(self):
@@ -141,21 +141,21 @@ class TestCovAdd:
         M = 2 * np.ones((10, 10))
         with pm.Model() as model:
             cov = pm.gp.cov.ExpQuad(1, 0.1) + M
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2.53940, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_leftadd_matrixt(self):
         X = np.linspace(0, 1, 10)[:, None]
-        M = 2 * tt.ones((10, 10))
+        M = 2 * aet.ones((10, 10))
         with pm.Model() as model:
             cov = M + pm.gp.cov.ExpQuad(1, 0.1)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2.53940, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_leftprod_matrix(self):
@@ -164,8 +164,8 @@ class TestCovAdd:
         with pm.Model() as model:
             cov = M + pm.gp.cov.ExpQuad(1, 0.1)
             cov_true = pm.gp.cov.ExpQuad(1, 0.1) + M
-        K = theano.function([], cov(X))()
-        K_true = theano.function([], cov_true(X))()
+        K = aesara.function([], cov(X))()
+        K_true = aesara.function([], cov_true(X))()
         assert np.allclose(K, K_true)
 
     def test_inv_rightadd(self):
@@ -181,10 +181,10 @@ class TestCovProd:
             cov1 = pm.gp.cov.ExpQuad(1, 0.1)
             cov2 = pm.gp.cov.ExpQuad(1, 0.1)
             cov = cov1 * cov2
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.53940 * 0.53940, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_rightprod_scalar(self):
@@ -192,10 +192,10 @@ class TestCovProd:
         with pm.Model() as model:
             a = 2
             cov = pm.gp.cov.ExpQuad(1, 0.1) * a
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_leftprod_scalar(self):
@@ -203,10 +203,10 @@ class TestCovProd:
         with pm.Model() as model:
             a = 2
             cov = a * pm.gp.cov.ExpQuad(1, 0.1)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_rightprod_matrix(self):
@@ -214,10 +214,10 @@ class TestCovProd:
         M = 2 * np.ones((10, 10))
         with pm.Model() as model:
             cov = pm.gp.cov.ExpQuad(1, 0.1) * M
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2 * 0.53940, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_leftprod_matrix(self):
@@ -226,8 +226,8 @@ class TestCovProd:
         with pm.Model() as model:
             cov = M * pm.gp.cov.ExpQuad(1, 0.1)
             cov_true = pm.gp.cov.ExpQuad(1, 0.1) * M
-        K = theano.function([], cov(X))()
-        K_true = theano.function([], cov_true(X))()
+        K = aesara.function([], cov(X))()
+        K_true = aesara.function([], cov_true(X))()
         assert np.allclose(K, K_true)
 
     def test_multiops(self):
@@ -244,12 +244,12 @@ class TestCovProd:
                 + pm.gp.cov.ExpQuad(1, 0.1)
                 + 3
             )
-        K1 = theano.function([], cov1(X))()
-        K2 = theano.function([], cov2(X))()
+        K1 = aesara.function([], cov1(X))()
+        K2 = aesara.function([], cov2(X))()
         assert np.allclose(K1, K2)
         # check diagonal
-        K1d = theano.function([], cov1(X, diag=True))()
-        K2d = theano.function([], cov2(X, diag=True))()
+        K1d = aesara.function([], cov1(X, diag=True))()
+        K2d = aesara.function([], cov2(X, diag=True))()
         npt.assert_allclose(np.diag(K1), K2d, atol=1e-5)
         npt.assert_allclose(np.diag(K2), K1d, atol=1e-5)
 
@@ -265,10 +265,10 @@ class TestCovExponentiation:
         with pm.Model() as model:
             cov1 = pm.gp.cov.ExpQuad(1, 0.1)
             cov = cov1 ** 2
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.53940 ** 2, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_covexp_numpy(self):
@@ -276,32 +276,32 @@ class TestCovExponentiation:
         with pm.Model() as model:
             a = np.array([[2]])
             cov = pm.gp.cov.ExpQuad(1, 0.1) ** a
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.53940 ** 2, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
-    def test_covexp_theano(self):
+    def test_covexp_aesara(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
-            a = tt.alloc(2.0, 1, 1)
+            a = aet.alloc(2.0, 1, 1)
             cov = pm.gp.cov.ExpQuad(1, 0.1) ** a
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.53940 ** 2, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_covexp_shared(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
-            a = theano.shared(2.0)
+            a = aesara.shared(2.0)
             cov = pm.gp.cov.ExpQuad(1, 0.1) ** a
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.53940 ** 2, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_invalid_covexp(self):
@@ -321,11 +321,11 @@ class TestCovKron:
             cov1 = pm.gp.cov.ExpQuad(1, 0.1)
             cov2 = pm.gp.cov.ExpQuad(1, 0.1)
             cov = pm.gp.cov.Kron([cov1, cov2])
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 1 * 0.53940, atol=1e-3)
         npt.assert_allclose(K[0, 11], 0.53940 * 0.53940, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_multiops(self):
@@ -342,8 +342,8 @@ class TestCovKron:
             )
             cov2 = pm.gp.cov.ExpQuad(1, 0.1) * pm.gp.cov.ExpQuad(2, 0.1)
             cov = pm.gp.cov.Kron([cov1, cov2])
-        K_true = kronecker(theano.function([], cov1(X1))(), theano.function([], cov2(X2))()).eval()
-        K = theano.function([], cov(X))()
+        K_true = kronecker(aesara.function([], cov1(X1))(), aesara.function([], cov2(X2))()).eval()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K_true, K)
 
 
@@ -352,30 +352,30 @@ class TestCovSliceDim:
         X = np.linspace(0, 1, 30).reshape(10, 3)
         with pm.Model() as model:
             cov = pm.gp.cov.ExpQuad(3, 0.1, active_dims=[0, 0, 1])
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.20084298, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_slice2(self):
         X = np.linspace(0, 1, 30).reshape(10, 3)
         with pm.Model() as model:
             cov = pm.gp.cov.ExpQuad(3, ls=[0.1, 0.1], active_dims=[1, 2])
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.34295549, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_slice3(self):
         X = np.linspace(0, 1, 30).reshape(10, 3)
         with pm.Model() as model:
             cov = pm.gp.cov.ExpQuad(3, ls=np.array([0.1, 0.1]), active_dims=[1, 2])
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.34295549, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_diffslice(self):
@@ -384,10 +384,10 @@ class TestCovSliceDim:
             cov = pm.gp.cov.ExpQuad(3, ls=0.1, active_dims=[1, 0, 0]) + pm.gp.cov.ExpQuad(
                 3, ls=[0.1, 0.2, 0.3]
             )
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.683572, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_raises(self):
@@ -402,7 +402,7 @@ class TestStability:
         X = np.random.uniform(low=320.0, high=400.0, size=[2000, 2])
         with pm.Model() as model:
             cov = pm.gp.cov.ExpQuad(2, 0.1)
-        dists = theano.function([], cov.square_dist(X, X))()
+        dists = aesara.function([], cov.square_dist(X, X))()
         assert not np.any(dists < 0)
 
 
@@ -411,44 +411,44 @@ class TestExpQuad:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.ExpQuad(1, 0.1)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.53940, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.53940, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_2d(self):
         X = np.linspace(0, 1, 10).reshape(5, 2)
         with pm.Model() as model:
             cov = pm.gp.cov.ExpQuad(2, 0.5)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.820754, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_2dard(self):
         X = np.linspace(0, 1, 10).reshape(5, 2)
         with pm.Model() as model:
             cov = pm.gp.cov.ExpQuad(2, np.array([1, 2]))
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.969607, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_inv_lengthscale(self):
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.ExpQuad(1, ls_inv=10)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.53940, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.53940, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
@@ -457,14 +457,14 @@ class TestWhiteNoise:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.WhiteNoise(sigma=0.5)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.0, atol=1e-3)
         npt.assert_allclose(K[0, 0], 0.5 ** 2, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
         # check predict
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.0, atol=1e-3)
         # white noise predicting should return all zeros
         npt.assert_allclose(K[0, 0], 0.0, atol=1e-3)
@@ -475,14 +475,14 @@ class TestConstant:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.Constant(2.5)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 2.5, atol=1e-3)
         npt.assert_allclose(K[0, 0], 2.5, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 2.5, atol=1e-3)
         npt.assert_allclose(K[0, 0], 2.5, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
@@ -491,12 +491,12 @@ class TestRatQuad:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.RatQuad(1, ls=0.1, alpha=0.5)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.66896, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.66896, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
@@ -505,12 +505,12 @@ class TestExponential:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.Exponential(1, 0.1)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.57375, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.57375, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
@@ -519,12 +519,12 @@ class TestMatern52:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.Matern52(1, 0.1)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.46202, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.46202, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
@@ -533,12 +533,12 @@ class TestMatern32:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.Matern32(1, 0.1)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.42682, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.42682, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
@@ -547,11 +547,11 @@ class TestMatern12:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.Matern12(1, 0.1)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.32919, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.32919, atol=1e-3)
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
@@ -560,12 +560,12 @@ class TestCosine:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.Cosine(1, 0.1)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.766, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.766, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
@@ -574,12 +574,12 @@ class TestPeriodic:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.Periodic(1, 0.1, 0.1)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.00288, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.00288, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
@@ -588,12 +588,12 @@ class TestLinear:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.Linear(1, 0.5)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.19444, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.19444, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
@@ -602,12 +602,12 @@ class TestPolynomial:
         X = np.linspace(0, 1, 10)[:, None]
         with pm.Model() as model:
             cov = pm.gp.cov.Polynomial(1, 0.5, 2, 0)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.03780, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.03780, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
 
@@ -616,17 +616,17 @@ class TestWarpedInput:
         X = np.linspace(0, 1, 10)[:, None]
 
         def warp_func(x, a, b, c):
-            return x + (a * tt.tanh(b * (x - c)))
+            return x + (a * aet.tanh(b * (x - c)))
 
         with pm.Model() as model:
             cov_m52 = pm.gp.cov.Matern52(1, 0.2)
             cov = pm.gp.cov.WarpedInput(1, warp_func=warp_func, args=(1, 10, 1), cov_func=cov_m52)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 0.79593, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 0.79593, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_raises(self):
@@ -642,16 +642,16 @@ class TestGibbs:
         X = np.linspace(0, 2, 10)[:, None]
 
         def tanh_func(x, x1, x2, w, x0):
-            return (x1 + x2) / 2.0 - (x1 - x2) / 2.0 * tt.tanh((x - x0) / w)
+            return (x1 + x2) / 2.0 - (x1 - x2) / 2.0 * aet.tanh((x - x0) / w)
 
         with pm.Model() as model:
             cov = pm.gp.cov.Gibbs(1, tanh_func, args=(0.05, 0.6, 0.4, 1.0))
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[2, 3], 0.136683, atol=1e-4)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[2, 3], 0.136683, atol=1e-4)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_raises(self):
@@ -673,12 +673,12 @@ class TestScaledCov:
         with pm.Model() as model:
             cov_m52 = pm.gp.cov.Matern52(1, 0.2)
             cov = pm.gp.cov.ScaledCov(1, scaling_func=scaling_func, args=(2, -1), cov_func=cov_m52)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], 3.00686, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], 3.00686, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_raises(self):
@@ -1200,12 +1200,12 @@ class TestCircular:
         etalon = 0.600881
         with pm.Model():
             cov = pm.gp.cov.Circular(1, 1, tau=5)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], etalon, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], etalon, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
 
     def test_1d_tau2(self):
@@ -1213,10 +1213,10 @@ class TestCircular:
         etalon = 0.691239
         with pm.Model():
             cov = pm.gp.cov.Circular(1, 1, tau=4)
-        K = theano.function([], cov(X))()
+        K = aesara.function([], cov(X))()
         npt.assert_allclose(K[0, 1], etalon, atol=1e-3)
-        K = theano.function([], cov(X, X))()
+        K = aesara.function([], cov(X, X))()
         npt.assert_allclose(K[0, 1], etalon, atol=1e-3)
         # check diagonal
-        Kd = theano.function([], cov(X, diag=True))()
+        Kd = aesara.function([], cov(X, diag=True))()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)

--- a/pymc3/tests/test_hmc.py
+++ b/pymc3/tests/test_hmc.py
@@ -19,9 +19,9 @@ import numpy.testing as npt
 
 import pymc3
 
+from pymc3.aesaraf import floatX
 from pymc3.step_methods.hmc.base_hmc import BaseHMC
 from pymc3.tests import models
-from pymc3.theanof import floatX
 
 logger = logging.getLogger("pymc3")
 

--- a/pymc3/tests/test_math.py
+++ b/pymc3/tests/test_math.py
@@ -12,14 +12,15 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara
+import aesara.tensor as aet
 import numpy as np
 import numpy.testing as npt
 import pytest
-import theano
-import theano.tensor as tt
 
 from scipy.special import logsumexp as scipy_logsumexp
 
+from pymc3.aesaraf import floatX
 from pymc3.math import (
     LogDet,
     cartesian,
@@ -36,7 +37,6 @@ from pymc3.math import (
     probit,
 )
 from pymc3.tests.helpers import SeededTest, verify_grad
-from pymc3.theanof import floatX
 
 
 def test_kronecker():
@@ -45,7 +45,7 @@ def test_kronecker():
     [a, b, c] = [np.random.rand(3, 3 + i) for i in range(3)]
 
     custom = kronecker(a, b, c)  # Custom version
-    nested = tt.slinalg.kron(a, tt.slinalg.kron(b, c))
+    nested = aet.slinalg.kron(a, aet.slinalg.kron(b, c))
     np.testing.assert_array_almost_equal(custom.eval(), nested.eval())  # Standard nested version
 
 
@@ -83,7 +83,7 @@ def test_kron_dot():
     x = np.random.rand(tot_size).reshape((tot_size, 1))
     # Construct entire kronecker product then multiply
     big = kronecker(*Ks)
-    slow_ans = tt.dot(big, x)
+    slow_ans = aet.dot(big, x)
     # Use tricks to avoid construction of entire kronecker product
     fast_ans = kron_dot(Ks, x)
     np.testing.assert_array_almost_equal(slow_ans.eval(), fast_ans.eval())
@@ -98,7 +98,7 @@ def test_kron_solve_lower():
     x = np.random.rand(tot_size).reshape((tot_size, 1))
     # Construct entire kronecker product then solve
     big = kronecker(*Ls)
-    slow_ans = tt.slinalg.solve_lower_triangular(big, x)
+    slow_ans = aet.slinalg.solve_lower_triangular(big, x)
     # Use tricks to avoid construction of entire kronecker product
     fast_ans = kron_solve_lower(Ls, x)
     np.testing.assert_array_almost_equal(slow_ans.eval(), fast_ans.eval())
@@ -170,10 +170,10 @@ class TestLogDet(SeededTest):
         self.op_class = LogDet
         self.op = logdet
 
-    @theano.config.change_flags(compute_test_value="ignore")
+    @aesara.config.change_flags(compute_test_value="ignore")
     def validate(self, input_mat):
-        x = theano.tensor.matrix()
-        f = theano.function([x], self.op(x))
+        x = aesara.tensor.matrix()
+        f = aesara.function([x], self.op(x))
         out = f(input_mat)
         svd_diag = np.linalg.svd(input_mat, compute_uv=False)
         numpy_out = np.sum(np.log(np.abs(svd_diag)))
@@ -185,24 +185,24 @@ class TestLogDet(SeededTest):
         verify_grad(self.op, [input_mat])
 
     @pytest.mark.skipif(
-        theano.config.device in ["cuda", "gpu"],
+        aesara.config.device in ["cuda", "gpu"],
         reason="No logDet implementation on GPU.",
     )
     def test_basic(self):
         # Calls validate with different params
         test_case_1 = np.random.randn(3, 3) / np.sqrt(3)
         test_case_2 = np.random.randn(10, 10) / np.sqrt(10)
-        self.validate(test_case_1.astype(theano.config.floatX))
-        self.validate(test_case_2.astype(theano.config.floatX))
+        self.validate(test_case_1.astype(aesara.config.floatX))
+        self.validate(test_case_2.astype(aesara.config.floatX))
 
 
 def test_expand_packed_triangular():
     with pytest.raises(ValueError):
-        x = tt.matrix("x")
-        x.tag.test_value = np.array([[1.0]], dtype=theano.config.floatX)
+        x = aet.matrix("x")
+        x.tag.test_value = np.array([[1.0]], dtype=aesara.config.floatX)
         expand_packed_triangular(5, x)
     N = 5
-    packed = tt.vector("packed")
+    packed = aet.vector("packed")
     packed.tag.test_value = floatX(np.zeros(N * (N + 1) // 2))
     with pytest.raises(TypeError):
         expand_packed_triangular(packed.shape[0], packed)

--- a/pymc3/tests/test_model_graph.py
+++ b/pymc3/tests/test_model_graph.py
@@ -12,8 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara as th
 import numpy as np
-import theano as th
 
 import pymc3 as pm
 

--- a/pymc3/tests/test_models_utils.py
+++ b/pymc3/tests/test_models_utils.py
@@ -12,10 +12,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara.tensor as aet
 import numpy as np
 import pandas as pd
 import pytest
-import theano.tensor as tt
 
 from pymc3.glm import utils
 
@@ -51,7 +51,7 @@ class TestUtils:
         m, l = utils.any_to_tensor_and_labels(self.data.to_dict("list"))
         self.assertMatrixLabels(m, l, mt=self.data[l].values, lt=l)
 
-        inp = {k: tt.as_tensor_variable(v.values) for k, v in self.data.to_dict("series").items()}
+        inp = {k: aet.as_tensor_variable(v.values) for k, v in self.data.to_dict("series").items()}
         m, l = utils.any_to_tensor_and_labels(inp)
         self.assertMatrixLabels(m, l, mt=self.data[l].values, lt=l)
 
@@ -63,18 +63,18 @@ class TestUtils:
 
     def test_tensor_input(self):
         m, l = utils.any_to_tensor_and_labels(
-            tt.as_tensor_variable(self.data.values.tolist()), labels=["x0", "x1"]
+            aet.as_tensor_variable(self.data.values.tolist()), labels=["x0", "x1"]
         )
         self.assertMatrixLabels(m, l, lt=["x0", "x1"])
         m, l = utils.any_to_tensor_and_labels(
-            tt.as_tensor_variable(self.data.values.tolist()), labels=["x2", "x3"]
+            aet.as_tensor_variable(self.data.values.tolist()), labels=["x2", "x3"]
         )
         self.assertMatrixLabels(m, l, lt=["x2", "x3"])
 
     def test_user_mistakes(self):
         # no labels for tensor variable
         with pytest.raises(ValueError):
-            utils.any_to_tensor_and_labels(tt.as_tensor_variable(self.data.values.tolist()))
+            utils.any_to_tensor_and_labels(aet.as_tensor_variable(self.data.values.tolist()))
         # len of labels is bad
         with pytest.raises(ValueError):
             utils.any_to_tensor_and_labels(self.data.values.tolist(), labels=["x"])

--- a/pymc3/tests/test_ode.py
+++ b/pymc3/tests/test_ode.py
@@ -12,9 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara
 import numpy as np
 import pytest
-import theano
 
 from scipy.integrate import odeint
 from scipy.stats import norm
@@ -26,13 +26,13 @@ from pymc3.ode.utils import augment_system
 
 
 def test_gradients():
-    """Tests the computation of the sensitivities from the theano computation graph"""
+    """Tests the computation of the sensitivities from the aesara computation graph"""
 
     # ODE system for which to compute gradients
     def ode_func(y, t, p):
         return np.exp(-t) - p[0] * y[0]
 
-    # Computation of graidients with Theano
+    # Computation of graidients with Aesara
     augmented_ode_func = augment_system(ode_func, 1, 1 + 1)
 
     # This is the new system, ODE + Sensitivities, which will be integrated
@@ -210,22 +210,22 @@ class TestErrors:
 
     ode_model = DifferentialEquation(func=system, t0=0, times=times, n_states=1, n_theta=1)
 
-    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_too_many_params(self):
         with pytest.raises(pm.ShapeError):
             self.ode_model(theta=[1, 1], y0=[0])
 
-    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_too_many_y0(self):
         with pytest.raises(pm.ShapeError):
             self.ode_model(theta=[1], y0=[0, 0])
 
-    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_too_few_params(self):
         with pytest.raises(pm.ShapeError):
             self.ode_model(theta=[], y0=[1])
 
-    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_too_few_y0(self):
         with pytest.raises(pm.ShapeError):
             self.ode_model(theta=[1], y0=[])

--- a/pymc3/tests/test_posdef_sym.py
+++ b/pymc3/tests/test_posdef_sym.py
@@ -12,19 +12,19 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara
 import numpy as np
-import theano
 
 from pymc3.distributions import multivariate as mv
 
 
 def test_posdef_symmetric1():
-    data = np.array([[1.0, 0], [0, 1]], dtype=theano.config.floatX)
+    data = np.array([[1.0, 0], [0, 1]], dtype=aesara.config.floatX)
     assert mv.posdef(data) == 1
 
 
 def test_posdef_symmetric2():
-    data = np.array([[1.0, 2], [2, 1]], dtype=theano.config.floatX)
+    data = np.array([[1.0, 2], [2, 1]], dtype=aesara.config.floatX)
     assert mv.posdef(data) == 0
 
 
@@ -33,11 +33,11 @@ def test_posdef_symmetric3():
 
     Is this correct?
     """
-    data = np.array([[1.0, 1], [1, 1]], dtype=theano.config.floatX)
+    data = np.array([[1.0, 1], [1, 1]], dtype=aesara.config.floatX)
     assert mv.posdef(data) == 0
 
 
 def test_posdef_symmetric4():
-    d = np.array([[1, 0.99, 1], [0.99, 1, 0.999], [1, 0.999, 1]], theano.config.floatX)
+    d = np.array([[1, 0.99, 1], [0.99, 1, 0.999], [1, 0.999, 1]], aesara.config.floatX)
 
     assert mv.posdef(d) == 0

--- a/pymc3/tests/test_posteriors.py
+++ b/pymc3/tests/test_posteriors.py
@@ -12,13 +12,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara
 import pytest
-import theano
 
 from pymc3.tests import sampler_fixtures as sf
 
 
-@pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+@pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
 class TestNUTSUniform(sf.NutsFixture, sf.UniformFixture):
     n_samples = 10000
     tune = 1000

--- a/pymc3/tests/test_quadpotential.py
+++ b/pymc3/tests/test_quadpotential.py
@@ -19,8 +19,8 @@ import scipy.sparse
 
 import pymc3
 
+from pymc3.aesaraf import floatX
 from pymc3.step_methods.hmc import quadpotential
-from pymc3.theanof import floatX
 
 
 def test_elemwise_posdef():

--- a/pymc3/tests/test_random.py
+++ b/pymc3/tests/test_random.py
@@ -12,11 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara
+import aesara.tensor as aet
 import numpy as np
 import numpy.testing as npt
 import pytest
-import theano
-import theano.tensor as tt
 
 from numpy import random as nr
 
@@ -30,15 +30,15 @@ def test_draw_value():
     npt.assert_equal(_draw_value(np.array([5, 6])), [5, 6])
     npt.assert_equal(_draw_value(np.array(5.0)), 5)
 
-    npt.assert_equal(_draw_value(tt.constant([5.0, 6.0])), [5, 6])
-    assert _draw_value(tt.constant(5)) == 5
-    npt.assert_equal(_draw_value(2 * tt.constant([5.0, 6.0])), [10, 12])
+    npt.assert_equal(_draw_value(aet.constant([5.0, 6.0])), [5, 6])
+    assert _draw_value(aet.constant(5)) == 5
+    npt.assert_equal(_draw_value(2 * aet.constant([5.0, 6.0])), [10, 12])
 
-    val = theano.shared(np.array([5.0, 6.0]))
+    val = aesara.shared(np.array([5.0, 6.0]))
     npt.assert_equal(_draw_value(val), [5, 6])
     npt.assert_equal(_draw_value(2 * val), [10, 12])
 
-    a = tt.scalar("a")
+    a = aet.scalar("a")
     a.tag.test_value = 6
     npt.assert_equal(_draw_value(2 * a, givens=[(a, 1)]), 2)
 
@@ -48,7 +48,7 @@ def test_draw_value():
     assert isinstance(_draw_value(5), type(5))
 
     with pm.Model():
-        mu = 2 * tt.constant(np.array([5.0, 6.0])) + theano.shared(np.array(5))
+        mu = 2 * aet.constant(np.array([5.0, 6.0])) + aesara.shared(np.array(5))
         a = pm.Normal("a", mu=mu, sigma=5, shape=2)
 
     val1 = _draw_value(a)
@@ -68,17 +68,17 @@ class TestDrawValues:
         npt.assert_equal(draw_values([np.array([5, 6])])[0], [5, 6])
         npt.assert_equal(draw_values([np.array(5.0)])[0], 5)
 
-        npt.assert_equal(draw_values([tt.constant([5.0, 6.0])])[0], [5, 6])
-        assert draw_values([tt.constant(5)])[0] == 5
-        npt.assert_equal(draw_values([2 * tt.constant([5.0, 6.0])])[0], [10, 12])
+        npt.assert_equal(draw_values([aet.constant([5.0, 6.0])])[0], [5, 6])
+        assert draw_values([aet.constant(5)])[0] == 5
+        npt.assert_equal(draw_values([2 * aet.constant([5.0, 6.0])])[0], [10, 12])
 
-        val = theano.shared(np.array([5.0, 6.0]))
+        val = aesara.shared(np.array([5.0, 6.0]))
         npt.assert_equal(draw_values([val])[0], [5, 6])
         npt.assert_equal(draw_values([2 * val])[0], [10, 12])
 
     def test_simple_model(self):
         with pm.Model():
-            mu = 2 * tt.constant(np.array([5.0, 6.0])) + theano.shared(np.array(5))
+            mu = 2 * aet.constant(np.array([5.0, 6.0])) + aesara.shared(np.array(5))
             a = pm.Normal("a", mu=mu, sigma=5, shape=2)
 
         val1 = draw_values([a])
@@ -90,7 +90,7 @@ class TestDrawValues:
 
     def test_dep_vars(self):
         with pm.Model():
-            mu = 2 * tt.constant(np.array([5.0, 6.0])) + theano.shared(np.array(5))
+            mu = 2 * aet.constant(np.array([5.0, 6.0])) + aesara.shared(np.array(5))
             sd = pm.HalfNormal("sd", shape=2)
             tau = 1 / sd ** 2
             a = pm.Normal("a", mu=mu, tau=tau, shape=2)
@@ -116,7 +116,7 @@ class TestDrawValues:
 
     def test_graph_constant(self):
         # Issue 3595 pointed out that slice(None) can introduce
-        # theano.graph.basic.Constant into the compute graph, which wasn't
+        # aesara.graph.basic.Constant into the compute graph, which wasn't
         # handled correctly by draw_values
         n_d = 500
         n_x = 2

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -655,6 +655,8 @@ class TestSamplePPC(SeededTest):
         npt.assert_allclose(post_pred["p"], expected_p)
 
     def test_deterministic_of_observed(self):
+        np.random.seed(8442)
+
         meas_in_1 = pm.aesaraf.floatX(2 + 4 * np.random.randn(10))
         meas_in_2 = pm.aesaraf.floatX(5 + 4 * np.random.randn(10))
         nchains = 2

--- a/pymc3/tests/test_shape_handling.py
+++ b/pymc3/tests/test_shape_handling.py
@@ -15,7 +15,7 @@
 import numpy as np
 import pytest
 
-from theano import tensor as tt
+from aesara import tensor as aet
 
 import pymc3 as pm
 
@@ -106,7 +106,7 @@ def fixture_model():
             cov = pm.InverseGamma("cov", alpha=1, beta=1)
             x = pm.Normal("x", mu=np.ones((dim,)), sigma=pm.math.sqrt(cov), shape=(n, dim))
             eps = pm.HalfNormal("eps", np.ones((n, 1)), shape=(n, dim))
-            mu = pm.Deterministic("mu", tt.sum(x + eps, axis=-1))
+            mu = pm.Deterministic("mu", aet.sum(x + eps, axis=-1))
             y = pm.Normal("y", mu=mu, sigma=1, shape=(n,))
     return model, [cov, x, eps, y]
 

--- a/pymc3/tests/test_shared.py
+++ b/pymc3/tests/test_shared.py
@@ -12,8 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara
 import numpy as np
-import theano
 
 import pymc3 as pm
 
@@ -24,7 +24,7 @@ class TestShared(SeededTest):
     def test_deterministic(self):
         with pm.Model() as model:
             data_values = np.array([0.5, 0.4, 5, 2])
-            X = theano.shared(np.asarray(data_values, dtype=theano.config.floatX), borrow=True)
+            X = aesara.shared(np.asarray(data_values, dtype=aesara.config.floatX), borrow=True)
             pm.Normal("y", 0, 1, observed=X)
             model.logp(model.test_point)
 
@@ -34,7 +34,7 @@ class TestShared(SeededTest):
 
         x_pred = np.linspace(-3, 3, 200)
 
-        x_shared = theano.shared(x)
+        x_shared = aesara.shared(x)
 
         with pm.Model() as model:
             b = pm.Normal("b", 0.0, 10.0)

--- a/pymc3/tests/test_smc.py
+++ b/pymc3/tests/test_smc.py
@@ -12,9 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara.tensor as aet
 import numpy as np
 import pytest
-import theano.tensor as tt
 
 import pymc3 as pm
 
@@ -39,16 +39,16 @@ class TestSMC(SeededTest):
 
         def two_gaussians(x):
             log_like1 = (
-                -0.5 * n * tt.log(2 * np.pi)
-                - 0.5 * tt.log(dsigma)
+                -0.5 * n * aet.log(2 * np.pi)
+                - 0.5 * aet.log(dsigma)
                 - 0.5 * (x - mu1).T.dot(isigma).dot(x - mu1)
             )
             log_like2 = (
-                -0.5 * n * tt.log(2 * np.pi)
-                - 0.5 * tt.log(dsigma)
+                -0.5 * n * aet.log(2 * np.pi)
+                - 0.5 * aet.log(dsigma)
                 - 0.5 * (x - mu2).T.dot(isigma).dot(x - mu2)
             )
-            return tt.log(w1 * tt.exp(log_like1) + w2 * tt.exp(log_like2))
+            return aet.log(w1 * aet.exp(log_like1) + w2 * aet.exp(log_like2))
 
         with pm.Model() as self.SMC_test:
             X = pm.Uniform("X", lower=-2, upper=2.0, shape=n)

--- a/pymc3/tests/test_special_functions.py
+++ b/pymc3/tests/test_special_functions.py
@@ -12,11 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara.tensor as aet
 import numpy as np
 import scipy.special as ss
-import theano.tensor as tt
 
-from theano import function
+from aesara import function
 
 import pymc3.distributions.special as ps
 
@@ -26,10 +26,10 @@ from pymc3.tests.checks import close_to
 def test_functions():
     xvals = list(map(np.atleast_1d, [0.01, 0.1, 2, 100, 10000]))
 
-    x = tt.dvector("x")
+    x = aet.dvector("x")
     x.tag.test_value = xvals[0]
 
-    p = tt.iscalar("p")
+    p = aet.iscalar("p")
     p.tag.test_value = 1
 
     gammaln = function([x], ps.gammaln(x))
@@ -55,10 +55,10 @@ In [14]:
 def t_multigamma():
     xvals = list(map(np.atleast_1d, [0, 0.1, 2, 100]))
 
-    x = tt.dvector("x")
+    x = aet.dvector("x")
     x.tag.test_value = xvals[0]
 
-    p = tt.iscalar("p")
+    p = aet.iscalar("p")
     p.tag.test_value = 1
 
     multigammaln = function([x, p], ps.multigammaln(x, p))

--- a/pymc3/tests/test_transforms.py
+++ b/pymc3/tests/test_transforms.py
@@ -12,14 +12,17 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara
+import aesara.tensor as aet
 import numpy as np
 import pytest
-import theano
-import theano.tensor as tt
+
+from aesara.tensor.var import TensorConstant
 
 import pymc3 as pm
 import pymc3.distributions.transforms as tr
 
+from pymc3.aesaraf import jacobian
 from pymc3.tests.checks import close_to, close_to_logical
 from pymc3.tests.helpers import SeededTest
 from pymc3.tests.test_distributions import (
@@ -34,38 +37,37 @@ from pymc3.tests.test_distributions import (
     UnitSortedVector,
     Vector,
 )
-from pymc3.theanof import jacobian
 
 # some transforms (stick breaking) require additon of small slack in order to be numerically
 # stable. The minimal addable slack for float32 is higher thus we need to be less strict
-tol = 1e-7 if theano.config.floatX == "float64" else 1e-6
+tol = 1e-7 if aesara.config.floatX == "float64" else 1e-6
 
 
-def check_transform(transform, domain, constructor=tt.dscalar, test=0):
+def check_transform(transform, domain, constructor=aet.dscalar, test=0):
     x = constructor("x")
     x.tag.test_value = test
     # test forward and forward_val
-    forward_f = theano.function([x], transform.forward(x))
+    forward_f = aesara.function([x], transform.forward(x))
     # test transform identity
-    identity_f = theano.function([x], transform.backward(transform.forward(x)))
+    identity_f = aesara.function([x], transform.backward(transform.forward(x)))
     for val in domain.vals:
         close_to(val, identity_f(val), tol)
         close_to(transform.forward_val(val), forward_f(val), tol)
 
 
 def check_vector_transform(transform, domain):
-    return check_transform(transform, domain, tt.dvector, test=np.array([0, 0]))
+    return check_transform(transform, domain, aet.dvector, test=np.array([0, 0]))
 
 
-def get_values(transform, domain=R, constructor=tt.dscalar, test=0):
+def get_values(transform, domain=R, constructor=aet.dscalar, test=0):
     x = constructor("x")
     x.tag.test_value = test
-    f = theano.function([x], transform.backward(x))
+    f = aesara.function([x], transform.backward(x))
     return np.array([f(val) for val in domain.vals])
 
 
 def check_jacobian_det(
-    transform, domain, constructor=tt.dscalar, test=0, make_comparable=None, elemwise=False
+    transform, domain, constructor=aet.dscalar, test=0, make_comparable=None, elemwise=False
 ):
     y = constructor("y")
     y.tag.test_value = test
@@ -75,15 +77,15 @@ def check_jacobian_det(
         x = make_comparable(x)
 
     if not elemwise:
-        jac = tt.log(tt.nlinalg.det(jacobian(x, [y])))
+        jac = aet.log(aet.nlinalg.det(jacobian(x, [y])))
     else:
-        jac = tt.log(tt.abs_(tt.diag(jacobian(x, [y]))))
+        jac = aet.log(aet.abs_(aet.diag(jacobian(x, [y]))))
 
     # ljd = log jacobian det
-    actual_ljd = theano.function([y], jac)
+    actual_ljd = aesara.function([y], jac)
 
-    computed_ljd = theano.function(
-        [y], tt.as_tensor_variable(transform.jacobian_det(y)), on_unused_input="ignore"
+    computed_ljd = aesara.function(
+        [y], aet.as_tensor_variable(transform.jacobian_det(y)), on_unused_input="ignore"
     )
 
     for yval in domain.vals:
@@ -99,27 +101,27 @@ def test_stickbreaking():
     check_vector_transform(tr.stick_breaking, Simplex(4))
 
     check_transform(
-        tr.stick_breaking, MultiSimplex(3, 2), constructor=tt.dmatrix, test=np.zeros((2, 2))
+        tr.stick_breaking, MultiSimplex(3, 2), constructor=aet.dmatrix, test=np.zeros((2, 2))
     )
 
 
 def test_stickbreaking_bounds():
-    vals = get_values(tr.stick_breaking, Vector(R, 2), tt.dvector, np.array([0, 0]))
+    vals = get_values(tr.stick_breaking, Vector(R, 2), aet.dvector, np.array([0, 0]))
 
     close_to(vals.sum(axis=1), 1, tol)
     close_to_logical(vals > 0, True, tol)
     close_to_logical(vals < 1, True, tol)
 
     check_jacobian_det(
-        tr.stick_breaking, Vector(R, 2), tt.dvector, np.array([0, 0]), lambda x: x[:-1]
+        tr.stick_breaking, Vector(R, 2), aet.dvector, np.array([0, 0]), lambda x: x[:-1]
     )
 
 
 def test_stickbreaking_accuracy():
     val = np.array([-30])
-    x = tt.dvector("x")
+    x = aet.dvector("x")
     x.tag.test_value = val
-    identity_f = theano.function([x], tr.stick_breaking.forward(tr.stick_breaking.backward(x)))
+    identity_f = aesara.function([x], tr.stick_breaking.forward(tr.stick_breaking.backward(x)))
     close_to(val, identity_f(val), tol)
 
 
@@ -127,14 +129,16 @@ def test_sum_to_1():
     check_vector_transform(tr.sum_to_1, Simplex(2))
     check_vector_transform(tr.sum_to_1, Simplex(4))
 
-    check_jacobian_det(tr.sum_to_1, Vector(Unit, 2), tt.dvector, np.array([0, 0]), lambda x: x[:-1])
+    check_jacobian_det(
+        tr.sum_to_1, Vector(Unit, 2), aet.dvector, np.array([0, 0]), lambda x: x[:-1]
+    )
 
 
 def test_log():
     check_transform(tr.log, Rplusbig)
 
     check_jacobian_det(tr.log, Rplusbig, elemwise=True)
-    check_jacobian_det(tr.log, Vector(Rplusbig, 2), tt.dvector, [0, 0], elemwise=True)
+    check_jacobian_det(tr.log, Vector(Rplusbig, 2), aet.dvector, [0, 0], elemwise=True)
 
     vals = get_values(tr.log)
     close_to_logical(vals > 0, True, tol)
@@ -144,7 +148,7 @@ def test_log_exp_m1():
     check_transform(tr.log_exp_m1, Rplusbig)
 
     check_jacobian_det(tr.log_exp_m1, Rplusbig, elemwise=True)
-    check_jacobian_det(tr.log_exp_m1, Vector(Rplusbig, 2), tt.dvector, [0, 0], elemwise=True)
+    check_jacobian_det(tr.log_exp_m1, Vector(Rplusbig, 2), aet.dvector, [0, 0], elemwise=True)
 
     vals = get_values(tr.log_exp_m1)
     close_to_logical(vals > 0, True, tol)
@@ -154,7 +158,7 @@ def test_logodds():
     check_transform(tr.logodds, Unit)
 
     check_jacobian_det(tr.logodds, Unit, elemwise=True)
-    check_jacobian_det(tr.logodds, Vector(Unit, 2), tt.dvector, [0.5, 0.5], elemwise=True)
+    check_jacobian_det(tr.logodds, Vector(Unit, 2), aet.dvector, [0.5, 0.5], elemwise=True)
 
     vals = get_values(tr.logodds)
     close_to_logical(vals > 0, True, tol)
@@ -166,7 +170,7 @@ def test_lowerbound():
     check_transform(trans, Rplusbig)
 
     check_jacobian_det(trans, Rplusbig, elemwise=True)
-    check_jacobian_det(trans, Vector(Rplusbig, 2), tt.dvector, [0, 0], elemwise=True)
+    check_jacobian_det(trans, Vector(Rplusbig, 2), aet.dvector, [0, 0], elemwise=True)
 
     vals = get_values(trans)
     close_to_logical(vals > 0, True, tol)
@@ -177,7 +181,7 @@ def test_upperbound():
     check_transform(trans, Rminusbig)
 
     check_jacobian_det(trans, Rminusbig, elemwise=True)
-    check_jacobian_det(trans, Vector(Rminusbig, 2), tt.dvector, [-1, -1], elemwise=True)
+    check_jacobian_det(trans, Vector(Rminusbig, 2), aet.dvector, [-1, -1], elemwise=True)
 
     vals = get_values(trans)
     close_to_logical(vals < 0, True, tol)
@@ -196,7 +200,7 @@ def test_interval():
         close_to_logical(vals < b, True, tol)
 
 
-@pytest.mark.skipif(theano.config.floatX == "float32", reason="Test fails on 32 bit")
+@pytest.mark.skipif(aesara.config.floatX == "float32", reason="Test fails on 32 bit")
 def test_interval_near_boundary():
     lb = -1.0
     ub = 1e-7
@@ -219,26 +223,26 @@ def test_circular():
     close_to_logical(vals > -np.pi, True, tol)
     close_to_logical(vals < np.pi, True, tol)
 
-    assert isinstance(trans.forward(1), tt.TensorConstant)
+    assert isinstance(trans.forward(1), TensorConstant)
 
 
 def test_ordered():
     check_vector_transform(tr.ordered, SortedVector(6))
 
-    check_jacobian_det(tr.ordered, Vector(R, 2), tt.dvector, np.array([0, 0]), elemwise=False)
+    check_jacobian_det(tr.ordered, Vector(R, 2), aet.dvector, np.array([0, 0]), elemwise=False)
 
-    vals = get_values(tr.ordered, Vector(R, 3), tt.dvector, np.zeros(3))
+    vals = get_values(tr.ordered, Vector(R, 3), aet.dvector, np.zeros(3))
     close_to_logical(np.diff(vals) >= 0, True, tol)
 
 
-@pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+@pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
 def test_chain():
     chain_tranf = tr.Chain([tr.logodds, tr.ordered])
     check_vector_transform(chain_tranf, UnitSortedVector(3))
 
-    check_jacobian_det(chain_tranf, Vector(R, 4), tt.dvector, np.zeros(4), elemwise=False)
+    check_jacobian_det(chain_tranf, Vector(R, 4), aet.dvector, np.zeros(4), elemwise=False)
 
-    vals = get_values(chain_tranf, Vector(R, 5), tt.dvector, np.zeros(5))
+    vals = get_values(chain_tranf, Vector(R, 5), aet.dvector, np.zeros(5))
     close_to_logical(np.diff(vals) >= 0, True, tol)
 
 
@@ -260,7 +264,7 @@ class TestElementWiseLogp(SeededTest):
         pt[x.name] = array
         dist = x.distribution
         logp_nojac = x0.distribution.logp(dist.transform_used.backward(array))
-        jacob_det = dist.transform_used.jacobian_det(theano.shared(array))
+        jacob_det = dist.transform_used.jacobian_det(aesara.shared(array))
         assert x.logp_elemwiset.ndim == jacob_det.ndim
 
         elementwiselogp = logp_nojac + jacob_det
@@ -277,7 +281,7 @@ class TestElementWiseLogp(SeededTest):
         pt[x.name] = array
         dist = x.distribution
         logp_nojac = x0.distribution.logp(dist.transform_used.backward(array))
-        jacob_det = dist.transform_used.jacobian_det(theano.shared(array))
+        jacob_det = dist.transform_used.jacobian_det(aesara.shared(array))
         assert x.logp_elemwiset.ndim == jacob_det.ndim
 
         if vect_opt == 0:
@@ -369,7 +373,7 @@ class TestElementWiseLogp(SeededTest):
             (np.ones(3), (4, 3)),
         ],
     )
-    @pytest.mark.xfail(condition=(theano.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_half_normal_ordered(self, sd, shape):
         testval = np.sort(np.abs(np.random.randn(*shape)))
         model = self.build_model(

--- a/pymc3/tests/test_types.py
+++ b/pymc3/tests/test_types.py
@@ -14,8 +14,8 @@
 
 from copy import copy
 
+import aesara
 import numpy as np
-import theano
 
 from pymc3.distributions import Normal
 from pymc3.model import Model
@@ -27,14 +27,14 @@ class TestType:
     samplers = (Metropolis, Slice, HamiltonianMC, NUTS)
 
     def setup_method(self):
-        # save theano config object
-        self.theano_config = copy(theano.config)
+        # save aesara config object
+        self.aesara_config = copy(aesara.config)
 
     def teardown_method(self):
-        # restore theano config
-        theano.config = self.theano_config
+        # restore aesara config
+        aesara.config = self.aesara_config
 
-    @theano.config.change_flags({"floatX": "float64", "warn_float64": "ignore"})
+    @aesara.config.change_flags({"floatX": "float64", "warn_float64": "ignore"})
     def test_float64(self):
         with Model() as model:
             x = Normal("x", testval=np.array(1.0, dtype="float64"))
@@ -47,7 +47,7 @@ class TestType:
             with model:
                 sample(10, sampler())
 
-    @theano.config.change_flags({"floatX": "float32", "warn_float64": "warn"})
+    @aesara.config.change_flags({"floatX": "float32", "warn_float64": "warn"})
     def test_float32(self):
         with Model() as model:
             x = Normal("x", testval=np.array(1.0, dtype="float32"))
@@ -60,7 +60,7 @@ class TestType:
             with model:
                 sample(10, sampler())
 
-    @theano.config.change_flags({"floatX": "float64", "warn_float64": "ignore"})
+    @aesara.config.change_flags({"floatX": "float64", "warn_float64": "ignore"})
     def test_float64_MLDA(self):
         data = np.random.randn(5)
 
@@ -78,7 +78,7 @@ class TestType:
         with model:
             sample(10, MLDA(coarse_models=[coarse_model]))
 
-    @theano.config.change_flags({"floatX": "float32", "warn_float64": "warn"})
+    @aesara.config.change_flags({"floatX": "float32", "warn_float64": "warn"})
     def test_float32_MLDA(self):
         data = np.random.randn(5).astype("float32")
 

--- a/pymc3/tests/test_updates.py
+++ b/pymc3/tests/test_updates.py
@@ -12,9 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara
 import numpy as np
 import pytest
-import theano
 
 from pymc3.variational.updates import (
     adadelta,
@@ -28,12 +28,12 @@ from pymc3.variational.updates import (
     sgd,
 )
 
-_a = theano.shared(1.0)
+_a = aesara.shared(1.0)
 _b = _a * 2
 
-_m = theano.shared(np.empty((10,), theano.config.floatX))
+_m = aesara.shared(np.empty((10,), aesara.config.floatX))
 _n = _m.sum()
-_m2 = theano.shared(np.empty((10, 10, 10), theano.config.floatX))
+_m2 = aesara.shared(np.empty((10, 10, 10), aesara.config.floatX))
 _n2 = _b + _n + _m2.sum()
 
 
@@ -71,7 +71,7 @@ _n2 = _b + _n + _m2.sum()
     ids=["scalar", "matrix", "mixed"],
 )
 def test_updates_fast(opt, loss_and_params, kwargs, getter):
-    with theano.config.change_flags(compute_test_value="ignore"):
+    with aesara.config.change_flags(compute_test_value="ignore"):
         loss, param = getter(loss_and_params)
         args = dict()
         args.update(**kwargs)

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -16,18 +16,18 @@ import functools
 import io
 import operator
 
+import aesara
+import aesara.tensor as aet
 import numpy as np
 import pytest
-import theano
-import theano.tensor as tt
 
 import pymc3 as pm
 import pymc3.memoize
 import pymc3.util
 
+from pymc3.aesaraf import intX
 from pymc3.tests import models
 from pymc3.tests.helpers import not_raises
-from pymc3.theanof import intX
 from pymc3.variational import flows, opvi
 from pymc3.variational.approximations import (
     Empirical,
@@ -51,7 +51,7 @@ def test_callbacks_convergence(diff, ord):
     cb = pm.variational.callbacks.CheckParametersConvergence(every=1, diff=diff, ord=ord)
 
     class _approx:
-        params = (theano.shared(np.asarray([1, 2, 3])),)
+        params = (aesara.shared(np.asarray([1, 2, 3])),)
 
     approx = _approx()
 
@@ -186,7 +186,7 @@ def test_sample_simple(three_var_approx, request):
 
 @pytest.fixture
 def aevb_initial():
-    return theano.shared(np.random.rand(3, 7).astype("float32"))
+    return aesara.shared(np.random.rand(3, 7).astype("float32"))
 
 
 @pytest.fixture(
@@ -251,7 +251,7 @@ def test_sample_aevb(three_var_aevb_approx, aevb_initial):
 
 
 def test_replacements_in_sample_node_aevb(three_var_aevb_approx, aevb_initial):
-    inp = tt.matrix(dtype="float32")
+    inp = aet.matrix(dtype="float32")
     three_var_aevb_approx.sample_node(
         three_var_aevb_approx.model.one, 2, more_replacements={aevb_initial: inp}
     ).eval({inp: np.random.rand(7, 7).astype("float32")})
@@ -265,14 +265,14 @@ def test_vae():
     minibatch_size = 10
     data = pm.floatX(np.random.rand(100))
     x_mini = pm.Minibatch(data, minibatch_size)
-    x_inp = tt.vector()
+    x_inp = aet.vector()
     x_inp.tag.test_value = data[:minibatch_size]
 
-    ae = theano.shared(pm.floatX([0.1, 0.1]))
-    be = theano.shared(pm.floatX(1.0))
+    ae = aesara.shared(pm.floatX([0.1, 0.1]))
+    be = aesara.shared(pm.floatX(1.0))
 
-    ad = theano.shared(pm.floatX(1.0))
-    bd = theano.shared(pm.floatX(1.0))
+    ad = aesara.shared(pm.floatX(1.0))
+    bd = aesara.shared(pm.floatX(1.0))
 
     enc = x_inp.dimshuffle(0, "x") * ae.dimshuffle("x", 0) + be
     mu, rho = enc[:, 0], enc[:, 1]
@@ -496,8 +496,8 @@ def test_elbo():
     sigma = 1.0
     y_obs = np.array([1.6, 1.4])
 
-    post_mu = np.array([1.88], dtype=theano.config.floatX)
-    post_sigma = np.array([1], dtype=theano.config.floatX)
+    post_mu = np.array([1.88], dtype=aesara.config.floatX)
+    post_sigma = np.array([1], dtype=aesara.config.floatX)
     # Create a model for test
     with pm.Model() as model:
         mu = pm.Normal("mu", mu=mu0, sigma=sigma)
@@ -505,13 +505,13 @@ def test_elbo():
 
     # Create variational gradient tensor
     mean_field = MeanField(model=model)
-    with theano.config.change_flags(compute_test_value="off"):
+    with aesara.config.change_flags(compute_test_value="off"):
         elbo = -pm.operators.KL(mean_field)()(10000)
 
     mean_field.shared_params["mu"].set_value(post_mu)
     mean_field.shared_params["rho"].set_value(np.log(np.exp(post_sigma) - 1))
 
-    f = theano.function([], elbo)
+    f = aesara.function([], elbo)
     elbo_mc = f()
 
     # Exact value
@@ -534,17 +534,17 @@ def test_scale_cost_to_minibatch_works(aux_total_size):
     y_obs = np.array([1.6, 1.4])
     beta = len(y_obs) / float(aux_total_size)
 
-    # TODO: theano_config
-    # with pm.Model(theano_config=dict(floatX='float64')):
+    # TODO: aesara_config
+    # with pm.Model(aesara_config=dict(floatX='float64')):
     # did not not work as expected
     # there were some numeric problems, so float64 is forced
-    with theano.config.change_flags(floatX="float64", warn_float64="ignore"):
+    with aesara.config.change_flags(floatX="float64", warn_float64="ignore"):
 
-        assert theano.config.floatX == "float64"
-        assert theano.config.warn_float64 == "ignore"
+        assert aesara.config.floatX == "float64"
+        assert aesara.config.warn_float64 == "ignore"
 
-        post_mu = np.array([1.88], dtype=theano.config.floatX)
-        post_sigma = np.array([1], dtype=theano.config.floatX)
+        post_mu = np.array([1.88], dtype=aesara.config.floatX)
+        post_sigma = np.array([1], dtype=aesara.config.floatX)
 
         with pm.Model():
             mu = pm.Normal("mu", mu=mu0, sigma=sigma)
@@ -555,7 +555,7 @@ def test_scale_cost_to_minibatch_works(aux_total_size):
             mean_field_1.shared_params["mu"].set_value(post_mu)
             mean_field_1.shared_params["rho"].set_value(np.log(np.exp(post_sigma) - 1))
 
-            with theano.config.change_flags(compute_test_value="off"):
+            with aesara.config.change_flags(compute_test_value="off"):
                 elbo_via_total_size_scaled = -pm.operators.KL(mean_field_1)()(10000)
 
         with pm.Model():
@@ -569,7 +569,7 @@ def test_scale_cost_to_minibatch_works(aux_total_size):
             mean_field_2.shared_params["mu"].set_value(post_mu)
             mean_field_2.shared_params["rho"].set_value(np.log(np.exp(post_sigma) - 1))
 
-        with theano.config.change_flags(compute_test_value="off"):
+        with aesara.config.change_flags(compute_test_value="off"):
             elbo_via_total_size_unscaled = -pm.operators.KL(mean_field_2)()(10000)
 
         np.testing.assert_allclose(
@@ -587,10 +587,10 @@ def test_elbo_beta_kl(aux_total_size):
     y_obs = np.array([1.6, 1.4])
     beta = len(y_obs) / float(aux_total_size)
 
-    with theano.config.change_flags(floatX="float64", warn_float64="ignore"):
+    with aesara.config.change_flags(floatX="float64", warn_float64="ignore"):
 
-        post_mu = np.array([1.88], dtype=theano.config.floatX)
-        post_sigma = np.array([1], dtype=theano.config.floatX)
+        post_mu = np.array([1.88], dtype=aesara.config.floatX)
+        post_sigma = np.array([1], dtype=aesara.config.floatX)
 
         with pm.Model():
             mu = pm.Normal("mu", mu=mu0, sigma=sigma)
@@ -601,7 +601,7 @@ def test_elbo_beta_kl(aux_total_size):
             mean_field_1.shared_params["mu"].set_value(post_mu)
             mean_field_1.shared_params["rho"].set_value(np.log(np.exp(post_sigma) - 1))
 
-            with theano.config.change_flags(compute_test_value="off"):
+            with aesara.config.change_flags(compute_test_value="off"):
                 elbo_via_total_size_scaled = -pm.operators.KL(mean_field_1)()(10000)
 
         with pm.Model():
@@ -612,7 +612,7 @@ def test_elbo_beta_kl(aux_total_size):
             mean_field_3.shared_params["mu"].set_value(post_mu)
             mean_field_3.shared_params["rho"].set_value(np.log(np.exp(post_sigma) - 1))
 
-            with theano.config.change_flags(compute_test_value="off"):
+            with aesara.config.change_flags(compute_test_value="off"):
                 elbo_via_beta_kl = -pm.operators.KL(mean_field_3, beta=beta)()(10000)
 
         np.testing.assert_allclose(
@@ -750,7 +750,7 @@ def test_remove_scan_op():
         inference = ADVI()
         buff = io.StringIO()
         inference.run_profiling(n=10).summary(buff)
-        assert "theano.scan.op.Scan" not in buff.getvalue()
+        assert "aesara.scan.op.Scan" not in buff.getvalue()
         buff.close()
 
 
@@ -780,7 +780,7 @@ def test_clear_cache():
 def another_simple_model():
     _model = models.simple_model()[1]
     with _model:
-        pm.Potential("pot", tt.ones((10, 10)))
+        pm.Potential("pot", aet.ones((10, 10)))
     return _model
 
 
@@ -831,8 +831,8 @@ def aevb_model():
         pm.Normal("y", shape=(2,))
     x = model.x
     y = model.y
-    mu = theano.shared(x.init_value)
-    rho = theano.shared(np.zeros_like(x.init_value))
+    mu = aesara.shared(x.init_value)
+    rho = aesara.shared(np.zeros_like(x.init_value))
     return {"model": model, "y": y, "x": x, "replace": dict(mu=mu, rho=rho)}
 
 
@@ -911,13 +911,13 @@ def binomial_model_inference(binomial_model, inference_spec):
 
 
 def test_replacements(binomial_model_inference):
-    d = tt.bscalar()
+    d = aet.bscalar()
     d.tag.test_value = 1
     approx = binomial_model_inference.approx
     p = approx.model.p
     p_t = p ** 3
     p_s = approx.sample_node(p_t)
-    if theano.config.compute_test_value != "off":
+    if aesara.config.compute_test_value != "off":
         assert p_s.tag.test_value.shape == p_t.tag.test_value.shape
     sampled = [p_s.eval() for _ in range(100)]
     assert any(map(operator.ne, sampled[1:], sampled[:-1]))  # stochastic
@@ -934,13 +934,13 @@ def test_replacements(binomial_model_inference):
 
 
 def test_sample_replacements(binomial_model_inference):
-    i = tt.iscalar()
+    i = aet.iscalar()
     i.tag.test_value = 1
     approx = binomial_model_inference.approx
     p = approx.model.p
     p_t = p ** 3
     p_s = approx.sample_node(p_t, size=100)
-    if theano.config.compute_test_value != "off":
+    if aesara.config.compute_test_value != "off":
         assert p_s.tag.test_value.shape == (100,) + p_t.tag.test_value.shape
     sampled = p_s.eval()
     assert any(map(operator.ne, sampled[1:], sampled[:-1]))  # stochastic
@@ -961,7 +961,7 @@ def test_discrete_not_allowed():
 
     with pm.Model():
         mu = pm.Normal("mu", mu=0, sigma=10, shape=3)
-        z = pm.Categorical("z", p=tt.ones(3) / 3, shape=len(y))
+        z = pm.Categorical("z", p=aet.ones(3) / 3, shape=len(y))
         pm.Normal("y_obs", mu=mu[z], sigma=1.0, observed=y)
         with pytest.raises(opvi.ParametrizationError):
             pm.fit(n=1)  # fails
@@ -1016,34 +1016,34 @@ def flow_spec(request):
 
 
 def test_flow_det(flow_spec):
-    z0 = tt.arange(0, 20).astype("float32")
+    z0 = aet.arange(0, 20).astype("float32")
     flow = flow_spec(dim=20, z0=z0.dimshuffle("x", 0))
-    with theano.config.change_flags(compute_test_value="off"):
+    with aesara.config.change_flags(compute_test_value="off"):
         z1 = flow.forward.flatten()
-        J = tt.jacobian(z1, z0)
-        logJdet = tt.log(tt.abs_(tt.nlinalg.det(J)))
+        J = aet.jacobian(z1, z0)
+        logJdet = aet.log(aet.abs_(aet.nlinalg.det(J)))
         det = flow.logdet[0]
     np.testing.assert_allclose(logJdet.eval(), det.eval(), atol=0.0001)
 
 
 def test_flow_det_local(flow_spec):
-    z0 = tt.arange(0, 12).astype("float32")
+    z0 = aet.arange(0, 12).astype("float32")
     spec = flow_spec.cls.get_param_spec_for(d=12)
     params = dict()
     for k, shp in spec.items():
         params[k] = np.random.randn(1, *shp).astype("float32")
     flow = flow_spec(dim=12, z0=z0.reshape((1, 1, 12)), **params)
     assert flow.batched
-    with theano.config.change_flags(compute_test_value="off"):
+    with aesara.config.change_flags(compute_test_value="off"):
         z1 = flow.forward.flatten()
-        J = tt.jacobian(z1, z0)
-        logJdet = tt.log(tt.abs_(tt.nlinalg.det(J)))
+        J = aet.jacobian(z1, z0)
+        logJdet = aet.log(aet.abs_(aet.nlinalg.det(J)))
         det = flow.logdet[0]
     np.testing.assert_allclose(logJdet.eval(), det.eval(), atol=0.0001)
 
 
 def test_flows_collect_chain():
-    initial = tt.ones((3, 2))
+    initial = aet.ones((3, 2))
     flow1 = flows.PlanarFlow(dim=2, z0=initial)
     flow2 = flows.PlanarFlow(dim=2, z0=flow1)
     assert len(flow2.params) == 3
@@ -1067,4 +1067,4 @@ def test_flow_formula(formula, length, order):
     assert len(flows_list) == length
     if order is not None:
         assert flows_list == order
-    spec(dim=2, jitter=1)(tt.ones((3, 2))).eval()  # should work
+    spec(dim=2, jitter=1)(aet.ones((3, 2))).eval()  # should work

--- a/pymc3/tuning/scaling.py
+++ b/pymc3/tuning/scaling.py
@@ -16,9 +16,9 @@ import numpy as np
 
 from numpy import exp, log, sqrt
 
+from pymc3.aesaraf import hessian_diag, inputvars
 from pymc3.blocking import ArrayOrdering, DictToArrayBijection
 from pymc3.model import Point, modelcontext
-from pymc3.theanof import hessian_diag, inputvars
 from pymc3.util import get_var_name
 
 __all__ = ["find_hessian", "trace_cov", "guess_scaling"]

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -19,8 +19,8 @@ Created on Mar 12, 2011
 """
 import copy
 
+import aesara.gradient as tg
 import numpy as np
-import theano.gradient as tg
 
 from fastprogress.fastprogress import ProgressBar, progress_bar
 from numpy import isfinite, nan_to_num
@@ -28,9 +28,9 @@ from scipy.optimize import minimize
 
 import pymc3 as pm
 
+from pymc3.aesaraf import inputvars
 from pymc3.blocking import ArrayOrdering, DictToArrayBijection
 from pymc3.model import Point, modelcontext
-from pymc3.theanof import inputvars
 from pymc3.util import (
     check_start_vals,
     get_default_varnames,

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -22,7 +22,7 @@ import arviz
 import numpy as np
 import xarray
 
-from theano.tensor import TensorVariable
+from aesara.tensor.var import TensorVariable
 
 from pymc3.exceptions import SamplingError
 
@@ -169,7 +169,7 @@ def get_repr_for_variable(variable, formatting="plain"):
 
 def get_var_name(var):
     """Get an appropriate, plain variable name for a variable. Necessary
-    because we override theano.tensor.TensorVariable.__str__ to give informative
+    because we override aesara.tensor.var.TensorVariable.__str__ to give informative
     string representations to our pymc3.PyMC3Variables, yet we want to use the
     plain name as e.g. keys in dicts.
     """

--- a/pymc3/variational/inference.py
+++ b/pymc3/variational/inference.py
@@ -130,7 +130,7 @@ class Inference:
         total_grad_norm_constraint: `float`
             Bounds gradient norm, prevents exploding gradient problem
         fn_kwargs: `dict`
-            Add kwargs to theano.function (e.g. `{'profile': True}`)
+            Add kwargs to aesara.function (e.g. `{'profile': True}`)
         more_replacements: `dict`
             Apply custom replacements before calculating gradients
 
@@ -423,7 +423,7 @@ class ADVI(KLqp):
 
         The tensors to which mini-bathced samples are supplied are
         handled separately by using callbacks in :func:`Inference.fit` method
-        that change storage of shared theano variable or by :func:`pymc3.generator`
+        that change storage of shared aesara variable or by :func:`pymc3.generator`
         that automatically iterates over minibatches and defined beforehand.
 
     -   (optional) Parameters of deterministic mappings
@@ -794,7 +794,7 @@ def fit(
     total_grad_norm_constraint: `float`
         Bounds gradient norm, prevents exploding gradient problem
     fn_kwargs: `dict`
-        Add kwargs to theano.function (e.g. `{'profile': True}`)
+        Add kwargs to aesara.function (e.g. `{'profile': True}`)
     more_replacements: `dict`
         Apply custom replacements before calculating gradients
 

--- a/pymc3/variational/operators.py
+++ b/pymc3/variational/operators.py
@@ -11,9 +11,9 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import theano
+import aesara
 
-from theano import tensor as tt
+from aesara import tensor as aet
 
 import pymc3 as pm
 
@@ -75,7 +75,7 @@ class KSDObjective(ObjectiveFunction):
             raise opvi.ParametrizationError("Op should be KSD")
         ObjectiveFunction.__init__(self, op, tf)
 
-    @theano.config.change_flags(compute_test_value="off")
+    @aesara.config.change_flags(compute_test_value="off")
     def __call__(self, nmc, **kwargs):
         op = self.op  # type: KSD
         grad = op.apply(self.tf)
@@ -88,7 +88,7 @@ class KSDObjective(ObjectiveFunction):
         else:
             params = self.test_params + kwargs["more_tf_params"]
             grad *= pm.floatX(-1)
-        grads = tt.grad(None, params, known_grads={z: grad})
+        grads = aet.grad(None, params, known_grads={z: grad})
         return self.approx.set_size_and_deterministic(
             grads, nmc, 0, kwargs.get("more_replacements")
         )

--- a/pymc3/variational/opvi.py
+++ b/pymc3/variational/opvi.py
@@ -49,17 +49,19 @@ import collections
 import itertools
 import warnings
 
+import aesara
+import aesara.tensor as aet
 import numpy as np
-import theano
-import theano.tensor as tt
+
+from aesara.graph.basic import Variable
 
 import pymc3 as pm
 
+from pymc3.aesaraf import aet_rng, identity
 from pymc3.backends import NDArray
 from pymc3.blocking import ArrayOrdering, DictToArrayBijection, VarMap
 from pymc3.memoize import WithMemoization, memoize
 from pymc3.model import modelcontext
-from pymc3.theanof import identity, tt_rng
 from pymc3.util import get_default_varnames, get_transformed
 from pymc3.variational.updates import adagrad_window
 
@@ -116,7 +118,7 @@ def node_property(f):
         def wrapper(fn):
             return property(
                 memoize(
-                    theano.config.change_flags(compute_test_value="off")(append_name(f)(fn)),
+                    aesara.config.change_flags(compute_test_value="off")(append_name(f)(fn)),
                     bound=True,
                 )
             )
@@ -124,16 +126,16 @@ def node_property(f):
         return wrapper
     else:
         return property(
-            memoize(theano.config.change_flags(compute_test_value="off")(f), bound=True)
+            memoize(aesara.config.change_flags(compute_test_value="off")(f), bound=True)
         )
 
 
-@theano.config.change_flags(compute_test_value="ignore")
+@aesara.config.change_flags(compute_test_value="ignore")
 def try_to_set_test_value(node_in, node_out, s):
     _s = s
     if s is None:
         s = 1
-    s = theano.compile.view_op(tt.as_tensor(s))
+    s = aesara.compile.view_op(aet.as_tensor(s))
     if not isinstance(node_in, (list, tuple)):
         node_in = [node_in]
     if not isinstance(node_out, (list, tuple)):
@@ -150,7 +152,7 @@ def try_to_set_test_value(node_in, node_out, s):
                 o.tag.test_value = tv
 
 
-class ObjectiveUpdates(theano.OrderedUpdates):
+class ObjectiveUpdates(aesara.OrderedUpdates):
     """OrderedUpdates extension for storing loss"""
 
     loss = None
@@ -291,7 +293,7 @@ class ObjectiveFunction:
         if self.op.returns_loss:
             updates.loss = obj_target
 
-    @theano.config.change_flags(compute_test_value="off")
+    @aesara.config.change_flags(compute_test_value="off")
     def step_function(
         self,
         obj_n_mc=None,
@@ -335,13 +337,13 @@ class ObjectiveFunction:
         score: `bool`
             calculate loss on each step? Defaults to False for speed
         fn_kwargs: `dict`
-            Add kwargs to theano.function (e.g. `{'profile': True}`)
+            Add kwargs to aesara.function (e.g. `{'profile': True}`)
         more_replacements: `dict`
             Apply custom replacements before calculating gradients
 
         Returns
         -------
-        `theano.function`
+        `aesara.function`
         """
         if fn_kwargs is None:
             fn_kwargs = {}
@@ -359,12 +361,12 @@ class ObjectiveFunction:
             total_grad_norm_constraint=total_grad_norm_constraint,
         )
         if score:
-            step_fn = theano.function([], updates.loss, updates=updates, **fn_kwargs)
+            step_fn = aesara.function([], updates.loss, updates=updates, **fn_kwargs)
         else:
-            step_fn = theano.function([], None, updates=updates, **fn_kwargs)
+            step_fn = aesara.function([], None, updates=updates, **fn_kwargs)
         return step_fn
 
-    @theano.config.change_flags(compute_test_value="off")
+    @aesara.config.change_flags(compute_test_value="off")
     def score_function(
         self, sc_n_mc=None, more_replacements=None, fn_kwargs=None
     ):  # pragma: no cover
@@ -377,11 +379,11 @@ class ObjectiveFunction:
         more_replacements:
             Apply custom replacements before compiling a function
         fn_kwargs: `dict`
-            arbitrary kwargs passed to `theano.function`
+            arbitrary kwargs passed to `aesara.function`
 
         Returns
         -------
-        theano.function
+        aesara.function
         """
         if fn_kwargs is None:
             fn_kwargs = {}
@@ -390,9 +392,9 @@ class ObjectiveFunction:
         if more_replacements is None:
             more_replacements = {}
         loss = self(sc_n_mc, more_replacements=more_replacements)
-        return theano.function([], loss, **fn_kwargs)
+        return aesara.function([], loss, **fn_kwargs)
 
-    @theano.config.change_flags(compute_test_value="off")
+    @aesara.config.change_flags(compute_test_value="off")
     def __call__(self, nmc, **kwargs):
         if "more_tf_params" in kwargs:
             m = -1.0
@@ -504,7 +506,7 @@ def collect_shared_to_list(params):
         return list(
             t[1]
             for t in sorted(params.items(), key=lambda t: t[0])
-            if isinstance(t[1], theano.compile.SharedVariable)
+            if isinstance(t[1], aesara.compile.SharedVariable)
         )
     elif params is None:
         return []
@@ -842,7 +844,7 @@ class Group(WithMemoization):
         self._vfam = vfam
         self._local = local
         self._batched = rowwise
-        self._rng = tt_rng(random_seed)
+        self._rng = aet_rng(random_seed)
         model = modelcontext(model)
         self.model = model
         self.group = group
@@ -895,7 +897,7 @@ class Group(WithMemoization):
                 shape = (-1,) + shape
             elif self.batched:
                 shape = (self.bdim,) + shape
-            self._user_params[name] = tt.as_tensor(param).reshape(shape)
+            self._user_params[name] = aet.as_tensor(param).reshape(shape)
         return True
 
     def _initial_type(self, name):
@@ -910,9 +912,9 @@ class Group(WithMemoization):
         tensor
         """
         if self.batched:
-            return tt.tensor3(name)
+            return aet.tensor3(name)
         else:
-            return tt.matrix(name)
+            return aet.matrix(name)
 
     def _input_type(self, name):
         R"""*Dev* - input type with given name. The correct type depends on `self.batched`
@@ -926,11 +928,11 @@ class Group(WithMemoization):
         tensor
         """
         if self.batched:
-            return tt.matrix(name)
+            return aet.matrix(name)
         else:
-            return tt.vector(name)
+            return aet.vector(name)
 
-    @theano.config.change_flags(compute_test_value="off")
+    @aesara.config.change_flags(compute_test_value="off")
     def __init_group__(self, group):
         if not group:
             raise GroupError("Got empty group")
@@ -1020,11 +1022,11 @@ class Group(WithMemoization):
         shape vector
         """
         if self.batched:
-            bdim = tt.as_tensor(self.bdim)
-            bdim = theano.clone(bdim, more_replacements)
-            return tt.stack([size, bdim, dim])
+            bdim = aet.as_tensor(self.bdim)
+            bdim = aesara.clone_replace(bdim, more_replacements)
+            return aet.stack([size, bdim, dim])
         else:
-            return tt.stack([size, dim])
+            return aet.stack([size, dim])
 
     @node_property
     def bdim(self):
@@ -1071,22 +1073,22 @@ class Group(WithMemoization):
         """
         if size is None:
             size = 1
-        if not isinstance(deterministic, tt.Variable):
+        if not isinstance(deterministic, Variable):
             deterministic = np.int8(deterministic)
         dim, dist_name, dist_map = (self.ddim, self.initial_dist_name, self.initial_dist_map)
         dtype = self.symbolic_initial.dtype
-        dim = tt.as_tensor(dim)
-        size = tt.as_tensor(size)
+        dim = aet.as_tensor(dim)
+        size = aet.as_tensor(size)
         shape = self._new_initial_shape(size, dim, more_replacements)
         # apply optimizations if possible
-        if not isinstance(deterministic, tt.Variable):
+        if not isinstance(deterministic, Variable):
             if deterministic:
-                return tt.ones(shape, dtype) * dist_map
+                return aet.ones(shape, dtype) * dist_map
             else:
                 return getattr(self._rng, dist_name)(size=shape)
         else:
             sample = getattr(self._rng, dist_name)(size=shape)
-            initial = tt.switch(deterministic, tt.ones(shape, dtype) * dist_map, sample)
+            initial = aet.switch(deterministic, aet.ones(shape, dtype) * dist_map, sample)
             return initial
 
     @node_property
@@ -1111,7 +1113,7 @@ class Group(WithMemoization):
         else:
             return self.symbolic_random
 
-    @theano.config.change_flags(compute_test_value="off")
+    @aesara.config.change_flags(compute_test_value="off")
     def set_size_and_deterministic(self, node, s, d, more_replacements=None):
         """*Dev* - after node is sampled via :func:`symbolic_sample_over_posterior` or
         :func:`symbolic_single_sample` new random generator can be allocated and applied to node
@@ -1119,7 +1121,7 @@ class Group(WithMemoization):
         Parameters
         ----------
         node: :class:`Variable`
-            Theano node with symbolically applied VI replacements
+            Aesara node with symbolically applied VI replacements
         s: scalar
             desired number of samples
         d: bool or int
@@ -1132,13 +1134,13 @@ class Group(WithMemoization):
         :class:`Variable` with applied replacements, ready to use
         """
         flat2rand = self.make_size_and_deterministic_replacements(s, d, more_replacements)
-        node_out = theano.clone(node, flat2rand)
+        node_out = aesara.clone_replace(node, flat2rand)
         try_to_set_test_value(node, node_out, s)
         return node_out
 
     def to_flat_input(self, node):
         """*Dev* - replace vars with flattened view stored in `self.inputs`"""
-        return theano.clone(node, self.replacements)
+        return aesara.clone_replace(node, self.replacements)
 
     def symbolic_sample_over_posterior(self, node):
         """*Dev* - performs sampling of node applying independent samples from posterior each time.
@@ -1146,12 +1148,12 @@ class Group(WithMemoization):
         """
         node = self.to_flat_input(node)
         random = self.symbolic_random.astype(self.symbolic_initial.dtype)
-        random = tt.patternbroadcast(random, self.symbolic_initial.broadcastable)
+        random = aet.patternbroadcast(random, self.symbolic_initial.broadcastable)
 
         def sample(post):
-            return theano.clone(node, {self.input: post})
+            return aesara.clone_replace(node, {self.input: post})
 
-        nodes, _ = theano.scan(sample, random)
+        nodes, _ = aesara.scan(sample, random)
         return nodes
 
     def symbolic_single_sample(self, node):
@@ -1161,8 +1163,8 @@ class Group(WithMemoization):
         """
         node = self.to_flat_input(node)
         random = self.symbolic_random.astype(self.symbolic_initial.dtype)
-        random = tt.patternbroadcast(random, self.symbolic_initial.broadcastable)
-        return theano.clone(node, {self.input: random[0]})
+        random = aet.patternbroadcast(random, self.symbolic_initial.broadcastable)
+        return aesara.clone_replace(node, {self.input: random[0]})
 
     def make_size_and_deterministic_replacements(self, s, d, more_replacements=None):
         """*Dev* - creates correct replacements for initial depending on
@@ -1182,15 +1184,15 @@ class Group(WithMemoization):
         dict with replacements for initial
         """
         initial = self._new_initial(s, d, more_replacements)
-        initial = tt.patternbroadcast(initial, self.symbolic_initial.broadcastable)
+        initial = aet.patternbroadcast(initial, self.symbolic_initial.broadcastable)
         if more_replacements:
-            initial = theano.clone(initial, more_replacements)
+            initial = aesara.clone_replace(initial, more_replacements)
         return {self.symbolic_initial: initial}
 
     @node_property
     def symbolic_normalizing_constant(self):
         """*Dev* - normalizing constant for `self.logq`, scales it to `minibatch_size` instead of `total_size`"""
-        t = self.to_flat_input(tt.max([v.scaling for v in self.group]))
+        t = self.to_flat_input(aet.max([v.scaling for v in self.group]))
         t = self.symbolic_single_sample(t)
         return pm.floatX(t)
 
@@ -1282,7 +1284,7 @@ class Approximation(WithMemoization):
     """
 
     def __init__(self, groups, model=None):
-        self._scale_cost_to_minibatch = theano.shared(np.int8(1))
+        self._scale_cost_to_minibatch = aesara.shared(np.int8(1))
         model = modelcontext(model)
         if not model.free_RVs:
             raise TypeError("Model does not have FreeRVs")
@@ -1341,22 +1343,22 @@ class Approximation(WithMemoization):
         """*Dev* - normalizing constant for `self.logq`, scales it to `minibatch_size` instead of `total_size`.
         Here the effect is controlled by `self.scale_cost_to_minibatch`
         """
-        t = tt.max(
+        t = aet.max(
             self.collect("symbolic_normalizing_constant")
             + [var.scaling for var in self.model.observed_RVs]
         )
-        t = tt.switch(self._scale_cost_to_minibatch, t, tt.constant(1, dtype=t.dtype))
+        t = aet.switch(self._scale_cost_to_minibatch, t, aet.constant(1, dtype=t.dtype))
         return pm.floatX(t)
 
     @node_property
     def symbolic_logq(self):
         """*Dev* - collects `symbolic_logq` for all groups"""
-        return tt.add(*self.collect("symbolic_logq"))
+        return aet.add(*self.collect("symbolic_logq"))
 
     @node_property
     def logq(self):
         """*Dev* - collects `logQ` for all groups"""
-        return tt.add(*self.collect("logq"))
+        return aet.add(*self.collect("logq"))
 
     @node_property
     def logq_norm(self):
@@ -1365,7 +1367,7 @@ class Approximation(WithMemoization):
 
     @node_property
     def _sized_symbolic_varlogp_and_datalogp(self):
-        """*Dev* - computes sampled prior term from model via `theano.scan`"""
+        """*Dev* - computes sampled prior term from model via `aesara.scan`"""
         varlogp_s, datalogp_s = self.symbolic_sample_over_posterior(
             [self.model.varlogpt, self.model.datalogpt]
         )
@@ -1373,55 +1375,55 @@ class Approximation(WithMemoization):
 
     @node_property
     def sized_symbolic_varlogp(self):
-        """*Dev* - computes sampled prior term from model via `theano.scan`"""
+        """*Dev* - computes sampled prior term from model via `aesara.scan`"""
         return self._sized_symbolic_varlogp_and_datalogp[0]  # shape (s,)
 
     @node_property
     def sized_symbolic_datalogp(self):
-        """*Dev* - computes sampled data term from model via `theano.scan`"""
+        """*Dev* - computes sampled data term from model via `aesara.scan`"""
         return self._sized_symbolic_varlogp_and_datalogp[1]  # shape (s,)
 
     @node_property
     def sized_symbolic_logp(self):
-        """*Dev* - computes sampled logP from model via `theano.scan`"""
+        """*Dev* - computes sampled logP from model via `aesara.scan`"""
         return self.sized_symbolic_varlogp + self.sized_symbolic_datalogp  # shape (s,)
 
     @node_property
     def logp(self):
-        """*Dev* - computes :math:`E_{q}(logP)` from model via `theano.scan` that can be optimized later"""
+        """*Dev* - computes :math:`E_{q}(logP)` from model via `aesara.scan` that can be optimized later"""
         return self.varlogp + self.datalogp
 
     @node_property
     def varlogp(self):
-        """*Dev* - computes :math:`E_{q}(prior term)` from model via `theano.scan` that can be optimized later"""
+        """*Dev* - computes :math:`E_{q}(prior term)` from model via `aesara.scan` that can be optimized later"""
         return self.sized_symbolic_varlogp.mean(0)
 
     @node_property
     def datalogp(self):
-        """*Dev* - computes :math:`E_{q}(data term)` from model via `theano.scan` that can be optimized later"""
+        """*Dev* - computes :math:`E_{q}(data term)` from model via `aesara.scan` that can be optimized later"""
         return self.sized_symbolic_datalogp.mean(0)
 
     @node_property
     def _single_symbolic_varlogp_and_datalogp(self):
-        """*Dev* - computes sampled prior term from model via `theano.scan`"""
+        """*Dev* - computes sampled prior term from model via `aesara.scan`"""
         varlogp, datalogp = self.symbolic_single_sample([self.model.varlogpt, self.model.datalogpt])
         return varlogp, datalogp
 
     @node_property
     def single_symbolic_varlogp(self):
-        """*Dev* - for single MC sample estimate of :math:`E_{q}(prior term)` `theano.scan`
+        """*Dev* - for single MC sample estimate of :math:`E_{q}(prior term)` `aesara.scan`
         is not needed and code can be optimized"""
         return self._single_symbolic_varlogp_and_datalogp[0]
 
     @node_property
     def single_symbolic_datalogp(self):
-        """*Dev* - for single MC sample estimate of :math:`E_{q}(data term)` `theano.scan`
+        """*Dev* - for single MC sample estimate of :math:`E_{q}(data term)` `aesara.scan`
         is not needed and code can be optimized"""
         return self._single_symbolic_varlogp_and_datalogp[1]
 
     @node_property
     def single_symbolic_logp(self):
-        """*Dev* - for single MC sample estimate of :math:`E_{q}(logP)` `theano.scan`
+        """*Dev* - for single MC sample estimate of :math:`E_{q}(logP)` `aesara.scan`
         is not needed and code can be optimized"""
         return self.single_symbolic_datalogp + self.single_symbolic_varlogp
 
@@ -1472,7 +1474,7 @@ class Approximation(WithMemoization):
         flat2rand.update(more_replacements)
         return flat2rand
 
-    @theano.config.change_flags(compute_test_value="off")
+    @aesara.config.change_flags(compute_test_value="off")
     def set_size_and_deterministic(self, node, s, d, more_replacements=None):
         """*Dev* - after node is sampled via :func:`symbolic_sample_over_posterior` or
         :func:`symbolic_single_sample` new random generator can be allocated and applied to node
@@ -1480,7 +1482,7 @@ class Approximation(WithMemoization):
         Parameters
         ----------
         node: :class:`Variable`
-            Theano node with symbolically applied VI replacements
+            Aesara node with symbolically applied VI replacements
         s: scalar
             desired number of samples
         d: bool or int
@@ -1495,14 +1497,14 @@ class Approximation(WithMemoization):
         _node = node
         optimizations = self.get_optimization_replacements(s, d)
         flat2rand = self.make_size_and_deterministic_replacements(s, d, more_replacements)
-        node = theano.clone(node, optimizations)
-        node = theano.clone(node, flat2rand)
+        node = aesara.clone_replace(node, optimizations)
+        node = aesara.clone_replace(node, flat2rand)
         try_to_set_test_value(_node, node, s)
         return node
 
     def to_flat_input(self, node):
         """*Dev* - replace vars with flattened view stored in `self.inputs`"""
-        return theano.clone(node, self.replacements)
+        return aesara.clone_replace(node, self.replacements)
 
     def symbolic_sample_over_posterior(self, node):
         """*Dev* - performs sampling of node applying independent samples from posterior each time.
@@ -1511,9 +1513,9 @@ class Approximation(WithMemoization):
         node = self.to_flat_input(node)
 
         def sample(*post):
-            return theano.clone(node, dict(zip(self.inputs, post)))
+            return aesara.clone_replace(node, dict(zip(self.inputs, post)))
 
-        nodes, _ = theano.scan(sample, self.symbolic_randoms)
+        nodes, _ = aesara.scan(sample, self.symbolic_randoms)
         return nodes
 
     def symbolic_single_sample(self, node):
@@ -1524,11 +1526,11 @@ class Approximation(WithMemoization):
         node = self.to_flat_input(node)
         post = [v[0] for v in self.symbolic_randoms]
         inp = self.inputs
-        return theano.clone(node, dict(zip(inp, post)))
+        return aesara.clone_replace(node, dict(zip(inp, post)))
 
     def get_optimization_replacements(self, s, d):
         """*Dev* - optimizations for logP. If sample size is static and equal to 1:
-        then `theano.scan` MC estimate is replaced with single sample without call to `theano.scan`.
+        then `aesara.scan` MC estimate is replaced with single sample without call to `aesara.scan`.
         """
         repl = collections.OrderedDict()
         # avoid scan if size is constant and equal to one
@@ -1537,13 +1539,13 @@ class Approximation(WithMemoization):
             repl[self.datalogp] = self.single_symbolic_datalogp
         return repl
 
-    @theano.config.change_flags(compute_test_value="off")
+    @aesara.config.change_flags(compute_test_value="off")
     def sample_node(self, node, size=None, deterministic=False, more_replacements=None):
         """Samples given node or nodes over shared posterior
 
         Parameters
         ----------
-        node: Theano Variables (or Theano expressions)
+        node: Aesara Variables (or Aesara expressions)
         size: None or scalar
             number of samples
         more_replacements: `dict`
@@ -1557,7 +1559,7 @@ class Approximation(WithMemoization):
         sampled node(s) with replacements
         """
         node_in = node
-        node = theano.clone(node, more_replacements)
+        node = aesara.clone_replace(node, more_replacements)
         if size is None:
             node_out = self.symbolic_single_sample(node)
         else:
@@ -1567,7 +1569,7 @@ class Approximation(WithMemoization):
         return node_out
 
     def rslice(self, name):
-        """*Dev* - vectorized sampling for named random variable without call to `theano.scan`.
+        """*Dev* - vectorized sampling for named random variable without call to `aesara.scan`.
         This node still needs :func:`set_size_and_deterministic` to be evaluated
         """
 
@@ -1588,13 +1590,13 @@ class Approximation(WithMemoization):
 
     @property
     @memoize(bound=True)
-    @theano.config.change_flags(compute_test_value="off")
+    @aesara.config.change_flags(compute_test_value="off")
     def sample_dict_fn(self):
-        s = tt.iscalar()
+        s = aet.iscalar()
         names = [v.name for v in self.model.free_RVs]
         sampled = [self.rslice(name) for name in names]
         sampled = self.set_size_and_deterministic(sampled, s, 0)
-        sample_fn = theano.function([s], sampled)
+        sample_fn = aesara.function([s], sampled)
 
         def inner(draws=100):
             _samples = sample_fn(draws)
@@ -1658,7 +1660,7 @@ class Approximation(WithMemoization):
 
     @node_property
     def symbolic_random(self):
-        return tt.concatenate(self.collect("symbolic_random2d"), axis=-1)
+        return aet.concatenate(self.collect("symbolic_random2d"), axis=-1)
 
     def __str__(self):
         if len(self.groups) < 5:
@@ -1679,7 +1681,7 @@ class Approximation(WithMemoization):
     def joint_histogram(self):
         if not self.all_histograms:
             raise VariationalInferenceError("%s does not consist of all Empirical approximations")
-        return tt.concatenate(self.collect("histogram"), axis=-1)
+        return aet.concatenate(self.collect("histogram"), axis=-1)
 
     @property
     def params(self):

--- a/pymc3/variational/stein.py
+++ b/pymc3/variational/stein.py
@@ -12,11 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import theano
-import theano.tensor as tt
+import aesara
+import aesara.tensor as aet
 
+from pymc3.aesaraf import floatX
 from pymc3.memoize import WithMemoization, memoize
-from pymc3.theanof import floatX
 from pymc3.variational.opvi import node_property
 from pymc3.variational.test_functions import rbf
 
@@ -46,12 +46,12 @@ class Stein(WithMemoization):
 
     @node_property
     def dlogp(self):
-        grad = tt.grad(self.logp_norm.sum(), self.approx_symbolic_matrices)
+        grad = aet.grad(self.logp_norm.sum(), self.approx_symbolic_matrices)
 
         def flatten2(tensor):
             return tensor.flatten(2)
 
-        return tt.concatenate(list(map(flatten2, grad)), -1)
+        return aet.concatenate(list(map(flatten2, grad)), -1)
 
     @node_property
     def grad(self):
@@ -64,7 +64,7 @@ class Stein(WithMemoization):
     def density_part_grad(self):
         Kxy = self.Kxy
         dlogpdx = self.dlogp
-        return tt.dot(Kxy, dlogpdx)
+        return aet.dot(Kxy, dlogpdx)
 
     @node_property
     def repulsive_part_grad(self):
@@ -84,13 +84,13 @@ class Stein(WithMemoization):
     def logp_norm(self):
         sized_symbolic_logp = self.approx.sized_symbolic_logp
         if self.use_histogram:
-            sized_symbolic_logp = theano.clone(
+            sized_symbolic_logp = aesara.clone_replace(
                 sized_symbolic_logp,
                 dict(zip(self.approx.symbolic_randoms, self.approx.collect("histogram"))),
             )
         return sized_symbolic_logp / self.approx.symbolic_normalizing_constant
 
     @memoize
-    @theano.config.change_flags(compute_test_value="off")
+    @aesara.config.change_flags(compute_test_value="off")
     def _kernel(self):
         return self._kernel_f(self.input_joint_matrix)

--- a/pymc3/variational/test_functions.py
+++ b/pymc3/variational/test_functions.py
@@ -12,9 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from theano import tensor as tt
+from aesara import tensor as aet
 
-from pymc3.theanof import floatX
+from pymc3.aesaraf import floatX
 from pymc3.variational.opvi import TestFunction
 
 __all__ = ["rbf"]
@@ -34,30 +34,30 @@ class Kernel(TestFunction):
 class RBF(Kernel):
     def __call__(self, X):
         XY = X.dot(X.T)
-        x2 = tt.sum(X ** 2, axis=1).dimshuffle(0, "x")
-        X2e = tt.repeat(x2, X.shape[0], axis=1)
+        x2 = aet.sum(X ** 2, axis=1).dimshuffle(0, "x")
+        X2e = aet.repeat(x2, X.shape[0], axis=1)
         H = X2e + X2e.T - 2.0 * XY
 
-        V = tt.sort(H.flatten())
+        V = aet.sort(H.flatten())
         length = V.shape[0]
         # median distance
-        m = tt.switch(
-            tt.eq((length % 2), 0),
+        m = aet.switch(
+            aet.eq((length % 2), 0),
             # if even vector
-            tt.mean(V[((length // 2) - 1) : ((length // 2) + 1)]),
+            aet.mean(V[((length // 2) - 1) : ((length // 2) + 1)]),
             # if odd vector
             V[length // 2],
         )
 
-        h = 0.5 * m / tt.log(floatX(H.shape[0]) + floatX(1))
+        h = 0.5 * m / aet.log(floatX(H.shape[0]) + floatX(1))
 
         #  RBF
-        Kxy = tt.exp(-H / h / 2.0)
+        Kxy = aet.exp(-H / h / 2.0)
 
         # Derivative
-        dxkxy = -tt.dot(Kxy, X)
-        sumkxy = tt.sum(Kxy, axis=-1, keepdims=True)
-        dxkxy = tt.add(dxkxy, tt.mul(X, sumkxy)) / h
+        dxkxy = -aet.dot(Kxy, X)
+        sumkxy = aet.sum(Kxy, axis=-1, keepdims=True)
+        dxkxy = aet.add(dxkxy, aet.mul(X, sumkxy)) / h
 
         return Kxy, dxkxy
 

--- a/pymc3/vartypes.py
+++ b/pymc3/vartypes.py
@@ -12,9 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from theano.graph.basic import Constant as graph_constant
-from theano.tensor import Constant as tensor_constant
-
 __all__ = [
     "bool_types",
     "int_types",
@@ -24,7 +21,6 @@ __all__ = [
     "discrete_types",
     "typefilter",
     "isgenerator",
-    "theano_constant",
 ]
 
 bool_types = {"int8"}
@@ -45,6 +41,3 @@ def typefilter(vars, types):
 
 def isgenerator(obj):
     return hasattr(obj, "__next__")
-
-
-theano_constant = (tensor_constant, graph_constant)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-arviz>=0.11.0
+aesara>=2.0.1
+arviz>=0.11.1
 dill
 fastprogress>=0.2.0
 numpy>=1.15.0
 pandas>=0.24.0
 patsy>=0.5.1
 scipy>=1.2.0
-theano-pymc==1.1.2
 typing-extensions>=3.7.4

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,4 +3,4 @@
 set -e
 
 _FLOATX=${FLOATX:=float64}
-THEANO_FLAGS="floatX=${_FLOATX},gcc__cxxflags='-march=core2'" pytest -v --cov=pymc3 --cov-report=xml "$@" --cov-report term
+AESARA_FLAGS="floatX=${_FLOATX},gcc__cxxflags='-march=core2'" pytest -v --cov=pymc3 --cov-report=xml "$@" --cov-report term

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from os.path import dirname, join, realpath
 from setuptools import find_packages, setup
 
 DISTNAME = "pymc3"
-DESCRIPTION = "Probabilistic Programming in Python: Bayesian Modeling and Probabilistic Machine Learning with Theano"
+DESCRIPTION = "Probabilistic Programming in Python: Bayesian Modeling and Probabilistic Machine Learning with Aesara"
 AUTHOR = "PyMC Developers"
 AUTHOR_EMAIL = "pymc.devs@gmail.com"
 URL = "http://github.com/pymc-devs/pymc3"


### PR DESCRIPTION
This PR renames Theano to Aesara, changes the Theano-PyMC dependency to Aesara, etc.  Included in the rename is a rename of the `theanof` module to `aesaraf`.

~This most likely won't pass until the `conda-forge` rename (https://github.com/conda-forge/staged-recipes/pull/13825) and Arviz changes (https://github.com/arviz-devs/arviz/pull/1553) next release for Arviz is cut.~