### PR TITLE
switch from pickle/dill to cloudpickle

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,7 @@
 - Logp method of `Uniform` and `DiscreteUniform` no longer depends on `pymc3.distributions.dist_math.bound` for proper evaluation (see [#4541](https://github.com/pymc-devs/pymc3/pull/4541)).
 - `Model.RV_dims` and `Model.coords` are now read-only properties. To modify the `coords` dictionary use `Model.add_coord`. Also `dims` or coordinate values that are `None` will be auto-completed (see [#4625](https://github.com/pymc-devs/pymc3/pull/4625)).
 - The length of `dims` in the model is now tracked symbolically through `Model.dim_lengths` (see [#4625](https://github.com/pymc-devs/pymc3/pull/4625)).
+- We now include `cloudpickle` as a required dependency, and no longer depend on `dill` (see [#4858](https://github.com/pymc-devs/pymc3/pull/4858)).
 - ...
 
 ## PyMC3 3.11.2 (14 March 2021)

--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -6,7 +6,7 @@ dependencies:
 - aesara>=2.0.9
 - arviz>=0.11.2
 - cachetools>=4.2.1
-- dill
+- cloudpickle
 - fastprogress>=0.2.0
 - h5py>=2.7
 - ipython>=7.16

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -6,7 +6,7 @@ dependencies:
 - aesara>=2.0.9
 - arviz>=0.11.2
 - cachetools>=4.2.1
-- dill
+- cloudpickle
 - fastprogress>=0.2.0
 - h5py>=2.7
 - ipython>=7.16

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -6,7 +6,7 @@ dependencies:
 - aesara>=2.0.9
 - arviz>=0.11.2
 - cachetools>=4.2.1
-- dill
+- cloudpickle
 - fastprogress>=0.2.0
 - h5py>=2.7
 - ipython>=7.16

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -7,7 +7,7 @@ dependencies:
 - aesara>=2.0.9
 - arviz>=0.11.2
 - cachetools>=4.2.1
-- dill
+- cloudpickle
 - fastprogress>=0.2.0
 - h5py>=2.7
 - libpython

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -16,7 +16,6 @@
 
 import collections.abc as abc
 import logging
-import pickle
 import sys
 import time
 import warnings
@@ -26,6 +25,7 @@ from copy import copy, deepcopy
 from typing import Any, Dict, Iterable, List, Optional, Set, Union, cast
 
 import aesara.gradient as tg
+import cloudpickle
 import numpy as np
 import xarray
 
@@ -268,7 +268,6 @@ def sample(
     return_inferencedata=None,
     idata_kwargs: dict = None,
     mp_ctx=None,
-    pickle_backend: str = "pickle",
     **kwargs,
 ):
     r"""Draw samples from the posterior using the given step methods.
@@ -362,10 +361,6 @@ def sample(
     mp_ctx : multiprocessing.context.BaseContent
         A multiprocessing context for parallel sampling. See multiprocessing
         documentation for details.
-    pickle_backend : str
-        One of `'pickle'` or `'dill'`. The library used to pickle models
-        in parallel sampling if the multiprocessing context is not of type
-        `fork`.
 
     Returns
     -------
@@ -548,7 +543,6 @@ def sample(
         "discard_tuned_samples": discard_tuned_samples,
     }
     parallel_args = {
-        "pickle_backend": pickle_backend,
         "mp_ctx": mp_ctx,
     }
 
@@ -1100,7 +1094,7 @@ class PopulationStepper:
                     enumerate(progress_bar(steppers)) if progressbar else enumerate(steppers)
                 ):
                     secondary_end, primary_end = multiprocessing.Pipe()
-                    stepper_dumps = pickle.dumps(stepper, protocol=4)
+                    stepper_dumps = cloudpickle.dumps(stepper, protocol=4)
                     process = multiprocessing.Process(
                         target=self.__class__._run_secondary,
                         args=(c, stepper_dumps, secondary_end),
@@ -1159,7 +1153,7 @@ class PopulationStepper:
         # re-seed each child process to make them unique
         np.random.seed(None)
         try:
-            stepper = pickle.loads(stepper_dumps)
+            stepper = cloudpickle.loads(stepper_dumps)
             # the stepper is not necessarily a PopulationArraySharedStep itself,
             # but rather a CompoundStep. PopulationArrayStepShared.population
             # has to be updated, therefore we identify the substeppers first.
@@ -1418,7 +1412,6 @@ def _mp_sample(
     callback=None,
     discard_tuned_samples=True,
     mp_ctx=None,
-    pickle_backend="pickle",
     **kwargs,
 ):
     """Main iteration for multiprocess sampling.
@@ -1491,7 +1484,6 @@ def _mp_sample(
         chain,
         progressbar,
         mp_ctx=mp_ctx,
-        pickle_backend=pickle_backend,
     )
     try:
         try:

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -16,6 +16,7 @@
 
 import collections.abc as abc
 import logging
+import pickle
 import sys
 import time
 import warnings

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -3109,9 +3109,9 @@ def test_serialize_density_dist():
         y = pm.DensityDist("y", func)
         pm.sample(draws=5, tune=1, mp_ctx="spawn")
 
-    import pickle
+    import cloudpickle
 
-    pickle.loads(pickle.dumps(y))
+    cloudpickle.loads(cloudpickle.dumps(y))
 
 
 def test_distinct_rvs():

--- a/pymc3/tests/test_minibatches.py
+++ b/pymc3/tests/test_minibatches.py
@@ -13,9 +13,9 @@
 #   limitations under the License.
 
 import itertools
-import pickle
 
 import aesara
+import cloudpickle
 import numpy as np
 import pytest
 
@@ -132,10 +132,10 @@ class TestGenerator:
 
     def test_pickling(self, datagen):
         gen = generator(datagen)
-        pickle.loads(pickle.dumps(gen))
+        cloudpickle.loads(cloudpickle.dumps(gen))
         bad_gen = generator(integers())
-        with pytest.raises(Exception):
-            pickle.dumps(bad_gen)
+        with pytest.raises(TypeError, match="cannot pickle 'generator' object"):
+            cloudpickle.dumps(bad_gen)
 
     def test_gen_cloning_with_shape_change(self, datagen):
         gen = generator(datagen)

--- a/pymc3/tests/test_minibatches.py
+++ b/pymc3/tests/test_minibatches.py
@@ -134,7 +134,7 @@ class TestGenerator:
         gen = generator(datagen)
         cloudpickle.loads(cloudpickle.dumps(gen))
         bad_gen = generator(integers())
-        with pytest.raises(TypeError, match="cannot pickle 'generator' object"):
+        with pytest.raises(TypeError):
             cloudpickle.dumps(bad_gen)
 
     def test_gen_cloning_with_shape_change(self, datagen):

--- a/pymc3/tests/test_model.py
+++ b/pymc3/tests/test_model.py
@@ -11,7 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import pickle
 import unittest
 
 from functools import reduce
@@ -19,6 +18,7 @@ from functools import reduce
 import aesara
 import aesara.sparse as sparse
 import aesara.tensor as at
+import cloudpickle
 import numpy as np
 import numpy.ma as ma
 import numpy.testing as npt
@@ -407,9 +407,7 @@ def test_model_pickle(tmpdir):
         x = pm.Normal("x")
         pm.Normal("y", observed=1)
 
-    file_path = tmpdir.join("model.p")
-    with open(file_path, "wb") as buff:
-        pickle.dump(model, buff)
+    cloudpickle.loads(cloudpickle.dumps(model))
 
 
 def test_model_pickle_deterministic(tmpdir):
@@ -420,9 +418,7 @@ def test_model_pickle_deterministic(tmpdir):
         pm.Deterministic("w", x / z)
         pm.Normal("y", observed=1)
 
-    file_path = tmpdir.join("model.p")
-    with open(file_path, "wb") as buff:
-        pickle.dump(model, buff)
+    cloudpickle.loads(cloudpickle.dumps(model))
 
 
 def test_model_vars():

--- a/pymc3/tests/test_parallel_sampling.py
+++ b/pymc3/tests/test_parallel_sampling.py
@@ -71,12 +71,6 @@ def _crash_remote_process(a, master_pid):
     return 2 * np.array(a)
 
 
-def test_dill():
-    with pm.Model():
-        pm.Normal("x")
-        pm.sample(tune=1, draws=1, chains=2, cores=2, pickle_backend="dill", mp_ctx="spawn")
-
-
 def test_remote_pipe_closed():
     master_pid = os.getpid()
     with pm.Model():
@@ -112,7 +106,6 @@ def test_abort():
             mp_ctx=ctx,
             start={"a": np.array([1.0]), "b_log__": np.array(2.0)},
             step_method_pickled=None,
-            pickle_backend="pickle",
         )
         proc.start()
         while True:
@@ -147,7 +140,6 @@ def test_explicit_sample():
         mp_ctx=ctx,
         start={"a": np.array([1.0]), "b_log__": np.array(2.0)},
         step_method_pickled=None,
-        pickle_backend="pickle",
     )
     proc.start()
     while True:

--- a/pymc3/tests/test_pickling.py
+++ b/pymc3/tests/test_pickling.py
@@ -15,6 +15,8 @@
 import pickle
 import traceback
 
+import cloudpickle
+
 from pymc3.tests.models import simple_model
 
 
@@ -26,8 +28,8 @@ class TestPickling:
         m = self.model
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             try:
-                s = pickle.dumps(m, proto)
-                pickle.loads(s)
+                s = cloudpickle.dumps(m, proto)
+                cloudpickle.loads(s)
             except Exception:
                 raise AssertionError(
                     "Exception while trying roundtrip with pickle protocol %d:\n" % proto

--- a/pymc3/tests/test_variational_inference.py
+++ b/pymc3/tests/test_variational_inference.py
@@ -757,7 +757,7 @@ def test_remove_scan_op():
 
 
 def test_clear_cache():
-    import pickle
+    import cloudpickle
 
     with pm.Model():
         pm.Normal("n", 0, 1)
@@ -767,7 +767,7 @@ def test_clear_cache():
         inference.approx._cache.clear()
         # should not be cleared at this call
         assert all(len(c) == 0 for c in inference.approx._cache.values())
-        new_a = pickle.loads(pickle.dumps(inference.approx))
+        new_a = cloudpickle.loads(cloudpickle.dumps(inference.approx))
         assert not hasattr(new_a, "_cache")
         inference_new = pm.KLqp(new_a)
         inference_new.fit(n=10)
@@ -871,26 +871,26 @@ def test_rowwise_approx(three_var_model, parametric_grouped_approxes):
 
 
 def test_pickle_approx(three_var_approx):
-    import pickle
+    import cloudpickle
 
-    dump = pickle.dumps(three_var_approx)
-    new = pickle.loads(dump)
+    dump = cloudpickle.dumps(three_var_approx)
+    new = cloudpickle.loads(dump)
     assert new.sample(1)
 
 
 def test_pickle_single_group(three_var_approx_single_group_mf):
-    import pickle
+    import cloudpickle
 
-    dump = pickle.dumps(three_var_approx_single_group_mf)
-    new = pickle.loads(dump)
+    dump = cloudpickle.dumps(three_var_approx_single_group_mf)
+    new = cloudpickle.loads(dump)
     assert new.sample(1)
 
 
 def test_pickle_approx_aevb(three_var_aevb_approx):
-    import pickle
+    import cloudpickle
 
-    dump = pickle.dumps(three_var_aevb_approx)
-    new = pickle.loads(dump)
+    dump = cloudpickle.dumps(three_var_aevb_approx)
+    new = cloudpickle.loads(dump)
     assert new.sample(1000)
 
 

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -19,7 +19,7 @@ import warnings
 from typing import Dict, List, Tuple, Union
 
 import arviz
-import dill
+import cloudpickle
 import numpy as np
 import xarray
 
@@ -347,7 +347,7 @@ def hashable(a=None) -> int:
         pass
     # Not hashable >>>
     try:
-        return hash(dill.dumps(a))
+        return hash(cloudpickle.dumps(a))
     except Exception:
         if hasattr(a, "__dict__"):
             return hashable(a.__dict__)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 aesara>=2.0.9
 arviz>=0.11.2
 cachetools>=4.2.1
-dill
+cloudpickle
 fastprogress>=0.2.0
 h5py>=2.7
 ipython>=7.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aesara>=2.0.9
 arviz>=0.11.2
 cachetools>=4.2.1
-dill
+cloudpickle
 fastprogress>=0.2.0
 numpy>=1.15.0
 pandas>=0.24.0


### PR DESCRIPTION
Fixing #4856 and (hopefully) preventing future issues with serialization, parallel sampling, etc. This PR also removes the `pickle_backend` parameter from `pm.sample`.

@twiecki @michaelosthege 