### PR TITLE
Fast docs build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docs/source/pymc-examples"]
 	path = docs/source/pymc-examples
-	url = https://github.com/pymc-devs/pymc-examples.git
-        branch = main
+	url = https://github.com/Pyrsos/pymc-examples
+        branch = fast-docs-build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docs/source/pymc-examples"]
 	path = docs/source/pymc-examples
-	url = https://github.com/Pyrsos/pymc-examples
+	url = https://github.com/pymc-devs/pymc-examples.git
         branch = fast-docs-build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docs/source/pymc-examples"]
 	path = docs/source/pymc-examples
 	url = https://github.com/pymc-devs/pymc-examples.git
-        branch = fast-docs-build
+        branch = main

--- a/fast_build_and_deploy_docs.sh
+++ b/fast_build_and_deploy_docs.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+latesttag=$(git describe --tags `git rev-list --tags --max-count=1`)
+echo checking out ${latesttag}
+git checkout ${latesttag}
+git submodule update --remote
+pushd docs/source
+git checkout
+make html
+ghp-import -c docs.pymc.io -n -p _build/html/
+popd
+cd docs/source/pymc-examples
+echo checking out pymc-examples fast build branch
+git checkout fast-docs-build


### PR DESCRIPTION
This PR addresses the issue raised in #4435 with regards to building pymc3 faster. To this end a new branch was created in the pymc-examples submodules excluding all Python notebooks. I have tested this on my system and it brings the total build time from ~7 minutes to ~1 minute.  The `pymc-examples` PR (https://github.com/pymc-devs/pymc-examples/pull/36) needs to be completed first, since the .gitmodules file needs to point to a different branch.

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
Both the pymc3 and pymc-example PRs are not to be merged on the main/master branch, so there are not any breaking changes
+ [ ] important background, or details about the implementation
+ [ ] are the changes—especially new features—covered by tests and docstrings?
Not applicable
+ [ ] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
No core code changes, so not applicable
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
These have been update, ie removed in this case to allow faster build.
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
