### PR TITLE
Test predictive sampling with deterministic of shared

### DIFF
--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1315,6 +1315,7 @@ class TestMatchesScipy:
             R,
             {"b": Rplus, "kappa": Rplus, "mu": R},
             laplace_asymmetric_logpdf,
+            decimal=select_by_precision(float64=6, float32=2),
         )
 
     def test_lognormal(self):

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -1011,9 +1011,11 @@ class TestSamplePriorPredictive(SeededTest):
         with pm.Model() as m:
             p = pm.Beta("p", 1.0, 1.0)
             y = pm.Bernoulli("y", p, observed=obs)
+            o = pm.Deterministic("o", obs)
             gen1 = pm.sample_prior_predictive(draws)
 
         assert gen1["y"].shape == (draws, n1)
+        assert gen1["o"].shape == (draws, n1)
 
         n2 = 20
         obs.set_value(np.random.rand(n2) < 0.5)
@@ -1021,6 +1023,7 @@ class TestSamplePriorPredictive(SeededTest):
             gen2 = pm.sample_prior_predictive(draws)
 
         assert gen2["y"].shape == (draws, n2)
+        assert gen2["o"].shape == (draws, n2)
 
     @pytest.mark.xfail(reason="DensityDist not refactored for v4")
     def test_density_dist(self):


### PR DESCRIPTION
Tweak test to cover issue reported in #3665. 

This test fails in `V3`, but passes in `main` after the `V4` refactoring.