### PR TITLE
More options for `sample_numpyro_nuts`: chain_method and jit placement

### DIFF
--- a/pymc3/sampling_jax.py
+++ b/pymc3/sampling_jax.py
@@ -125,7 +125,7 @@ def sample_numpyro_nuts(
     progress_bar=True,
     chain_method="parallel",
     keep_untransformed=False,
-    jit_sample_fn=False,
+    jit_sample_fn=True,
 ):
     from numpyro.infer import MCMC, NUTS
 
@@ -137,6 +137,7 @@ def sample_numpyro_nuts(
 
     fgraph = aesara.graph.fg.FunctionGraph(model.free_RVs, [model.logpt])
     fns = jax_funcify(fgraph)
+
     logp_fn_jax = jax.jit(fns[0]) if not jit_sample_fn else fns[0]
 
     rv_names = [rv.name for rv in model.free_RVs]


### PR DESCRIPTION
Hi all,

further to my comment in https://github.com/pymc-devs/pymc3/issues/4288, I thought I'd go ahead and make the pull request. Only a few lines are changed, essentially amounting to two new optional kwargs to `sample_numpyro_nuts`. The defaults match the current ones, so there should be no changes to default behaviour. The motivation is explained in the linked issue. One key fix is that it should allow the use of `chain_method='vectorized'` on the GPU, which can be faster than `chain_method='parallel'` (again see issue for an example) and also shows a progress bar.

Keen to hear people's thoughts!

Thanks,
Martin