### PR TITLE
proper handling of chain_idx in sample()

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1452,9 +1452,9 @@ def _mp_sample(
         # dict does not contain all parameters
         update_start_vals(start[idx - chain], model.test_point, model)
         if step.generates_stats and strace.supports_sampler_stats:
-            strace.setup(draws + tune, idx + chain, step.stats_dtypes)
+            strace.setup(draws + tune, idx, step.stats_dtypes)
         else:
-            strace.setup(draws + tune, idx + chain)
+            strace.setup(draws + tune, idx)
         traces.append(strace)
 
     sampler = ps.ParallelSampler(

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1715,6 +1715,10 @@ def sample_posterior_predictive(
 
     ppc_trace_t = _DefaultTrace(samples)
     try:
+        if hasattr(_trace, "_straces"):
+            # trace dict is unordered, but we want to return ppc samples in
+            # a predictable ordering, so sort the chain indices
+            chain_idx_mapping = sorted(_trace._straces.keys())
         for idx in indices:
             if nchain > 1:
                 # the trace object will either be a MultiTrace (and have _straces)...
@@ -1722,7 +1726,7 @@ def sample_posterior_predictive(
                     chain_idx, point_idx = np.divmod(idx, len_trace)
                     chain_idx = chain_idx % nchain
                     # chain indices might not always start at 0, convert to proper index
-                    chain_idx = list(_trace._straces.keys())[chain_idx]
+                    chain_idx = chain_idx_mapping[chain_idx]
                     param = cast(MultiTrace, _trace)._straces[chain_idx].point(point_idx)
                 # ... or a PointList
                 else:

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -1720,7 +1720,10 @@ def sample_posterior_predictive(
                 # the trace object will either be a MultiTrace (and have _straces)...
                 if hasattr(_trace, "_straces"):
                     chain_idx, point_idx = np.divmod(idx, len_trace)
-                    param = cast(MultiTrace, _trace)._straces[chain_idx % nchain].point(point_idx)
+                    chain_idx = chain_idx % nchain
+                    # chain indices might not always start at 0, convert to proper index
+                    chain_idx = list(_trace._straces.keys())[chain_idx]
+                    param = cast(MultiTrace, _trace)._straces[chain_idx].point(point_idx)
                 # ... or a PointList
                 else:
                     param = cast(PointList, _trace)[idx % (len_trace * nchain)]

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -599,7 +599,7 @@ def sample(
     # count the number of tune/draw iterations that happened
     # ideally via the "tune" statistic, but not all samplers record it!
     if "tune" in trace.stat_names:
-        stat = trace.get_sampler_stats("tune", chains=0)
+        stat = trace.get_sampler_stats("tune", chains=chain_idx)
         # when CompoundStep is used, the stat is 2 dimensional!
         if len(stat.shape) == 2:
             stat = stat[:, 0]

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -332,6 +332,9 @@ def test_chain_idx():
         # before
         trace = pm.sample(draws=150, tune=10, chain_idx=1)
 
+        ppc = pm.sample_posterior_predictive(trace)
+        ppc = pm.sample_posterior_predictive(trace, keep_size=True)
+
 
 @pytest.mark.parametrize(
     "n_points, tune, expected_length, expected_n_traces",

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -321,6 +321,7 @@ def test_partial_trace_sample():
         trace = pm.sample(trace=[a])
 
 
+@pytest.mark.xfail
 def test_chain_idx():
     # see https://github.com/pymc-devs/pymc3/issues/4469
     with pm.Model():

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -321,6 +321,17 @@ def test_partial_trace_sample():
         trace = pm.sample(trace=[a])
 
 
+def test_chain_idx():
+    # see https://github.com/pymc-devs/pymc3/issues/4469
+    with pm.Model():
+        mu = pm.Normal("mu")
+        x = pm.Normal("x", mu=mu, sigma=1, observed=np.asarray(3))
+        # note draws-tune must be >100 AND we need an observed RV for this to properly
+        # trigger convergence checks, which is one particular case in which this failed
+        # before
+        trace = pm.sample(draws=150, tune=10, chain_idx=1)
+
+
 @pytest.mark.parametrize(
     "n_points, tune, expected_length, expected_n_traces",
     [


### PR DESCRIPTION
This will fix #4469, in conjunction with https://github.com/arviz-devs/arviz/pull/1590 on Arviz.

This particular PR ensures proper handling of `chain_idx`. It also adds a new test, which is now still expected to fail (marked as `xfail`), pending the merge of the Arviz PR.