### PR TITLE
(Truncated) StickBreakingWeights for Dirichlet Processes

### DIFF
--- a/pymc3/distributions/__init__.py
+++ b/pymc3/distributions/__init__.py
@@ -97,6 +97,7 @@ from pymc3.distributions.multivariate import (
     MvNormal,
     MvStudentT,
     OrderedMultinomial,
+    StickBreakingWeights,
     Wishart,
     WishartBartlett,
 )
@@ -163,6 +164,7 @@ __all__ = [
     "Multinomial",
     "DirichletMultinomial",
     "OrderedMultinomial",
+    "StickBreakingWeights",
     "Wishart",
     "WishartBartlett",
     "LKJCholeskyCov",

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -43,7 +43,7 @@ import pymc3 as pm
 
 from pymc3.aesaraf import floatX, intX
 from pymc3.distributions import transforms
-from pymc3.distributions.continuous import ChiSquared, Normal, assert_negative_support, UnitContinuous
+from pymc3.distributions.continuous import ChiSquared, Normal, assert_negative_support
 from pymc3.distributions.dist_math import bound, factln, logpow, multigammaln
 from pymc3.distributions.distribution import Continuous, Discrete
 from pymc3.distributions.shape_utils import broadcast_dist_samples_to, to_tuple
@@ -63,6 +63,7 @@ __all__ = [
     "MatrixNormal",
     "KroneckerNormal",
     "CAR",
+    "StickBreakingWeights"
 ]
 
 # Step methods and advi do not catch LinAlgErrors at the
@@ -2138,7 +2139,7 @@ class StickBreakingWeightsRV(RandomVariable):
 stickbreakingweights = StickBreakingWeightsRV()
 
 
-class StickBreakingWeights(UnitContinuous):
+class StickBreakingWeights(Continuous):
     r"""
     Weights obtained by a (truncated) stick-breaking process
 
@@ -2155,7 +2156,7 @@ class StickBreakingWeights(UnitContinuous):
         return super().__new__(cls, name, *args, **kwargs)
 
     @classmethod
-    def dist(cls, alpha, K, *args, **kwargs):
+    def dist(cls, alpha, K, **kwargs):
         alpha = at.as_tensor_variable(floatX(alpha))
         K = at.as_tensor_variable(K)
 
@@ -2186,4 +2187,6 @@ class StickBreakingWeights(UnitContinuous):
         return bound(
             at.sum(pm.Beta.logp(value, 1, alpha)),
             alpha > 0,
+            at.all(value > 0),
+            at.all(value <= 1)
         )

--- a/pymc3/distributions/multivariate.py
+++ b/pymc3/distributions/multivariate.py
@@ -2183,6 +2183,7 @@ class StickBreakingWeights(Continuous):
         return bound(
             logp,
             alpha > 0,
+            K > 0,
             at.all(value >= 0),
             at.all(value <= 1),
         )

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -2651,6 +2651,14 @@ class TestMatchesScipy:
 
                 self.check_logp(TestedInterpolated, R, {}, ref_pdf)
 
+    # def test_stickbreakingweights(self):
+    #     self.check_logp(
+
+    #     )
+    
+    # def test_stickbreakingweights_shape(self):
+    #     pass
+
 
 class TestBound:
     """Tests for pm.Bound distribution"""

--- a/pymc3/tests/test_distributions_random.py
+++ b/pymc3/tests/test_distributions_random.py
@@ -2416,3 +2416,27 @@ def test_car_rng_fn(sparse):
         )
         f -= 1
     assert p > delta
+
+class TestStickBreakingWeights(BaseTestDistribution):
+    pymc_dist = pm.StickBreakingWeights
+
+    pymc_dist_params = {"alpha": 2., "K": 19}
+    expected_rv_op_params = {"alpha": 2., "K": 19}
+
+    sizes_to_check = [None, (1), (4,), (3, 4)]
+    sizes_expected = [(20,), (1, 20), (4, 20), (3, 4, 20)]
+
+    tests_to_run = [
+        "check_pymc_params_match_rv_op",
+        "test_random_draws",
+        "check_rv_size",
+    ]
+
+    def test_random_draws(self):
+        draws = pm.StickBreakingWeights.dist(
+            alpha=0.5,
+            K=19,
+            size=(47, 53),
+        ).eval()
+        assert np.all(draws.sum(-1) == 1)
+        assert np.all(draws.mean(-1) == 1/(19 + 1))


### PR DESCRIPTION
Here is my PR on adding stick-breaking weights which would be useful for Dirichlet Processes. For the time being, I am labelling this as a WIP and I have yet to write tests for this distribution.

I am able to call `rng_fn` on the instance `stickbreakingweights` (see output [here](https://github.com/larryshamalama/pymc3-playground/blob/95b6d6f9cb9b47322d9d0c005af2668a72cc0e81/notebooks/progress/stickbreakingweights.ipynb)*), but I obtain `IndexError: list index out of range` when calling `stickbreakingweights(2).eval()`. @ricardoV94 mentioned that this should be fixable via `_shape_from_params` (or `_infer_shape` according to bullet point 3 in section 1 [here](https://github.com/pymc-devs/pymc3/blob/main/docs/source/developer_guide_implementing_distribution.md)), but I don't understand these methods enough to solve my problem. Some comments are included as a code review.

Any help or pointers would be appreciated. Thanks!

CC: @ricardoV94 @AustinRochford @fonnesbeck

*Edited to reflect the version of the notebook when writing this message