### PR TITLE
LaTeX and pretty str representations for v4, continued

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -68,6 +68,7 @@ from pymc3.math import (
 from pymc3.model import *
 from pymc3.model_graph import model_to_graphviz
 from pymc3.plots import *
+from pymc3.printing import *
 from pymc3.sampling import *
 from pymc3.smc import *
 from pymc3.stats import *

--- a/pymc3/distributions/bart.py
+++ b/pymc3/distributions/bart.py
@@ -282,16 +282,3 @@ class BART(BaseBART):
 
     def __init__(self, X, Y, m=200, alpha=0.25, split_prior=None):
         super().__init__(X, Y, m, alpha, split_prior)
-
-    def _str_repr(self, name=None, dist=None, formatting="plain"):
-        if dist is None:
-            dist = self
-        X = (type(self.X),)
-        Y = (type(self.Y),)
-        alpha = self.alpha
-        m = self.m
-
-        if "latex" in formatting:
-            return f"$\\text{{{name}}} \\sim  \\text{{BART}}(\\text{{alpha = }}\\text{{{alpha}}}, \\text{{m = }}\\text{{{m}}})$"
-        else:
-            return f"{name} ~ BART(alpha = {alpha}, m = {m})"

--- a/pymc3/distributions/bound.py
+++ b/pymc3/distributions/bound.py
@@ -143,25 +143,6 @@ class _Bounded(Distribution):
         #     )
         pass
 
-    def _distr_parameters_for_repr(self):
-        return ["lower", "upper"]
-
-    def _distr_name_for_repr(self):
-        return "Bound"
-
-    def _str_repr(self, **kwargs):
-        distr_repr = self._wrapped._str_repr(**{**kwargs, "dist": self._wrapped})
-        if "formatting" in kwargs and "latex" in kwargs["formatting"]:
-            distr_repr = distr_repr[distr_repr.index(r" \sim") + 6 :]
-        else:
-            distr_repr = distr_repr[distr_repr.index(" ~") + 3 :]
-        self_repr = super()._str_repr(**kwargs)
-
-        if "formatting" in kwargs and "latex" in kwargs["formatting"]:
-            return self_repr + " -- " + distr_repr
-        else:
-            return self_repr + "-" + distr_repr
-
 
 class _DiscreteBounded(_Bounded, Discrete):
     def __init__(self, distribution, lower, upper, transform="infer", *args, **kwargs):

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -41,7 +41,7 @@ from pymc3.distributions.shape_utils import (
     resize_from_dims,
     resize_from_observed,
 )
-from pymc3.printing import str_repr
+from pymc3.printing import str_for_dist
 from pymc3.util import UNSET
 from pymc3.vartypes import string_types
 
@@ -228,9 +228,9 @@ class Distribution(metaclass=DistributionMeta):
         )
 
         # add in pretty-printing support
-        rv_out.str_repr = types.MethodType(str_repr, rv_out)
+        rv_out.str_repr = types.MethodType(str_for_dist, rv_out)
         rv_out._repr_latex_ = types.MethodType(
-            functools.partial(str_repr, formatting="latex"), rv_out
+            functools.partial(str_for_dist, formatting="latex"), rv_out
         )
 
         return rv_out

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 import contextvars
 import functools
-import inspect
 import multiprocessing
 import sys
 import types
@@ -43,7 +42,7 @@ from pymc3.distributions.shape_utils import (
     resize_from_observed,
 )
 from pymc3.printing import str_repr
