### PR TITLE
Replace matplotlib seaborn style plots with Arviz Plots in Documentation (WIP)

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -194,7 +194,8 @@ class Uniform(BoundedContinuous):
 
         import matplotlib.pyplot as plt
         import numpy as np
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-3, 3, 500)
         ls = [0., -2]
         us = [2., 1]
@@ -445,7 +446,8 @@ class Normal(Continuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-5, 5, 1000)
         mus = [0., 0., 0., -2.]
         sigmas = [0.4, 1., 2., 0.4]
@@ -591,7 +593,8 @@ class TruncatedNormal(BoundedContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-10, 10, 1000)
         mus = [0.,  0., 0.]
         sigmas = [3.,5.,7.]
@@ -809,7 +812,8 @@ class HalfNormal(PositiveContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 5, 200)
         for sigma in [0.4, 1., 2.]:
             pdf = st.halfnorm.pdf(x, scale=sigma)
@@ -949,7 +953,8 @@ class Wald(PositiveContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 3, 500)
         mus = [1., 1., 1., 3.]
         lams = [1., .2, 3., 1.]
@@ -1169,7 +1174,8 @@ class Beta(UnitContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 1, 200)
         alphas = [.5, 5., 1., 2., 2.]
         betas = [.5, 1., 3., 2., 5.]
@@ -1347,7 +1353,8 @@ class Kumaraswamy(UnitContinuous):
 
         import matplotlib.pyplot as plt
         import numpy as np
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 1, 200)
         a_s = [.5, 5., 1., 2., 2.]
         b_s = [.5, 1., 3., 2., 5.]
@@ -1453,7 +1460,8 @@ class Exponential(PositiveContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 3, 100)
         for lam in [0.5, 1., 2.]:
             pdf = st.expon.pdf(x, scale=1.0/lam)
@@ -1566,7 +1574,8 @@ class Laplace(Continuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-10, 10, 1000)
         mus = [0., 0., 0., -5.]
         bs = [1., 2., 4., 4.]
@@ -1794,7 +1803,8 @@ class Lognormal(PositiveContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 3, 100)
         mus = [0., 0., 0.]
         sigmas = [.25, .5, 1.]
@@ -1951,7 +1961,8 @@ class StudentT(Continuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-8, 8, 200)
         mus = [0., 0., -2., -2.]
         sigmas = [1., 1., 1., 2.]
@@ -2115,7 +2126,8 @@ class Pareto(Continuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 4, 1000)
         alphas = [1., 2., 5., 5.]
         ms = [1., 1., 1., 2.]
@@ -2257,7 +2269,8 @@ class Cauchy(Continuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-5, 5, 500)
         alphas = [0., 0., 0., -2.]
         betas = [.5, 1., 2., 1.]
@@ -2373,7 +2386,8 @@ class HalfCauchy(PositiveContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 5, 200)
         for b in [0.5, 1.0, 2.0]:
             pdf = st.cauchy.pdf(x, scale=b)
@@ -2490,7 +2504,8 @@ class Gamma(PositiveContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 20, 200)
         alphas = [1., 2., 3., 7.5]
         betas = [.5, .5, 1., 1.]
@@ -2654,7 +2669,8 @@ class InverseGamma(PositiveContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 3, 500)
         alphas = [1., 2., 3., 3.]
         betas = [1., 1., 1., .5]
@@ -2823,7 +2839,8 @@ class ChiSquared(Gamma):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 15, 200)
         for df in [1, 2, 3, 6, 9]:
             pdf = st.chi2.pdf(x, df)
@@ -2868,7 +2885,8 @@ class Weibull(PositiveContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 3, 200)
         alphas = [.5, 1., 1.5, 5., 5.]
         betas = [1., 1., 1., 1.,  2]
@@ -3003,7 +3021,8 @@ class HalfStudentT(PositiveContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 5, 200)
         sigmas = [1., 1., 2., 1.]
         nus = [.5, 1., 1., 30.]
@@ -3138,7 +3157,8 @@ class ExGaussian(Continuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-6, 9, 200)
         mus = [0., -2., 0., -3.]
         sigmas = [1., 1., 3., 1.]
@@ -3319,7 +3339,8 @@ class VonMises(Continuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-np.pi, np.pi, 200)
         mus = [0., 0., 0.,  -2.5]
         kappas = [.01, 0.5,  4., 2.]
