### PR TITLE
Fail CI on XPASS and remove XFAIL marks on tests that succeed

### DIFF
--- a/pymc3/tests/backend_fixtures.py
+++ b/pymc3/tests/backend_fixtures.py
@@ -250,7 +250,6 @@ class SamplingTestCase(ModelBackendSetupTestCase):
         else:
             self.strace.record(point=point)
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_standard_close(self):
         for idx in range(self.draws):
             self.record_point(idx)
@@ -293,14 +292,12 @@ class SelectionTestCase(ModelBackendSampledTestCase):
     - shape
     """
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_get_values_default(self):
         for varname in self.test_point.keys():
             expected = np.concatenate([self.expected[chain][varname] for chain in [0, 1]])
             result = self.mtrace.get_values(varname)
             npt.assert_equal(result, expected)
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_get_values_nocombine_burn_keyword(self):
         burn = 2
         for varname in self.test_point.keys():
@@ -311,7 +308,6 @@ class SelectionTestCase(ModelBackendSampledTestCase):
     def test_len(self):
         assert len(self.mtrace) == self.draws
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_dtypes(self):
         for varname in self.test_point.keys():
             assert (

--- a/pymc3/tests/test_data_container.py
+++ b/pymc3/tests/test_data_container.py
@@ -36,7 +36,6 @@ class TestData(SeededTest):
             pm.Normal("y", 0, 1, observed=X)
             model.logp(model.initial_point)
 
-    @pytest.mark.xfail(reason="Competence hasn't been updated")
     def test_sample(self):
         x = np.random.normal(size=100)
         y = x + np.random.normal(scale=1e-2, size=100)

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1274,7 +1274,6 @@ class TestMatchesScipy:
             n_samples=10,
         )
 
-    @pytest.mark.xfail(reason="Distribution not refactored yet")
     @pytest.mark.parametrize(
         "mu, p, alpha, n, expected",
         [
@@ -1580,7 +1579,6 @@ class TestMatchesScipy:
             lambda value, alpha, beta, n: sp.betabinom.logpmf(value, a=alpha, b=beta, n=n),
         )
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     @pytest.mark.skipif(
         condition=(SCIPY_VERSION < parse("1.4.0")), reason="betabinom is new in Scipy 1.4.0"
     )
@@ -2051,7 +2049,7 @@ class TestMatchesScipy:
         #
         # self.checkd(Wishart, PdMatrix(n), {'n': Domain([2, 3, 4, 2000]), 'V': PdMatrix(n)},
         #             checks=[self.check_dlogp])
-        pass
+        raise NotImplementedError("Test is not implemented because of numerical issues.")
 
     @pytest.mark.parametrize("x,eta,n,lp", LKJ_CASES)
     @pytest.mark.xfail(reason="Distribution not refactored yet")
@@ -2584,6 +2582,8 @@ class TestMatchesScipy:
             {"b": Rplus, "sigma": Rplusbig},
             lambda value, b, sigma: sp.rice.logpdf(value, b=b, loc=0, scale=sigma),
         )
+        if aesara.config.floatX == "float32":
+            raise Exception("Flaky test: It passed this time, but XPASS is not allowed.")
 
     def test_rice_nu(self):
         self.check_logp(
@@ -2614,6 +2614,8 @@ class TestMatchesScipy:
             {"mu": R, "sigma": Rplusbig},
             lambda value, mu, sigma: floatX(sp.moyal.logcdf(value, mu, sigma)),
         )
+        if aesara.config.floatX == "float32":
+            raise Exception("Flaky test: It passed this time, but XPASS is not allowed.")
 
     @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_interpolated(self):

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -1324,7 +1324,6 @@ class TestInterpolated(BaseTestDistribution):
     )
     tests_to_run = ["check_rv_size", "test_interpolated"]
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_interpolated(self):
         for mu in R.vals:
             for sigma in Rplus.vals:
@@ -1821,7 +1820,6 @@ class TestDensityDist:
             pm.sample_posterior_predictive(idata, samples=samples, model=model, size=100)
 
 
-@pytest.mark.xfail(reason="This distribution has not been refactored for v4")
 class TestNestedRandom(SeededTest):
     def build_model(self, distribution, shape, nested_rvs_info):
         with pm.Model() as model:
@@ -2045,6 +2043,7 @@ class TestNestedRandom(SeededTest):
         ],
         ids=str,
     )
+    @pytest.mark.xfail(reason="TruncatedNormal not yet refactored for v4")
     def test_TruncatedNormal(
         self,
         prior_samples,

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -194,7 +194,6 @@ def build_disaster_model(masked=False):
 
 
 class TestDisasterModel(SeededTest):
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     # Time series of recorded coal mining disasters in the UK from 1851 to 1962
     def test_disaster_model(self):
         model = build_disaster_model(masked=False)
@@ -206,7 +205,6 @@ class TestDisasterModel(SeededTest):
             idata = pm.sample(500, tune=50, start=start, step=step, chains=2)
             az.summary(idata)
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_disaster_model_missing(self):
         model = build_disaster_model(masked=True)
         with model:
@@ -319,7 +317,6 @@ class TestRSV(SeededTest):
             pm.sample(50, step=[pm.NUTS(), pm.Metropolis()])
 
 
-@pytest.mark.xfail(reason="MLDA hasn't been refactored")
 class TestMultilevelNormal(SeededTest):
     """
     Toy three-level normal model sampled using MLDA. The finest model is a

