### PR TITLE
Hotfix theano.printing upon import

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## PyMC3 3.11.3 (TBD)
+### Maintenance
++ A deprecation warning from the `semver` package we use for checking backend compatibility was dealt with (see [#4547](https://github.com/pymc-devs/pymc3/pull/4547)).
++ `theano.printing.pydotprint` is now hotfixed upon import (see [#4594](https://github.com/pymc-devs/pymc3/pull/4594)).
+
 ## PyMC3 3.11.2 (14 March 2021)
 
 ### New Features

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -62,8 +62,22 @@ def __set_compiler_flags():
     theano.config.gcc__cxxflags = f"{current} -Wno-c++11-narrowing"
 
 
+def _hotfix_theano_printing():
+    """ This is a workaround for https://github.com/pymc-devs/aesara/issues/309 """
+    try:
+        import pydot
+        import theano.printing
+
+        if theano.printing.Node != pydot.Node:
+            theano.printing.Node = pydot.Node
+    except ImportError:
+        # pydot is not installed
+        pass
+
+
 _check_backend_version()
 __set_compiler_flags()
+_hotfix_theano_printing()
 
 from pymc3 import gp, ode, sampling
 from pymc3.backends import load_trace, save_trace


### PR DESCRIPTION
A workaround for https://github.com/pymc-devs/aesara/issues/309

While `pm.model_to_graphiz` is not affected by the bug, virtually everybody who uses Theano-PyMC does it in combination with PyMC3.
This hotfix allows us to be lazy and not make a patch release for Theano-PyMC.

This PR also adds a `3.11.3` section to the release notes.