### PR TITLE
Fix param:type rendering in v3 docs

### DIFF
--- a/docs/source/_static/main.css
+++ b/docs/source/_static/main.css
@@ -1,0 +1,5 @@
+.classifier:before {
+    font-style: normal;
+    margin: 0.5em;
+    content: ":";
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -332,6 +332,7 @@ texinfo_documents = [
 def setup(app):
     app.add_css_file("https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css")
     app.add_css_file("default.css")
+    app.add_css_file("main.css")
     dir_root = Path(__file__).parent
     for directory in html_static_path:
         os.makedirs(str(dir_root / directory), exist_ok=True)


### PR DESCRIPTION
**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [X] what are the (breaking) changes that this PR makes?
Fixes https://github.com/pymc-devs/pymc3/issues/4284 for v3 docs. 
Preview [the docs built](https://pymc3-fork.readthedocs.io/en/fix_docstrings/api/inference.html#pymc3.sampling.init_nuts) on my fork with respect to [docs.pymc.io](https://docs.pymc.io/api/inference.html#pymc3.sampling.init_nuts)

+ [X] important background, or details about the implementation
Added custom css as per https://github.com/sphinx-doc/sphinx/pull/5976. 
We could have also used the entire sphinx [basic.css](https://github.com/sphinx-doc/sphinx/blob/4.x/sphinx/themes/basic/static/basic.css_t) file, but I just used a small css snippet which is enough to solve the issue. Adding the entire basic.css file changes a lot how v3 docs look.

+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
