### PR TITLE
Monkeypatch instructions for migrating away from the old rv.logp API

### DIFF
--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -123,6 +123,13 @@ class DistributionMeta(ABCMeta):
         return new_cls
 
 
+def _make_nice_attr_error(oldcode: str, newcode: str):
+    def fn(*args, **kwargs):
+        raise AttributeError(f"The `{oldcode}` method was removed. Instead use `{newcode}`.`")
+
+    return fn
+
+
 class Distribution(metaclass=DistributionMeta):
     """Statistical distribution"""
 
@@ -244,6 +251,9 @@ class Distribution(metaclass=DistributionMeta):
             functools.partial(str_for_dist, formatting="latex"), rv_out
         )
 
+        rv_out.logp = _make_nice_attr_error("rv.logp(x)", "pm.logp(rv, x)")
+        rv_out.logcdf = _make_nice_attr_error("rv.logcdf(x)", "pm.logcdf(rv, x)")
+        rv_out.random = _make_nice_attr_error("rv.random()", "rv.eval()")
         return rv_out
 
     @classmethod
@@ -334,6 +344,9 @@ class Distribution(metaclass=DistributionMeta):
             rv_out.update = (rng, new_rng)
             rng.default_update = new_rng
 
+        rv_out.logp = _make_nice_attr_error("rv.logp(x)", "pm.logp(rv, x)")
+        rv_out.logcdf = _make_nice_attr_error("rv.logcdf(x)", "pm.logcdf(rv, x)")
+        rv_out.random = _make_nice_attr_error("rv.random()", "rv.eval()")
         return rv_out
 
 


### PR DESCRIPTION
In `v3` the logp was a method on the RV value variables returned from distributions, but it is no longer available with `v4`.

This PR monkeypatches a method that raises an `AttributeError` with migration instructions instead of the non-informative default one.