### PR TITLE
Reintroduce `logit_p` Bernoulli parametrization and deprecate `eps` in `math.invlogit`

### DIFF
--- a/pymc3/distributions/transforms.py
+++ b/pymc3/distributions/transforms.py
@@ -170,7 +170,7 @@ class LogOdds(ElemwiseTransform):
     name = "logodds"
 
     def backward(self, rv_var, rv_value):
-        return invlogit(rv_value, 0.0)
+        return invlogit(rv_value)
 
     def forward(self, rv_var, rv_value):
         return logit(rv_value)

--- a/pymc3/math.py
+++ b/pymc3/math.py
@@ -200,9 +200,15 @@ def logdiffexp_numpy(a, b):
     return a + log1mexp_numpy(b - a, negative_input=True)
 
 
-def invlogit(x, eps=sys.float_info.epsilon):
+def invlogit(x, eps=None):
     """The inverse of the logit function, 1 / (1 + exp(-x))."""
-    return (1.0 - 2.0 * eps) / (1.0 + at.exp(-x)) + eps
+    if eps is not None:
+        warnings.warn(
+            "pymc3.math.invlogit no longer supports the ``eps`` argument and it will be ignored.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    return at.sigmoid(x)
 
 
 def logbern(log_p):

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1608,8 +1608,13 @@ class TestMatchesScipy:
             {"alpha": Rplus, "beta": Rplus, "n": NatSmall},
         )
 
