### PR TITLE
Fix obs broadcast mismatch

### DIFF
--- a/pymc3/aesaraf.py
+++ b/pymc3/aesaraf.py
@@ -156,6 +156,10 @@ def change_rv_size(
             size = rv_node.op._infer_shape(size, dist_params)
         new_size = tuple(np.atleast_1d(new_size)) + tuple(size)
 
+    # Make sure the new size is int64 so that it doesn't unnecessarily pick
+    # up a `Cast` in some cases
+    new_size = at.as_tensor(new_size, ndim=1, dtype="int64")
+
     new_rv_node = rv_node.op.make_node(rng, new_size, dtype, *dist_params)
     rv_var = new_rv_node.outputs[-1]
     rv_var.name = name

--- a/pymc3/aesaraf.py
+++ b/pymc3/aesaraf.py
@@ -156,7 +156,7 @@ def change_rv_size(
             size = rv_node.op._infer_shape(size, dist_params)
         new_size = tuple(np.atleast_1d(new_size)) + tuple(size)
 
-    # Make sure the new size is int64 so that it doesn't unnecessarily pick
+    # Make sure the new size is a tensor. This helps to not unnecessarily pick
     # up a `Cast` in some cases
     new_size = at.as_tensor(new_size, ndim=1, dtype="int64")
 

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1116,8 +1116,6 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
             ):
                 raise TypeError("Observed data cannot consist of symbolic variables.")
 
-            data = pandas_to_array(data)
-
             # `rv_var` is potentially a new variable (e.g. the original
             # variable could have its size changed to match the data, or be a
             # new graph that accounts for missing data)

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -379,13 +379,9 @@ class BaseTestDistribution(SeededTest):
         sizes_to_check = self.sizes_to_check or [None, (), 1, (1,), 5, (4, 5), (2, 4, 2)]
         sizes_expected = self.sizes_expected or [(), (), (1,), (1,), (5,), (4, 5), (2, 4, 2)]
         for size, expected in zip(sizes_to_check, sizes_expected):
-            actual = change_rv_size(self.pymc_rv, size).eval().shape
+            pymc_rv = self.pymc_dist.dist(**self.pymc_dist_params, size=size)
+            actual = tuple(pymc_rv.shape.eval())
             assert actual == expected, f"size={size}, expected={expected}, actual={actual}"
-
-        # test negative sizes raise
-        for size in [-2, (3, -2)]:
-            with pytest.raises(ValueError):
-                change_rv_size(self.pymc_rv, size).eval()
 
         # test multi-parameters sampling for univariate distributions (with univariate inputs)
         if self.pymc_dist.rv_op.ndim_supp == 0 and sum(self.pymc_dist.rv_op.ndims_params) == 0:
@@ -400,7 +396,8 @@ class BaseTestDistribution(SeededTest):
                 (5, self.repeated_params_shape),
             ]
             for size, expected in zip(sizes_to_check, sizes_expected):
-                actual = change_rv_size(self.pymc_rv, size).eval().shape
+                pymc_rv = self.pymc_dist.dist(**params, size=size)
+                actual = tuple(pymc_rv.shape.eval())
                 assert actual == expected
 
     def validate_tests_list(self):


### PR DESCRIPTION
This PR casts `new_shape` values in `pymc3.aesaraf.change_rv_size` before calling `RandomVariable.make_node`, which prevents unnecessary `Cast`s in the resulting `RandomVariable`'s `size` parameter when `new_shape` is a constant.

As a follow-up and/or alternative, `RandomVariable.make_node` can be updated in Aesara and accomplish the same thing.

Closes #4652.