### PR TITLE
Update survival_analysis.ipynb

### DIFF
--- a/docs/source/notebooks/survival_analysis.ipynb
+++ b/docs/source/notebooks/survival_analysis.ipynb
@@ -45,7 +45,7 @@
    "source": [
     "df = pd.read_csv(pm.get_data('mastectomy.csv'))\n",
     "df.event = df.event.astype(np.int64)\n",
-    "df.metastized = (df.metastized == 'yes').astype(np.int64)\n",
+    "df.metastasized = (df.metastasized == 'yes').astype(np.int64)\n",
     "n_patients = df.shape[0]\n",
     "patients = np.arange(n_patients)"
    ]
@@ -78,7 +78,7 @@
        "      <th></th>\n",
        "      <th>time</th>\n",
        "      <th>event</th>\n",
-       "      <th>metastized</th>\n",
+       "      <th>metastasized</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -117,7 +117,7 @@
        "</div>"
       ],
       "text/plain": [
-       "   time  event  metastized\n",
+       "   time  event  metastasized\n",
        "0    23      1           0\n",
        "1    47      1           0\n",
        "2    69      1           0\n",
@@ -158,9 +158,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each row represents observations from a woman diagnosed with breast cancer that underwent a mastectomy.  The column `time` represents the time (in months) post-surgery that the woman was observed.  The column `event` indicates whether or not the woman died during the observation period.  The column `metastized` represents whether the cancer had [metastized](https://en.wikipedia.org/wiki/Metastatic_breast_cancer) prior to surgery.\n",
+    "Each row represents observations from a woman diagnosed with breast cancer that underwent a mastectomy.  The column `time` represents the time (in months) post-surgery that the woman was observed.  The column `event` indicates whether or not the woman died during the observation period.  The column `metastasized` represents whether the cancer had [metastasized](https://en.wikipedia.org/wiki/Metastatic_breast_cancer) prior to surgery.\n",
     "\n",
-    "This tutorial analyzes the relationship between survival time post-mastectomy and whether or not the cancer had metastized."
+    "This tutorial analyzes the relationship between survival time post-mastectomy and whether or not the cancer had metastasized."
    ]
   },
   {
@@ -191,7 +191,7 @@
     "\n",
     "$$\\Lambda(t) = \\int_0^t \\lambda(s)\\ ds$$\n",
     "\n",
-    "is an important quantity in survival analysis, since we may consicesly write $S(t) = \\exp(-\\Lambda(t)).$\n",
+    "is an important quantity in survival analysis, since we may concisely write $S(t) = \\exp(-\\Lambda(t)).$\n",
     "\n",
     "An important, but subtle, point in survival analysis is [censoring](https://en.wikipedia.org/wiki/Survival_analysis#Censoring).  Even though the quantity we are interested in estimating is the time between surgery and death, we do not observe the death of every subject.  At the point in time that we perform our analysis, some of our subjects will thankfully still be alive. In the case of our mastectomy study, `df.event` is one if the subject's death was observed (the observation is not censored) and is zero if the death was not observed (the observation is censored)."
    ]
@@ -250,8 +250,8 @@
     "ax.hlines(patients[df.event.values == 1], 0, df[df.event.values == 1].time,\n",
     "          color=red, label='Uncensored')\n",
     "\n",
-    "ax.scatter(df[df.metastized.values == 1].time, patients[df.metastized.values == 1],\n",
-    "           color='k', zorder=10, label='Metastized')\n",
+    "ax.scatter(df[df.metastasized.values == 1].time, patients[df.metastasized.values == 1],\n",
+    "           color='k', zorder=10, label='Metastasized')\n",
     "\n",
     "ax.set_xlim(left=0)\n",
     "ax.set_xlabel('Months since mastectomy')\n",
@@ -267,9 +267,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When an observation is censored (`df.event` is zero), `df.time` is not the subject's survival time.  All we can conclude from such a censored obsevation is that the subject's true survival time exceeds `df.time`.\n",
+    "When an observation is censored (`df.event` is zero), `df.time` is not the subject's survival time.  All we can conclude from such a censored observation is that the subject's true survival time exceeds `df.time`.\n",
     "\n",
