### PR TITLE
Reenable tests that were mostly good already

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -71,6 +71,7 @@ jobs:
           - |
             pymc3/tests/test_parallel_sampling.py
             pymc3/tests/test_sampling.py
+            pymc3/tests/test_tuning.py
 
           - |
             pymc3/tests/test_idata_conversion.py
@@ -152,6 +153,7 @@ jobs:
           - |
             pymc3/tests/test_parallel_sampling.py
             pymc3/tests/test_sampling.py
+            pymc3/tests/test_tuning.py
             pymc3/tests/test_shared.py
           - |
             pymc3/tests/test_gp.py

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,6 +34,7 @@ jobs:
             --ignore=pymc3/tests/test_model_graph.py
             --ignore=pymc3/tests/test_modelcontext.py
             --ignore=pymc3/tests/test_parallel_sampling.py
+            --ignore=pymc3/tests/test_sampling.py
             --ignore=pymc3/tests/test_profile.py
             --ignore=pymc3/tests/test_step.py
             --ignore=pymc3/tests/test_tuning.py
@@ -68,6 +69,10 @@ jobs:
             pymc3/tests/test_updates.py
 
           - |
+            pymc3/tests/test_parallel_sampling.py
+            pymc3/tests/test_sampling.py
+
+          - |
             pymc3/tests/test_idata_conversion.py
             pymc3/tests/test_distributions_random.py
             pymc3/tests/test_distributions_timeseries.py
@@ -78,6 +83,7 @@ jobs:
             pymc3/tests/test_model_graph.py
             pymc3/tests/test_ode.py
             pymc3/tests/test_posdef_sym.py
+            pymc3/tests/test_profile.py
             pymc3/tests/test_quadpotential.py
             pymc3/tests/test_shape_handling.py
             pymc3/tests/test_step.py
@@ -144,6 +150,7 @@ jobs:
             pymc3/tests/test_distributions_random.py
             pymc3/tests/test_distributions_timeseries.py
           - |
+            pymc3/tests/test_parallel_sampling.py
             pymc3/tests/test_sampling.py
             pymc3/tests/test_shared.py
           - |
@@ -155,6 +162,7 @@ jobs:
             pymc3/tests/test_modelcontext.py
             pymc3/tests/test_model_graph.py
             pymc3/tests/test_pickling.py
+            pymc3/tests/test_profile.py
 
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,6 +57,8 @@ jobs:
             --ignore=pymc3/tests/test_distributions_random.py
             --ignore=pymc3/tests/test_idata_conversion.py
 
+          - pymc3/tests/test_distributions.py
+
           - |
             pymc3/tests/test_modelcontext.py
             pymc3/tests/test_dist_math.py
@@ -67,7 +69,6 @@ jobs:
 
           - |
             pymc3/tests/test_idata_conversion.py
-            pymc3/tests/test_distributions.py
             pymc3/tests/test_distributions_random.py
             pymc3/tests/test_examples.py
             pymc3/tests/test_gp.py

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -70,6 +70,7 @@ jobs:
           - |
             pymc3/tests/test_idata_conversion.py
             pymc3/tests/test_distributions_random.py
+            pymc3/tests/test_distributions_timeseries.py
             pymc3/tests/test_examples.py
             pymc3/tests/test_gp.py
             pymc3/tests/test_model.py
@@ -141,6 +142,7 @@ jobs:
         test-subset:
           - |
             pymc3/tests/test_distributions_random.py
+            pymc3/tests/test_distributions_timeseries.py
           - |
             pymc3/tests/test_sampling.py
             pymc3/tests/test_shared.py

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,10 +34,12 @@ jobs:
             --ignore=pymc3/tests/test_model_graph.py
             --ignore=pymc3/tests/test_modelcontext.py
             --ignore=pymc3/tests/test_parallel_sampling.py
+            --ignore=pymc3/tests/test_posteriors.py
             --ignore=pymc3/tests/test_sampling.py
             --ignore=pymc3/tests/test_profile.py
             --ignore=pymc3/tests/test_step.py
             --ignore=pymc3/tests/test_tuning.py
+            --ignore=pymc3/tests/test_transforms.py
             --ignore=pymc3/tests/test_types.py
             --ignore=pymc3/tests/test_variational_inference.py
             --ignore=pymc3/tests/test_sampling_jax.py
@@ -67,11 +69,13 @@ jobs:
             pymc3/tests/test_pickling.py
             pymc3/tests/test_plots.py
             pymc3/tests/test_updates.py
+            pymc3/tests/test_transforms.py
 
           - |
             pymc3/tests/test_parallel_sampling.py
             pymc3/tests/test_sampling.py
             pymc3/tests/test_tuning.py