--- a/pymc3/tests/test_model_func.py
+++ b/pymc3/tests/test_model_func.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 
 import numpy as np
-import pytest
 import scipy.stats as sp
 
 import pymc3 as pm
@@ -37,7 +36,6 @@ def test_dlogp():
     close_to(dlogp(start), -(start["x"] - mu) / sig ** 2, 1.0 / sig ** 2 / 100.0)
 
 
-@pytest.mark.xfail(reason="MvNormal not implemented")
 def test_dlogp2():
     start, model, (_, sig) = mv_simple()
     H = np.linalg.inv(sig)

--- a/pymc3/tests/test_ode.py
+++ b/pymc3/tests/test_ode.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import sys
+
 import aesara
 import numpy as np
 import pytest
@@ -23,6 +25,9 @@ import pymc3 as pm
 
 from pymc3.ode import DifferentialEquation
 from pymc3.ode.utils import augment_system
+
+IS_FLOAT32 = aesara.config.floatX == "float32"
+IS_WINDOWS = sys.platform == "win32"
 
 
 def test_gradients():
@@ -211,22 +216,22 @@ class TestErrors:
 
     ode_model = DifferentialEquation(func=system, t0=0, times=times, n_states=1, n_theta=1)
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_many_params(self):
         with pytest.raises(pm.ShapeError):
             self.ode_model(theta=[1, 1], y0=[0])
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_many_y0(self):
         with pytest.raises(pm.ShapeError):
             self.ode_model(theta=[1], y0=[0, 0])
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_few_params(self):
         with pytest.raises(pm.ShapeError):
             self.ode_model(theta=[], y0=[1])
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_few_y0(self):
         with pytest.raises(pm.ShapeError):
             self.ode_model(theta=[1], y0=[])
@@ -326,7 +331,9 @@ class TestDiffEqModel:
         assert idata.posterior["y0"].shape == (1, 100)
         assert idata.posterior["sigma"].shape == (1, 100)
 
-    @pytest.mark.xfail(reason="https://github.com/pymc-devs/aesara/issues/390")
+    @pytest.mark.xfail(
+        condition=IS_WINDOWS, reason="https://github.com/pymc-devs/aesara/issues/390"
+    )
     def test_vector_ode_1_param(self):
         """Test running model for a vector ODE with 1 parameter"""
 

--- a/pymc3/tests/test_posteriors.py
+++ b/pymc3/tests/test_posteriors.py
@@ -12,13 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import aesara
 import pytest
 
 from pymc3.tests import sampler_fixtures as sf
 
 
-@pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
 class TestNUTSUniform(sf.NutsFixture, sf.UniformFixture):
     n_samples = 10000
     tune = 1000

--- a/pymc3/tests/test_quadpotential.py
+++ b/pymc3/tests/test_quadpotential.py
@@ -281,7 +281,6 @@ def test_full_adapt_sampling(seed=289586):
         pymc3.sample(draws=10, tune=1000, random_seed=seed, step=step, cores=1, chains=1)
 
 
-@pytest.mark.xfail(reason="ADVI has not been refactored for v4")
 def test_issue_3965():
     with pymc3.Model():
         pymc3.Normal("n")

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -38,7 +38,6 @@ from pymc3.tests.helpers import SeededTest
 from pymc3.tests.models import simple_init
 
 
-@pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
 class TestSample(SeededTest):
     def setup_method(self):
         super().setup_method()

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -958,7 +958,6 @@ class TestDEMetropolisZ:
 
 
 class TestNutsCheckTrace:
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_multiple_samplers(self, caplog):
         with Model():
             prob = Beta("prob", alpha=5.0, beta=3.0)

--- a/pymc3/tests/test_transforms.py
+++ b/pymc3/tests/test_transforms.py
@@ -261,7 +261,6 @@ def test_chain_values():
     close_to_logical(np.diff(vals) >= 0, True, tol)
 
 
-@pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
 def test_chain_vector_transform():
     chain_tranf = tr.Chain([tr.logodds, tr.ordered])
     check_vector_transform(chain_tranf, UnitSortedVector(3))
@@ -420,7 +419,6 @@ class TestElementWiseLogp(SeededTest):
             (np.ones(3), (4, 3)),
         ],
     )
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_half_normal_ordered(self, sd, size):
         initval = np.sort(np.abs(np.random.randn(*size)))
         model = self.build_model(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
-[pytest]
+[tool.pytest.ini_options]
+minversion = "6.0"
 xfail_strict=true
 
 [tool.black]


### PR DESCRIPTION
Closes #4743

This may lead to quite a number of CI failures during refactoring, but this way we can solidify the refactored API faster.

My local runs of the test suites indicated that we have at least 72 tests that are XPASSing... https://github.com/conda-forge/pymc3-feedstock/issues/69#issuecomment-869166748

The first commit/CI run will fail spectacularly. I'll fowllow it up with a commit that removes the XFAIL marks on all the tests that XPASS.