### PR TITLE
Deprecated

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -52,6 +52,8 @@ from aesara.tensor.random.basic import (
 from aesara.tensor.random.op import RandomVariable
 from aesara.tensor.var import TensorConstant, TensorVariable
 
+from pymc.util import deprecator
+
 try:
     from polyagamma import polyagamma_cdf, polyagamma_pdf, random_polyagamma
 except ImportError:  # pragma: no cover
@@ -1690,10 +1692,9 @@ class AsymmetricLaplace(Continuous):
         )
 
 
+@deprecator(reason="use LogNormal now!", version=4.0)
 class LogNormal(PositiveContinuous):
     r"""
-    Note: Class name Lognormal is deprecated, use LogNormal now!
-
     Log-normal log-likelihood.
 
     Distribution of any random variable whose logarithm is normally


### PR DESCRIPTION
this pr is made to branch out efforts in #5008 which will be a draft for figuring out the auto formatting sphinx with respect to deprecated parameters. this PR does the following:
- deprecator that deprecated functions or classes (lets you choose to emit or not emit warnings) 
- tests for deprecator
- adds deprecated in docstring for methods, functions and classes
- additionally you can deprecate arguments as well. to be able to document argument deprecation im doing #5008 

things to do:

- [x] add a docstring for what the parameters in the deprecator function do
- [ ] test existing deprecated class with this decorator
- [ ] make a table of all the deprecated functions in documentation