### PR TITLE
BART with non-gaussian likelihoods

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,9 @@
 + A deprecation warning from the `semver` package we use for checking backend compatibility was dealt with (see [#4547](https://github.com/pymc-devs/pymc3/pull/4547)).
 + `theano.printing.pydotprint` is now hotfixed upon import (see [#4594](https://github.com/pymc-devs/pymc3/pull/4594)).
 
+### New Features
++ BART with non-gaussian likelihoods (see [#4675](https://github.com/pymc-devs/pymc3/pull/4675)).
+
 ## PyMC3 3.11.2 (14 March 2021)
 
 ### New Features

--- a/pymc3/distributions/bart.py
+++ b/pymc3/distributions/bart.py
@@ -24,9 +24,20 @@ __all__ = ["BART"]
 
 class BaseBART(NoDistribution):
     def __init__(
-        self, X, Y, m=200, alpha=0.25, split_prior=None, scale=None, inv_link=None, *args, **kwargs
+        self,
+        X,
+        Y,
+        m=200,
+        alpha=0.25,
+        split_prior=None,
+        scale=None,
+        inv_link=None,
+        jitter=False,
+        *args,
+        **kwargs,
     ):
 
+        self.jitter = jitter
         self.X, self.Y, self.missing_data = self.preprocess_XY(X, Y)
 
         super().__init__(shape=X.shape[0], dtype="float64", testval=self.Y.mean(), *args, **kwargs)
@@ -79,7 +90,8 @@ class BaseBART(NoDistribution):
         if isinstance(X, (Series, DataFrame)):
             X = X.to_numpy()
         missing_data = np.any(np.isnan(X))
-        X = np.random.normal(X, np.nanstd(X, 0) / 100000)
+        if self.jitter:
+            X = np.random.normal(X, np.nanstd(X, 0) / 100000)
         Y = Y.astype(float)
         return X, Y, missing_data
 
@@ -312,9 +324,15 @@ class BART(BaseBART):
         and the scale parameter. Defaults to None, i.e the variance is 0.
     inv_link : numpy function
         Inverse link function defaults to None, i.e. the identity function.
+    jitter : bool
+        Whether to jitter the X values or not. Defaults to False. When values of X are repeated,
+        jittering X has the effect of increasing the number of effective spliting variables,
+        otherwise it does not have any effect.
     """
 
-    def __init__(self, X, Y, m=200, alpha=0.25, split_prior=None, scale=None, inv_link=None):
+    def __init__(
+        self, X, Y, m=200, alpha=0.25, split_prior=None, scale=None, inv_link=None, jitter=False
+    ):
         super().__init__(X, Y, m, alpha, split_prior, scale, inv_link)
 
     def _str_repr(self, name=None, dist=None, formatting="plain"):

--- a/pymc3/distributions/bart.py
+++ b/pymc3/distributions/bart.py
@@ -79,7 +79,7 @@ class BaseBART(NoDistribution):
         if isinstance(X, (Series, DataFrame)):
             X = X.to_numpy()
         missing_data = np.any(np.isnan(X))
-        X = np.random.normal(X, np.std(X, 0) / 100)
+        X = np.random.normal(X, np.nanstd(X, 0) / 100000)
         Y = Y.astype(float)
         return X, Y, missing_data
 

--- a/pymc3/distributions/bart.py
+++ b/pymc3/distributions/bart.py
@@ -23,11 +23,13 @@ __all__ = ["BART"]
 
 
 class BaseBART(NoDistribution):
-    def __init__(self, X, Y, m=200, alpha=0.25, split_prior=None, *args, **kwargs):
+    def __init__(
+        self, X, Y, m=200, alpha=0.25, split_prior=None, scale=None, inv_link=None, *args, **kwargs
+    ):
 
         self.X, self.Y, self.missing_data = self.preprocess_XY(X, Y)
 
-        super().__init__(shape=X.shape[0], dtype="float64", testval=0, *args, **kwargs)
+        super().__init__(shape=X.shape[0], dtype="float64", testval=self.Y.mean(), *args, **kwargs)
 
         if self.X.ndim != 2:
             raise ValueError("The design matrix X must have two dimensions")
@@ -48,13 +50,24 @@ class BaseBART(NoDistribution):
                 "The value for the alpha parameter for the tree structure "
                 "must be in the interval (0, 1)"
             )
+        self.m = m
+        self.alpha = alpha
+        self.y_std = Y.std()
+
+        if scale is None:
+            self.leaf_scale = NormalSampler(sigma=None)
+        elif isinstance(scale, (int, float)):
+            self.leaf_scale = NormalSampler(sigma=Y.std() / self.m ** scale)
+
+        if inv_link is None:
+            self.inv_link = lambda x: x
+        else:
+            self.inv_link = inv_link
 
         self.num_observations = X.shape[0]
         self.num_variates = X.shape[1]
         self.available_predictors = list(range(self.num_variates))
         self.ssv = SampleSplittingVariable(split_prior, self.num_variates)
-        self.m = m
-        self.alpha = alpha
         self.trees = self.init_list_of_trees()
         self.all_trees = []
         self.mean = fast_mean()
@@ -67,6 +80,7 @@ class BaseBART(NoDistribution):
             X = X.to_numpy()
         missing_data = np.any(np.isnan(X))
         X = np.random.normal(X, np.std(X, 0) / 100)
+        Y = Y.astype(float)
         return X, Y, missing_data
 
     def init_list_of_trees(self):
@@ -155,18 +169,14 @@ class BaseBART(NoDistribution):
 
     def get_residuals(self):
         """Compute the residuals."""
-        R_j = self.Y - self.sum_trees_output
-        return R_j
+        R_j = self.Y - self.inv_link(self.sum_trees_output)
 
-    def get_residuals_loo(self, tree):
-        """Compute the residuals without leaving the passed tree out."""
-        R_j = self.Y - (self.sum_trees_output - tree.predict_output(self.num_observations))
         return R_j
 
     def draw_leaf_value(self, idx_data_points):
-        """ Draw the residual mean."""
+        """Draw the residual mean."""
         R_j = self.get_residuals()[idx_data_points]
-        draw = self.mean(R_j)
+        draw = self.mean(R_j) + self.leaf_scale.random()
         return draw
 
     def predict(self, X_new):
@@ -174,13 +184,12 @@ class BaseBART(NoDistribution):
         trees = self.all_trees
         num_observations = X_new.shape[0]
         pred = np.zeros((len(trees), num_observations))
-        np.random.randint(len(trees))
         for draw, trees_to_sum in enumerate(trees):
             new_Y = np.zeros(num_observations)
             for tree in trees_to_sum:
                 new_Y += [tree.predict_out_of_sample(x) for x in X_new]
             pred[draw] = new_Y
-        return pred
+        return self.inv_link(pred)
 
 
 def compute_prior_probability(alpha):
@@ -257,6 +266,24 @@ class SampleSplittingVariable:
                     return i
 
 
+class NormalSampler:
+    def __init__(self, sigma):
+        self.size = 5000
+        self.cache = []
+        self.sigma = sigma
+
+    def random(self):
+        if self.sigma is None:
+            return 0
+        else:
+            if not self.cache:
+                self.update()
+        return self.cache.pop()
+
+    def update(self):
+        self.cache = np.random.normal(loc=0.0, scale=self.sigma, size=self.size).tolist()
+
+
 class BART(BaseBART):
     """
     BART distribution.
@@ -278,10 +305,17 @@ class BART(BaseBART):
         Each element of split_prior should be in the [0, 1] interval and the elements should sum
         to 1. Otherwise they will be normalized.
         Defaults to None, all variable have the same a prior probability
+    scale : float
+        Controls the variance of the proposed leaf value. The leaf values are computed as a
+        Gaussian with mean equal to the conditional residual mean and variance proportional to
+        the variance of the response variable, and inversely proportional to the number of trees
+        and the scale parameter. Defaults to None, i.e the variance is 0.
+    inv_link : numpy function
+        Inverse link function defaults to None, i.e. the identity function.
     """
 
-    def __init__(self, X, Y, m=200, alpha=0.25, split_prior=None):
-        super().__init__(X, Y, m, alpha, split_prior)
+    def __init__(self, X, Y, m=200, alpha=0.25, split_prior=None, scale=None, inv_link=None):
+        super().__init__(X, Y, m, alpha, split_prior, scale, inv_link)
 
     def _str_repr(self, name=None, dist=None, formatting="plain"):
         if dist is None:

--- a/pymc3/distributions/tree.py
+++ b/pymc3/distributions/tree.py
@@ -45,12 +45,13 @@ class Tree:
     tree_id : int, optional
     """
 
-    def __init__(self, tree_id=0):
+    def __init__(self, tree_id=0, num_observations=0):
         self.tree_structure = {}
         self.num_nodes = 0
         self.idx_leaf_nodes = []
         self.idx_prunable_split_nodes = []
         self.tree_id = tree_id
+        self.num_observations = num_observations
 
     def __getitem__(self, index):
         return self.get_node(index)
@@ -77,11 +78,12 @@ class Tree:
         del self.tree_structure[index]
         self.num_nodes -= 1
 
-    def predict_output(self, num_observations):
-        output = np.zeros(num_observations)
+    def predict_output(self):
+        output = np.zeros(self.num_observations)
         for node_index in self.idx_leaf_nodes:
             current_node = self.get_node(node_index)
             output[current_node.idx_data_points] = current_node.value
+
         return output
 
     def predict_out_of_sample(self, x):
@@ -163,7 +165,7 @@ class Tree:
         -------
 
         """
-        new_tree = Tree(tree_id)
+        new_tree = Tree(tree_id, len(idx_data_points))
         new_tree[0] = LeafNode(index=0, value=leaf_node_value, idx_data_points=idx_data_points)
         return new_tree
 

--- a/pymc3/tests/test_bart.py
+++ b/pymc3/tests/test_bart.py
@@ -1,0 +1,105 @@
+import numpy as np
+
+from scipy.special import expit
+
+import pymc3 as pm
+
+
+def test_split_node():
+    split_node = pm.distributions.bart.SplitNode(index=5, idx_split_variable=2, split_value=3.0)
+    assert split_node.index == 5
+    assert split_node.idx_split_variable == 2
+    assert split_node.split_value == 3.0
+    assert split_node.depth == 2
+    assert split_node.get_idx_parent_node() == 2
+    assert split_node.get_idx_left_child() == 11
+    assert split_node.get_idx_right_child() == 12
+
+
+def test_leaf_node():
+    leaf_node = pm.distributions.bart.LeafNode(index=5, value=3.14, idx_data_points=[1, 2, 3])
+    assert leaf_node.index == 5
+    assert np.array_equal(leaf_node.idx_data_points, [1, 2, 3])
+    assert leaf_node.value == 3.14
+    assert leaf_node.get_idx_parent_node() == 2
+    assert leaf_node.get_idx_left_child() == 11
+    assert leaf_node.get_idx_right_child() == 12
+
+
+def test_bart():
+    X = np.random.sample(size=(100, 4))
+    Y = np.random.sample(size=(100))
+
+    with pm.Model():
+        b = pm.BART("b", X=X, Y=Y)
+
+    bart = b.distribution
+    assert bart.num_observations == 100
+    assert bart.num_variates == 4
+    assert len(bart.trees) == bart.m
+
+    assert np.array_equal(bart.trees[0][0].idx_data_points, np.array(range(100), dtype="int32"))
+
+
+def test_available_splitting_rules():
+    X = np.array([[1.0, 2.0, 3.0, np.nan], [2.0, 2.0, 3.0, 99.9], [3.0, 4.0, 3.0, -3.3]])
+    Y = np.random.sample(size=(3))
+    with pm.Model():
+        b = pm.BART("b", X=X, Y=Y)
+
+    bart = b.distribution
+
+    idx_split_variable = 0
+    idx_data_points = np.array(range(bart.num_observations), dtype="int32")
+    available_splitting_rules = bart.get_available_splitting_rules(
+        idx_data_points, idx_split_variable
+    )
+    assert available_splitting_rules.size == 2
+    np.testing.assert_almost_equal(available_splitting_rules, np.array([1.0, 2.0]), 3)
+
+    idx_split_variable = 1
+    idx_data_points = np.array(range(bart.num_observations), dtype="int32")
+    available_splitting_rules = bart.get_available_splitting_rules(
+        idx_data_points, idx_split_variable
+    )
+    assert available_splitting_rules.size == 2
+    np.testing.assert_almost_equal(available_splitting_rules, np.array([2.0, 2.0]), 3)
+
+    idx_split_variable = 2
+    idx_data_points = np.array(range(bart.num_observations), dtype="int32")
+    available_splitting_rules = bart.get_available_splitting_rules(
+        idx_data_points, idx_split_variable
+    )
+    assert available_splitting_rules.size == 0
+    np.testing.assert_almost_equal(available_splitting_rules, np.array([]))
+
+    idx_split_variable = 3
+    idx_data_points = np.array(range(bart.num_observations), dtype="int32")
+    available_splitting_rules = bart.get_available_splitting_rules(
+        idx_data_points, idx_split_variable
+    )
+    assert available_splitting_rules.size == 1
+    np.testing.assert_almost_equal(available_splitting_rules, np.array([-3.3]), 3)
+
+
+def test_model():
+    np.random.seed(212480)
+    X = np.linspace(7, 15, 100)
+    Y = np.sin(np.random.normal(X, 0.2)) + 3
+    X = X[:, None]
+
+    with pm.Model() as model:
+        sigma = pm.HalfNormal("sigma", 1)
+        mu = pm.BART("mu", X, Y, m=50)
+        y = pm.Normal("y", mu, sigma, observed=Y)
+        trace = pm.sample(1000, random_seed=212480)
+
+    np.testing.assert_allclose(trace[mu].mean(0), Y, 0.5)
+
+    Y = np.repeat([0, 1], 50)
+    with pm.Model() as model:
+        mu = pm.BART("mu", X, Y, m=50, inv_link=expit, scale=0.25)
+        y = pm.Bernoulli("y", mu, observed=Y)
+        trace = pm.sample(1000, random_seed=212480)
+
+    np.testing.assert_allclose(trace[mu].mean(0), Y, atol=0.5)

--- a/pymc3/tests/test_bart.py
+++ b/pymc3/tests/test_bart.py
@@ -55,7 +55,7 @@ def test_available_splitting_rules():
         idx_data_points, idx_split_variable
     )
     assert available_splitting_rules.size == 2
-    np.testing.assert_almost_equal(available_splitting_rules, np.array([1.0, 2.0]), 3)
+    np.testing.assert_almost_equal(available_splitting_rules, np.array([1.0, 2.0]), 1)
 
     idx_split_variable = 1
     idx_data_points = np.array(range(bart.num_observations), dtype="int32")
@@ -63,7 +63,7 @@ def test_available_splitting_rules():
         idx_data_points, idx_split_variable
     )
     assert available_splitting_rules.size == 2
-    np.testing.assert_almost_equal(available_splitting_rules, np.array([2.0, 2.0]), 3)
+    np.testing.assert_almost_equal(available_splitting_rules, np.array([2.0, 2.0]), 1)
 
     idx_split_variable = 2
     idx_data_points = np.array(range(bart.num_observations), dtype="int32")
@@ -79,7 +79,7 @@ def test_available_splitting_rules():
         idx_data_points, idx_split_variable
     )
     assert available_splitting_rules.size == 1
-    np.testing.assert_almost_equal(available_splitting_rules, np.array([-3.3]), 3)
+    np.testing.assert_almost_equal(available_splitting_rules, np.array([-3.3]), 1)
 
 
 def test_model():

--- a/pymc3/tests/test_bart.py
+++ b/pymc3/tests/test_bart.py
@@ -62,8 +62,16 @@ def test_available_splitting_rules():
     available_splitting_rules = bart.get_available_splitting_rules(
         idx_data_points, idx_split_variable
     )
-    assert available_splitting_rules.size == 2
-    np.testing.assert_almost_equal(available_splitting_rules, np.array([2.0, 2.0]), 1)
+    assert available_splitting_rules.size == 1
+    np.testing.assert_almost_equal(
+        available_splitting_rules,
+        np.array(
+            [
+                2.0,
+            ]
+        ),
+        1,
+    )
 
     idx_split_variable = 2
     idx_data_points = np.array(range(bart.num_observations), dtype="int32")


### PR DESCRIPTION
This allows to use other likelihoods than the Gaussian one. Adds a new argument `inv_link` to allow the user to specify the proper inverse link function, defaults to identity.  This also introduce an `scale` argument that allows to control the proposal of the leaf values. For the Gaussian likelihoods (and probably other unbounded likelihoods like the Student T) the default scale is ok, for other model like the binomial it may need to be adjusted for better results. It seems LOO can be use for this purpose. 

A simple example

```python
from scipy.special import expit

with pm.Model() as model:
    μ = pm.BART('μ', X, Y, m=50, scale=0.25, inv_link=expit)
    y = pm.Bernoulli('y', μ, observed=Y)
    trace = pm.sample(1000, return_inferencedata=True)
```

![test_01b](https://user-images.githubusercontent.com/1338958/116856163-08dabe80-abd1-11eb-8279-48c415810b2a.png)
