### PR TITLE
Improve tuning by skipping the first samples + add new experimental tuning method

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,8 @@
 - The `OrderedMultinomial` distribution has been added for use on ordinal data which are _aggregated_ by trial, like multinomial observations, whereas `OrderedLogistic` only accepts ordinal data in a _disaggregated_ format, like categorical
   observations (see [#4773](https://github.com/pymc-devs/pymc3/pull/4773)).
 - The `Polya-Gamma` distribution has been added (see [#4531](https://github.com/pymc-devs/pymc3/pull/4531)). To make use of this distribution, the [`polyagamma>=1.3.1`](https://pypi.org/project/polyagamma/) library must be installed and available in the user's environment.
+- A small change to the default mass matrix tuning method jitter+adapt_diag improves performance early on during tuning for some models. [#5004](https://github.com/pymc-devs/pymc3/pull/5004)
+- New experimental mass matrix tuning method jitter+adapt_diag_grad. [#5004](https://github.com/pymc-devs/pymc3/pull/5004)
 - ...
 
 ### Maintenance

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,7 +23,7 @@
 - The `OrderedMultinomial` distribution has been added for use on ordinal data which are _aggregated_ by trial, like multinomial observations, whereas `OrderedLogistic` only accepts ordinal data in a _disaggregated_ format, like categorical
   observations (see [#4773](https://github.com/pymc-devs/pymc3/pull/4773)).
 - The `Polya-Gamma` distribution has been added (see [#4531](https://github.com/pymc-devs/pymc3/pull/4531)). To make use of this distribution, the [`polyagamma>=1.3.1`](https://pypi.org/project/polyagamma/) library must be installed and available in the user's environment.
-- A small change to the default mass matrix tuning method jitter+adapt_diag improves performance early on during tuning for some models. [#5004](https://github.com/pymc-devs/pymc3/pull/5004)
+- A small change to the mass matrix tuning methods jitter+adapt_diag (the default) and adapt_diag improves performance early on during tuning for some models. [#5004](https://github.com/pymc-devs/pymc3/pull/5004)
 - New experimental mass matrix tuning method jitter+adapt_diag_grad. [#5004](https://github.com/pymc-devs/pymc3/pull/5004)
 - ...
 

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -287,25 +287,7 @@ def sample(
         by default. See ``discard_tuned_samples``.
     init : str
         Initialization method to use for auto-assigned NUTS samplers.
-
-        * auto: Choose a default initialization method automatically.
-          Currently, this is ``jitter+adapt_diag``, but this can change in the future.
-          If you depend on the exact behaviour, choose an initialization method explicitly.
-        * adapt_diag: Start with a identity mass matrix and then adapt a diagonal based on the
-          variance of the tuning samples. All chains use the test value (usually the prior mean)
-          as starting point.
-        * jitter+adapt_diag: Same as ``adapt_diag``, but add uniform jitter in [-1, 1] to the
-          starting point in each chain.
-        * advi+adapt_diag: Run ADVI and then adapt the resulting diagonal mass matrix based on the
-          sample variance of the tuning samples.
-        * advi+adapt_diag_grad: Run ADVI and then adapt the resulting diagonal mass matrix based
-          on the variance of the gradients during tuning. This is **experimental** and might be
-          removed in a future release.
-        * advi: Run ADVI to estimate posterior mean and diagonal mass matrix.
-        * advi_map: Initialize ADVI with MAP and use MAP as starting point.
-        * map: Use the MAP as starting point. This is discouraged.
-        * adapt_full: Adapt a dense mass matrix using the sample covariances
-
+        See `pm.init_nuts` for a list of all options.
     step : function or iterable of functions
         A step function or collection of functions. If there are variables without step methods,
         step methods for those variables will be assigned automatically.  By default the NUTS step
@@ -2106,9 +2088,6 @@ def init_nuts(
           during tuning.
         * advi+adapt_diag: Run ADVI and then adapt the resulting diagonal mass matrix based on the
           sample variance of the tuning samples.
-        * advi+adapt_diag_grad: Run ADVI and then adapt the resulting diagonal mass matrix based
-          on the variance of the gradients during tuning. This is **experimental** and might be
-          removed in a future release.
         * advi: Run ADVI to estimate posterior mean and diagonal mass matrix.
         * advi_map: Initialize ADVI with MAP and use MAP as starting point.
         * map: Use the MAP as starting point. This is discouraged.
@@ -2197,24 +2176,6 @@ def init_nuts(
             use_grads=True,
             stop_adaptation=stop_adaptation,
         )
-    elif init == "advi+adapt_diag_grad":
-        approx: pm.MeanField = pm.fit(
-            random_seed=random_seed,
-            n=n_init,
-            method="advi",
-            model=model,
-            callbacks=cb,
-            progressbar=progressbar,
-            obj_optimizer=pm.adagrad_window,
-        )
-        start = approx.sample(draws=chains)
-        start = list(start)
-        std_apoint = approx.std.eval()
-        cov = std_apoint ** 2
-        mean = approx.mean.get_value()
-        weight = 50
-        n = len(cov)
-        potential = quadpotential.QuadPotentialDiagAdaptGrad(n, mean, cov, weight)
     elif init == "advi+adapt_diag":
         approx = pm.fit(
             random_seed=random_seed,

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -2164,7 +2164,7 @@ def init_nuts(
         var = np.ones_like(mean)
         n = len(var)
 
-        if tune is not None and tune > 200:
+        if tune is not None and tune > 250:
             stop_adaptation = tune - 50
         else:
             stop_adaptation = None

--- a/pymc3/sampling.py
+++ b/pymc3/sampling.py
@@ -2101,6 +2101,9 @@ def init_nuts(
           as starting point.
         * jitter+adapt_diag: Same as ``adapt_diag``, but use test value plus a uniform jitter in
           [-1, 1] as starting point in each chain.
+        * jitter+adapt_diag_grad:
+          An experimental initialization method that uses information from gradients and samples
+          during tuning.
         * advi+adapt_diag: Run ADVI and then adapt the resulting diagonal mass matrix based on the
           sample variance of the tuning samples.
         * advi+adapt_diag_grad: Run ADVI and then adapt the resulting diagonal mass matrix based

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -253,9 +253,7 @@ class _Tree:
         self.start_energy = np.array(start.energy)
 
         self.left = self.right = start
-        self.proposal = Proposal(
-            start.q.data, start.q_grad, start.energy, 1.0, start.model_logp
-        )
+        self.proposal = Proposal(start.q.data, start.q_grad, start.energy, 1.0, start.model_logp)
         self.depth = 0
         self.log_size = 0
         self.log_weighted_accept_sum = -np.inf

--- a/pymc3/step_methods/hmc/nuts.py
+++ b/pymc3/step_methods/hmc/nuts.py
@@ -254,7 +254,7 @@ class _Tree:
 
         self.left = self.right = start
         self.proposal = Proposal(
-            start.q.data, start.q_grad.data, start.energy, 1.0, start.model_logp
+            start.q.data, start.q_grad, start.energy, 1.0, start.model_logp
         )
         self.depth = 0
         self.log_size = 0
@@ -350,7 +350,7 @@ class _Tree:
                 log_size = -energy_change
                 proposal = Proposal(
                     right.q.data,
-                    right.q_grad.data,
+                    right.q_grad,
                     right.energy,
                     log_p_accept_weighted,
                     right.model_logp,

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -361,7 +361,7 @@ class _WeightedVariance:
     def add_sample(self, x, weight):
         x = np.asarray(x)
         if weight != 1:
-            raise ValueError("weight is unused and broken")
+            raise ValueError("Setting weight != 1 is not supported.")
         self.n_samples += 1
         old_diff = x - self.mean
         self.mean[:] += old_diff / self.n_samples
@@ -389,8 +389,8 @@ class _ExpWeightedVariance:
     def add_sample(self, value):
         alpha = self._alpha
         delta = value - self._mean
-        self._mean += alpha * delta
-        self._variance = (1 - alpha) * (self._variance + alpha * delta ** 2)
+        self._mean[...] += alpha * delta
+        self._variance[...] = (1 - alpha) * (self._variance + alpha * delta ** 2)
 
     def current_variance(self, out=None):
         if out is None:

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -293,47 +293,6 @@ class QuadPotentialDiagAdapt(QuadPotential):
             raise ValueError("\n".join(errmsg))
 
 
-class QuadPotentialDiagAdaptGrad(QuadPotentialDiagAdapt):
-    """Adapt a diagonal mass matrix from the variances of the gradients.
-
-    This is experimental, and may be removed without prior deprication.
-    """
-
-    def reset(self):
-        super().reset()
-        self._grads1 = np.zeros(self._n, dtype=self.dtype)
-        self._ngrads1 = 0
-        self._grads2 = np.zeros(self._n, dtype=self.dtype)
-        self._ngrads2 = 0
-
-    def _update(self, var):
-        self._var[:] = var
-        np.sqrt(self._var, out=self._stds)
-        np.divide(1, self._stds, out=self._inv_stds)
-        self._var_aesara.set_value(self._var)
-
-    def update(self, sample, grad, tune):
-        """Inform the potential about a new sample during tuning."""
-        if not tune:
-            return
-
-        self._grads1[:] += np.abs(grad)
-        self._grads2[:] += np.abs(grad)
-        self._ngrads1 += 1
-        self._ngrads2 += 1
-
-        if self._n_samples <= 150:
-            super().update(sample, grad, tune)
-        else:
-            self._update((self._ngrads1 / self._grads1) ** 2)
-
-        if self._n_samples > 100 and self._n_samples % 100 == 50:
-            self._ngrads1 = self._ngrads2
-            self._ngrads2 = 1
-            self._grads1[:] = self._grads2
-            self._grads2[:] = 1
-
-
 class _WeightedVariance:
     """Online algorithm for computing mean of variance."""
 

--- a/pymc3/step_methods/hmc/quadpotential.py
+++ b/pymc3/step_methods/hmc/quadpotential.py
@@ -410,6 +410,9 @@ class QuadPotentialDiagAdaptExp(QuadPotentialDiagAdapt):
         super().__init__(*args, **kwargs)
         self._alpha = alpha
         self._use_grads = use_grads
+
+        if stop_adaptation is None:
+            stop_adaptation = np.inf
         self._stop_adaptation = stop_adaptation
 
     def update(self, sample, grad, tune):

--- a/pymc3/tests/test_quadpotential.py
+++ b/pymc3/tests/test_quadpotential.py
@@ -279,9 +279,3 @@ def test_full_adapt_sampling(seed=289586):
         pot = quadpotential.QuadPotentialFullAdapt(initial_point_size, np.zeros(initial_point_size))
         step = pymc3.NUTS(model=model, potential=pot)
         pymc3.sample(draws=10, tune=1000, random_seed=seed, step=step, cores=1, chains=1)
-
-
-def test_issue_3965():
-    with pymc3.Model():
-        pymc3.Normal("n")
-        pymc3.sample(100, tune=300, chains=1, init="advi+adapt_diag_grad")

--- a/pymc3/tests/test_quadpotential.py
+++ b/pymc3/tests/test_quadpotential.py
@@ -169,7 +169,7 @@ def test_weighted_covariance(ndim=10, seed=5432):
 
     est = quadpotential._WeightedCovariance(ndim)
     for sample in samples:
-        est.add_sample(sample, 1)
+        est.add_sample(sample)
     mu_est = est.current_mean()
     cov_est = est.current_covariance()
 
@@ -184,7 +184,7 @@ def test_weighted_covariance(ndim=10, seed=5432):
         10,
     )
     for sample in samples[10:]:
-        est2.add_sample(sample, 1)
+        est2.add_sample(sample)
     mu_est2 = est2.current_mean()
     cov_est2 = est2.current_covariance()
 

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -94,8 +94,6 @@ class TestSample(SeededTest):
                 "adapt_diag",
                 "jitter+adapt_diag",
                 "jitter+adapt_diag_grad",
-                "advi+adapt_diag_grad",
-                "advi+adapt_diag",
                 "adapt_full",
                 "jitter+adapt_full",
             ):

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -87,7 +87,7 @@ class TestSample(SeededTest):
 
     def test_sample_init(self):
         with self.model:
-            for init in ("advi", "advi_map", "map"):
+            for init in ("advi", "advi_map", "map", "jitter+adapt_diag_grad"):
                 pm.sample(
                     init=init,
                     tune=0,

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -87,10 +87,21 @@ class TestSample(SeededTest):
 
     def test_sample_init(self):
         with self.model:
-            for init in ("advi", "advi_map", "map", "jitter+adapt_diag_grad"):
+            for init in (
+                "advi",
+                "advi_map",
+                "map",
+                "adapt_diag",
+                "jitter+adapt_diag",
+                "jitter+adapt_diag_grad",
+                "advi+adapt_diag_grad",
+                "advi+adapt_diag",
+                "adapt_full",
+                "jitter+adapt_full",
+            ):
                 pm.sample(
                     init=init,
-                    tune=0,
+                    tune=120,
                     n_init=1000,
                     draws=50,
                     random_seed=self.random_seed,


### PR DESCRIPTION
Tuning the mass matrix starts right away in the current implementation, but in most models during the first couple of samples we are only moving to the typical set, so we do not get information about the posterior variance at all. In the worst case we learn a mass matrix that doesn't match the posterior at all, so that sampling the the first adaptation window will be very slow (you can see this a slowdown of sampling after step 100). Usually, we will recover from this, but it seems to be better to just skip those samples during adaptation in the first place.

In an example model by @ricardoV94 we can see this behavior clearly when we look at the distance of the currently used mass matrix to the final mass matrix:

![image](https://user-images.githubusercontent.com/1882397/133996706-4b7a242c-2e0e-4b27-a06c-f778409725fd.png)


This PR also contains an experimental tuning implementation using gradients and samples that can be enabled by `init="jitter+adapt_diag_grad"`. During tests on a few models this seems to be more stable than the only sample based tuning system we use right now, but there are also a few cases where it performs worse. For posteriors that are normal it should converge to the same mass matrix as our current implementation (and much faster), but for non-normal posteriors the result can differ. Unfortunately I don't know of any other way to tell which is better other than trying it on a large number of models.

An example notebook can be found here:
https://gist.github.com/aseyboldt/7897fbddacacaa0c86efc917afe9ce3f