### PR TITLE
adjust definition of energy change in HMC

### DIFF
--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -119,7 +119,7 @@ class HamiltonianMC(BaseHMC):
         n_steps = max(1, int(self.path_length / step_size))
         n_steps = min(self.max_steps, n_steps)
 
-        energy_change = -np.inf
+        energy_change = np.inf
         state = start
         last = state
         div_info = None
@@ -132,9 +132,9 @@ class HamiltonianMC(BaseHMC):
         else:
             if not np.isfinite(state.energy):
                 div_info = DivergenceInfo("Divergence encountered, bad energy.", None, last, state)
-            energy_change = start.energy - state.energy
+            energy_change = state.energy - start.energy
             if np.isnan(energy_change):
-                energy_change = -np.inf
+                energy_change = np.inf
             if np.abs(energy_change) > self.Emax:
                 div_info = DivergenceInfo(
                     f"Divergence encountered, energy change larger than {self.Emax}.",
@@ -143,7 +143,7 @@ class HamiltonianMC(BaseHMC):
                     state,
                 )
 
-        accept_stat = min(1, np.exp(energy_change))
+        accept_stat = min(1, np.exp(-energy_change))
 
         if div_info is not None or np.random.rand() >= accept_stat:
             end = start


### PR DESCRIPTION
This small PR adjusts the definition of `energy_change` in HMC such that an energy increase in a proposed step gives `energy_change>0`, and an energy decrease gives `energy_change<0`.

This brings it in line with the definitions of energy change in `nuts.py`[here](https://github.com/pymc-devs/pymc3/blob/6d2aa5ddebed01d81c2ab66b9d4bd02194f82508/pymc3/step_methods/hmc/nuts.py#L337) and [here](https://github.com/pymc-devs/pymc3/blob/6d2aa5ddebed01d81c2ab66b9d4bd02194f82508/pymc3/step_methods/hmc/nuts.py#L420).
