### PR TITLE
Fix flaky test `test_deterministic_of_observed_modified_interface`

### DIFF
--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -685,10 +685,10 @@ class TestSamplePPC(SeededTest):
         meas_in_1 = pm.aesaraf.floatX(2 + 4 * np.random.randn(100))
         meas_in_2 = pm.aesaraf.floatX(5 + 4 * np.random.randn(100))
         with pm.Model() as model:
-            mu_in_1 = pm.Normal("mu_in_1", 0, 1)
-            sigma_in_1 = pm.HalfNormal("sd_in_1", 1)
-            mu_in_2 = pm.Normal("mu_in_2", 0, 1)
-            sigma_in_2 = pm.HalfNormal("sd__in_2", 1)
+            mu_in_1 = pm.Normal("mu_in_1", 0, 1, testval=0)
+            sigma_in_1 = pm.HalfNormal("sd_in_1", 1, testval=1)
+            mu_in_2 = pm.Normal("mu_in_2", 0, 1, testval=0)
+            sigma_in_2 = pm.HalfNormal("sd__in_2", 1, testval=1)
 
             in_1 = pm.Normal("in_1", mu_in_1, sigma_in_1, observed=meas_in_1)
             in_2 = pm.Normal("in_2", mu_in_2, sigma_in_2, observed=meas_in_2)


### PR DESCRIPTION
This test has been failing frequently in the CI. I think it has to do with the initial values being stochastic and sometimes giving combinations that lead to a derivative underflow in `float32`. I fixed the testvals and made sure it passes on `float32` locally. 

Confidence this will fix issues: 85%

Closes #4661 

Edit: to be clear I managed to induce the failure locally by running in a loop and monitoring the random start values. Fixing the observed start values to those made the test fail systematically. I am just not sure this was the only thing that was causing the failures. 