### PR TITLE
Use `to_tuple` function in pm.fast_sample_posterior_predictive

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,7 @@
 + Fix `LKJCorr.random` method to work with `pm.sample_prior_predictive`. (see [#4780](https://github.com/pymc-devs/pymc3/pull/4780)).
 + Enable documentation generation via ReadTheDocs for upcoming v3 releases. (see [#4805](https://github.com/pymc-devs/pymc3/pull/4805)).
 + Remove `float128` dtype support (see [#4834](https://github.com/pymc-devs/pymc3/pull/4834)).
++ Use `to_tuple` function in `pm.fast_sample_posterior_predictive` to pass shape assertions (see [#4927](https://github.com/pymc-devs/pymc3/pull/4927)).
 
 ### New Features
 + Generalized BART, bounded distributions like Binomial and Poisson can now be used as likelihoods (see [#4675](https://github.com/pymc-devs/pymc3/pull/4675), [#4709](https://github.com/pymc-devs/pymc3/pull/4709) and

--- a/pymc3/distributions/posterior_predictive.py
+++ b/pymc3/distributions/posterior_predictive.py
@@ -26,6 +26,7 @@ from pymc3.distributions.distribution import (
     is_fast_drawable,
     vectorized_ppc,
 )
+from pymc3.distributions.shape_utils import to_tuple
 from pymc3.exceptions import IncorrectArgumentsError
 from pymc3.model import (
     Model,
@@ -551,7 +552,7 @@ class _PosteriorPredictiveSampler(AbstractContextManager):
         ) -> np.ndarray:
             val = meth(point=point, size=size)
             try:
-                assert val.shape == (size,) + shape, (
+                assert val.shape == to_tuple(size) + to_tuple(shape), (
                     "Sampling from random of %s yields wrong shape" % param
                 )
             # error-quashing here is *extremely* ugly, but it seems to be what the logic in DensityDist wants.

--- a/pymc3/tests/test_posterior_predictive.py
+++ b/pymc3/tests/test_posterior_predictive.py
@@ -46,7 +46,7 @@ def test_fast_sample_posterior_predictive_shape_assertions():
     """
     with pm.Model():
         p = pm.Beta("p", 2, 2)
-        trace = pm.sample(draws=500, chains=1, return_inferencedata=True)
+        trace = pm.sample(tune=30, draws=50, chains=1, return_inferencedata=True, compute_convergence_checks=False)
 
     with pm.Model() as m_forward:
         p = pm.Beta("p", 2, 2)
@@ -57,4 +57,4 @@ def test_fast_sample_posterior_predictive_shape_assertions():
         trace_forward = pm.fast_sample_posterior_predictive(trace, var_names=["p", "b2", "b3"])
 
     for free_rv in trace_forward.values():
-        assert free_rv.shape[0] == 500
+        assert free_rv.shape[0] == 50

--- a/pymc3/tests/test_posterior_predictive.py
+++ b/pymc3/tests/test_posterior_predictive.py
@@ -46,7 +46,9 @@ def test_fast_sample_posterior_predictive_shape_assertions():
     """
     with pm.Model():
         p = pm.Beta("p", 2, 2)
-        trace = pm.sample(tune=30, draws=50, chains=1, return_inferencedata=True, compute_convergence_checks=False)
+        trace = pm.sample(
+            tune=30, draws=50, chains=1, return_inferencedata=True, compute_convergence_checks=False
+        )
 
     with pm.Model() as m_forward:
         p = pm.Beta("p", 2, 2)

--- a/pymc3/tests/test_posterior_predictive.py
+++ b/pymc3/tests/test_posterior_predictive.py
@@ -37,3 +37,24 @@ def test_build_TraceDict_point_list():
         assert len(dict) == 1
         assert len(dict["mu"]) == 1
         assert dict["mu"][0] == 0.0
+
+
+def test_fast_sample_posterior_predictive_shape_assertions():
+    """
+    This test checks the shape assertions in pm.fast_sample_posterior_predictive.
+    Originally reported - https://github.com/pymc-devs/pymc3/issues/4778
+    """
+    with pm.Model():
+        p = pm.Beta("p", 2, 2)
+        trace = pm.sample(draws=500, chains=1, return_inferencedata=True)
+
+    with pm.Model() as m_forward:
+        p = pm.Beta("p", 2, 2)
+        b2 = pm.Binomial("b2", n=1, p=p)
+        b3 = pm.Binomial("b3", n=1, p=p * b2)
+
+    with m_forward:
+        trace_forward = pm.fast_sample_posterior_predictive(trace, var_names=["p", "b2", "b3"])
+
+    for free_rv in trace_forward.values():
+        assert free_rv.shape[0] == 500


### PR DESCRIPTION
**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes?
Fixes #4854 
+ [x] important background, or details about the implementation
Just use `to_tuple` to handle edge cases
+ [x] are the changes—especially new features—covered by tests and docstrings?
Yes. I added a test.
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
