### PR TITLE
Port Truncated Normal and Wald Distributions to V4

### DIFF
--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -891,7 +891,7 @@ class WaldRV(RandomVariable):
 
     @classmethod
     def rng_fn(cls, rng, mu, lam, alpha, size):
-        return getattr(np.random.RandomState, cls.name)(rng, mu, lam, size) + alpha
+        return rng.wald(mu, lam, size=size) + alpha
 
 
 wald = WaldRV()

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -585,7 +585,7 @@ class TruncatedNormalRV(RandomVariable):
         upper: Union[np.ndarray, float],
         size: Optional[Union[List[int], int]],
     ) -> np.ndarray:
-        vals = stats.truncnorm.rvs(
+        return stats.truncnorm.rvs(
             a=(lower - mu) / sigma,
             b=(upper - mu) / sigma,
             loc=mu,
@@ -593,7 +593,6 @@ class TruncatedNormalRV(RandomVariable):
             size=size,
             random_state=rng,
         )
-        return vals
 
 
 truncated_normal = TruncatedNormalRV()

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -905,24 +905,8 @@ class WaldRV(RandomVariable):
     _print_name = ("Wald", "\\operatorname{Wald}")
 
     @classmethod
-    def rng_fn(
-        cls,
-        rng: np.random.RandomState,
-        mu: Union[np.ndarray, float],
-        lam: Union[np.ndarray, float],
-        alpha: Union[np.ndarray, float],
-        size: Optional[Union[List[int], int]],
-    ) -> np.ndarray:
-        v = rng.normal(size=size) ** 2
-        z = rng.uniform(size=size)
-        value = (
-            mu
-            + (mu ** 2) * v / (2.0 * lam)
-            - mu / (2.0 * lam) * np.sqrt(4.0 * mu * lam * v + (mu * v) ** 2)
-        )
-        i = np.floor(z - mu / (mu + value)) * 2 + 1
-        value = (value ** -i) * (mu ** (i + 1))
-        return value + alpha
+    def rng_fn(cls, rng, mu, lam, alpha, size):
+        return getattr(np.random.RandomState, cls.name)(rng, mu, lam, size) + alpha
 
 
 wald = WaldRV()

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -2811,21 +2811,6 @@ class TestBoundedContinuous:
         assert lower_interval.value == -1
         assert upper_interval is None
 
-    def test_rich_context(self):
-        with Model() as model:
-            sigma = TruncatedNormal("lower_bounded", mu=2, sigma=1.5, lower=0, upper=None)
-            mu = TruncatedNormal("upper_bounded", mu=0, sigma=2, lower=None, upper=3)
-            Normal("normal", mu=mu, sigma=sigma, observed=[1.3, -1.4, 2.0])
-        (
-            (_, _, lower, upper),
-            lower_interval,
-            upper_interval,
-        ) = self.get_dist_params_and_interval_bounds(model, "upper_bounded")
-        assert lower.value == -np.inf
-        assert upper.value == 3
-        assert lower_interval is None
-        assert upper_interval.value == 3
-
 
 @pytest.mark.xfail(reason="LaTeX repr and str no longer applicable")
 class TestStrAndLatexRepr:

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -2773,9 +2773,26 @@ class TestBoundedContinuous:
             )
         dist_params, lower, upper = self.get_dist_params_and_interval_bounds(model, bounded_rv_name)
 
