### PR TITLE
Refactor `pm.Simulator`

### DIFF
--- a/docs/source/api/distributions.rst
+++ b/docs/source/api/distributions.rst
@@ -8,6 +8,7 @@ Distributions
    distributions/discrete
    distributions/multivariate
    distributions/mixture
+   distributions/simulator
    distributions/timeseries
    distributions/transforms
    distributions/utilities

--- a/docs/source/api/distributions/simulator.rst
+++ b/docs/source/api/distributions/simulator.rst
@@ -1,0 +1,11 @@
+**********
+Simulator
+**********
+
+.. currentmodule:: pymc3.distributions.simulator
+.. autosummary::
+
+   Simulator
+
+.. automodule:: pymc3.distributions.simulator
+   :members:

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -23,7 +23,6 @@ from functools import singledispatch
 from typing import Optional
 
 import aesara
-import aesara.tensor as at
 
 from aesara.tensor.random.op import RandomVariable
 from aesara.tensor.random.var import RandomStateSharedVariable
@@ -353,47 +352,6 @@ def get_moment(rv: TensorVariable) -> TensorVariable:
     return _get_moment(rv.owner.op, rv, size, *rv.owner.inputs[3:])
 
 
-class NoDistribution(Distribution):
-    def __init__(
-        self,
-        shape,
-        dtype,
-        initval=None,
-        defaults=(),
-        parent_dist=None,
-        *args,
-        **kwargs,
-    ):
-        super().__init__(
-            shape=shape, dtype=dtype, initval=initval, defaults=defaults, *args, **kwargs
-        )
-        self.parent_dist = parent_dist
-
-    def __getattr__(self, name):
-        # Do not use __getstate__ and __setstate__ from parent_dist
-        # to avoid infinite recursion during unpickling
-        if name.startswith("__"):
-            raise AttributeError("'NoDistribution' has no attribute '%s'" % name)
-        return getattr(self.parent_dist, name)
-
-    def logp(self, x):
-        """Calculate log probability.
-
-        Parameters
-        ----------
-        x: numeric
-            Value for which log-probability is calculated.
-
-        Returns
-        -------
-        TensorVariable
-        """
-        return at.zeros_like(x)
-
-    def _distr_parameters_for_repr(self):
-        return []
-
-
 class Discrete(Distribution):
     """Base class for discrete distributions"""
 
@@ -407,6 +365,13 @@ class Discrete(Distribution):
 
 class Continuous(Distribution):
     """Base class for continuous distributions"""
+
+
+class NoDistribution(Distribution):
+    """Base class for artifical distributions
+
+    RandomVariables that share this type are allowed in logprob graphs
+    """
 
 
 class DensityDist(Distribution):

--- a/pymc3/distributions/simulator.py
+++ b/pymc3/distributions/simulator.py
@@ -244,12 +244,8 @@ class Simulator(NoDistribution):
 
         # Create a new simulatorRV with identical inputs as the original one
         sim_op = sim_rv.owner.op
-        new_rng, sim_value = sim_op.make_node(rng, *sim_rv.owner.inputs[1:]).outputs
+        sim_value = sim_op.make_node(rng, *sim_rv.owner.inputs[1:]).default_output()
         sim_value.name = "sim_value"
