### PR TITLE
Raise Not_Implemented_Error for iterating over t in trace (Issue #4819)

### DIFF
--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -541,8 +541,7 @@ class MultiTrace:
             If a chain is not given, the highest chain number is used.
         """
         if chain is None:
-            chain = self.chains[-1]
-        return self._straces[chain].point(idx)
+            raise NotImplementedError
 
     def points(self, chains=None):
         """Return an iterator over all or some of the sample points


### PR DESCRIPTION
MultiTrace does not implement an `__iter__` method, but for some reason you can still do for `t in trace`.  This iteration yields iteration over the last chain `chain[-1]` only. Since`MultiTrace` will ultimately be deprecated in favour of `InferenceData`, this change is resolved by raising a `NotImplementedError`.

See issue #4819.