### PR TITLE
Fix sequential backend

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -755,7 +755,6 @@ def _sample_many(
                 traces.append(trace)
             break
         else:
-
             traces.append(trace)
     return MultiTrace(traces)
 

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -755,6 +755,7 @@ def _sample_many(
                 traces.append(trace)
             break
         else:
+
             traces.append(trace)
     return MultiTrace(traces)
 
@@ -869,6 +870,8 @@ def _sample(
         A ``BaseTrace`` object that contains the samples for this chain.
     """
     skip_first = kwargs.get("skip_first", 0)
+
+    trace = copy(trace)
 
     sampling = _iter_sample(draws, step, start, trace, chain, tune, model, random_seed, callback)
     _pbar_data = {"chain": chain, "divergences": 0}

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -289,6 +289,11 @@ class TestSample(SeededTest):
             )
             assert len(trace) == trace_cancel_length
 
+    def test_sequential_backend(self):
+        with self.model:
+            backend = NDArray()
+            trace = pm.sample(10, cores=1, chains=2, trace=backend)
+
 
 @pytest.mark.xfail(reason="Lognormal not refactored for v4")
 def test_sample_find_MAP_does_not_modify_start():


### PR DESCRIPTION
This PR fixes #4568 which involved failure to copy backend objects when multiple chains are sampled sequentially with `cores=1` for `pm.sample`.

+ what are the (breaking) changes that this PR makes?
This PR copies any incoming backend or trace objects at the beginning of `_sample`, which is the main function which is used in each per-chain iteration of multichain sequential sampling. 

+ [x] are the changes—especially new features—covered by tests and docstrings?
A single new test has been added to verify that the fix works.
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)

+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
