### PR TITLE
Refactor CI workflow to get codecov reports back

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,3 @@
 omit =
     # exclude tests files from coverage calculation
     pymc3/tests/test_*.py
-    pymc3/examples/*

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   require_ci_to_pass: no
   notify:
-      after_n_builds: 16
+      after_n_builds: 6
 
 coverage:
   precision: 2


### PR DESCRIPTION
Trying to get the codecov comments back.

I'm not optimistic about this first try, but we can copyedit from Aesara: https://github.com/aesara-devs/aesara/blob/main/.github/workflows/test.yml