### PR TITLE
Add Zenodo DOI badges and citation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
     :alt: PyMC3 logo
     :align: center
 
-|Build Status| |Coverage| |NumFOCUS_badge| |Binder| |Dockerhub|
+|Build Status| |Coverage| |NumFOCUS_badge| |Binder| |Dockerhub| |DOIzenodo|
 
 PyMC3 is a Python package for Bayesian statistical modeling and Probabilistic Machine Learning
 focusing on advanced Markov chain Monte Carlo (MCMC) and variational inference (VI)
@@ -74,10 +74,16 @@ To install PyMC3 on your system, follow the instructions on the appropriate inst
 
 Citing PyMC3
 ============
+Please choose from the following:
 
-Salvatier J., Wiecki T.V., Fonnesbeck C. (2016) Probabilistic programming
-in Python using PyMC3. PeerJ Computer Science 2:e55
-`DOI: 10.7717/peerj-cs.55 <https://doi.org/10.7717/peerj-cs.55>`__.
+- |DOIpaper| *Probabilistic programming in Python using PyMC3*, Salvatier J., Wiecki T.V., Fonnesbeck C. (2016)
+- |DOIzenodo| A DOI for all versions.
+- DOIs for specific versions are shown on Zenodo and under `Releases <https://github.com/pymc-devs/pymc3/releases>`_
+
+.. |DOIpaper| image:: https://img.shields.io/badge/DOI-10.7717%2Fpeerj--cs.55-blue
+     :target: https://doi.org/10.7717/peerj-cs.55
+.. |DOIzenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4603970.svg
+   :target: https://doi.org/10.5281/zenodo.4603970
 
 Contact
 =======

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -115,8 +115,12 @@
 
         <div class="ui vertical segment">
             <h2 class="ui dividing header">Citing PyMC3</h2>
-            <p>Salvatier J., Wiecki T.V., Fonnesbeck C. (2016) Probabilistic programming in Python using PyMC3. PeerJ
-                Computer Science 2:e55 <a href="https://doi.org/10.7717/peerj-cs.55">DOI: 10.7717/peerj-cs.55</a>.</p>
+            <p>Please choose from the following:</p>
+            <ul>
+                <li><a href="https://doi.org/10.7717/peerj-cs.55" rel="nofollow"><img alt="DOIpaper" src="https://camo.githubusercontent.com/6a7e1c555ea828c2f9253f7cff0868debe9fdc711694424b913bf95f6d2da9dd/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f444f492d31302e37373137253246706565726a2d2d63732e35352d626c7565" data-canonical-src="https://img.shields.io/badge/DOI-10.7717%2Fpeerj--cs.55-blue" style="max-width:100%;"></a> <em>Probabilistic programming in Python using PyMC3</em>, Salvatier J., Wiecki T.V., Fonnesbeck C. (2016)</li>
+                <li><a href="https://doi.org/10.5281/zenodo.4603970" rel="nofollow"><img alt="DOIzenodo" src="https://camo.githubusercontent.com/2b33f91dc16d9e7ad37aede0119d197776fbef41b8080c7e38a3629df3d9c201/68747470733a2f2f7a656e6f646f2e6f72672f62616467652f444f492f31302e353238312f7a656e6f646f2e343630333937302e737667" data-canonical-src="https://zenodo.org/badge/DOI/10.5281/zenodo.4603970.svg" style="max-width:100%;"></a> A DOI for all versions.</li>
+                <li>DOIs for specific versions are shown on Zenodo and under <a href="https://github.com/pymc-devs/pymc3/releases">Releases</a></li>
+            </ul>
             <p>See <a href="https://scholar.google.de/scholar?oi=bibs&hl=en&authuser=1&cites=6936955228135731011">Google Scholar</a> for a continuously updated list of papers citing PyMC3.</p>
         </div>
 


### PR DESCRIPTION
Zenodo DOIs are now created automatically.

@fonnesbeck I think you can log in there to specify further metadata

This PR adds the DOIs to the main readme. I'm not great with restructured text formatting; please just add/commit changes as you see fit.