### PR TITLE
DOC Add PyMC Labs as sponsors in docs

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -187,7 +187,7 @@ The end result? All of the capabilities you expect from commercial-grade softwar
 Sponsors
 ========
 
-|NumFOCUS| |Quantopian| |ODSC|
+|NumFOCUS| |PyMCLabs|
 
 More details about sponsoring PyMC3 can be found `here <https://github.com/pymc-devs/pymc3/blob/main/GOVERNANCE.md#institutional-partners-and-funding>`_.
 If you are interested in becoming a sponsor, reach out to `pymc.devs@gmail.com <pymc.devs@gmail.com>`_
@@ -266,9 +266,6 @@ See also
 .. |NumFOCUS| image:: https://numfocus.org/wp-content/uploads/2017/07/NumFocus_LRG.png
    :target: http://www.numfocus.org/
    :height: 120px
-.. |Quantopian| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/quantopianlogo.jpg
-   :target: https://quantopian.com
-   :height: 120px
-.. |ODSC| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/odsc_logo.png
-   :target: https://odsc.com
+.. |PyMCLabs| image:: https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/pymc-labs-logo.png
+   :target: https://pymc-labs.io
    :height: 120px

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -152,13 +152,8 @@
                     </a>
                 </div>
                 <div class="column">
-                    <a href="https://quantopian.com">
-                        <img class="ui image" height="120" src="https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/quantopianlogo.jpg"/>
-                    </a>
-                </div>
-                <div class="column">
-                    <a href="https://odsc.com/">
-                        <img class="ui image" height="120" src="https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/odsc_logo.png"/>
+                    <a href="https://pymc-labs.io">
+                        <img class="ui image" height="120" src="https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/pymc-labs-logo.png"/>
                     </a>
                 </div>
             </div>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -150,8 +150,6 @@
                     <a href="https://numfocus.org/">
                         <img class="ui image" height="120" src="https://www.numfocus.org/wp-content/uploads/2017/07/NumFocus_LRG.png"/>
                     </a>
-                </div>
-                <div class="column">
                     <a href="https://pymc-labs.io">
                         <img class="ui image" height="120" src="https://raw.githubusercontent.com/pymc-devs/pymc3/main/docs/pymc-labs-logo.png"/>
                     </a>


### PR DESCRIPTION
Follow up to https://github.com/pymc-devs/pymc3/commit/d32022c65604f72240174d9838df92584d5eb489 (The image links are currently broken on `main`.)