### PR TITLE
SMC return inferencedata and perform convergence checks

### DIFF
--- a/pymc3/backends/arviz.py
+++ b/pymc3/backends/arviz.py
@@ -119,7 +119,12 @@ def dict_to_dataset(
     """
     if default_dims is None:
         return _dict_to_dataset(
-            data, library=library, coords=coords, dims=dims, skip_event_dims=skip_event_dims
+            data,
+            attrs=attrs,
+            library=library,
+            coords=coords,
+            dims=dims,
+            skip_event_dims=skip_event_dims,
         )
     else:
         out_data = {}
@@ -129,7 +134,7 @@ def dict_to_dataset(
             val_dims, coords = generate_dims_coords(vals.shape, name, dims=val_dims, coords=coords)
             coords = {key: xr.IndexVariable((key,), data=coords[key]) for key in val_dims}
             out_data[name] = xr.DataArray(vals, dims=val_dims, coords=coords)
-        return xr.Dataset(data_vars=out_data, attrs=make_attrs(library=library))
+        return xr.Dataset(data_vars=out_data, attrs=make_attrs(attrs=attrs, library=library))
 
 
 class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes

--- a/pymc3/tests/test_smc.py
+++ b/pymc3/tests/test_smc.py
@@ -62,7 +62,7 @@ class TestSMC(SeededTest):
 
     def test_sample(self):
         with self.SMC_test:
-            mtrace = pm.sample_smc(draws=self.samples)
+            mtrace = pm.sample_smc(draws=self.samples, return_inferencedata=False)
 
         x = mtrace["X"]
         mu1d = np.abs(x).mean(axis=0)
@@ -73,7 +73,7 @@ class TestSMC(SeededTest):
             a = pm.Poisson("a", 5)
             b = pm.HalfNormal("b", 10)
             y = pm.Normal("y", a, b, observed=[1, 2, 3, 4])
-            trace = pm.sample_smc()
+            trace = pm.sample_smc(draws=10)
 
     def test_ml(self):
         data = np.repeat([1, 0], [50, 50])
@@ -85,7 +85,7 @@ class TestSMC(SeededTest):
             with pm.Model() as model:
                 a = pm.Beta("a", alpha, beta)
                 y = pm.Bernoulli("y", a, observed=data)
-                trace = pm.sample_smc(2000)
+                trace = pm.sample_smc(2000, return_inferencedata=False)
                 marginals.append(trace.report.log_marginal_likelihood)
         # compare to the analytical result
         assert abs(np.exp(np.mean(marginals[1]) - np.mean(marginals[0])) - 4.0) <= 1
@@ -99,7 +99,7 @@ class TestSMC(SeededTest):
                 "a": np.random.poisson(5, size=500),
                 "b_log__": np.abs(np.random.normal(0, 10, size=500)),
             }
-            trace = pm.sample_smc(500, start=start)
+            trace = pm.sample_smc(500, chains=1, start=start)
 
     def test_slowdown_warning(self):
         with aesara.config.change_flags(floatX="float32"):
@@ -107,7 +107,7 @@ class TestSMC(SeededTest):
                 with pm.Model() as model:
                     a = pm.Poisson("a", 5)
                     y = pm.Normal("y", a, 5, observed=[1, 2, 3, 4])
-                    trace = pm.sample_smc()
+                    trace = pm.sample_smc(draws=100, chains=2)
 
     def test_return_datatype(self):
         chains = 2

--- a/pymc3/tests/test_smc.py
+++ b/pymc3/tests/test_smc.py
@@ -109,8 +109,8 @@ class TestSMC(SeededTest):
                     y = pm.Normal("y", a, 5, observed=[1, 2, 3, 4])
                     trace = pm.sample_smc(draws=100, chains=2)
 
-    def test_return_datatype(self):
-        chains = 2
+    @pytest.mark.parametrize("chains", (1, 2))
+    def test_return_datatype(self, chains):
         draws = 10
 
         with pm.Model() as m:
@@ -121,6 +121,7 @@ class TestSMC(SeededTest):
             mt = pm.sample_smc(chains=chains, draws=draws, return_inferencedata=False)
 
         assert isinstance(idata, InferenceData)
+        assert "sample_stats" in idata
         assert len(idata.posterior.chain) == chains
         assert len(idata.posterior.draw) == draws
 


### PR DESCRIPTION
This PR makes `sample_smc` return InferenceData and run convergence checks by default.

@aloctavodia I am not familiar at all with `InferenceData` objects so let me know if I am doing something wrong or not returning as much information as we could / should. 

You mentioned in https://github.com/pymc-devs/pymc3/pull/4802#discussion_r659476595 that we could store the `betas` and the `log_likelihood` in `sample_stats`. However, the `log_likelihood` appears magically in the returned idata, is this one correct? Should we manually add ours instead, since it is already pre-computed. Or did you mean the `log_marginal_likelihood`?

These are the variables stored previously in `trace.report`:
```python
trace.report._n_draws = draws
trace.report._n_tune = 0
trace.report.log_marginal_likelihood = np.array(log_marginal_likelihoods)
trace.report.log_pseudolikelihood = log_pseudolikelihood
trace.report.betas = betas
trace.report.accept_ratios = accept_ratios
trace.report.nsteps = nsteps
trace.report._t_sampling = time.time() - t1
```

Also I am running the same convergence checks as in the normal `pm.sample`, should we do this or instead, implement specific checks for `SMC` (or do nothing at all)?

