### PR TITLE
Create dedicated environment YML for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('conda-envs/environment-dev-py38.yml') }}
+            hashFiles('conda-envs/windows-environment-dev-py38.yml') }}
       - name: Cache multiple paths
         uses: actions/cache@v2
         env:
@@ -48,7 +48,7 @@ jobs:
         with:
           activate-environment: pymc3-dev-py38
           channel-priority: strict
-          environment-file: conda-envs/environment-dev-py38.yml
+          environment-file: conda-envs/windows-environment-dev-py38.yml
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Install-pymc3
         run: |

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -1,0 +1,26 @@
+name: pymc3-dev-py38
+channels:
+- conda-forge
+- defaults
+dependencies:
+ # base dependencies (see install guide for Windows)
+- h5py>=2.7
+- libpython
+- mkl-service
+- m2w64-toolchain
+- numba
+- pip
+- python=3.8
+- python-graphviz
+- scipy
+# Extra stuff for dev, testing and docs build
+- ipython>=7.16
+- nbsphinx>=0.4
+- numpydoc>=0.9
+- pre-commit>=2.8.0
+- pytest-cov>=2.5
+- pytest>=3.0
+- recommonmark>=0.4
+- sphinx-autobuild>=0.7
+- sphinx>=1.5
+- watermark

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -41,7 +41,17 @@ import re
 
 import yaml
 
-EXCLUDE = {"python", "libblas", "mkl-service", "python-graphviz"}
+EXCLUDE = {
+    "pip",
+    "python",
+    "libblas",
+    "libpython",
+    "m2w64-toolchain",
+    "mkl-service",
+    "numba",
+    "scipy",
+    "python-graphviz",
+}
 RENAME = {}
 
 


### PR DESCRIPTION
The install installation guide for Windows was recently updated after it was discovered that the combination of numba+scipy dependencies leads to the correct installation of BLAS dependencies.

This PR creates a conda `environment.yml` specifically for Windows. That's because the `m2w64-toolchain` dependency is Windows-only and conda does not yet support flags to make dependencies OS-specific.

The GitHub Action for Windows was changed to use the new environment file.
Maybe this fixes the CI issues for the `v3` branch.
