### PR TITLE
Break down tests having multiple checks and xfail decorated

### DIFF
--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -899,7 +899,6 @@ class TestMatchesScipy:
         )
 
     @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
-    # this test doesn't always result in the same outcome (pass/not pass)
     def test_normal_logcdf(self):
         self.check_logcdf(
             Normal,
@@ -1250,7 +1249,6 @@ class TestMatchesScipy:
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to numerical issues",
     )
-    # this test doesn't always result in the same outcome fail/success
     def test_gamma_logcdf(self):
         # pymc-devs/aesara#224: skip_paramdomain_outside_edge_test has to be set
         # True to avoid triggering a C-level assertion in the Aesara GammaQ function
@@ -1337,7 +1335,6 @@ class TestMatchesScipy:
         reason="Fails on float32 due to inf issues",
     )
     def test_weibull_logcdf(self):
-        # this test result is non-deterministic
         self.check_logcdf(
             Weibull,
             Rplus,
@@ -1527,7 +1524,6 @@ class TestMatchesScipy:
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to inf issues",
     )
-    # this test doesn't always result in the same outcome (pass/not pass)
     def test_zeroinflatednegativebinomial_distribution(self):
         self.checkd(
             ZeroInflatedNegativeBinomial,

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1383,7 +1383,7 @@ class TestMatchesScipy:
 
     # Too lazy to propagate decimal parameter through the whole chain of deps
     @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(SCIPY_VERSION < parse("1.4.0")), reason="betabinom is new in Scipy 1.4.0"
     )
     def test_beta_binomial_logcdf(self):
@@ -1410,7 +1410,7 @@ class TestMatchesScipy:
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
         )
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(SCIPY_VERSION < parse("1.4.0")), reason="betabinom is new in Scipy 1.4.0"
     )
     def test_beta_binomial_logp(self):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1397,11 +1397,14 @@ class TestMatchesScipy:
             lambda value, alpha, beta, n: sp.betabinom.logcdf(value, a=alpha, b=beta, n=n),
         )
 
-    @pytest.mark.xfail(
-        condition=(SCIPY_VERSION < parse("1.4.0")), reason="betabinom is new in Scipy 1.4.0"
-    )
     def test_beta_binomial(self):
         self.checkd(
+            BetaBinomial,
+            Nat,
+            {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
+        )
+
+        self.check_selfconsistency_discrete_logcdf(
             BetaBinomial,
             Nat,
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
@@ -1416,13 +1419,6 @@ class TestMatchesScipy:
             Nat,
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
             lambda value, alpha, beta, n: sp.betabinom.logpmf(value, a=alpha, b=beta, n=n),
-        )
-
-    def test_beta_binomial_discrete_logcdf(self):
-        self.check_selfconsistency_discrete_logcdf(
-            BetaBinomial,
-            Nat,
-            {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
         )
 
     def test_bernoulli(self):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1246,6 +1246,7 @@ class TestMatchesScipy:
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to numerical issues",
     )
+    # this test doesn't always result in the same outcome fail/success
     def test_gamma_logcdf(self):
         # pymc-devs/aesara#224: skip_paramdomain_outside_edge_test has to be set
         # True to avoid triggering a C-level assertion in the Aesara GammaQ function
@@ -1541,13 +1542,14 @@ class TestMatchesScipy:
         )
 
     # Too lazy to propagate decimal parameter through the whole chain of deps
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
-    def test_zeroinflatedbinomial(self):
+    def test_zeroinflatedbinomial_distribution(self):
         self.checkd(
             ZeroInflatedBinomial,
             Nat,
             {"n": NatSmall, "p": Unit, "psi": Unit},
         )
