### PR TITLE
remove obsolete multiplication with 1.0 in get_sigma_tau

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -171,11 +171,6 @@ def get_tau_sigma(tau=None, sigma=None):
         else:
             sigma = tau ** -0.5
 
-    # cast tau and sigma to float in a way that works for both np.arrays
-    # and pure python
-    tau = 1.0 * tau
-    sigma = 1.0 * sigma
-
     return floatX(tau), floatX(sigma)
 
 


### PR DESCRIPTION
There was a multplication with `1.0` in order to cast to `float` (according to the comments), but this is obsolete as further down an explicit cast to `floatX` is performed anyway. Multiplying with 1 adds a redundant node to the Aesara graph, which interferes with pretty printing. (I.e., after `sigma = pm.HalfNormal(...); x = pm.Normal(..., sigma)`, `x`'s variable `sigma` is actually an `Elemwise{mul}`, and not the originally created random variable.)

Edit: I'm filing this as a separate (small) PR because it's in principle unrelated to the pretty-printing business I'm otherwise working on, and want to make sure this doesn't raise objections before I go ahead.