### PR TITLE
Remove unnecessary gammaln and psi from pymc3.distributions.special

### DIFF
--- a/pymc3/distributions/special.py
+++ b/pymc3/distributions/special.py
@@ -15,14 +15,9 @@
 import aesara.tensor as at
 import numpy as np
 
-from aesara import scalar
-from aesara.scalar.basic_scipy import GammaLn, Psi
-from aesara.tensor.elemwise import Elemwise
+from aesara.tensor.math import gammaln, psi
 
 __all__ = ["gammaln", "multigammaln", "psi", "log_i0"]
-
-scalar_gammaln = GammaLn(scalar.upgrade_to_float, name="scalar_gammaln")
-gammaln = Elemwise(scalar_gammaln, name="gammaln")
 
 
 def multigammaln(a, p):
@@ -61,7 +56,3 @@ def log_i0(x):
             + 11025.0 / (98304.0 * x ** 4.0)
         ),
     )
-
-
-scalar_psi = Psi(scalar.upgrade_to_float, name="scalar_psi")
-psi = Elemwise(scalar_psi, name="psi")

--- a/pymc3/tests/test_special_functions.py
+++ b/pymc3/tests/test_special_functions.py
@@ -16,61 +16,30 @@ import aesara.tensor as at
 import numpy as np
 import scipy.special as ss
 
-from aesara import function
+from aesara import config, function
 
 import pymc3.distributions.special as ps
 
 from pymc3.tests.checks import close_to
 
 
-def test_functions():
-    xvals = list(map(np.atleast_1d, [0.01, 0.1, 2, 100, 10000]))
-
-    x = at.dvector("x")
-    x.tag.test_value = xvals[0]
-
-    p = at.iscalar("p")
-    p.tag.test_value = 1
-
-    gammaln = function([x], ps.gammaln(x))
-    psi = function([x], ps.psi(x))
-    function([x, p], ps.multigammaln(x, p))
-    for x in xvals:
-        check_vals(gammaln, ss.gammaln, x)
-    for x in xvals[1:]:
-        check_vals(psi, ss.psi, x)
+def check_vals(fn1, fn2, *args):
+    v = fn1(*args)
+    close_to(v, fn2(*args), 1e-6 if v.dtype == np.float64 else 1e-4)
 
 
-"""
-scipy.special.multigammaln gives bad values if you pass a non scalar to a
-In [14]:
+def test_multigamma():
+    x = at.vector("x")
+    p = at.scalar("p")
 
-    import scipy.special
-    scipy.special.multigammaln([2.1], 3)
-    Out[14]:
-        array([ 1.76253257,  1.60450306,  1.66722239])
-"""
+    xvals = [np.array([v], dtype=config.floatX) for v in [0.1, 2, 5, 10, 50, 100]]
 
-
-def t_multigamma():
-    xvals = list(map(np.atleast_1d, [0, 0.1, 2, 100]))
-
-    x = at.dvector("x")
-    x.tag.test_value = xvals[0]
-
-    p = at.iscalar("p")
-    p.tag.test_value = 1
-
-    multigammaln = function([x, p], ps.multigammaln(x, p))
+    multigammaln = function([x, p], ps.multigammaln(x, p), mode="FAST_COMPILE")
 
     def ssmultigammaln(a, b):
-        return ss.multigammaln(a[0], b)
+        return np.array(ss.multigammaln(a[0], b), config.floatX)
 
     for p in [0, 1, 2, 3, 4, 100]:
         for x in xvals:
-            check_vals(multigammaln, ssmultigammaln, x, p)
-
-
-def check_vals(fn1, fn2, *args):
-    v = fn1(*args)
-    close_to(v, fn2(*args), 1e-6)
+            if np.all(x > 0.5 * (p - 1)):
+                check_vals(multigammaln, ssmultigammaln, x, p)


### PR DESCRIPTION
This PR updates `pymc3.distributions.special` so that it's compatible with the changes introduced in https://github.com/pymc-devs/aesara/pull/445.  It also finishes the unused test for `multigammaln`.