-from pymc3.util import UNSET, get_repr_for_variable
+from pymc3.util import UNSET
 from pymc3.vartypes import string_types
 
 __all__ = [
@@ -324,77 +323,6 @@ class Distribution(metaclass=DistributionMeta):
             rng.default_update = new_rng
 
         return rv_out
-
-    def _distr_parameters_for_repr(self):
-        """Return the names of the parameters for this distribution (e.g. "mu"
-        and "sigma" for Normal). Used in generating string (and LaTeX etc.)
-        representations of Distribution objects. By default based on inspection
-        of __init__, but can be overwritten if necessary (e.g. to avoid including
-        "sd" and "tau").
-        """
-        return inspect.getfullargspec(self.__init__).args[1:]
-
-    def _distr_name_for_repr(self):
-        return self.__class__.__name__
-
-    def _str_repr(self, name=None, dist=None, formatting="plain"):
-        """
-        Generate string representation for this distribution, optionally
-        including LaTeX markup (formatting='latex').
-
-        Parameters
-        ----------
-        name : str
-            name of the distribution
-        dist : Distribution
-            the distribution object
-        formatting : str
-            one of { "latex", "plain", "latex_with_params", "plain_with_params" }
-        """
-        if dist is None:
-            dist = self
-        if name is None:
-            name = "[unnamed]"
-        supported_formattings = {"latex", "plain", "latex_with_params", "plain_with_params"}
-        if not formatting in supported_formattings:
-            raise ValueError(f"Unsupported formatting ''. Choose one of {supported_formattings}.")
-
-        param_names = self._distr_parameters_for_repr()
-        param_values = [
-            get_repr_for_variable(getattr(dist, x), formatting=formatting) for x in param_names
-        ]
-
-        if "latex" in formatting:
-            param_string = ",~".join(
-                [fr"\mathit{{{name}}}={value}" for name, value in zip(param_names, param_values)]
-            )
-            if formatting == "latex_with_params":
-                return r"$\text{{{var_name}}} \sim \text{{{distr_name}}}({params})$".format(
-                    var_name=name, distr_name=dist._distr_name_for_repr(), params=param_string
-                )
-            return r"$\text{{{var_name}}} \sim \text{{{distr_name}}}$".format(
-                var_name=name, distr_name=dist._distr_name_for_repr()
-            )
-        else:
-            # one of the plain formattings
-            param_string = ", ".join(
-                [f"{name}={value}" for name, value in zip(param_names, param_values)]
-            )
-            if formatting == "plain_with_params":
-                return f"{name} ~ {dist._distr_name_for_repr()}({param_string})"
-            return f"{name} ~ {dist._distr_name_for_repr()}"
-
-    def __str__(self, **kwargs):
-        try:
-            return self._str_repr(formatting="plain", **kwargs)
-        except:
-            return super().__str__()
-
-    def _repr_latex_(self, *, formatting="latex_with_params", **kwargs):
-        """Magic method name for IPython to use for LaTeX formatting."""
-        return self._str_repr(formatting=formatting, **kwargs)
-
-    __latex__ = _repr_latex_
 
 
 class NoDistribution(Distribution):

--- a/pymc3/distributions/simulator.py
+++ b/pymc3/distributions/simulator.py
@@ -121,20 +121,6 @@ class Simulator(NoDistribution):
         # else:
         #     return np.array([self.function(*params) for _ in range(size[0])])
 
-    def _str_repr(self, name=None, dist=None, formatting="plain"):
-        if dist is None:
-            dist = self
-        name = name
-        function = dist.function.__name__
-        params = ", ".join([var.name for var in dist.params])
-        sum_stat = self.sum_stat.__name__ if hasattr(self.sum_stat, "__call__") else self.sum_stat
-        distance = getattr(self.distance, "__name__", self.distance.__class__.__name__)
-
-        if "latex" in formatting:
-            return f"$\\text{{{name}}} \\sim  \\text{{Simulator}}(\\text{{{function}}}({params}), \\text{{{distance}}}, \\text{{{sum_stat}}})$"
-        else:
-            return f"{name} ~ Simulator({function}({params}), {distance}, {sum_stat})"
-
 
 def identity(x):
     """Identity function, used as a summary statistics."""

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 import collections
+import functools
 import threading
 import types
 import warnings
@@ -671,6 +672,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
         from pymc3.printing import str_repr
 
         self.str_repr = types.MethodType(str_repr, self)
+        self._repr_latex_ = types.MethodType(functools.partial(str_repr, formatting="latex"), self)
 
     @property
     def model(self):

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -15,6 +15,7 @@
 import collections
 import itertools
 import threading
+import types
 import warnings
 
 from sys import modules
@@ -667,6 +668,10 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
             self.auto_deterministics = treelist()
             self.deterministics = treelist()
             self.potentials = treelist()
+
+        from pymc3.printing import str_repr
+
+        self.str_repr = types.MethodType(str_repr, self)
 
     @property
     def model(self):

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 
 import collections
-import itertools
 import threading
 import types
 import warnings
@@ -1632,46 +1631,6 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
             },
             name="Log-probability of test_point",
         )
