### PR TITLE
Bring back stats and plotting aliases

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,12 +1,12 @@
 # Release Notes
 
-## PyMC3 vNext (TBD)
+## PyMC3 3.11.2 (TBD)
 ### Breaking Changes
 + ...
 
 ### New Features
 + `pm.math.cartesian` can now handle inputs that are themselves >1D (see [#4482](https://github.com/pymc-devs/pymc3/pull/4482)).
-+ ...
++ Statistics and plotting functions that were removed in `3.11.0` were brought back, albeit with deprecation warnings (see [#4536](https://github.com/pymc-devs/pymc3/pull/4536)).
 
 ### Maintenance
 - ⚠ Our memoization mechanism wasn't robust against hash collisions (#4506), sometimes resulting in incorrect values in, for example, posterior predictives. The `pymc3.memoize` module was removed and replaced with `cachetools`.  The `hashable` function and `WithMemoization` class were moved to `pymc3.util` (see #4525).

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,7 +6,15 @@
 
 ### New Features
 + `pm.math.cartesian` can now handle inputs that are themselves >1D (see [#4482](https://github.com/pymc-devs/pymc3/pull/4482)).
-+ Statistics and plotting functions that were removed in `3.11.0` were brought back, albeit with deprecation warnings (see [#4536](https://github.com/pymc-devs/pymc3/pull/4536)).
++ Statistics and plotting functions that were removed in `3.11.0` were brought back, albeit with deprecation warnings if an old naming scheme is used (see [#4536](https://github.com/pymc-devs/pymc3/pull/4536)). In order to future proof your code, rename these function calls:
+  + `pm.traceplot` → `pm.plot_trace`
+  + `pm.compareplot` → `pm.plot_compare` (here you might need to rename some columns in the input according to the [`arviz.plot_compare` documentation](https://arviz-devs.github.io/arviz/api/generated/arviz.plot_compare.html))
+  + `pm.autocorrplot` → `pm.plot_autocorr`
+  + `pm.forestplot` → `pm.plot_forest`
+  + `pm.kdeplot` → `pm.plot_kde`
+  + `pm.energyplot` → `pm.plot_energy`
+  + `pm.densityplot` → `pm.plot_density`
+  + `pm.pairplot` → `pm.plot_pair`
 
 ### Maintenance
 - ⚠ Our memoization mechanism wasn't robust against hash collisions (#4506), sometimes resulting in incorrect values in, for example, posterior predictives. The `pymc3.memoize` module was removed and replaced with `cachetools`.  The `hashable` function and `WithMemoization` class were moved to `pymc3.util` (see #4525).

--- a/docs/source/api/plots.rst
+++ b/docs/source/api/plots.rst
@@ -8,7 +8,16 @@ Plots are delegated to the
 `ArviZ <https://arviz-devs.github.io/arviz/index.html>`_.
 library, a general purpose library for
 "exploratory analysis of Bayesian models."
-Refer to its documentation to use the plotting functions directly.
+For plots, ``pymc3.<function>`` are now aliases
+for ArviZ functions. Thus, the links below will redirect you to
+ArviZ docs:
 
-.. automodule:: pymc3.plots.posteriorplot
-   :members:
+- :func:`pymc3.traceplot <arviz:arviz.plot_trace>`
+- :func:`pymc3.plot_posterior <arviz:arviz.plot_posterior>`
+- :func:`pymc3.forestplot <arviz:arviz.plot_forest>`
+- :func:`pymc3.compareplot <arviz:arviz.plot_compare>`
+- :func:`pymc3.autocorrplot <arviz:arviz.plot_autocorr>`
+- :func:`pymc3.energyplot <arviz:arviz.plot_energy>`
+- :func:`pymc3.kdeplot <arviz:arviz.plot_kde>`
+- :func:`pymc3.densityplot <arviz:arviz.plot_density>`
+- :func:`pymc3.pairplot <arviz:arviz.plot_pair>`

--- a/docs/source/api/plots.rst
+++ b/docs/source/api/plots.rst
@@ -7,17 +7,7 @@ Plots
 Plots are delegated to the
 `ArviZ <https://arviz-devs.github.io/arviz/index.html>`_.
 library, a general purpose library for
-"exploratory analysis of Bayesian models."
-For plots, ``pymc3.<function>`` are now aliases
-for ArviZ functions. Thus, the links below will redirect you to
-ArviZ docs:
+"exploratory analysis of Bayesian models".
 
-- :func:`pymc3.traceplot <arviz:arviz.plot_trace>`
-- :func:`pymc3.plot_posterior <arviz:arviz.plot_posterior>`
-- :func:`pymc3.forestplot <arviz:arviz.plot_forest>`
-- :func:`pymc3.compareplot <arviz:arviz.plot_compare>`
-- :func:`pymc3.autocorrplot <arviz:arviz.plot_autocorr>`
-- :func:`pymc3.energyplot <arviz:arviz.plot_energy>`
-- :func:`pymc3.kdeplot <arviz:arviz.plot_kde>`
-- :func:`pymc3.densityplot <arviz:arviz.plot_density>`
-- :func:`pymc3.pairplot <arviz:arviz.plot_pair>`
+Functions from the `arviz.plots` module are available through ``pymc3.<function>`` or ``pymc3.plots.<function>``,
+but for their API documentation please refer to the `ArviZ documentation <https://arviz-devs.github.io/arviz/api/plots.html>`_.

--- a/docs/source/api/plots.rst
+++ b/docs/source/api/plots.rst
@@ -10,4 +10,4 @@ library, a general purpose library for
 "exploratory analysis of Bayesian models".
 
 Functions from the `arviz.plots` module are available through ``pymc3.<function>`` or ``pymc3.plots.<function>``,
-but for their API documentation please refer to the `ArviZ documentation <https://arviz-devs.github.io/arviz/api/plots.html>`_.
+but for their API documentation please refer to the :ref:`ArviZ documentation <arviz:plot_api>`.

--- a/docs/source/api/stats.rst
+++ b/docs/source/api/stats.rst
@@ -5,4 +5,21 @@ Statistics and diagnostics are delegated to the
 `ArviZ <https://arviz-devs.github.io/arviz/index.html>`_.
 library, a general purpose library for
 "exploratory analysis of Bayesian models."
-Refer to its documentation to use the diagnostics functions directly.
+For statistics and diagnostics, ``pymc3.<function>`` are now aliases
+for ArviZ functions. Thus, the links below will redirect you to
+ArviZ docs:
+
+.. currentmodule:: pymc3.stats
+
+
+- :func:`pymc3.bfmi <arviz:arviz.bfmi>`
+- :func:`pymc3.compare <arviz:arviz.compare>`
+- :func:`pymc3.ess <arviz:arviz.ess>`
+- :data:`pymc3.geweke <arviz:arviz.geweke>`
+- :func:`pymc3.hpd <arviz:arviz.hpd>`
+- :func:`pymc3.loo <arviz:arviz.loo>`
+- :func:`pymc3.mcse <arviz:arviz.mcse>`
+- :func:`pymc3.r2_score <arviz:arviz.r2_score>`
+- :func:`pymc3.rhat <arviz:arviz.rhat>`
+- :func:`pymc3.summary <arviz:arviz.summary>`
+- :func:`pymc3.waic <arviz:arviz.waic>`

--- a/docs/source/api/stats.rst
+++ b/docs/source/api/stats.rst
@@ -10,4 +10,4 @@ library, a general purpose library for
 "exploratory analysis of Bayesian models".
 
 Functions from the `arviz.stats` module are available through ``pymc3.<function>`` or ``pymc3.stats.<function>``,
-but for their API documentation please refer to the `ArviZ documentation <https://arviz-devs.github.io/arviz/api/stats.html>`_.
+but for their API documentation please refer to the :ref:`ArviZ documentation <arviz:stats_api>`.

--- a/docs/source/api/stats.rst
+++ b/docs/source/api/stats.rst
@@ -1,25 +1,13 @@
 *****
 Stats
 *****
-Statistics and diagnostics are delegated to the
-`ArviZ <https://arviz-devs.github.io/arviz/index.html>`_.
-library, a general purpose library for
-"exploratory analysis of Bayesian models."
-For statistics and diagnostics, ``pymc3.<function>`` are now aliases
-for ArviZ functions. Thus, the links below will redirect you to
-ArviZ docs:
 
 .. currentmodule:: pymc3.stats
 
+Statistics and diagnostics are delegated to the
+`ArviZ <https://arviz-devs.github.io/arviz/index.html>`_.
+library, a general purpose library for
+"exploratory analysis of Bayesian models".
 
-- :func:`pymc3.bfmi <arviz:arviz.bfmi>`
-- :func:`pymc3.compare <arviz:arviz.compare>`
-- :func:`pymc3.ess <arviz:arviz.ess>`
-- :data:`pymc3.geweke <arviz:arviz.geweke>`
-- :func:`pymc3.hpd <arviz:arviz.hpd>`
-- :func:`pymc3.loo <arviz:arviz.loo>`
-- :func:`pymc3.mcse <arviz:arviz.mcse>`
-- :func:`pymc3.r2_score <arviz:arviz.r2_score>`
-- :func:`pymc3.rhat <arviz:arviz.rhat>`
-- :func:`pymc3.summary <arviz:arviz.summary>`
-- :func:`pymc3.waic <arviz:arviz.waic>`
+Functions from the `arviz.stats` module are available through ``pymc3.<function>`` or ``pymc3.stats.<function>``,
+but for their API documentation please refer to the `ArviZ documentation <https://arviz-devs.github.io/arviz/api/stats.html>`_.

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -61,6 +61,7 @@ from pymc3.model_graph import model_to_graphviz
 from pymc3.plots import *
 from pymc3.sampling import *
 from pymc3.smc import *
+from pymc3.stats import *
 from pymc3.step_methods import *
 from pymc3.tests import test
 from pymc3.theanof import *

--- a/pymc3/plots/__init__.py
+++ b/pymc3/plots/__init__.py
@@ -1,4 +1,4 @@
-#   Copyright 2020 The PyMC Developers
+#   Copyright 2021 The PyMC Developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import warnings
 import arviz as az
 
 # Makes this module as identical to arviz.plots as possible
-for attr in dir(az.plots):
+for attr in az.plots.__all__:
     obj = getattr(az.plots, attr)
     if not attr.startswith("__"):
         setattr(sys.modules[__name__], attr, obj)
@@ -35,23 +35,29 @@ def map_args(func, alias: str):
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
         if "varnames" in kwargs:
-            raise DeprecationWarning(f"The `varnames` kwarg was renamed to `var_names`.")
+            raise DeprecationWarning(
+                f"The `varnames` kwarg was renamed to `var_names`.", stacklevel=2
+            )
         original = func.__name__
         warnings.warn(
             f"The function `{alias}` from PyMC3 is just an alias for `{original}` from ArviZ. "
             f"Please switch to `pymc3.{original}` or `arviz.{original}`.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return func(*args, **kwargs)
 
     return wrapped
 
 
+# Always show the DeprecationWarnings
+warnings.filterwarnings("once", category=DeprecationWarning, module="pymc3.plots")
+
+
 # Aliases of ArviZ functions
 autocorrplot = map_args(az.plot_autocorr, alias="autocorrplot")
 forestplot = map_args(az.plot_forest, alias="forestplot")
 kdeplot = map_args(az.plot_kde, alias="kdeplot")
-plot_posterior = map_args(az.plot_posterior, alias="plot_posterior")
 energyplot = map_args(az.plot_energy, alias="energyplot")
 densityplot = map_args(az.plot_density, alias="densityplot")
 pairplot = map_args(az.plot_pair, alias="pairplot")
@@ -66,6 +72,7 @@ def compareplot(*args, **kwargs):
         "It also applies some kwarg replacements. Nevertheless, please switch "
         f"to `pymc3.plot_compare` or `arviz.plot_compare`.",
         DeprecationWarning,
+        stacklevel=2,
     )
     if "comp_df" in kwargs:
         comp_df = kwargs["comp_df"].copy()

--- a/pymc3/plots/__init__.py
+++ b/pymc3/plots/__init__.py
@@ -14,10 +14,9 @@
 
 """PyMC3 Plotting.
 
-Plots are delegated to the `ArviZ <https://arviz-devs.github.io/arviz/>`_ library, a general purpose library for
-exploratory analysis of Bayesian models. For more details, see https://arviz-devs.github.io/arviz/.
-
-Only `plot_posterior_predictive_glm` is kept in the PyMC code base for now, but it will move to ArviZ once the latter adds features for regression plots.
+Plots are delegated to the ArviZ library, a general purpose library for
+"exploratory analysis of Bayesian models." See https://arviz-devs.github.io/arviz/
+for details on plots.
 """
 import functools
 import sys
@@ -25,6 +24,98 @@ import warnings
 
 import arviz as az
 
+
+def map_args(func):
+    swaps = [("varnames", "var_names")]
+
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        for (old, new) in swaps:
+            if old in kwargs and new not in kwargs:
+                warnings.warn(
+                    f"Keyword argument `{old}` renamed to `{new}`, and will be removed in pymc3 3.8"
+                )
+                kwargs[new] = kwargs.pop(old)
+            return func(*args, **kwargs)
+
+    return wrapped
+
+
+# pymc3 custom plots: override these names for custom behavior
+autocorrplot = map_args(az.plot_autocorr)
+forestplot = map_args(az.plot_forest)
+kdeplot = map_args(az.plot_kde)
+plot_posterior = map_args(az.plot_posterior)
+energyplot = map_args(az.plot_energy)
+densityplot = map_args(az.plot_density)
+pairplot = map_args(az.plot_pair)
+
+# Use compact traceplot by default
+@map_args
+@functools.wraps(az.plot_trace)
+def traceplot(*args, **kwargs):
+    try:
+        kwargs.setdefault("compact", True)
+        return az.plot_trace(*args, **kwargs)
+    except TypeError:
+        kwargs.pop("compact")
+        return az.plot_trace(*args, **kwargs)
+
+
+# addition arg mapping for compare plot
+@functools.wraps(az.plot_compare)
+def compareplot(*args, **kwargs):
+    if "comp_df" in kwargs:
+        comp_df = kwargs["comp_df"].copy()
+    else:
+        args = list(args)
+        comp_df = args[0].copy()
+    if "WAIC" in comp_df.columns:
+        comp_df = comp_df.rename(
+            index=str,
+            columns={
+                "WAIC": "waic",
+                "pWAIC": "p_waic",
+                "dWAIC": "d_waic",
+                "SE": "se",
+                "dSE": "dse",
+                "var_warn": "warning",
+            },
+        )
+    elif "LOO" in comp_df.columns:
+        comp_df = comp_df.rename(
+            index=str,
+            columns={
+                "LOO": "loo",
+                "pLOO": "p_loo",
+                "dLOO": "d_loo",
+                "SE": "se",
+                "dSE": "dse",
+                "shape_warn": "warning",
+            },
+        )
+    if "comp_df" in kwargs:
+        kwargs["comp_df"] = comp_df
+    else:
+        args[0] = comp_df
+    return az.plot_compare(*args, **kwargs)
+
+
 from pymc3.plots.posteriorplot import plot_posterior_predictive_glm
 
-__all__ = ["plot_posterior_predictive_glm"]
+# Access to arviz plots: base plots provided by arviz
+for plot in az.plots.__all__:
+    setattr(sys.modules[__name__], plot, map_args(getattr(az.plots, plot)))
+
+__all__ = tuple(az.plots.__all__) + (
+    "autocorrplot",
+    "compareplot",
+    "forestplot",
+    "kdeplot",
+    "plot_posterior",
+    "traceplot",
+    "energyplot",
+    "densityplot",
+    "pairplot",
+    "plot_posterior_predictive_glm",
+)

--- a/pymc3/stats/__init__.py
+++ b/pymc3/stats/__init__.py
@@ -1,0 +1,69 @@
+#   Copyright 2020 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Statistical utility functions for PyMC3
+
+Diagnostics and auxiliary statistical functions are delegated to the ArviZ library, a general
+purpose library for "exploratory analysis of Bayesian models." See
+https://arviz-devs.github.io/arviz/ for details.
+"""
+import functools
+import warnings
+
+import arviz as az
+
+
+def map_args(func):
+    swaps = [("varnames", "var_names")]
+
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        for (old, new) in swaps:
+            if old in kwargs and new not in kwargs:
+                warnings.warn(
+                    "Keyword argument `{old}` renamed to `{new}`, and will be removed in "
+                    "pymc3 3.9".format(old=old, new=new)
+                )
+                kwargs[new] = kwargs.pop(old)
+            return func(*args, **kwargs)
+
+    return wrapped
+
+
+bfmi = map_args(az.bfmi)
+compare = map_args(az.compare)
+ess = map_args(az.ess)
+geweke = map_args(az.geweke)
+hpd = map_args(az.hpd)
+loo = map_args(az.loo)
+mcse = map_args(az.mcse)
+r2_score = map_args(az.r2_score)
+rhat = map_args(az.rhat)
+summary = map_args(az.summary)
+waic = map_args(az.waic)
+
+
+__all__ = [
+    "bfmi",
+    "compare",
+    "ess",
+    "geweke",
+    "hpd",
+    "loo",
+    "mcse",
+    "r2_score",
+    "rhat",
+    "summary",
+    "waic",
+]

--- a/pymc3/stats/__init__.py
+++ b/pymc3/stats/__init__.py
@@ -1,4 +1,4 @@
-#   Copyright 2020 The PyMC Developers
+#   Copyright 2021 The PyMC Developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import sys
 
 import arviz as az
 
-for attr in dir(az.stats):
+for attr in az.stats.__all__:
     obj = getattr(az.stats, attr)
     if not attr.startswith("__"):
         setattr(sys.modules[__name__], attr, obj)

--- a/pymc3/stats/__init__.py
+++ b/pymc3/stats/__init__.py
@@ -12,58 +12,20 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-"""Statistical utility functions for PyMC3
+"""Alias for the `stats` submodule from ArviZ.
 
 Diagnostics and auxiliary statistical functions are delegated to the ArviZ library, a general
-purpose library for "exploratory analysis of Bayesian models." See
-https://arviz-devs.github.io/arviz/ for details.
+purpose library for "exploratory analysis of Bayesian models."
+See https://arviz-devs.github.io/arviz/ for details.
 """
-import functools
-import warnings
+import sys
 
 import arviz as az
 
-
-def map_args(func):
-    swaps = [("varnames", "var_names")]
-
-    @functools.wraps(func)
-    def wrapped(*args, **kwargs):
-        for (old, new) in swaps:
-            if old in kwargs and new not in kwargs:
-                warnings.warn(
-                    "Keyword argument `{old}` renamed to `{new}`, and will be removed in "
-                    "pymc3 3.9".format(old=old, new=new)
-                )
-                kwargs[new] = kwargs.pop(old)
-            return func(*args, **kwargs)
-
-    return wrapped
+for attr in dir(az.stats):
+    obj = getattr(az.stats, attr)
+    if not attr.startswith("__"):
+        setattr(sys.modules[__name__], attr, obj)
 
 
-bfmi = map_args(az.bfmi)
-compare = map_args(az.compare)
-ess = map_args(az.ess)
-geweke = map_args(az.geweke)
-hpd = map_args(az.hpd)
-loo = map_args(az.loo)
-mcse = map_args(az.mcse)
-r2_score = map_args(az.r2_score)
-rhat = map_args(az.rhat)
-summary = map_args(az.summary)
-waic = map_args(az.waic)
-
-
-__all__ = [
-    "bfmi",
-    "compare",
-    "ess",
-    "geweke",
-    "hpd",
-    "loo",
-    "mcse",
-    "r2_score",
-    "rhat",
-    "summary",
-    "waic",
-]
+__all__ = tuple(az.stats.__all__)


### PR DESCRIPTION
As discussed in #4528 this PR brings back the old `pm.plotting` and `pm.stats` submodules.

However they now have deprecation warnings that instruct users to switch to the original function names, either via `pm.*` or `arviz` directly.

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] <s>what are the (breaking) changes that this PR makes?</s> It un-breaks!
+ [x] <s>important background, or details about the implementation</s> All objects except `__*` ones are stolen from the `arviz.stats` or `arviz.plots` submodules. This is to make `pm.plots` and `pm.stats` as identical as possible, so users can seamlessly switch to the original ArviZ submodules.
+ [x] <s>are the changes—especially new features—covered by tests and docstrings?</s> They are covered in ArviZ.
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [x] <s>[consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)</s> No.
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