+            pymc3/tests/test_posteriors.py
 
           - |
             pymc3/tests/test_idata_conversion.py

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1056,7 +1056,7 @@ class TestMatchesScipy:
             lambda value, nu: sp.chi2.logpdf(value, df=nu),
         )
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to numerical issues",
     )
@@ -1423,7 +1423,7 @@ class TestMatchesScipy:
             test_fun,
         )
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to numerical issues",
     )
@@ -1449,7 +1449,7 @@ class TestMatchesScipy:
         # pymc-devs/aesara#224: skip_paramdomain_outside_edge_test has to be set
         # True to avoid triggering a C-level assertion in the Aesara GammaQ function
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to numerical issues",
     )
@@ -1465,7 +1465,7 @@ class TestMatchesScipy:
             skip_paramdomain_outside_edge_test=True,
         )
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to scaling issues",
     )
@@ -1496,7 +1496,7 @@ class TestMatchesScipy:
             lambda value, alpha, m: sp.pareto.logcdf(value, alpha, scale=m),
         )
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to numerical issues",
     )
@@ -1508,7 +1508,7 @@ class TestMatchesScipy:
             lambda value, alpha, beta: sp.exponweib.logpdf(value, 1, alpha, scale=beta),
         )
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to inf issues",
     )
@@ -1560,7 +1560,7 @@ class TestMatchesScipy:
         )
 
     @pytest.mark.xfail(reason="checkd tests has not been refactored")
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.skipif(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_beta_binomial_distribution(self):
         self.checkd(
             BetaBinomial,
@@ -1681,7 +1681,7 @@ class TestMatchesScipy:
         self.check_logp(Constant, I, {"c": I}, lambda value, c: np.log(c == value))
 
     @pytest.mark.xfail(reason="Test has not been refactored")
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to inf issues",
     )
@@ -1723,7 +1723,7 @@ class TestMatchesScipy:
         )
 
     @pytest.mark.xfail(reason="Test not refactored yet")
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to inf issues",
     )
@@ -1860,7 +1860,7 @@ class TestMatchesScipy:
             extra_args={"lower": False},
         )
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(aesara.config.floatX == "float32"),
         reason="Fails on float32 due to inf issues",
     )
@@ -2521,7 +2521,7 @@ class TestMatchesScipy:
             skip_paramdomain_inside_edge_test=True,  # Valid values are tested above
         )
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.skipif(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_vonmises(self):
         self.check_logp(
             VonMises,
@@ -2571,7 +2571,7 @@ class TestMatchesScipy:
             decimal=select_by_precision(float64=6, float32=1),
         )
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(aesara.config.floatX == "float32"),
         reason="Some combinations underflow to -inf in float32 in pymc version",
     )
@@ -2603,7 +2603,7 @@ class TestMatchesScipy:
             lambda value, mu, sigma: floatX(sp.moyal.logpdf(value, mu, sigma)),
         )
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         condition=(aesara.config.floatX == "float32"),
         reason="Pymc3 underflows earlier than scipy on float32",
     )
@@ -2617,7 +2617,7 @@ class TestMatchesScipy:
         if aesara.config.floatX == "float32":
             raise Exception("Flaky test: It passed this time, but XPASS is not allowed.")
 
-    @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
+    @pytest.mark.skipif(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
     def test_interpolated(self):
         for mu in R.vals:
             for sigma in Rplus.vals:

--- a/pymc3/tests/test_profile.py
+++ b/pymc3/tests/test_profile.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import pymc3 as pm
+
 from pymc3.tests.models import simple_model
 
 
@@ -23,7 +25,8 @@ class TestProfile:
         assert self.model.profile(self.model.logpt).fct_call_time > 0
 
     def test_profile_variable(self):
-        assert self.model.profile(self.model.value_vars[0].logpt).fct_call_time > 0
+        rv = self.model.basic_RVs[0]
+        assert self.model.profile(pm.logpt(rv, self.model.rvs_to_values[rv])).fct_call_time
 
     def test_profile_count(self):
         count = 1005


### PR DESCRIPTION
This PR includes more test files in the CI actions.
Only three remain excluded:
+ `test_types.py` where I wasn't familiar enough with what's going on internally (see #4828)
+ `test_mixture.py`
+ `test_variational_inference.py`

I also split up the test jobs based on their runtime. This was before, labeled by the name of the first test in each job.
![grafik](https://user-images.githubusercontent.com/5894642/124177264-46b07200-dab0-11eb-8276-6b8bf8544825.png)

The `test_distributions.py` is by far the largest single one. We should definitely split it into two or three files and run them separately!!
