### PR TITLE
Implement backwards-compatible shape and dims with Ellipsis support

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,8 +12,9 @@
 - The `CAR` distribution has been added to allow for use of conditional autoregressions which often are used in spatial and network models.
 - The dimensionality of model variables can now be parametrized through either of `shape`, `dims` or `size` (see [#4696](https://github.com/pymc-devs/pymc3/pull/4696)):
   - With `shape` the length of dimensions must be given numerically or as scalar Aesara `Variables`. Numeric entries in `shape` restrict the model variable to the exact length and re-sizing is no longer possible.
-  - `dims` keeps model variables re-sizeable (for example through `pm.Data`) and leads to well defined coordinates in `InferenceData` objects. An `Ellipsis` (`...`) in the last position of `dims` can be used as short-hand notation for implied dimensions.
+  - `dims` keeps model variables re-sizeable (for example through `pm.Data`) and leads to well defined coordinates in `InferenceData` objects.
   - The `size` kwarg behaves like it does in Aesara/NumPy. For univariate RVs it is the same as `shape`, but for multivariate RVs it depends on how the RV implements broadcasting to dimensionality greater than `RVOp.ndim_supp`.
+  - An `Ellipsis` (`...`) in the last position of `shape` or `dims` can be used as short-hand notation for implied dimensions.
 - Add `logcdf` method to Kumaraswamy distribution (see [#4706](https://github.com/pymc-devs/pymc3/pull/4706)).
 - ...
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,10 @@
 
 ### New Features
 - The `CAR` distribution has been added to allow for use of conditional autoregressions which often are used in spatial and network models.
+- The dimensionality of model variables can now be parametrized through either of `shape`, `dims` or `size` (see [#4696](https://github.com/pymc-devs/pymc3/pull/4696)):
+  - With `shape` the length of dimensions must be given numerically or as scalar Aesara `Variables`. Numeric entries in `shape` restrict the model variable to the exact length and re-sizing is no longer possible.
+  - `dims` keeps model variables re-sizeable (for example through `pm.Data`) and leads to well defined coordinates in `InferenceData` objects. An `Ellipsis` (`...`) in the last position of `dims` can be used as short-hand notation for implied dimensions.
+  - The `size` kwarg behaves like it does in Aesara/NumPy. For univariate RVs it is the same as `shape`, but for multivariate RVs it depends on how the RV implements broadcasting to dimensionality greater than `RVOp.ndim_supp`.
 - Add `logcdf` method to Kumaraswamy distribution (see [#4706](https://github.com/pymc-devs/pymc3/pull/4706)).
 - ...
 

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -202,9 +202,9 @@ class Distribution(metaclass=DistributionMeta):
             )
         dims = convert_dims(dims)
 
-        # Create the RV without specifying testval, because the testval may have a shape
+        # Create the RV without specifying initval, because the initval may have a shape
         # that only matches after replicating with a size implied by dims (see below).
-        rv_out = cls.dist(*args, rng=rng, testval=None, **kwargs)
+        rv_out = cls.dist(*args, rng=rng, initval=None, **kwargs)
         ndim_actual = rv_out.ndim
         resize_shape = None
 

--- a/pymc3/distributions/shape_utils.py
+++ b/pymc3/distributions/shape_utils.py
@@ -1,4 +1,4 @@
-#   Copyright 2020 The PyMC Developers
+#   Copyright 2021 The PyMC Developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -14,10 +14,21 @@
 
 # -*- coding: utf-8 -*-
 """
-A collection of common numpy array shape operations needed for broadcasting
+A collection of common shape operations needed for broadcasting
 samples from probability distributions for stochastic nodes in PyMC.
 """
+
+import warnings
+
+from typing import Optional, Sequence, Tuple, Union
+
 import numpy as np
+
+from aesara.graph.basic import Variable
+from aesara.tensor.var import TensorVariable
+
+from pymc3.aesaraf import change_rv_size, pandas_to_array
+from pymc3.exceptions import ShapeError, ShapeWarning
 
 __all__ = [
     "to_tuple",
@@ -397,3 +408,269 @@ def broadcast_dist_samples_to(to_shape, samples, size=None):
         samples, size=size, must_bcast_with=to_shape, return_out_shape=True
     )
     return [np.broadcast_to(o, to_shape) for o in samples]
+
+
+# User-provided can be lazily specified as scalars
+Shape = Union[int, TensorVariable, Sequence[Union[int, TensorVariable, type(Ellipsis)]]]
+Dims = Union[str, Sequence[Union[str, None, type(Ellipsis)]]]
+Size = Union[int, TensorVariable, Sequence[Union[int, TensorVariable]]]
+
+# After conversion to vectors
+WeakShape = Union[TensorVariable, Tuple[Union[int, TensorVariable, type(Ellipsis)], ...]]
+WeakDims = Tuple[Union[str, None, type(Ellipsis)], ...]
+
+# After Ellipsis were substituted
+StrongShape = Union[TensorVariable, Tuple[Union[int, TensorVariable], ...]]
+StrongDims = Sequence[Union[str, None]]
+StrongSize = Union[TensorVariable, Tuple[Union[int, TensorVariable], ...]]
+
+
+def convert_dims(dims: Dims) -> Optional[WeakDims]:
+    """ Process a user-provided dims variable into None or a valid dims tuple. """
+    if dims is None:
+        return None
+
+    if isinstance(dims, str):
+        dims = (dims,)
+    elif isinstance(dims, (list, tuple)):
+        dims = tuple(dims)
+    else:
+        raise ValueError(f"The `dims` parameter must be a tuple, str or list. Actual: {type(dims)}")
+
+    if any(d == Ellipsis for d in dims[:-1]):
+        raise ValueError(f"Ellipsis in `dims` may only appear in the last position. Actual: {dims}")
+
+    return dims
+
+
+def convert_shape(shape: Shape) -> Optional[WeakShape]:
+    """ Process a user-provided shape variable into None or a valid shape object. """
+    if shape is None:
+        return None
+
+    if isinstance(shape, int) or (isinstance(shape, TensorVariable) and shape.ndim == 0):
+        shape = (shape,)
+    elif isinstance(shape, (list, tuple)):
+        shape = tuple(shape)
+    else:
+        raise ValueError(
+            f"The `shape` parameter must be a tuple, TensorVariable, int or list. Actual: {type(shape)}"
+        )
+
+    if isinstance(shape, tuple) and any(s == Ellipsis for s in shape[:-1]):
+        raise ValueError(
+            f"Ellipsis in `shape` may only appear in the last position. Actual: {shape}"
+        )
+
+    return shape
+
+
+def convert_size(size: Size) -> Optional[StrongSize]:
+    """ Process a user-provided size variable into None or a valid size object. """
+    if size is None:
+        return None
+
+    if isinstance(size, int) or (isinstance(size, TensorVariable) and size.ndim == 0):
+        size = (size,)
+    elif isinstance(size, (list, tuple)):
+        size = tuple(size)
+    else:
+        raise ValueError(
+            f"The `size` parameter must be a tuple, TensorVariable, int or list. Actual: {type(size)}"
+        )
+
+    if isinstance(size, tuple) and Ellipsis in size:
+        raise ValueError(f"The `size` parameter cannot contain an Ellipsis. Actual: {size}")
+
+    return size
+
+
+def resize_from_dims(
+    dims: WeakDims, ndim_implied: int, model
+) -> Tuple[int, StrongSize, StrongDims]:
+    """Determines a potential resize shape from a `dims` tuple.
+
+    Parameters
+    ----------
+    dims : array-like
+        A vector of dimension names, None or Ellipsis.
+    ndim_implied : int
+        Number of RV dimensions that were implied from its inputs alone.
+    model : pm.Model
+        The current model on stack.
+
+    Returns
+    -------
+    ndim_resize : int
+        Number of dimensions that should be added through resizing.
+    resize_shape : array-like
+        The shape of the new dimensions.
+    """
+    if Ellipsis in dims:
+        # Auto-complete the dims tuple to the full length.
+        # We don't have a way to know the names of implied
+        # dimensions, so they will be `None`.
+        dims = (*dims[:-1], *[None] * ndim_implied)
+
+    ndim_resize = len(dims) - ndim_implied
+
+    # All resize dims must be known already (numerically or symbolically).
+    unknowndim_resize_dims = set(dims[:ndim_resize]) - set(model.dim_lengths)
+    if unknowndim_resize_dims:
+        raise KeyError(
+            f"Dimensions {unknowndim_resize_dims} are unknown to the model and cannot be used to specify a `size`."
+        )
+
+    # The numeric/symbolic resize tuple can be created using model.RV_dim_lengths
+    resize_shape = tuple(model.dim_lengths[dname] for dname in dims[:ndim_resize])
+    return ndim_resize, resize_shape, dims
+
+
+def resize_from_observed(
+    observed, ndim_implied: int
+) -> Tuple[int, StrongSize, Union[np.ndarray, Variable]]:
+    """Determines a potential resize shape from observations.
+
+    Parameters
+    ----------
+    observed : scalar, array-like
+        The value of the `observed` kwarg to the RV creation.
+    ndim_implied : int
+        Number of RV dimensions that were implied from its inputs alone.
+
+    Returns
+    -------
+    ndim_resize : int
+        Number of dimensions that should be added through resizing.
+    resize_shape : array-like
+        The shape of the new dimensions.
+    observed : scalar, array-like
+        Observations as numpy array or `Variable`.
+    """
+    if not hasattr(observed, "shape"):
+        observed = pandas_to_array(observed)
+    ndim_resize = observed.ndim - ndim_implied
+    resize_shape = tuple(observed.shape[d] for d in range(ndim_resize))
+    return ndim_resize, resize_shape, observed
+
+
+def find_size(shape=None, size=None, ndim_supp=None):
+    """Determines the size keyword argument for creating a Distribution.
+
+    Parameters
+    ----------
+    shape : tuple
+        A tuple specifying the final shape of a distribution
+    size : tuple
+        A tuple specifying the size of a distribution
+    ndim_supp : int
+        The support dimension of the distribution.
+        0 if a univariate distribution, 1 if a multivariate distribution.
+
+    Returns
+    -------
+    create_size : int
+        The size argument to be passed to the distribution
+    ndim_expected : int
+        Number of dimensions expected after distribution was created
+    ndim_batch : int
+        Number of batch dimensions
+    ndim_supp : int
+        Number of support dimensions
+    """
+
+    ndim_expected = None
+    ndim_batch = None
+    create_size = None
+
+    if shape is not None:
+        if Ellipsis in shape:
+            # Ellipsis short-hands all implied dimensions. Therefore
+            # we don't know how many dimensions to expect.
+            ndim_expected = ndim_batch = None
+            # Create the RV with its implied shape and resize later
+            create_size = None
+        else:
+            ndim_expected = len(tuple(shape))
+            ndim_batch = ndim_expected - ndim_supp
+            create_size = tuple(shape)[:ndim_batch]
+    elif size is not None:
+        ndim_expected = ndim_supp + len(tuple(size))
+        ndim_batch = ndim_expected - ndim_supp
+        create_size = size
+
+    return create_size, ndim_expected, ndim_batch, ndim_supp
+
+
+def maybe_resize(
+    rv_out,
+    rv_op,
+    dist_params,
+    ndim_expected,
+    ndim_batch,
+    ndim_supp,
+    shape,
+    size,
+    **kwargs,
+):
+    """Resize a distribution if necessary.
+
+    Parameters
+    ----------
+    rv_out : RandomVariable
+        The RandomVariable to be resized if necessary
+    rv_op : RandomVariable.__class__
+        The RandomVariable class to recreate it
+    dist_params : dict
+        Input parameters to recreate the RandomVariable
+    ndim_expected : int
+        Number of dimensions expected after distribution was created
+    ndim_batch : int
+        Number of batch dimensions
+    ndim_supp : int
+        The support dimension of the distribution.
+        0 if a univariate distribution, 1 if a multivariate distribution.
+    shape : tuple
+        A tuple specifying the final shape of a distribution
+    size : tuple
+        A tuple specifying the size of a distribution
+
+    Returns
+    -------
+    rv_out : int
+        The size argument to be passed to the distribution
+    """
+    ndim_actual = rv_out.ndim
+    ndims_unexpected = ndim_actual != ndim_expected
+
+    if shape is not None and ndims_unexpected:
+        if Ellipsis in shape:
+            # Resize and we're done!
+            rv_out = change_rv_size(rv_var=rv_out, new_size=shape[:-1], expand=True)
+        else:
+            # This is rare, but happens, for example, with MvNormal(np.ones((2, 3)), np.eye(3), shape=(2, 3)).
+            # Recreate the RV without passing `size` to created it with just the implied dimensions.
+            rv_out = rv_op(*dist_params, size=None, **kwargs)
+
+            # Now resize by any remaining "extra" dimensions that were not implied from support and parameters
+            if rv_out.ndim < ndim_expected:
+                expand_shape = shape[: ndim_expected - rv_out.ndim]
+                rv_out = change_rv_size(rv_var=rv_out, new_size=expand_shape, expand=True)
+            if not rv_out.ndim == ndim_expected:
+                raise ShapeError(
+                    f"Failed to create the RV with the expected dimensionality. "
+                    f"This indicates a severe problem. Please open an issue.",
+                    actual=ndim_actual,
+                    expected=ndim_batch + ndim_supp,
+                )
+
+    # Warn about the edge cases where the RV Op creates more dimensions than
+    # it should based on `size` and `RVOp.ndim_supp`.
+    if size is not None and ndims_unexpected:
+        warnings.warn(
+            f"You may have expected a ({len(tuple(size))}+{ndim_supp})-dimensional RV, but the resulting RV will be {ndim_actual}-dimensional."
+            ' To silence this warning use `warnings.simplefilter("ignore", pm.ShapeWarning)`.',
+            ShapeWarning,
+        )
+
+    return rv_out

--- a/pymc3/exceptions.py
+++ b/pymc3/exceptions.py
@@ -17,6 +17,7 @@ __all__ = [
     "IncorrectArgumentsError",
     "TraceDirectoryError",
     "ImputationWarning",
+    "ShapeWarning",
     "ShapeError",
 ]
 
@@ -37,6 +38,12 @@ class TraceDirectoryError(ValueError):
 
 class ImputationWarning(UserWarning):
     """Warning that there are missing values that will be imputed."""
+
+    pass
+
+
+class ShapeWarning(UserWarning):
+    """ Something that could lead to shape problems down the line. """
 
     pass
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1000,7 +1000,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
         ----------
         name : str
             Name of the dimension.
-            Forbidden: {"chain", "draw"}
+            Forbidden: {"chain", "draw", "__sample__"}
         values : optional, array-like
             Coordinate values or ``None`` (for auto-numbering).
             If ``None`` is passed, a ``length`` must be specified.
@@ -1008,9 +1008,10 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
             A symbolic scalar of the dimensions length.
             Defaults to ``aesara.shared(len(values))``.
         """
-        if name in {"draw", "chain"}:
+        if name in {"draw", "chain", "__sample__"}:
             raise ValueError(
-                "Dimensions can not be named `draw` or `chain`, as they are reserved for the sampler's outputs."
+                "Dimensions can not be named `draw`, `chain` or `__sample__`, "
+                "as those are reserved for use in `InferenceData`."
             )
         if values is None and length is None:
             raise ValueError(
@@ -1022,7 +1023,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
             )
         if name in self.coords:
             if not values.equals(self.coords[name]):
-                raise ValueError("Duplicate and incompatiple coordinate: %s." % name)
+                raise ValueError(f"Duplicate and incompatible coordinate: {name}.")
         else:
             self._coords[name] = values
             self._dim_lengths[name] = length or aesara.shared(len(values))

--- a/pymc3/tests/test_aesaraf.py
+++ b/pymc3/tests/test_aesaraf.py
@@ -41,6 +41,7 @@ from pymc3.aesaraf import (
     take_along_axis,
     walk_model,
 )
+from pymc3.exceptions import ShapeError
 from pymc3.vartypes import int_types
 
 FLOATX = str(aesara.config.floatX)
@@ -52,6 +53,11 @@ def test_change_rv_size():
     rv = normal(loc=loc)
     assert rv.ndim == 1
     assert tuple(rv.shape.eval()) == (2,)
+
+    with pytest.raises(ShapeError, match="must be ≤1-dimensional"):
+        change_rv_size(rv, new_size=[[2, 3]])
+    with pytest.raises(ShapeError, match="must be ≤1-dimensional"):
+        change_rv_size(rv, new_size=at.as_tensor_variable([[2, 3], [4, 5]]))
 
     rv_new = change_rv_size(rv, new_size=(3,), expand=True)
     assert rv_new.ndim == 2

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -187,11 +187,10 @@ class BaseTestCases:
 
         @staticmethod
         def sample_random_variable(random_variable, size):
-            """Draws samples from a RandomVariable using its .random() method."""
-            if size is None:
-                return random_variable.eval()
-            else:
-                return change_rv_size(random_variable, size, expand=True).eval()
+            """ Draws samples from a RandomVariable. """
+            if size:
+                random_variable = change_rv_size(random_variable, size, expand=True)
+            return random_variable.eval()
 
         @pytest.mark.parametrize("size", [None, (), 1, (1,), 5, (4, 5)], ids=str)
         @pytest.mark.parametrize("shape", [None, ()], ids=str)

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -35,6 +35,7 @@ import pymc3 as pm
 from pymc3 import Deterministic, Potential
 from pymc3.blocking import DictToArrayBijection, RaveledVars
 from pymc3.distributions import Normal, logpt_sum, transforms
+from pymc3.exceptions import ShapeError
 from pymc3.model import Point, ValueGradFunction
 from pymc3.tests.helpers import SeededTest
 
@@ -461,33 +462,33 @@ def test_make_obs_var():
     # Create a fake model and fake distribution to be used for the test
     fake_model = pm.Model()
     with fake_model:
-        fake_distribution = pm.Normal.dist(mu=0, sigma=1)
-        # Create the initval attribute simply for the sake of model testing
+        fake_distribution = pm.Normal.dist(mu=0, sigma=1, size=(3, 3))
+        # Create the testval attribute simply for the sake of model testing
         fake_distribution.name = input_name
 
+    # The function requires data and RV dimensionality to be compatible
+    with pytest.raises(ShapeError, match="Dimensionality of data and RV don't match."):
+        fake_model.make_obs_var(fake_distribution, np.ones((3, 3, 1)), None, None)
+
     # Check function behavior using the various inputs
+    # dense, sparse: Ensure that the missing values are appropriately set to None
+    # masked: a deterministic variable is returned
+
     dense_output = fake_model.make_obs_var(fake_distribution, dense_input, None, None)
-    del fake_model.named_vars[fake_distribution.name]
-    sparse_output = fake_model.make_obs_var(fake_distribution, sparse_input, None, None)
-    del fake_model.named_vars[fake_distribution.name]
-    masked_output = fake_model.make_obs_var(fake_distribution, masked_array_input, None, None)
-    assert not isinstance(masked_output, RandomVariable)
-
-    # Ensure that the missing values are appropriately set to None
-    for func_output in [dense_output, sparse_output]:
-        assert isinstance(func_output.owner.op, RandomVariable)
-
-    # Ensure that the Aesara variable names are correctly set.
-    # Note that the output for masked inputs do not have their names set
-    # to the passed value.
-    for func_output in [dense_output, sparse_output]:
-        assert func_output.name == input_name
-
-    # Ensure the that returned functions are all of the correct type
+    assert dense_output == fake_distribution
     assert isinstance(dense_output.tag.observations, TensorConstant)
-    assert sparse.basic._is_sparse_variable(sparse_output.tag.observations)
+    del fake_model.named_vars[fake_distribution.name]
 
-    # Masked output is something weird. Just ensure it has missing values
+    sparse_output = fake_model.make_obs_var(fake_distribution, sparse_input, None, None)
+    assert sparse_output == fake_distribution
+    assert sparse.basic._is_sparse_variable(sparse_output.tag.observations)
+    del fake_model.named_vars[fake_distribution.name]
+
+    # Here the RandomVariable is split into observed/imputed and a Deterministic is returned
+    masked_output = fake_model.make_obs_var(fake_distribution, masked_array_input, None, None)
+    assert masked_output != fake_distribution
+    assert not isinstance(masked_output, RandomVariable)
+    # Ensure it has missing values
     assert {"testing_inputs_missing"} == {v.name for v in fake_model.vars}
     assert {"testing_inputs", "testing_inputs_observed"} == {
         v.name for v in fake_model.observed_RVs

--- a/pymc3/tests/test_ode.py
+++ b/pymc3/tests/test_ode.py
@@ -11,7 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import sys
 
 import aesara
 import numpy as np
@@ -169,9 +168,7 @@ class TestSensitivityInitialCondition:
         np.testing.assert_array_equal(np.ravel(model5_sens_ic), model5._sens_ic)
 
 
-@pytest.mark.xfail(
-    condition=sys.platform == "win32", reason="https://github.com/pymc-devs/aesara/issues/390"
-)
+@pytest.mark.xfail(reason="https://github.com/pymc-devs/aesara/issues/390")
 def test_logp_scalar_ode():
     """Test the computation of the log probability for these models"""
 

--- a/pymc3/tests/test_ode.py
+++ b/pymc3/tests/test_ode.py
@@ -11,6 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import sys
 
 import aesara
 import numpy as np
@@ -168,6 +169,9 @@ class TestSensitivityInitialCondition:
         np.testing.assert_array_equal(np.ravel(model5_sens_ic), model5._sens_ic)
 
 
+@pytest.mark.xfail(
+    condition=sys.platform == "win32", reason="https://github.com/pymc-devs/aesara/issues/390"
+)
 def test_logp_scalar_ode():
     """Test the computation of the log probability for these models"""
 

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -214,7 +214,7 @@ class TestSample(SeededTest):
                 return_inferencedata=True,
                 discard_tuned_samples=True,
                 idata_kwargs={"prior": prior},
-                random_seed=-1
+                random_seed=-1,
             )
             assert "prior" in result
             assert isinstance(result, InferenceData)

--- a/pymc3/tests/test_shape_handling.py
+++ b/pymc3/tests/test_shape_handling.py
@@ -1,4 +1,4 @@
-#   Copyright 2020 The PyMC Developers
+#   Copyright 2021 The PyMC Developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -20,15 +20,13 @@ from aesara import tensor as at
 
 import pymc3 as pm
 
-from pymc3.distributions.distribution import (
-    _convert_dims,
-    _convert_shape,
-    _convert_size,
-)
 from pymc3.distributions.shape_utils import (
     broadcast_dist_samples_shape,
     broadcast_dist_samples_to,
     broadcast_distribution_samples,
+    convert_dims,
+    convert_shape,
+    convert_size,
     get_broadcastable_dist_samples,
     shapes_broadcasting,
     to_tuple,
@@ -419,25 +417,25 @@ class TestShapeDimsSize:
             assert tuple(rv.shape.eval()) == (5, 4, 5, 4, 3)
 
     def test_convert_dims(self):
-        assert _convert_dims(dims="town") == ("town",)
+        assert convert_dims(dims="town") == ("town",)
         with pytest.raises(ValueError, match="must be a tuple, str or list"):
-            _convert_dims(3)
+            convert_dims(3)
         with pytest.raises(ValueError, match="may only appear in the last position"):
-            _convert_dims(dims=(..., "town"))
+            convert_dims(dims=(..., "town"))
 
     def test_convert_shape(self):
-        assert _convert_shape(5) == (5,)
+        assert convert_shape(5) == (5,)
         with pytest.raises(ValueError, match="tuple, TensorVariable, int or list"):
-            _convert_shape(shape="notashape")
+            convert_shape(shape="notashape")
         with pytest.raises(ValueError, match="may only appear in the last position"):
-            _convert_shape(shape=(3, ..., 2))
+            convert_shape(shape=(3, ..., 2))
 
     def test_convert_size(self):
-        assert _convert_size(7) == (7,)
+        assert convert_size(7) == (7,)
         with pytest.raises(ValueError, match="tuple, TensorVariable, int or list"):
-            _convert_size(size="notasize")
+            convert_size(size="notasize")
         with pytest.raises(ValueError, match="cannot contain"):
-            _convert_size(size=(3, ...))
+            convert_size(size=(3, ...))
 
     def test_lazy_flavors(self):
         assert pm.Uniform.dist(2, [4, 5], size=[3, 2]).eval().shape == (3, 2)

--- a/pymc3/tests/test_shape_handling.py
+++ b/pymc3/tests/test_shape_handling.py
@@ -20,6 +20,11 @@ from aesara import tensor as at
 
 import pymc3 as pm
 
+from pymc3.distributions.distribution import (
+    _convert_dims,
+    _convert_shape,
+    _convert_size,
+)
 from pymc3.distributions.shape_utils import (
     broadcast_dist_samples_shape,
     broadcast_dist_samples_to,
@@ -28,6 +33,7 @@ from pymc3.distributions.shape_utils import (
     shapes_broadcasting,
     to_tuple,
 )
+from pymc3.exceptions import ShapeWarning
 
 test_shapes = [
     (tuple(), (1,), (4,), (5, 4)),
@@ -222,30 +228,230 @@ def test_sample_generate_values(fixture_model, fixture_sizes):
             assert prior[rv.name].shape == size + tuple(rv.distribution.shape)
 
 
-@pytest.mark.xfail(reason="https://github.com/pymc-devs/aesara/issues/390")
-def test_size32_doesnt_break_broadcasting():
-    size32 = at.constant([1, 10], dtype="int32")
-    rv = pm.Normal.dist(0, 1, size=size32)
-    assert rv.broadcastable == (True, False)
+class TestShapeDimsSize:
+    @pytest.mark.parametrize("param_shape", [(), (3,)])
+    @pytest.mark.parametrize("batch_shape", [(), (3,)])
+    @pytest.mark.parametrize(
+        "parametrization",
+        [
+            "implicit",
+            "shape",
+            # "shape...",
+            "dims",
+            "dims...",
+            "size",
+        ],
+    )
+    def test_param_and_batch_shape_combos(
+        self, param_shape: tuple, batch_shape: tuple, parametrization: str
+    ):
+        coords = {}
+        param_dims = []
+        batch_dims = []
 
+        # Create coordinates corresponding to the parameter shape
+        for d in param_shape:
+            dname = f"param_dim_{d}"
+            coords[dname] = [f"c_{i}" for i in range(d)]
+            param_dims.append(dname)
+        assert len(param_dims) == len(param_shape)
+        # Create coordinates corresponding to the batch shape
+        for d in batch_shape:
+            dname = f"batch_dim_{d}"
+            coords[dname] = [f"c_{i}" for i in range(d)]
+            batch_dims.append(dname)
+        assert len(batch_dims) == len(batch_shape)
 
-def test_observed_with_column_vector():
-    """This test is related to https://github.com/pymc-devs/aesara/issues/390 which breaks
-    broadcastability of column-vector RVs. This unexpected change in type can lead to
-    incompatibilities during graph rewriting for model.logp evaluation.
-    """
-    with pm.Model() as model:
-        # The `observed` is a broadcastable column vector
-        obs = at.as_tensor_variable(np.ones((3, 1), dtype=aesara.config.floatX))
-        assert obs.broadcastable == (False, True)
+        with pm.Model(coords=coords) as pmodel:
+            mu = aesara.shared(np.random.normal(size=param_shape))
 
-        # Both shapes describe broadcastable volumn vectors
-        size64 = at.constant([3, 1], dtype="int64")
-        # But the second shape is upcasted from an int32 vector
-        cast64 = at.cast(at.constant([3, 1], dtype="int32"), dtype="int64")
+            with pytest.warns(None):
+                if parametrization == "implicit":
+                    rv = pm.Normal("rv", mu=mu).shape == param_shape
+                else:
+                    expected_shape = batch_shape + param_shape
+                    if parametrization == "shape":
+                        rv = pm.Normal("rv", mu=mu, shape=batch_shape + param_shape)
+                        assert rv.eval().shape == expected_shape
+                    # elif parametrization == "shape...":
+                    #     rv = pm.Normal("rv", mu=mu, shape=(*batch_shape, ...))
+                    #     assert rv.eval().shape == batch_shape + param_shape
+                    elif parametrization == "dims":
+                        rv = pm.Normal("rv", mu=mu, dims=batch_dims + param_dims)
+                        assert rv.eval().shape == expected_shape
+                    elif parametrization == "dims...":
+                        rv = pm.Normal("rv", mu=mu, dims=(*batch_dims, ...))
+                        n_size = len(batch_shape)
+                        n_implied = len(param_shape)
+                        ndim = n_size + n_implied
+                        assert len(pmodel.RV_dims["rv"]) == ndim, pmodel.RV_dims
+                        assert len(pmodel.RV_dims["rv"][:n_size]) == len(batch_dims)
+                        assert len(pmodel.RV_dims["rv"][n_size:]) == len(param_dims)
+                        if n_implied > 0:
+                            assert pmodel.RV_dims["rv"][-1] is None
+                    elif parametrization == "size":
+                        rv = pm.Normal("rv", mu=mu, size=batch_shape + param_shape)
+                        assert rv.eval().shape == expected_shape
+                    else:
+                        raise NotImplementedError("Invalid test case parametrization.")
 
-        pm.Normal("x_size64", mu=0, sd=1, size=size64, observed=obs)
-        model.logp()
+    def test_define_dims_on_the_fly(self):
+        with pm.Model() as pmodel:
+            agedata = aesara.shared(np.array([10, 20, 30]))
 
-        pm.Normal("x_cast64", mu=0, sd=1, size=cast64, observed=obs)
-        model.logp()
+            # Associate the "patient" dim with an implied dimension
+            age = pm.Normal("age", agedata, dims=("patient",))
+            assert "patient" in pmodel.dim_lengths
+            assert pmodel.dim_lengths["patient"].eval() == 3
+
+            # Use the dim to replicate a new RV
+            effect = pm.Normal("effect", 0, dims=("patient",))
+            assert effect.ndim == 1
+            assert effect.eval().shape == (3,)
+
+            # Now change the length of the implied dimension
+            agedata.set_value([1, 2, 3, 4])
+            # The change should propagate all the way through
+            assert effect.eval().shape == (4,)
+
+    @pytest.mark.xfail(reason="Simultaneous use of size and dims is not implemented")
+    def test_data_defined_size_dimension_can_register_dimname(self):
+        with pm.Model() as pmodel:
+            x = pm.Data("x", [[1, 2, 3, 4]], dims=("first", "second"))
+            assert "first" in pmodel.dim_lengths
+            assert "second" in pmodel.dim_lengths
+            # two dimensions are implied; a "third" dimension is created
+            y = pm.Normal("y", mu=x, size=2, dims=("third", "first", "second"))
+            assert "third" in pmodel.dim_lengths
+            assert y.eval().shape() == (2, 1, 4)
+
+    def test_can_resize_data_defined_size(self):
+        with pm.Model() as pmodel:
+            x = pm.Data("x", [[1, 2, 3, 4]], dims=("first", "second"))
+            y = pm.Normal("y", mu=0, dims=("first", "second"))
+            z = pm.Normal("z", mu=y, observed=np.ones((1, 4)))
+            assert x.eval().shape == (1, 4)
+            assert y.eval().shape == (1, 4)
+            assert z.eval().shape == (1, 4)
+            assert "first" in pmodel.dim_lengths
+            assert "second" in pmodel.dim_lengths
+            pmodel.set_data("x", [[1, 2], [3, 4], [5, 6]])
+            assert x.eval().shape == (3, 2)
+            assert y.eval().shape == (3, 2)
+            assert z.eval().shape == (3, 2)
+
+    @pytest.mark.xfail(reason="https://github.com/pymc-devs/aesara/issues/390")
+    def test_size32_doesnt_break_broadcasting():
+        size32 = at.constant([1, 10], dtype="int32")
+        rv = pm.Normal.dist(0, 1, size=size32)
+        assert rv.broadcastable == (True, False)
+
+    @pytest.mark.xfail(reason="https://github.com/pymc-devs/aesara/issues/390")
+    def test_observed_with_column_vector(self):
+        """This test is related to https://github.com/pymc-devs/aesara/issues/390 which breaks
+        broadcastability of column-vector RVs. This unexpected change in type can lead to
+        incompatibilities during graph rewriting for model.logp evaluation.
+        """
+        with pm.Model() as model:
+            # The `observed` is a broadcastable column vector
+            obs = at.as_tensor_variable(np.ones((3, 1), dtype=aesara.config.floatX))
+            assert obs.broadcastable == (False, True)
+
+            # Both shapes describe broadcastable volumn vectors
+            size64 = at.constant([3, 1], dtype="int64")
+            # But the second shape is upcasted from an int32 vector
+            cast64 = at.cast(at.constant([3, 1], dtype="int32"), dtype="int64")
+
+            pm.Normal("size64", mu=0, sd=1, size=size64, observed=obs)
+            pm.Normal("shape64", mu=0, sd=1, shape=size64, observed=obs)
+            model.logp()
+
+            pm.Normal("size_cast64", mu=0, sd=1, size=cast64, observed=obs)
+            pm.Normal("shape_cast64", mu=0, sd=1, shape=cast64, observed=obs)
+            model.logp()
+
+    def test_dist_api_works(self):
+        mu = aesara.shared(np.array([1, 2, 3]))
+        with pytest.raises(NotImplementedError, match="API is not supported"):
+            pm.Normal.dist(mu=mu, dims=("town",))
+        assert pm.Normal.dist(mu=mu, shape=(3,)).eval().shape == (3,)
+        assert pm.Normal.dist(mu=mu, shape=(5, 3)).eval().shape == (5, 3)
+        # assert pm.Normal.dist(mu=mu, shape=(7, ...)).eval().shape == (7, 3)
+        assert pm.Normal.dist(mu=mu, size=(3,)).eval().shape == (3,)
+        assert pm.Normal.dist(mu=mu, size=(4, 3)).eval().shape == (4, 3)
+
+    def test_mvnormal_shape_size_difference(self):
+        # Parameters add one batch dimension (4), shape is what you'd expect.
+        # Under the hood the shape(4, 3) becomes size=(4,) and the RV is initially
+        # created as (4, 4, 3). The internal ndim-check then recreates it with size=None.
+        rv = pm.MvNormal.dist(mu=np.ones((4, 3)), cov=np.eye(3), shape=(4, 3))
+        assert rv.ndim == 2
+        assert tuple(rv.shape.eval()) == (4, 3)
+
+        # shape adds two dimensions (5, 4)
+        # Under the hood the shape=(5, 4, 3) becomes size=(5, 4).
+        # The RV is created as (5, 4, 3) right away.
+        rv = pm.MvNormal.dist(mu=[1, 2, 3], cov=np.eye(3), shape=(5, 4, 3))
+        assert rv.ndim == 3
+        assert tuple(rv.shape.eval()) == (5, 4, 3)
+
+        # parameters add 1 batch dimension (4), shape adds another (5)
+        # Under the hood the shape=(5, 4, 3) becomes size=(5, 4)
+        # The RV is initially created as (5, 4, 3, 4, 3) and then recreated and resized.
+        rv = pm.MvNormal.dist(mu=np.ones((4, 3)), cov=np.eye(3), shape=(5, 4, 3))
+        assert rv.ndim == 3
+        assert tuple(rv.shape.eval()) == (5, 4, 3)
+
+        # rv = pm.MvNormal.dist(mu=np.ones((4, 3, 2)), cov=np.eye(2), shape=(6, 5, ...))
+        # assert rv.ndim == 5
+        # assert tuple(rv.shape.eval()) == (6, 5, 4, 3, 2)
+
+        with pytest.warns(None):
+            rv = pm.MvNormal.dist(mu=[1, 2, 3], cov=np.eye(3), size=(5, 4))
+            assert tuple(rv.shape.eval()) == (5, 4, 3)
+
+        # When using `size` the API behaves like Aesara/NumPy
+        with pytest.warns(
+            ShapeWarning,
+            match=r"You may have expected a \(2\+1\)-dimensional RV, but the resulting RV will be 5-dimensional",
+        ):
+            rv = pm.MvNormal.dist(mu=np.ones((5, 4, 3)), cov=np.eye(3), size=(5, 4))
+            assert tuple(rv.shape.eval()) == (5, 4, 5, 4, 3)
+
+    def test_convert_dims(self):
+        assert _convert_dims(dims="town") == ("town",)
+        with pytest.raises(ValueError, match="must be a tuple, str or list"):
+            _convert_dims(3)
+        with pytest.raises(ValueError, match="may only appear in the last position"):
+            _convert_dims(dims=(..., "town"))
+
+    def test_convert_shape(self):
+        assert _convert_shape(5) == (5,)
+        with pytest.raises(ValueError, match="tuple, TensorVariable, int or list"):
+            _convert_shape(shape="notashape")
+        with pytest.raises(ValueError, match="may only appear in the last position"):
+            _convert_shape(shape=(3, ..., 2))
+
+    def test_convert_size(self):
+        assert _convert_size(7) == (7,)
+        with pytest.raises(ValueError, match="tuple, TensorVariable, int or list"):
+            _convert_size(size="notasize")
+        with pytest.raises(ValueError, match="cannot contain"):
+            _convert_size(size=(3, ...))
+
+    def test_lazy_flavors(self):
+        assert pm.Uniform.dist(2, [4, 5], size=[3, 2]).eval().shape == (3, 2)
+        assert pm.Uniform.dist(2, [4, 5], shape=[3, 2]).eval().shape == (3, 2)
+        with pm.Model(coords=dict(town=["Greifswald", "Madrid"])):
+            assert pm.Normal("n1", mu=[1, 2], dims="town").eval().shape == (2,)
+            assert pm.Normal("n2", mu=[1, 2], dims=["town"]).eval().shape == (2,)
+
+    def test_invalid_flavors(self):
+        with pytest.raises(ValueError, match="Passing both"):
+            pm.Normal.dist(0, 1, shape=(3,), size=(3,))
+
+        with pm.Model():
+            with pytest.raises(ValueError, match="Passing both"):
+                pm.Normal("n", shape=(2,), dims=("town",))
+            with pytest.raises(ValueError, match="Passing both"):
+                pm.Normal("n", dims=("town",), size=(2,))

--- a/pymc3/tests/test_shape_handling.py
+++ b/pymc3/tests/test_shape_handling.py
@@ -236,7 +236,7 @@ class TestShapeDimsSize:
         [
             "implicit",
             "shape",
-            # "shape...",
+            "shape...",
             "dims",
             "dims...",
             "size",
@@ -273,9 +273,9 @@ class TestShapeDimsSize:
                     if parametrization == "shape":
                         rv = pm.Normal("rv", mu=mu, shape=batch_shape + param_shape)
                         assert rv.eval().shape == expected_shape
-                    # elif parametrization == "shape...":
-                    #     rv = pm.Normal("rv", mu=mu, shape=(*batch_shape, ...))
-                    #     assert rv.eval().shape == batch_shape + param_shape
+                    elif parametrization == "shape...":
+                        rv = pm.Normal("rv", mu=mu, shape=(*batch_shape, ...))
+                        assert rv.eval().shape == batch_shape + param_shape
                     elif parametrization == "dims":
                         rv = pm.Normal("rv", mu=mu, dims=batch_dims + param_dims)
                         assert rv.eval().shape == expected_shape
@@ -376,7 +376,7 @@ class TestShapeDimsSize:
             pm.Normal.dist(mu=mu, dims=("town",))
         assert pm.Normal.dist(mu=mu, shape=(3,)).eval().shape == (3,)
         assert pm.Normal.dist(mu=mu, shape=(5, 3)).eval().shape == (5, 3)
-        # assert pm.Normal.dist(mu=mu, shape=(7, ...)).eval().shape == (7, 3)
+        assert pm.Normal.dist(mu=mu, shape=(7, ...)).eval().shape == (7, 3)
         assert pm.Normal.dist(mu=mu, size=(3,)).eval().shape == (3,)
         assert pm.Normal.dist(mu=mu, size=(4, 3)).eval().shape == (4, 3)
 
@@ -402,9 +402,9 @@ class TestShapeDimsSize:
         assert rv.ndim == 3
         assert tuple(rv.shape.eval()) == (5, 4, 3)
 
-        # rv = pm.MvNormal.dist(mu=np.ones((4, 3, 2)), cov=np.eye(2), shape=(6, 5, ...))
-        # assert rv.ndim == 5
-        # assert tuple(rv.shape.eval()) == (6, 5, 4, 3, 2)
+        rv = pm.MvNormal.dist(mu=np.ones((4, 3, 2)), cov=np.eye(2), shape=(6, 5, ...))
+        assert rv.ndim == 5
+        assert tuple(rv.shape.eval()) == (6, 5, 4, 3, 2)
 
         with pytest.warns(None):
             rv = pm.MvNormal.dist(mu=[1, 2, 3], cov=np.eye(3), size=(5, 4))


### PR DESCRIPTION
Here is what I did:
Create a diff between #4693 and #4667 and stage that diff onto a branch off of #4693 (no conflicts!). I then ran `git commit -p` and only selected those that seemed necessary here. Mostly there were some changes to tests that changed `size` to `shape` I did not commit.

Remember: Before merging still need to change author to @michaelosthege.