### PR TITLE
Add a type guard for `intX`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 - `pm.make_shared_replacements` now retains broadcasting information which fixes issues with Metropolis samplers (see [#4492](https://github.com/pymc-devs/pymc3/pull/4492)).
 
 **Release manager** for 3.11.2: Michael Osthege ([@michaelosthege](https://github.com/michaelosthege))
+- `pm.intX` did bad job with downcasting integers. It is fixed in [#4569](https://github.com/pymc-devs/pymc3/pull/4569). 
 
 ## PyMC3 3.11.1 (12 February 2021)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,7 +19,7 @@
 - `pm.make_shared_replacements` now retains broadcasting information which fixes issues with Metropolis samplers (see [#4492](https://github.com/pymc-devs/pymc3/pull/4492)).
 
 **Release manager** for 3.11.2: Michael Osthege ([@michaelosthege](https://github.com/michaelosthege))
-- `pm.intX` did bad job with downcasting integers. It is fixed in [#4569](https://github.com/pymc-devs/pymc3/pull/4569). 
+- `pm.intX` did bad job with downcasting integers. It is fixed in [#4569](https://github.com/pymc-devs/pymc3/pull/4569).
 
 ## PyMC3 3.11.1 (12 February 2021)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,7 +19,7 @@
 - `pm.make_shared_replacements` now retains broadcasting information which fixes issues with Metropolis samplers (see [#4492](https://github.com/pymc-devs/pymc3/pull/4492)).
 
 **Release manager** for 3.11.2: Michael Osthege ([@michaelosthege](https://github.com/michaelosthege))
-- `pm.intX` did bad job with downcasting integers. It is fixed in [#4569](https://github.com/pymc-devs/pymc3/pull/4569).
+- `pm.intX` no longer downcasts integers unnecessarily (see [#4569](https://github.com/pymc-devs/pymc3/pull/4569))
 
 ## PyMC3 3.11.1 (12 February 2021)
 

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -78,7 +78,7 @@ class TestData(SeededTest):
             trace = pm.sample(1000, tune=1000, chains=1)
         # Predict on new data.
         with model:
-            x_test = [5, 6, 9]
+            x_test = [5.0, 6.0, 9.0]
             pm.set_data(new_data={"x": x_test})
             y_test = pm.sample_posterior_predictive(trace)
             y_test1 = pm.fast_sample_posterior_predictive(trace)

--- a/pymc3/tests/test_model_helpers.py
+++ b/pymc3/tests/test_model_helpers.py
@@ -82,7 +82,7 @@ class TestHelperFunc:
         assert isinstance(theano_output, theano.graph.basic.Variable)
         npt.assert_allclose(theano_output.eval(), theano_graph_input.eval())
         intX = pm.theanof._conversion_map[theano.config.floatX]
-        if dense_input.dtype == intX or dense_input.dtype == theano.config.floatX:
+        if "int" in str(dense_input.dtype) or dense_input.dtype == theano.config.floatX:
             assert theano_output.owner is None  # func should not have added new nodes
             assert theano_output.name == input_name
         else:
@@ -92,7 +92,8 @@ class TestHelperFunc:
         if "float" in input_dtype:
             assert theano_output.dtype == theano.config.floatX
         else:
-            assert theano_output.dtype == intX
+            # only cast floats, leave ints as is
+            assert theano_output.dtype == input_dtype
 
         # Check function behavior with generator data
         generator_output = func(square_generator)

--- a/pymc3/theanof.py
+++ b/pymc3/theanof.py
@@ -93,6 +93,9 @@ def intX(X):
     """
     Convert a theano tensor or numpy array to theano.tensor.int32 type.
     """
+    # check value is already int, do nothing in this case
+    if (hasattr(X, "dtype") and "int" in str(X.dtype)) or isinstance(X, int):
+        return X
     intX = _conversion_map[theano.config.floatX]
     try:
         return X.astype(intX)


### PR DESCRIPTION
+ [x] what are the (breaking) changes that this PR makes?
    Integer dtypes are now not downcasted in intX
+ [x] important background, or details about the implementation
    In discrete distributions there is a usage of `intX` that enforces unreasonable limitations in UX (see #4553)
+ [x] are the changes—especially new features—covered by tests and docstrings?
    I did not yet create a unit test covering this specific usecase
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
    Ran `black` on it
+ [x] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
    Not required
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md

**Note:** Questions before we go ahead, the alternative would be leave the function as is and covert parameters in Discrete distributions