### PR TITLE
Extract initval evaluation into its own method

### DIFF
--- a/pymc3/model.py
+++ b/pymc3/model.py
@@ -38,6 +38,7 @@ import aesara.tensor as at
 import numpy as np
 import scipy.sparse as sps
 
+from aesara.compile.mode import Mode, get_mode
 from aesara.compile.sharedvalue import SharedVariable
 from aesara.graph.basic import Constant, Variable, graph_inputs
 from aesara.graph.fg import FunctionGraph
@@ -955,7 +956,6 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
         if initval is None or transform:
             # Sample/evaluate this using the existing initial values, and
             # with the least effect on the RNGs involved (i.e. no in-placing)
-            from aesara.compile.mode import Mode, get_mode
 
             mode = get_mode(None)
             opt_qry = mode.provided_optimizer.excluding("random_make_inplace")


### PR DESCRIPTION
This is a refactoring in preparation of changing how and when initial values are numerified.

This PR does not change any behavior. It just extracts a code block into a private method and adds unit tests for it that are more targeted than our current tests for it.

We may want to add more test cases to cover chained initial values too. (Suggestions welcome!)