### PR TITLE
Fewer sigfigs for acceptance probability warning

### DIFF
--- a/pymc3/step_methods/hmc/hmc.py
+++ b/pymc3/step_methods/hmc/hmc.py
@@ -119,7 +119,7 @@ class HamiltonianMC(BaseHMC):
         n_steps = max(1, int(self.path_length / step_size))
         n_steps = min(self.max_steps, n_steps)
 
-        energy_change = -np.inf
+        energy_change = np.inf
         state = start
         last = state
         div_info = None
@@ -132,9 +132,9 @@ class HamiltonianMC(BaseHMC):
         else:
             if not np.isfinite(state.energy):
                 div_info = DivergenceInfo("Divergence encountered, bad energy.", None, last, state)
-            energy_change = start.energy - state.energy
+            energy_change = state.energy - start.energy
             if np.isnan(energy_change):
-                energy_change = -np.inf
+                energy_change = np.inf
             if np.abs(energy_change) > self.Emax:
                 div_info = DivergenceInfo(
                     f"Divergence encountered, energy change larger than {self.Emax}.",
@@ -143,7 +143,7 @@ class HamiltonianMC(BaseHMC):
                     state,
                 )
 
-        accept_stat = min(1, np.exp(energy_change))
+        accept_stat = min(1, np.exp(-energy_change))
 
         if div_info is not None or np.random.rand() >= accept_stat:
             end = start

--- a/pymc3/step_methods/step_sizes.py
+++ b/pymc3/step_methods/step_sizes.py
@@ -67,15 +67,15 @@ class DualAverageAdaptation:
         mean_accept = np.mean(accept)
         target_accept = self._target
         # Try to find a reasonable interval for acceptable acceptance
-        # probabilities. Finding this was mostry trial and error.
+        # probabilities. Finding this was mostly trial and error.
         n_bound = min(100, len(accept))
         n_good, n_bad = mean_accept * n_bound, (1 - mean_accept) * n_bound
         lower, upper = stats.beta(n_good + 1, n_bad + 1).interval(0.95)
         if target_accept < lower or target_accept > upper:
             msg = (
-                "The acceptance probability does not match the target. It "
-                "is %s, but should be close to %s. Try to increase the "
-                "number of tuning steps." % (mean_accept, target_accept)
+                f"The acceptance probability does not match the target. "
+                f"It is {mean_accept:0.4f}, but should be close to {target_accept}. "
+                f"Try to increase the number of tuning steps."
             )
             info = {"target": target_accept, "actual": mean_accept}
             warning = SamplerWarning(WarningType.BAD_ACCEPTANCE, msg, "warn", extra=info)


### PR DESCRIPTION
This small PR adjusts the NUTS sampler warning that reports an acceptance probability above the target. It reduces the number of sigfigs that are shown from >10 to 4.

Showing more than 4 sigfigs makes no sense, given that chains have on the order of 1000s-10000s of samples, and given the heuristic nature of this comparison. Somewhat related is the [old discussion on Discourse](https://discourse.pymc.io/t/warning-when-nuts-probability-is-greater-than-acceptance-level/594) about this warning.

Example:

Before:
```
The acceptance probability does not match the target. It is 0.94542317739, but should be close to 0.8.
```

After:
```
The acceptance probability does not match the target. It is 0.9454, but should be close to 0.8.
```


