### PR TITLE
Add documentation and verify arguments for incsubtensor_logp

### DIFF
--- a/pymc3/distributions/logprob.py
+++ b/pymc3/distributions/logprob.py
@@ -286,8 +286,10 @@ def indices_from_subtensor(idx_list, indices):
 @_logp.register(IncSubtensor)
 @_logp.register(AdvancedIncSubtensor)
 @_logp.register(AdvancedIncSubtensor1)
-def incsubtensor_logp(op, var, rvs_to_values, indexed_rv_var, rv_values, *indices, **kwargs):
-
+def incsubtensor_logp(op, indexed_rv_var, rv_values, *indices, **kwargs):
+    """
+    Use the incremented subtensor to create a measure-space (i.e. log-likelihood) graph for a random variable at a given point.
+    """
     index = indices_from_subtensor(getattr(op, "idx_list", None), indices)
 
     _, (new_rv_var,) = clone(


### PR DESCRIPTION
**What are the (breaking) changes that this PR makes?**
Resolves #4881.

**Important background, or details about the implementation**
Removes arguments `var` and `rvs_to_values` from the function `incsubtensor_logp`. Adds a brief docstring. Doesn't change that much.

**[linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)**
Yes