### PR TITLE
Rename references to the PyMC3 master branch to main

### DIFF
--- a/.github/workflows/arviz_compat.yml
+++ b/.github/workflows/arviz_compat.yml
@@ -3,7 +3,7 @@ name: arviz-compatibility
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   pytest:

--- a/.github/workflows/jaxtests.yml
+++ b/.github/workflows/jaxtests.yml
@@ -3,7 +3,7 @@ name: jax-sampling
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   pytest:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,7 +3,7 @@ name: pytest
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   pytest:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ name: windows
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   pytest:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ The preferred workflow for contributing to PyMC3 is to fork the [GitHub reposito
    $ git checkout -b my-feature
    ```
 
-   Always use a ``feature`` branch. It's good practice to never routinely work on the ``master`` branch of any repository.
+   Always use a ``feature`` branch. It's good practice to never routinely work on the ``main`` branch of any repository.
 
 4. Project requirements are in ``requirements.txt``, and libraries used for development are in ``requirements-dev.txt``. The easiest (and recommended) way to set up a development environment is via [miniconda](https://docs.conda.io/en/latest/miniconda.html):
 
@@ -73,7 +73,7 @@ The preferred workflow for contributing to PyMC3 is to fork the [GitHub reposito
    After committing, it is a good idea to sync with the base repository in case there have been any changes:
    ```bash
    $ git fetch upstream
-   $ git rebase upstream/master
+   $ git rebase upstream/main
    ```
 
    Then push the changes to your GitHub account with:

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://cdn.rawgit.com/pymc-devs/pymc3/master/docs/logos/svg/PyMC3_banner.svg
+.. image:: https://cdn.rawgit.com/pymc-devs/pymc3/main/docs/logos/svg/PyMC3_banner.svg
     :height: 100px
     :alt: PyMC3 logo
     :align: center
@@ -11,7 +11,7 @@ algorithms. Its flexibility and extensibility make it applicable to a
 large suite of problems.
 
 Check out the `getting started guide <http://docs.pymc.io/notebooks/getting_started>`__,  or
-`interact with live examples <https://mybinder.org/v2/gh/pymc-devs/pymc3/master?filepath=%2Fdocs%2Fsource%2Fnotebooks>`__
+`interact with live examples <https://mybinder.org/v2/gh/pymc-devs/pymc3/main?filepath=%2Fdocs%2Fsource%2Fnotebooks>`__
 using Binder!
 For questions on PyMC3, head on over to our `PyMC Discourse <https://discourse.pymc.io/>`__ forum.
 
@@ -100,7 +100,7 @@ License
 =======
 
 `Apache License, Version
-2.0 <https://github.com/pymc-devs/pymc3/blob/master/LICENSE>`__
+2.0 <https://github.com/pymc-devs/pymc3/blob/main/LICENSE>`__
 
 
 Software using PyMC3
@@ -129,7 +129,7 @@ Contributors
 ============
 
 See the `GitHub contributor
-page <https://github.com/pymc-devs/pymc3/graphs/contributors>`__. Also read our `Code of Conduct <https://github.com/pymc-devs/pymc3/blob/master/CODE_OF_CONDUCT.md>`__ guidelines for a better contributing experience.
+page <https://github.com/pymc-devs/pymc3/graphs/contributors>`__. Also read our `Code of Conduct <https://github.com/pymc-devs/pymc3/blob/main/CODE_OF_CONDUCT.md>`__ guidelines for a better contributing experience.
 
 Support
 =======
@@ -158,20 +158,20 @@ Sponsors
 |ODSC|
 
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/pymc-devs/pymc3/master?filepath=%2Fdocs%2Fsource%2Fnotebooks
+   :target: https://mybinder.org/v2/gh/pymc-devs/pymc3/main?filepath=%2Fdocs%2Fsource%2Fnotebooks
 .. |Build Status| image:: https://github.com/pymc-devs/pymc3/workflows/pytest/badge.svg
    :target: https://github.com/pymc-devs/pymc3/actions
-.. |Coverage| image:: https://codecov.io/gh/pymc-devs/pymc3/branch/master/graph/badge.svg
+.. |Coverage| image:: https://codecov.io/gh/pymc-devs/pymc3/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/pymc-devs/pymc3
 .. |Dockerhub| image:: https://img.shields.io/docker/automated/pymc/pymc3.svg
   :target: https://hub.docker.com/r/pymc/pymc3
 .. |NumFOCUS| image:: https://www.numfocus.org/wp-content/uploads/2017/03/1457562110.png
    :target: http://www.numfocus.org/
-.. |Quantopian| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/master/docs/quantopianlogo.jpg
+.. |Quantopian| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/quantopianlogo.jpg
    :target: https://quantopian.com
 .. |NumFOCUS_badge| image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
    :target: http://www.numfocus.org/
-.. |ODSC| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/master/docs/odsc_logo.png
+.. |ODSC| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/odsc_logo.png
    :target: https://odsc.com
 .. |tidelift| image:: https://img.shields.io/badge/-lifted!-2dd160.svg?colorA=58595b&style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAOCAYAAADJ7fe0AAAAAXNSR0IArs4c6QAAAAlwSFlzAAAWJQAAFiUBSVIk8AAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAAVhJREFUKBV1kj0vBFEUhmd2sdZHh2IlGhKFQuOviEYiNlFodCqtUqPxA%2FwCjUTnDygkGoVERFQaZFlE9nreO%2BdM5u5wkifvuee892Pu3CyEcA0DeIc%2B9IwftJsR6Cko3uCjguZdjuBZhhwmYDjGrOC96WED41UtsgEdGEAPlmAfpuAbFF%2BFZLfoMfRBGzThDtLgePPwBIpdddGzOArhPHUXowbNptE2www6a%2Fm96Y3pHN7oQ1s%2B13pxt1ENaKzBFWyWzaJ%2BRO0C9Jny6VPSoKjLVbMDC5bn5OPuJF%2BBSe95PVEMuugY5AegS9fCh7BedP45hRnj8TC34QQUe9bTZyh2KgvFk2vc8GIlXyTfsvqr6bPpNgv52ynnlomZJNpB70Xhl%2Bf6Sa02p1bApEfnETwxVa%2Faj%2BW%2FFtHltmxS%2FO3krvpTtTnVgu%2F6gvHRFvG78Ef3kOe5PimJXycY74blT5R%2BAAAAAElFTkSuQmCC
    :target: https://tidelift.com/subscription/pkg/pypi-pymc3?utm_source=pypi-pymc3&utm_medium=referral&utm_campaign=enterprise

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -13,9 +13,9 @@
     // project being benchmarked
     "repo": "..",
 
-    // List of branches to benchmark. If not provided, defaults to "master"
+    // List of branches to benchmark. If not provided, defaults to "main"
     // (for git) or "tip" (for mercurial).
-    "branches": ["master"],
+    "branches": ["main"],
 
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -189,7 +189,7 @@ Sponsors
 
 |NumFOCUS| |Quantopian| |ODSC|
 
-More details about sponsoring PyMC3 can be found `here <https://github.com/pymc-devs/pymc3/blob/master/GOVERNANCE.md#institutional-partners-and-funding>`_.
+More details about sponsoring PyMC3 can be found `here <https://github.com/pymc-devs/pymc3/blob/main/GOVERNANCE.md#institutional-partners-and-funding>`_.
 If you are interested in becoming a sponsor, reach out to `pymc.devs@gmail.com <pymc.devs@gmail.com>`_
 
 **************
@@ -266,9 +266,9 @@ See also
 .. |NumFOCUS| image:: https://numfocus.org/wp-content/uploads/2017/07/NumFocus_LRG.png
    :target: http://www.numfocus.org/
    :height: 120px
-.. |Quantopian| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/master/docs/quantopianlogo.jpg
+.. |Quantopian| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/quantopianlogo.jpg
    :target: https://quantopian.com
    :height: 120px
-.. |ODSC| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/master/docs/odsc_logo.png
+.. |ODSC| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/odsc_logo.png
    :target: https://odsc.com
    :height: 120px

--- a/docs/source/api/bounds.rst
+++ b/docs/source/api/bounds.rst
@@ -66,7 +66,7 @@ Caveats
 
 * Bounds cannot be given to variables that are ``observed``.  To model
   truncated data, use a :func:`~pymc3.model.Potential` in combination with a cumulative
-  probability function.  See `this example notebook <https://github.com/pymc-devs/pymc-examples/blob/main/examples/survival_analysis/weibull_aft.ipynb>`_.
+  probability function.  See `this example notebook <https://docs.pymc.io/pymc-examples/examples/survival_analysis/weibull_aft.html>`_.
 
 * The automatic transformation applied to continuous distributions results in
   an unnormalized probability distribution.  This doesn't effect inference

--- a/docs/source/api/bounds.rst
+++ b/docs/source/api/bounds.rst
@@ -66,7 +66,7 @@ Caveats
 
 * Bounds cannot be given to variables that are ``observed``.  To model
   truncated data, use a :func:`~pymc3.model.Potential` in combination with a cumulative
-  probability function.  See `this example notebook <https://github.com/pymc-devs/pymc3/blob/master/docs/source/notebooks/weibull_aft.ipynb>`_.
+  probability function.  See `this example notebook <https://github.com/pymc-devs/pymc-examples/blob/main/examples/survival_analysis/weibull_aft.ipynb>`_.
 
 * The automatic transformation applied to continuous distributions results in
   an unnormalized probability distribution.  This doesn't effect inference

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -23,9 +23,9 @@ Distribution
 A high-level introduction of ``Distribution`` in PyMC3 can be found in
 the `documentation <https://docs.pymc.io/Probability_Distributions.html>`__. The source
 code of the probability distributions is nested under
-`pymc3/distributions <https://github.com/pymc-devs/pymc3/blob/master/pymc3/distributions/>`__,
+`pymc3/distributions <https://github.com/pymc-devs/pymc3/blob/main/pymc3/distributions/>`__,
 with the ``Distribution`` class defined in `distribution.py
-<https://github.com/pymc-devs/pymc3/blob/master/pymc3/distributions/distribution.py#L23-L44>`__.
+<https://github.com/pymc-devs/pymc3/blob/main/pymc3/distributions/distribution.py#L23-L44>`__.
 A few important points to highlight in the Distribution Class:
 
 .. code:: python
@@ -712,7 +712,7 @@ dictionary with the free\_RVs being sampled now has a new value (if
 accepted, see
 `here <https://github.com/pymc-devs/pymc3/blob/6d07591962a6c135640a3c31903eba66b34e71d8/pymc3/step_methods/compound.py#L27>`__
 and
-`here <https://github.com/pymc-devs/pymc3/blob/master/pymc3/step_methods/compound.py#L41>`__).
+`here <https://github.com/pymc-devs/pymc3/blob/main/pymc3/step_methods/compound.py#L41>`__).
 There are some example in the `CompoundStep
 doc <https://docs.pymc.io/notebooks/sampling_compound_step.html#Specify-compound-steps>`__.
 
