### PR TITLE
V4 update test framework for distributions random method 2nd attempt

### DIFF
--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -713,16 +713,16 @@ class NegativeBinomial(Discrete):
 
     @classmethod
     def dist(cls, mu=None, alpha=None, p=None, n=None, *args, **kwargs):
-        n, p = cls.get_mu_alpha(mu, alpha, p, n)
+        n, p = cls.get_n_p(mu, alpha, p, n)
         n = at.as_tensor_variable(floatX(n))
         p = at.as_tensor_variable(floatX(p))
         return super().dist([n, p], *args, **kwargs)
 
     @classmethod
-    def get_mu_alpha(cls, mu=None, alpha=None, p=None, n=None):
+    def get_n_p(cls, mu=None, alpha=None, p=None, n=None):
         if n is None:
             if alpha is not None:
-                n = at.as_tensor_variable(floatX(alpha))
+                n = alpha
             else:
                 raise ValueError("Incompatible parametrization. Must specify either alpha or n.")
         elif alpha is not None:
@@ -730,7 +730,6 @@ class NegativeBinomial(Discrete):
 
         if p is None:
             if mu is not None:
-                mu = at.as_tensor_variable(floatX(mu))
                 p = n / (mu + n)
             else:
                 raise ValueError("Incompatible parametrization. Must specify either mu or p.")

--- a/pymc3/tests/helpers.py
+++ b/pymc3/tests/helpers.py
@@ -27,6 +27,7 @@ from pymc3.aesaraf import at_rng, set_at_rng
 
 class SeededTest:
     random_seed = 20160911
+    random_state = None
 
     @classmethod
     def setup_class(cls):
@@ -39,6 +40,11 @@ class SeededTest:
 
     def teardown_method(self):
         set_at_rng(self.old_at_rng)
+
+    def get_random_state(self):
+        if self.random_state is None:
+            self.random_state = nr.RandomState(self.random_seed)
+        return self.random_state
 
 
 class LoggingHandler(BufferingHandler):

--- a/pymc3/tests/helpers.py
+++ b/pymc3/tests/helpers.py
@@ -41,8 +41,8 @@ class SeededTest:
     def teardown_method(self):
         set_at_rng(self.old_at_rng)
 
-    def get_random_state(self):
-        if self.random_state is None:
+    def get_random_state(self, reset=False):
+        if self.random_state is None or reset:
             self.random_state = nr.RandomState(self.random_seed)
         return self.random_state
 

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -587,9 +587,6 @@ class TestCorrectParametrizationMappingPymcToScipy(SeededTest):
         params = [("n", 85), ("p", np.array([0.28, 0.62, 0.10]))]
         self._compare_pymc_sampling_with_aesara_one(params, list(params), pm.Multinomial)
 
-    @pytest.mark.xfail(
-        reason="Requires bug fix in aesara 2.0.5 release. Commit id 02378861f1a77135f2556018630092a09262ea76"
-    )
     def test_categorical(self):
         params = [("p", np.array([0.28, 0.62, 0.10]))]
         self._compare_pymc_sampling_with_aesara_one(params, list(params), pm.Categorical)

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -240,12 +240,6 @@ class TestGaussianRandomWalk(BaseTestCases.BaseTestCase):
     default_shape = (1,)
 
 
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestNormal(BaseTestCases.BaseTestCase):
-    distribution = pm.Normal
-    params = {"mu": 0.0, "tau": 1.0}
-
-
 @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
 class TestTruncatedNormal(BaseTestCases.BaseTestCase):
     distribution = pm.TruncatedNormal
@@ -268,18 +262,6 @@ class TestTruncatedNormalUpper(BaseTestCases.BaseTestCase):
 class TestSkewNormal(BaseTestCases.BaseTestCase):
     distribution = pm.SkewNormal
     params = {"mu": 0.0, "sigma": 1.0, "alpha": 5.0}
-
-
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestHalfNormal(BaseTestCases.BaseTestCase):
-    distribution = pm.HalfNormal
-    params = {"tau": 1.0}
-
-
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestUniform(BaseTestCases.BaseTestCase):
-    distribution = pm.Uniform
-    params = {"lower": 0.0, "upper": 1.0}
 
 
 @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
@@ -305,12 +287,6 @@ class TestKumaraswamy(BaseTestCases.BaseTestCase):
     params = {"a": 1.0, "b": 1.0}
 
 
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestExponential(BaseTestCases.BaseTestCase):
-    distribution = pm.Exponential
-    params = {"lam": 1.0}
-
-
 @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
 class TestLaplace(BaseTestCases.BaseTestCase):
     distribution = pm.Laplace
@@ -333,30 +309,6 @@ class TestLognormal(BaseTestCases.BaseTestCase):
 class TestStudentT(BaseTestCases.BaseTestCase):
     distribution = pm.StudentT
     params = {"nu": 5.0, "mu": 0.0, "lam": 1.0}
-
-
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestCauchy(BaseTestCases.BaseTestCase):
-    distribution = pm.Cauchy
-    params = {"alpha": 1.0, "beta": 1.0}
-
-
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestHalfCauchy(BaseTestCases.BaseTestCase):
-    distribution = pm.HalfCauchy
-    params = {"beta": 1.0}
-
-
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestGamma(BaseTestCases.BaseTestCase):
-    distribution = pm.Gamma
-    params = {"alpha": 1.0, "beta": 1.0}
-
-
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestInverseGamma(BaseTestCases.BaseTestCase):
-    distribution = pm.InverseGamma
-    params = {"alpha": 0.5, "beta": 0.5}
 
 
 @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
@@ -401,12 +353,6 @@ class TestLogitNormal(BaseTestCases.BaseTestCase):
     params = {"mu": 0.0, "sigma": 1.0}
 
 
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestBinomial(BaseTestCases.BaseTestCase):
-    distribution = pm.Binomial
-    params = {"n": 5, "p": 0.5}
-
-
 @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
 class TestBetaBinomial(BaseTestCases.BaseTestCase):
     distribution = pm.BetaBinomial
