### PR TITLE
Remove custom math functions

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -30,6 +30,7 @@
 - The length of `dims` in the model is now tracked symbolically through `Model.dim_lengths` (see [#4625](https://github.com/pymc-devs/pymc3/pull/4625)).
 - We now include `cloudpickle` as a required dependency, and no longer depend on `dill` (see [#4858](https://github.com/pymc-devs/pymc3/pull/4858)).
 - The `incomplete_beta` function in `pymc3.distributions.dist_math` was replaced by `aesara.tensor.betainc` (see [4857](https://github.com/pymc-devs/pymc3/pull/4857)).
+- `math.log1mexp` and `math.log1mexp_numpy` will expect negative inputs in the future. A `FutureWarning` is now raised unless `negative_input=True` is set (see [#4860](https://github.com/pymc-devs/pymc3/pull/4860)).
 - ...
 
 ## PyMC3 3.11.2 (14 March 2021)

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -67,7 +67,7 @@ from pymc3.distributions.dist_math import (
     zvalue,
 )
 from pymc3.distributions.distribution import Continuous
-from pymc3.math import log1mexp, log1pexp, logdiffexp, logit
+from pymc3.math import logdiffexp, logit
 from pymc3.util import UNSET
 
 __all__ = [
@@ -1095,7 +1095,7 @@ class Wald(PositiveContinuous):
         return bound(
             at.switch(
                 at.lt(value, np.inf),
-                a + log1pexp(b - a),
+                a + at.log1pexp(b - a),
                 0,
             ),
             0 < value,
@@ -1370,7 +1370,7 @@ class Kumaraswamy(UnitContinuous):
         -------
         TensorVariable
         """
-        logcdf = log1mexp(-(b * at.log1p(-(value ** a))))
+        logcdf = at.log1mexp(b * at.log1p(-(value ** a)))
         return bound(at.switch(value < 1, logcdf, 0), value >= 0, a > 0, b > 0)
 
 
@@ -1462,7 +1462,7 @@ class Exponential(PositiveContinuous):
         """
         lam = at.inv(mu)
         return bound(
-            log1mexp(lam * value),
+            at.log1mexp(-lam * value),
             0 <= value,
             0 <= lam,
         )
@@ -2711,7 +2711,7 @@ class Weibull(PositiveContinuous):
         """
         a = (value / beta) ** alpha
         return bound(
-            log1mexp(a),
+            at.log1mexp(-a),
             0 <= value,
             0 < alpha,
             0 < beta,
@@ -3662,7 +3662,7 @@ class Logistic(Continuous):
         """
 
         return bound(
-            -log1pexp(-(value - mu) / s),
+            -at.log1pexp(-(value - mu) / s),
             0 < s,
         )
 

--- a/pymc3/distributions/discrete.py
+++ b/pymc3/distributions/discrete.py
@@ -42,7 +42,7 @@ from pymc3.distributions.dist_math import (
 )
 from pymc3.distributions.distribution import Discrete
 from pymc3.distributions.logprob import _logcdf, _logp
-from pymc3.math import log1mexp, logaddexp, logsumexp, sigmoid
+from pymc3.math import sigmoid
 
 __all__ = [
     "Binomial",
@@ -279,7 +279,7 @@ class BetaBinomial(Discrete):
         return bound(
             at.switch(
                 at.lt(value, n),
-                logsumexp(
+                at.logsumexp(
                     BetaBinomial.logp(at.arange(safe_lower, value + 1), n, alpha, beta),
                     keepdims=False,
                 ),
@@ -826,7 +826,7 @@ class Geometric(Discrete):
         """
 
         return bound(
-            log1mexp(-at.log1p(-p) * value),
+            at.log1mexp(at.log1p(-p) * value),
             0 <= value,
             0 <= p,
             p <= 1,
@@ -945,7 +945,7 @@ class HyperGeometric(Discrete):
         return bound(
             at.switch(
                 at.lt(value, n),
-                logsumexp(
+                at.logsumexp(
                     HyperGeometric.logp(at.arange(safe_lower, value + 1), good, bad, n),
                     keepdims=False,
                 ),
@@ -1300,7 +1300,7 @@ class ZeroInflatedPoisson(Discrete):
         logp_val = at.switch(
             at.gt(value, 0),
             at.log(psi) + _logp(poisson, value, {}, theta),
-            logaddexp(at.log1p(-psi), at.log(psi) - theta),
+            at.logaddexp(at.log1p(-psi), at.log(psi) - theta),
         )
 
         return bound(
@@ -1328,7 +1328,7 @@ class ZeroInflatedPoisson(Discrete):
         """
 
         return bound(
-            logaddexp(at.log1p(-psi), at.log(psi) + _logcdf(poisson, value, {}, theta)),
+            at.logaddexp(at.log1p(-psi), at.log(psi) + _logcdf(poisson, value, {}, theta)),
             0 <= value,
             0 <= psi,
             psi <= 1,
@@ -1430,7 +1430,7 @@ class ZeroInflatedBinomial(Discrete):
         logp_val = at.switch(
             at.gt(value, 0),
             at.log(psi) + _logp(binomial, value, {}, n, p),
-            logaddexp(at.log1p(-psi), at.log(psi) + n * at.log1p(-p)),
+            at.logaddexp(at.log1p(-psi), at.log(psi) + n * at.log1p(-p)),
         )
 
         return bound(
@@ -1460,7 +1460,7 @@ class ZeroInflatedBinomial(Discrete):
         """
 
         return bound(
-            logaddexp(at.log1p(-psi), at.log(psi) + _logcdf(binomial, value, {}, n, p)),
+            at.logaddexp(at.log1p(-psi), at.log(psi) + _logcdf(binomial, value, {}, n, p)),
             0 <= value,
             value <= n,
             0 <= psi,
@@ -1583,7 +1583,7 @@ class ZeroInflatedNegativeBinomial(Discrete):
             at.switch(
                 at.gt(value, 0),
                 at.log(psi) + _logp(nbinom, value, {}, n, p),
-                logaddexp(at.log1p(-psi), at.log(psi) + n * at.log(p)),
+                at.logaddexp(at.log1p(-psi), at.log(psi) + n * at.log(p)),
             ),
             0 <= value,
             0 <= psi,
@@ -1609,7 +1609,7 @@ class ZeroInflatedNegativeBinomial(Discrete):
         TensorVariable
         """
         return bound(
-            logaddexp(at.log1p(-psi), at.log(psi) + _logcdf(nbinom, value, {}, n, p)),
+            at.logaddexp(at.log1p(-psi), at.log(psi) + _logcdf(nbinom, value, {}, n, p)),
             0 <= value,
             0 <= psi,
             psi <= 1,

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1165,7 +1165,7 @@ class TestMatchesScipy:
             )
 
         def scipy_log_cdf(value, a, b):
-            return pm.math.log1mexp_numpy(-(b * np.log1p(-(value ** a))))
+            return pm.math.log1mexp_numpy(b * np.log1p(-(value ** a)), negative_input=True)
 
         self.check_logp(
             Kumaraswamy,

--- a/pymc3/tests/test_math.py
+++ b/pymc3/tests/test_math.py
@@ -18,8 +18,6 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from scipy.special import logsumexp as scipy_logsumexp
-
 from pymc3.aesaraf import floatX
 from pymc3.math import (
     LogDet,
@@ -31,9 +29,9 @@ from pymc3.math import (
     kronecker,
     log1mexp,
     log1mexp_numpy,
-    log1pexp,
     logdet,
-    logsumexp,
+    logdiffexp,
+    logdiffexp_numpy,
     probit,
 )
 from pymc3.tests.helpers import SeededTest, verify_grad
@@ -126,28 +124,6 @@ def test_probit():
     np.testing.assert_allclose(invprobit(probit(p)).eval(), p, atol=1e-5)
 
 
-def test_log1pexp():
-    vals = np.array([-1e20, -100, -10, -1e-4, 0, 1e-4, 10, 100, 1e20])
-    # import mpmath
-    # mpmath.mp.dps = 1000
-    # [float(mpmath.log(1 + mpmath.exp(x))) for x in vals]
-    expected = np.array(
-        [
-            0.0,
-            3.720075976020836e-44,
-            4.539889921686465e-05,
-            0.6930971818099453,
-            0.6931471805599453,
-            0.6931971818099453,
-            10.000045398899218,
-            100.0,
-            1e20,
-        ]
-    )
-    actual = log1pexp(vals).eval()
-    npt.assert_allclose(actual, expected)
-
-
 def test_log1mexp():
     vals = np.array([-1, 0, 1e-20, 1e-4, 10, 100, 1e20])
     vals_ = vals.copy()
@@ -165,9 +141,9 @@ def test_log1mexp():
             0.0,
         ]
     )
-    actual = log1mexp(vals).eval()
+    actual = at.log1mexp(-vals).eval()
     npt.assert_allclose(actual, expected)
-    actual_ = log1mexp_numpy(vals)
+    actual_ = log1mexp_numpy(-vals, negative_input=True)
     npt.assert_allclose(actual_, expected)
     # Check that input was not changed in place
     npt.assert_allclose(vals, vals_)
@@ -176,8 +152,45 @@ def test_log1mexp():
 def test_log1mexp_numpy_no_warning():
     """Assert RuntimeWarning is not raised for very small numbers"""
     with pytest.warns(None) as record:
-        log1mexp_numpy(1e-25)
+        log1mexp_numpy(-1e-25, negative_input=True)
     assert not record
+
+
+def test_log1mexp_numpy_integer_input():
+    assert np.isclose(log1mexp_numpy(-2, negative_input=True), at.log1mexp(-2).eval())
+
+
+def test_log1mexp_deprecation_warnings():
+    with pytest.warns(
+        FutureWarning,
+        match="pymc3.math.log1mexp_numpy will expect a negative input",
+    ):
+        res_pos = log1mexp_numpy(2)
+
+    with pytest.warns(None) as record:
+        res_neg = log1mexp_numpy(-2, negative_input=True)
+    assert not record
+
+    with pytest.warns(
+        FutureWarning,
+        match="pymc3.math.log1mexp will expect a negative input",
+    ):
+        res_pos_at = log1mexp(2).eval()
+
+    with pytest.warns(None):
+        res_neg_at = log1mexp(-2, negative_input=True).eval()
+
+    assert np.isclose(res_pos, res_neg)
+    assert np.isclose(res_pos_at, res_neg)
+    assert np.isclose(res_neg_at, res_neg)
+
+
+def test_logdiffexp():
+    a = np.log([1, 2, 3, 4])
+    b = np.log([0, 1, 2, 3])
+
+    assert np.allclose(logdiffexp_numpy(a, b), 0)
+    assert np.allclose(logdiffexp(a, b).eval(), 0)
 
 
 class TestLogDet(SeededTest):
@@ -237,27 +250,3 @@ def test_expand_packed_triangular():
     assert np.all(expand_upper.eval({packed: upper_packed}) == upper)
     assert np.all(expand_diag_lower.eval({packed: lower_packed}) == floatX(np.diag(vals)))
     assert np.all(expand_diag_upper.eval({packed: upper_packed}) == floatX(np.diag(vals)))
-
-
-@pytest.mark.parametrize(
-    "values, axis, keepdims",
-    [
-        (np.array([-4, -2]), None, True),
-        (np.array([-np.inf, -2]), None, True),
-        (np.array([-2, np.inf]), None, True),
-        (np.array([-np.inf, -np.inf]), None, True),
-        (np.array([np.inf, np.inf]), None, True),
-        (np.array([-np.inf, np.inf]), None, True),
-        (np.array([[-np.inf, -np.inf], [-np.inf, -np.inf]]), None, True),
-        (np.array([[-np.inf, -np.inf], [-np.inf, -np.inf]]), 0, True),
-        (np.array([[-np.inf, -np.inf], [-np.inf, -np.inf]]), 1, True),
-        (np.array([[-np.inf, -np.inf], [-np.inf, -np.inf]]), 0, False),
-        (np.array([[-np.inf, -np.inf], [-np.inf, -np.inf]]), 1, False),
-        (np.array([[-2, np.inf], [-np.inf, -np.inf]]), 0, True),
-    ],
-)
-def test_logsumexp(values, axis, keepdims):
-    npt.assert_almost_equal(
-        logsumexp(values, axis=axis, keepdims=keepdims).eval(),
-        scipy_logsumexp(values, axis=axis, keepdims=keepdims),
-    )


### PR DESCRIPTION
This PR removes the custom `logaddexp`, `logsumexp`, and `log1pexp` functions and deprecates `log1mexp` in favor of Aesara implementations.

A deprecation warning is added for `log1mexp` (and the numpy counterpart) because the Aesara function, more logically, expects a negative input.

Also fixed a bug in `log1mexp_numpy` when the input was an integer.

Closes #4747