### PR TITLE
Fixed MatrixNormal shape handling

### DIFF
--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -1525,6 +1525,10 @@ class MatrixNormalRV(RandomVariable):
     dtype = "floatX"
     _print_name = ("MatrixNormal", "\\operatorname{MatrixNormal}")
 
+    def _infer_shape(self, size, dist_params, param_shapes=None):
+        shape = tuple(size) + tuple(dist_params[0].shape)
+        return shape
+
     @classmethod
     def rng_fn(cls, rng, mu, rowchol, colchol, size=None):
 
@@ -1596,7 +1600,7 @@ class MatrixNormal(Continuous):
         n = colcov.shape[0]
         mu = np.zeros((m, n))
         vals = pm.MatrixNormal('vals', mu=mu, colcov=colcov,
-                               rowcov=rowcov, shape=(m, n))
+                               rowcov=rowcov)
 
     Above, the ith row in vals has a variance that is scaled by 4^i.
     Alternatively, row or column cholesky matrices could be substituted for
@@ -1634,7 +1638,7 @@ class MatrixNormal(Continuous):
             rowcov = at.diag([scale**(2*i) for i in range(m)])
 
             vals = pm.MatrixNormal('vals', mu=mu, colchol=colchol, rowcov=rowcov,
-                                   observed=data, shape=(m, n))
+                                   observed=data)
     """
     rv_op = matrixnormal
 
@@ -1646,16 +1650,22 @@ class MatrixNormal(Continuous):
         rowchol=None,
         colcov=None,
         colchol=None,
-        shape=None,
         *args,
         **kwargs,
     ):
 
         cholesky = Cholesky(lower=True, on_error="raise")
 
-        if mu.ndim == 1:
-            raise ValueError(
-                "1x1 Matrix was provided. Please use Normal distribution for such cases."
+        if kwargs.get("size", None) is not None:
+            raise NotImplementedError("MatrixNormal doesn't support size argument")
+
+        if "shape" in kwargs:
+            kwargs.pop("shape")
+            warnings.warn(
+                "Passing shape to MatrixNormal is now depricated."
+                "MatrixNormal automatically derives the shape"
+                "from row and column matrix dimensions.",
+                DeprecationWarning,
             )
 
         # Among-row matrices
@@ -1687,6 +1697,11 @@ class MatrixNormal(Continuous):
                 raise ValueError("colchol must be two dimensional.")
             colchol_cov = at.as_tensor_variable(colchol)
 
+        dist_shape = (rowchol_cov.shape[0], colchol_cov.shape[0])
+
+        # Broadcasting mu
+        mu = at.extra_ops.broadcast_to(a=mu, shape=dist_shape)
+
         mu = at.as_tensor_variable(floatX(mu))
         # mean = median = mode = mu
 
@@ -1706,6 +1721,9 @@ class MatrixNormal(Continuous):
         -------
         TensorVariable
         """
+
+        if value.ndim != 2:
+            raise ValueError("Value must be two dimensional.")
 
         # Compute Tr[colcov^-1 @ (x - mu).T @ rowcov^-1 @ (x - mu)] and
         # the logdet of colcov and rowcov.

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -1662,7 +1662,7 @@ class MatrixNormal(Continuous):
         if "shape" in kwargs:
             kwargs.pop("shape")
             warnings.warn(
-                "Passing shape to MatrixNormal is now depricated."
+                "The shape argument in MatrixNormal is deprecated and will be ignored."
                 "MatrixNormal automatically derives the shape"
                 "from row and column matrix dimensions.",
                 DeprecationWarning,

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1912,7 +1912,7 @@ class TestMatchesScipy:
             with pytest.raises(ValueError):
                 x = MvNormal("x", mu=np.zeros(3), cov=np.eye(3), tau=np.eye(3), size=3)
 
-    @pytest.mark.parametrize("n", [2, 3])
+    @pytest.mark.parametrize("n", [1, 2, 3])
     def test_matrixnormal(self, n):
         mat_scale = 1e3  # To reduce logp magnitude
         mean_scale = 0.1
@@ -1925,7 +1925,6 @@ class TestMatchesScipy:
                 "colcov": PdMatrix(n) * mat_scale,
             },
             matrix_normal_logpdf_cov,
-            extra_args={"size": n},
             decimal=select_by_precision(float64=5, float32=3),
         )
         self.check_logp(
@@ -1937,7 +1936,6 @@ class TestMatchesScipy:
                 "colcov": PdMatrix(n) * mat_scale,
             },
             matrix_normal_logpdf_cov,
-            extra_args={"size": n},
             decimal=select_by_precision(float64=5, float32=3),
         )
         self.check_logp(
@@ -1949,7 +1947,6 @@ class TestMatchesScipy:
                 "colchol": PdMatrixChol(n) * mat_scale,
             },
             matrix_normal_logpdf_chol,
-            extra_args={"size": n},
             decimal=select_by_precision(float64=5, float32=3),
         )
         self.check_logp(
@@ -1961,7 +1958,6 @@ class TestMatchesScipy:
                 "colchol": PdMatrixChol(3) * mat_scale,
             },
             matrix_normal_logpdf_chol,
