### PR TITLE
Add workaround to make pylint pass until gp.predict is refactored

### DIFF
--- a/pymc3/gp/gp.py
+++ b/pymc3/gp/gp.py
@@ -555,6 +555,7 @@ class Marginal(Base):
         mu, cov = self.predictt(Xnew, diag, pred_noise, given)
         # XXX: This needs to be refactored
         # return draw_values([mu, cov], point=point)
+        return None, None
 
     def predictt(self, Xnew, diag=False, pred_noise=False, given=None):
         R"""
@@ -1195,6 +1196,7 @@ class MarginalKron(Base):
         mu, cov = self._build_conditional(Xnew, pred_noise, diag)
         # XXX: This needs to be refactored
         # return draw_values([mu, cov], point=point)
+        return None, None
 
     def predictt(self, Xnew, diag=False, pred_noise=False):
         R"""

--- a/pymc3/tests/test_gp.py
+++ b/pymc3/tests/test_gp.py
@@ -813,7 +813,7 @@ class TestMarginalVsLatent:
         npt.assert_allclose(latent_logp, self.logp, atol=5)
 
 
-@pytest.mark.xfail(reason="MvNormal was not yet refactored")
+@pytest.mark.xfail(reason="The `gp.predict` method was not yet refactored")
 class TestMarginalVsMarginalSparse:
     R"""
     Compare logp of models Marginal and MarginalSparse.
@@ -1114,7 +1114,7 @@ class TestLatentKron:
             gp.prior("f", Xs=[np.linspace(0, 1, 7)[:, None], np.linspace(0, 1, 5)[:, None]])
 
 
-@pytest.mark.xfail(reason="MvNormal was not yet refactored")
+@pytest.mark.xfail(reason="The `gp.predict` method was not yet refactored")
 class TestMarginalKron:
     """
     Compare gp.MarginalKron to gp.Marginal.


### PR DESCRIPTION
This adds a `return None, None` just to fix the `pylint` pre-commit check until the `gp.predict` method is refactored.

The latter is probably not too difficult, but should be combined with fixing the `pm.gp` module alltogether.