@@ -720,7 +720,7 @@ Transition kernel
 ^^^^^^^^^^^^^^^^^
 
 The base class for most MCMC sampler (except SMC) is in
-`ArrayStep <https://github.com/pymc-devs/pymc3/blob/master/pymc3/step_methods/arraystep.py>`__.
+`ArrayStep <https://github.com/pymc-devs/pymc3/blob/main/pymc3/step_methods/arraystep.py>`__.
 You can see that the ``step.step()`` is mapping the ``point`` into an
 array, and call ``self.astep()``, which is an array in, array out
 function. A pymc3 model compile a conditional logp/dlogp function that
@@ -764,7 +764,7 @@ The design of the VI module takes a different approach than
 MCMC - it has a functional design, and everything is done within Aesara
 (i.e., Optimization and building the variational objective). The base
 class of variational inference is
-`pymc3.variational.Inference <https://github.com/pymc-devs/pymc3/blob/master/pymc3/variational/inference.py>`__,
+`pymc3.variational.Inference <https://github.com/pymc-devs/pymc3/blob/main/pymc3/variational/inference.py>`__,
 where it builds the objective function by calling:
 
 .. code:: python
@@ -789,7 +789,7 @@ Approximation, and Test functions to combine them into single objective
 function. Currently we do not care too much about the test function, it
 is usually not required (and not implemented). The other primitives are
 defined as base classes in `this
-file <https://github.com/pymc-devs/pymc3/blob/master/pymc3/variational/opvi.py>`__.
+file <https://github.com/pymc-devs/pymc3/blob/main/pymc3/variational/opvi.py>`__.
 We use inheritance to easily implement a broad class of VI methods
 leaving a lot of flexibility for further extensions.
 