-            extra_args={"size": n},
             decimal=select_by_precision(float64=5, float32=3),
         )
 

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -42,6 +42,7 @@ from scipy.special import expit
 import pymc3 as pm
 
 from pymc3.aesaraf import change_rv_size, floatX, intX
+from pymc3.distributions import _logp
 from pymc3.distributions.continuous import get_tau_sigma, interpolated
 from pymc3.distributions.discrete import _OrderedLogistic, _OrderedProbit
 from pymc3.distributions.dist_math import clipped_beta_rvs
@@ -1562,52 +1563,85 @@ class TestMatrixNormal(BaseTestDistribution):
     mu = np.random.random((3, 3))
     row_cov = np.eye(3)
     col_cov = np.eye(3)
-
+    shape = None
+    size = None
     pymc_dist_params = {"mu": mu, "rowcov": row_cov, "colcov": col_cov}
     expected_rv_op_params = {"mu": mu, "rowcov": row_cov, "colcov": col_cov}
 
-    sizes_to_check = [None, 1, (2, 3)]
-    sizes_expected = [(3,), (1, 3), (2, 3, 3)]
-
-    tests_to_run = ["check_rv_size", "check_pymc_params_match_rv_op", "test_matrix_normal"]
+    tests_to_run = ["check_pymc_params_match_rv_op", "test_matrix_normal", "test_errors"]
 
     def test_matrix_normal(self):
         delta = 0.05  # limit for KS p-value
         n_fails = 10  # Allows the KS fails a certain number of times
-        size = (100,)
 
-        def ref_rand(size, mu, rowcov, colcov):
-            return st.matrix_normal.rvs(mean=mu, rowcov=rowcov, colcov=colcov, size=size)
+        def ref_rand(mu, rowcov, colcov):
+            return st.matrix_normal.rvs(mean=mu, rowcov=rowcov, colcov=colcov)
 
         with pm.Model(rng_seeder=1):
             matrixnormal = pm.MatrixNormal(
-                "mvnormal",
+                "matnormal",
                 mu=np.random.random((3, 3)),
                 rowcov=np.eye(3),
                 colcov=np.eye(3),
-                size=size,
             )
             check = pm.sample_prior_predictive(n_fails)
 
-        ref_smp = ref_rand(size[0], mu=np.random.random((3, 3)), rowcov=np.eye(3), colcov=np.eye(3))
+        ref_smp = ref_rand(mu=np.random.random((3, 3)), rowcov=np.eye(3), colcov=np.eye(3))
 
         p, f = delta, n_fails
         while p <= delta and f > 0:
-            matrixnormal_smp = check["mvnormal"][f - 1, :, :]
-            curr_ref_smp = ref_smp[f - 1, :, :]
+            matrixnormal_smp = check["matnormal"]
 
             p = np.min(
                 [
                     st.ks_2samp(
-                        np.atleast_1d(matrixnormal_smp[..., idx]).flatten(),
-                        np.atleast_1d(curr_ref_smp[..., idx]).flatten(),
-                    )[1]
-                    for idx in range(matrixnormal_smp.shape[-1])
+                        np.atleast_1d(matrixnormal_smp).flatten(),
+                        np.atleast_1d(ref_smp).flatten(),
+                    )
                 ]
             )
             f -= 1
 
         assert p > delta
+
+    def test_errors(self):
+        msg = "MatrixNormal doesn't support size argument"
+        with pm.Model():
+            with pytest.raises(NotImplementedError, match=msg):
+                matrixnormal = pm.MatrixNormal(
+                    "matnormal",
+                    mu=np.random.random((3, 3)),
+                    rowcov=np.eye(3),
+                    colcov=np.eye(3),
+                    size=15,
+                )
+
+        msg = "Value must be two dimensional."
+        with pm.Model():
+            matrixnormal = pm.MatrixNormal(
+                "matnormal",
+                mu=np.random.random((3, 3)),
+                rowcov=np.eye(3),
+                colcov=np.eye(3),
+            )
+            with pytest.raises(ValueError, match=msg):
+                rvs_to_values = {matrixnormal: aesara.tensor.ones((3, 3, 3))}
+                _logp(
+                    matrixnormal.owner.op,
+                    matrixnormal,
+                    rvs_to_values,
+                    *matrixnormal.owner.inputs[3:],
+                )
+
+        with pm.Model():
+            with pytest.warns(DeprecationWarning):
+                matrixnormal = pm.MatrixNormal(
+                    "matnormal",
+                    mu=np.random.random((3, 3)),
+                    rowcov=np.eye(3),
+                    colcov=np.eye(3),
+                    shape=15,
+                )
 
 
 class TestInterpolated(BaseTestDistribution):


### PR DESCRIPTION
Linked Issue: #4845 

So it turns out that the shape handling was a bit off in `MatrixNormal` as it didn't support `mu` broadcasting, also it'll be better to just remove the `1x1` error since it won't make much sense if we have it supported already. 