@@ -3419,7 +3440,8 @@ class SkewNormal(Continuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-4, 4, 200)
         for alpha in [-6, 0, 6]:
             pdf = st.skewnorm.pdf(x, alpha, loc=0, scale=1)
@@ -3554,7 +3576,8 @@ class Triangular(BoundedContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-2, 10, 500)
         lowers = [0., -1, 2]
         cs = [2., 0., 6.5]
@@ -3709,7 +3732,8 @@ class Gumbel(Continuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-10, 20, 200)
         mus = [0., 4., -1.]
         betas = [2., 2., 4.]
@@ -3832,7 +3856,8 @@ class Rice(PositiveContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0, 8, 500)
         nus = [0., 0., 4., 4.]
         sigmas = [1., 2., 1., 2.]
@@ -3994,7 +4019,8 @@ class Logistic(Continuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-5, 5, 200)
         mus = [0., 0., 0., -2.]
         ss = [.4, 1., 2., .4]
@@ -4116,7 +4142,8 @@ class LogitNormal(UnitContinuous):
         import numpy as np
         import scipy.stats as st
         from scipy.special import logit
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0.0001, 0.9999, 500)
         mus = [0., 0., 0., 1.]
         sigmas = [0.3, 1., 2., 1.]
@@ -4350,7 +4377,8 @@ class Moyal(Continuous):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(-10, 20, 200)
         mus = [-1., 0., 4.]
         sigmas = [2., 2., 4.]

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -4241,7 +4241,7 @@ class Interpolated(BoundedContinuous):
         ax.plot(points, pdf, color='black', marker='o', label='Lattice Points',alpha=0.5,linestyle='')
         ax.plot(x, np.exp(interpolated.logp(x).eval()),'C1',label='Interpolated pdf',alpha=0.8,lw=3)
         r = interpolated.random(size=1000)
