### PR TITLE
Filter out constants from `pm.sample_prior_predictive` inputs

### DIFF
--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -31,6 +31,7 @@ import numpy as np
 import xarray
 
 from aesara.compile.mode import Mode
+from aesara.graph.basic import Constant
 from aesara.tensor.sharedvar import SharedVariable
 from arviz import InferenceData
 from fastprogress.fastprogress import progress_bar
@@ -2001,7 +2002,7 @@ def sample_prior_predictive(
             names.append(rv_var.name)
             vars_to_sample.append(rv_var)
 
-    inputs = [i for i in inputvars(vars_to_sample) if not isinstance(i, SharedVariable)]
+    inputs = [i for i in inputvars(vars_to_sample) if not isinstance(i, (SharedVariable, Constant))]
 
     sampler_fn = compile_rv_inplace(
         inputs, vars_to_sample, allow_input_downcast=True, accept_inplace=True, mode=mode


### PR DESCRIPTION
This PR addressed issue #4959, which may be due to this [PR](https://github.com/aesara-devs/aesara/pull/556).

In [sampling.py](https://github.com/pymc-devs/pymc3/blob/main/pymc3/sampling.py#L2004), `inputs` can be a list of `TensorConstant`s, which is not permitted in [`compile_rv_function`](https://github.com/pymc-devs/pymc3/blob/main/pymc3/aesaraf.py#L879), more specifically in [`pfunc`](https://github.com/aesara-devs/aesara/blob/main/aesara/compile/function/pfunc.py#L538).

A naive fix to the example mentioned in the issue is to exclude `TensorConstant`s on top of `SharedVariable`s in `inputs`. Would this have other implications that I am not aware of?