### PR TITLE
Use an incrementally updated RNG state in `Model`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,7 @@
 - ⚠ Theano-PyMC has been replaced with Aesara, so all external references to `theano`, `tt`, and `pymc3.theanof` need to be replaced with `aesara`, `at`, and `pymc3.aesaraf` (see [4471](https://github.com/pymc-devs/pymc3/pull/4471)).
 - ArviZ `plots` and `stats` *wrappers* were removed. The functions are now just available by their original names (see [#4549](https://github.com/pymc-devs/pymc3/pull/4471) and `3.11.2` release notes).
 - The GLM submodule has been removed, please use [Bambi](https://bambinos.github.io/bambi/) instead.
+- The `Distribution` keyword argument `testval` has been deprecated in favor of `initval`.
 - ...
 
 ### New Features

--- a/pymc3/aesaraf.py
+++ b/pymc3/aesaraf.py
@@ -31,6 +31,7 @@ import numpy as np
 import scipy.sparse as sps
 
 from aesara import config, scalar
+from aesara.compile.mode import Mode, get_mode
 from aesara.gradient import grad
 from aesara.graph.basic import (
     Apply,
@@ -861,3 +862,16 @@ def take_along_axis(arr, indices, axis=0):
 
     # use the fancy index
     return arr[_make_along_axis_idx(arr_shape, indices, _axis)]
+
+
+def compile_rv_inplace(inputs, outputs, mode=None, **kwargs):
+    """Use ``aesara.function`` with the random_make_inplace optimization always enabled.
+
+    Using this function ensures that compiled functions containing random
+    variables will produce new samples on each call.
+    """
+    mode = get_mode(mode)
+    opt_qry = mode.provided_optimizer.including("random_make_inplace")
+    mode = Mode(linker=mode.linker, optimizer=opt_qry)
+    aesara_function = aesara.function(inputs, outputs, mode=mode, **kwargs)
+    return aesara_function

--- a/pymc3/distributions/bart.py
+++ b/pymc3/distributions/bart.py
@@ -27,7 +27,7 @@ class BaseBART(NoDistribution):
 
         self.X, self.Y, self.missing_data = self.preprocess_XY(X, Y)
 
-        super().__init__(shape=X.shape[0], dtype="float64", testval=0, *args, **kwargs)
+        super().__init__(shape=X.shape[0], dtype="float64", initval=0, *args, **kwargs)
 
         if self.X.ndim != 2:
             raise ValueError("The design matrix X must have two dimensions")

--- a/pymc3/distributions/bound.py
+++ b/pymc3/distributions/bound.py
@@ -42,7 +42,7 @@ class _Bounded(Distribution):
         super().__init__(
             shape=self._wrapped.shape,
             dtype=self._wrapped.dtype,
-            testval=self._wrapped.testval,
+            initval=self._wrapped.initval,
             defaults=defaults,
             transform=self._wrapped.transform,
         )
@@ -252,15 +252,15 @@ class Bound:
 
         with pm.Model():
             NegativeNormal = pm.Bound(pm.Normal, upper=0.0)
-            par1 = NegativeNormal('par`', mu=0.0, sigma=1.0, testval=-0.5)
+            par1 = NegativeNormal('par`', mu=0.0, sigma=1.0, initval=-0.5)
             # you can use the Bound object multiple times to
             # create multiple bounded random variables
-            par1_1 = NegativeNormal('par1_1', mu=-1.0, sigma=1.0, testval=-1.5)
+            par1_1 = NegativeNormal('par1_1', mu=-1.0, sigma=1.0, initval=-1.5)
 
             # you can also define a Bound implicitly, while applying
             # it to a random variable
             par2 = pm.Bound(pm.Normal, lower=-1.0, upper=1.0)(
-                    'par2', mu=0.0, sigma=1.0, testval=1.0)
+                    'par2', mu=0.0, sigma=1.0, initval=1.0)
     """
 
     def __init__(self, distribution, lower=None, upper=None):

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -332,10 +332,12 @@ class Flat(Continuous):
     rv_op = flat
 
     @classmethod
-    def dist(cls, *, size=None, testval=None, **kwargs):
-        if testval is None:
-            testval = np.full(size, floatX(0.0))
-        return super().dist([], size=size, testval=testval, **kwargs)
+    def dist(cls, *, size=None, initval=None, **kwargs):
+        if initval is None:
+            initval = np.full(size, floatX(0.0))
+        res = super().dist([], size=size, **kwargs)
+        res.tag.test_value = initval
+        return res
 
     def logp(value):
         """
@@ -394,10 +396,12 @@ class HalfFlat(PositiveContinuous):
     rv_op = halfflat
 
     @classmethod
-    def dist(cls, *, size=None, testval=None, **kwargs):
-        if testval is None:
-            testval = np.full(size, floatX(1.0))
-        return super().dist([], size=size, testval=testval, **kwargs)
+    def dist(cls, *, size=None, initval=None, **kwargs):
+        if initval is None:
+            initval = np.full(size, floatX(1.0))
+        res = super().dist([], size=size, **kwargs)
+        res.tag.test_value = initval
+        return res
 
     def logp(value):
         """

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -277,14 +277,14 @@ class NoDistribution(Distribution):
         self,
         shape,
         dtype,
-        testval=None,
+        initval=None,
         defaults=(),
         parent_dist=None,
         *args,
         **kwargs,
     ):
         super().__init__(
-            shape=shape, dtype=dtype, testval=testval, defaults=defaults, *args, **kwargs
+            shape=shape, dtype=dtype, initval=initval, defaults=defaults, *args, **kwargs
         )
         self.parent_dist = parent_dist
 
@@ -342,7 +342,7 @@ class DensityDist(Distribution):
         logp,
         shape=(),
         dtype=None,
-        testval=0,
+        initval=0,
         random=None,
         wrap_random_with_dist_shape=True,
         check_shape_in_random=True,
@@ -363,8 +363,8 @@ class DensityDist(Distribution):
             a value here.
         dtype: None, str (Optional)
             The dtype of the distribution.
-        testval: number or array (Optional)
-            The ``testval`` of the RV's tensor that follow the ``DensityDist``
+        initval: number or array (Optional)
+            The ``initval`` of the RV's tensor that follow the ``DensityDist``
             distribution.
         args, kwargs: (Optional)
             These are passed to the parent class' ``__init__``.
@@ -400,7 +400,7 @@ class DensityDist(Distribution):
         """
         if dtype is None:
             dtype = aesara.config.floatX
-        super().__init__(shape, dtype, testval, *args, **kwargs)
+        super().__init__(shape, dtype, initval, *args, **kwargs)
         self.logp = logp
         if type(self.logp) == types.MethodType:
             if PLATFORM != "linux":

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -143,21 +143,44 @@ class Distribution(metaclass=DistributionMeta):
         if "shape" in kwargs:
             raise DeprecationWarning("The `shape` keyword is deprecated; use `size`.")
 
+        testval = kwargs.pop("testval", None)
+
+        if testval is not None:
+            warnings.warn(
+                "The `testval` argument is deprecated; use `initval`.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        initval = kwargs.pop("initval", testval)
+
         transform = kwargs.pop("transform", UNSET)
 
         rv_out = cls.dist(*args, rng=rng, **kwargs)
 
-        return model.register_rv(rv_out, name, data, total_size, dims=dims, transform=transform)
+        if testval is not None:
+            rv_out.tag.test_value = testval
+
+        return model.register_rv(
+            rv_out, name, data, total_size, dims=dims, transform=transform, initval=initval
+        )
 
     @classmethod
     def dist(cls, dist_params, rng=None, **kwargs):
 
         testval = kwargs.pop("testval", None)
 
-        rv_var = cls.rv_op(*dist_params, rng=rng, **kwargs)
-
         if testval is not None:
-            rv_var.tag.test_value = testval
+            warnings.warn(
+                "The `testval` argument is deprecated. "
+                "Use `initval` to set initial values for a `Model`; "
+                "otherwise, set test values on Aesara parameters explicitly "
+                "when attempting to use Aesara's test value debugging features.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        rv_var = cls.rv_op(*dist_params, rng=rng, **kwargs)
 
         if (
             rv_var.owner

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -137,7 +137,7 @@ class Distribution(metaclass=DistributionMeta):
         rng = kwargs.pop("rng", None)
 
         if rng is None:
-            rng = model.default_rng
+            rng = model.next_rng()
 
         if not isinstance(name, string_types):
             raise TypeError(f"Name needs to be a string but got: {name}")

--- a/pymc3/distributions/mixture.py
+++ b/pymc3/distributions/mixture.py
@@ -609,7 +609,7 @@ class NormalMixture(Mixture):
                 10,
                 shape=n_components,
                 transform=pm.transforms.ordered,
-                testval=[1, 2, 3],
+                initval=[1, 2, 3],
             )
             σ = pm.HalfNormal("σ", 10, shape=n_components)
             weights = pm.Dirichlet("w", np.ones(n_components))
@@ -684,7 +684,7 @@ class MixtureSameFamily(Distribution):
         self.mixture_axis = mixture_axis
         kwargs.setdefault("dtype", self.comp_dists.dtype)
 
-        # Compute the mode so we don't always have to pass a testval
+        # Compute the mode so we don't always have to pass a initval
         defaults = kwargs.pop("defaults", [])
         event_shape = self.comp_dists.shape[mixture_axis + 1 :]
         _w = at.shape_padleft(

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -840,7 +840,7 @@ class Wishart(Continuous):
         )
 
 
-def WishartBartlett(name, S, nu, is_cholesky=False, return_cholesky=False, testval=None):
+def WishartBartlett(name, S, nu, is_cholesky=False, return_cholesky=False, initval=None):
     R"""
     Bartlett decomposition of the Wishart distribution. As the Wishart
     distribution requires the matrix to be symmetric positive semi-definite
@@ -875,7 +875,7 @@ def WishartBartlett(name, S, nu, is_cholesky=False, return_cholesky=False, testv
         Input matrix S is already Cholesky decomposed as S.T * S
     return_cholesky: bool (default=False)
         Only return the Cholesky decomposed matrix.
-    testval: ndarray
+    initval: ndarray
         p x p positive definite matrix used to initialize
 
     Notes
@@ -894,21 +894,21 @@ def WishartBartlett(name, S, nu, is_cholesky=False, return_cholesky=False, testv
     n_diag = len(diag_idx[0])
     n_tril = len(tril_idx[0])
 
-    if testval is not None:
+    if initval is not None:
         # Inverse transform
-        testval = np.dot(np.dot(np.linalg.inv(L), testval), np.linalg.inv(L.T))
-        testval = linalg.cholesky(testval, lower=True)
-        diag_testval = testval[diag_idx] ** 2
-        tril_testval = testval[tril_idx]
+        initval = np.dot(np.dot(np.linalg.inv(L), initval), np.linalg.inv(L.T))
+        initval = linalg.cholesky(initval, lower=True)
+        diag_testval = initval[diag_idx] ** 2
+        tril_testval = initval[tril_idx]
     else:
         diag_testval = None
         tril_testval = None
 
     c = at.sqrt(
-        ChiSquared("%s_c" % name, nu - np.arange(2, 2 + n_diag), shape=n_diag, testval=diag_testval)
+        ChiSquared("%s_c" % name, nu - np.arange(2, 2 + n_diag), shape=n_diag, initval=diag_testval)
     )
     pm._log.info("Added new variable %s_c to model diagonal of Wishart." % name)
-    z = Normal("%s_z" % name, 0.0, 1.0, shape=n_tril, testval=tril_testval)
+    z = Normal("%s_z" % name, 0.0, 1.0, shape=n_tril, initval=tril_testval)
     pm._log.info("Added new variable %s_z to model off-diagonals of Wishart." % name)
     # Construct A matrix
     A = at.zeros(S.shape, dtype=np.float32)

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -49,6 +49,7 @@ from pandas import Series
 
 from pymc3.aesaraf import (
     change_rv_size,
+    compile_rv_inplace,
     gradient,
     hessian,
     inputvars,
@@ -455,7 +456,7 @@ class ValueGradFunction:
 
         inputs = grad_vars
 
-        self._aesara_function = aesara.function(inputs, outputs, givens=givens, **kwargs)
+        self._aesara_function = compile_rv_inplace(inputs, outputs, givens=givens, **kwargs)
 
     def set_weights(self, values):
         if values.shape != (self._n_costs - 1,):
@@ -1378,7 +1379,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
         Compiled Aesara function
         """
         with self:
-            return aesara.function(
+            return compile_rv_inplace(
                 self.value_vars,
                 outs,
                 allow_input_downcast=True,

--- a/pymc3/sampling_jax.py
+++ b/pymc3/sampling_jax.py
@@ -7,7 +7,6 @@ xla_flags = os.getenv("XLA_FLAGS", "").lstrip("--")
 xla_flags = re.sub(r"xla_force_host_platform_device_count=.+\s", "", xla_flags).split()
 os.environ["XLA_FLAGS"] = " ".join(["--xla_force_host_platform_device_count={}".format(100)])
 
-import aesara.graph.fg
 import aesara.tensor as at
 import arviz as az
 import jax
@@ -23,6 +22,7 @@ from aesara.link.jax.dispatch import jax_funcify
 from aesara.tensor.type import TensorType
 
 from pymc3 import modelcontext
+from pymc3.aesaraf import compile_rv_inplace
 
 warnings.warn("This module is experimental.")
 
@@ -209,7 +209,7 @@ def sample_numpyro_nuts(
     print("Compiling...")
 
     tic1 = pd.Timestamp.now()
-    _sample = aesara.function(
+    _sample = compile_rv_inplace(
         [],
         sample_outputs + [numpyro_samples[-1]],
         allow_input_downcast=True,

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 from typing import Any, Callable, Dict, List, Tuple
 
-import aesara
 import numpy as np
 import numpy.random as nr
 import scipy.linalg
@@ -23,7 +22,7 @@ from aesara.tensor.random.basic import BernoulliRV, CategoricalRV
 
 import pymc3 as pm
 
-from pymc3.aesaraf import floatX, rvs_to_value_vars
+from pymc3.aesaraf import compile_rv_inplace, floatX, rvs_to_value_vars
 from pymc3.blocking import DictToArrayBijection, RaveledVars
 from pymc3.step_methods.arraystep import (
     ArrayStep,
@@ -985,6 +984,6 @@ def delta_logp(point, logp, vars, shared):
 
     logp1 = pm.CallableTensor(logp0)(inarray1)
 
-    f = aesara.function([inarray1, inarray0], logp1 - logp0)
+    f = compile_rv_inplace([inarray1, inarray0], logp1 - logp0)
     f.trust_input = True
     return f

--- a/pymc3/tests/models.py
+++ b/pymc3/tests/models.py
@@ -30,7 +30,7 @@ def simple_model():
     mu = -2.1
     tau = 1.3
     with Model() as model:
-        Normal("x", mu, tau=tau, size=2, testval=floatX_array([0.1, 0.1]))
+        Normal("x", mu, tau=tau, size=2, initval=floatX_array([0.1, 0.1]))
 
     return model.initial_point, model, (mu, tau ** -0.5)
 
@@ -39,7 +39,7 @@ def simple_categorical():
     p = floatX_array([0.1, 0.2, 0.3, 0.4])
     v = floatX_array([0.0, 1.0, 2.0, 3.0])
     with Model() as model:
-        Categorical("x", p, size=3, testval=[1, 2, 3])
+        Categorical("x", p, size=3, initval=[1, 2, 3])
 
     mu = np.dot(p, v)
     var = np.dot(p, (v - mu) ** 2)
@@ -50,7 +50,7 @@ def multidimensional_model():
     mu = -2.1
     tau = 1.3
     with Model() as model:
-        Normal("x", mu, tau=tau, size=(3, 2), testval=0.1 * np.ones((3, 2)))
+        Normal("x", mu, tau=tau, size=(3, 2), initval=0.1 * np.ones((3, 2)))
 
     return model.initial_point, model, (mu, tau ** -0.5)
 
@@ -81,7 +81,7 @@ def simple_2model():
     tau = 1.3
     p = 0.4
     with Model() as model:
-        x = pm.Normal("x", mu, tau=tau, testval=0.1)
+        x = pm.Normal("x", mu, tau=tau, initval=0.1)
         pm.Deterministic("logx", at.log(x))
         pm.Bernoulli("y", p)
     return model.initial_point, model
@@ -91,7 +91,7 @@ def simple_2model_continuous():
     mu = -2.1
     tau = 1.3
     with Model() as model:
-        x = pm.Normal("x", mu, tau=tau, testval=0.1)
+        x = pm.Normal("x", mu, tau=tau, initval=0.1)
         pm.Deterministic("logx", at.log(x))
         pm.Beta("y", alpha=1, beta=1, size=2)
     return model.initial_point, model
@@ -106,7 +106,7 @@ def mv_simple():
             "x",
             at.constant(mu),
             tau=at.constant(tau),
-            testval=floatX_array([0.1, 1.0, 0.8]),
+            initval=floatX_array([0.1, 1.0, 0.8]),
         )
     H = tau
     C = np.linalg.inv(H)
@@ -122,7 +122,7 @@ def mv_simple_coarse():
             "x",
             at.constant(mu),
             tau=at.constant(tau),
-            testval=floatX_array([0.1, 1.0, 0.8]),
+            initval=floatX_array([0.1, 1.0, 0.8]),
         )
     H = tau
     C = np.linalg.inv(H)
@@ -138,7 +138,7 @@ def mv_simple_very_coarse():
             "x",
             at.constant(mu),
             tau=at.constant(tau),
-            testval=floatX_array([0.1, 1.0, 0.8]),
+            initval=floatX_array([0.1, 1.0, 0.8]),
         )
     H = tau
     C = np.linalg.inv(H)
@@ -150,7 +150,7 @@ def mv_simple_discrete():
     n = 5
     p = floatX_array([0.15, 0.85])
     with pm.Model() as model:
-        pm.Multinomial("x", n, at.constant(p), testval=np.array([1, 4]))
+        pm.Multinomial("x", n, at.constant(p), initval=np.array([1, 4]))
         mu = n * p
         # covariance matrix
         C = np.zeros((d, d))

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -2944,3 +2944,25 @@ def test_serialize_density_dist():
     import pickle
 
     pickle.loads(pickle.dumps(y))
+
+
+def test_distinct_rvs():
+    """Make sure `RandomVariable`s generated using a `Model`'s default RNG state all have distinct states."""
+
+    with pm.Model(rng_seeder=np.random.RandomState(2023532)) as model:
+        X_rv = pm.Normal("x")
+        Y_rv = pm.Normal("y")
+
+        pp_samples = pm.sample_prior_predictive(samples=2)
+
+    assert X_rv.owner.inputs[0] != Y_rv.owner.inputs[0]
+
+    assert len(model.rng_seq) == 2
+
+    with pm.Model(rng_seeder=np.random.RandomState(2023532)):
+        X_rv = pm.Normal("x")
+        Y_rv = pm.Normal("y")
+
+        pp_samples_2 = pm.sample_prior_predictive(samples=2)
+
+    assert np.array_equal(pp_samples["y"], pp_samples_2["y"])

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -327,17 +327,13 @@ class BaseTestDistribution(SeededTest):
 
     def _instantiate_pymc_rv(self, dist_params=None):
         params = dist_params if dist_params else self.pymc_dist_params
-        with pm.Model():
-            self.pymc_rv = self.pymc_dist(
-                **params,
-                size=self.size,
-                rng=aesara.shared(self.get_random_state(reset=True)),
-                name=f"{self.pymc_dist.rv_op.name}_test",
-            )
+        self.pymc_rv = self.pymc_dist.dist(
+            **params, size=self.size, rng=aesara.shared(self.get_random_state(reset=True))
+        )
 
     def check_pymc_draws_match_reference(self):
         # need to re-instantiate it to make sure that the order of drawings match the reference distribution one
-        self._instantiate_pymc_rv()
+        # self._instantiate_pymc_rv()
         assert_array_almost_equal(
             self.pymc_rv.eval(), self.reference_dist_draws, decimal=self.decimal
         )

--- a/pymc3/tests/test_distributions_timeseries.py
+++ b/pymc3/tests/test_distributions_timeseries.py
@@ -68,13 +68,13 @@ def test_AR_nd():
     beta_tp = np.random.randn(p, n)
     y_tp = np.random.randn(T, n)
     with Model() as t0:
-        beta = Normal("beta", 0.0, 1.0, shape=(p, n), testval=beta_tp)
-        AR("y", beta, sigma=1.0, shape=(T, n), testval=y_tp)
+        beta = Normal("beta", 0.0, 1.0, shape=(p, n), initval=beta_tp)
+        AR("y", beta, sigma=1.0, shape=(T, n), initval=y_tp)
 
     with Model() as t1:
-        beta = Normal("beta", 0.0, 1.0, shape=(p, n), testval=beta_tp)
+        beta = Normal("beta", 0.0, 1.0, shape=(p, n), initval=beta_tp)
         for i in range(n):
-            AR("y_%d" % i, beta[:, i], sigma=1.0, shape=T, testval=y_tp[:, i])
+            AR("y_%d" % i, beta[:, i], sigma=1.0, shape=T, initval=y_tp[:, i])
 
     np.testing.assert_allclose(t0.logp(t0.initial_point), t1.logp(t1.initial_point))
 
@@ -150,7 +150,7 @@ def test_linear():
     # build model
     with Model() as model:
         lamh = Flat("lamh")
-        xh = EulerMaruyama("xh", dt, sde, (lamh,), shape=N + 1, testval=x)
+        xh = EulerMaruyama("xh", dt, sde, (lamh,), shape=N + 1, initval=x)
         Normal("zh", mu=xh, sigma=sig2, observed=z)
     # invert
     with model:

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -57,7 +57,7 @@ class DocstringModel(pm.Model):
         super().__init__(name, model)
         self.register_rv(Normal.dist(mu=mean, sigma=sigma), "v1")
         Normal("v2", mu=mean, sigma=sigma)
-        Normal("v3", mu=mean, sigma=Normal("sd", mu=10, sigma=1, testval=1.0))
+        Normal("v3", mu=mean, sigma=Normal("sd", mu=10, sigma=1, initval=1.0))
         Deterministic("v3_sq", self.v3 ** 2)
         Potential("p1", at.constant(1))
 
@@ -462,7 +462,7 @@ def test_make_obs_var():
     fake_model = pm.Model()
     with fake_model:
         fake_distribution = pm.Normal.dist(mu=0, sigma=1)
-        # Create the testval attribute simply for the sake of model testing
+        # Create the initval attribute simply for the sake of model testing
         fake_distribution.name = input_name
 
     # Check function behavior using the various inputs

--- a/pymc3/tests/test_ndarray_backend.py
+++ b/pymc3/tests/test_ndarray_backend.py
@@ -209,8 +209,8 @@ class TestSqueezeCat:
 
 class TestSaveLoad:
     @staticmethod
-    def model():
-        with pm.Model() as model:
+    def model(rng_seeder=None):
+        with pm.Model(rng_seeder=rng_seeder) as model:
             x = pm.Normal("x", 0, 1)
             y = pm.Normal("y", x, 1, observed=2)
             z = pm.Normal("z", x + y, 1)
@@ -267,15 +267,16 @@ class TestSaveLoad:
 
         assert save_dir == directory
 
-        with TestSaveLoad.model() as model:
-            model.default_rng.get_value(borrow=True).seed(10)
+        rng = np.random.RandomState(10)
+
+        with TestSaveLoad.model(rng_seeder=rng):
             ppc = pm.sample_posterior_predictive(self.trace)
 
-        with TestSaveLoad.model() as model:
+        rng = np.random.RandomState(10)
+
+        with TestSaveLoad.model(rng_seeder=rng):
             trace2 = pm.load_trace(directory)
-            model.default_rng.get_value(borrow=True).seed(10)
             ppc2 = pm.sample_posterior_predictive(trace2)
-            ppc2f = pm.sample_posterior_predictive(trace2)
 
         for key, value in ppc.items():
             assert (value == ppc2[key]).all()

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -31,6 +31,7 @@ from scipy import stats
 
 import pymc3 as pm
 
+from pymc3.aesaraf import compile_rv_inplace
 from pymc3.backends.ndarray import NDArray
 from pymc3.exceptions import IncorrectArgumentsError, SamplingError
 from pymc3.tests.helpers import SeededTest
@@ -973,7 +974,7 @@ class TestSamplePriorPredictive(SeededTest):
             a = pm.Uniform("a", lower=0, upper=1, size=10)
             b = pm.Binomial("b", n=1, p=a, size=10)
 
-        b_sampler = aesara.function([], b)
+        b_sampler = compile_rv_inplace([], b, mode="FAST_RUN")
         avg = np.stack([b_sampler() for i in range(10000)]).mean(0)
         npt.assert_array_almost_equal(avg, 0.5 * np.ones((10,)), decimal=2)
 

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -387,7 +387,7 @@ class TestNamedSampling(SeededTest):
                 mu=np.atleast_2d(0),
                 tau=np.atleast_2d(1e20),
                 size=(1, 1),
-                testval=np.atleast_2d(0),
+                initval=np.atleast_2d(0),
             )
             theta = pm.Normal(
                 "theta", mu=at.dot(G_var, theta0), tau=np.atleast_2d(1e20), size=(1, 1)
@@ -403,7 +403,7 @@ class TestNamedSampling(SeededTest):
                 mu=np.atleast_2d(0),
                 tau=np.atleast_2d(1e20),
                 size=(1, 1),
-                testval=np.atleast_2d(0),
+                initval=np.atleast_2d(0),
             )
             theta = pm.Normal(
                 "theta", mu=at.dot(G_var, theta0), tau=np.atleast_2d(1e20), size=(1, 1)
@@ -419,7 +419,7 @@ class TestNamedSampling(SeededTest):
                 mu=np.atleast_2d(0),
                 tau=np.atleast_2d(1e20),
                 size=(1, 1),
-                testval=np.atleast_2d(0),
+                initval=np.atleast_2d(0),
             )
             theta = pm.Normal(
                 "theta", mu=at.dot(G_var, theta0), tau=np.atleast_2d(1e20), size=(1, 1)
@@ -688,10 +688,10 @@ class TestSamplePPC(SeededTest):
         meas_in_1 = pm.aesaraf.floatX(2 + 4 * rng.randn(100))
         meas_in_2 = pm.aesaraf.floatX(5 + 4 * rng.randn(100))
         with pm.Model(rng_seeder=rng) as model:
-            mu_in_1 = pm.Normal("mu_in_1", 0, 1, testval=0)
-            sigma_in_1 = pm.HalfNormal("sd_in_1", 1, testval=1)
-            mu_in_2 = pm.Normal("mu_in_2", 0, 1, testval=0)
-            sigma_in_2 = pm.HalfNormal("sd__in_2", 1, testval=1)
+            mu_in_1 = pm.Normal("mu_in_1", 0, 1, initval=0)
+            sigma_in_1 = pm.HalfNormal("sd_in_1", 1, initval=1)
+            mu_in_2 = pm.Normal("mu_in_2", 0, 1, initval=0)
+            sigma_in_2 = pm.HalfNormal("sd__in_2", 1, initval=1)
 
             in_1 = pm.Normal("in_1", mu_in_1, sigma_in_1, observed=meas_in_1)
             in_2 = pm.Normal("in_2", mu_in_2, sigma_in_2, observed=meas_in_2)
@@ -882,7 +882,7 @@ def test_default_sample_nuts_jitter(init, start, expectation, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "testval, jitter_max_retries, expectation",
+    "initval, jitter_max_retries, expectation",
     [
         (0, 0, pytest.raises(SamplingError)),
         (0, 1, pytest.raises(SamplingError)),
@@ -891,9 +891,9 @@ def test_default_sample_nuts_jitter(init, start, expectation, monkeypatch):
         (1, 0, does_not_raise()),
     ],
 )
-def test_init_jitter(testval, jitter_max_retries, expectation):
+def test_init_jitter(initval, jitter_max_retries, expectation):
     with pm.Model() as m:
-        pm.HalfNormal("x", transform=None, testval=testval)
+        pm.HalfNormal("x", transform=None, initval=initval)
 
     with expectation:
         # Starting value is negative (invalid) when np.random.rand returns 0 (jitter = -1)

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -1657,7 +1657,9 @@ class TestMLDA:
                 mout = []
                 coarse_models = []
 
-                with Model() as coarse_model_0:
+                rng = np.random.RandomState(seed)
+
+                with Model(rng_seeder=rng) as coarse_model_0:
                     if aesara.config.floatX == "float32":
                         Q = Data("Q", np.float32(0.0))
                     else:
@@ -1674,9 +1676,9 @@ class TestMLDA:
 
                     coarse_models.append(coarse_model_0)
 
-                coarse_model_0.default_rng.get_value(borrow=True).seed(seed)
+                rng = np.random.RandomState(seed)
 
-                with Model() as coarse_model_1:
+                with Model(rng_seeder=rng) as coarse_model_1:
                     if aesara.config.floatX == "float32":
                         Q = Data("Q", np.float32(0.0))
                     else:
@@ -1693,9 +1695,9 @@ class TestMLDA:
 
                     coarse_models.append(coarse_model_1)
 
-                coarse_model_1.default_rng.get_value(borrow=True).seed(seed)
+                rng = np.random.RandomState(seed)
 
-                with Model() as model:
+                with Model(rng_seeder=rng) as model:
                     if aesara.config.floatX == "float32":
                         Q = Data("Q", np.float32(0.0))
                     else:

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -964,7 +964,7 @@ class TestNutsCheckTrace:
 
     def test_bad_init_nonparallel(self):
         with Model():
-            HalfNormal("a", sigma=1, testval=-1, transform=None)
+            HalfNormal("a", sigma=1, initval=-1, transform=None)
             with pytest.raises(SamplingError) as error:
                 sample(init=None, chains=1, random_seed=1)
             error.match("Initial evaluation")
@@ -972,17 +972,17 @@ class TestNutsCheckTrace:
     @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
     def test_bad_init_parallel(self):
         with Model():
-            HalfNormal("a", sigma=1, testval=-1, transform=None)
+            HalfNormal("a", sigma=1, initval=-1, transform=None)
             with pytest.raises(SamplingError) as error:
                 sample(init=None, cores=2, random_seed=1)
             error.match("Initial evaluation")
 
     def test_linalg(self, caplog):
         with Model():
-            a = Normal("a", size=2, testval=floatX(np.zeros(2)))
+            a = Normal("a", size=2, initval=floatX(np.zeros(2)))
             a = at.switch(a > 0, np.inf, a)
             b = at.slinalg.solve(floatX(np.eye(2)), a)
-            Normal("c", mu=b, size=2, testval=floatX(np.r_[0.0, 0.0]))
+            Normal("c", mu=b, size=2, initval=floatX(np.r_[0.0, 0.0]))
             caplog.clear()
             trace = sample(20, init=None, tune=5, chains=2)
             warns = [msg.msg for msg in caplog.records]

--- a/pymc3/tests/test_transforms.py
+++ b/pymc3/tests/test_transforms.py
@@ -227,7 +227,7 @@ def test_interval_near_boundary():
     x0 = np.nextafter(ub, lb)
 
     with pm.Model() as model:
-        pm.Uniform("x", testval=x0, lower=lb, upper=ub)
+        pm.Uniform("x", initval=x0, lower=lb, upper=ub)
 
     log_prob = model.point_logps()
     np.testing.assert_allclose(log_prob, np.array([-52.68]))
@@ -274,11 +274,11 @@ def test_chain_jacob_det():
 
 
 class TestElementWiseLogp(SeededTest):
-    def build_model(self, distfam, params, size, transform, testval=None):
-        if testval is not None:
-            testval = pm.floatX(testval)
+    def build_model(self, distfam, params, size, transform, initval=None):
+        if initval is not None:
+            initval = pm.floatX(initval)
         with pm.Model() as m:
-            distfam("x", size=size, transform=transform, testval=testval, **params)
+            distfam("x", size=size, transform=transform, initval=initval, **params)
         return m
 
     def check_transform_elementwise_logp(self, model):
@@ -408,7 +408,7 @@ class TestElementWiseLogp(SeededTest):
             pm.Normal,
             {"mu": 0.0, "sd": 1.0},
             size=3,
-            testval=np.asarray([-1.0, 1.0, 4.0]),
+            initval=np.asarray([-1.0, 1.0, 4.0]),
             transform=tr.ordered,
         )
         self.check_vectortransform_elementwise_logp(model, vect_opt=0)
@@ -422,24 +422,24 @@ class TestElementWiseLogp(SeededTest):
     )
     @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_half_normal_ordered(self, sd, size):
-        testval = np.sort(np.abs(np.random.randn(*size)))
+        initval = np.sort(np.abs(np.random.randn(*size)))
         model = self.build_model(
             pm.HalfNormal,
             {"sd": sd},
             size=size,
-            testval=testval,
+            initval=initval,
             transform=tr.Chain([tr.log, tr.ordered]),
         )
         self.check_vectortransform_elementwise_logp(model, vect_opt=0)
 
     @pytest.mark.parametrize("lam,size", [(2.5, (2,)), (np.ones(3), (4, 3))])
     def test_exponential_ordered(self, lam, size):
-        testval = np.sort(np.abs(np.random.randn(*size)))
+        initval = np.sort(np.abs(np.random.randn(*size)))
         model = self.build_model(
             pm.Exponential,
             {"lam": lam},
             size=size,
-            testval=testval,
+            initval=initval,
             transform=tr.Chain([tr.log, tr.ordered]),
         )
         self.check_vectortransform_elementwise_logp(model, vect_opt=0)
@@ -452,12 +452,12 @@ class TestElementWiseLogp(SeededTest):
         ],
     )
     def test_beta_ordered(self, a, b, size):
-        testval = np.sort(np.abs(np.random.rand(*size)))
+        initval = np.sort(np.abs(np.random.rand(*size)))
         model = self.build_model(
             pm.Beta,
             {"alpha": a, "beta": b},
             size=size,
-            testval=testval,
+            initval=initval,
             transform=tr.Chain([tr.logodds, tr.ordered]),
         )
         self.check_vectortransform_elementwise_logp(model, vect_opt=0)
@@ -475,24 +475,24 @@ class TestElementWiseLogp(SeededTest):
 
         interval = tr.Interval(transform_params)
 
-        testval = np.sort(np.abs(np.random.rand(*size)))
+        initval = np.sort(np.abs(np.random.rand(*size)))
         model = self.build_model(
             pm.Uniform,
             {"lower": lower, "upper": upper},
             size=size,
-            testval=testval,
+            initval=initval,
             transform=tr.Chain([interval, tr.ordered]),
         )
         self.check_vectortransform_elementwise_logp(model, vect_opt=1)
 
     @pytest.mark.parametrize("mu,kappa,size", [(0.0, 1.0, (2,)), (np.zeros(3), np.ones(3), (4, 3))])
     def test_vonmises_ordered(self, mu, kappa, size):
-        testval = np.sort(np.abs(np.random.rand(*size)))
+        initval = np.sort(np.abs(np.random.rand(*size)))
         model = self.build_model(
             pm.VonMises,
             {"mu": mu, "kappa": kappa},
             size=size,
-            testval=testval,
+            initval=initval,
             transform=tr.Chain([tr.circular, tr.ordered]),
         )
         self.check_vectortransform_elementwise_logp(model, vect_opt=0)
@@ -506,12 +506,12 @@ class TestElementWiseLogp(SeededTest):
         ],
     )
     def test_uniform_other(self, lower, upper, size, transform):
-        testval = np.ones(size) / size[-1]
+        initval = np.ones(size) / size[-1]
         model = self.build_model(
             pm.Uniform,
             {"lower": lower, "upper": upper},
             size=size,
-            testval=testval,
+            initval=initval,
             transform=transform,
         )
         self.check_vectortransform_elementwise_logp(model, vect_opt=1)
@@ -524,9 +524,9 @@ class TestElementWiseLogp(SeededTest):
         ],
     )
     def test_mvnormal_ordered(self, mu, cov, size, shape):
-        testval = np.sort(np.random.randn(*shape))
+        initval = np.sort(np.random.randn(*shape))
         model = self.build_model(
-            pm.MvNormal, {"mu": mu, "cov": cov}, size=size, testval=testval, transform=tr.ordered
+            pm.MvNormal, {"mu": mu, "cov": cov}, size=size, initval=initval, transform=tr.ordered
         )
         self.check_vectortransform_elementwise_logp(model, vect_opt=1)
 

--- a/pymc3/tests/test_types.py
+++ b/pymc3/tests/test_types.py
@@ -37,7 +37,7 @@ class TestType:
     @aesara.config.change_flags({"floatX": "float64", "warn_float64": "ignore"})
     def test_float64(self):
         with Model() as model:
-            x = Normal("x", testval=np.array(1.0, dtype="float64"))
+            x = Normal("x", initval=np.array(1.0, dtype="float64"))
             obs = Normal("obs", mu=x, sigma=1.0, observed=np.random.randn(5))
 
         assert x.dtype == "float64"
@@ -50,7 +50,7 @@ class TestType:
     @aesara.config.change_flags({"floatX": "float32", "warn_float64": "warn"})
     def test_float32(self):
         with Model() as model:
-            x = Normal("x", testval=np.array(1.0, dtype="float32"))
+            x = Normal("x", initval=np.array(1.0, dtype="float32"))
             obs = Normal("obs", mu=x, sigma=1.0, observed=np.random.randn(5).astype("float32"))
 
         assert x.dtype == "float32"
@@ -65,11 +65,11 @@ class TestType:
         data = np.random.randn(5)
 
         with Model() as coarse_model:
-            x = Normal("x", testval=np.array(1.0, dtype="float64"))
+            x = Normal("x", initval=np.array(1.0, dtype="float64"))
             obs = Normal("obs", mu=x, sigma=1.0, observed=data + 0.5)
 
         with Model() as model:
-            x = Normal("x", testval=np.array(1.0, dtype="float64"))
+            x = Normal("x", initval=np.array(1.0, dtype="float64"))
             obs = Normal("obs", mu=x, sigma=1.0, observed=data)
 
         assert x.dtype == "float64"
@@ -83,11 +83,11 @@ class TestType:
         data = np.random.randn(5).astype("float32")
 
         with Model() as coarse_model:
-            x = Normal("x", testval=np.array(1.0, dtype="float32"))
+            x = Normal("x", initval=np.array(1.0, dtype="float32"))
             obs = Normal("obs", mu=x, sigma=1.0, observed=data + 0.5)
 
         with Model() as model:
-            x = Normal("x", testval=np.array(1.0, dtype="float32"))
+            x = Normal("x", initval=np.array(1.0, dtype="float32"))
             obs = Normal("obs", mu=x, sigma=1.0, observed=data)
 
         assert x.dtype == "float32"

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -655,7 +655,7 @@ def simple_model_data(use_minibatch):
 def simple_model(simple_model_data):
     with pm.Model() as model:
         mu_ = pm.Normal(
-            "mu", mu=simple_model_data["mu0"], sigma=simple_model_data["sigma0"], testval=0
+            "mu", mu=simple_model_data["mu0"], sigma=simple_model_data["sigma0"], initval=0
         )
         pm.Normal(
             "x",


### PR DESCRIPTION
This PR updates the role of `Model.default_rng` by adding a `Model.next_rng` that is incrementally updated when variables are registered.

Under this change, `Model.default_rng` still serves as a mutable starting point for RNG seeding, while also (softly) guaranteeing that newly added/registered random variables&mdash;that don't specify their own `rng` parameters&mdash;will be unique.

This PR also updates how initial values are specified, stored, and generated.  Since computing initial values may require sampling, these updates were needed in order to prevent initial values from unnecessarily affecting the RNG states in confusing ways.

Closes #4728