### PR TITLE
Sum observations logp in `model.datalogpt`

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -801,7 +801,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
     @property
     def datalogpt(self):
         with self:
-            factors = [logpt(obs, obs.tag.observations) for obs in self.observed_RVs]
+            factors = [logpt_sum(obs, obs.tag.observations) for obs in self.observed_RVs]
 
             # Convert random variables into their log-likelihood inputs and
             # apply their transforms, if any

--- a/pymc3/smc/smc.py
+++ b/pymc3/smc/smc.py
@@ -307,7 +307,7 @@ def logp_forw(point, out_vars, vars, shared):
         f = aesara_function([inarray0], out_list[0], allow_input_downcast=True)
     else:
         f = aesara_function([inarray0], out_list[0])
-        f.trust_input = False
+        f.trust_input = True
     return f
 
 

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -655,3 +655,17 @@ def test_set_initval():
         y = pm.Normal("y", x, 1)
 
     assert model.rvs_to_values[y] in model.initial_values
+
+
+def test_datalogpt_multiple_shapes():
+    with pm.Model() as m:
+        x = pm.Normal("x", 0, 1)
+        z1 = pm.Potential("z1", x)
+        z2 = pm.Potential("z2", at.full((1, 3), x))
+        y1 = pm.Normal("y1", x, 1, observed=np.array([1]))
+        y2 = pm.Normal("y2", x, 1, observed=np.array([1, 2]))
+        y3 = pm.Normal("y3", x, 1, observed=np.array([1, 2, 3]))
+
+    # This would raise a TypeError, see #4803 and #4804
+    x_val = m.rvs_to_values[x]
+    m.datalogpt.eval({x_val: 0})


### PR DESCRIPTION
Fixes #4803 and #4804, which was caused by a failure in the output of `model.datalogpt` when a model contained observations and/or potential terms with different shapes.