@@ -419,21 +365,10 @@ class TestBernoulli(BaseTestCases.BaseTestCase):
     params = {"p": 0.5}
 
 
+@pytest.mark.xfail(reason="This distribution has not been refactored for v4")
 class TestDiscreteWeibull(BaseTestCases.BaseTestCase):
     distribution = pm.DiscreteWeibull
     params = {"q": 0.25, "beta": 2.0}
-
-
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestPoisson(BaseTestCases.BaseTestCase):
-    distribution = pm.Poisson
-    params = {"mu": 1.0}
-
-
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestNegativeBinomial(BaseTestCases.BaseTestCase):
-    distribution = pm.NegativeBinomial
-    params = {"mu": 1.0, "alpha": 1.0}
 
 
 @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
@@ -482,45 +417,6 @@ class TestHyperGeometric(BaseTestCases.BaseTestCase):
 class TestMoyal(BaseTestCases.BaseTestCase):
     distribution = pm.Moyal
     params = {"mu": 0.0, "sigma": 1.0}
-
-
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestCategorical(BaseTestCases.BaseTestCase):
-    distribution = pm.Categorical
-    params = {"p": np.ones(BaseTestCases.BaseTestCase.shape)}
-
-    def get_random_variable(
-        self, shape, with_vector_params=False, **kwargs
-    ):  # don't transform categories
-        return super().get_random_variable(shape, with_vector_params=False, **kwargs)
-
-    def test_probability_vector_shape(self):
-        """Check that if a 2d array of probabilities are passed to categorical correct shape is returned"""
-        p = np.ones((10, 5))
-        assert pm.Categorical.dist(p=p).random().shape == (10,)
-        assert pm.Categorical.dist(p=p).random(size=4).shape == (4, 10)
-        p = np.ones((3, 7, 5))
-        assert pm.Categorical.dist(p=p).random().shape == (3, 7)
-        assert pm.Categorical.dist(p=p).random(size=4).shape == (4, 3, 7)
-
-
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestDirichlet(SeededTest):
-    @pytest.mark.parametrize(
-        "shape, size",
-        [
-            ((2), (1)),
-            ((2), (2)),
-            ((2, 2), (2, 100)),
-            ((3, 4), (3, 4)),
-            ((3, 4), (3, 4, 100)),
-            ((3, 4), (100)),
-            ((3, 4), (1)),
-        ],
-    )
-    def test_dirichlet_random_shape(self, shape, size):
-        out_shape = to_tuple(size) + to_tuple(shape)
-        assert pm.Dirichlet.dist(a=np.ones(shape)).random(size=size).shape == out_shape
 
 
 class TestCorrectParametrizationMappingPymcToScipy(SeededTest):

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -533,9 +533,7 @@ class TestCorrectParametrizationMappingPymcToScipy(SeededTest):
         # I am assuming there will always only be 1 Apply parent node in this context
         return parents[0].inputs
 
-    def test_pymc_params_match_rv_ones(
-        self, pymc_params, expected_aesara_params, pymc_dist, decimal=6
-    ):
+    def _pymc_params_match_rv_ones(self, pymc_params, expected_aesara_params, pymc_dist, decimal=6):
         pymc_dist_output = pymc_dist.dist(**dict(pymc_params))
         aesera_dist_inputs = self.get_inputs_from_apply_node_outputs(pymc_dist_output)[3:]
         assert len(expected_aesara_params) == len(aesera_dist_inputs)
@@ -546,52 +544,88 @@ class TestCorrectParametrizationMappingPymcToScipy(SeededTest):
 
     def test_normal(self):
         params = [("mu", 5.0), ("sigma", 10.0)]
-        self.test_pymc_params_match_rv_ones(params, params, pm.Normal)
+        self._pymc_params_match_rv_ones(params, params, pm.Normal)
 
     def test_uniform(self):
         params = [("lower", 0.5), ("upper", 1.5)]
-        self.test_pymc_params_match_rv_ones(params, params, pm.Uniform)
+        self._pymc_params_match_rv_ones(params, params, pm.Uniform)
 
     def test_half_normal(self):
         params, expected_aesara_params = [("sigma", 10.0)], [("mean", 0), ("sigma", 10.0)]
-        self.test_pymc_params_match_rv_ones(params, expected_aesara_params, pm.HalfNormal)
+        self._pymc_params_match_rv_ones(params, expected_aesara_params, pm.HalfNormal)
 
     def test_beta_alpha_beta(self):
         params = [("alpha", 2.0), ("beta", 5.0)]
-        self.test_pymc_params_match_rv_ones(params, params, pm.Beta)
+        self._pymc_params_match_rv_ones(params, params, pm.Beta)
 
     def test_beta_mu_sigma(self):
         params = [("mu", 2.0), ("sigma", 5.0)]
         expected_alpha, expected_beta = pm.Beta.get_alpha_beta(mu=params[0][1], sigma=params[1][1])
         expected_params = [("alpha", expected_alpha), ("beta", expected_beta)]
-        self.test_pymc_params_match_rv_ones(params, expected_params, pm.Beta)
+        self._pymc_params_match_rv_ones(params, expected_params, pm.Beta)
 
     @pytest.mark.skip(reason="Expected to fail due to bug")
     def test_exponential(self):
         params = [("lam", 10.0)]
         expected_params = [("lam", 1 / params[0][1])]
-        self.test_pymc_params_match_rv_ones(params, expected_params, pm.Exponential)
+        self._pymc_params_match_rv_ones(params, expected_params, pm.Exponential)
 
     def test_cauchy(self):
         params = [("alpha", 2.0), ("beta", 5.0)]
-        self.test_pymc_params_match_rv_ones(params, params, pm.Cauchy)
+        self._pymc_params_match_rv_ones(params, params, pm.Cauchy)
 
     def test_half_cauchy(self):
         params = [("alpha", 2.0), ("beta", 5.0)]
