### PR TITLE
Add docstrings to functions in gp/utils.py

### DIFF
--- a/pymc3/gp/util.py
+++ b/pymc3/gp/util.py
@@ -27,6 +27,12 @@ solve = Solve(A_structure="general")
 
 
 def infer_shape(X, n_points=None):
+    R"""
+    Maybe attempt to infer the shape of a Gaussian process input matrix.
+
+    If a specific shape cannot be inferred, for instance if X is symbolic, then an
+    error is raised.
+    """
     if n_points is None:
         try:
             n_points = np.int(X.shape[0])
@@ -35,12 +41,22 @@ def infer_shape(X, n_points=None):
     return n_points
 
 
-def stabilize(K):
-    """adds small diagonal to a covariance matrix"""
-    return K + 1e-6 * at.identity_like(K)
+def stabilize(K, c=1e-6):
+    R"""
+    Adds small diagonal to a covariance matrix.  
+
+    Often the matrices calculated from covariance functions, `K = cov_func(X)`
+    do not appear numerically to be positive semi-definite.  Adding a small 
+    correction, `c`, to the diagonal is usually enough to fix this.
+    """
+    return K + c * at.identity_like(K)
 
 
 def kmeans_inducing_points(n_inducing, X):
+    R"""
+    Use the K-means algorithm to initialize the locations `X` for the inducing
+    points `fu`.
+    """
     # first whiten X
     if isinstance(X, TensorConstant):
         X = X.value

--- a/pymc3/gp/util.py
+++ b/pymc3/gp/util.py
@@ -32,6 +32,14 @@ def infer_shape(X, n_points=None):
 
     If a specific shape cannot be inferred, for instance if X is symbolic, then an
     error is raised.
+
+    Parameters
+    ----------
+    X: array-like
+        Gaussian process input matrix.
+    n_points: None or int
+        The number of rows of `X`.  If `None`, the number of rows of `X` is 
+        calculated from `X` if possible.
     """
     if n_points is None:
         try:
@@ -48,6 +56,13 @@ def stabilize(K, c=1e-6):
     Often the matrices calculated from covariance functions, `K = cov_func(X)`
     do not appear numerically to be positive semi-definite.  Adding a small 
     correction, `c`, to the diagonal is usually enough to fix this.
+
+    Parameters
+    ----------
+    K: array-like
+        A square covariance or kernel matrix.
+    c: float
+        A small constant.
     """
     return K + c * at.identity_like(K)
 
@@ -56,6 +71,13 @@ def kmeans_inducing_points(n_inducing, X):
     R"""
     Use the K-means algorithm to initialize the locations `X` for the inducing
     points `fu`.
+
+    Parameters
+    ----------
+    n_inducing: int
+        The number of inducing points (or k, the number of clusters)
+    X: array-like
+        Gaussian process input matrix.
     """
     # first whiten X
     if isinstance(X, TensorConstant):

--- a/pymc3/gp/util.py
+++ b/pymc3/gp/util.py
@@ -38,7 +38,7 @@ def infer_shape(X, n_points=None):
     X: array-like
         Gaussian process input matrix.
     n_points: None or int
-        The number of rows of `X`.  If `None`, the number of rows of `X` is 
+        The number of rows of `X`.  If `None`, the number of rows of `X` is
         calculated from `X` if possible.
     """
     if n_points is None:
@@ -51,10 +51,10 @@ def infer_shape(X, n_points=None):
 
 def stabilize(K, c=1e-6):
     R"""
-    Adds small diagonal to a covariance matrix.  
+    Adds small diagonal to a covariance matrix.
 
     Often the matrices calculated from covariance functions, `K = cov_func(X)`
-    do not appear numerically to be positive semi-definite.  Adding a small 
+    do not appear numerically to be positive semi-definite.  Adding a small
     correction, `c`, to the diagonal is usually enough to fix this.
 
     Parameters


### PR DESCRIPTION
Fix for #4763 by adding a docstring to `gp/utils.py:stabilize`.  Also added short docstrings to `infer_shape` and `kmeans_inducing_points`. 


**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [ ] important background, or details about the implementation. Docstring fix
+ [ ] are the changes—especially new features—covered by tests and docstrings? NA
+ [ ] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples) NA
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