-
-    def _str_repr(self, formatting="plain", **kwargs):
-        all_rv = itertools.chain(self.unobserved_RVs, self.observed_RVs)
-
-        if "latex" in formatting:
-            rv_reprs = [rv.__latex__(formatting=formatting) for rv in all_rv]
-            rv_reprs = [
-                rv_repr.replace(r"\sim", r"&\sim &").strip("$")
-                for rv_repr in rv_reprs
-                if rv_repr is not None
-            ]
-            return r"""$$
-                \begin{{array}}{{rcl}}
-                {}
-                \end{{array}}
-                $$""".format(
-                "\\\\".join(rv_reprs)
-            )
-        else:
-            rv_reprs = [rv.__str__() for rv in all_rv]
-            rv_reprs = [
-                rv_repr for rv_repr in rv_reprs if "TransformedDistribution()" not in rv_repr
-            ]
-            # align vars on their ~
-            names = [s[: s.index("~") - 1] for s in rv_reprs]
-            distrs = [s[s.index("~") + 2 :] for s in rv_reprs]
-            maxlen = str(max(len(x) for x in names))
-            rv_reprs = [
-                ("{name:>" + maxlen + "} ~ {distr}").format(name=n, distr=d)
-                for n, d in zip(names, distrs)
-            ]
-            return "\n".join(rv_reprs)
-
-    def __str__(self, **kwargs):
-        return self._str_repr(formatting="plain", **kwargs)
-
-    def _repr_latex_(self, *, formatting="latex", **kwargs):
-        return self._str_repr(formatting=formatting, **kwargs)
-
-    __latex__ = _repr_latex_
 
 
 # this is really disgusting, but it breaks a self-loop: I can't pass Model

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -669,10 +669,12 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
             self.deterministics = treelist()
             self.potentials = treelist()
 
-        from pymc3.printing import str_repr
+        from pymc3.printing import str_for_model
 
-        self.str_repr = types.MethodType(str_repr, self)
-        self._repr_latex_ = types.MethodType(functools.partial(str_repr, formatting="latex"), self)
+        self.str_repr = types.MethodType(str_for_model, self)
+        self._repr_latex_ = types.MethodType(
+            functools.partial(str_for_model, formatting="latex"), self
+        )
 
     @property
     def model(self):
@@ -1787,6 +1789,13 @@ def Deterministic(name, var, model=None, dims=None, auto=False):
         model.deterministics.append(var)
     model.add_random_variable(var, dims)
 
+    from pymc3.printing import str_for_deterministic
+
+    var.str_repr = types.MethodType(str_for_deterministic, var)
+    var._repr_latex_ = types.MethodType(
+        functools.partial(str_for_deterministic, formatting="latex"), var
+    )
+
     return var
 
 
@@ -1807,4 +1816,12 @@ def Potential(name, var, model=None):
     var.tag.scaling = None
     model.potentials.append(var)
     model.add_random_variable(var)
+
+    from pymc3.printing import str_for_potential
+
+    var.str_repr = types.MethodType(str_for_potential, var)
+    var._repr_latex_ = types.MethodType(
+        functools.partial(str_for_potential, formatting="latex"), var
+    )
+
     return var

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1789,11 +1789,16 @@ def Deterministic(name, var, model=None, dims=None, auto=False):
         model.deterministics.append(var)
     model.add_random_variable(var, dims)
 
