### PR TITLE
Add prominent warnings about having theano/pymc3 installed in parallel

### DIFF
--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -37,7 +37,7 @@ def _check_install_compatibilitites():
             + f"\nYour Python environment has Theano(-PyMC) {theano.__version__} installed, "
             + f"but you are importing PyMC {__version__} which uses Aesara as its backend."
             + f"\nFor PyMC {__version__} to work as expected you should uninstall Theano(-PyMC)."
-            + "\nSee https://github.com/pymc-devs/pymc3/wiki for installation instructions.\n"
+            + "\nSee https://github.com/pymc-devs/pymc/wiki for update instructions.\n"
             + "!" * 60
         )
     except ImportError:
@@ -51,7 +51,7 @@ def _check_install_compatibilitites():
             + f"\nYou are importing PyMC {__version__}, but your environment also has"
             + f" the legacy version PyMC3 {pymc3.__version__} installed."
             + f"\nFor PyMC {__version__} to work as expected you should uninstall PyMC3."
-            + "\nSee https://github.com/pymc-devs/pymc3/wiki for installation instructions.\n"
+            + "\nSee https://github.com/pymc-devs/pymc/wiki for update instructions.\n"
             + "!" * 60
         )
     except ImportError:

--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # pylint: disable=wildcard-import
-__version__ = "4.0"
+__version__ = "4.0.0"
 
 import logging
 import multiprocessing as mp
@@ -27,6 +27,38 @@ if not logging.root.handlers:
         handler = logging.StreamHandler()
         _log.addHandler(handler)
 
+
+def _check_install_compatibilitites():
+    try:
+        import theano
+
+        print(
+            "!" * 60
+            + f"\nYour Python environment has Theano(-PyMC) {theano.__version__} installed, "
+            + f"but you are importing PyMC {__version__} which uses Aesara as its backend."
+            + f"\nFor PyMC {__version__} to work as expected you should uninstall Theano(-PyMC)."
+            + "\nSee https://github.com/pymc-devs/pymc3/wiki for installation instructions.\n"
+            + "!" * 60
+        )
+    except ImportError:
+        pass
+
+    try:
+        import pymc3
+
+        print(
+            "!" * 60
+            + f"\nYou are importing PyMC {__version__}, but your environment also has"
+            + f" the legacy version PyMC3 {pymc3.__version__} installed."
+            + f"\nFor PyMC {__version__} to work as expected you should uninstall PyMC3."
+            + "\nSee https://github.com/pymc-devs/pymc3/wiki for installation instructions.\n"
+            + "!" * 60
+        )
+    except ImportError:
+        pass
+
+
+_check_install_compatibilitites()
 _log.info(
     "You are running the v4 development version of PyMC which currently still lacks key features. You probably want to use the stable v3 instead which you can either install via conda or find on the v3 GitHub branch: https://github.com/pymc-devs/pymc/tree/v3"
 )


### PR DESCRIPTION
This is similar to https://github.com/pymc-devs/pymc3/commit/33c0e3555e3fc6a6e8bf5a13ef5b8e9b0dbda022.

Example output:
```
(pm3v4) E:\Repos\pm3v4>python -c "import pymc"
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
Your Python environment has Theano(-PyMC) 1.1.2 installed, but you are importing PyMC 4.0.0 which uses Aesara as its backend.
For PyMC 4.0.0 to work as expected you should uninstall Theano(-PyMC).
See https://github.com/pymc-devs/pymc3/wiki for installation instructions.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
You are importing PyMC 4.0.0, but your environment also has the legacy version PyMC3 3.11.4 installed.
For PyMC 4.0.0 to work as expected you should uninstall PyMC3.
See https://github.com/pymc-devs/pymc3/wiki for installation instructions.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
You are running the v4 development version of PyMC which currently still lacks key features. You probably want to use the stable v3 instead which you can either install via conda or find on the v3 GitHub branch: https://github.com/pymc-devs/pymc/tree/v3
```