+
+    def test_zeroinflatedbinomial_logcdf(self):
         self.check_selfconsistency_discrete_logcdf(
             ZeroInflatedBinomial,
             Nat,

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1376,6 +1376,7 @@ class TestMatchesScipy:
             Binomial,
             Nat,
             {"n": NatSmall, "p": Unit},
+            n_samples=10,
         )
 
     # Too lazy to propagate decimal parameter through the whole chain of deps

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1408,6 +1408,7 @@ class TestMatchesScipy:
             BetaBinomial,
             Nat,
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
+            n_samples=-1,
         )
 
     @pytest.mark.skipif(

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -898,13 +898,15 @@ class TestMatchesScipy:
             decimal=select_by_precision(float64=6, float32=1),
         )
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+    # @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_normal_logcdf(self):
         self.check_logcdf(
             Normal,
             R,
             {"mu": R, "sigma": Rplus},
             lambda value, mu, sigma: sp.norm.logcdf(value, mu, sigma),
+            decimal=select_by_precision(float64=6, float32=2),
+            n_samples=-1,
         )
 
     def test_truncated_normal(self):
@@ -2314,22 +2316,26 @@ class TestMatchesScipy:
             lambda value, b, sigma: sp.rice.logpdf(value, b=b, loc=0, scale=sigma),
         )
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+    # @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_moyal_logp(self):
+        value_domain = Domain([-inf, -1.5, -1, -0.01, 0.0, 0.01, 1, 1.5, inf])
         self.check_logp(
             Moyal,
-            R,
+            value_domain,
             {"mu": R, "sigma": Rplusbig},
             lambda value, mu, sigma: floatX(sp.moyal.logpdf(value, mu, sigma)),
+            n_samples=-1,
         )
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+    # @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_moyal_logcdf(self):
+        value_domain = Domain([-inf, -1.5, -1, -0.01, 0.0, 0.01, 1, 1.5, inf])
         self.check_logcdf(
             Moyal,
-            R,
+            value_domain,
             {"mu": R, "sigma": Rplusbig},
             lambda value, mu, sigma: floatX(sp.moyal.logcdf(value, mu, sigma)),
+            n_samples=-1,
         )
 
     @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -889,7 +889,7 @@ class TestMatchesScipy:
         assert 0.0 == HalfFlat.dist().logcdf(np.inf).tag.test_value
         assert -np.inf == HalfFlat.dist().logcdf(-np.inf).tag.test_value
 
-    def test_normal(self):
+    def test_normal_logp(self):
         self.check_logp(
             Normal,
             R,
@@ -897,6 +897,10 @@ class TestMatchesScipy:
             lambda value, mu, sigma: sp.norm.logpdf(value, mu, sigma),
             decimal=select_by_precision(float64=6, float32=1),
         )
+
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+    # this test doesn't always result in the same outcome (pass/not pass)
+    def test_normal_logcdf(self):
         self.check_logcdf(
             Normal,
             R,

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1378,7 +1378,6 @@ class TestMatchesScipy:
             Binomial,
             Nat,
             {"n": NatSmall, "p": Unit},
-            n_samples=-1,
         )
 
     # Too lazy to propagate decimal parameter through the whole chain of deps
@@ -1400,7 +1399,6 @@ class TestMatchesScipy:
             BetaBinomial,
             Nat,
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
-            checks=(lambda *args: self.check_int_to_1(*args, n_samples=-1),),
         )
 
     def test_beta_binomial_selfconsistency(self):
@@ -1408,7 +1406,6 @@ class TestMatchesScipy:
             BetaBinomial,
             Nat,
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
-            n_samples=-1,
         )
 
     @pytest.mark.skipif(
@@ -1546,7 +1543,6 @@ class TestMatchesScipy:
             ZeroInflatedBinomial,
             Nat,
             {"n": NatSmall, "p": Unit, "psi": Unit},
-            checks=(lambda *args: self.check_int_to_1(*args, n_samples=-1),),
         )
 
     def test_zeroinflatedbinomial_logcdf(self):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -896,6 +896,7 @@ class TestMatchesScipy:
             {"mu": R, "sigma": Rplus},
             lambda value, mu, sigma: sp.norm.logpdf(value, mu, sigma),
             decimal=select_by_precision(float64=6, float32=1),
