### PR TITLE
Remove float128 dtype 

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,7 +9,8 @@
 + ...
 
 ### Maintenance
-- The `pymc3.memoize` module was removed and replaced with `cachetools`.  The `hashable` function and `WithMemoization` class were moved to `pymc3.util`.
+- The `pymc3.memoize` module was removed and replaced with `cachetools`.  The `hashable` function and `WithMemoization` class were moved to `pymc3.util` (see [#4509](https://github.com/pymc-devs/pymc3/pull/4509)).
+- Remove float128 dtype support (see [#4514](https://github.com/pymc-devs/pymc3/pull/4514)).
 
 ## PyMC3 3.11.1 (12 February 2021)
 

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -45,11 +45,6 @@ _beta_clip_values = {
     dtype: (np.nextafter(0, 1, dtype=dtype), np.nextafter(1, 0, dtype=dtype))
     for dtype in ["float16", "float32", "float64"]
 }
-if platform.system() in ["Linux", "Darwin"]:
-    _beta_clip_values["float128"] = (
-        np.nextafter(0, 1, dtype="float128"),
-        np.nextafter(1, 0, dtype="float128"),
-    )
 
 
 def bound(logp, *conditions, **kwargs):

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -1,4 +1,4 @@
-#   Copyright 2020 The PyMC Developers
+#   Copyright 2021 The PyMC Developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@ Created on Mar 7, 2011
 
 @author: johnsalvatier
 """
-import platform
-
 import aesara
 import aesara.tensor as aet
 import numpy as np

--- a/pymc3/tests/test_dist_math.py
+++ b/pymc3/tests/test_dist_math.py
@@ -237,10 +237,7 @@ class TestI0e:
         verify_grad(i0e, [[[0.5, -2.0]]])
 
 
-@pytest.mark.parametrize(
-    "dtype",
-    ["float16", "float32", "float64"]
-)
+@pytest.mark.parametrize("dtype", ["float16", "float32", "float64"])
 def test_clipped_beta_rvs(dtype):
     # Verify that the samples drawn from the beta distribution are never
     # equal to zero or one (issue #3898)

--- a/pymc3/tests/test_dist_math.py
+++ b/pymc3/tests/test_dist_math.py
@@ -1,4 +1,4 @@
-#   Copyright 2020 The PyMC Developers
+#   Copyright 2021 The PyMC Developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import sys
-
 import aesara
 import aesara.tensor as aet
 import numpy as np

--- a/pymc3/tests/test_dist_math.py
+++ b/pymc3/tests/test_dist_math.py
@@ -239,9 +239,7 @@ class TestI0e:
 
 @pytest.mark.parametrize(
     "dtype",
-    ["float16", "float32", "float64", "float128"]
-    if sys.platform != "win32"
-    else ["float16", "float32", "float64"],
+    ["float16", "float32", "float64"]
 )
 def test_clipped_beta_rvs(dtype):
     # Verify that the samples drawn from the beta distribution are never


### PR DESCRIPTION
Does not exist on Windows and newer OSX versions and furthermore does not to be properly supported even if it does exist: https://stackoverflow.com/questions/29820829/cannot-use-128bit-float-in-python-on-64bit-architecture

Closes #4513.

**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes?
+ [x] important background, or details about the implementation
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [x] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
