### PR TITLE
Move from nbsphinx to myst-nb

### DIFF
--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -7,7 +7,7 @@ dependencies:
 - ipython>=7.16
 - libblas=*=*mkl
 - mkl-service
-- nbsphinx>=0.4
+- myst-nb
 - numpy=1.15
 - numpydoc>=0.9
 - pandas=0.24
@@ -16,7 +16,6 @@ dependencies:
 - pytest>=3.0
 - python-graphviz
 - python=3.7
-- recommonmark>=0.4
 - scipy=1.2
 - sphinx-autobuild>=0.7
 - sphinx>=1.5

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -7,14 +7,13 @@ dependencies:
 - ipython>=7.16
 - libblas=*=*mkl
 - mkl-service
-- nbsphinx>=0.4
+- myst-nb
 - numpydoc>=0.9
 - pre-commit>=2.8.0
 - pytest-cov>=2.5
 - pytest>=3.0
 - python-graphviz
 - python=3.8
-- recommonmark>=0.4
 - sphinx-autobuild>=0.7
 - sphinx>=1.5
 - watermark

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -7,14 +7,13 @@ dependencies:
 - ipython>=7.16
 - libblas=*=*mkl
 - mkl-service
-- nbsphinx>=0.4
+- myst-nb
 - numpydoc>=0.9
 - pre-commit>=2.8.0
 - pytest-cov>=2.5
 - pytest>=3.0
 - python-graphviz
 - python=3.9
-- recommonmark>=0.4
 - sphinx-autobuild>=0.7
 - sphinx>=1.5
 - watermark

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,7 @@
+""" Sphinx configuration file.
+
+   isort:skip_file
+"""
 #!/usr/bin/env python3
 #
 # pymc3 documentation build configuration file, created by
@@ -15,13 +19,13 @@
 import os
 import sys
 
-import pymc3
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(os.path.join("..", "..")))
 sys.path.insert(0, os.path.abspath("sphinxext"))
+import pymc3  # isort:skip
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,14 +37,13 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.mathjax",
     "sphinx.ext.intersphinx",
-    "nbsphinx",
     "numpydoc",
     "IPython.sphinxext.ipython_console_highlighting",
     "IPython.sphinxext.ipython_directive",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.napoleon",
     "gallery_generator",
-    "recommonmark",
+    "myst_nb",
 ]
 
 # Don't auto-generate summary for class members.
@@ -72,8 +71,8 @@ master_doc = "index"
 
 # General information about the project.
 project = "PyMC3"
-copyright = "2018, The PyMC Development Team"
-author = "PyMC developers"
+copyright = "2021, The PyMC Development Team"
+author = "PyMC contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -101,7 +100,7 @@ language = None
 # directories to ignore when looking for source files.
 exclude_patterns = ["_build", "**.ipynb_checkpoints"]
 
-nbsphinx_execute = "never"
+jupyter_execute_notebooks = "off"
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/fast_build_docs.sh
+++ b/fast_build_docs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-git --git-dir=docs/source/pymc-examples/.git --work-tree=docs/source/pymc-examples checkout fast-docs-build
+git --git-dir=docs/source/pymc-examples/.git --work-tree=docs/source/pymc-examples checkout main
 pushd docs/source
 make clean
 make html

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -531,7 +531,7 @@ class DirichletMultinomial(Discrete):
 
     .. math::
 
-    f(x \mid n, a) = \frac{\Gamma(n + 1)\Gamma(\sum a_k)}
+        f(x \mid n, a) = \frac{\Gamma(n + 1)\Gamma(\sum a_k)}
                               {\Gamma(\n + \sum a_k)}
                          \prod_{k=1}^K
                          \frac{\Gamma(x_k +  a_k)}

--- a/pymc3/distributions/timeseries.py
+++ b/pymc3/distributions/timeseries.py
@@ -486,6 +486,7 @@ class MvGaussianRandomWalk(distribution.Continuous):
 
         Examples
         -------
+
         .. code-block:: python
 
             with pm.Model():
@@ -502,6 +503,7 @@ class MvGaussianRandomWalk(distribution.Continuous):
                 # draw four samples from a 2-dimensional Gaussian random walk with 10 timesteps,
                 # indexed with a (2, 2) array
                 sample = MvGaussianRandomWalk(mu, cov, shape=(10, 2)).random(size=(2, 2))
+
         """
 
         # for each draw specified by the size input, we need to draw time_steps many

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -241,10 +241,9 @@ def log1mexp(x):
     https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
 
     References
-        ----------
-        .. [Machler2012] Martin Mächler (2012).
-            "Accurately computing `\log(1-\exp(- \mid a \mid))` Assessed by the Rmpfr
-            package"
+    ----------
+    .. [Machler2012] Martin Mächler (2012).
+       "Accurately computing `\log(1-\exp(- \mid a \mid))` Assessed by the Rmpfr package"
 
     """
     return at.switch(at.lt(x, 0.6931471805599453), at.log(-at.expm1(-x)), at.log1p(-at.exp(-x)))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,12 +3,11 @@
 
 h5py>=2.7
 ipython>=7.16
-nbsphinx>=0.4
+myst-nb
 numpydoc>=0.9
 pre-commit>=2.8.0
 pytest-cov>=2.5
 pytest>=3.0
-recommonmark>=0.4
 sphinx-autobuild>=0.7
 sphinx>=1.5
 watermark


### PR DESCRIPTION
My plan is to first make this change, which will work once the widget issue in
https://github.com/pymc-devs/pymc-examples/issues/83 is fixed, @chiral-carbon will
send a PR for this at some point tomorrow. Moving from nbsphinx to myst-nb will allow us
to use all sphinx features from within markdown. Therefore, if we write a glossary,
we'll be able to link to terms defined there with `` {term}`RV` `` from within any markdown cell
in notebooks, we'll be able to link to respective api docs with ``
{func}`pymc3.to_inference_data` `` or `` {class}`pymc3.Normal` ``, to define anchors with
`(anchor_name)=` and reference them with `` {ref}`anchor_name` `` and so on.

After that, I will also change the theme to pydata-sphinx-theme, like pandas and ArviZ. Note that
both changes are independent and we could do only one without the other, which is why I'm doing two
separate PRs. I think it would be great to change the appearance of the docs with 4.0, but
it would still be good to have myst already in v3 so we can start using it in pymc-examples without
breaking anything. We can then cherry pick this one onto v4 but not port the theme one.

cc @martinacantaro @ricardoV94 

+ [x] what are the (breaking) changes that this PR makes? **None**
+ [x] important background, or details about the implementation **see above**
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