-        assert all(a == b for a, b in zip(dist_params[2].value, np.array([-1, 0])))
-        assert all(a == b for a, b in zip(dist_params[3].value, np.array([np.inf, np.inf])))
-        assert all(a == b for a, b in zip(lower.value, np.array([-1, 0])))
+        assert np.array_equal(dist_params[2].value, [-1, 0])
+        assert dist_params[3].value == np.inf
+        assert np.array_equal(lower.value, [-1, 0])
+        assert upper is None
+
+    def test_missing_partial_upper_bound_array(self):
+        bounded_rv_name = "upper_bounded"
+        with Model() as model:
+            TruncatedNormal(
+                bounded_rv_name,
+                mu=np.array([1, 1]),
+                sigma=np.array([2, 3]),
+                lower=np.array([-1.0, -np.inf]),
+                upper=None,
+            )
+        dist_params, lower, upper = self.get_dist_params_and_interval_bounds(model, bounded_rv_name)
+
+        assert np.array_equal(dist_params[2].value, [-1, -np.inf])
+        assert dist_params[3].value == np.inf
+        assert np.array_equal(lower.value, [-1, -np.inf])
         assert upper is None
 
     def test_missing_upper_bound_with_richer_context(self):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1068,7 +1068,6 @@ class TestMatchesScipy:
             lambda value, nu: sp.chi2.logcdf(value, df=nu),
         )
 
-    @pytest.mark.xfail(reason="Distribution not refactored yet")
     def test_wald_logp(self):
         self.check_logp(
             Wald,
@@ -1078,7 +1077,6 @@ class TestMatchesScipy:
             decimal=select_by_precision(float64=6, float32=1),
         )
 
-    @pytest.mark.xfail(reason="Distribution not refactored yet")
     @pytest.mark.xfail(
         condition=(aesara.config.floatX == "float32"),
         reason="Poor CDF in SciPy. See scipy/scipy#869 for details.",
@@ -1091,7 +1089,6 @@ class TestMatchesScipy:
             lambda value, mu, alpha: sp.invgauss.logcdf(value, mu=mu, loc=alpha),
         )
 
-    @pytest.mark.xfail(reason="Distribution not refactored yet")
     @pytest.mark.parametrize(
         "value,mu,lam,phi,alpha,logp",
         [
@@ -1111,7 +1108,6 @@ class TestMatchesScipy:
             (50.0, 15.0, None, 0.666666, 10.0, -5.6481874),
         ],
     )
-    @pytest.mark.xfail(reason="Distribution not refactored yet")
     def test_wald_logp_custom_points(self, value, mu, lam, phi, alpha, logp):
         # Log probabilities calculated using the dIG function from the R package gamlss.
         # See e.g., doi: 10.1111/j.1467-9876.2005.00510.x, or

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1019,7 +1019,6 @@ class TestMatchesScipy:
             decimal=select_by_precision(float64=6, float32=1),
         )
 
-    @pytest.mark.xfail(reason="Distribution not refactored yet")
     def test_truncated_normal(self):
         def scipy_logp(value, mu, sigma, lower, upper):
             return sp.truncnorm.logpdf(

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -676,47 +676,44 @@ class TestTruncatedNormalUpperTau(BaseTestDistribution):
     ]
 
 
-class BaseTestWald(BaseTestDistribution):
-    def wald_rng_fn(self, size, mu, lam, alpha, uniform_rng_fct, normal_rng_fct):
-        v = normal_rng_fct(size=size) ** 2
-        z = uniform_rng_fct(size=size)
-        value = (
-            mu
-            + (mu ** 2) * v / (2.0 * lam)
-            - mu / (2.0 * lam) * np.sqrt(4.0 * mu * lam * v + (mu * v) ** 2)
-        )
-        i = np.floor(z - mu / (mu + value)) * 2 + 1
-        value = (value ** -i) * (mu ** (i + 1))
-        return value + alpha
-
-    def seeded_wald_rng_fn(self):
-        uniform_rng_fct = functools.partial(
-            getattr(np.random.RandomState, "uniform"), self.get_random_state()
-        )
-        normal_rng_fct = functools.partial(
-            getattr(np.random.RandomState, "normal"), self.get_random_state()
-        )
-        return functools.partial(
-            self.wald_rng_fn, uniform_rng_fct=uniform_rng_fct, normal_rng_fct=normal_rng_fct
-        )
-
+class TestWald(BaseTestDistribution):
     pymc_dist = pm.Wald