-        self.test_pymc_params_match_rv_ones(params, params, pm.HalfCauchy)
+        self._pymc_params_match_rv_ones(params, params, pm.HalfCauchy)
 
     @pytest.mark.skip(reason="Expected to fail due to bug")
     def test_gamma_alpha_beta(self):
         params = [("alpha", 2.0), ("beta", 5.0)]
         expected_params = [("alpha", params[0][1]), ("beta", 1 / params[1][1])]
-        self.test_pymc_params_match_rv_ones(params, expected_params, pm.Gamma)
+        self._pymc_params_match_rv_ones(params, expected_params, pm.Gamma)
 
     @pytest.mark.skip(reason="Expected to fail due to bug")
     def test_gamma_mu_sigma(self):
         params = [("mu", 2.0), ("sigma", 5.0)]
         expected_alpha, expected_beta = pm.Gamma.get_alpha_beta(mu=params[0][1], sigma=params[1][1])
         expected_params = [("alpha", expected_alpha), ("beta", 1 / expected_beta)]
-        self.test_pymc_params_match_rv_ones(params, expected_params, pm.Gamma)
+        self._pymc_params_match_rv_ones(params, expected_params, pm.Gamma)
+
+    def test_inverse_gamma_alpha_beta(self):
+        params = [("alpha", 2.0), ("beta", 5.0)]
+        self._pymc_params_match_rv_ones(params, params, pm.InverseGamma)
+
+    def test_inverse_gamma_mu_sigma(self):
+        params = [("mu", 2.0), ("sigma", 5.0)]
+        expected_alpha, expected_beta = pm.InverseGamma._get_alpha_beta(
+            mu=params[0][1], sigma=params[1][1], alpha=None, beta=None
+        )
+        expected_params = [("alpha", expected_alpha), ("beta", expected_beta)]
+        self._pymc_params_match_rv_ones(params, expected_params, pm.InverseGamma)
+
+    def test_binomial(self):
+        params = [("n", 100), ("p", 0.33)]
+        self._pymc_params_match_rv_ones(params, params, pm.Binomial)
+
+    def test_negative_binomial(self):
+        params = [("n", 100), ("p", 0.33)]
+        self._pymc_params_match_rv_ones(params, params, pm.NegativeBinomial)
+
+    def test_negative_binomial_mu_sigma(self):
+        params = [("mu", 5.0), ("alpha", 8.0)]
+        expected_n, expected_p = pm.NegativeBinomial.get_n_p(
+            mu=params[0][1], alpha=params[1][1], n=None, p=None
+        )
+        expected_params = [("n", expected_n), ("p", expected_p)]
+        self._pymc_params_match_rv_ones(params, expected_params, pm.NegativeBinomial)
+
+    def test_bernoulli(self):
+        params = [("p", 0.33)]
+        self._pymc_params_match_rv_ones(params, params, pm.Bernoulli)
+
+    def test_poisson(self):
+        params = [("mu", 4)]
+        self._pymc_params_match_rv_ones(params, params, pm.Poisson)
 
 
 class TestScalarParameterSamples(SeededTest):
@@ -689,14 +723,6 @@ class TestScalarParameterSamples(SeededTest):
 
         pymc3_random(pm.StudentT, {"nu": Rplus, "mu": R, "lam": Rplus}, ref_rand=ref_rand)
 
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-
-    def test_inverse_gamma(self):
-        def ref_rand(size, alpha, beta):
-            return st.invgamma.rvs(a=alpha, scale=beta, size=size)
-
-        pymc3_random(pm.InverseGamma, {"alpha": Rplus, "beta": Rplus}, ref_rand=ref_rand)
-
     @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
     def test_ex_gaussian(self):
         def ref_rand(size, mu, sigma, nu):