-    from pymc3.printing import str_for_deterministic
+    from pymc3.printing import str_for_potential_or_deterministic
 
-    var.str_repr = types.MethodType(str_for_deterministic, var)
+    var.str_repr = types.MethodType(
+        functools.partial(str_for_potential_or_deterministic, dist_name="Deterministic"), var
+    )
     var._repr_latex_ = types.MethodType(
-        functools.partial(str_for_deterministic, formatting="latex"), var
+        functools.partial(
+            str_for_potential_or_deterministic, dist_name="Deterministic", formatting="latex"
+        ),
+        var,
     )
 
     return var
@@ -1817,11 +1822,16 @@ def Potential(name, var, model=None):
     model.potentials.append(var)
     model.add_random_variable(var)
 
-    from pymc3.printing import str_for_potential
+    from pymc3.printing import str_for_potential_or_deterministic
 
-    var.str_repr = types.MethodType(str_for_potential, var)
+    var.str_repr = types.MethodType(
+        functools.partial(str_for_potential_or_deterministic, dist_name="Potential"), var
+    )
     var._repr_latex_ = types.MethodType(
-        functools.partial(str_for_potential, formatting="latex"), var
+        functools.partial(
+            str_for_potential_or_deterministic, dist_name="Potential", formatting="latex"
+        ),
+        var,
     )
 
     return var