+            n_samples=-1,
         )
 
     @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
@@ -906,6 +907,7 @@ class TestMatchesScipy:
             R,
             {"mu": R, "sigma": Rplus},
             lambda value, mu, sigma: sp.norm.logcdf(value, mu, sigma),
+            n_samples=-1,
         )
 
     def test_truncated_normal(self):
@@ -952,6 +954,7 @@ class TestMatchesScipy:
             {"mu": Rplus, "alpha": Rplus},
             lambda value, mu, alpha: sp.invgauss.logpdf(value, mu=mu, loc=alpha),
             decimal=select_by_precision(float64=6, float32=1),
+            n_samples=-1,
         )
 
     @pytest.mark.xfail(
@@ -964,6 +967,7 @@ class TestMatchesScipy:
             Rplus,
             {"mu": Rplus, "alpha": Rplus},
             lambda value, mu, alpha: sp.invgauss.logcdf(value, mu=mu, loc=alpha),
+            n_samples=-1,
         )
 
     @pytest.mark.parametrize(
@@ -1261,6 +1265,7 @@ class TestMatchesScipy:
             {"alpha": Rplusbig, "beta": Rplusbig},
             lambda value, alpha, beta: sp.gamma.logcdf(value, alpha, scale=1.0 / beta),
             skip_paramdomain_outside_edge_test=True,
+            n_samples=-1,
         )
 
     def test_inverse_gamma_logp(self):
@@ -1269,6 +1274,7 @@ class TestMatchesScipy:
             Rplus,
             {"alpha": Rplus, "beta": Rplus},
             lambda value, alpha, beta: sp.invgamma.logpdf(value, alpha, scale=beta),
+            n_samples=-1,
         )
         # pymc-devs/aesara#224: skip_paramdomain_outside_edge_test has to be set
         # True to avoid triggering a C-level assertion in the Aesara GammaQ function
@@ -1287,6 +1293,7 @@ class TestMatchesScipy:
             {"alpha": Rplus, "beta": Rplus},
             lambda value, alpha, beta: sp.invgamma.logcdf(value, alpha, scale=beta),
             skip_paramdomain_outside_edge_test=True,
+            n_samples=-1,
         )
 
     @pytest.mark.xfail(
@@ -1330,6 +1337,7 @@ class TestMatchesScipy:
             Rplus,
             {"alpha": Rplusbig, "beta": Rplusbig},
             lambda value, alpha, beta: sp.exponweib.logpdf(value, 1, alpha, scale=beta),
+            n_samples=-1,
         )
 
     @pytest.mark.xfail(
@@ -1343,6 +1351,7 @@ class TestMatchesScipy:
             Rplus,
             {"alpha": Rplusbig, "beta": Rplusbig},
             lambda value, alpha, beta: sp.exponweib.logcdf(value, 1, alpha, scale=beta),
+            n_samples=-1,
         )
 
     def test_half_studentt(self):
@@ -1381,7 +1390,7 @@ class TestMatchesScipy:
             Binomial,
             Nat,
             {"n": NatSmall, "p": Unit},
-            n_samples=10,
+            n_samples=-1,
         )
 
     # Too lazy to propagate decimal parameter through the whole chain of deps
@@ -1395,6 +1404,7 @@ class TestMatchesScipy:
             Nat,
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
             lambda value, alpha, beta, n: sp.betabinom.logcdf(value, a=alpha, b=beta, n=n),
+            n_samples=-1,
         )
 
     def test_beta_binomial(self):
@@ -1419,6 +1429,7 @@ class TestMatchesScipy:
             Nat,
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
             lambda value, alpha, beta, n: sp.betabinom.logpmf(value, a=alpha, b=beta, n=n),