-    reference_dist = seeded_wald_rng_fn
+    mu, lam, alpha = 1.0, 1.0, 0.0
+    mu_rv, lam_rv, phi_rv = pm.Wald.get_mu_lam_phi(mu=mu, lam=lam, phi=None)
+    pymc_dist_params = {"mu": mu, "lam": lam, "alpha": alpha}
+    expected_rv_op_params = {"mu": mu_rv, "lam": lam_rv, "alpha": alpha}
+    reference_dist_params = [mu, lam_rv]
+    reference_dist = seeded_numpy_distribution_builder("wald")
     tests_to_run = [
         "check_pymc_params_match_rv_op",
         "check_pymc_draws_match_reference",
         "check_rv_size",
     ]
 
+    def test_distribution(self):
+        self.validate_tests_list()
+        self._instantiate_pymc_rv()
+        if self.reference_dist is not None:
+            self.reference_dist_draws = self.reference_dist()(
+                *self.reference_dist_params, self.size
+            )
+        for check_name in self.tests_to_run:
+            getattr(self, check_name)()
 
-class TestWaldPureScipy(BaseTestDistribution):
+    def check_pymc_draws_match_reference(self):
+        assert_array_almost_equal(
+            self.pymc_rv.eval(), self.reference_dist_draws + self.alpha, decimal=self.decimal
+        )
+
+
+class TestWaldAlpha(TestWald):
     pymc_dist = pm.Wald
     mu, lam, alpha = 1.0, 1.0, 2.0
     mu_rv, lam_rv, phi_rv = pm.Wald.get_mu_lam_phi(mu=mu, lam=lam, phi=None)
     pymc_dist_params = {"mu": mu, "lam": lam, "alpha": alpha}
     expected_rv_op_params = {"mu": mu_rv, "lam": lam_rv, "alpha": alpha}
-    reference_dist_params = {"loc": alpha}
-    reference_dist = seeded_scipy_distribution_builder("wald")
+    reference_dist_params = [mu, lam_rv]
+    reference_dist = seeded_numpy_distribution_builder("wald")
     tests_to_run = [
         "check_pymc_params_match_rv_op",
         "check_pymc_draws_match_reference",
@@ -724,28 +721,19 @@ class TestWaldPureScipy(BaseTestDistribution):
     ]
 
 
-class TestWaldMuLam(BaseTestWald):
-    mu, lam, alpha = 1.0, 3.0, 0.0
-    mu_rv, lam_rv, phi_rv = pm.Wald.get_mu_lam_phi(mu=mu, lam=lam, phi=None)
-    pymc_dist_params = {"mu": mu, "lam": lam}
-    expected_rv_op_params = {"mu": mu_rv, "lam": lam_rv, "alpha": 0.0}
-    reference_dist_params = {"mu": mu_rv, "lam": lam_rv, "alpha": 0.0}
-
-
-class TestWaldMuLamShifted(BaseTestWald):
-    mu, lam, alpha = 1.0, 3.0, 2.0
-    mu_rv, lam_rv, phi_rv = pm.Wald.get_mu_lam_phi(mu=mu, lam=lam, phi=None)
-    pymc_dist_params = {"mu": mu, "lam": lam, "alpha": alpha}
-    expected_rv_op_params = {"mu": mu_rv, "lam": lam_rv, "alpha": 2.0}
-    reference_dist_params = {"mu": mu_rv, "lam": lam_rv, "alpha": 2.0}
-
-
-class TestWaldMuPhi(BaseTestWald):
+class TestWaldMuPhi(TestWald):
+    pymc_dist = pm.Wald
     mu, phi, alpha = 1.0, 3.0, 0.0
     mu_rv, lam_rv, phi_rv = pm.Wald.get_mu_lam_phi(mu=mu, lam=None, phi=phi)
     pymc_dist_params = {"mu": mu, "phi": phi, "alpha": alpha}
