### PR TITLE
Fixup broken docs links for v3

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -134,16 +134,6 @@
                         <img class="ui image" height="120" src="https://www.numfocus.org/wp-content/uploads/2017/07/NumFocus_LRG.png"/>
                     </a>
                 </div>
-                <div class="column">
-                    <a href="https://quantopian.com">
-                        <img class="ui image" height="120" src="https://raw.githubusercontent.com/pymc-devs/pymc3/master/docs/quantopianlogo.jpg"/>
-                    </a>
-                </div>
-                <div class="column">
-                    <a href="https://odsc.com/">
-                        <img class="ui image" height="120" src="https://raw.githubusercontent.com/pymc-devs/pymc3/master/docs/odsc_logo.png"/>
-                    </a>
-                </div>
             </div>
         </div>
     </div>

--- a/docs/source/learn.rst
+++ b/docs/source/learn.rst
@@ -104,7 +104,7 @@
 
         <div class="card">
             <div class="image">
-                <img src="https://lh5.googleusercontent.com/Ms2ssellxl7cM6OEL_kpiKRojcj2E4ZaUWDXOa8zEwi-v9orJGYuhjczbwFSDJNsEb_ruiwtCJONNjoo7T1c7qorZm3LsAnroMAm4S5WzNT_PVqWz9aE=w1280">
+                <img src="https://jkkweb.sitehost.iu.edu/DoingBayesianDataAnalysis/DBDA2Ecover.png">
             </div>
             <div class="content">
                 <div class="header">Doing Bayesian Data Analysis</div>


### PR DESCRIPTION
Fixup broken docs links for v3
- Removed dead sponsorship links from landing page
- Fixed dead links from Books + Videos page

This PR points to `v3.11.4` branch. After this PR gets merged, `v3.11.4` branch can be merged to `v3` for a new release.

