### PR TITLE
Fixup stacklevels of sampling warnings

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -480,6 +480,7 @@ def sample(
             " complications in your downstream analysis. Please consider to switch to `InferenceData`:\n"
             "`pm.sample(..., return_inferencedata=True)`",
             UserWarning,
+            stacklevel=2,
         )
 
     if return_inferencedata is None:
@@ -614,6 +615,7 @@ def sample(
                     "DEMetropolis should be used with more chains than dimensions! "
                     "(The model has {} dimensions.)".format(initial_point_model_size),
                     UserWarning,
+                    stacklevel=2,
                 )
             _print_step_hierarchy(step)
             trace = _sample_population(parallelize=cores > 1, **sample_args)
@@ -666,7 +668,9 @@ def sample(
 
     if compute_convergence_checks:
         if draws - tune < 100:
-            warnings.warn("The number of samples is too small to check convergence reliably.")
+            warnings.warn(
+                "The number of samples is too small to check convergence reliably.", stacklevel=2
+            )
         else:
             trace.report._run_convergence_checks(idata, model)
     trace.report._log_summary()
@@ -1664,7 +1668,8 @@ def sample_posterior_predictive(
         warnings.warn(
             "samples parameter is smaller than nchains times ndraws, some draws "
             "and/or chains may not be represented in the returned posterior "
-            "predictive sample"
+            "predictive sample",
+            stacklevel=2,
         )
 
     model = modelcontext(model)
@@ -1674,6 +1679,7 @@ def sample_posterior_predictive(
             "The effect of Potentials on other parameters is ignored during posterior predictive sampling. "
             "This is likely to lead to invalid or biased predictive samples.",
             UserWarning,
+            stacklevel=2,
         )
 
     if var_names is not None:
@@ -1829,6 +1835,7 @@ def sample_posterior_predictive_w(
                 "The effect of Potentials on other parameters is ignored during posterior predictive sampling. "
                 "This is likely to lead to invalid or biased predictive samples.",
                 UserWarning,
+                stacklevel=2,
             )
             break
 
@@ -1952,6 +1959,7 @@ def sample_prior_predictive(
             "The effect of Potentials on other parameters is ignored during prior predictive sampling. "
             "This is likely to lead to invalid or biased predictive samples.",
             UserWarning,
+            stacklevel=2,
         )
 
     if var_names is None:


### PR DESCRIPTION
Noticed in https://app.reviewnb.com/pymc-devs/pymc-examples/pull/146/

Without this change, if we have `t.py`:
```python
import pymc3 as pm
with pm.model() as model:
    x = pm.normal('x')
    y = pm.normal('y', observed=[1,2,3])

with model:
    trace = pm.sample()

with model:
    pm.sample_posterior_predictive(trace=trace, samples=1)
```

without this change, the warning refers to the PyMC3 source code:
```python-traceback
t.py:7: FutureWarning: In v4.0, pm.sample will return an `arviz.InferenceData` object instead of a `MultiTrace` by default. You can pass return_inferencedata=True or return_inferencedata=False to be safe and silence this warning.
  trace = pm.sample()
Auto-assigning NUTS sampler...
Initializing NUTS using jitter+adapt_diag...
Multiprocess sampling (4 chains in 4 jobs)
NUTS: [x]
Sampling 4 chains for 1_000 tune and 1_000 draw iterations (4_000 + 4_000 draws total) took 1 seconds.% [8000/8000 00:00<00:00 Sampling 4 chains, 0 divergences]
/home/marco/pymc3-dev/pymc3/sampling.py:1664: UserWarning: samples parameter is smaller than nchains times ndraws, some draws and/or chains may not be represented in the returned posterior predictive sample
  warnings.warn(
```

with this change, it refers to the user's code:
```python-traceback
t.py:7: FutureWarning: In v4.0, pm.sample will return an `arviz.InferenceData` object instead of a `MultiTrace` by default. You can pass return_inferencedata=True or return_inferencedata=False to be safe and silence this warning.
  trace = pm.sample()
Auto-assigning NUTS sampler...
Initializing NUTS using jitter+adapt_diag...
Multiprocess sampling (4 chains in 4 jobs)
NUTS: [x]
Sampling 4 chains for 1_000 tune and 1_000 draw iterations (4_000 + 4_000 draws total) took 1 seconds.% [8000/8000 00:00<00:00 Sampling 4 chains, 0 divergences]
t.py:10: UserWarning: samples parameter is smaller than nchains times ndraws, some draws and/or chains may not be represented in the returned posterior predictive sample
  pm.sample_posterior_predictive(trace=trace, samples=1)
```