### PR TITLE
Update model.py

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -1224,9 +1224,9 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
         name = rv_var.name
         data = pandas_to_array(data).astype(rv_var.dtype)
 
-        if data.ndim != rv_var.ndim:
+        if data.ndim != rv_var.ndim_supp:
             raise ShapeError(
-                "Dimensionality of data and RV don't match.", actual=data.ndim, expected=rv_var.ndim
+                "Dimensionality of data and RV don't match.", actual=data.ndim, expected=rv_var.ndim_supp
             )
 
         if aesara.config.compute_test_value != "off":


### PR DESCRIPTION
i'm not sure of this,  but the new v4 dev guide has `ndim_supp` instead of `ndim`, so despite setting the `ndim_supp`as 1 in  my definition of RV, when i try to use the distribution it expects a shape of 2 for the data???
