### PR TITLE
VAR update

### DIFF
--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -97,7 +97,9 @@ class AR(distribution.Continuous):
     Parameters
     ----------
     rho: tensor
-        Tensor of autoregressive coefficients. The first dimension is the p lag.
+        Tensor of autoregressive coefficients. The first dimension is the p lag. For allowing
+        cross-series dependencies, rho must have 3 dimensions. For example, a rho of shape (2,3,3)
+        indicates that 2 lags are to be used for 3 series, each assumed to be dependent upon the other 2.
     sigma: float
         Standard deviation of innovation (sigma > 0). (only required if tau is not specified)
     tau: float


### PR DESCRIPTION
This PR modifies the `AR` distribution to accommodate cross-series coefficients as desired in a vector autoregressive model. More information can be found at https://discourse.pymc.io/t/how-to-implement-vector-autoregression-with-interdependencies/4287/2 and #4665. This is marked as a WIP as I would like some advice on how to handle the `constant` argument for the `AR` distribution.

+ [x] what are the (breaking) changes that this PR makes?
Depending on the dimensions of `rho`, the `logp` function will either use an elementwise operation or a matrix multiplication for the independent and dependent time series cases, respectively. However, models which assume 2 or more dimensions indexing independent time series will no longer behave the same. In this case, the recommended approach is to reshape these two dimensions into a single one so that a `rho` tensor with shape `[lags, d, d]` can be interpreted as using multiple `d` x `d` cross-series coefficients.

+ [ ] important background, or details about the implementation
There is a `constant` argument for the `AR` distribution which I am unable to decipher and have not been able to address the case in which `constant` is used.
+ [x] are the changes—especially new features—covered by tests and docstrings?
No new tests or doc modifications have been added yet.
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