-        ax.hist(r, density=True, histtype='stepfilled', alpha=0.4,align ='right',color='grey')
+        ax.hist(r, density=True, alpha=0.4,align ='mid',color='grey')
         ax.legend(loc='best', frameon=False)
         plt.show()
 

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -11,7 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-
+#checkingsomething
 # coding: utf-8
 """
 A collection of common probability distributions for stochastic

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -4230,12 +4230,12 @@ class Interpolated(BoundedContinuous):
         import pymc3 as pm
         import arviz as az
         from scipy.stats import gamma
+        plt.style.use('arviz-darkgrid')
         rv = gamma(1.99)
         x = np.linspace(rv.ppf(0.01),rv.ppf(0.99), 1000)
         points = np.linspace(x[0], x[-1], 50)
         pdf = rv.pdf(points)
         interpolated = pm.Interpolated.dist(points, pdf)
-        plt.style.use('arviz-darkgrid')
         fig, ax = plt.subplots(1, 1)
         ax.plot(x, rv.pdf(x), 'C0', linestyle = '--',  label='Original Gamma pdf',alpha=0.8,lw=2)
         ax.plot(points, pdf, color='black', marker='o', label='Lattice Points',alpha=0.5,linestyle='')

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -4223,26 +4223,20 @@ class Interpolated(BoundedContinuous):
     Both parameters ``x_points`` and values ``pdf_points`` are not variables, but
     plain array-like objects, so they are constant and cannot be sampled.
 
-    ========  ===========================================
-    Support   :math:`x \in [x\_points[0], x\_points[-1]]`
-    ========  ===========================================
-    
+    .. plot::
     import matplotlib.pyplot as plt
     import numpy as np
     import pymc3 as pm
+    import arviz as az
     import warnings
     warnings.simplefilter(action="ignore", category=FutureWarning)
     from scipy.stats import gamma
-    a = 1.99
-    mean, var, skew, kurt = gamma.stats(a, moments='mvsk')
-    rv = gamma(a)
+    rv = gamma(1.99)
     x = np.linspace(rv.ppf(0.01),rv.ppf(0.99), 1000)
     points = np.linspace(x[0], x[-1], 50)
     pdf = rv.pdf(points)
     interpolated = pm.Interpolated.dist(points, pdf)
     plt.style.use('arviz-darkgrid')
-    plt.style.use('tableau-colorblind10')
-    #plt.set_cmap('coolwarm')
     fig, ax = plt.subplots(1, 1)
     ax.plot(x, rv.pdf(x), 'C0', linestyle = '--',  label='Original Gamma pdf',alpha=0.8,lw=2)
     ax.plot(points, pdf, color='black', marker='o', label='Lattice Points',alpha=0.5,linestyle='')
@@ -4251,6 +4245,10 @@ class Interpolated(BoundedContinuous):
     ax.hist(r, density=True, histtype='stepfilled', alpha=0.4,align ='right',color='grey')
     ax.legend(loc='best', frameon=False)
     plt.show()
+
+    ========  ===========================================
+    Support   :math:`x \in [x\_points[0], x\_points[-1]]`
+    ========  ===========================================
 
     Parameters
     ----------

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -4224,27 +4224,26 @@ class Interpolated(BoundedContinuous):
     plain array-like objects, so they are constant and cannot be sampled.
 
     .. plot::
-    import matplotlib.pyplot as plt
-    import numpy as np
-    import pymc3 as pm
-    import arviz as az
-    import warnings
-    warnings.simplefilter(action="ignore", category=FutureWarning)
-    from scipy.stats import gamma
-    rv = gamma(1.99)
-    x = np.linspace(rv.ppf(0.01),rv.ppf(0.99), 1000)
-    points = np.linspace(x[0], x[-1], 50)
-    pdf = rv.pdf(points)
-    interpolated = pm.Interpolated.dist(points, pdf)
-    plt.style.use('arviz-darkgrid')
-    fig, ax = plt.subplots(1, 1)
-    ax.plot(x, rv.pdf(x), 'C0', linestyle = '--',  label='Original Gamma pdf',alpha=0.8,lw=2)
-    ax.plot(points, pdf, color='black', marker='o', label='Lattice Points',alpha=0.5,linestyle='')
-    ax.plot(x, np.exp(interpolated.logp(x).eval()),'C1',label='Interpolated pdf',alpha=0.8,lw=3)
-    r = interpolated.random(size=1000)
-    ax.hist(r, density=True, histtype='stepfilled', alpha=0.4,align ='right',color='grey')
-    ax.legend(loc='best', frameon=False)
-    plt.show()
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import pymc3 as pm
+        import arviz as az
+        from scipy.stats import gamma
+        rv = gamma(1.99)
+        x = np.linspace(rv.ppf(0.01),rv.ppf(0.99), 1000)
+        points = np.linspace(x[0], x[-1], 50)
+        pdf = rv.pdf(points)
+        interpolated = pm.Interpolated.dist(points, pdf)
+        plt.style.use('arviz-darkgrid')
+        fig, ax = plt.subplots(1, 1)
+        ax.plot(x, rv.pdf(x), 'C0', linestyle = '--',  label='Original Gamma pdf',alpha=0.8,lw=2)
+        ax.plot(points, pdf, color='black', marker='o', label='Lattice Points',alpha=0.5,linestyle='')
+        ax.plot(x, np.exp(interpolated.logp(x).eval()),'C1',label='Interpolated pdf',alpha=0.8,lw=3)
+        r = interpolated.random(size=1000)
+        ax.hist(r, density=True, histtype='stepfilled', alpha=0.4,align ='right',color='grey')
+        ax.legend(loc='best', frameon=False)
+        plt.show()
 
     ========  ===========================================
     Support   :math:`x \in [x\_points[0], x\_points[-1]]`

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -4226,6 +4226,31 @@ class Interpolated(BoundedContinuous):
     ========  ===========================================
     Support   :math:`x \in [x\_points[0], x\_points[-1]]`
     ========  ===========================================
+    
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pymc3 as pm
+    import warnings
+    warnings.simplefilter(action="ignore", category=FutureWarning)
+    from scipy.stats import gamma
+    a = 1.99
+    mean, var, skew, kurt = gamma.stats(a, moments='mvsk')
+    rv = gamma(a)
+    x = np.linspace(rv.ppf(0.01),rv.ppf(0.99), 1000)
+    points = np.linspace(x[0], x[-1], 50)
+    pdf = rv.pdf(points)
+    interpolated = pm.Interpolated.dist(points, pdf)
+    plt.style.use('arviz-darkgrid')
+    plt.style.use('tableau-colorblind10')
+    #plt.set_cmap('coolwarm')
+    fig, ax = plt.subplots(1, 1)
+    ax.plot(x, rv.pdf(x), 'C0', linestyle = '--',  label='Original Gamma pdf',alpha=0.8,lw=2)
+    ax.plot(points, pdf, color='black', marker='o', label='Lattice Points',alpha=0.5,linestyle='')
+    ax.plot(x, np.exp(interpolated.logp(x).eval()),'C1',label='Interpolated pdf',alpha=0.8,lw=3)
+    r = interpolated.random(size=1000)
+    ax.hist(r, density=True, histtype='stepfilled', alpha=0.4,align ='right',color='grey')
+    ax.legend(loc='best', frameon=False)
+    plt.show()
 
     Parameters
     ----------

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -72,7 +72,8 @@ class Binomial(Discrete):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.arange(0, 22)
         ns = [10, 17]
         ps = [0.5, 0.7]
@@ -206,7 +207,8 @@ class BetaBinomial(Discrete):
         import numpy as np
         import scipy.stats as st
         from scipy import special
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
 
         def BetaBinom(a, b, n, x):
             pmf = special.binom(n, x) * (special.beta(x+a, n-x+b) / special.beta(a, b))
@@ -369,7 +371,8 @@ class Bernoulli(Discrete):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = [0, 1]
         for p in [0, 0.5, 0.8]:
             pmf = st.bernoulli.pmf(x, p)
@@ -504,7 +507,8 @@ class DiscreteWeibull(Discrete):
         import numpy as np
         import scipy.stats as st
         from scipy import special
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
 
         def DiscreteWeibull(q, b, x):
             return q**(x**b) - q**((x + 1)**b)
@@ -640,7 +644,8 @@ class Poisson(Discrete):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.arange(0, 15)
         for m in [0.5, 3, 8]:
             pmf = st.poisson.pmf(x, m)
@@ -761,7 +766,8 @@ class NegativeBinomial(Discrete):
         import numpy as np
         import scipy.stats as st
         from scipy import special
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
 
         def NegBinom(a, m, x):
             pmf = special.binom(x + a - 1, x) * (a / (m + a))**a * (m / (m + a))**x
@@ -947,7 +953,8 @@ class Geometric(Discrete):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.arange(1, 11)
         for p in [0.1, 0.25, 0.75]:
             pmf = st.geom.pmf(x, p)
@@ -1052,7 +1059,8 @@ class HyperGeometric(Discrete):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.arange(1, 15)
         N = 50
         k = 10
@@ -1203,7 +1211,8 @@ class DiscreteUniform(Discrete):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         ls = [1, -2]
         us = [6, 2]
         for l, u in zip(ls, us):
@@ -1327,7 +1336,8 @@ class Categorical(Discrete):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         ps = [[0.1, 0.6, 0.3], [0.3, 0.1, 0.1, 0.5]]
         for p in ps:
             x = range(len(p))
@@ -1518,7 +1528,8 @@ class ZeroInflatedPoisson(Discrete):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.arange(0, 22)
         psis = [0.7, 0.4]
         thetas = [8, 4]
@@ -1645,7 +1656,8 @@ class ZeroInflatedBinomial(Discrete):
         import matplotlib.pyplot as plt
         import numpy as np
         import scipy.stats as st
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.arange(0, 25)
         ns = [10, 20]
         ps = [0.5, 0.7]
@@ -1794,7 +1806,8 @@ class ZeroInflatedNegativeBinomial(Discrete):
         import numpy as np
         import scipy.stats as st
         from scipy import special
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
 
         def ZeroInfNegBinom(a, m, psi, x):
             pmf = special.binom(x + a - 1, x) * (a / (m + a))**a * (m / (m + a))**x


### PR DESCRIPTION
While working on issue 3859 , we saw seaborn-darkgrid is not the best of color friendly styles, and seaborn-colorblind is not regularly updated. arviz-darkgrid is relatively better and additionally as @ OriolAbril pointed out - matplotlib styles have not been updated in ~5 years, so using ArviZ would give us better control and the ability to easily update the style if needed.

This PR changes plt.style.use("seaborn-darkgrid") to arviz-darkgrid and adds a line of importing arviz, which is anyway a pymc3 dependency.

These changes are in continuous.py and discrete.py (i.e. The sample plots in documentation)