### PR TITLE
Mention both backends in the version number enumeration

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -18,7 +18,7 @@ If you have questions about a specific use case, or you are not sure whether thi
 ## Versions and main components
 
 * PyMC3 Version:
-* Aesara Version:
+* Aesara/Theano Version:
 * Python Version:
 * Operating system:
 * How did you install PyMC3: (conda/pip)


### PR DESCRIPTION
Lately people forget to include the `theano-pymc` version, because the issue template asks for Aesara.