### PR TITLE
config issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,8 @@
-If you have questions about a specific use case, or you are not sure whether this is a bug or not, please post it to our discourse channel: https://discourse.pymc.io
+---
+name: 'Bug Report'
+about: Inform about bugs in the PyMC3 library
+
+---
 
 ## Description of your problem
 
@@ -8,9 +12,14 @@ If you have questions about a specific use case, or you are not sure whether thi
 ```
 
 **Please provide the full traceback.**
+
+<details><summary>Complete error traceback</summary>
+
 ```python
-[The error output here]
+[The complete error output here]
 ```
+
+</details>
 
 **Please provide any additional information below.**
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: PyMC Discourse
+    url: https://discourse.pymc.io/
+    about: Ask usage questions about PyMC3
+  - name: Example notebook error report
+    url: https://github.com/pymc-devs/pymc-examples/issues
+    about: Please report errors or desired extensions to the tutorials and examples here.


### PR DESCRIPTION
This will add a menu automatically when users click on "New Issue" button. IIUC, this
menu will have 4 options:

* Use bug report template to submit an issue to pymc3 repo
* Link to discourse for usage questions
* Link to pymc-examples/issues for notebook related issues
* Automatic link to security vulnerabilities page

We may want to add a feature request template or something of the sort.