@@ -736,10 +762,6 @@ class TestScalarParameterSamples(SeededTest):
             with pytest.raises(ValueError):
                 f.random(1)
 
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_binomial(self):
-        pymc3_random_discrete(pm.Binomial, {"n": Nat, "p": Unit}, ref_rand=st.binom.rvs)
-
     @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
     @pytest.mark.xfail(
         sys.platform.startswith("win"),
@@ -752,29 +774,6 @@ class TestScalarParameterSamples(SeededTest):
 
     def _beta_bin(self, n, alpha, beta, size=None):
         return st.binom.rvs(n, st.beta.rvs(a=alpha, b=beta, size=size))
-
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_bernoulli(self):
-        pymc3_random_discrete(
-            pm.Bernoulli, {"p": Unit}, ref_rand=lambda size, p=None: st.bernoulli.rvs(p, size=size)
-        )
-
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_poisson(self):
-        pymc3_random_discrete(pm.Poisson, {"mu": Rplusbig}, size=500, ref_rand=st.poisson.rvs)
-
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_negative_binomial(self):
-        def ref_rand(size, alpha, mu):
-            return st.nbinom.rvs(alpha, alpha / (mu + alpha), size=size)
-
-        pymc3_random_discrete(
-            pm.NegativeBinomial,
-            {"mu": Rplusbig, "alpha": Rplusbig},
-            size=100,
-            fails=50,
-            ref_rand=ref_rand,
-        )
 
     @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
     def test_geometric(self):

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -25,12 +25,12 @@ import pytest
 import scipy.stats as st
 
 from numpy.testing import assert_almost_equal
-from scipy import linalg
 from scipy.special import expit
 
 import pymc3 as pm
 
 from pymc3.aesaraf import change_rv_size, floatX, intX
+from pymc3.distributions.multivariate import quaddist_matrix
 from pymc3.distributions.shape_utils import to_tuple
 from pymc3.exceptions import ShapeError
 from pymc3.tests.helpers import SeededTest, select_by_precision
@@ -41,7 +41,6 @@ from pymc3.tests.test_distributions import (
     NatSmall,
     PdMatrix,
     PdMatrixChol,
-    PdMatrixCholUpper,
     R,
     RandomPdMatrix,
     RealMatrix,
@@ -627,6 +626,34 @@ class TestCorrectParametrizationMappingPymcToScipy(SeededTest):
         params = [("mu", 4)]
         self._pymc_params_match_rv_ones(params, params, pm.Poisson)
 
+    def test_mv_distribution(self):
+        params = [("mu", np.array([1.0, 2.0])), ("cov", np.array([[2.0, 0.0], [0.0, 3.5]]))]
+        self._pymc_params_match_rv_ones(params, params, pm.MvNormal)
+
+    def test_mv_distribution_chol(self):
+        params = [("mu", np.array([1.0, 2.0])), ("chol", np.array([[2.0, 0.0], [0.0, 3.5]]))]
+        expected_cov = quaddist_matrix(chol=params[1][1])
+        expected_params = [("mu", np.array([1.0, 2.0])), ("cov", expected_cov.eval())]
+        self._pymc_params_match_rv_ones(params, expected_params, pm.MvNormal)
+
+    def test_mv_distribution_tau(self):
+        params = [("mu", np.array([1.0, 2.0])), ("tau", np.array([[2.0, 0.0], [0.0, 3.5]]))]
+        expected_cov = quaddist_matrix(tau=params[1][1])
+        expected_params = [("mu", np.array([1.0, 2.0])), ("cov", expected_cov.eval())]
+        self._pymc_params_match_rv_ones(params, expected_params, pm.MvNormal)
+
+    def test_dirichlet(self):
+        params = [("a", np.array([1.0, 2.0]))]
+        self._pymc_params_match_rv_ones(params, params, pm.Dirichlet)
+
+    def test_multinomial(self):
+        params = [("n", 85), ("p", np.array([0.28, 0.62, 0.10]))]
+        self._pymc_params_match_rv_ones(params, params, pm.Multinomial)
+
+    def test_categorical(self):
+        params = [("p", np.array([0.28, 0.62, 0.10]))]
+        self._pymc_params_match_rv_ones(params, params, pm.Categorical)
+
 
 class TestScalarParameterSamples(SeededTest):
     @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
@@ -815,65 +842,12 @@ class TestScalarParameterSamples(SeededTest):
             pm.DiscreteWeibull, {"q": Unit, "beta": Rplusdunif}, ref_rand=ref_rand
         )
 
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    @pytest.mark.parametrize("s", [2, 3, 4])
-    def test_categorical_random(self, s):
-        def ref_rand(size, p):
-            return nr.choice(np.arange(p.shape[0]), p=p, size=size)
-
-        pymc3_random_discrete(pm.Categorical, {"p": Simplex(s)}, ref_rand=ref_rand)
-
     @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
     def test_constant_dist(self):
         def ref_rand(size, c):
             return c * np.ones(size, dtype=int)
 
         pymc3_random_discrete(pm.Constant, {"c": I}, ref_rand=ref_rand)
-
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_mv_normal(self):
-        def ref_rand(size, mu, cov):
-            return st.multivariate_normal.rvs(mean=mu, cov=cov, size=size)
-
-        def ref_rand_tau(size, mu, tau):
-            return ref_rand(size, mu, linalg.inv(tau))
-
-        def ref_rand_chol(size, mu, chol):
-            return ref_rand(size, mu, np.dot(chol, chol.T))
-
-        def ref_rand_uchol(size, mu, chol):
-            return ref_rand(size, mu, np.dot(chol.T, chol))
-
-        for n in [2, 3]:
-            pymc3_random(
-                pm.MvNormal,
-                {"mu": Vector(R, n), "cov": PdMatrix(n)},
-                size=100,
-                valuedomain=Vector(R, n),
-                ref_rand=ref_rand,
-            )
-            pymc3_random(
-                pm.MvNormal,
-                {"mu": Vector(R, n), "tau": PdMatrix(n)},
-                size=100,
-                valuedomain=Vector(R, n),
-                ref_rand=ref_rand_tau,
-            )
-            pymc3_random(
-                pm.MvNormal,
-                {"mu": Vector(R, n), "chol": PdMatrixChol(n)},
-                size=100,
-                valuedomain=Vector(R, n),
-                ref_rand=ref_rand_chol,
-            )
-            pymc3_random(
-                pm.MvNormal,
-                {"mu": Vector(R, n), "chol": PdMatrixCholUpper(n)},
-                size=100,
-                valuedomain=Vector(R, n),
-                ref_rand=ref_rand_uchol,
-                extra_args={"lower": False},
-            )
 
     @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
     def test_matrix_normal(self):
@@ -1017,20 +991,6 @@ class TestScalarParameterSamples(SeededTest):
                 ref_rand=ref_rand,
             )
 
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_dirichlet(self):
-        def ref_rand(size, a):
-            return st.dirichlet.rvs(a, size=size)
-
-        for n in [2, 3]:
-            pymc3_random(
-                pm.Dirichlet,
-                {"a": Vector(Rplus, n)},
-                valuedomain=Simplex(n),
-                size=100,
-                ref_rand=ref_rand,
-            )
-
     @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
     def test_dirichlet_multinomial(self):
         def ref_rand(size, a, n):
@@ -1097,20 +1057,6 @@ class TestScalarParameterSamples(SeededTest):
         m = pm.DirichletMultinomial.dist(n=n, a=a, shape=shape)
         with expectation:
             m.random()
-
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_multinomial(self):
-        def ref_rand(size, p, n):
-            return nr.multinomial(pvals=p, n=n, size=size)
-
-        for n in [2, 3]:
-            pymc3_random_discrete(
-                pm.Multinomial,
-                {"p": Simplex(n), "n": Nat},
-                valuedomain=Vector(Nat, n),
-                size=100,
-                ref_rand=ref_rand,
-            )
 
     @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
     def test_gumbel(self):

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -508,7 +508,7 @@ def seeded_numpy_distribution_builder(dist_name: str) -> Callable:
     )
 
 
-class TestGumbelDistribution(BaseTestDistribution):
+class TestGumbel(BaseTestDistribution):
     pymc_dist = pm.Gumbel
     pymc_dist_params = {"mu": 1.5, "beta": 3.0}
     expected_rv_op_params = {"mu": 1.5, "beta": 3.0}