@@ -824,7 +824,7 @@ allows you to combine approximation into new approximation, but we will
 skip this for now and only consider ``SingleGroupApproximation`` like
 ``MeanField``): The definition of ``datalogp_norm``, ``logq_norm``,
 ``varlogp_norm`` are in
-`variational/opvi <https://github.com/pymc-devs/pymc3/blob/master/pymc3/variational/opvi.py>`__,
+`variational/opvi <https://github.com/pymc-devs/pymc3/blob/main/pymc3/variational/opvi.py>`__,
 strip away the normalizing term, ``datalogp`` and ``varlogp`` are
 expectation of the variational free\_RVs and data logp - we clone the
 datalogp and varlogp from the model, replace its input with Aesara
@@ -859,10 +859,10 @@ Some challenges and insights from implementing VI.
    on this feature. Internal usages are uncountable:
 
    -  we use this to `vectorize the
-      model <https://github.com/pymc-devs/pymc3/blob/master/pymc3/model.py#L972>`__
+      model <https://github.com/pymc-devs/pymc3/blob/main/pymc3/model.py#L972>`__
       for both MCMC and VI to speed up computations
    -  we use this to `create sampling
-      graph <https://github.com/pymc-devs/pymc3/blob/master/pymc3/variational/opvi.py#L1483>`__
+      graph <https://github.com/pymc-devs/pymc3/blob/main/pymc3/variational/opvi.py#L1483>`__
       for VI. This is the case you want posterior predictive as a part
       of computational graph.
 

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -712,7 +712,7 @@ dictionary with the free\_RVs being sampled now has a new value (if
 accepted, see
 `here <https://github.com/pymc-devs/pymc3/blob/6d07591962a6c135640a3c31903eba66b34e71d8/pymc3/step_methods/compound.py#L27>`__
 and
-`here <https://github.com/pymc-devs/pymc3/blob/main/pymc3/step_methods/compound.py#L41>`__).
+`here <https://github.com/pymc-devs/pymc3/blob/main/pymc3/step_methods/compound.py>`__).
 There are some example in the `CompoundStep
 doc <https://docs.pymc.io/notebooks/sampling_compound_step.html#Specify-compound-steps>`__.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -110,7 +110,7 @@
 
         <div class="ui vertical segment">
             <h2 class="ui dividing header">License</h2>
