### PR TITLE
Speed up step method transfer to workers during parallel sampling

### DIFF
--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -127,6 +127,15 @@ class _Process:
                     self._step_method = dill.loads(data)
                 except Exception:
                     raise ValueError(unpickle_error)
+            elif self._pickle_backend == "cloudpickle":
+                try:
+                    import cloudpickle
+                except ImportError:
+                    raise ValueError("cloudpickle must be installed for pickle_backend='cloudpickle'.")
+                try:
+                    self._step_method = cloudpickle.loads(data)
+                except Exception:
+                    raise ValueError(unpickle_error)
             else:
                 raise ValueError("Unknown pickle backend")
 
@@ -429,6 +438,12 @@ class ParallelSampler:
                 except ImportError:
                     raise ValueError("dill must be installed for pickle_backend='dill'.")
                 step_method_pickled = dill.dumps(step_method, protocol=-1)
+            elif pickle_backend == "cloudpickle":
+                try:
+                    import cloudpickle
+                except ImportError:
+                    raise ValueError("cloudpickle must be installed for pickle_backend='cloudpickle'.")
+                step_method_pickled = cloudpickle.dumps(step_method, protocol=-1)
 
             step_method_pickled = mp_ctx.Array("b", step_method_pickled, lock=False)
 

--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -111,9 +111,11 @@ class _Process:
             "or forkserver."
         )
         if self._step_method_is_pickled:
+            data = bytes(self._step_method)
+
             if self._pickle_backend == "pickle":
                 try:
-                    self._step_method = pickle.loads(self._step_method)
+                    self._step_method = pickle.loads(data)
                 except Exception:
                     raise ValueError(unpickle_error)
             elif self._pickle_backend == "dill":
@@ -122,7 +124,7 @@ class _Process:
                 except ImportError:
                     raise ValueError("dill must be installed for pickle_backend='dill'.")
                 try:
-                    self._step_method = dill.loads(self._step_method)
+                    self._step_method = dill.loads(data)
                 except Exception:
                     raise ValueError(unpickle_error)
             else:
@@ -427,6 +429,8 @@ class ParallelSampler:
                 except ImportError:
                     raise ValueError("dill must be installed for pickle_backend='dill'.")
                 step_method_pickled = dill.dumps(step_method, protocol=-1)
+
+            step_method_pickled = mp_ctx.Array("b", step_method_pickled, lock=False)
 
         self._samplers = [
             ProcessAdapter(

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -348,7 +348,7 @@ def sample(
         A multiprocessing context for parallel sampling. See multiprocessing
         documentation for details.
     pickle_backend : str
-        One of `'pickle'` or `'dill'`. The library used to pickle models
+        One of `'pickle'`, `'dill'` or `'cloudpickle`'. The library used to pickle models
         in parallel sampling if the multiprocessing context is not of type
         `fork`.
 


### PR DESCRIPTION
I observed on my machine (on py38) that transferring a pickled step method to worker processes can take quite some time, if `mp_ctx != "fork"`. This PR uses shared memory to transfer the step method.
I also added support for cloudpickle