--- a/pymc3/printing.py
+++ b/pymc3/printing.py
@@ -99,14 +99,12 @@ def str_for_potential_or_deterministic(
 
 
 def _str_for_input_var(var: Variable, formatting: str) -> str:
-    # note we're dispatching both on type(var) and on type(var.owner.op) so cannot
-    # use the standard functools.singledispatch
-
     def _is_potential_or_determinstic(var: Variable) -> bool:
-        return (
-            hasattr(var, "str_repr")
-            and var.str_repr.__func__.func is str_for_potential_or_deterministic
-        )
+        try:
+            return var.str_repr.__func__.func is str_for_potential_or_deterministic
+        except AttributeError:
+            # in case other code overrides str_repr, fallback
+            return False
 
     if isinstance(var, TensorConstant):
         return _str_for_constant(var, formatting)

--- a/pymc3/printing.py
+++ b/pymc3/printing.py
@@ -144,16 +144,25 @@ def _latex_escape(text: str) -> str:
 
 
 def _default_repr_pretty(obj: Union[TensorVariable, Model], p, cycle):
-    """Handy plug-in method to instruct IPython-like REPLs to use our str_repr below."""
+    """Handy plug-in method to instruct IPython-like REPLs to use our str_repr above."""
     # we know that our str_repr does not recurse, so we can ignore cycle
     try:
-        p.text(obj.str_repr())
+        output = obj.str_repr()
+        # Find newlines and replace them with p.break_()
+        # (see IPython.lib.pretty._repr_pprint)
+        lines = output.splitlines()
+        with p.group():
+            for idx, output_line in enumerate(lines):
+                if idx:
+                    p.break_()
+                p.text(output_line)
     except AttributeError:
-        # the default fallback option
+        # the default fallback option (no str_repr method)
         IPython.lib.pretty._repr_pprint(obj, p, cycle)
 
 
 try:
+    # register our custom pretty printer in ipython shells
     import IPython
 
     IPython.lib.pretty.for_type(TensorVariable, _default_repr_pretty)

--- a/pymc3/printing.py
+++ b/pymc3/printing.py
@@ -1,0 +1,163 @@
+#   Copyright 2021 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import itertools
+
+from functools import singledispatch
+from typing import Union
+
+from aesara.graph.basic import walk
+from aesara.tensor.basic import TensorVariable, Variable
+from aesara.tensor.elemwise import DimShuffle
+from aesara.tensor.random.basic import RandomVariable
+from aesara.tensor.var import TensorConstant
+
+from pymc3.model import Model
+
+
+@singledispatch
+def str_repr(rv: RandomVariable, formatting: str = "plain", include_params: bool = True) -> str:
+    """Make a human-readable string representation of a RandomVariable in a model, either
+    LaTeX or plain, optionally with distribution parameter values included."""
+
+    if include_params:
+        # first 3 args are always (rng, size, dtype), rest is relevant for distribution
+        dist_args = [_str_for_input_var(x, formatting=formatting) for x in rv.owner.inputs[3:]]
+
+    print_name = rv.name if rv.name is not None else "<unnamed>"
+    if "latex" in formatting:
+        print_name = r"\text{" + _latex_escape(print_name) + "}"
+        dist_name = rv.owner.op._print_name[1]
+        if include_params:
+            return r"${} \sim {}({})$".format(print_name, dist_name, ",~".join(dist_args))
+        else:
+            return fr"${print_name} \sim {dist_name}$"
+    else:  # plain
+        dist_name = rv.owner.op._print_name[0]
+        if include_params:
+            return r"{} ~ {}({})".format(print_name, dist_name, ", ".join(dist_args))
+        else:
+            return fr"{print_name} ~ {dist_name}"
+
+
+@str_repr.register
+def _(model: Model, formatting: str = "plain", include_params: bool = True) -> str:
+    """Make a human-readable string representation of Model, listing all random variables
+    and their distributions, optionally including parameter values."""
+    all_rv = itertools.chain(model.unobserved_RVs, model.observed_RVs)
+
+    rv_reprs = [rv.str_repr(formatting=formatting, include_params=include_params) for rv in all_rv]
+    rv_reprs = [rv_repr for rv_repr in rv_reprs if "TransformedDistribution()" not in rv_repr]
+    if "latex" in formatting:
+        rv_reprs = [
+            rv_repr.replace(r"\sim", r"&\sim &").strip("$")
+            for rv_repr in rv_reprs
+            if rv_repr is not None
+        ]
+        return r"""$$
+            \begin{{array}}{{rcl}}
+            {}
+            \end{{array}}
+            $$""".format(
+            "\\\\".join(rv_reprs)
+        )
+    else:
+        # align vars on their ~
+        names = [s[: s.index("~") - 1] for s in rv_reprs]
+        distrs = [s[s.index("~") + 2 :] for s in rv_reprs]
+        maxlen = str(max(len(x) for x in names))
+        rv_reprs = [
+            ("{name:>" + maxlen + "} ~ {distr}").format(name=n, distr=d)
+            for n, d in zip(names, distrs)
+        ]
+        return "\n".join(rv_reprs)
+
+
+def _str_for_input_var(var: Variable, formatting: str) -> str:
+    # note we're dispatching both on type(var) and on type(var.owner.op) so cannot
+    # use the standard functools.singledispatch
+    if isinstance(var, TensorConstant):
+        return _str_for_constant(var, formatting)
+    elif isinstance(var.owner.op, RandomVariable):
+        return _str_for_input_rv(var, formatting)
+    elif isinstance(var.owner.op, DimShuffle):
+        return _str_for_input_var(var.owner.inputs[0], formatting)
+    else:
+        return _str_for_expression(var, formatting)
+
+
+def _str_for_input_rv(var: Variable, formatting: str) -> str:
+    _str = var.name if var.name is not None else "<unnamed>"
+    if "latex" in formatting:
+        return r"\text{" + _latex_escape(_str) + "}"
+    else:
+        return _str
+
+
+def _str_for_constant(var: TensorConstant, formatting: str) -> str:
+    if len(var.data.shape) == 0:
+        return f"{var.data:.3g}"
+    elif len(var.data.shape) == 1 and var.data.shape[0] == 1:
+        return f"{var.data[0]:.3g}"
+    elif "latex" in formatting:
+        return r"\text{<constant>}"
+    else:
+        return r"<constant>"
+
+
+def _str_for_expression(var: Variable, formatting: str) -> str:
+    # construct a string like f(a1, ..., aN) listing all random variables a as arguments
+    def _expand(x):
+        if x.owner and (not isinstance(x.owner.op, RandomVariable)):
+            return reversed(x.owner.inputs)
+
+    parents = [
+        x
+        for x in walk(nodes=var.owner.inputs, expand=_expand)
+        if x.owner and isinstance(x.owner.op, RandomVariable)
+    ]
+    names = [x.name for x in parents]
+
+    if "latex" in formatting:
+        return r"f(" + ",~".join([r"\text{" + _latex_escape(n) + "}" for n in names]) + ")"
+    else:
+        return r"f(" + ", ".join(names) + ")"
+
+
+def _latex_escape(text: str) -> str:
+    # Note that this is *NOT* a proper LaTeX escaper, on purpose. _repr_latex_ is
+    # primarily used in the context of Jupyter notebooks, which render using MathJax.
+    # MathJax is a subset of LaTeX proper, which expects only $ to be escaped. If we were
+    # to also escape e.g. _ (replace with \_), then "\_" will show up in the output, etc.
+    return text.replace("$", r"\$")
+
+
+def _default_repr_pretty(obj: Union[TensorVariable, Model], p, cycle):
+    """Handy plug-in method to instruct IPython-like REPLs to use our str_repr below."""
+    # we know that our str_repr does not recurse, so we can ignore cycle
+    try:
+        p.text(obj.str_repr())
+    except AttributeError:
+        # the default fallback option
+        IPython.lib.pretty._repr_pprint(obj, p, cycle)
+
+
+try:
+    import IPython
+
+    IPython.lib.pretty.for_type(TensorVariable, _default_repr_pretty)
+    IPython.lib.pretty.for_type(Model, _default_repr_pretty)
+except (ModuleNotFoundError, AttributeError):
+    # no ipython shell
+    pass

--- a/pymc3/printing.py
+++ b/pymc3/printing.py
@@ -122,15 +122,18 @@ def _str_for_input_var(var: Variable, formatting: str) -> str:
     # use the standard functools.singledispatch
     if isinstance(var, TensorConstant):
         return _str_for_constant(var, formatting)
-    elif isinstance(var.owner.op, RandomVariable):
+    elif isinstance(var.owner.op, RandomVariable) or (
+        hasattr(var, "str_repr")
+        and (
+            var.str_repr.__func__ is str_for_deterministic
+            or var.str_repr.__func__ is str_for_potential
+        )
+    ):
+        # show the names for RandomVariables, Deterministics, and Potentials, rather
+        # than the full expression
         return _str_for_input_rv(var, formatting)
     elif isinstance(var.owner.op, DimShuffle):
         return _str_for_input_var(var.owner.inputs[0], formatting)
-    elif hasattr(var, "str_repr") and (
-        var.str_repr.__func__ is str_for_deterministic or var.str_repr.__func__ is str_for_potential
-    ):
-        # display the name for a Deterministic or Potential, rather than the full expression
-        return var.name
     else:
         return _str_for_expression(var, formatting)
 

--- a/pymc3/printing.py
+++ b/pymc3/printing.py
@@ -27,7 +27,7 @@ from pymc3.model import Model
 
 
 @singledispatch
-def str_repr(rv: RandomVariable, formatting: str = "plain", include_params: bool = True) -> str:
+def str_repr(rv: TensorVariable, formatting: str = "plain", include_params: bool = True) -> str:
     """Make a human-readable string representation of a RandomVariable in a model, either
     LaTeX or plain, optionally with distribution parameter values included."""
 

--- a/pymc3/printing.py
+++ b/pymc3/printing.py
@@ -24,6 +24,12 @@ from aesara.tensor.var import TensorConstant
 
 from pymc3.model import Model
 
+__all__ = [
+    "str_for_dist",
+    "str_for_model",
+    "str_for_potential_or_deterministic",
+]
+
 
 def str_for_dist(rv: TensorVariable, formatting: str = "plain", include_params: bool = True) -> str:
     """Make a human-readable string representation of a RandomVariable in a model, either
@@ -82,8 +88,13 @@ def str_for_model(model: Model, formatting: str = "plain", include_params: bool 
 
 
 def str_for_potential_or_deterministic(
-    var: TensorVariable, dist_name: str, formatting: str = "plain", include_params: bool = True
+    var: TensorVariable,
+    formatting: str = "plain",
+    include_params: bool = True,
+    dist_name: str = "Deterministic",
 ) -> str:
+    """Make a human-readable string representation of a Deterministic or Potential in a model, either
+    LaTeX or plain, optionally with distribution parameter values included."""
     print_name = var.name if var.name is not None else "<unnamed>"
     if "latex" in formatting:
         print_name = r"\text{" + _latex_escape(print_name) + "}"

--- a/pymc3/printing.py
+++ b/pymc3/printing.py
@@ -88,9 +88,9 @@ def str_for_deterministic(
     if "latex" in formatting:
         print_name = r"\text{" + _latex_escape(print_name) + "}"
         if include_params:
-            return fr"${print_name} \sim Deterministic[{_str_for_expression(var, formatting=formatting)}]$"
+            return fr"${print_name} \sim \operatorname{{Deterministic}}[{_str_for_expression(var, formatting=formatting)}]$"
         else:
-            return fr"${print_name} \sim Deterministic$"
+            return fr"${print_name} \sim \operatorname{{Deterministic}}$"
     else:  # plain
         if include_params:
             return (
@@ -107,11 +107,9 @@ def str_for_potential(
     if "latex" in formatting:
         print_name = r"\text{" + _latex_escape(print_name) + "}"
         if include_params:
-            return (
-                fr"${print_name} \sim Potential[{_str_for_expression(var, formatting=formatting)}]$"
-            )
+            return fr"${print_name} \sim \operatorname{{Potential}}[{_str_for_expression(var, formatting=formatting)}]$"
         else:
-            return fr"${print_name} \sim Potential$"
+            return fr"${print_name} \sim \operatorname{{Potential}}$"
     else:  # plain
         if include_params:
             return fr"{print_name} ~ Potential[{_str_for_expression(var, formatting=formatting)}]"

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -218,44 +218,6 @@ def get_default_varnames(var_iterator, include_transformed):
         return [var for var in var_iterator if not is_transformed_name(get_var_name(var))]
 
 
-def get_repr_for_variable(variable, formatting="plain"):
-    """Build a human-readable string representation for a variable."""
-    if variable is not None and hasattr(variable, "name"):
-        name = variable.name
-    elif type(variable) in [float, int, str]:
-        name = str(variable)
-    else:
-        name = None
-
-    if name is None and variable is not None:
-        if hasattr(variable, "get_parents"):
-            try:
-                names = [
-                    get_repr_for_variable(item, formatting=formatting)
-                    for item in variable.get_parents()[0].inputs
-                ]
-                # do not escape_latex these, since it is not idempotent
-                if "latex" in formatting:
-                    return "f({args})".format(
-                        args=",~".join([n for n in names if isinstance(n, str)])
-                    )
-                else:
-                    return "f({args})".format(
-                        args=", ".join([n for n in names if isinstance(n, str)])
-                    )
-            except IndexError:
-                pass
-        value = variable.eval()
-        if not value.shape or value.shape == (1,):
-            return value.item()
-        return "array"
-
-    if "latex" in formatting:
-        return fr"\text{{{name}}}"
-    else:
-        return name
-
-
 def get_var_name(var):
     """Get an appropriate, plain variable name for a variable."""
     return getattr(var, "name", str(var))

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 
 import functools
-import re
 import warnings
 
 from typing import Dict, List, Tuple, Union
@@ -24,8 +23,6 @@ import numpy as np
 import xarray
 
 from cachetools import LRUCache, cachedmethod
-
-LATEX_ESCAPE_RE = re.compile(r"(%|_|\$|#|&)", re.MULTILINE)
 
 UNSET = object()
 
@@ -116,30 +113,6 @@ class treedict(dict):
             return dict.__contains__(self, item) or self.parent.__contains__(item)
         else:
             return dict.__contains__(self, item)
-
-
-def escape_latex(strng):
-    r"""Consistently escape LaTeX special characters for _repr_latex_ in IPython
-
-    Implementation taken from the IPython magic `format_latex`
-
-    Examples
-    --------
-        escape_latex('disease_rate')  # 'disease\_rate'
-
-    Parameters
-    ----------
-    strng: str
-        string to escape LaTeX characters
-
-    Returns
-    -------
-    str
-        A string with LaTeX escaped
-    """
-    if strng is None:
-        return "None"
-    return LATEX_ESCAPE_RE.sub(r"\\\1", strng)
 
 
 def get_transformed_name(name, transform):


### PR DESCRIPTION
This achieves largely the same as discussed in #4692, though now without either type patching or overriding `__repr__` or `__str__` in Aesara. I've also updated the relevant tests.

Quoting the previous PR:

> This PR adds LaTeX and string representations for distributions and `Model`s for v4, fixing #4494. Specifically, it adds the following functionality:
> 
> ```python
> model = pm.Model()
> with model:
>     b_mu = pm.Normal('b_mu', mu=0, sigma=10)
>     b_sigma = pm.HalfNormal('b_sigma', sigma=10)
> 
>     a_mu = pm.Normal('a_mu', mu=0, sigma=10)
>     a_sigma = pm.HalfNormal('a_sigma', sigma=10)
> 
>     b = pm.Normal('b', mu=b_mu, sigma=b_sigma)
>     a = pm.Normal('a', mu=a_mu, sigma=a_sigma)
> 
>     y_sigma = pm.HalfNormal('y_sigma', sigma=10)
>     y = pm.Normal('y', mu=a+b*obs_x, sigma=y_sigma, observed=obs_y)
> ```
> 
> after which (in interactive console session), we can do:
> 
> ```
> >>> y
> y ~ N(f(a, b), y_sigma)
> 
> >>> model
>    b_mu ~ N(0, 10)
> b_sigma ~ N**+(0, 10)
>    a_mu ~ N(0, 10)
> a_sigma ~ N**+(0, 10)
>       b ~ N(b_mu, b_sigma)
>       a ~ N(a_mu, a_sigma)
> y_sigma ~ N**+(0, 10)
>       y ~ N(f(a, b), y_sigma)
> ```
> 
> Additionally, in Jupyter notebooks, the model now renders as LaTeX (MathJax, to be precise):
> 
> ![image](https://user-images.githubusercontent.com/3042751/118109007-ef135580-b3e0-11eb-815e-a6603e61ff16.png)
> 
> There are some changes w.r.t. how this functionality was implemented in v3:
> 
> * The distribution's names are now provided by the Aesara `RandomVariable._print_name`.
> * Distribution parameters are printed without names (e.g. `N(0, 1)` instead of `N(mu=0, sigma=1)`. This is a consequence of `RandomVariable`'s interface. I considered using inspection to extract the parameter names (like before). However, Aesara follows numpy's naming (e.g. "loc" and "scale" for `NormalRV`), while PyMC3 uses its own ("mu" and "sigma"). For now I decided not to include parameter names to avoid this mismatch, but am open to implement it after all. In general I would actually prefer to have the parameter names.
> * Previously, in more complex models, parameter strings would often become very long, in the form of `f(f(f(f(f(a)), f(f(f(b))), ...`. I've now changed this such that the entire graph going into a parameter is flattened, and only `f(a1, a2, ..., aN)` is left, for every `RandomVariable` `a` occurring in the graph. This should make the strings a lot easier to read.
> * I've grouped all printing-related code in a new module `printing`.

The code is structured somewhat differently from the previous PR, and in terms of functionality the main difference is that this PR will only provide pretty printing in IPython shells (and Jupyter), by registering custom pretty printing handlers on import of `pymc3.printing`. The previous PR attempted to be universal (also in plain python shells) by overriding `__repr__`, leading to potentially hairy situations.