### PR TITLE
Remove initval from `dist()` API and add docstrings, type hints, tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,6 +30,7 @@ jobs:
         # → pytest will run only these files
           - |
             --ignore=pymc3/tests/test_distributions_timeseries.py
+            --ignore=pymc3/tests/test_initvals.py
             --ignore=pymc3/tests/test_mixture.py
             --ignore=pymc3/tests/test_model_graph.py
             --ignore=pymc3/tests/test_modelcontext.py
@@ -60,7 +61,9 @@ jobs:
             --ignore=pymc3/tests/test_distributions_random.py
             --ignore=pymc3/tests/test_idata_conversion.py
 
-          - pymc3/tests/test_distributions.py
+          - |
+            pymc3/tests/test_initvals.py
+            pymc3/tests/test_distributions.py
 
           - |
             pymc3/tests/test_modelcontext.py
@@ -153,6 +156,7 @@ jobs:
         floatx: [float32, float64]
         test-subset:
           - |
+            pymc3/tests/test_initvals.py
             pymc3/tests/test_distributions_random.py
             pymc3/tests/test_distributions_timeseries.py
           - |

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,7 +6,7 @@
 - ⚠ PyMC3 now requires Scipy version `>= 1.4.1` (see [4857](https://github.com/pymc-devs/pymc3/pull/4857)).
 - ArviZ `plots` and `stats` *wrappers* were removed. The functions are now just available by their original names (see [#4549](https://github.com/pymc-devs/pymc3/pull/4471) and `3.11.2` release notes).
 - The GLM submodule has been removed, please use [Bambi](https://bambinos.github.io/bambi/) instead.
-- The `Distribution` keyword argument `testval` has been deprecated in favor of `initval`.
+- The `Distribution` keyword argument `testval` has been deprecated in favor of `initval`. Furthermore `initval` no longer assigns a `tag.test_value` on tensors since the initial values are now kept track of by the model object ([see #4913](https://github.com/pymc-devs/pymc3/pull/4913)).
 - `pm.sample` now returns results as `InferenceData` instead of `MultiTrace` by default (see [#4744](https://github.com/pymc-devs/pymc3/pull/4744)).
 - `pm.sample_prior_predictive` no longer returns transformed variable values by default. Pass them by name in `var_names` if you want to obtain these draws (see [4769](https://github.com/pymc-devs/pymc3/pull/4769)).
 - ...

--- a/pymc3/distributions/continuous.py
+++ b/pymc3/distributions/continuous.py
@@ -361,11 +361,9 @@ class Flat(Continuous):
     rv_op = flat
 
     @classmethod
-    def dist(cls, *, size=None, initval=None, **kwargs):
-        if initval is None:
-            initval = np.full(size, floatX(0.0))
+    def dist(cls, *, size=None, **kwargs):
         res = super().dist([], size=size, **kwargs)
-        res.tag.test_value = initval
+        res.tag.test_value = np.full(size, floatX(0.0))
         return res
 
     def logp(value):
@@ -425,11 +423,9 @@ class HalfFlat(PositiveContinuous):
     rv_op = halfflat
 
     @classmethod
-    def dist(cls, *, size=None, initval=None, **kwargs):
-        if initval is None:
-            initval = np.full(size, floatX(1.0))
+    def dist(cls, *, size=None, **kwargs):
         res = super().dist([], size=size, **kwargs)
-        res.tag.test_value = initval
+        res.tag.test_value = np.full(size, floatX(1.0))
         return res
 
     def logp(value):

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -219,12 +219,14 @@ class Distribution(metaclass=DistributionMeta):
             # A batch size was specified through `dims`, or implied by `observed`.
             rv_out = change_rv_size(rv_var=rv_out, new_size=resize_shape, expand=True)
 
-        if initval is not None:
-            # Assigning the testval earlier causes trouble because the RV may not be created with the final shape already.
-            rv_out.tag.test_value = initval
-
         rv_out = model.register_rv(
-            rv_out, name, observed, total_size, dims=dims, transform=transform
+            rv_out,
+            name,
+            observed,
+            total_size,
+            dims=dims,
+            transform=transform,
+            initval=initval,
         )
 
         # add in pretty-printing support

--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -39,7 +39,6 @@ import numpy as np
 import scipy.sparse as sps
 
 from aesara.compile.sharedvalue import SharedVariable
-from aesara.gradient import grad
 from aesara.graph.basic import Constant, Variable, graph_inputs
 from aesara.graph.fg import FunctionGraph
 from aesara.tensor.random.opt import local_subtensor_rv_lift
@@ -446,7 +445,7 @@ class ValueGradFunction:
             givens.append((var, shared))
 
         if compute_grads:
-            grads = grad(cost, grad_vars, disconnected_inputs="ignore")
+            grads = aesara.grad(cost, grad_vars, disconnected_inputs="ignore")
             for grad_wrt, var in zip(grads, grad_vars):
                 grad_wrt.name = f"{var.name}_grad"
             outputs = [cost] + grads

--- a/pymc3/tests/test_initvals.py
+++ b/pymc3/tests/test_initvals.py
@@ -1,0 +1,48 @@
+#   Copyright 2020 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import pytest
+
+import pymc3 as pm
+
+
+def transform_fwd(rv, expected_untransformed):
+    return rv.tag.value_var.tag.transform.forward(rv, expected_untransformed).eval()
+
+
+class TestInitvalAssignment:
+    def test_dist_warnings_and_errors(self):
+        with pytest.warns(DeprecationWarning, match="argument is deprecated and has no effect"):
+            rv = pm.Exponential.dist(lam=1, testval=0.5)
+        assert not hasattr(rv.tag, "test_value")
+
+        with pytest.raises(TypeError, match="Unexpected keyword argument `initval`."):
+            pm.Normal.dist(1, 2, initval=None)
+        pass
+
+    def test_new_warnings(self):
+        with pm.Model() as pmodel:
+            with pytest.warns(DeprecationWarning, match="`testval` argument is deprecated"):
+                rv = pm.Uniform("u", 0, 1, testval=0.75)
+                assert pmodel.initial_values[rv.tag.value_var] == transform_fwd(rv, 0.75)
+        pass
+
+
+class TestSpecialDistributions:
+    def test_automatically_assigned_test_values(self):
+        # ...because they don't have random number generators.
+        rv = pm.Flat.dist()
+        assert hasattr(rv.tag, "test_value")
+        rv = pm.HalfFlat.dist()
+        assert hasattr(rv.tag, "test_value")
+        pass

--- a/pymc3/tests/test_initvals.py
+++ b/pymc3/tests/test_initvals.py
@@ -35,6 +35,7 @@ class TestInitvalAssignment:
             with pytest.warns(DeprecationWarning, match="`testval` argument is deprecated"):
                 rv = pm.Uniform("u", 0, 1, testval=0.75)
                 assert pmodel.initial_values[rv.tag.value_var] == transform_fwd(rv, 0.75)
+                assert not hasattr(rv.tag, "test_value")
         pass
 
 

--- a/pymc3/tests/test_util.py
+++ b/pymc3/tests/test_util.py
@@ -20,7 +20,7 @@ from cachetools import cached
 import pymc3 as pm
 
 from pymc3.distributions.transforms import Transform
-from pymc3.util import hash_key, hashable, locally_cachedmethod
+from pymc3.util import UNSET, hash_key, hashable, locally_cachedmethod
 
 
 class TestTransformName:
@@ -127,3 +127,12 @@ def test_hash_key():
 
     tc = TestClass()
     assert tc.some_method(b1) != tc.some_method(b2)
+
+
+def test_unset_repr(capsys):
+    def fn(a=UNSET):
+        return
+
+    help(fn)
+    captured = capsys.readouterr()
+    assert "a=UNSET" in captured.out

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -191,9 +191,9 @@ def get_default_varnames(var_iterator, include_transformed):
         return [var for var in var_iterator if not is_transformed_name(get_var_name(var))]
 
 
-def get_var_name(var):
+def get_var_name(var) -> str:
     """Get an appropriate, plain variable name for a variable."""
-    return getattr(var, "name", str(var))
+    return str(getattr(var, "name", var))
 
 
 def get_transformed(z):

--- a/pymc3/util.py
+++ b/pymc3/util.py
@@ -24,7 +24,18 @@ import xarray
 
 from cachetools import LRUCache, cachedmethod
 
-UNSET = object()
+
+class _UnsetType:
+    """Type for the `UNSET` object to make it look nice in `help(...)` outputs."""
+
+    def __str__(self):
+        return "UNSET"
+
+    def __repr__(self):
+        return str(self)
+
+
+UNSET = _UnsetType()
 
 
 def withparent(meth):


### PR DESCRIPTION
This PR makes `initial_values` a property with docstring and type hints. It also adds some more type hints and docstrings to related functions and properties.

For the `UNSET` constant I added its own type, because inspecting signatures with `UNSET` kwargs (for example `pm.Normal`) results in confusing output, as demonstrated by this example:

```
>>> UNSET = object()
>>>
>>> def say_hello(name=UNSET):
...     print("Hi!" if name is UNSET else f"Hello {name}.")
...
>>>
>>> help(say_hello)
Help on function say_hello in module __main__:

say_hello(name=<object object at 0x0000018BD4226150>)
#                👆
```

With the new repr it just becomes
```
Help on function say_hello in module __main__:

say_hello(name=UNSET)
```

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] ~what are the (breaking) changes that this PR makes?~ None
+ [x] important background, or details about the implementation
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [x] ~[consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)~
+ [x] ~right before it's ready to merge, mention the PR in the RELEASE-NOTES.md~ not relevant enough
