### PR TITLE
Use optimized graph for JAX conversion

### DIFF
--- a/pymc3/sampling_jax.py
+++ b/pymc3/sampling_jax.py
@@ -47,7 +47,7 @@ def sample_tfp_nuts(
 
     seed = jax.random.PRNGKey(random_seed)
 
-    fgraph = aesara.graph.fg.FunctionGraph(model.free_RVs, [model.logpt])
+    fgraph = model.logp.f.maker.fgraph
     fns = jax_funcify(fgraph)
     logp_fn_jax = fns[0]
 


### PR DESCRIPTION
This PR uses the Aesara optimized graph for JAX sampling.  See the discussion [here](https://gist.github.com/twiecki/a77104299535b64b58953de3c84df56f#gistcomment-3703154).