### PR TITLE
Issue #4819, PR revision 1.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -33,6 +33,7 @@
 - We now include `cloudpickle` as a required dependency, and no longer depend on `dill` (see [#4858](https://github.com/pymc-devs/pymc3/pull/4858)).
 - The `incomplete_beta` function in `pymc3.distributions.dist_math` was replaced by `aesara.tensor.betainc` (see [4857](https://github.com/pymc-devs/pymc3/pull/4857)).
 - `math.log1mexp` and `math.log1mexp_numpy` will expect negative inputs in the future. A `FutureWarning` is now raised unless `negative_input=True` is set (see [#4860](https://github.com/pymc-devs/pymc3/pull/4860)).
+- Attempt to iterate over MultiTrace will raise NotImplementedError
 - ...
 
 ## PyMC3 3.11.2 (14 March 2021)

--- a/pymc3/backends/base.py
+++ b/pymc3/backends/base.py
@@ -313,6 +313,9 @@ class MultiTrace:
     def report(self):
         return self._report
 
+    def __iter__(self):
+        raise NotImplementedError
+
     def __getitem__(self, idx):
         if isinstance(idx, slice):
             return self._slice(idx)

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -297,6 +297,15 @@ class TestSample(SeededTest):
             backend = NDArray()
             pm.sample(10, cores=1, chains=2, trace=backend)
 
+    def test_exceptions(self):
+        # Test iteration over MultiTrace NotImplementedError
+        with pm.Model() as model:
+            mu = pm.Normal("mu", 0.0, 1.0)
+            a = pm.Normal("a", mu=mu, sigma=1, observed=np.array([0.5, 0.2]))
+            trace = pm.sample(tune=0, return_inferencedata=False)
+            with pytest.raises(NotImplementedError):
+                xvars = [t['mu'] for t in trace]
+
 
 @pytest.mark.xfail(reason="Lognormal not refactored for v4")
 def test_sample_find_MAP_does_not_modify_start():

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -304,7 +304,7 @@ class TestSample(SeededTest):
             a = pm.Normal("a", mu=mu, sigma=1, observed=np.array([0.5, 0.2]))
             trace = pm.sample(tune=0, draws=10, chains=2, return_inferencedata=False)
             with pytest.raises(NotImplementedError):
-                xvars = [t['mu'] for t in trace]
+                xvars = [t["mu"] for t in trace]
 
 
 @pytest.mark.xfail(reason="Lognormal not refactored for v4")

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -302,7 +302,7 @@ class TestSample(SeededTest):
         with pm.Model() as model:
             mu = pm.Normal("mu", 0.0, 1.0)
             a = pm.Normal("a", mu=mu, sigma=1, observed=np.array([0.5, 0.2]))
-            trace = pm.sample(tune=0, return_inferencedata=False)
+            trace = pm.sample(tune=0, draws=10, chains=2, return_inferencedata=False)
             with pytest.raises(NotImplementedError):
                 xvars = [t['mu'] for t in trace]
 


### PR DESCRIPTION
This PR addresses issue #4819. It adds NotImplementedError on MultiTrace.iter. This is a revision to the original PR and has been run against the standard test suite.