### PR TITLE
regularize binomial bart

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,7 +7,8 @@
 + Fix bug in the computation of the log pseudolikelihood values (SMC-ABC). (see [#4672](https://github.com/pymc-devs/pymc3/pull/4672)).
 
 ### New Features
-+ BART with non-gaussian likelihoods (see [#4675](https://github.com/pymc-devs/pymc3/pull/4675) and [#4709](https://github.com/pymc-devs/pymc3/pull/4709)).
++ Generalized BART, bounded distributions like Binomial and Poisson can now be used as likelihoods (see [#4675](https://github.com/pymc-devs/pymc3/pull/4675), [#4709](https://github.com/pymc-devs/pymc3/pull/4709) and
+[#4720](https://github.com/pymc-devs/pymc3/pull/4720)).
 
 ## PyMC3 3.11.2 (14 March 2021)
 


### PR DESCRIPTION
This is a follow up of my previous PR, basically I realize that we need to have a regularization term when using logistic transformation.  This PR also improves the docstring and set the default of trees (m) to 50, as this is generally a better starting point 