@@ -522,7 +522,7 @@ class TestGumbelDistribution(BaseTestDistribution):
     ]
 
 
-class TestNormalDistribution(BaseTestDistribution):
+class TestNormal(BaseTestDistribution):
     pymc_dist = pm.Normal
     pymc_dist_params = {"mu": 5.0, "sigma": 10.0}
     expected_rv_op_params = {"mu": 5.0, "sigma": 10.0}
@@ -536,7 +536,7 @@ class TestNormalDistribution(BaseTestDistribution):
     ]
 
 
-class TestNormalTauDistribution(BaseTestDistribution):
+class TestNormalTau(BaseTestDistribution):
     pymc_dist = pm.Normal
     tau, sigma = get_tau_sigma(tau=25.0)
     pymc_dist_params = {"mu": 1.0, "sigma": sigma}
@@ -544,28 +544,28 @@ class TestNormalTauDistribution(BaseTestDistribution):
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestNormalSdDistribution(BaseTestDistribution):
+class TestNormalSd(BaseTestDistribution):
     pymc_dist = pm.Normal
     pymc_dist_params = {"mu": 1.0, "sd": 5.0}
     expected_rv_op_params = {"mu": 1.0, "sigma": 5.0}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestUniformDistribution(BaseTestDistribution):
+class TestUniform(BaseTestDistribution):
     pymc_dist = pm.Uniform
     pymc_dist_params = {"lower": 0.5, "upper": 1.5}
     expected_rv_op_params = {"lower": 0.5, "upper": 1.5}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestHalfNormalDistribution(BaseTestDistribution):
+class TestHalfNormal(BaseTestDistribution):
     pymc_dist = pm.HalfNormal
     pymc_dist_params = {"sigma": 10.0}
     expected_rv_op_params = {"mean": 0, "sigma": 10.0}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestHalfNormalTauDistribution(BaseTestDistribution):
+class TestHalfNormalTau(BaseTestDistribution):
     pymc_dist = pm.Normal
     tau, sigma = get_tau_sigma(tau=25.0)
     pymc_dist_params = {"sigma": sigma}
@@ -573,21 +573,21 @@ class TestHalfNormalTauDistribution(BaseTestDistribution):
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestHalfNormalSdDistribution(BaseTestDistribution):
+class TestHalfNormalSd(BaseTestDistribution):
     pymc_dist = pm.Normal
     pymc_dist_params = {"sd": 5.0}
     expected_rv_op_params = {"mu": 0.0, "sigma": 5.0}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestBetaAlphaBetaDistribution(BaseTestDistribution):
+class TestBeta(BaseTestDistribution):
     pymc_dist = pm.Beta
     pymc_dist_params = {"alpha": 2.0, "beta": 5.0}
     expected_rv_op_params = {"alpha": 2.0, "beta": 5.0}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestBetaMuSigmaDistribution(BaseTestDistribution):
