### PR TITLE
Fix documentation error in description of Gamma function

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2486,7 +2486,7 @@ class Gamma(PositiveContinuous):
     Gamma log-likelihood.
 
     Represents the sum of alpha exponentially distributed random variables,
-    each of which has mean beta.
+    each of which has rate beta.
 
     The pdf of this distribution is
 


### PR DESCRIPTION
Fixes the issue #4601. It's a really simple documentation fix about the description of Gamma function - represents the sum of alpha exponentially distributed random variables, each of which has `rate beta` instead of `mean beta`.
There was no error noted in the description of Inverse Gamma Function.

I was not exactly sure how to rebuild docs, and I assumed that there would be a hook in the CI/CD pipeline. Please let me know if it needs to be done manually.
