### PR TITLE
Fix `_check_start_shape` and `BinaryMetropolis.astep`

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -684,6 +684,11 @@ def sample(
 def _check_start_shape(model, start):
     if not isinstance(start, dict):
         raise TypeError("start argument must be a dict or an array-like of dicts")
+
+    # Filter "non-input" variables
+    initial_point = model.initial_point
+    start = {k: v for k, v in start.items() if k in initial_point}
+
     e = ""
     for var in model.basic_RVs:
         var_shape = model.fastfn(var.shape)(start)

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -329,6 +329,7 @@ class BinaryMetropolis(ArrayStep):
 
     def astep(self, q0: RaveledVars, logp) -> Tuple[RaveledVars, List[Dict[str, Any]]]:
 
+        logp_q0 = logp(q0)
         point_map_info = q0.point_map_info
         q0 = q0.data
 
@@ -340,8 +341,9 @@ class BinaryMetropolis(ArrayStep):
         # Locations where switches occur, according to p_jump
         switch_locs = rand_array < p_jump
         q[switch_locs] = True - q[switch_locs]
+        logp_q = logp(RaveledVars(q, point_map_info))
 
-        accept = logp(q) - logp(q0)
+        accept = logp_q - logp_q0
         q_new, accepted = metrop_select(accept, q, q0)
         self.accepted += accepted
 

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -194,7 +194,7 @@ def build_disaster_model(masked=False):
 
 
 @pytest.mark.xfail(
-    reason="_check_start_shape fails with start dictionary"
+    reason="Arviz summary fails"
     # condition=(aesara.config.floatX == "float32"), reason="Fails on float32"
 )
 class TestDisasterModel(SeededTest):
@@ -222,7 +222,6 @@ class TestDisasterModel(SeededTest):
             az.summary(tr)
 
 
-@pytest.mark.xfail(reason="_check_start_shape fails with start dictionary")
 class TestLatentOccupancy(SeededTest):
     """
     From the PyMC example list
@@ -278,7 +277,7 @@ class TestLatentOccupancy(SeededTest):
                 "theta": np.array(5, dtype="f"),
             }
             step_one = pm.Metropolis([model["theta_interval__"], model["psi_logodds__"]])
-            step_two = pm.BinaryMetropolis([model.z])
+            step_two = pm.BinaryMetropolis([model.rvs_to_values[model["z"]]])
             pm.sample(50, step=[step_one, step_two], start=start, chains=1)
 
 


### PR DESCRIPTION
This PR fixes two small issues in the methods mentioned in the PR title.

Two tests are now failing because they end in a call to `az.summary`, is this known to still be broken?