### PR TITLE
Reintroduce Bernoulli logitp parametrization

### DIFF
--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1221,7 +1221,6 @@ class TestMatchesScipy:
             n_samples=10,
         )
 
-    @pytest.mark.xfail(reason="Distribution not refactored yet")
     @pytest.mark.parametrize(
         "mu, p, alpha, n, expected",
         [
@@ -1522,21 +1521,6 @@ class TestMatchesScipy:
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
         )
 
-    @pytest.mark.xfail(reason="Bernoulli logit_p not refactored yet")
-    def test_bernoulli_logit_p(self):
-        self.check_logp(
-            Bernoulli,
-            Bool,
-            {"logit_p": R},
-            lambda value, logit_p: sp.bernoulli.logpmf(value, scipy.special.expit(logit_p)),
-        )
-        self.check_logcdf(
-            Bernoulli,
-            Bool,
-            {"logit_p": R},
-            lambda value, logit_p: sp.bernoulli.logcdf(value, scipy.special.expit(logit_p)),
-        )
-
     def test_bernoulli(self):
         self.check_logp(
             Bernoulli,
@@ -1555,6 +1539,32 @@ class TestMatchesScipy:
             Bool,
             {"p": Unit},
         )
+
+    def test_bernoulli_logitp(self):
+        self.check_logp(
+            Bernoulli,
+            Bool,
+            {"logit_p": R},
+            lambda value, logit_p: sp.bernoulli.logpmf(value, scipy.special.expit(logit_p)),
+        )
+        self.check_logcdf(
+            Bernoulli,
+            Bool,
+            {"logit_p": R},
+            lambda value, logit_p: sp.bernoulli.logcdf(value, scipy.special.expit(logit_p)),
+        )
+
+    @pytest.mark.parametrize(
+        "p, logit_p, expected",
+        [
+            (None, None, "Must specify either p or logit_p."),
+            (0.5, 0.5, "Can't specify both p and logit_p."),
+        ],
+    )
+    def test_bernoulli_init_fail(self, p, logit_p, expected):
+        with Model():
+            with pytest.raises(ValueError, match=f"Incompatible parametrization. {expected}"):
+                Bernoulli("x", p=p, logit_p=logit_p)
 
     @pytest.mark.xfail(reason="Distribution not refactored yet")
     def test_discrete_weibull(self):

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -731,10 +731,15 @@ class TestScalarParameterSamples(SeededTest):
     def _beta_bin(self, n, alpha, beta, size=None):
         return st.binom.rvs(n, st.beta.rvs(a=alpha, b=beta, size=size))
 
-    @pytest.mark.skip(reason="This test is covered by Aesara")
     def test_bernoulli(self):
         pymc3_random_discrete(
-            pm.Bernoulli, {"p": Unit}, ref_rand=lambda size, p=None: st.bernoulli.rvs(p, size=size)
+            pm.Bernoulli, {"p": Unit}, ref_rand=lambda size, p: st.bernoulli.rvs(p, size=size)
+        )
+
+        pymc3_random_discrete(
+            pm.Bernoulli,
+            {"logit_p": R},
+            ref_rand=lambda size, logit_p: st.bernoulli.rvs(expit(logit_p), size=size),
         )
 
     @pytest.mark.skip(reason="This test is covered by Aesara")

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -51,7 +51,6 @@ def get_city_data():
     return data.merge(unique, "inner", on="fips")
 
 
-@pytest.mark.xfail(reason="Bernoulli distribution not refactored")
 class TestARM5_4(SeededTest):
     def build_model(self):
         data = pd.read_csv(
@@ -68,7 +67,7 @@ class TestARM5_4(SeededTest):
         P["1"] = 1
 
         with pm.Model() as model:
-            effects = pm.Normal("effects", mu=0, sigma=100, shape=len(P.columns))
+            effects = pm.Normal("effects", mu=0, sigma=100, size=len(P.columns))
             logit_p = at.dot(floatX(np.array(P)), effects)
             pm.Bernoulli("s", logit_p=logit_p, observed=floatX(data.switch.values))
         return model


### PR DESCRIPTION
This is a proposal of how we might reintroduce the `logit_p` parametrization to the `Bernoulli` distribution.

I parametrized everything (sampling, logp, logcdf) in terms of `logit_p` as this should be numerically more stable. This required changing the BernoulliOp from Aesara. I didn't run any benchmarks to see if this would incur a significant loss in speed relative to the `p` parametrization.

Also, we get a divide by zero `RuntimeWarning` if creating a Bernoulli with `p=1`.

I am happy to listen if you think there might be a better approach. 

***

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [x] important background, or details about the implementation
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [x] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