-
-        # Automatically update rng when expression is evaluated
-        sim_value.update = (rng, new_rng)
-        rng.default_update = new_rng
 
         return sim_op.distance(
             sim_op.epsilon,

--- a/pymc3/smc/sample_smc.py
+++ b/pymc3/smc/sample_smc.py
@@ -182,15 +182,6 @@ def sample_smc(
         if parallel is False:
             cores = 1
 
-    _log = logging.getLogger("pymc3")
-    _log.info("Initializing SMC sampler...")
-
-    model = modelcontext(model)
-    if model.name:
-        raise NotImplementedError(
-            "The SMC implementation currently does not support named models. "
-            "See https://github.com/pymc-devs/pymc3/pull/4365."
-        )
     if cores is None:
         cores = _cpu_count()
 
@@ -198,11 +189,6 @@ def sample_smc(
         chains = max(2, cores)
     else:
         cores = min(chains, cores)
-
-    _log.info(
-        f"Sampling {chains} chain{'s' if chains > 1 else ''} "
-        f"in {cores} job{'s' if cores > 1 else ''}"
-    )
 
     if random_seed == -1:
         random_seed = None
@@ -214,6 +200,15 @@ def sample_smc(
         random_seed = [np.random.randint(2 ** 30) for _ in range(chains)]
     if not isinstance(random_seed, Iterable):
         raise TypeError("Invalid value for `random_seed`. Must be tuple, list or int")
+
+    model = modelcontext(model)
+
+    _log = logging.getLogger("pymc3")
+    _log.info("Initializing SMC sampler...")
+    _log.info(
+        f"Sampling {chains} chain{'s' if chains > 1 else ''} "
+        f"in {cores} job{'s' if cores > 1 else ''}"
+    )
 
     params = (
         draws,

--- a/pymc3/smc/smc.py
+++ b/pymc3/smc/smc.py
@@ -19,12 +19,12 @@ from typing import Dict
 import aesara.tensor as at
 import numpy as np
 
-from aesara import function as aesara_function
 from aesara.graph.basic import clone_replace
 from scipy.special import logsumexp
 from scipy.stats import multivariate_normal
 
 from pymc3.aesaraf import (
+    compile_rv_inplace,
     floatX,
     inputvars,
     join_nonshared_inputs,
@@ -575,6 +575,6 @@ def _logp_forw(point, out_vars, vars, shared):
         vars = new_vars
 
     out_list, inarray0 = join_nonshared_inputs(point, out_vars, vars, shared)
-    f = aesara_function([inarray0], out_list[0])
+    f = compile_rv_inplace([inarray0], out_list[0])
     f.trust_input = True
     return f

--- a/pymc3/tests/test_smc.py
+++ b/pymc3/tests/test_smc.py
@@ -12,11 +12,19 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import aesara
 import aesara.tensor as at
 import numpy as np
 import pytest
 import scipy.stats as st
 
+from aesara.graph.basic import ancestors
+from aesara.tensor.random.op import RandomVariable
+from aesara.tensor.random.var import (
+    RandomGeneratorSharedVariable,
+    RandomStateSharedVariable,
+)
+from aesara.tensor.sort import SortOp
 from arviz.data.inference_data import InferenceData
 
 import pymc3 as pm
@@ -236,82 +244,256 @@ class TestSMC(SeededTest):
                 pm.sample_smc(draws=10, chains=1, save_log_pseudolikelihood=True)
 
 
-@pytest.mark.xfail(reason="SMC-ABC not refactored yet")
-class TestSMCABC(SeededTest):
+class TestSimulator(SeededTest):
+    """
+    Tests for pm.Simulator. They are included in this file because Simulator was
+    designed primarily to be used with SMC sampling.
+    """
+
+    @staticmethod
+    def count_rvs(end_node):
+        return len(
+            [
+                node
+                for node in ancestors([end_node])
+                if node.owner is not None and isinstance(node.owner.op, RandomVariable)
+            ]
+        )
+
+    @staticmethod
+    def normal_sim(rng, a, b, size):
+        return rng.normal(a, b, size=size)
+
+    @staticmethod
+    def abs_diff(eps, obs_data, sim_data):
+        return np.mean(np.abs((obs_data - sim_data) / eps))
+
+    @staticmethod
+    def quantiles(x):
+        return np.quantile(x, [0.25, 0.5, 0.75])
+
     def setup_class(self):
         super().setup_class()
         self.data = np.random.normal(loc=0, scale=1, size=1000)
 
-        def normal_sim(a, b):
-            return np.random.normal(a, b, 1000)
-
         with pm.Model() as self.SMABC_test:
             a = pm.Normal("a", mu=0, sigma=1)
             b = pm.HalfNormal("b", sigma=1)
-            s = pm.Simulator(
-                "s", normal_sim, params=(a, b), sum_stat="sort", epsilon=1, observed=self.data
-            )
+            s = pm.Simulator("s", self.normal_sim, a, b, sum_stat="sort", observed=self.data)
             self.s = s
 
-        def quantiles(x):
-            return np.quantile(x, [0.25, 0.5, 0.75])
+        with pm.Model() as self.SMABC_potential:
+            a = pm.Normal("a", mu=0, sigma=1, initval=0.5)
+            b = pm.HalfNormal("b", sigma=1)
+            c = pm.Potential("c", pm.math.switch(a > 0, 0, -np.inf))
+            s = pm.Simulator("s", self.normal_sim, a, b, observed=self.data)
 
-        def abs_diff(eps, obs_data, sim_data):
-            return np.mean(np.abs((obs_data - sim_data) / eps))
+    def test_one_gaussian(self):
+        assert self.count_rvs(self.SMABC_test.logpt) == 1
 
-        with pm.Model() as self.SMABC_test2:
+        with self.SMABC_test:
+            trace = pm.sample_smc(draws=1000, return_inferencedata=False)
+            pr_p = pm.sample_prior_predictive(1000)
+            po_p = pm.sample_posterior_predictive(trace, 1000)
+
+        assert abs(self.data.mean() - trace["a"].mean()) < 0.05
+        assert abs(self.data.std() - trace["b"].mean()) < 0.05
+
+        assert pr_p["s"].shape == (1000, 1000)
+        assert abs(0 - pr_p["s"].mean()) < 0.10
+        assert abs(1.4 - pr_p["s"].std()) < 0.10
+
+        assert po_p["s"].shape == (1000, 1000)
+        assert abs(self.data.mean() - po_p["s"].mean()) < 0.10
+        assert abs(self.data.std() - po_p["s"].std()) < 0.10
+
+    def test_custom_dist_sum_stat(self):
+        with pm.Model() as m:
             a = pm.Normal("a", mu=0, sigma=1)
             b = pm.HalfNormal("b", sigma=1)
             s = pm.Simulator(
                 "s",
-                normal_sim,
-                params=(a, b),
-                distance=abs_diff,
-                sum_stat=quantiles,
-                epsilon=1,
+                self.normal_sim,
+                a,
+                b,
+                distance=self.abs_diff,
+                sum_stat=self.quantiles,
                 observed=self.data,
             )
 
-        with pm.Model() as self.SMABC_potential:
-            a = pm.Normal("a", mu=0, sigma=1)
-            b = pm.HalfNormal("b", sigma=1)
-            c = pm.Potential("c", pm.math.switch(a > 0, 0, -np.inf))
+        assert self.count_rvs(m.logpt) == 1
+
+        with m:
+            pm.sample_smc(draws=100)
+
+    def test_custom_dist_sum_stat_scalar(self):
+        """
+        Test that automatically wrapped functions cope well with scalar inputs
+        """
+        scalar_data = 5
+
+        with pm.Model() as m:
             s = pm.Simulator(
-                "s", normal_sim, params=(a, b), sum_stat="sort", epsilon=1, observed=self.data
+                "s",
+                self.normal_sim,
+                0,
+                1,
+                distance=self.abs_diff,
+                sum_stat=self.quantiles,
+                observed=scalar_data,
             )
+        assert self.count_rvs(m.logpt) == 1
 
-    def test_one_gaussian(self):
-        with self.SMABC_test:
-            trace = pm.sample_smc(draws=1000, kernel="ABC")
+        with pm.Model() as m:
+            s = pm.Simulator(
+                "s",
+                self.normal_sim,
+                0,
+                1,
+                distance=self.abs_diff,
+                sum_stat="mean",
+                observed=scalar_data,
+            )
+        assert self.count_rvs(m.logpt) == 1
 
-        np.testing.assert_almost_equal(self.data.mean(), trace["a"].mean(), decimal=2)
-        np.testing.assert_almost_equal(self.data.std(), trace["b"].mean(), decimal=1)
+    def test_model_with_potential(self):
+        assert self.count_rvs(self.SMABC_potential.logpt) == 1
 
-    def test_sim_data_ppc(self):
-        with self.SMABC_test:
-            trace, sim_data = pm.sample_smc(draws=1000, kernel="ABC", chains=2, save_sim_data=True)
-            pr_p = pm.sample_prior_predictive(1000)
-            po_p = pm.sample_posterior_predictive(trace, 1000)
-
-        assert sim_data["s"].shape == (2, 1000, 1000)
-        np.testing.assert_almost_equal(self.data.mean(), sim_data["s"].mean(), decimal=2)
-        np.testing.assert_almost_equal(self.data.std(), sim_data["s"].std(), decimal=1)
-        assert pr_p["s"].shape == (1000, 1000)
-        np.testing.assert_almost_equal(0, pr_p["s"].mean(), decimal=1)
-        np.testing.assert_almost_equal(1.4, pr_p["s"].std(), decimal=1)
-        assert po_p["s"].shape == (1000, 1000)
-        np.testing.assert_almost_equal(0, po_p["s"].mean(), decimal=2)
-        np.testing.assert_almost_equal(1, po_p["s"].std(), decimal=1)
-
-    def test_custom_dist_sum(self):
-        with self.SMABC_test2:
-            trace = pm.sample_smc(draws=1000, kernel="ABC")
-
-    def test_potential(self):
         with self.SMABC_potential:
-            trace = pm.sample_smc(draws=1000, kernel="ABC")
+            trace = pm.sample_smc(draws=100, chains=1, return_inferencedata=False)
             assert np.all(trace["a"] >= 0)
 
+    def test_simulator_metropolis_mcmc(self):
+        with self.SMABC_test as m:
+            step = pm.Metropolis([m.rvs_to_values[m["a"]], m.rvs_to_values[m["b"]]])
+            trace = pm.sample(step=step, return_inferencedata=False)
+
+        assert abs(self.data.mean() - trace["a"].mean()) < 0.05
+        assert abs(self.data.std() - trace["b"].mean()) < 0.05
+
+    def test_multiple_simulators(self):
+        true_a = 2
+        true_b = -2
+
+        data1 = np.random.normal(true_a, 0.1, size=1000)
+        data2 = np.random.normal(true_b, 0.1, size=1000)
+
+        with pm.Model() as m:
+            a = pm.Normal("a", mu=0, sigma=3)
+            b = pm.Normal("b", mu=0, sigma=3)
+            sim1 = pm.Simulator(
+                "sim1",
+                self.normal_sim,
+                a,
+                0.1,
+                distance="gaussian",
+                sum_stat="sort",
+                observed=data1,
+            )
+            sim2 = pm.Simulator(
+                "sim2",
+                self.normal_sim,
+                b,
+                0.1,
+                distance="laplace",
+                sum_stat="mean",
+                epsilon=0.1,
+                observed=data2,
+            )
+
+        assert self.count_rvs(m.logpt) == 2
+
+        # Check that the logps use the correct methods
+        a_val = m.rvs_to_values[a]
+        sim1_val = m.rvs_to_values[sim1]
+        logp_sim1 = pm.logp(sim1, sim1_val)
+        logp_sim1_fn = aesara.function([sim1_val, a_val], logp_sim1)
+
+        b_val = m.rvs_to_values[b]
+        sim2_val = m.rvs_to_values[sim2]
+        logp_sim2 = pm.logp(sim2, sim2_val)
+        logp_sim2_fn = aesara.function([sim2_val, b_val], logp_sim2)
+
+        assert any(
+            node for node in logp_sim1_fn.maker.fgraph.toposort() if isinstance(node.op, SortOp)
+        )
+
+        assert not any(
+            node for node in logp_sim2_fn.maker.fgraph.toposort() if isinstance(node.op, SortOp)
+        )
+
+        with m:
+            trace = pm.sample_smc(return_inferencedata=False)
+
+        assert abs(true_a - trace["a"].mean()) < 0.05
+        assert abs(true_b - trace["b"].mean()) < 0.05
+
+    def test_nested_simulators(self):
+        true_a = 2
+        rng = self.get_random_state()
+        data = rng.normal(true_a, 0.1, size=1000)
+
+        with pm.Model() as m:
+            sim1 = pm.Simulator(
+                "sim1",
+                self.normal_sim,
+                params=(0, 4),
+                distance="gaussian",
+                sum_stat="identity",
+            )
+            sim2 = pm.Simulator(
+                "sim2",
+                self.normal_sim,
+                params=(sim1, 0.1),
+                distance="gaussian",
+                sum_stat="mean",
+                epsilon=0.1,
+                observed=data,
+            )
+
+        assert self.count_rvs(m.logpt) == 2
+
+        with m:
+            trace = pm.sample_smc(return_inferencedata=False)
+
+        assert np.abs(true_a - trace["sim1"].mean()) < 0.1
+
+    def test_upstream_rngs_not_in_compiled_logp(self):
+        smc = IMH(model=self.SMABC_test)
+        smc.initialize_population()
+        smc._initialize_kernel()
+        likelihood_func = smc.likelihood_logp_func
+
+        # Test graph is stochastic
+        inarray = floatX(np.array([0, 0]))
+        assert likelihood_func(inarray) != likelihood_func(inarray)
+
+        # Test only one shared RNG is present
+        compiled_graph = likelihood_func.maker.fgraph.outputs
+        shared_rng_vars = [
+            node
+            for node in ancestors(compiled_graph)
+            if isinstance(node, (RandomStateSharedVariable, RandomGeneratorSharedVariable))
+        ]
+        assert len(shared_rng_vars) == 1
+
+    def test_simulator_error_msg(self):
+        msg = "The distance metric not_real is not implemented"
+        with pytest.raises(ValueError, match=msg):
+            with pm.Model() as m:
+                sim = pm.Simulator("sim", self.normal_sim, 0, 1, distance="not_real")
+
+        msg = "The summary statistic not_real is not implemented"
+        with pytest.raises(ValueError, match=msg):
+            with pm.Model() as m:
+                sim = pm.Simulator("sim", self.normal_sim, 0, 1, sum_stat="not_real")
+
+        msg = "Cannot pass both unnamed parameters and `params`"
+        with pytest.raises(ValueError, match=msg):
+            with pm.Model() as m:
+                sim = pm.Simulator("sim", self.normal_sim, 0, params=(1))
+
+    @pytest.mark.xfail(reason="KL not refactored")
     def test_automatic_use_of_sort(self):
         with pm.Model() as model:
             s_k = pm.Simulator(
@@ -324,31 +506,26 @@ class TestSMCABC(SeededTest):
             )
         assert s_k.distribution.sum_stat is pm.distributions.simulator.identity
 
-    def test_repr_latex(self):
-        expected = "$\\text{s} \\sim  \\text{Simulator}(\\text{normal_sim}(a, b), \\text{gaussian}, \\text{sort})$"
-        assert expected == self.s._repr_latex_()
-        assert self.s._repr_latex_() == self.s.__latex__()
-        assert self.SMABC_test.model._repr_latex_() == self.SMABC_test.model.__latex__()
-
     def test_name_is_string_type(self):
         with self.SMABC_potential:
             assert not self.SMABC_potential.name
-            trace = pm.sample_smc(draws=10, kernel="ABC")
+            trace = pm.sample_smc(draws=10, chains=1, return_inferencedata=False)
             assert isinstance(trace._straces[0].name, str)
 
-    def test_named_models_are_unsupported(self):
-        def normal_sim(a, b):
-            return np.random.normal(a, b, 1000)
-
-        with pm.Model(name="NamedModel"):
+    def test_named_model(self):
+        # Named models used to fail with Simulator because the arguments to the
+        # random fn used to be passed by name. This is no longer true.
+        # https://github.com/pymc-devs/pymc3/pull/4365#issuecomment-761221146
+        name = "NamedModel"
+        with pm.Model(name=name):
             a = pm.Normal("a", mu=0, sigma=1)
             b = pm.HalfNormal("b", sigma=1)
-            c = pm.Potential("c", pm.math.switch(a > 0, 0, -np.inf))
-            s = pm.Simulator(
-                "s", normal_sim, params=(a, b), sum_stat="sort", epsilon=1, observed=self.data
-            )
-            with pytest.raises(NotImplementedError, match="named models"):
-                pm.sample_smc(draws=10, kernel="ABC")
+            s = pm.Simulator("s", self.normal_sim, a, b, observed=self.data)
+
+            trace = pm.sample_smc(draws=10, chains=2, return_inferencedata=False)
+            assert f"{name}_a" in trace.varnames
+            assert f"{name}_b" in trace.varnames
+            assert f"{name}_b_log__" in trace.varnames
 
 
 class TestMHKernel(SeededTest):


### PR DESCRIPTION
Third attempt at refactoring `pm.Simulator`.

Apparently `cloudpickle` overcomes the limitations that we were facing in previous iterations of this PR in #4802 and #4877 
