### PR TITLE
Estimate missing data

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -62,6 +62,7 @@ jobs:
             --ignore=pymc3/tests/test_shape_handling.py
             --ignore=pymc3/tests/test_distributions.py
             --ignore=pymc3/tests/test_distributions_random.py
+            --ignore=pymc3/tests/test_idata_conversion.py
 
           - |
             pymc3/tests/test_modelcontext.py
@@ -73,6 +74,7 @@ jobs:
             pymc3/tests/test_updates.py
 
           - |
+            pymc3/tests/test_idata_conversion.py
             pymc3/tests/test_distributions.py
             pymc3/tests/test_distributions_random.py
             pymc3/tests/test_examples.py

--- a/pymc3/aesaraf.py
+++ b/pymc3/aesaraf.py
@@ -11,6 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import warnings
+
 from typing import (
     Callable,
     Dict,
@@ -168,19 +170,17 @@ def change_rv_size(
 def extract_rv_and_value_vars(
     var: TensorVariable,
 ) -> Tuple[TensorVariable, TensorVariable]:
-    """Extract a random variable and its corresponding value variable from a generic
-    `TensorVariable`.
+    """Return a random variable and it's observations or value variable, or ``None``.
 
     Parameters
     ==========
     var
-        A variable corresponding to a `RandomVariable`.
+        A variable corresponding to a ``RandomVariable``.
 
     Returns
     =======
-    The first value in the tuple is the `RandomVariable`, and the second is the
-    measure-space variable that corresponds with the latter (i.e. the "value"
-    variable).
+    The first value in the tuple is the ``RandomVariable``, and the second is the
+    measure/log-likelihood value variable that corresponds with the latter.
 
     """
     if not var.owner:
@@ -194,7 +194,7 @@ def extract_rv_and_value_vars(
 
 
 def extract_obs_data(x: TensorVariable) -> np.ndarray:
-    """Extract data observed symbolic variables.
+    """Extract data from observed symbolic variables.
 
     Raises
     ------
@@ -330,17 +330,24 @@ def rvs_to_value_vars(
         rv_var, rv_value_var = extract_rv_and_value_vars(var)
 
         if rv_value_var is None:
+            warnings.warn(
+                f"No value variable found for {rv_var}; "
+                "the random variable will not be replaced."
+            )
             return []
 
         transform = getattr(rv_value_var.tag, "transform", None)
 
         if transform is None or not apply_transforms:
             replacements[var] = rv_value_var
-            return []
+            # In case the value variable is itself a graph, we walk it for
+            # potential replacements
+            return [rv_value_var]
 
         trans_rv_value = transform.backward(rv_var, rv_value_var)
         replacements[var] = trans_rv_value
 
+        # Walk the transformed variable and make replacements
         return [trans_rv_value]
 
     return replace_rvs_in_graphs(graphs, transform_replacements, initial_replacements, **kwargs)

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -427,7 +427,9 @@ class ValueGradFunction:
         givens = []
         self._extra_vars_shared = {}
         for var, value in extra_vars_and_values.items():
-            shared = aesara.shared(value, var.name + "_shared__")
+            shared = aesara.shared(
+                value, var.name + "_shared__", broadcastable=[s == 1 for s in value.shape]
+            )
             self._extra_vars_shared[var.name] = shared
             givens.append((var, shared))
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -467,7 +467,7 @@ class ValueGradFunction:
             raise ValueError("Extra values are not set.")
 
         if isinstance(grad_vars, RaveledVars):
-            grad_vars = DictToArrayBijection.rmap(grad_vars, as_list=True)
+            grad_vars = list(DictToArrayBijection.rmap(grad_vars).values())
 
         cost, *grads = self._aesara_function(*grad_vars)
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -11,7 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from typing import Any, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 import aesara
 import numpy as np
@@ -425,7 +425,7 @@ class BinaryGibbsMetropolis(ArrayStep):
 
         super().__init__(vars, [model.fastlogp])
 
-    def astep(self, q0: RaveledVars, logp) -> RaveledVars:
+    def astep(self, q0: RaveledVars, logp: Callable[[RaveledVars], np.ndarray]) -> RaveledVars:
 
         order = self.order
         if self.shuffle_dims:
@@ -475,6 +475,7 @@ class BinaryGibbsMetropolis(ArrayStep):
 
 class CategoricalGibbsMetropolis(ArrayStep):
     """A Metropolis-within-Gibbs step method optimized for categorical variables.
+
     This step method works for Bernoulli variables as well, but it is not
     optimized for them, like BinaryGibbsMetropolis is. Step method supports
     two types of proposals: A uniform proposal and a proportional proposal,
@@ -573,6 +574,9 @@ class CategoricalGibbsMetropolis(ArrayStep):
             logp_curr = self.metropolis_proportional(q, logp, logp_curr, dim, k)
 
         return q
+
+    def astep(self, q0, logp):
+        raise NotImplementedError()
 
     def metropolis_proportional(self, q, logp, logp_curr, dim, k):
         given_cat = int(q.data[dim])

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -427,27 +427,23 @@ class BinaryGibbsMetropolis(ArrayStep):
 
     def astep(self, q0: RaveledVars, logp) -> RaveledVars:
 
-        point_map_info = q0.point_map_info
-        q0 = q0.data
-
         order = self.order
         if self.shuffle_dims:
             nr.shuffle(order)
 
-        q = np.copy(q0)
+        q = RaveledVars(np.copy(q0.data), q0.point_map_info)
+
         logp_curr = logp(q)
 
         for idx in order:
             # No need to do metropolis update if the same value is proposed,
             # as you will get the same value regardless of accepted or reject
             if nr.rand() < self.transit_p:
-                curr_val, q[idx] = q[idx], True - q[idx]
+                curr_val, q.data[idx] = q.data[idx], True - q.data[idx]
                 logp_prop = logp(q)
-                q[idx], accepted = metrop_select(logp_prop - logp_curr, q[idx], curr_val)
+                q.data[idx], accepted = metrop_select(logp_prop - logp_curr, q.data[idx], curr_val)
                 if accepted:
                     logp_curr = logp_prop
-
-        q = RaveledVars(q, point_map_info)
 
         return q
 

--- a/pymc3/tests/test_hmc.py
+++ b/pymc3/tests/test_hmc.py
@@ -32,7 +32,13 @@ def test_leapfrog_reversible():
     start, model, _ = models.non_normal(n)
     size = sum(start[n.name].size for n in model.value_vars)
     scaling = floatX(np.random.rand(size))
-    step = BaseHMC(vars=model.value_vars, model=model, scaling=scaling)
+
+    class HMC(BaseHMC):
+        def _hamiltonian_step(self, *args, **kwargs):
+            pass
+
+    step = HMC(vars=model.value_vars, model=model, scaling=scaling)
+
     step.integrator._logp_dlogp_func.set_extra_values({})
     astart = DictToArrayBijection.map(start)
     p = RaveledVars(floatX(step.potential.random()), astart.point_map_info)

--- a/pymc3/tests/test_idata_conversion.py
+++ b/pymc3/tests/test_idata_conversion.py
@@ -306,9 +306,13 @@ class TestDataPyMC3:
             inference_data = pm.sample(100, chains=2, return_inferencedata=True)
 
         # make sure that data is really missing
-        assert isinstance(y.owner.op, AdvancedIncSubtensor)
+        assert "y_missing" in model.named_vars
 
-        test_dict = {"posterior": ["x"], "observed_data": ["y"], "log_likelihood": ["y"]}
+        test_dict = {
+            "posterior": ["x", "y", "y_missing"],
+            "observed_data": ["y_observed"],
+            "log_likelihood": ["y_observed"],
+        }
         fails = check_multiple_attrs(test_dict, inference_data)
         assert not fails
 

--- a/pymc3/tests/test_missing.py
+++ b/pymc3/tests/test_missing.py
@@ -12,19 +12,23 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import numpy
+import aesara
+import numpy as np
 import pandas as pd
 import pytest
 
-from aesara.tensor.subtensor import AdvancedIncSubtensor
 from numpy import array, ma
 
-from pymc3 import ImputationWarning, Model, Normal, sample, sample_prior_predictive
+from pymc3.distributions.continuous import Gamma, Normal, Uniform
+from pymc3.distributions.transforms import Interval
+from pymc3.exceptions import ImputationWarning
+from pymc3.model import Model
+from pymc3.sampling import sample, sample_prior_predictive
 
 
 @pytest.mark.parametrize(
     "data",
-    [ma.masked_values([1, 2, -1, 4, -1], value=-1), pd.DataFrame([1, 2, numpy.nan, 4, numpy.nan])],
+    [ma.masked_values([1, 2, -1, 4, -1], value=-1), pd.DataFrame([1, 2, np.nan, 4, np.nan])],
 )
 def test_missing(data):
 
@@ -33,10 +37,10 @@ def test_missing(data):
         with pytest.warns(ImputationWarning):
             y = Normal("y", x, 1, observed=data)
 
-    assert isinstance(y.owner.op, AdvancedIncSubtensor)
+    assert "y_missing" in model.named_vars
 
     test_point = model.initial_point
-    assert not numpy.isnan(model.logp(test_point))
+    assert not np.isnan(model.logp(test_point))
 
     with model:
         prior_trace = sample_prior_predictive()
@@ -51,10 +55,10 @@ def test_missing_with_predictors():
         with pytest.warns(ImputationWarning):
             y = Normal("y", x * predictors, 1, observed=data)
 
-    assert isinstance(y.owner.op, AdvancedIncSubtensor)
+    assert "y_missing" in model.named_vars
 
     test_point = model.initial_point
-    assert not numpy.isnan(model.logp(test_point))
+    assert not np.isnan(model.logp(test_point))
 
     with model:
         prior_trace = sample_prior_predictive()
@@ -76,24 +80,62 @@ def test_missing_dual_observations():
         prior_trace = sample_prior_predictive()
         assert {"beta1", "beta2", "theta", "o1", "o2"} <= set(prior_trace.keys())
         # TODO: Assert something
-        sample()
+        trace = sample(chains=1)
 
 
-@pytest.mark.skip(
-    reason="This doesn't make sense in v4, because there are no "
-    "explicit variables to sample.  The missing values are "
-    "implicit random variables."
-)
 def test_internal_missing_observations():
     with Model() as model:
         obs1 = ma.masked_values([1, 2, -1, 4, -1], value=-1)
         obs2 = ma.masked_values([-1, -1, 6, -1, 8], value=-1)
+
+        rng = aesara.shared(np.random.RandomState(2323), borrow=True)
+
         with pytest.warns(ImputationWarning):
-            theta1 = Normal("theta1", mu=2, observed=obs1)
+            theta1 = Uniform("theta1", 0, 5, observed=obs1, rng=rng)
         with pytest.warns(ImputationWarning):
-            theta2 = Normal("theta2", mu=theta1, observed=obs2)
+            theta2 = Normal("theta2", mu=theta1, observed=obs2, rng=rng)
+
+        assert "theta1_observed_interval__" in model.named_vars
+        assert "theta1_missing_interval__" in model.named_vars
+        assert isinstance(
+            model.rvs_to_values[model.named_vars["theta1_observed"]].tag.transform, Interval
+        )
 
         prior_trace = sample_prior_predictive()
+
+        # Make sure the observed + missing combined deterministics have the
+        # same shape as the original observations vectors
+        assert prior_trace["theta1"].shape[-1] == obs1.shape[0]
+        assert prior_trace["theta2"].shape[-1] == obs2.shape[0]
+
+        # Make sure that the observed values are newly generated samples
+        assert np.var(prior_trace["theta1_observed"]) > 0.0
+        assert np.var(prior_trace["theta2_observed"]) > 0.0
+
+        # Make sure the missing parts of the combined deterministic matches the
+        # sampled missing and observed variable values
+        assert np.mean(prior_trace["theta1"][:, obs1.mask] - prior_trace["theta1_missing"]) == 0.0
+        assert np.mean(prior_trace["theta1"][:, ~obs1.mask] - prior_trace["theta1_observed"]) == 0.0
+        assert np.mean(prior_trace["theta2"][:, obs2.mask] - prior_trace["theta2_missing"]) == 0.0
+        assert np.mean(prior_trace["theta2"][:, ~obs2.mask] - prior_trace["theta2_observed"]) == 0.0
+
         assert {"theta1", "theta2"} <= set(prior_trace.keys())
-        # TODO: Assert something
-        sample()
+
+        trace = sample(chains=1)
+
+        assert np.all(0 < trace["theta1_missing"].mean(0))
+        assert np.all(0 < trace["theta2_missing"].mean(0))
+
+
+def test_double_counting():
+    with Model(check_bounds=False) as m1:
+        x = Gamma("x", 1, 1, size=4)
+
+    logp_val = m1.logp({"x_log__": np.array([0, 0, 0, 0])})
+    assert logp_val == -4.0
+
+    with Model(check_bounds=False) as m2:
+        x = Gamma("x", 1, 1, observed=[1, 1, 1, np.nan])
+
+    logp_val = m2.logp({"x_missing_log__": np.array([0])})
+    assert logp_val == -4.0

--- a/pymc3/tuning/starting.py
+++ b/pymc3/tuning/starting.py
@@ -49,10 +49,11 @@ def find_MAP(
     *args,
     **kwargs
 ):
-    """
-    Finds the local maximum a posteriori point given a model.
+    """Finds the local maximum a posteriori point given a model.
 
-    find_MAP should not be used to initialize the NUTS sampler. Simply call pymc3.sample() and it will automatically initialize NUTS in a better way.
+    `find_MAP` should not be used to initialize the NUTS sampler. Simply call
+    ``pymc3.sample()`` and it will automatically initialize NUTS in a better
+    way.
 
     Parameters
     ----------
@@ -79,10 +80,10 @@ def find_MAP(
 
     Notes
     -----
-    Older code examples used find_MAP() to initialize the NUTS sampler,
+    Older code examples used `find_MAP` to initialize the NUTS sampler,
     but this is not an effective way of choosing starting values for sampling.
     As a result, we have greatly enhanced the initialization of NUTS and
-    wrapped it inside pymc3.sample() and you should thus avoid this method.
+    wrapped it inside ``pymc3.sample()`` and you should thus avoid this method.
     """
     model = modelcontext(model)
 


### PR DESCRIPTION
This PR re-establishes the `v3` way of handling missing data: i.e. add missing data terms to the model and estimate them during MCMC.

In this case, transformed values should also be handled correctly.