### PR TITLE
Keep broadcasting information in make_shared_replacements

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,8 @@
 ### Maintenance
 - The `pymc3.memoize` module was removed and replaced with `cachetools`.  The `hashable` function and `WithMemoization` class were moved to `pymc3.util` (see [#4509](https://github.com/pymc-devs/pymc3/pull/4509)).
 - Remove float128 dtype support (see [#4514](https://github.com/pymc-devs/pymc3/pull/4514)).
+- `pm.make_shared_replacements` now retains broadcasting information which fixes issues with Metropolis samplers (see [#4492](https://github.com/pymc-devs/pymc3/pull/4492)).
++ ...
 
 ## PyMC3 3.11.1 (12 February 2021)
 

--- a/pymc3/aesaraf.py
+++ b/pymc3/aesaraf.py
@@ -238,7 +238,12 @@ def make_shared_replacements(vars, model):
     Dict of variable -> new shared variable
     """
     othervars = set(model.vars) - set(vars)
-    return {var: aesara.shared(var.tag.test_value, var.name + "_shared") for var in othervars}
+    return {
+        var: aesara.shared(
+            var.tag.test_value, var.name + "_shared", broadcastable=var.broadcastable
+        )
+        for var in othervars
+    }
 
 
 def join_nonshared_inputs(xs, vars, shared, make_shared=False):


### PR DESCRIPTION
It seems like broadcasting information gets lost when applying
`pm.make_shared_replacements`, leading to problems with the metropolis
sampler. Potentially related issues below:
 - https://github.com/pymc-devs/pymc3/issues/1083
 - https://github.com/pymc-devs/pymc3/issues/1304
 - https://github.com/pymc-devs/pymc3/issues/1983

This fix was previously suggested in the following issue:
 - https://github.com/pymc-devs/pymc3/issues/3337

It could be that further adaptations are necessary as indicated in the
issue. Strangely, this does not seem to lead to problems when using
NUTS.

This fixes issue #4491 and #3337


TODOs:
- [X] are the changes—especially new features—covered by tests and docstrings? (should add test)
- [X] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
- [X] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