-    expected_rv_op_params = {"mu": mu_rv, "lam": phi_rv, "alpha": 0.0}
-    reference_dist_params = {"mu": mu_rv, "lam": lam_rv, "alpha": 0.0}
+    expected_rv_op_params = {"mu": mu_rv, "lam": lam_rv, "alpha": alpha}
+    reference_dist_params = [mu, lam_rv]
+    reference_dist = seeded_numpy_distribution_builder("wald")
+    tests_to_run = [
+        "check_pymc_params_match_rv_op",
+        "check_pymc_draws_match_reference",
+        "check_rv_size",
+    ]
 
 
 class TestSkewNormal(BaseTestDistribution):

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -736,6 +736,31 @@ class TestWaldMuPhi(TestWald):
     ]
 
 
+class TestTruncatedNormalUpperArray(BaseTestDistribution):
+    pymc_dist = pm.TruncatedNormal
+    lower, upper, mu, tau = (
+        np.array([-np.inf, -np.inf]),
+        np.array([3, 2]),
+        np.array([0, 0]),
+        np.array(
+            [
+                1,
+                1,
+            ]
+        ),
+    )
+    size = (15, 2)
+    tau, sigma = get_tau_sigma(tau=tau, sigma=None)
+    pymc_dist_params = {"mu": mu, "tau": tau, "upper": upper}
+    expected_rv_op_params = {"mu": mu, "sigma": sigma, "lower": lower, "upper": upper}
+    reference_dist_params = {"loc": mu, "scale": sigma, "a": lower, "b": (upper - mu) / sigma}
+    reference_dist = seeded_scipy_distribution_builder("truncnorm")
+    tests_to_run = [
+        "check_pymc_params_match_rv_op",
+        "check_pymc_draws_match_reference",
+    ]
+
+
 class TestSkewNormal(BaseTestDistribution):
     pymc_dist = pm.SkewNormal
     pymc_dist_params = {"mu": 0.0, "sigma": 1.0, "alpha": 5.0}

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -2145,7 +2145,6 @@ class TestNestedRandom(SeededTest):
         ],
         ids=str,
     )
-    @pytest.mark.xfail(reason="TruncatedNormal not yet refactored for v4")
     def test_TruncatedNormal(
         self,
         prior_samples,

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -331,7 +331,6 @@ class TestValueGradFunction(unittest.TestCase):
             np.log(0.5) * 10,
         )
 
-    @pytest.mark.xfail(reason="TruncatedNormal not refactored for v4")
     def test_aesara_switch_broadcast_edge_cases_2(self):
         # Known issue 2: https://github.com/pymc-devs/pymc3/issues/4417
         # fmt: off
@@ -344,7 +343,7 @@ class TestValueGradFunction(unittest.TestCase):
             mu = pm.Normal("mu", 0, 5)
             obs = pm.TruncatedNormal("obs", mu=mu, sigma=1, lower=-1, upper=2, observed=data)
 
-        npt.assert_allclose(m.dlogp([mu])({"mu": 0}), 2.499424682024436, rtol=1e-5)
+        npt.assert_allclose(m.dlogp([m.rvs_to_values[mu]])({"mu": 0}), 2.499424682024436, rtol=1e-5)
 
 
 @pytest.mark.xfail(reason="DensityDist not refactored for v4")


### PR DESCRIPTION
Port Truncated Normal and Wald to V4 as per #4686 guidelines

Still need to do/check the followings:

- TruncatedNormal
+ [x] Need to investigate why `pymc3.tests.test_model.TestValueGradFunction.test_aesara_switch_broadcast_edge_cases_2` is failing
+ [x] Is it fine to rewrite a new RV? according to the issue there should be one already, but I couldn't find it 
+ [x] Is it fine to pass `transform` as argument in `dist` ?
+ [x] Is `_defaultval` deprecated? I haven't been able to find any use of it

- Wald
+ [x] Refactor as per [guidelines](https://github.com/pymc-devs/pymc3/issues/4686#issuecomment-839541040)
+ [ ] Investigate why `pymc3.tests.test_distributions_random.TestWaldAlpha` is failing.