### PR TITLE
Fix bug in pseudo_likelihood computation

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,7 @@
 ### Maintenance
 + A deprecation warning from the `semver` package we use for checking backend compatibility was dealt with (see [#4547](https://github.com/pymc-devs/pymc3/pull/4547)).
 + `theano.printing.pydotprint` is now hotfixed upon import (see [#4594](https://github.com/pymc-devs/pymc3/pull/4594)).
++ Fix bug in the computation of the log pseudolikelihood values (SMC-ABC). (see [#4672](https://github.com/pymc-devs/pymc3/pull/4672)).
 
 ## PyMC3 3.11.2 (14 March 2021)
 

--- a/pymc3/smc/smc.py
+++ b/pymc3/smc/smc.py
@@ -190,8 +190,10 @@ class SMC:
         self.prior_logp = self.prior_logp[resampling_indexes]
         self.likelihood_logp = self.likelihood_logp[resampling_indexes]
         self.posterior_logp = self.prior_logp + self.likelihood_logp * self.beta
-        if self.save_sim_data:
+        if self.kernel == "abc" and self.save_sim_data:
             self.sim_data = self.sim_data[resampling_indexes]
+        if self.kernel == "abc" and self.save_log_pseudolikelihood:
+            self.log_pseudolikelihood = self.log_pseudolikelihood[resampling_indexes]
 
     def update_proposal(self):
         """Update proposal based on the covariance matrix from tempered posterior."""

--- a/pymc3/tests/test_smc.py
+++ b/pymc3/tests/test_smc.py
@@ -141,6 +141,13 @@ class TestSMCABC(SeededTest):
                 "s", normal_sim, params=(a, b), sum_stat="sort", epsilon=1, observed=self.data
             )
 
+        with pm.Model() as self.SMABC_log_pseudolikelihood:
+            a = pm.Normal("a", mu=0, sigma=1)
+            b = pm.HalfNormal("b", sigma=10)
+            s = pm.Simulator(
+                "s", normal_sim, params=(a, b), sum_stat="mean", epsilon=0.2, observed=self.data
+            )
+
     def test_one_gaussian(self):
         with self.SMABC_test:
             trace = pm.sample_smc(draws=1000, kernel="ABC")
@@ -210,3 +217,9 @@ class TestSMCABC(SeededTest):
             )
             with pytest.raises(NotImplementedError, match="named models"):
                 pm.sample_smc(draws=10, kernel="ABC")
+
+    def test_log_pseudolikelihood(self):
+        with self.SMABC_log_pseudolikelihood:
+            trace = pm.sample_smc(draws=1000, chains=2, kernel="ABC")
+            assert trace.report.log_pseudolikelihood[0].var() < 1
+            assert trace.report.log_pseudolikelihood[1].var() < 1


### PR DESCRIPTION
log_pseudolikelihood computations were wrong as the indexes were not properly resampled.