### PR TITLE
Fix bug in NUTS variable assignment

### DIFF
--- a/pymc3/parallel_sampling.py
+++ b/pymc3/parallel_sampling.py
@@ -257,6 +257,10 @@ class ProcessAdapter:
         if step_method_pickled is not None:
             step_method_send = step_method_pickled
         else:
+            if mp_ctx.get_start_method() == "spawn":
+                raise ValueError(
+                    "please provide a pre-pickled step method when multiprocessing start method is 'spawn'"
+                )
             step_method_send = step_method
 
         self._process = mp_ctx.Process(

--- a/pymc3/step_methods/hmc/base_hmc.py
+++ b/pymc3/step_methods/hmc/base_hmc.py
@@ -101,8 +101,8 @@ class BaseHMC(GradientSharedStep):
         # XXX: If the dimensions of these terms change, the step size
         # dimension-scaling should change as well, no?
         test_point = self._model.initial_point
-        continuous_vars = [test_point[v.name] for v in self._model.cont_vars]
-        size = sum(v.size for v in continuous_vars)
+        nuts_vars = [test_point[v.name] for v in vars]
+        size = sum(v.size for v in nuts_vars)
 
         self.step_size = step_scale / (size ** 0.25)
         self.step_adapt = step_sizes.DualAverageAdaptation(

--- a/pymc3/tests/test_parallel_sampling.py
+++ b/pymc3/tests/test_parallel_sampling.py
@@ -87,7 +87,7 @@ def test_remote_pipe_closed():
             pm.sample(step=step, mp_ctx="spawn", tune=2, draws=2, cores=2, chains=2)
 
 
-@pytest.mark.xfail(reason="Unclear")
+@pytest.mark.skip(reason="Unclear")
 @pytest.mark.parametrize("mp_start_method", ["spawn", "fork"])
 def test_abort(mp_start_method):
     with pm.Model() as model:


### PR DESCRIPTION
This is a bug I found while working on bringing BART to V4 #4914. NUTS should use the variables passed to the sampler and not get them from the model. @ricardoV94 recommend having this fix in its own PR and separated from the BART PR. 