### PR TITLE
Combine coverage across test matrix

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Run tests
         run: |
           conda activate pymc3-dev-py37
-          python -m pytest -vv --cov=pymc3 --cov-report=xml --cov-report term --durations=50 $TEST_SUBSET
+          python -m pytest -vv --cov=pymc3 --cov-append --cov-report=xml --cov-report term --durations=50 $TEST_SUBSET
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
@@ -200,4 +200,4 @@ jobs:
         # The ">-" in the next line replaces newlines with spaces (see https://stackoverflow.com/a/66809682).
         run: >-
           conda activate pymc3-dev-py38 &&
-          python -m pytest -vv --cov=pymc3 --cov-report=xml --cov-report term --durations=50 %TEST_SUBSET%
+          python -m pytest -vv --cov=pymc3 --cov-append --cov-report=xml --cov-report term --durations=50 %TEST_SUBSET%


### PR DESCRIPTION
The coverage badge in the readme shows only 69 %.. It's probably because the coverage stats are not combined across test jobs.

Even better would be to add a separate upload job that depends on both `ubuntu` and `windows` jobs. This way we could merge coverage across platforms.

Does anybody here speak GitHub Action YAML ?