### PR TITLE
Fix use of `ValueGradFunction` in `Model` and re-enable tests

### DIFF
--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -241,7 +241,7 @@ class TestGLMLinear(SeededTest):
             pm.sample(50, pm.Slice(), start=start)
 
 
-@pytest.mark.xfail(reason="Metropolis samplers haven't been refactored")
+@pytest.mark.xfail(reason="ZeroInflatedPoisson hasn't been refactored for v4")
 class TestLatentOccupancy(SeededTest):
     """
     From the PyMC example list

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -216,7 +216,7 @@ class TestValueGradFunction(unittest.TestCase):
     def test_no_extra(self):
         a = aet.vector("a")
         a.tag.test_value = np.zeros(3, dtype=a.dtype)
-        f_grad = ValueGradFunction([a.sum()], [a], [], mode="FAST_COMPILE")
+        f_grad = ValueGradFunction([a.sum()], [a], {}, mode="FAST_COMPILE")
         assert f_grad._extra_vars == []
 
     def test_invalid_type(self):
@@ -225,25 +225,22 @@ class TestValueGradFunction(unittest.TestCase):
         a.dshape = (3,)
         a.dsize = 3
         with pytest.raises(TypeError) as err:
-            ValueGradFunction([a.sum()], [a], [], mode="FAST_COMPILE")
+            ValueGradFunction([a.sum()], [a], {}, mode="FAST_COMPILE")
         err.match("Invalid dtype")
 
     def setUp(self):
         extra1 = aet.iscalar("extra1")
         extra1_ = np.array(0, dtype=extra1.dtype)
-        extra1.tag.test_value = extra1_
         extra1.dshape = tuple()
         extra1.dsize = 1
 
         val1 = aet.vector("val1")
         val1_ = np.zeros(3, dtype=val1.dtype)
-        val1.tag.test_value = val1_
         val1.dshape = (3,)
         val1.dsize = 3
 
         val2 = aet.matrix("val2")
         val2_ = np.zeros((2, 3), dtype=val2.dtype)
-        val2.tag.test_value = val2_
         val2.dshape = (2, 3)
         val2.dsize = 6
 
@@ -253,7 +250,9 @@ class TestValueGradFunction(unittest.TestCase):
 
         self.cost = extra1 * val1.sum() + val2.sum()
 
-        self.f_grad = ValueGradFunction([self.cost], [val1, val2], [extra1], mode="FAST_COMPILE")
+        self.f_grad = ValueGradFunction(
+            [self.cost], [val1, val2], {extra1: extra1_}, mode="FAST_COMPILE"
+        )
 
     def test_extra_not_set(self):
         with pytest.raises(ValueError) as err:

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -967,6 +967,8 @@ class TestSamplePriorPredictive(SeededTest):
             a = pm.Uniform("a", lower=0, upper=1, size=10)
             b = pm.Binomial("b", n=1, p=a, size=10)
 
+        model.default_rng.get_value(borrow=True).seed(232093)
+
         b_sampler = aesara.function([], b)
         avg = np.stack([b_sampler() for i in range(10000)]).mean(0)
         npt.assert_array_almost_equal(avg, 0.5 * np.ones((10,)), decimal=2)


### PR DESCRIPTION
This PR fixes the use of `ValueGradFunction` in `Model` and re-enables some tests in `pymc3.tests.test_model`.