### PR TITLE
Fix for multinomial random test

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # pylint: disable=wildcard-import
-__version__ = "3.11.2"
+__version__ = "3.11.3"
 
 import logging
 import multiprocessing as mp

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -109,9 +109,10 @@ def pymc3_random_discrete(
             e = np.atleast_1d(e).flatten()
             observed = dict(zip(*np.unique(o, return_counts=True)))
             expected = dict(zip(*np.unique(e, return_counts=True)))
-            for e in expected.keys():
-                expected[e] = (observed.get(e, 0), expected[e])
-            k = np.array([v for v in expected.values()])
+            obs_exp = {
+                i: (observed.get(i, 0), expected.get(i, 0)) for i in set().union(observed, expected)
+            }
+            k = np.array([v for v in obs_exp.values()])
             if np.all(k[:, 0] == k[:, 1]):
                 p = 1.0
             else:


### PR DESCRIPTION
Fixes failure that was triggered by addition of `st.chisquare` denominator test in scipy. I assume we want this merged to v3.11.3.

Closes #4810 