### PR TITLE
Check Theano version upon import

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -19,6 +19,9 @@ import logging
 import multiprocessing as mp
 import platform
 
+import semver
+import theano
+
 _log = logging.getLogger("pymc3")
 
 if not logging.root.handlers:
@@ -28,10 +31,18 @@ if not logging.root.handlers:
         _log.addHandler(handler)
 
 
+if not semver.match(theano.__version__, ">=1.1.2"):
+    print(
+        "!" * 60
+        + f"\nThe installed Theano(-PyMC) version ({theano.__version__}) does not match the PyMC3 requirements."
+        + "\nFor PyMC3 to work, Theano must be uninstalled and replaced with Theano-PyMC."
+        + "\nSee https://github.com/pymc-devs/pymc3/wiki for installation instructions.\n"
+        + "!" * 60
+    )
+
+
 def __set_compiler_flags():
     # Workarounds for Theano compiler problems on various platforms
-    import theano
-
     current = theano.config.gcc__cxxflags
     theano.config.gcc__cxxflags = f"{current} -Wno-c++11-narrowing"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ numpy>=1.15.0
 pandas>=0.24.0
 patsy>=0.5.1
 scipy>=1.2.0
+semver
 theano-pymc==1.1.2
 typing-extensions>=3.7.4


### PR DESCRIPTION
The right Theano-PyMC version is specified in `requirements.txt`, but this is not part of the directory of a pip/conda installed PyMC3.

The easy way out was to hard-code the `1.1.2` version into the `__init__.py` at the risk of going out of sync.

I don't think we should totally prevent PyMC3 from installing/importing without the right backend version, because sometimes one needs to go unorthodox installation routes or versions might not match during development with `--editable` installs.

I added a dpendency on [`semver`](https://github.com/python-semver/python-semver), because the current situation around version parsers from `setuptools`/`distutils`/`packaging` was just confusing and `semver` seems to do a better job with version string like `1.2.3+fc6a5d` that sometimes show up with Theano/Theano-PyMC/Aesara.