+            n_samples=-1,
         )
 
     def test_bernoulli(self):
@@ -1517,6 +1528,7 @@ class TestMatchesScipy:
             ZeroInflatedPoisson,
             Nat,
             {"theta": Rplus, "psi": Unit},
+            n_samples=-1,
         )
 
     # Too lazy to propagate decimal parameter through the whole chain of deps
@@ -1537,7 +1549,7 @@ class TestMatchesScipy:
             ZeroInflatedNegativeBinomial,
             Nat,
             {"mu": Rplusbig, "alpha": Rplusbig, "psi": Unit},
-            n_samples=10,
+            n_samples=-1,
         )
 
     # Too lazy to propagate decimal parameter through the whole chain of deps
@@ -1553,7 +1565,7 @@ class TestMatchesScipy:
             ZeroInflatedBinomial,
             Nat,
             {"n": NatSmall, "p": Unit, "psi": Unit},
-            n_samples=10,
+            n_samples=-1,
         )
 
     @pytest.mark.parametrize("n", [1, 2, 3])
@@ -2324,6 +2336,7 @@ class TestMatchesScipy:
             R,
             {"mu": R, "sigma": Rplusbig},
             lambda value, mu, sigma: floatX(sp.moyal.logpdf(value, mu, sigma)),
+            n_samples=-1,
         )
 
     @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
@@ -2333,6 +2346,7 @@ class TestMatchesScipy:
             R,
             {"mu": R, "sigma": Rplusbig},
             lambda value, mu, sigma: floatX(sp.moyal.logcdf(value, mu, sigma)),
+            n_samples=-1,
         )
 
     @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -898,15 +898,12 @@ class TestMatchesScipy:
             decimal=select_by_precision(float64=6, float32=1),
         )
 
-    # @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
-    def test_normal_logcdf(self):
         self.check_logcdf(
             Normal,
             R,
             {"mu": R, "sigma": Rplus},
             lambda value, mu, sigma: sp.norm.logcdf(value, mu, sigma),
             decimal=select_by_precision(float64=6, float32=2),
-            n_samples=-1,
         )
 
     def test_truncated_normal(self):
@@ -2316,26 +2313,26 @@ class TestMatchesScipy:
             lambda value, b, sigma: sp.rice.logpdf(value, b=b, loc=0, scale=sigma),
         )
 
-    # @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_moyal_logp(self):
+        # Using a custom domain, because the standard `R` domain undeflows with scipy in float64
         value_domain = Domain([-inf, -1.5, -1, -0.01, 0.0, 0.01, 1, 1.5, inf])
         self.check_logp(
             Moyal,
             value_domain,
             {"mu": R, "sigma": Rplusbig},
             lambda value, mu, sigma: floatX(sp.moyal.logpdf(value, mu, sigma)),
-            n_samples=-1,
         )
 
-    # @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(
+        condition=(aesara.config.floatX == "float32"),
+        reason="Pymc3 underflows earlier than scipy on float32",
+    )
     def test_moyal_logcdf(self):
-        value_domain = Domain([-inf, -1.5, -1, -0.01, 0.0, 0.01, 1, 1.5, inf])
         self.check_logcdf(
             Moyal,
-            value_domain,
+            R,
             {"mu": R, "sigma": Rplusbig},
             lambda value, mu, sigma: floatX(sp.moyal.logcdf(value, mu, sigma)),
-            n_samples=-1,
         )
 
     @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1505,7 +1505,6 @@ class TestMatchesScipy:
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to inf issues",
     )