-            <p>PyMC3 is licensed <a href="https://github.com/pymc-devs/pymc3/blob/master/LICENSE">under the Apache License, V2.</a></p>
+            <p>PyMC3 is licensed <a href="https://github.com/pymc-devs/pymc3/blob/main/LICENSE">under the Apache License, V2.</a></p>
         </div>
 
         <div class="ui vertical segment">
@@ -140,12 +140,12 @@
                 </div>
                 <div class="column">
                     <a href="https://quantopian.com">
-                        <img class="ui image" height="120" src="https://raw.githubusercontent.com/pymc-devs/pymc3/master/docs/quantopianlogo.jpg"/>
+                        <img class="ui image" height="120" src="https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/quantopianlogo.jpg"/>
                     </a>
                 </div>
                 <div class="column">
                     <a href="https://odsc.com/">
-                        <img class="ui image" height="120" src="https://raw.githubusercontent.com/pymc-devs/pymc3/master/docs/odsc_logo.png"/>
+                        <img class="ui image" height="120" src="https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/odsc_logo.png"/>
                     </a>
                 </div>
             </div>

--- a/docs/source/semantic_sphinx/layout.html
+++ b/docs/source/semantic_sphinx/layout.html
@@ -54,7 +54,7 @@ such as on Chrome for documents on localhost #}
     <div class="ui container">
         <div class="ui large secondary pointing menu">
             <a class="item" href="/">