-    "This is enough basic surival analysis theory for the purposes of this tutorial; for a more extensive introduction, consult Aalen et al.^[Aalen, Odd, Ornulf Borgan, and Hakon Gjessing. Survival and event history analysis: a process point of view. Springer Science & Business Media, 2008.]"
+    "This is enough basic survival analysis theory for the purposes of this tutorial; for a more extensive introduction, consult Aalen et al.^[Aalen, Odd, Ornulf Borgan, and Hakon Gjessing. Survival and event history analysis: a process point of view. Springer Science & Business Media, 2008.]"
    ]
   },
   {
@@ -278,11 +278,11 @@
    "source": [
     "#### Bayesian proportional hazards model\n",
     "\n",
-    "The two most basic estimators in survial analysis are the [Kaplan-Meier estimator](https://en.wikipedia.org/wiki/Kaplan%E2%80%93Meier_estimator) of the survival function and the [Nelson-Aalen estimator](https://en.wikipedia.org/wiki/Nelson%E2%80%93Aalen_estimator) of the cumulative hazard function.  However, since we want to understand the impact of metastization on survival time, a risk regression model is more appropriate.  Perhaps the most commonly used risk regression model is [Cox's proportional hazards model](https://en.wikipedia.org/wiki/Proportional_hazards_model).  In this model, if we have covariates $\\mathbf{x}$ and regression coefficients $\\beta$, the hazard rate is modeled as\n",
+    "The two most basic estimators in survival analysis are the [Kaplan-Meier estimator](https://en.wikipedia.org/wiki/Kaplan%E2%80%93Meier_estimator) of the survival function and the [Nelson-Aalen estimator](https://en.wikipedia.org/wiki/Nelson%E2%80%93Aalen_estimator) of the cumulative hazard function.  However, since we want to understand the impact of metastization on survival time, a risk regression model is more appropriate.  Perhaps the most commonly used risk regression model is [Cox's proportional hazards model](https://en.wikipedia.org/wiki/Proportional_hazards_model).  In this model, if we have covariates $\\mathbf{x}$ and regression coefficients $\\beta$, the hazard rate is modeled as\n",
     "\n",
     "$$\\lambda(t) = \\lambda_0(t) \\exp(\\mathbf{x} \\beta).$$\n",
     "\n",
-    "Here $\\lambda_0(t)$ is the baseline hazard, which is independent of the covariates $\\mathbf{x}$.  In this example, the covariates are the one-dimensonal vector `df.metastized`.\n",
+    "Here $\\lambda_0(t)$ is the baseline hazard, which is independent of the covariates $\\mathbf{x}$.  In this example, the covariates are the one-dimensional vector `df.metastasized`.\n",
     "\n",
     "Unlike in many regression situations, $\\mathbf{x}$ should not include a constant term corresponding to an intercept.  If $\\mathbf{x}$ includes a constant term corresponding to an intercept, the model becomes [unidentifiable](https://en.wikipedia.org/wiki/Identifiability).  To illustrate this unidentifiability, suppose that\n",
     "\n",
@@ -355,7 +355,7 @@
    "source": [
     "With the prior distributions on $\\beta$ and $\\lambda_0(t)$ chosen, we now show how the model may be fit using MCMC simulation with `pymc3`.  The key observation is that the piecewise-constant proportional hazard model is [closely related](http://data.princeton.edu/wws509/notes/c7s4.html) to a Poisson regression model.   (The models are not identical, but their likelihoods differ by a factor that depends only on the observed data and not the parameters $\\beta$ and $\\lambda_j$.  For details, see Germán Rodríguez's WWS 509 [course notes](http://data.princeton.edu/wws509/notes/c7s4.html).)\n",
     "\n",
-    "We define indicator variables based on whether or the $i$-th suject died in the $j$-th interval,\n",
+    "We define indicator variables based on whether or the $i$-th subject died in the $j$-th interval,\n",
     "\n",
     "$$d_{i, j} = \\begin{cases}\n",
     "    1 & \\textrm{if subject } i \\textrm{ died in interval } j \\\\\n",
@@ -398,7 +398,7 @@
    "source": [
     "Finally, denote the risk incurred by the $i$-th subject in the $j$-th interval as $\\lambda_{i, j} = \\lambda_j \\exp(\\mathbf{x}_i \\beta)$.\n",
     "\n",
-    "We may approximate $d_{i, j}$ with a Possion random variable with mean $t_{i, j}\\ \\lambda_{i, j}$.  This approximation leads to the following `pymc3` model."
+    "We may approximate $d_{i, j}$ with a Poisson random variable with mean $t_{i, j}\\ \\lambda_{i, j}$.  This approximation leads to the following `pymc3` model."
    ]
   },
   {
@@ -422,7 +422,7 @@
     "    \n",
     "    beta = pm.Normal('beta', 0, sigma=1000)\n",
     "    \n",
-    "    lambda_ = pm.Deterministic('lambda_', T.outer(T.exp(beta * df.metastized), lambda0))\n",
+    "    lambda_ = pm.Deterministic('lambda_', T.outer(T.exp(beta * df.metastasized), lambda0))\n",
     "    mu = pm.Deterministic('mu', exposure * lambda_)\n",
     "    \n",
     "    obs = pm.Poisson('obs', mu, observed=death)"
@@ -474,7 +474,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We see that the hazard rate for subjects whose cancer has metastized is about double the rate of those whose cancer has not metastized."
+    "We see that the hazard rate for subjects whose cancer has metastasized is about double the rate of those whose cancer has not metastasized."
    ]
   },
   {
@@ -603,9 +603,9 @@
     "fig, (hazard_ax, surv_ax) = plt.subplots(ncols=2, sharex=True, sharey=False, figsize=(16, 6))\n",
     "\n",
     "plot_with_hpd(interval_bounds[:-1], base_hazard, cum_hazard,\n",
-    "              hazard_ax, color=blue, label='Had not metastized')\n",
+    "              hazard_ax, color=blue, label='Had not metastasized')\n",
     "plot_with_hpd(interval_bounds[:-1], met_hazard, cum_hazard,\n",
-    "              hazard_ax, color=red, label='Metastized')\n",
+    "              hazard_ax, color=red, label='Metastasized')\n",
     "\n",
     "hazard_ax.set_xlim(0, df.time.max());\n",
     "hazard_ax.set_xlabel('Months since mastectomy');\n",
@@ -631,7 +631,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We see that the cumulative hazard for metastized subjects increases more rapidly initially (through about seventy months), after which it increases roughly in parallel with the baseline cumulative hazard.\n",
+    "We see that the cumulative hazard for metastasized subjects increases more rapidly initially (through about seventy months), after which it increases roughly in parallel with the baseline cumulative hazard.\n",
     "\n",
     "These plots also show the pointwise 95% high posterior density interval for each function.  One of the distinct advantages of the Bayesian model fit with `pymc3` is the inherent quantification of uncertainty in our estimates."
    ]
@@ -642,7 +642,7 @@
    "source": [
     "##### Time varying effects\n",
     "\n",
-    "Another of the advantages of the model we have built is its flexibility.  From the plots above, we may reasonable believe that the additional hazard due to metastization varies over time; it seems plausible that cancer that has metastized increases the hazard rate immediately after the mastectomy, but that the risk due to metastization decreases over time.  We can accomodate this mechanism in our model by allowing the regression coefficients to vary over time.  In the time-varying coefficent model, if $s_j \\leq t < s_{j + 1}$, we let $\\lambda(t) = \\lambda_j \\exp(\\mathbf{x} \\beta_j).$  The sequence of regression coefficients $\\beta_1, \\beta_2, \\ldots, \\beta_{N - 1}$ form a normal random walk with $\\beta_1 \\sim N(0, 1)$, $\\beta_j\\ |\\ \\beta_{j - 1} \\sim N(\\beta_{j - 1}, 1)$.\n",
+    "Another of the advantages of the model we have built is its flexibility.  From the plots above, we may reasonable believe that the additional hazard due to metastization varies over time; it seems plausible that cancer that has metastasized increases the hazard rate immediately after the mastectomy, but that the risk due to metastization decreases over time.  We can accomodate this mechanism in our model by allowing the regression coefficients to vary over time.  In the time-varying coefficent model, if $s_j \\leq t < s_{j + 1}$, we let $\\lambda(t) = \\lambda_j \\exp(\\mathbf{x} \\beta_j).$  The sequence of regression coefficients $\\beta_1, \\beta_2, \\ldots, \\beta_{N - 1}$ form a normal random walk with $\\beta_1 \\sim N(0, 1)$, $\\beta_j\\ |\\ \\beta_{j - 1} \\sim N(\\beta_{j - 1}, 1)$.\n",
     "\n",
     "We implement this model in `pymc3` as follows."
    ]
@@ -658,7 +658,7 @@
     "    lambda0 = pm.Gamma('lambda0', 0.01, 0.01, shape=n_intervals)\n",
     "    beta = GaussianRandomWalk('beta', tau=1., shape=n_intervals)\n",
     "    \n",
-    "    lambda_ = pm.Deterministic('h', lambda0 * T.exp(T.outer(T.constant(df.metastized), beta)))\n",
+    "    lambda_ = pm.Deterministic('h', lambda0 * T.exp(T.outer(T.constant(df.metastasized), beta)))\n",
     "    mu = pm.Deterministic('mu', exposure * lambda_)\n",
     "    \n",
     "    obs = pm.Poisson('obs', mu, observed=death)"
@@ -759,12 +759,12 @@
     "                color=blue, alpha=0.25);\n",
     "beta_hat = time_varying_trace['beta'].mean(axis=0)\n",
     "ax.step(interval_bounds[:-1], beta_hat, color=blue);\n",
-    "ax.scatter(interval_bounds[last_period[(df.event.values == 1) & (df.metastized == 1)]],\n",
-    "           beta_hat[last_period[(df.event.values == 1) & (df.metastized == 1)]],\n",
-    "           c=red, zorder=10, label='Died, cancer metastized');\n",
-    "ax.scatter(interval_bounds[last_period[(df.event.values == 0) & (df.metastized == 1)]],\n",
-    "           beta_hat[last_period[(df.event.values == 0) & (df.metastized == 1)]],\n",
-    "           c=blue, zorder=10, label='Censored, cancer metastized');\n",
+    "ax.scatter(interval_bounds[last_period[(df.event.values == 1) & (df.metastasized == 1)]],\n",
+    "           beta_hat[last_period[(df.event.values == 1) & (df.metastasized == 1)]],\n",
+    "           c=red, zorder=10, label='Died, cancer metastasized');\n",
+    "ax.scatter(interval_bounds[last_period[(df.event.values == 0) & (df.metastasized == 1)]],\n",
+    "           beta_hat[last_period[(df.event.values == 0) & (df.metastasized == 1)]],\n",
+    "           c=blue, zorder=10, label='Censored, cancer metastasized');\n",
     "\n",
     "ax.set_xlim(0, df.time.max());\n",
     "ax.set_xlabel('Months since mastectomy');\n",
@@ -778,7 +778,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The coefficients $\\beta_j$ begin declining rapidly around one hundred months post-mastectomy, which seems reasonable, given that only three of twelve subjects whose cancer had metastized lived past this point died during the study.\n",
+    "The coefficients $\\beta_j$ begin declining rapidly around one hundred months post-mastectomy, which seems reasonable, given that only three of twelve subjects whose cancer had metastasized lived past this point died during the study.\n",
     "\n",
     "The change in our estimate of the cumulative hazard and survival functions due to time-varying effects is also quite apparent in the following plots."
    ]
