### PR TITLE
Reduce sigfigs for acceptance probability warning

### DIFF
--- a/pymc3/step_methods/step_sizes.py
+++ b/pymc3/step_methods/step_sizes.py
@@ -67,15 +67,15 @@ class DualAverageAdaptation:
         mean_accept = np.mean(accept)
         target_accept = self._target
         # Try to find a reasonable interval for acceptable acceptance
-        # probabilities. Finding this was mostry trial and error.
+        # probabilities. Finding this was mostly trial and error.
         n_bound = min(100, len(accept))
         n_good, n_bad = mean_accept * n_bound, (1 - mean_accept) * n_bound
         lower, upper = stats.beta(n_good + 1, n_bad + 1).interval(0.95)
         if target_accept < lower or target_accept > upper:
             msg = (
-                "The acceptance probability does not match the target. It "
-                "is %s, but should be close to %s. Try to increase the "
-                "number of tuning steps." % (mean_accept, target_accept)
+                f"The acceptance probability does not match the target. "
+                f"It is {mean_accept:0.4g}, but should be close to {target_accept:0.4g}. "
+                f"Try to increase the number of tuning steps."
             )
             info = {"target": target_accept, "actual": mean_accept}
             warning = SamplerWarning(WarningType.BAD_ACCEPTANCE, msg, "warn", extra=info)


### PR DESCRIPTION
This small PR adjusts the NUTS sampler warning that reports an acceptance probability not close enough to the target acceptance probability set in `target_accept`. It reduces the number of sigfigs that are shown from >10 to 4.

Showing more than 4 sigfigs doesn't make sense, given the approximate nature of this comparison.

Somewhat related is the [old discussion on Discourse](https://discourse.pymc.io/t/warning-when-nuts-probability-is-greater-than-acceptance-level/594) about this warning.

Example:

Before:
```
The acceptance probability does not match the target. It is 0.94542317739, but should be close to 0.8.
```

After:
```
The acceptance probability does not match the target. It is 0.9454, but should be close to 0.8.
```