+class TestBetaMuSigma(BaseTestDistribution):
     pymc_dist = pm.Beta
     pymc_dist_params = {"mu": 0.5, "sigma": 0.25}
     expected_alpha, expected_beta = pm.Beta.get_alpha_beta(
@@ -597,35 +597,35 @@ class TestBetaMuSigmaDistribution(BaseTestDistribution):
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestExponentialDistribution(BaseTestDistribution):
+class TestExponential(BaseTestDistribution):
     pymc_dist = pm.Exponential
     pymc_dist_params = {"lam": 10.0}
     expected_rv_op_params = {"lam": 1.0 / pymc_dist_params["lam"]}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestCauchyDistribution(BaseTestDistribution):
+class TestCauchy(BaseTestDistribution):
     pymc_dist = pm.Cauchy
     pymc_dist_params = {"alpha": 2.0, "beta": 5.0}
     expected_rv_op_params = {"alpha": 2.0, "beta": 5.0}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestHalfCauchyDistribution(BaseTestDistribution):
+class TestHalfCauchyn(BaseTestDistribution):
     pymc_dist = pm.HalfCauchy
     pymc_dist_params = {"beta": 5.0}
     expected_rv_op_params = {"alpha": 0.0, "beta": 5.0}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestGammaAlphaBetaDistribution(BaseTestDistribution):
+class TestGamma(BaseTestDistribution):
     pymc_dist = pm.Gamma
     pymc_dist_params = {"alpha": 2.0, "beta": 5.0}
     expected_rv_op_params = {"alpha": 2.0, "beta": 1 / 5.0}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestGammaMuSigmaDistribution(BaseTestDistribution):
+class TestGammaMuSigma(BaseTestDistribution):
     pymc_dist = pm.Gamma
     pymc_dist_params = {"mu": 0.5, "sigma": 0.25}
     expected_alpha, expected_beta = pm.Gamma.get_alpha_beta(
@@ -635,14 +635,14 @@ class TestGammaMuSigmaDistribution(BaseTestDistribution):
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestInverseGammaAlphaBetaDistribution(BaseTestDistribution):
+class TestInverseGamma(BaseTestDistribution):
     pymc_dist = pm.InverseGamma
     pymc_dist_params = {"alpha": 2.0, "beta": 5.0}
     expected_rv_op_params = {"alpha": 2.0, "beta": 5.0}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestInverseGammaMuSigmaDistribution(BaseTestDistribution):
+class TestInverseGammaMuSigma(BaseTestDistribution):
     pymc_dist = pm.InverseGamma
     pymc_dist_params = {"mu": 0.5, "sigma": 0.25}
     expected_alpha, expected_beta = pm.InverseGamma._get_alpha_beta(
@@ -655,21 +655,21 @@ class TestInverseGammaMuSigmaDistribution(BaseTestDistribution):
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestBinomialDistribution(BaseTestDistribution):
+class TestBinomial(BaseTestDistribution):
     pymc_dist = pm.Binomial
     pymc_dist_params = {"n": 100, "p": 0.33}
     expected_rv_op_params = {"n": 100, "p": 0.33}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestNegativeBinomialVDistribution(BaseTestDistribution):
+class TestNegativeBinomial(BaseTestDistribution):
     pymc_dist = pm.NegativeBinomial
     pymc_dist_params = {"n": 100, "p": 0.33}
     expected_rv_op_params = {"n": 100, "p": 0.33}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestNegativeBinomialMuSigmaDistribution(BaseTestDistribution):
+class TestNegativeBinomialMuSigma(BaseTestDistribution):
     pymc_dist = pm.NegativeBinomial
     pymc_dist_params = {"mu": 5.0, "alpha": 8.0}
     expected_n, expected_p = pm.NegativeBinomial.get_n_p(
@@ -682,7 +682,7 @@ class TestNegativeBinomialMuSigmaDistribution(BaseTestDistribution):
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestBernoulliDistribution(BaseTestDistribution):
+class TestBernoulli(BaseTestDistribution):
     pymc_dist = pm.Bernoulli
     pymc_dist_params = {"p": 0.33}
     expected_rv_op_params = {"p": 0.33}
@@ -690,21 +690,21 @@ class TestBernoulliDistribution(BaseTestDistribution):
 
 
 @pytest.mark.skip("Still not implemented")
-class TestBernoulliLogitPDistribution(BaseTestDistribution):
+class TestBernoulliLogitP(BaseTestDistribution):
     pymc_dist = pm.Bernoulli
     pymc_dist_params = {"logit_p": 1.0}
     expected_rv_op_params = {"mean": 0, "sigma": 10.0}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestPoissonDistribution(BaseTestDistribution):
+class TestPoisson(BaseTestDistribution):
     pymc_dist = pm.Poisson
     pymc_dist_params = {"mu": 4.0}
     expected_rv_op_params = {"mu": 4.0}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestMvNormalDistribution(BaseTestDistribution):
+class TestMvNormal(BaseTestDistribution):
     pymc_dist = pm.MvNormal
     pymc_dist_params = {
         "mu": np.array([1.0, 2.0]),
@@ -719,7 +719,7 @@ class TestMvNormalDistribution(BaseTestDistribution):
     tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size"]
 
 
-class TestMvNormalDistributionChol(BaseTestDistribution):
+class TestMvNormalChol(BaseTestDistribution):
     pymc_dist = pm.MvNormal
     pymc_dist_params = {
         "mu": np.array([1.0, 2.0]),
@@ -732,7 +732,7 @@ class TestMvNormalDistributionChol(BaseTestDistribution):
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestMvNormalDistributionTau(BaseTestDistribution):
+class TestMvNormalTau(BaseTestDistribution):
     pymc_dist = pm.MvNormal
     pymc_dist_params = {
         "mu": np.array([1.0, 2.0]),
@@ -745,14 +745,14 @@ class TestMvNormalDistributionTau(BaseTestDistribution):
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestDirichletDistribution(BaseTestDistribution):
+class TestDirichlet(BaseTestDistribution):
     pymc_dist = pm.Dirichlet
     pymc_dist_params = {"a": np.array([1.0, 2.0])}
     expected_rv_op_params = {"a": np.array([1.0, 2.0])}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
-class TestMultinomialDistribution(BaseTestDistribution):
+class TestMultinomial(BaseTestDistribution):
     pymc_dist = pm.Multinomial
     pymc_dist_params = {"n": 85, "p": np.array([0.28, 0.62, 0.10])}
     expected_rv_op_params = {"n": 85, "p": np.array([0.28, 0.62, 0.10])}
@@ -761,7 +761,7 @@ class TestMultinomialDistribution(BaseTestDistribution):
     tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size"]
 
 
-class TestCategoricalDistribution(BaseTestDistribution):
+class TestCategorical(BaseTestDistribution):
     pymc_dist = pm.Categorical
     pymc_dist_params = {"p": np.array([0.28, 0.62, 0.10])}
     expected_rv_op_params = {"p": np.array([0.28, 0.62, 0.10])}

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -470,8 +470,9 @@ class TestCorrectParametrizationMappingPymcToScipy(SeededTest):
         self._pymc_params_match_rv_ones(params, params, pm.Cauchy)
 
     def test_half_cauchy(self):
-        params = [("alpha", 2.0), ("beta", 5.0)]
-        self._pymc_params_match_rv_ones(params, params, pm.HalfCauchy)
+        params = [("beta", 5.0)]
+        expected_params = [("alpha", 0.0), ("beta", 5.0)]
+        self._pymc_params_match_rv_ones(params, expected_params, pm.HalfCauchy)
 
     @pytest.mark.skip(reason="Expected to fail due to bug")
     def test_gamma_alpha_beta(self):
@@ -518,21 +519,27 @@ class TestCorrectParametrizationMappingPymcToScipy(SeededTest):
         params = [("p", 0.33)]
         self._pymc_params_match_rv_ones(params, params, pm.Bernoulli)
 
+    def test_bernoulli_logit_p(self):
+        logit_p_parameter = 1.0
+        bernoulli_sample = pm.Bernoulli.dist(logit_p=logit_p_parameter)
+        with pytest.raises(ValueError):
+            bernoulli_sample.eval()
+
     def test_poisson(self):
         params = [("mu", 4)]
         self._pymc_params_match_rv_ones(params, params, pm.Poisson)
 
-    def test_mv_distribution(self):
+    def test_mv_normal_distribution(self):
         params = [("mu", np.array([1.0, 2.0])), ("cov", np.array([[2.0, 0.0], [0.0, 3.5]]))]
         self._pymc_params_match_rv_ones(params, params, pm.MvNormal)
 
-    def test_mv_distribution_chol(self):
+    def test_mv_normal_distribution_chol(self):
         params = [("mu", np.array([1.0, 2.0])), ("chol", np.array([[2.0, 0.0], [0.0, 3.5]]))]
         expected_cov = quaddist_matrix(chol=params[1][1])
         expected_params = [("mu", np.array([1.0, 2.0])), ("cov", expected_cov.eval())]
         self._pymc_params_match_rv_ones(params, expected_params, pm.MvNormal)
 
-    def test_mv_distribution_tau(self):
+    def test_mv_normal_distribution_tau(self):
         params = [("mu", np.array([1.0, 2.0])), ("tau", np.array([[2.0, 0.0], [0.0, 3.5]]))]
         expected_cov = quaddist_matrix(tau=params[1][1])
         expected_params = [("mu", np.array([1.0, 2.0])), ("cov", expected_cov.eval())]

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -33,7 +33,7 @@ from pymc3.aesaraf import change_rv_size, floatX, intX
 from pymc3.distributions.multivariate import quaddist_matrix
 from pymc3.distributions.shape_utils import to_tuple
 from pymc3.exceptions import ShapeError
-from pymc3.tests.helpers import SeededTest, select_by_precision
+from pymc3.tests.helpers import SeededTest
 from pymc3.tests.test_distributions import (
     Domain,
     I,
@@ -1758,36 +1758,3 @@ class TestMvGaussianRandomWalk(SeededTest):
             prior = pm.sample_prior_predictive(samples=sample_shape)
 
         assert prior["mv"].shape == to_tuple(sample_shape) + dist_shape
-
-
-def test_exponential_parameterization():
-    test_lambda = floatX(10.0)
-
-    exp_pymc = pm.Exponential.dist(lam=test_lambda)
-    (rv_scale,) = exp_pymc.owner.inputs[3:]
-
-    npt.assert_almost_equal(rv_scale.eval(), 1 / test_lambda)
-
-
-def test_gamma_parameterization():
-
-    test_alpha = floatX(10.0)
-    test_beta = floatX(100.0)
-
-    gamma_pymc = pm.Gamma.dist(alpha=test_alpha, beta=test_beta)
-    rv_alpha, rv_inv_beta = gamma_pymc.owner.inputs[3:]
-
-    assert np.array_equal(rv_alpha.eval(), test_alpha)
-
-    decimal = select_by_precision(float64=6, float32=3)
-
-    npt.assert_almost_equal(rv_inv_beta.eval(), 1.0 / test_beta, decimal)
-
-    test_mu = test_alpha / test_beta
-    test_sigma = np.sqrt(test_mu / test_beta)
-
-    gamma_pymc = pm.Gamma.dist(mu=test_mu, sigma=test_sigma)
-    rv_alpha, rv_inv_beta = gamma_pymc.owner.inputs[3:]
-
-    npt.assert_almost_equal(rv_alpha.eval(), test_alpha, decimal)
-    npt.assert_almost_equal(rv_inv_beta.eval(), 1.0 / test_beta, decimal)

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -361,12 +361,6 @@ class TestBetaBinomial(BaseTestCases.BaseTestCase):
     params = {"n": 5, "alpha": 1.0, "beta": 1.0}
 
 
-@pytest.mark.skip(reason="This test is covered by Aesara")
-class TestBernoulli(BaseTestCases.BaseTestCase):
-    distribution = pm.Bernoulli
-    params = {"p": 0.5}
-
-
 class TestDiscreteWeibull(BaseTestCases.BaseTestCase):
     distribution = pm.DiscreteWeibull
     params = {"q": 0.25, "beta": 2.0}

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -24,13 +24,13 @@ import numpy.testing as npt
 import pytest
 import scipy.stats as st
 
+from numpy.testing import assert_almost_equal
 from scipy import linalg
 from scipy.special import expit
 
 import pymc3 as pm
 
 from pymc3.aesaraf import change_rv_size, floatX, intX
-from pymc3.distributions.dist_math import clipped_beta_rvs
 from pymc3.distributions.shape_utils import to_tuple
 from pymc3.exceptions import ShapeError
 from pymc3.tests.helpers import SeededTest, select_by_precision
@@ -524,6 +524,76 @@ class TestDirichlet(SeededTest):
         assert pm.Dirichlet.dist(a=np.ones(shape)).random(size=size).shape == out_shape
 
 
+class TestCorrectParametrizationMappingPymcToScipy(SeededTest):
+    @staticmethod
+    def get_inputs_from_apply_node_outputs(outputs):
+        parents = outputs.get_parents()
+        if not parents:
+            raise Exception("Parent Apply node missing for output")
+        # I am assuming there will always only be 1 Apply parent node in this context
+        return parents[0].inputs
+
+    def test_pymc_params_match_rv_ones(
+        self, pymc_params, expected_aesara_params, pymc_dist, decimal=6
+    ):
+        pymc_dist_output = pymc_dist.dist(**dict(pymc_params))
+        aesera_dist_inputs = self.get_inputs_from_apply_node_outputs(pymc_dist_output)[3:]
+        assert len(expected_aesara_params) == len(aesera_dist_inputs)
+        for (expected_name, expected_value), actual_variable in zip(
+            expected_aesara_params, aesera_dist_inputs
+        ):
+            assert_almost_equal(expected_value, actual_variable.eval(), decimal=decimal)
+
+    def test_normal(self):
+        params = [("mu", 5.0), ("sigma", 10.0)]
+        self.test_pymc_params_match_rv_ones(params, params, pm.Normal)
+
+    def test_uniform(self):
+        params = [("lower", 0.5), ("upper", 1.5)]
+        self.test_pymc_params_match_rv_ones(params, params, pm.Uniform)
+
+    def test_half_normal(self):
+        params, expected_aesara_params = [("sigma", 10.0)], [("mean", 0), ("sigma", 10.0)]
+        self.test_pymc_params_match_rv_ones(params, expected_aesara_params, pm.HalfNormal)
+
+    def test_beta_alpha_beta(self):
+        params = [("alpha", 2.0), ("beta", 5.0)]
+        self.test_pymc_params_match_rv_ones(params, params, pm.Beta)
+
+    def test_beta_mu_sigma(self):
+        params = [("mu", 2.0), ("sigma", 5.0)]
+        expected_alpha, expected_beta = pm.Beta.get_alpha_beta(mu=params[0][1], sigma=params[1][1])
+        expected_params = [("alpha", expected_alpha), ("beta", expected_beta)]
+        self.test_pymc_params_match_rv_ones(params, expected_params, pm.Beta)
+
+    @pytest.mark.skip(reason="Expected to fail due to bug")
+    def test_exponential(self):
+        params = [("lam", 10.0)]
+        expected_params = [("lam", 1 / params[0][1])]
+        self.test_pymc_params_match_rv_ones(params, expected_params, pm.Exponential)
+
+    def test_cauchy(self):
+        params = [("alpha", 2.0), ("beta", 5.0)]
+        self.test_pymc_params_match_rv_ones(params, params, pm.Cauchy)
+
+    def test_half_cauchy(self):
+        params = [("alpha", 2.0), ("beta", 5.0)]
+        self.test_pymc_params_match_rv_ones(params, params, pm.HalfCauchy)
+
+    @pytest.mark.skip(reason="Expected to fail due to bug")
+    def test_gamma_alpha_beta(self):
+        params = [("alpha", 2.0), ("beta", 5.0)]
+        expected_params = [("alpha", params[0][1]), ("beta", 1 / params[1][1])]
+        self.test_pymc_params_match_rv_ones(params, expected_params, pm.Gamma)
+
+    @pytest.mark.skip(reason="Expected to fail due to bug")
+    def test_gamma_mu_sigma(self):
+        params = [("mu", 2.0), ("sigma", 5.0)]
+        expected_alpha, expected_beta = pm.Gamma.get_alpha_beta(mu=params[0][1], sigma=params[1][1])
+        expected_params = [("alpha", expected_alpha), ("beta", 1 / expected_beta)]
+        self.test_pymc_params_match_rv_ones(params, expected_params, pm.Gamma)
+
+
 class TestScalarParameterSamples(SeededTest):
     @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
     def test_bounded(self):
@@ -534,20 +604,6 @@ class TestScalarParameterSamples(SeededTest):
             return -st.halfnorm.rvs(size=size, loc=0, scale=tau ** -0.5)
 
         pymc3_random(BoundedNormal, {"tau": Rplus}, ref_rand=ref_rand)
-
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_uniform(self):
-        def ref_rand(size, lower, upper):
-            return st.uniform.rvs(size=size, loc=lower, scale=upper - lower)
-
-        pymc3_random(pm.Uniform, {"lower": -Rplus, "upper": Rplus}, ref_rand=ref_rand)
-
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_normal(self):
-        def ref_rand(size, mu, sigma):
-            return st.norm.rvs(size=size, loc=mu, scale=sigma)
-
-        pymc3_random(pm.Normal, {"mu": R, "sigma": Rplus}, ref_rand=ref_rand)
 
     @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
     def test_truncated_normal(self):
@@ -587,13 +643,6 @@ class TestScalarParameterSamples(SeededTest):
 
         pymc3_random(pm.SkewNormal, {"mu": R, "sigma": Rplus, "alpha": R}, ref_rand=ref_rand)
 
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_half_normal(self):
-        def ref_rand(size, tau):
-            return st.halfnorm.rvs(size=size, loc=0, scale=tau ** -0.5)
-
-        pymc3_random(pm.HalfNormal, {"tau": Rplus}, ref_rand=ref_rand)
-
     @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
     def test_wald(self):
         # Cannot do anything too exciting as scipy wald is a
@@ -606,13 +655,6 @@ class TestScalarParameterSamples(SeededTest):
             {"mu": Domain([1.0, 1.0, 1.0]), "lam": Domain([1.0, 1.0, 1.0]), "alpha": Rplus},
             ref_rand=ref_rand,
         )
-
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_beta(self):
-        def ref_rand(size, alpha, beta):
-            return clipped_beta_rvs(a=alpha, b=beta, size=size)
-
-        pymc3_random(pm.Beta, {"alpha": Rplus, "beta": Rplus}, ref_rand=ref_rand)
 
     @pytest.mark.xfail(reason="This distribution has not been refactored for v4")
     def test_laplace(self):
@@ -648,20 +690,7 @@ class TestScalarParameterSamples(SeededTest):
         pymc3_random(pm.StudentT, {"nu": Rplus, "mu": R, "lam": Rplus}, ref_rand=ref_rand)
 
     @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_cauchy(self):
-        def ref_rand(size, alpha, beta):
-            return st.cauchy.rvs(alpha, beta, size=size)
 
-        pymc3_random(pm.Cauchy, {"alpha": R, "beta": Rplusbig}, ref_rand=ref_rand)
-
-    @pytest.mark.skip(reason="This test is covered by Aesara")
-    def test_half_cauchy(self):
-        def ref_rand(size, beta):
-            return st.halfcauchy.rvs(scale=beta, size=size)
-
-        pymc3_random(pm.HalfCauchy, {"beta": Rplusbig}, ref_rand=ref_rand)
-
-    @pytest.mark.skip(reason="This test is covered by Aesara")
     def test_inverse_gamma(self):
         def ref_rand(size, alpha, beta):
             return st.invgamma.rvs(a=alpha, scale=beta, size=size)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aesara>=2.0.1
+aesara>=2.0.5
 arviz>=0.11.2
 cachetools>=4.2.1
 dill


### PR DESCRIPTION
The recent distributions refactoring (#4508 and #4548) moves the logic to 
get a random variable from a distribution to aesara. 
This relies on numpy and scipy random variables implementation.
Given this change the main thing worth testing on the PyMC side is that 
the PyMC parametrization is sensible given the one on the Aesara side
(effectively the numpy/scipy one)

More details can be found on issue #4554

- this is the second attempt for doing this change. The first one can be found here: 
https://github.com/pymc-devs/pymc3/pull/4580

+ [x] what are the (breaking) changes that this PR makes? No breaking changes, only fixing currently broken tests
+ [x] are the changes—especially new features—covered by tests and docstrings? This change is only affecting tests
+ [x] Is there any other test not relevant anymore given the refactoring? 