@@ -813,14 +813,14 @@
     "fig, ax = plt.subplots(figsize=(8, 6))\n",
     "\n",
     "ax.step(interval_bounds[:-1], cum_hazard(base_hazard.mean(axis=0)),\n",
-    "        color=blue, label='Had not metastized');\n",
+    "        color=blue, label='Had not metastasized');\n",
     "ax.step(interval_bounds[:-1], cum_hazard(met_hazard.mean(axis=0)),\n",
-    "        color=red, label='Metastized');\n",
+    "        color=red, label='Metastasized');\n",
     "\n",
     "ax.step(interval_bounds[:-1], cum_hazard(tv_base_hazard.mean(axis=0)),\n",
-    "        color=blue, linestyle='--', label='Had not metastized (time varying effect)');\n",
+    "        color=blue, linestyle='--', label='Had not metastasized (time varying effect)');\n",
     "ax.step(interval_bounds[:-1], cum_hazard(tv_met_hazard.mean(axis=0)),\n",
-    "        color=red, linestyle='--', label='Metastized (time varying effect)');\n",
+    "        color=red, linestyle='--', label='Metastasized (time varying effect)');\n",
     "\n",
     "ax.set_xlim(0, df.time.max() - 4);\n",
     "ax.set_xlabel('Months since mastectomy');\n",
@@ -851,9 +851,9 @@
     "fig, (hazard_ax, surv_ax) = plt.subplots(ncols=2, sharex=True, sharey=False, figsize=(16, 6))\n",
     "\n",
     "plot_with_hpd(interval_bounds[:-1], tv_base_hazard, cum_hazard,\n",
-    "              hazard_ax, color=blue, label='Had not metastized')\n",
+    "              hazard_ax, color=blue, label='Had not metastasized')\n",
     "plot_with_hpd(interval_bounds[:-1], tv_met_hazard, cum_hazard,\n",
-    "              hazard_ax, color=red, label='Metastized')\n",
+    "              hazard_ax, color=red, label='Metastasized')\n",
     "\n",
     "hazard_ax.set_xlim(0, df.time.max());\n",
     "hazard_ax.set_xlabel('Months since mastectomy');\n",


### PR DESCRIPTION
Fixes typos in the survival_analysis notebook as per issue #4603, including typos in column names of the example df.