### PR TITLE
Replace incomplete_beta with betainc and speedup logcdf tests

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,7 +8,7 @@
 - The `Distribution` keyword argument `testval` has been deprecated in favor of `initval`.
 - `pm.sample` now returns results as `InferenceData` instead of `MultiTrace` by default (see [#4744](https://github.com/pymc-devs/pymc3/pull/4744)).
 - `pm.sample_prior_predictive` no longer returns transformed variable values by default. Pass them by name in `var_names` if you want to obtain these draws (see [4769](https://github.com/pymc-devs/pymc3/pull/4769)).
-...
+- ...
 
 ### New Features
 - The `CAR` distribution has been added to allow for use of conditional autoregressions which often are used in spatial and network models.
@@ -20,12 +20,14 @@
 - Add `logcdf` method to Kumaraswamy distribution (see [#4706](https://github.com/pymc-devs/pymc3/pull/4706)).
 - The `OrderedMultinomial` distribution has been added for use on ordinal data which are _aggregated_ by trial, like multinomial observations, whereas `OrderedLogistic` only accepts ordinal data in a _disaggregated_ format, like categorical
   observations (see [#4773](https://github.com/pymc-devs/pymc3/pull/4773)).
+- ...
 
 ### Maintenance
 - Remove float128 dtype support (see [#4514](https://github.com/pymc-devs/pymc3/pull/4514)).
 - Logp method of `Uniform` and `DiscreteUniform` no longer depends on `pymc3.distributions.dist_math.bound` for proper evaluation (see [#4541](https://github.com/pymc-devs/pymc3/pull/4541)).
 - `Model.RV_dims` and `Model.coords` are now read-only properties. To modify the `coords` dictionary use `Model.add_coord`. Also `dims` or coordinate values that are `None` will be auto-completed (see [#4625](https://github.com/pymc-devs/pymc3/pull/4625)).
 - The length of `dims` in the model is now tracked symbolically through `Model.dim_lengths` (see [#4625](https://github.com/pymc-devs/pymc3/pull/4625)).
+- The `incomplete_beta` function in `pymc3.distributions.dist_math` was replaced by `aesara.tensor.betainc` (see [4736](https://github.com/pymc-devs/pymc3/pull/4736)).
 - ...
 
 ## PyMC3 3.11.2 (14 March 2021)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,7 @@
 ## PyMC3 vNext (4.0.0)
 ### Breaking Changes
 - ⚠ Theano-PyMC has been replaced with Aesara, so all external references to `theano`, `tt`, and `pymc3.theanof` need to be replaced with `aesara`, `at`, and `pymc3.aesaraf` (see [4471](https://github.com/pymc-devs/pymc3/pull/4471)).
+- ⚠ PyMC3 now requires Scipy version `>= 1.4.1` (see [4736](https://github.com/pymc-devs/pymc3/pull/4736)).
 - ArviZ `plots` and `stats` *wrappers* were removed. The functions are now just available by their original names (see [#4549](https://github.com/pymc-devs/pymc3/pull/4471) and `3.11.2` release notes).
 - The GLM submodule has been removed, please use [Bambi](https://bambinos.github.io/bambi/) instead.
 - The `Distribution` keyword argument `testval` has been deprecated in favor of `initval`.

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -2370,13 +2370,8 @@ class Gamma(PositiveContinuous):
         """
         beta = at.inv(inv_beta)
 
-        # Avoid C-assertion when the gammainc function is called with invalid values (#4340)
-        safe_alpha = at.switch(at.lt(alpha, 0), 0, alpha)
-        safe_beta = at.switch(at.lt(beta, 0), 0, beta)
-        safe_value = at.switch(at.lt(value, 0), 0, value)
-
         return bound(
-            at.log(at.gammainc(safe_alpha, safe_beta * safe_value)),
+            at.log(at.gammainc(alpha, beta * value)),
             0 <= value,
             0 < alpha,
             0 < beta,
@@ -2518,13 +2513,9 @@ class InverseGamma(PositiveContinuous):
         -------
         TensorVariable
         """
-        # Avoid C-assertion when the gammaincc function is called with invalid values (#4340)
-        safe_alpha = at.switch(at.lt(alpha, 0), 0, alpha)
-        safe_beta = at.switch(at.lt(beta, 0), 0, beta)
-        safe_value = at.switch(at.lt(value, 0), 0, value)
 
         return bound(
-            at.log(at.gammaincc(safe_alpha, safe_beta / safe_value)),
+            at.log(at.gammaincc(alpha, beta / value)),
             0 <= value,
             0 < alpha,
             0 < beta,

--- a/pymc3/distributions/dist_math.py
+++ b/pymc3/distributions/dist_math.py
@@ -17,18 +17,18 @@ Created on Mar 7, 2011
 
 @author: johnsalvatier
 """
+import warnings
+
 import aesara
 import aesara.tensor as at
 import numpy as np
 import scipy.linalg
 import scipy.stats
 
-from aesara import scan
 from aesara.compile.builders import OpFromGraph
 from aesara.graph.basic import Apply
 from aesara.graph.op import Op
 from aesara.scalar import UnaryScalarOp, upgrade_to_float_no_complex
-from aesara.scan import until
 from aesara.tensor import gammaln
 from aesara.tensor.elemwise import Elemwise
 from aesara.tensor.slinalg import Cholesky
@@ -433,169 +433,6 @@ def zvalue(value, sigma, mu):
     return (value - mu) / sigma
 
 
-def incomplete_beta_cfe(a, b, x, small):
-    """Incomplete beta continued fraction expansions
-    based on Cephes library by Steve Moshier (incbet.c).
-    small: Choose element-wise which continued fraction expansion to use.
-    """
-    BIG = at.constant(4.503599627370496e15, dtype="float64")
-    BIGINV = at.constant(2.22044604925031308085e-16, dtype="float64")
-    THRESH = at.constant(3.0 * np.MachAr().eps, dtype="float64")
-
-    zero = at.constant(0.0, dtype="float64")
-    one = at.constant(1.0, dtype="float64")
-    two = at.constant(2.0, dtype="float64")
-
-    r = one
-    k1 = a
-    k3 = a
-    k4 = a + one
-    k5 = one
-    k8 = a + two
-
-    k2 = at.switch(small, a + b, b - one)
-    k6 = at.switch(small, b - one, a + b)
-    k7 = at.switch(small, k4, a + one)
-    k26update = at.switch(small, one, -one)
-    x = at.switch(small, x, x / (one - x))
-
-    pkm2 = zero
-    qkm2 = one
-    pkm1 = one
-    qkm1 = one
-    r = one
-
-    def _step(i, pkm1, pkm2, qkm1, qkm2, k1, k2, k3, k4, k5, k6, k7, k8, r, a, b, x, small):
-        xk = -(x * k1 * k2) / (k3 * k4)
-        pk = pkm1 + pkm2 * xk
-        qk = qkm1 + qkm2 * xk
-        pkm2 = pkm1
-        pkm1 = pk
-        qkm2 = qkm1
-        qkm1 = qk
-
-        xk = (x * k5 * k6) / (k7 * k8)
-        pk = pkm1 + pkm2 * xk
-        qk = qkm1 + qkm2 * xk
-        pkm2 = pkm1
-        pkm1 = pk
-        qkm2 = qkm1
-        qkm1 = qk
-
-        old_r = r
-        r = at.switch(at.eq(qk, zero), r, pk / qk)
-
-        k1 += one
-        k2 += k26update
-        k3 += two
-        k4 += two
-        k5 += one
-        k6 -= k26update
-        k7 += two
-        k8 += two
-
-        big_cond = at.gt(at.abs_(qk) + at.abs_(pk), BIG)
-        biginv_cond = at.or_(at.lt(at.abs_(qk), BIGINV), at.lt(at.abs_(pk), BIGINV))
-
-        pkm2 = at.switch(big_cond, pkm2 * BIGINV, pkm2)
-        pkm1 = at.switch(big_cond, pkm1 * BIGINV, pkm1)
-        qkm2 = at.switch(big_cond, qkm2 * BIGINV, qkm2)
-        qkm1 = at.switch(big_cond, qkm1 * BIGINV, qkm1)
-
-        pkm2 = at.switch(biginv_cond, pkm2 * BIG, pkm2)
-        pkm1 = at.switch(biginv_cond, pkm1 * BIG, pkm1)
-        qkm2 = at.switch(biginv_cond, qkm2 * BIG, qkm2)
-        qkm1 = at.switch(biginv_cond, qkm1 * BIG, qkm1)
-
-        return (
-            (pkm1, pkm2, qkm1, qkm2, k1, k2, k3, k4, k5, k6, k7, k8, r),
-            until(at.abs_(old_r - r) < (THRESH * at.abs_(r))),
-        )
-
-    (pkm1, pkm2, qkm1, qkm2, k1, k2, k3, k4, k5, k6, k7, k8, r), _ = scan(
-        _step,
-        sequences=[at.arange(0, 300)],
-        outputs_info=[
-            e
-            for e in at.cast((pkm1, pkm2, qkm1, qkm2, k1, k2, k3, k4, k5, k6, k7, k8, r), "float64")
-        ],
-        non_sequences=[a, b, x, small],
-    )
-
-    return r[-1]
-
-
-def incomplete_beta_ps(a, b, value):
-    """Power series for incomplete beta
-    Use when b*x is small and value not too close to 1.
-    Based on Cephes library by Steve Moshier (incbet.c)
-    """
-    one = at.constant(1, dtype="float64")
-    ai = one / a
-    u = (one - b) * value
-    t1 = u / (a + one)
-    t = u
-    threshold = np.MachAr().eps * ai
-    s = at.constant(0, dtype="float64")
-
-    def _step(i, t, s, a, b, value):
-        t *= (i - b) * value / i
-        step = t / (a + i)
-        s += step
-        return ((t, s), until(at.abs_(step) < threshold))
-
-    (t, s), _ = scan(
-        _step,
-        sequences=[at.arange(2, 302)],
-        outputs_info=[e for e in at.cast((t, s), "float64")],
-        non_sequences=[a, b, value],
-    )
-
-    s = s[-1] + t1 + ai
-
-    t = gammaln(a + b) - gammaln(a) - gammaln(b) + a * at.log(value) + at.log(s)
-    return at.exp(t)
-
-
-def incomplete_beta(a, b, value):
-    """Incomplete beta implementation
-    Power series and continued fraction expansions chosen for best numerical
-    convergence across the board based on inputs.
-    """
-    machep = at.constant(np.MachAr().eps, dtype="float64")
-    one = at.constant(1, dtype="float64")
-    w = one - value
-
-    ps = incomplete_beta_ps(a, b, value)
-
-    flip = at.gt(value, (a / (a + b)))
-    aa, bb = a, b
-    a = at.switch(flip, bb, aa)
-    b = at.switch(flip, aa, bb)
-    xc = at.switch(flip, value, w)
-    x = at.switch(flip, w, value)
-
-    tps = incomplete_beta_ps(a, b, x)
-    tps = at.switch(at.le(tps, machep), one - machep, one - tps)
-
-    # Choose which continued fraction expansion for best convergence.
-    small = at.lt(x * (a + b - 2.0) - (a - one), 0.0)
-    cfe = incomplete_beta_cfe(a, b, x, small)
-    w = at.switch(small, cfe, cfe / xc)
-
-    # Direct incomplete beta accounting for flipped a, b.
-    t = at.exp(
-        a * at.log(x) + b * at.log(xc) + gammaln(a + b) - gammaln(a) - gammaln(b) + at.log(w / a)
-    )
-
-    t = at.switch(flip, at.switch(at.le(t, machep), one - machep, one - t), t)
-    return at.switch(
-        at.and_(flip, at.and_(at.le((b * x), one), at.le(x, 0.95))),
-        tps,
-        at.switch(at.and_(at.le(b * value, one), at.le(value, 0.95)), ps, t),
-    )
-
-
 def clipped_beta_rvs(a, b, size=None, random_state=None, dtype="float64"):
     """Draw beta distributed random samples in the open :math:`(0, 1)` interval.
 
@@ -672,3 +509,12 @@ def log_i0(x):
             + 11025.0 / (98304.0 * x ** 4.0)
         ),
     )
+
+
+def incomplete_beta(a, b, value):
+    warnings.warn(
+        "incomplete_beta has been deprecated. Use aesara.tensor.betainc instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return at.betainc(a, b, value)

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -596,7 +596,6 @@ class TestMatchesScipy:
         n_samples=100,
         extra_args=None,
         scipy_args=None,
-        skip_params_fn=lambda x: False,
     ):
         """
         Generic test for PyMC3 logp methods
@@ -628,9 +627,6 @@ class TestMatchesScipy:
             the pymc3 distribution logp is calculated
         scipy_args : Dictionary with extra arguments needed to call scipy logp method
             Usually the same as extra_args
-        skip_params_fn: Callable
-            A function that takes a ``dict`` of the test points and returns a
-            boolean indicating whether or not to perform the test.
         """
         if decimal is None:
             decimal = select_by_precision(float64=6, float32=3)
@@ -652,8 +648,6 @@ class TestMatchesScipy:
         domains["value"] = domain
         for pt in product(domains, n_samples=n_samples):
             pt = dict(pt)
-            if skip_params_fn(pt):
-                continue
             pt_d = self._model_input_dict(model, param_vars, pt)
             pt_logp = Point(pt_d, model=model)
             pt_ref = Point(pt, filter_model_vars=False, model=model)
@@ -698,7 +692,6 @@ class TestMatchesScipy:
         n_samples=100,
         skip_paramdomain_inside_edge_test=False,
         skip_paramdomain_outside_edge_test=False,
-        skip_params_fn=lambda x: False,
     ):
         """
         Generic test for PyMC3 logcdf methods
@@ -739,9 +732,6 @@ class TestMatchesScipy:
         skip_paramdomain_outside_edge_test : Bool
             Whether to run test 2., which checks that pymc3 distribution logcdf
             returns -inf for invalid parameter values outside the supported domain edge
-        skip_params_fn: Callable
-            A function that takes a ``dict`` of the test points and returns a
-            boolean indicating whether or not to perform the test.
 
         Returns
         -------
@@ -761,9 +751,6 @@ class TestMatchesScipy:
 
             for pt in product(domains, n_samples=n_samples):
                 params = dict(pt)
-                if skip_params_fn(params):
-                    continue
-
                 scipy_eval = scipy_logcdf(**params)
 
                 value = params.pop("value")
@@ -853,7 +840,6 @@ class TestMatchesScipy:
         paramdomains,
         decimal=None,
         n_samples=100,
-        skip_params_fn=lambda x: False,
     ):
         """
         Check that logcdf of discrete distributions matches sum of logps up to value
@@ -872,8 +858,6 @@ class TestMatchesScipy:
 
         for pt in product(domains, n_samples=n_samples):
             params = dict(pt)
-            if skip_params_fn(params):
-                continue
             value = params.pop("value")
             values = np.arange(domain.lower, value + 1)
 
@@ -1256,20 +1240,17 @@ class TestMatchesScipy:
             Nat,
             {"N": NatSmall, "k": NatSmall, "n": NatSmall},
             modified_scipy_hypergeom_logpmf,
-            skip_params_fn=lambda x: x["N"] < x["n"] or x["N"] < x["k"],
         )
         self.check_logcdf(
             HyperGeometric,
             Nat,
             {"N": NatSmall, "k": NatSmall, "n": NatSmall},
             modified_scipy_hypergeom_logcdf,
-            skip_params_fn=lambda x: x["N"] < x["n"] or x["N"] < x["k"],
         )
         self.check_selfconsistency_discrete_logcdf(
             HyperGeometric,
             Nat,
             {"N": NatSmall, "k": NatSmall, "n": NatSmall},
-            skip_params_fn=lambda x: x["N"] < x["n"] or x["N"] < x["k"],
         )
 
     def test_negative_binomial(self):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -29,8 +29,6 @@ from aesara.tensor.random.op import RandomVariable
 from aesara.tensor.var import TensorVariable
 from numpy import array, inf, log
 from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
-from packaging.version import parse
-from scipy import __version__ as scipy_version
 from scipy import integrate
 from scipy.special import erf, logit
 
@@ -109,8 +107,6 @@ from pymc3.math import kronecker
 from pymc3.model import Deterministic, Model, Point
 from pymc3.tests.helpers import select_by_precision
 from pymc3.vartypes import continuous_types
-
-SCIPY_VERSION = parse(scipy_version)
 
 
 def get_lkj_cases():
@@ -1570,29 +1566,19 @@ class TestMatchesScipy:
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
         )
 
-    @pytest.mark.skipif(
-        condition=(SCIPY_VERSION < parse("1.4.0")), reason="betabinom is new in Scipy 1.4.0"
-    )
-    def test_beta_binomial_logp(self):
+    def test_beta_binomial(self):
         self.check_logp(
             BetaBinomial,
             Nat,
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
             lambda value, alpha, beta, n: sp.betabinom.logpmf(value, a=alpha, b=beta, n=n),
         )
-
-    @pytest.mark.skipif(
-        condition=(SCIPY_VERSION < parse("1.4.0")), reason="betabinom is new in Scipy 1.4.0"
-    )
-    def test_beta_binomial_logcdf(self):
         self.check_logcdf(
             BetaBinomial,
             Nat,
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
             lambda value, alpha, beta, n: sp.betabinom.logcdf(value, a=alpha, b=beta, n=n),
         )
-
-    def test_beta_binomial_selfconsistency(self):
         self.check_selfconsistency_discrete_logcdf(
             BetaBinomial,
             Nat,

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1442,15 +1442,11 @@ class TestMatchesScipy:
         reason="Fails on float32 due to numerical issues",
     )
     def test_gamma_logcdf(self):
-        # pymc-devs/aesara#224: skip_paramdomain_outside_edge_test has to be set
-        # True to avoid triggering a C-level assertion in the Aesara GammaQ function
-        # in gamma.c file. Can be set back to False (default) once that issue is solved
         self.check_logcdf(
             Gamma,
             Rplus,
             {"alpha": Rplusbig, "beta": Rplusbig},
             lambda value, alpha, beta: sp.gamma.logcdf(value, alpha, scale=1.0 / beta),
-            skip_paramdomain_outside_edge_test=True,
         )
 
     def test_inverse_gamma_logp(self):
@@ -1460,23 +1456,17 @@ class TestMatchesScipy:
             {"alpha": Rplus, "beta": Rplus},
             lambda value, alpha, beta: sp.invgamma.logpdf(value, alpha, scale=beta),
         )
-        # pymc-devs/aesara#224: skip_paramdomain_outside_edge_test has to be set
-        # True to avoid triggering a C-level assertion in the Aesara GammaQ function
 
     @pytest.mark.skipif(
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to numerical issues",
     )
     def test_inverse_gamma_logcdf(self):
-        # pymc-devs/aesara#224: skip_paramdomain_outside_edge_test has to be set
-        # True to avoid triggering a C-level assertion in the Aesara GammaQ function
-        # in gamma.c file. Can be set back to False (default) once that issue is solved
         self.check_logcdf(
             InverseGamma,
             Rplus,
             {"alpha": Rplus, "beta": Rplus},
             lambda value, alpha, beta: sp.invgamma.logcdf(value, alpha, scale=beta),
-            skip_paramdomain_outside_edge_test=True,
         )
 
     @pytest.mark.skipif(

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1151,7 +1151,7 @@ class TestMatchesScipy:
         decimals = select_by_precision(float64=6, float32=1)
         assert_almost_equal(model.fastlogp(pt), logp, decimal=decimals, err_msg=str(pt))
 
-    def test_beta(self):
+    def test_beta_logp(self):
         self.check_logp(
             Beta,
             Unit,
@@ -1164,12 +1164,17 @@ class TestMatchesScipy:
             {"mu": Unit, "sigma": Rplus},
             beta_mu_sigma,
         )
+
+    @pytest.mark.skipif(
+        condition=(aesara.config.floatX == "float32"),
+        reason="Fails on float32 due to numerical issues",
+    )
+    def test_beta_logcdf(self):
         self.check_logcdf(
             Beta,
             Unit,
             {"alpha": Rplus, "beta": Rplus},
             lambda value, alpha, beta: sp.beta.logcdf(value, alpha, beta),
-            decimal=select_by_precision(float64=5, float32=3),
         )
 
     def test_kumaraswamy(self):
@@ -1373,7 +1378,7 @@ class TestMatchesScipy:
             lambda value, mu, sigma: sp.lognorm.logcdf(value, sigma, 0, np.exp(mu)),
         )
 
-    def test_t(self):
+    def test_studentt_logp(self):
         self.check_logp(
             StudentT,
             R,
@@ -1386,21 +1391,24 @@ class TestMatchesScipy:
             {"nu": Rplus, "mu": R, "sigma": Rplus},
             lambda value, nu, mu, sigma: sp.t.logpdf(value, nu, mu, sigma),
         )
+
+    @pytest.mark.skipif(
+        condition=(aesara.config.floatX == "float32"),
+        reason="Fails on float32 due to numerical issues",
+    )
+    def test_studentt_logcdf(self):
         self.check_logcdf(
             StudentT,
             R,
             {"nu": Rplus, "mu": R, "lam": Rplus},
             lambda value, nu, mu, lam: sp.t.logcdf(value, nu, mu, lam ** -0.5),
         )
-        # TODO: reenable when PR #4736 is merged
-        """
         self.check_logcdf(
             StudentT,
             R,
             {"nu": Rplus, "mu": R, "sigma": Rplus},
             lambda value, nu, mu, sigma: sp.t.logcdf(value, nu, mu, sigma),
         )
-        """
 
     def test_cauchy(self):
         self.check_logp(

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -24,8 +24,6 @@ import pytest
 import scipy.stats as st
 
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
-from packaging.version import parse
-from scipy import __version__ as scipy_version
 from scipy.special import expit
 
 import pymc3 as pm
@@ -46,8 +44,6 @@ from pymc3.tests.test_distributions import (
     build_model,
     product,
 )
-
-SCIPY_VERSION = parse(scipy_version)
 
 
 def pymc3_random(
@@ -1317,10 +1313,6 @@ class TestWeibull(BaseTestDistribution):
     ]
 
 
-@pytest.mark.skipif(
-    condition=(SCIPY_VERSION < parse("1.4.0")),
-    reason="betabinom is new in Scipy 1.4.0",
-)
 class TestBetaBinomial(BaseTestDistribution):
     pymc_dist = pm.BetaBinomial
     pymc_dist_params = {"alpha": 2.0, "beta": 1.0, "n": 5}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ fastprogress>=0.2.0
 numpy>=1.15.0
 pandas>=0.24.0
 patsy>=0.5.1
-scipy>=1.2.0
+scipy>=1.4.1
 typing-extensions>=3.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aesara>=2.0.9
+aesara>=2.1.0
 arviz>=0.11.2
 cachetools>=4.2.1
 dill


### PR DESCRIPTION
# Implement Betainc

This PR replaces the incomplete_beta method in dist_math by an aesara op `betainc` that wraps the `scipy.special.betainc` method. Supersedes #4519; Closes #4420.

This provides a large increase in speed (and graph compilation) even without providing the c_code implementation directly (this can always be added later). I did some comparisons [here](https://github.com/ricardoV94/derivatives_betainc/blob/master/comparison_aesara.ipynb). On my machine, the compilation time of a simple input/output function for the `incomplete_beta` was around 10 seconds, and it's pretty much instantaneous for the `betainc` as would be expected. Run time is ~2 orders of magnitude faster for the main op (even though it's calling scipy via Python), and ~4-5 orders of magnitude faster for the gradient.

It also allows the evaluation of the logcdf for multiple values in Beta, StudentT, Binomial, NegativeBinomial (and zero inflated variants). I removed the previous limitation warning when trying to evaluate these methods for multiple values. These changes are critical for any practical implementation of Truncated Versions of these distributions.

The derivative algorithm was adapted from [this paper](https://core.ac.uk/download/pdf/6303153.pdf) and requires the use of two extra "pseudo aesara ops" that simply wrap the equivalent python function. This does not allow for further graph optimizations, but I doubt aesara could do much with the previous scan implementation either. I did some extensive comparison with the STAN implementation, and these derivatives seem to be both faster and more accurate than theirs, although it's not easy to find a good numerical reference. Some discussion can be found in https://github.com/stan-dev/math/issues/2417

The one downside is the constant warning that the op has no `c-implementation` whenever the logp/logcdf makes use of it.

# Speedup logcdf tests

The logcdf tests are refactored to avoid recreating the logcdf graph for every parameter / value evaluation. This supersedes #4734. The old `incomplete_beta` was found to be defective when attempting #4734, and so I decided to merge the two PRs into this one instead.

This allows to remove most of the custom `n_samples` limitations, and makes the test suite run considerably faster.

A temporary work-around for the `HyperGeometric` tests was added, related to an optimization issue on Aesara side https://github.com/pymc-devs/aesara/issues/461

Finally, closes #4467 