### PR TITLE
Revert breaking `size` changes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,7 +10,7 @@
 ### New Features
 - The `CAR` distribution has been added to allow for use of conditional autoregressions which often are used in spatial and network models.
 - The dimensionality of model variables can now be parametrized through either of `shape`, `dims` or `size` (see [#4625](https://github.com/pymc-devs/pymc3/pull/4625)):
-  - With `shape` the length of dimensions must be given numerically or as scalar Aesara `Variables`. A `SpecifyShape` `Op` is added automatically unless `Ellipsis` is used. Using `shape` restricts the model variable to the exact length and re-sizing is no longer possible.
+  - With `shape` the length of dimensions must be given numerically or as scalar Aesara `Variables`. Using `shape` restricts the model variable to the exact length and re-sizing is no longer possible.
   - `dims` keeps model variables re-sizeable (for example through `pm.Data`) and leads to well defined coordinates in `InferenceData` objects.
   - The `size` kwarg creates new dimensions in addition to what is implied by RV parameters.
   - An `Ellipsis` (`...`) in the last position of `shape` or `dims` can be used as short-hand notation for implied dimensions.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,11 +9,6 @@
 
 ### New Features
 - The `CAR` distribution has been added to allow for use of conditional autoregressions which often are used in spatial and network models.
-- The dimensionality of model variables can now be parametrized through either of `shape`, `dims` or `size` (see [#4625](https://github.com/pymc-devs/pymc3/pull/4625)):
-  - With `shape` the length of dimensions must be given numerically or as scalar Aesara `Variables`. Using `shape` restricts the model variable to the exact length and re-sizing is no longer possible.
-  - `dims` keeps model variables re-sizeable (for example through `pm.Data`) and leads to well defined coordinates in `InferenceData` objects.
-  - The `size` kwarg creates new dimensions in addition to what is implied by RV parameters.
-  - An `Ellipsis` (`...`) in the last position of `shape` or `dims` can be used as short-hand notation for implied dimensions.
 - ...
 
 ### Maintenance

--- a/pymc3/aesaraf.py
+++ b/pymc3/aesaraf.py
@@ -45,7 +45,6 @@ from aesara.graph.op import Op, compute_test_value
 from aesara.sandbox.rng_mrg import MRG_RandomStream as RandomStream
 from aesara.tensor.elemwise import Elemwise
 from aesara.tensor.random.op import RandomVariable
-from aesara.tensor.shape import SpecifyShape
 from aesara.tensor.sharedvar import SharedVariable
 from aesara.tensor.subtensor import AdvancedIncSubtensor, AdvancedIncSubtensor1
 from aesara.tensor.var import TensorVariable
@@ -147,8 +146,6 @@ def change_rv_size(
         Expand the existing size by `new_size`.
 
     """
-    if isinstance(rv_var.owner.op, SpecifyShape):
-        rv_var = rv_var.owner.inputs[0]
     rv_node = rv_var.owner
     rng, size, dtype, *dist_params = rv_node.inputs
     name = rv_var.name

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -28,7 +28,6 @@ import dill
 
 from aesara.graph.basic import Variable
 from aesara.tensor.random.op import RandomVariable
-from aesara.tensor.shape import SpecifyShape, specify_shape
 
 from pymc3.aesaraf import change_rv_size, pandas_to_array
 from pymc3.distributions import _logcdf, _logp
@@ -247,13 +246,6 @@ class Distribution(metaclass=DistributionMeta):
         rv_out = cls.dist(*args, rng=rng, testval=None, **kwargs)
         n_implied = rv_out.ndim
 
-        # The `.dist()` can wrap automatically with a SpecifyShape Op which brings informative
-        # error messages earlier in model construction.
-        # Here, however, the underyling RV must be used - a new SpecifyShape Op can be added at the end.
-        assert_shape = None
-        if isinstance(rv_out.owner.op, SpecifyShape):
-            rv_out, assert_shape = rv_out.owner.inputs
-
         # `dims` are only available with this API, because `.dist()` can be used
         # without a modelcontext and dims are not tracked at the Aesara level.
         if dims is not None:
@@ -293,15 +285,7 @@ class Distribution(metaclass=DistributionMeta):
             # Assigning the testval earlier causes trouble because the RV may not be created with the final shape already.
             rv_out.tag.test_value = testval
 
-        rv_registered = model.register_rv(
-            rv_out, name, observed, total_size, dims=dims, transform=transform
-        )
-
-        # Wrapping in specify_shape now does not break transforms:
-        if assert_shape is not None:
-            rv_registered = specify_shape(rv_registered, assert_shape)
-
-        return rv_registered
+        return model.register_rv(rv_out, name, observed, total_size, dims=dims, transform=transform)
 
     @classmethod
     def dist(
@@ -323,9 +307,6 @@ class Distribution(metaclass=DistributionMeta):
 
             Ellipsis (...) may be used in the last position of the tuple,
             and automatically expand to the shape implied by RV inputs.
-
-            Without Ellipsis, a `SpecifyShape` Op is automatically applied,
-            constraining this model variable to exactly the specified shape.
         size : int, tuple, Variable, optional
             A scalar or tuple for replicating the RV in addition
             to its implied shape/dimensionality.
@@ -342,7 +323,6 @@ class Distribution(metaclass=DistributionMeta):
             raise NotImplementedError("The use of a `.dist(dims=...)` API is not yet supported.")
 
         shape, _, size = _validate_shape_dims_size(shape=shape, size=size)
-        assert_shape = None
 
         # Create the RV without specifying size or testval.
         # The size will be expanded later (if necessary) and only then the testval fits.
@@ -351,16 +331,13 @@ class Distribution(metaclass=DistributionMeta):
         if shape is None and size is None:
             size = ()
         elif shape is not None:
-            # SpecifyShape is automatically applied for symbolic and non-Ellipsis shapes
             if isinstance(shape, Variable):
-                assert_shape = shape
                 size = ()
             else:
                 if Ellipsis in shape:
                     size = tuple(shape[:-1])
                 else:
                     size = tuple(shape[: len(shape) - rv_native.ndim])
-                    assert_shape = shape
         # no-op conditions:
         # `elif size is not None` (User already specified how to expand the RV)
         # `else` (Unreachable)
@@ -369,9 +346,6 @@ class Distribution(metaclass=DistributionMeta):
             rv_out = change_rv_size(rv_var=rv_native, new_size=size, expand=True)
         else:
             rv_out = rv_native
-
-        if assert_shape is not None:
-            rv_out = specify_shape(rv_out, shape=assert_shape)
 
         if testval is not None:
             rv_out.tag.test_value = testval

--- a/pymc3/tests/sampler_fixtures.py
+++ b/pymc3/tests/sampler_fixtures.py
@@ -92,7 +92,7 @@ class BetaBinomialFixture(KnownCDF):
     @classmethod
     def make_model(cls):
         with pm.Model() as model:
-            p = pm.Beta("p", [0.5, 0.5, 1.0], [0.5, 0.5, 1.0])
+            p = pm.Beta("p", [0.5, 0.5, 1.0], [0.5, 0.5, 1.0], size=3)
             pm.Binomial("y", p=p, n=[4, 12, 9], observed=[1, 2, 9])
         return model
 

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -18,13 +18,10 @@ import pytest
 
 from aesara import shared
 from aesara.tensor.sharedvar import ScalarSharedVariable
-from aesara.tensor.var import TensorVariable
 
 import pymc3 as pm
 
-from pymc3.aesaraf import floatX
 from pymc3.distributions import logpt
-from pymc3.exceptions import ShapeError
 from pymc3.tests.helpers import SeededTest
 
 
@@ -162,42 +159,22 @@ class TestData(SeededTest):
         """
         with pm.Model() as m:
             x = pm.Data("x", [1.0, 2.0, 3.0])
-            assert x.eval().shape == (3,)
-            y = pm.Normal("y", mu=x, size=2)
-            assert y.eval().shape == (2, 3)
-            idata = pm.sample(
-                chains=1,
-                tune=500,
-                draws=550,
-                return_inferencedata=True,
-                compute_convergence_checks=False,
+            _ = pm.Normal("y", mu=x, size=3)
+            trace = pm.sample(
+                chains=1, return_inferencedata=False, compute_convergence_checks=False
             )
-        samples = idata.posterior["y"]
-        assert samples.shape == (1, 550, 2, 3)
 
         np.testing.assert_allclose(np.array([1.0, 2.0, 3.0]), x.get_value(), atol=1e-1)
-        np.testing.assert_allclose(
-            np.array([1.0, 2.0, 3.0]), samples.mean(("chain", "draw", "y_dim_0")), atol=1e-1
-        )
+        np.testing.assert_allclose(np.array([1.0, 2.0, 3.0]), trace["y"].mean(0), atol=1e-1)
 
         with m:
             pm.set_data({"x": np.array([2.0, 4.0, 6.0])})
-            assert x.eval().shape == (3,)
-            assert y.eval().shape == (2, 3)
-            idata = pm.sample(
-                chains=1,
-                tune=500,
-                draws=620,
-                return_inferencedata=True,
-                compute_convergence_checks=False,
+            trace = pm.sample(
+                chains=1, return_inferencedata=False, compute_convergence_checks=False
             )
-        samples = idata.posterior["y"]
-        assert samples.shape == (1, 620, 2, 3)
 
         np.testing.assert_allclose(np.array([2.0, 4.0, 6.0]), x.get_value(), atol=1e-1)
-        np.testing.assert_allclose(
-            np.array([2.0, 4.0, 6.0]), samples.mean(("chain", "draw", "y_dim_0")), atol=1e-1
-        )
+        np.testing.assert_allclose(np.array([2.0, 4.0, 6.0]), trace["y"].mean(0), atol=1e-1)
 
     def test_shared_scalar_as_rv_input(self):
         # See https://github.com/pymc-devs/pymc3/issues/3139
@@ -240,7 +217,7 @@ class TestData(SeededTest):
             )
         with pytest.raises(TypeError) as error:
             pm.set_data({"beta": [1.1, 2.2, 3.3]}, model=model)
-        error.match("The variable `beta` must be a `SharedVariable`")
+        error.match("defined as `pymc3.Data` inside the model")
 
     @pytest.mark.xfail(reason="Depends on ModelGraph")
     def test_model_to_graphviz_for_model_with_data_container(self):
@@ -305,38 +282,6 @@ class TestData(SeededTest):
         assert "columns" in pmodel.dim_lengths
         assert isinstance(pmodel.dim_lengths["columns"], ScalarSharedVariable)
         assert pmodel.dim_lengths["columns"].eval() == 7
-
-    def test_symbolic_coords(self):
-        """
-        In v4 dimensions can be created without passing coordinate values.
-        Their lengths are then automatically linked to the corresponding Tensor dimension.
-        """
-        with pm.Model() as pmodel:
-            intensity = pm.Data("intensity", np.ones((2, 3)), dims=("row", "column"))
-            assert "row" in pmodel.dim_lengths
-            assert "column" in pmodel.dim_lengths
-            assert isinstance(pmodel.dim_lengths["row"], TensorVariable)
-            assert isinstance(pmodel.dim_lengths["column"], TensorVariable)
-            assert pmodel.dim_lengths["row"].eval() == 2
-            assert pmodel.dim_lengths["column"].eval() == 3
-
-            intensity.set_value(floatX(np.ones((4, 5))))
-            assert pmodel.dim_lengths["row"].eval() == 4
-            assert pmodel.dim_lengths["column"].eval() == 5
-
-    def test_no_resize_of_implied_dimensions(self):
-        with pm.Model() as pmodel:
-            # Imply a dimension through RV params
-            pm.Normal("n", mu=[1, 2, 3], dims="city")
-            # _Use_ the dimension for a data variable
-            inhabitants = pm.Data("inhabitants", [100, 200, 300], dims="city")
-
-            # Attempting to re-size the dimension through the data variable would
-            # cause shape problems in InferenceData conversion, because the RV remains (3,).
-            with pytest.raises(
-                ShapeError, match="was initialized from 'n' which is not a shared variable"
-            ):
-                pmodel.set_data("inhabitants", [1, 2, 3, 4])
 
     def test_implicit_coords_series(self):
         ser_sales = pd.Series(

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -174,7 +174,12 @@ class BaseTestCases:
                         # in the test case parametrization "None" means "no specified (default)"
                         return self.distribution(name, transform=None, **params)
                     else:
-                        return self.distribution(name, shape=shape, transform=None, **params)
+                        ndim_supp = self.distribution.rv_op.ndim_supp
+                        if ndim_supp == 0:
+                            size = shape
+                        else:
+                            size = shape[:-ndim_supp]
+                        return self.distribution(name, size=size, transform=None, **params)
                 except TypeError:
                     if np.sum(np.atleast_1d(shape)) == 0:
                         pytest.skip("Timeseries must have positive shape")
@@ -183,9 +188,10 @@ class BaseTestCases:
         @staticmethod
         def sample_random_variable(random_variable, size):
             """ Draws samples from a RandomVariable using its .random() method. """
-            if size:
-                random_variable = change_rv_size(random_variable, size, expand=True)
-            return random_variable.eval()
+            if size is None:
+                return random_variable.eval()
+            else:
+                return change_rv_size(random_variable, size, expand=True).eval()
 
         @pytest.mark.parametrize("size", [None, (), 1, (1,), 5, (4, 5)], ids=str)
         @pytest.mark.parametrize("shape", [None, ()], ids=str)

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -68,7 +68,7 @@ class TestARM5_4(SeededTest):
         P["1"] = 1
 
         with pm.Model() as model:
-            effects = pm.Normal("effects", mu=0, sigma=100, shape=len(P.columns))
+            effects = pm.Normal("effects", mu=0, sigma=100, size=len(P.columns))
             logit_p = at.dot(floatX(np.array(P)), effects)
             pm.Bernoulli("s", logit_p=logit_p, observed=floatX(data.switch.values))
         return model
@@ -94,7 +94,7 @@ class TestARM12_6(SeededTest):
             groupsd = pm.Uniform("groupsd", 0, 10.0)
             sd = pm.Uniform("sd", 0, 10.0)
             floor_m = pm.Normal("floor_m", 0, 5.0 ** -2.0)
-            means = pm.Normal("means", groupmean, groupsd ** -2.0, shape=len(self.obs_means))
+            means = pm.Normal("means", groupmean, groupsd ** -2.0, size=len(self.obs_means))
             pm.Normal("lr", floor * floor_m + means[group], sd ** -2.0, observed=lradon)
         return model
 
@@ -132,7 +132,7 @@ class TestARM12_6Uranium(SeededTest):
             sd = pm.Uniform("sd", 0, 10.0)
             floor_m = pm.Normal("floor_m", 0, 5.0 ** -2.0)
             u_m = pm.Normal("u_m", 0, 5.0 ** -2)
-            means = pm.Normal("means", groupmean, groupsd ** -2.0, shape=len(self.obs_means))
+            means = pm.Normal("means", groupmean, groupsd ** -2.0, size=len(self.obs_means))
             pm.Normal(
                 "lr",
                 floor * floor_m + means[group] + ufull * u_m,
@@ -310,11 +310,11 @@ class TestRSV(SeededTest):
             # Al Bashir hospital market share
             market_share = pm.Uniform("market_share", 0.5, 0.6)
             # Number of 1 y.o. in Amman
-            n_amman = pm.Binomial("n_amman", kids, amman_prop, shape=3)
+            n_amman = pm.Binomial("n_amman", kids, amman_prop, size=3)
             # Prior probability
-            prev_rsv = pm.Beta("prev_rsv", 1, 5, shape=3)
+            prev_rsv = pm.Beta("prev_rsv", 1, 5, size=3)
             # RSV in Amman
-            y_amman = pm.Binomial("y_amman", n_amman, prev_rsv, shape=3)
+            y_amman = pm.Binomial("y_amman", n_amman, prev_rsv, size=3)
             # Likelihood for number with RSV in hospital (assumes Pr(hosp | RSV) = 1)
             pm.Binomial("y_hosp", y_amman, market_share, observed=rsv_cases)
         return model

--- a/pymc3/tests/test_logp.py
+++ b/pymc3/tests/test_logp.py
@@ -70,7 +70,7 @@ def test_logpt_basic():
 
 
 @pytest.mark.parametrize(
-    "indices, shape",
+    "indices, size",
     [
         (slice(0, 2), 5),
         (np.r_[True, True, False, False, True], 5),
@@ -78,15 +78,15 @@ def test_logpt_basic():
         ((np.array([0, 1, 4]), np.array([0, 1, 4])), (5, 5)),
     ],
 )
-def test_logpt_incsubtensor(indices, shape):
+def test_logpt_incsubtensor(indices, size):
     """Make sure we can compute a log-likelihood for ``Y[idx] = data`` where ``Y`` is univariate."""
 
-    mu = floatX(np.power(10, np.arange(np.prod(shape)))).reshape(shape)
+    mu = floatX(np.power(10, np.arange(np.prod(size)))).reshape(size)
     data = mu[indices]
     sigma = 0.001
     rng = aesara.shared(np.random.RandomState(232), borrow=True)
 
-    a = Normal.dist(mu, sigma, shape=shape, rng=rng)
+    a = Normal.dist(mu, sigma, size=size, rng=rng)
     a.name = "a"
 
     a_idx = at.set_subtensor(a[indices], data)

--- a/pymc3/tests/test_logp.py
+++ b/pymc3/tests/test_logp.py
@@ -86,7 +86,7 @@ def test_logpt_incsubtensor(indices, shape):
     sigma = 0.001
     rng = aesara.shared(np.random.RandomState(232), borrow=True)
 
-    a = Normal.dist(mu, sigma, rng=rng)
+    a = Normal.dist(mu, sigma, shape=shape, rng=rng)
     a.name = "a"
 
     a_idx = at.set_subtensor(a[indices], data)

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -461,29 +461,33 @@ def test_make_obs_var():
     # Create a fake model and fake distribution to be used for the test
     fake_model = pm.Model()
     with fake_model:
-        fake_distribution = pm.Normal.dist(mu=0, sigma=1, size=(3, 3))
+        fake_distribution = pm.Normal.dist(mu=0, sigma=1)
         # Create the testval attribute simply for the sake of model testing
         fake_distribution.name = input_name
 
     # Check function behavior using the various inputs
-    # dense, sparse: Ensure that the missing values are appropriately set to None
-    # masked: a deterministic variable is returned
-
     dense_output = fake_model.make_obs_var(fake_distribution, dense_input, None, None)
-    assert dense_output == fake_distribution
-    assert isinstance(dense_output.tag.observations, TensorConstant)
     del fake_model.named_vars[fake_distribution.name]
-
     sparse_output = fake_model.make_obs_var(fake_distribution, sparse_input, None, None)
-    assert sparse_output == fake_distribution
-    assert sparse.basic._is_sparse_variable(sparse_output.tag.observations)
     del fake_model.named_vars[fake_distribution.name]
-
-    # Here the RandomVariable is split into observed/imputed and a Deterministic is returned
     masked_output = fake_model.make_obs_var(fake_distribution, masked_array_input, None, None)
-    assert masked_output != fake_distribution
     assert not isinstance(masked_output, RandomVariable)
-    # Ensure it has missing values
+
+    # Ensure that the missing values are appropriately set to None
+    for func_output in [dense_output, sparse_output]:
+        assert isinstance(func_output.owner.op, RandomVariable)
+
+    # Ensure that the Aesara variable names are correctly set.
+    # Note that the output for masked inputs do not have their names set
+    # to the passed value.
+    for func_output in [dense_output, sparse_output]:
+        assert func_output.name == input_name
+
+    # Ensure the that returned functions are all of the correct type
+    assert isinstance(dense_output.tag.observations, TensorConstant)
+    assert sparse.basic._is_sparse_variable(sparse_output.tag.observations)
+
+    # Masked output is something weird. Just ensure it has missing values
     assert {"testing_inputs_missing"} == {v.name for v in fake_model.vars}
     assert {"testing_inputs", "testing_inputs_observed"} == {
         v.name for v in fake_model.observed_RVs

--- a/pymc3/tests/test_ode.py
+++ b/pymc3/tests/test_ode.py
@@ -168,7 +168,6 @@ class TestSensitivityInitialCondition:
         np.testing.assert_array_equal(np.ravel(model5_sens_ic), model5._sens_ic)
 
 
-@pytest.mark.xfail(reason="See https://github.com/pymc-devs/pymc3/issues/4652.")
 def test_logp_scalar_ode():
     """Test the computation of the log probability for these models"""
 

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -213,7 +213,7 @@ class TestSample(SeededTest):
                 return_inferencedata=True,
                 discard_tuned_samples=True,
                 idata_kwargs={"prior": prior},
-                random_seed=-1,
+                random_seed=-1
             )
             assert "prior" in result
             assert isinstance(result, InferenceData)
@@ -385,10 +385,11 @@ class TestNamedSampling(SeededTest):
                 "theta0",
                 mu=np.atleast_2d(0),
                 tau=np.atleast_2d(1e20),
+                size=(1, 1),
                 testval=np.atleast_2d(0),
             )
             theta = pm.Normal(
-                "theta", mu=at.dot(G_var, theta0), tau=np.atleast_2d(1e20), shape=(1, 1)
+                "theta", mu=at.dot(G_var, theta0), tau=np.atleast_2d(1e20), size=(1, 1)
             )
             res = theta.eval()
             assert np.isclose(res, 0.0)
@@ -400,10 +401,11 @@ class TestNamedSampling(SeededTest):
                 "theta0",
                 mu=np.atleast_2d(0),
                 tau=np.atleast_2d(1e20),
+                size=(1, 1),
                 testval=np.atleast_2d(0),
             )
             theta = pm.Normal(
-                "theta", mu=at.dot(G_var, theta0), tau=np.atleast_2d(1e20), shape=(1, 1)
+                "theta", mu=at.dot(G_var, theta0), tau=np.atleast_2d(1e20), size=(1, 1)
             )
             res = theta.eval()
             assert np.isclose(res, 0.0)
@@ -415,10 +417,11 @@ class TestNamedSampling(SeededTest):
                 "theta0",
                 mu=np.atleast_2d(0),
                 tau=np.atleast_2d(1e20),
+                size=(1, 1),
                 testval=np.atleast_2d(0),
             )
             theta = pm.Normal(
-                "theta", mu=at.dot(G_var, theta0), tau=np.atleast_2d(1e20), shape=(1, 1)
+                "theta", mu=at.dot(G_var, theta0), tau=np.atleast_2d(1e20), size=(1, 1)
             )
 
             res = theta.eval()
@@ -933,13 +936,14 @@ class TestSamplePriorPredictive(SeededTest):
         npt.assert_array_almost_equal(prior["positive_mu"], np.abs(prior["mu"]), decimal=4)
 
     def test_respects_shape(self):
-        for shape in ((2,), (10, 2), (10, 10)):
+        for shape in (2, (2,), (10, 2), (10, 10)):
             with pm.Model():
-                mu = pm.Gamma("mu", 3, 1)
-                goals = pm.Poisson("goals", mu, shape=shape)
-                assert goals.eval().shape == shape, f"Current shape setting: {shape}"
+                mu = pm.Gamma("mu", 3, 1, size=1)
+                goals = pm.Poisson("goals", mu, size=shape)
                 trace1 = pm.sample_prior_predictive(10, var_names=["mu", "mu", "goals"])
                 trace2 = pm.sample_prior_predictive(10, var_names=["mu", "goals"])
+            if shape == 2:  # want to test shape as an int
+                shape = (2,)
             assert trace1["goals"].shape == (10,) + shape
             assert trace2["goals"].shape == (10,) + shape
 
@@ -967,14 +971,14 @@ class TestSamplePriorPredictive(SeededTest):
 
     def test_layers(self):
         with pm.Model() as model:
-            a = pm.Uniform("a", lower=0, upper=1, size=5)
-            b = pm.Binomial("b", n=1, p=a, size=7)
+            a = pm.Uniform("a", lower=0, upper=1, size=10)
+            b = pm.Binomial("b", n=1, p=a, size=10)
 
         model.default_rng.get_value(borrow=True).seed(232093)
 
         b_sampler = aesara.function([], b)
         avg = np.stack([b_sampler() for i in range(10000)]).mean(0)
-        npt.assert_array_almost_equal(avg, 0.5 * np.ones((7, 5)), decimal=2)
+        npt.assert_array_almost_equal(avg, 0.5 * np.ones((10,)), decimal=2)
 
     def test_transformed(self):
         n = 18

--- a/pymc3/tests/test_shape_handling.py
+++ b/pymc3/tests/test_shape_handling.py
@@ -350,39 +350,6 @@ class TestShapeDimsSize:
         assert pm.Normal.dist(mu=mu, shape=(7, ...)).eval().shape == (7, 3)
         assert pm.Normal.dist(mu=mu, size=(4,)).eval().shape == (4, 3)
 
-    def test_auto_assert_shape(self):
-        with pytest.raises(AssertionError, match="will never match"):
-            pm.Normal.dist(mu=[1, 2], shape=[])
-
-        mu = at.vector(name="mu_input")
-        rv = pm.Normal.dist(mu=mu, shape=[3, 4])
-        f = aesara.function([mu], rv, mode=aesara.Mode("py"))
-        assert f([1, 2, 3, 4]).shape == (3, 4)
-
-        with pytest.raises(AssertionError, match=r"Got shape \(3, 2\), expected \(3, 4\)."):
-            f([1, 2])
-
-        # The `shape` can be symbolic!
-        s = at.vector(dtype="int32")
-        rv = pm.Uniform.dist(2, [4, 5], shape=s)
-        f = aesara.function([s], rv, mode=aesara.Mode("py"))
-        f(
-            [
-                2,
-            ]
-        )
-        with pytest.raises(
-            AssertionError,
-            match=r"Got 1 dimensions \(shape \(2,\)\), expected 2 dimensions with shape \(3, 4\).",
-        ):
-            f([3, 4])
-        with pytest.raises(
-            AssertionError,
-            match=r"Got 1 dimensions \(shape \(2,\)\), expected 0 dimensions with shape \(\).",
-        ):
-            f([])
-        pass
-
     def test_lazy_flavors(self):
 
         _validate_shape_dims_size(shape=5)

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -982,7 +982,7 @@ class TestNutsCheckTrace:
             a = Normal("a", size=2, testval=floatX(np.zeros(2)))
             a = at.switch(a > 0, np.inf, a)
             b = at.slinalg.solve(floatX(np.eye(2)), a)
-            Normal("c", mu=b, shape=(2,), testval=floatX(np.r_[0.0, 0.0]))
+            Normal("c", mu=b, size=2, testval=floatX(np.r_[0.0, 0.0]))
             caplog.clear()
             trace = sample(20, init=None, tune=5, chains=2)
             warns = [msg.msg for msg in caplog.records]


### PR DESCRIPTION
This PR reverts the `size`-related breaking changes and `Model`/`Distribution` design issues introduced by #4625.


Closes #4662.