-    # this test doesn't always result in the same outcome (pass/not pass)
     def test_zeroinflatedpoisson_distribution(self):
         self.checkd(
             ZeroInflatedPoisson,
@@ -2318,6 +2317,7 @@ class TestMatchesScipy:
             lambda value, b, sigma: sp.rice.logpdf(value, b=b, loc=0, scale=sigma),
         )
 
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_moyal_logp(self):
         self.check_logp(
             Moyal,

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -192,8 +192,8 @@ def build_disaster_model(masked=False):
     return model
 
 
-@pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
 class TestDisasterModel(SeededTest):
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     # Time series of recorded coal mining disasters in the UK from 1851 to 1962
     def test_disaster_model(self):
         model = build_disaster_model(masked=False)
@@ -205,6 +205,7 @@ class TestDisasterModel(SeededTest):
             tr = pm.sample(500, tune=50, start=start, step=step, chains=2)
             az.summary(tr)
 
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_disaster_model_missing(self):
         model = build_disaster_model(masked=True)
         with model:

--- a/pymc3/tests/test_models_utils.py
+++ b/pymc3/tests/test_models_utils.py
@@ -40,7 +40,6 @@ class TestUtils:
         m, l = utils.any_to_tensor_and_labels(self.data, labels=["x2", "x3"])
         self.assertMatrixLabels(m, l, lt=["x2", "x3"])
 
-    @pytest.mark.xfail
     def test_dict_input(self):
         m, l = utils.any_to_tensor_and_labels(self.data.to_dict("dict"))
         self.assertMatrixLabels(m, l, mt=self.data[l].values, lt=l)
@@ -51,6 +50,8 @@ class TestUtils:
         m, l = utils.any_to_tensor_and_labels(self.data.to_dict("list"))
         self.assertMatrixLabels(m, l, mt=self.data[l].values, lt=l)
 
+    @pytest.mark.xfail
+    def test_dict_input_pandas_series(self):
         inp = {k: aet.as_tensor_variable(v.values) for k, v in self.data.to_dict("series").items()}
         m, l = utils.any_to_tensor_and_labels(inp)
         self.assertMatrixLabels(m, l, mt=self.data[l].values, lt=l)

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -957,8 +957,8 @@ class TestDEMetropolisZ:
         pass
 
 
-@pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
 class TestNutsCheckTrace:
+    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_multiple_samplers(self, caplog):
         with Model():
             prob = Beta("prob", alpha=5.0, beta=3.0)

--- a/pymc3/tests/test_transforms.py
+++ b/pymc3/tests/test_transforms.py
@@ -235,15 +235,22 @@ def test_ordered():
     close_to_logical(np.diff(vals) >= 0, True, tol)
 
 
+def test_chain_values():
+    chain_tranf = tr.Chain([tr.logodds, tr.ordered])
+    vals = get_values(chain_tranf, Vector(R, 5), aet.dvector, np.zeros(5))
+    close_to_logical(np.diff(vals) >= 0, True, tol)
+
+
 @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
-def test_chain():
+def test_chain_vector_transform():
     chain_tranf = tr.Chain([tr.logodds, tr.ordered])
     check_vector_transform(chain_tranf, UnitSortedVector(3))
 
-    check_jacobian_det(chain_tranf, Vector(R, 4), aet.dvector, np.zeros(4), elemwise=False)
 
-    vals = get_values(chain_tranf, Vector(R, 5), aet.dvector, np.zeros(5))
-    close_to_logical(np.diff(vals) >= 0, True, tol)
+@pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+def test_chain_jacob_det():
+    chain_tranf = tr.Chain([tr.logodds, tr.ordered])
+    check_jacobian_det(chain_tranf, Vector(R, 4), aet.dvector, np.zeros(4), elemwise=False)
 
 
 class TestElementWiseLogp(SeededTest):


### PR DESCRIPTION
Closes #4425 

Xfail is going to care only about the first failed assert statement and
ignore all the other ones in the same test.

Sometimes xfail is being used to decorate a test or class function calling
several other sub-functions. This makes it hard to monitor what is happening
for the sub-fuctions that are not failing (given that the failure will take
priority and mark the test function as xfailed). By breaking down each
function into individual sub-functions it's easier to monitor individual
tests behavior


**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] important background, or details about the implementation
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