-                <img class="ui bottom aligned tiny image" src="https://cdn.rawgit.com/pymc-devs/pymc3/master/docs/logos/svg/PyMC3_banner.svg" />
+                <img class="ui bottom aligned tiny image" src="https://cdn.rawgit.com/pymc-devs/pymc3/main/docs/logos/svg/PyMC3_banner.svg" />
             </a>
             {% if
             theme_navbar_links %} {%- for link in theme_navbar_links %} <a href="{{ pathto(*link[1:]) }}" class="item">{{
@@ -74,7 +74,7 @@ such as on Chrome for documents on localhost #}
     </div>
     {% if pagename == 'index' %}
     <div class="ui center aligned text container">
-        <img src="https://cdn.rawgit.com/pymc-devs/pymc3/master/docs/logos/svg/PyMC3_banner.svg" />
+        <img src="https://cdn.rawgit.com/pymc-devs/pymc3/main/docs/logos/svg/PyMC3_banner.svg" />
         <h2>Probabilistic Programming in Python</h2>
         <a href="pymc-examples/examples/pymc3_howto/api_quickstart.html">
             <div class="ui huge primary button">Quickstart <i class="right arrow icon"></i></div>
@@ -89,14 +89,14 @@ such as on Chrome for documents on localhost #}
         <a class="ui image" href="https://github.com/pymc-devs/pymc3/actions">
             <img src="https://github.com/pymc-devs/pymc3/workflows/pytest/badge.svg">
         </a>
-        <a class="ui image" href="https://coveralls.io/github/pymc-devs/pymc3?branch=master">
-            <img src="https://coveralls.io/repos/github/pymc-devs/pymc3/badge.svg?branch=master">
+        <a class="ui image" href="https://coveralls.io/github/pymc-devs/pymc3?branch=main">
+            <img src="https://coveralls.io/repos/github/pymc-devs/pymc3/badge.svg?branch=main">
         </a>
         <a class="ui image" href="https://tidelift.com/subscription/pkg/pypi-pymc3?utm_source=pypi-pymc3&utm_medium=referral&utm_campaign=enterprise">
         <a class="ui image" href="https://www.numfocus.org/">
             <img src="https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A">
         </a>
-        <a class="ui image" href="https://mybinder.org/v2/gh/pymc-devs/pymc3/master?filepath=%2Fdocs%2Fsource%2Fnotebooks">
+        <a class="ui image" href="https://mybinder.org/v2/gh/pymc-devs/pymc3/main?filepath=%2Fdocs%2Fsource%2Fnotebooks">
             <img src="https://mybinder.org/badge_logo.svg">
         </a>
         <a class="ui image" href="https://hub.docker.com/r/pymc/pymc3">


### PR DESCRIPTION
This also renames the conditions in GitHub action workflow definitions.

Let's hope off this works out with the CI.