### PR TITLE
Add progressbar to `sample_smc` and deprecate `parallel`

### DIFF
--- a/pymc3/tests/test_smc.py
+++ b/pymc3/tests/test_smc.py
@@ -75,7 +75,7 @@ class TestSMC(SeededTest):
 
             mtrace = pm.sample_smc(
                 draws=self.samples,
-                cores=1,  # Fails in pallel due to #4799
+                cores=1,  # Fails in parallel due to #4799
                 return_inferencedata=False,
             )
 

--- a/pymc3/tests/test_smc.py
+++ b/pymc3/tests/test_smc.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import time
+
 import aesara
 import aesara.tensor as at
 import numpy as np
@@ -60,9 +62,22 @@ class TestSMC(SeededTest):
 
         self.muref = mu1
 
+        with pm.Model() as self.fast_model:
+            x = pm.Normal("x", 0, 1)
+            y = pm.Normal("y", x, 1, observed=0)
+
+        with pm.Model() as self.slow_model:
+            x = pm.Normal("x", 0, 1)
+            y = pm.Normal("y", x, 1, observed=100)
+
     def test_sample(self):
         with self.SMC_test:
-            mtrace = pm.sample_smc(draws=self.samples, return_inferencedata=False)
+
+            mtrace = pm.sample_smc(
+                draws=self.samples,
+                cores=1,  # Fails in pallel due to #4799
+                return_inferencedata=False,
+            )
 
         x = mtrace["X"]
         mu1d = np.abs(x).mean(axis=0)
@@ -107,38 +122,64 @@ class TestSMC(SeededTest):
                 with pm.Model() as model:
                     a = pm.Poisson("a", 5)
                     y = pm.Normal("y", a, 5, observed=[1, 2, 3, 4])
-                    trace = pm.sample_smc(draws=100, chains=2)
+                    trace = pm.sample_smc(draws=100, chains=2, cores=1)
 
     @pytest.mark.parametrize("chains", (1, 2))
     def test_return_datatype(self, chains):
         draws = 10
 
-        with pm.Model() as m:
-            x = pm.Normal("x", 0, 1)
-            y = pm.Normal("y", x, 1, observed=5)
-
+        with self.fast_model:
             idata = pm.sample_smc(chains=chains, draws=draws)
             mt = pm.sample_smc(chains=chains, draws=draws, return_inferencedata=False)
 
         assert isinstance(idata, InferenceData)
         assert "sample_stats" in idata
-        assert len(idata.posterior.chain) == chains
-        assert len(idata.posterior.draw) == draws
+        assert idata.posterior.dims["chain"] == chains
+        assert idata.posterior.dims["draw"] == draws
 
         assert isinstance(mt, MultiTrace)
         assert mt.nchains == chains
         assert mt["x"].size == chains * draws
 
     def test_convergence_checks(self):
-        with pm.Model() as m:
-            x = pm.Normal("x", 0, 1)
-            y = pm.Normal("y", x, 1, observed=5)
-
+        with self.fast_model:
             with pytest.warns(
                 UserWarning,
                 match="The number of samples is too small",
             ):
                 pm.sample_smc(draws=99)
+
+    def test_parallel_sampling(self):
+        # Cache graph
+        with self.slow_model:
+            _ = pm.sample_smc(draws=10, chains=1, cores=1, return_inferencedata=False)
+
+        chains = 4
+        draws = 100
+
+        t0 = time.time()
+        with self.slow_model:
+            idata = pm.sample_smc(draws=draws, chains=chains, cores=4)
+        t_mp = time.time() - t0
+        assert idata.posterior.dims["chain"] == chains
+        assert idata.posterior.dims["draw"] == draws
+
+        t0 = time.time()
+        with self.slow_model:
+            idata = pm.sample_smc(draws=draws, chains=chains, cores=1)
+        t_seq = time.time() - t0
+        assert idata.posterior.dims["chain"] == chains
+        assert idata.posterior.dims["draw"] == draws
+
+        assert t_mp < t_seq
+
+    def test_depracated_parallel_arg(self):
+        with self.fast_model:
+            with pytest.warns(
+                DeprecationWarning,
+                match="The argument parallel is deprecated",
+            ):
+                pm.sample_smc(draws=10, chains=1, parallel=False)
 
 
 @pytest.mark.xfail(reason="SMC-ABC not refactored yet")


### PR DESCRIPTION
This PR adds a progressbar to `sample_smc` and deprecates `parallel` argument to bring its signature closer to `pm.sample`.

The progressbar shares the same limitations described in #https://github.com/pymc-devs/pymc3/issues/4349