-    @pytest.mark.xfail(reason="Bernoulli logit_p not refactored yet")
-    def test_bernoulli_logit_p(self):
+    def test_bernoulli(self):
+        self.check_logp(
+            Bernoulli,
+            Bool,
+            {"p": Unit},
+            lambda value, p: sp.bernoulli.logpmf(value, p),
+        )
         self.check_logp(
             Bernoulli,
             Bool,
@@ -1619,28 +1624,33 @@ class TestMatchesScipy:
         self.check_logcdf(
             Bernoulli,
             Bool,
-            {"logit_p": R},
-            lambda value, logit_p: sp.bernoulli.logcdf(value, scipy.special.expit(logit_p)),
-        )
-
-    def test_bernoulli(self):
-        self.check_logp(
-            Bernoulli,
-            Bool,
             {"p": Unit},
-            lambda value, p: sp.bernoulli.logpmf(value, p),
+            lambda value, p: sp.bernoulli.logcdf(value, p),
         )
         self.check_logcdf(
             Bernoulli,
             Bool,
-            {"p": Unit},
-            lambda value, p: sp.bernoulli.logcdf(value, p),
+            {"logit_p": R},
+            lambda value, logit_p: sp.bernoulli.logcdf(value, scipy.special.expit(logit_p)),
         )
         self.check_selfconsistency_discrete_logcdf(
             Bernoulli,
             Bool,
             {"p": Unit},
         )
+
+    def test_bernoulli_wrong_arguments(self):
+        m = pm.Model()
+
+        msg = "Incompatible parametrization. Can't specify both p and logit_p"
+        with m:
+            with pytest.raises(ValueError, match=msg):
+                Bernoulli("x", p=0.5, logit_p=0)
+
+        msg = "Incompatible parametrization. Must specify either p or logit_p"
+        with m:
+            with pytest.raises(ValueError, match=msg):
+                Bernoulli("x")
 
     def test_discrete_weibull(self):
         self.check_logp(

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -1025,11 +1025,10 @@ class TestBernoulli(BaseTestDistribution):
     ]
 
 
-@pytest.mark.skip("Still not implemented")
 class TestBernoulliLogitP(BaseTestDistribution):
     pymc_dist = pm.Bernoulli
     pymc_dist_params = {"logit_p": 1.0}
-    expected_rv_op_params = {"mean": 0, "sigma": 10.0}
+    expected_rv_op_params = {"p": expit(1.0)}
     tests_to_run = ["check_pymc_params_match_rv_op"]
 
 

--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -51,7 +51,6 @@ def get_city_data():
     return data.merge(unique, "inner", on="fips")
 
 
-@pytest.mark.xfail(reason="Bernoulli logitp distribution not refactored")
 class TestARM5_4(SeededTest):
     def build_model(self):
         data = pd.read_csv(

--- a/pymc3/tests/test_math.py
+++ b/pymc3/tests/test_math.py
@@ -23,6 +23,7 @@ from pymc3.math import (
     LogDet,
     cartesian,
     expand_packed_triangular,
+    invlogit,
     invprobit,
     kron_dot,
     kron_solve_lower,
@@ -250,3 +251,17 @@ def test_expand_packed_triangular():
     assert np.all(expand_upper.eval({packed: upper_packed}) == upper)
     assert np.all(expand_diag_lower.eval({packed: lower_packed}) == floatX(np.diag(vals)))
     assert np.all(expand_diag_upper.eval({packed: upper_packed}) == floatX(np.diag(vals)))
+
+
+def test_invlogit_deprecation_warning():
+    with pytest.warns(
+        DeprecationWarning,
+        match="pymc3.math.invlogit no longer supports the",
+    ):
+        res = invlogit(np.array(-750.0), 1e-5).eval()
+
+    with pytest.warns(None) as record:
+        res_zero_eps = invlogit(np.array(-750.0)).eval()
+    assert not record
+
+    assert np.isclose(res, res_zero_eps)


### PR DESCRIPTION
The function `math.invlogit` had an artificial truncation point to avoid numerical issues that occurred in the past with the bernoulli:
https://github.com/pymc-devs/pymc3/issues/1147
https://github.com/pymc-devs/pymc3/pull/3006

However, there has been some progress on `Aesara` for making the invlogit (and related rewrites) more numerically stable:
https://github.com/aesara-devs/aesara/pull/473
https://github.com/aesara-devs/aesara/pull/531
https://github.com/aesara-devs/aesara/pull/262
https://github.com/aesara-devs/aesara/pull/32

And this no longer seems necessary. After this PR:
```python
import aesara 
import aesara.tensor as at
import pymc3 as pm 

logit_p = at.scalar("logit_p")
value = at.lscalar("value")
logp = pm.logp(pm.Bernoulli.dist(p=pm.math.invlogit(logit_p)), value)
fn = aesara.function([logit_p, value], logp)  

fn(-745, 0)  # array(-5.e-324)
fn(-746, 0)  # array(-0.)  # overflows here as before

fn(745, 1)  # array(-5.e-324)
fn(746, 1)  # array(-0.)  # overflows here, new!!!

fn(1000, 0)  # array(-1000.)  # never underflows

fn(-1000, 1)  # array(-1000.)  # never underflows
```

In v3:
```python
import theano 
import theano.tensor as tt
import pymc3 as pm 

logit_p = tt.scalar("logit_p")                                                     
value = tt.lscalar("value")                                            
logp = pm.Bernoulli.dist(p=pm.math.invlogit(logit_p)).logp(value)            
fn = theano.function([logit_p, value], logp)   

fn(-745, 0)  # array(-5.e-324)
fn(-746, 0)  # array(-0.)  # same overflow point

fn(1000, 1)  # array(-2.22044605e-16)  # never overflows
fn(37, 1)  # array(-2.22044605e-16)  # but value would be flat from >= 37

fn(1000, 0)  # array(-1000.)  # never underflows either

fn(-1000, 1)  # array(-36.04365339)  # never underflows either
fn(-69, 1)  # array(-36.04365339)  # but value would be flat from ~<=-69
```

Regarding the old `logit_p` logp implementation, I ran some benchmarks and there is some small loss in speed from forcing it to be computed on the natural scale, but this is rather small. On the other hand forcing a natural probability to be computed on the logit scale would have been considerably slower: https://gist.github.com/ricardoV94/65a334968472deec65ffc285ae2a809f