### PR TITLE
Added Generalized Extreme Value distribution

### DIFF
--- a/docs/source/api/distributions/continuous.rst
+++ b/docs/source/api/distributions/continuous.rst
@@ -37,6 +37,7 @@ Continuous
    LogitNormal
    Interpolated
    PolyaGamma
+   GenExtreme
 
 .. automodule:: pymc.distributions.continuous
    :members:

--- a/pymc/distributions/__init__.py
+++ b/pymc/distributions/__init__.py
@@ -32,6 +32,7 @@ from pymc.distributions.continuous import (
     Exponential,
     Flat,
     Gamma,
+    GenExtreme,
     Gumbel,
     HalfCauchy,
     HalfFlat,
@@ -198,4 +199,5 @@ __all__ = [
     "logcdf",
     "_logcdf",
     "logpt_sum",
+    "GenExtreme",
 ]

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -4283,7 +4283,7 @@ class GenExtreme(Continuous):
 
     .. math::
 
-       G(x \mid \mu, \sigma, \xi) = exp\{ -\[1 + \xi z\]^{-\frac{1}{\xi}} \}
+       G(x \mid \mu, \sigma, \xi) = \exp\left[ -\left(1 + \xi z\right)^{-\frac{1}{\xi}} \right]
 
     where
 
@@ -4295,10 +4295,10 @@ class GenExtreme(Continuous):
 
     .. math::
 
-        {x: 1 + \xi(\frac{x-\mu}{\sigma}) > 0}
+        \left\{x: 1 + \xi(\frac{x-\mu}{\sigma}) > 0 \right\}
 
     Note that this parametrization differs from that of Scipy in the sign of
-    the shape parameter, $\xi$.
+    the shape parameter, :math:`\xi`.
 
     .. plot::
 
@@ -4320,19 +4320,19 @@ class GenExtreme(Continuous):
         plt.show()
 
 
-    ========  ==========================================
-    Support   :math: `x \in [\mu - \sigma/\xi, +\inf]`, when :math: `\xi > 0`
-              :math: `x \in \mathbb{R}` when \xi = 0
-              :math: `x \in [-\inf, \mu - \sigma/\xi]`, when :math: `\xi < 0`
-    Mean      :math: `\mu + \sigma(g_1 - 1)/\xi`, when `\xi \neq 0, \xi < 1`
-              :math: `\mu + \sigma \gamma`, when `\xi = 0`
-              :math: `\inf`, when `xi \geq 1`
+    ========  =========================================================================
+    Support   * :math:`x \in [\mu - \sigma/\xi, +\infty]`, when :math: `\xi > 0`
+              * :math:`x \in \mathbb{R}` when \xi = 0
+              * :math:`x \in [-\infty, \mu - \sigma/\xi]`, when :math: `\xi < 0`
+    Mean      * :math:`\mu + \sigma(g_1 - 1)/\xi`, when `\xi \neq 0, \xi < 1`
+              * :math:`\mu + \sigma \gamma`, when `\xi = 0`
+              * :math:`\infty`, when `xi \geq 1`
                 where :math:`\gamma` is the Euler-Mascheroni constant, and
                 :math:`g_k = \Gamma (1-k\xi)`
-    Variance  :math:`\sigma^2 (g_2 - g_1^2)/\xi^2`, when `\xi \neq 0, \xi < 0.5`
-              :math:`\frac{\pi^2}{6} \sigma^2`, when `\xi = 0`
-              :math:`\inf`, when `\xi \geq 0.5`
-    ========  ==========================================
+    Variance  * :math:`\sigma^2 (g_2 - g_1^2)/\xi^2`, when :math:`\xi \neq 0, \xi < 0.5`
+              * :math:`\frac{\pi^2}{6} \sigma^2`, when :math:`\xi = 0`
+              * :math:`\infty`, when :math:`\xi \geq 0.5`
+    ========  =========================================================================
 
     Parameters
     ----------
@@ -4344,7 +4344,7 @@ class GenExtreme(Continuous):
         Shape parameter
     scipy: bool
         Whether or not to use the Scipy interpretation of the shape parameter
-        default False.
+        (defaults to `False`).
     """
 
     rv_op = gev

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -4420,3 +4420,10 @@ class GenExtreme(Continuous):
             at.isclose(xi, 0), -at.exp(-scaled), -at.pow(1 + xi * scaled, -1 / xi)
         )
         return bound(logc_expression, 1 + xi * scaled > 0, sigma > 0)
+
+    def get_moment(value_var, size, mu, sigma, xi):
+        r"""
+        Using the mode, as the mean can be infinite when :math:`\xi > 1`
+        """
+        mode = at.switch(at.isclose(xi, 0), mu, mu + sigma * (at.pow(1 + xi, -xi) - 1) / xi)
+        return at.full(size, mode, dtype=aesara.config.floatX)

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -4386,7 +4386,7 @@ class GenExtreme(Continuous):
 
         logp_expression = at.switch(
             at.isclose(xi, 0),
-            at.log(sigma) - scaled - at.exp(-scaled),
+            -at.log(sigma) - scaled - at.exp(-scaled),
             -at.log(sigma)
             - ((xi + 1) / xi) * at.log1p(xi * scaled)
             - at.pow(1 + xi * scaled, -1 / xi),

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -4289,16 +4289,16 @@ class GenExtreme(Continuous):
 
     .. math::
 
-        z = \frac{x - \mu}{\sigma}.
+        z = \frac{x - \mu}{\sigma}
 
     and is defined on the set:
 
     .. math::
 
-        \left\{x: 1 + \xi(\frac{x-\mu}{\sigma}) > 0 \right\}
+        \left\{x: 1 + \xi\left(\frac{x-\mu}{\sigma}\right) > 0 \right\}.
 
-    Note that this parametrization differs from that of Scipy in the sign of
-    the shape parameter, :math:`\xi`.
+    Note that this parametrization is per Coles (2001), and differs from that of
+    Scipy in the sign of the shape parameter, :math:`\xi`.
 
     .. plot::
 
@@ -4325,8 +4325,8 @@ class GenExtreme(Continuous):
               * :math:`x \in \mathbb{R}` when \xi = 0
               * :math:`x \in [-\infty, \mu - \sigma/\xi]`, when :math: `\xi < 0`
     Mean      * :math:`\mu + \sigma(g_1 - 1)/\xi`, when `\xi \neq 0, \xi < 1`
-              * :math:`\mu + \sigma \gamma`, when `\xi = 0`
-              * :math:`\infty`, when `xi \geq 1`
+              * :math:`\mu + \sigma \gamma`, when :math:`\xi = 0`
+              * :math:`\infty`, when :math:`xi \geq 1`
                 where :math:`\gamma` is the Euler-Mascheroni constant, and
                 :math:`g_k = \Gamma (1-k\xi)`
     Variance  * :math:`\sigma^2 (g_2 - g_1^2)/\xi^2`, when :math:`\xi \neq 0, \xi < 0.5`
@@ -4345,6 +4345,13 @@ class GenExtreme(Continuous):
     scipy: bool
         Whether or not to use the Scipy interpretation of the shape parameter
         (defaults to `False`).
+
+    Reference
+    ---------
+    .. [Coles2001] Coles, S.G. (2001).
+        An Introduction to the Statistical Modeling of Extreme Values
+        Springer-Verlag, London
+
     """
 
     rv_op = gev

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -4321,12 +4321,12 @@ class GenExtreme(Continuous):
 
 
     ========  =========================================================================
-    Support   * :math:`x \in [\mu - \sigma/\xi, +\infty]`, when :math: `\xi > 0`
-              * :math:`x \in \mathbb{R}` when \xi = 0
-              * :math:`x \in [-\infty, \mu - \sigma/\xi]`, when :math: `\xi < 0`
-    Mean      * :math:`\mu + \sigma(g_1 - 1)/\xi`, when `\xi \neq 0, \xi < 1`
+    Support   * :math:`x \in [\mu - \sigma/\xi, +\infty]`, when :math:`\xi > 0`
+              * :math:`x \in \mathbb{R}` when :math:`\xi = 0`
+              * :math:`x \in [-\infty, \mu - \sigma/\xi]`, when :math:`\xi < 0`
+    Mean      * :math:`\mu + \sigma(g_1 - 1)/\xi`, when :math:`\xi \neq 0, \xi < 1`
               * :math:`\mu + \sigma \gamma`, when :math:`\xi = 0`
-              * :math:`\infty`, when :math:`xi \geq 1`
+              * :math:`\infty`, when :math:`\xi \geq 1`
                 where :math:`\gamma` is the Euler-Mascheroni constant, and
                 :math:`g_k = \Gamma (1-k\xi)`
     Variance  * :math:`\sigma^2 (g_2 - g_1^2)/\xi^2`, when :math:`\xi \neq 0, \xi < 0.5`
@@ -4346,8 +4346,8 @@ class GenExtreme(Continuous):
         Whether or not to use the Scipy interpretation of the shape parameter
         (defaults to `False`).
 
-    Reference
-    ---------
+    References
+    ----------
     .. [Coles2001] Coles, S.G. (2001).
         An Introduction to the Statistical Modeling of Extreme Values
         Springer-Verlag, London

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -75,6 +75,7 @@ from pymc.distributions import (
     Flat,
     Gamma,
     Geometric,
+    GenExtreme,
     Gumbel,
     HalfCauchy,
     HalfFlat,
@@ -2542,6 +2543,20 @@ class TestMatchesScipy:
             R,
             {"mu": R, "beta": Rplusbig},
             lambda value, mu, beta: sp.gumbel_r.logcdf(value, loc=mu, scale=beta),
+        )
+
+    def test_genextreme(self):
+        self.check_logp(
+            GenExtreme,
+            R,
+            {"mu": R, "sigma": Rplus, "xi": Domain([-1, 1])},
+            lambda value, mu, sigma, xi: sp.genextreme.logpdf(value, c=-xi, loc=mu, scale=sigma),
+        )
+        self.check_logcdf(
+            GenExtreme,
+            R,
+            {"mu": R, "sigma": Rplus, "xi": Domain([-1, 1])},
+            lambda value, mu, sigma, xi: sp.genextreme.logcdf(value, c=-xi, loc=mu, scale=sigma),
         )
 
     def test_logistic(self):

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -2551,14 +2551,12 @@ class TestMatchesScipy:
             R,
             {"mu": R, "sigma": Rplus, "xi": Domain([-1, -1, -0.5, 0, 0.5, 1, 1])},
             lambda value, mu, sigma, xi: sp.genextreme.logpdf(value, c=-xi, loc=mu, scale=sigma),
-            n_samples=-1,
         )
         self.check_logcdf(
             GenExtreme,
             R,
             {"mu": R, "sigma": Rplus, "xi": Domain([-1, -1, -0.5, 0, 0.5, 1, 1])},
             lambda value, mu, sigma, xi: sp.genextreme.logcdf(value, c=-xi, loc=mu, scale=sigma),
-            n_samples=-1,
         )
 
     def test_logistic(self):

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -2549,14 +2549,18 @@ class TestMatchesScipy:
         self.check_logp(
             GenExtreme,
             R,
-            {"mu": R, "sigma": Rplus, "xi": Domain([-1, 1])},
-            lambda value, mu, sigma, xi: sp.genextreme.logpdf(value, c=-xi, loc=mu, scale=sigma),
+            {"mu": R, "sigma": Rplus, "xi": Domain([-1, -1, -0.5, 0, 0.5, 1, 1])},
+            lambda value, mu, sigma, xi: sp.genextreme.logpdf(
+                value, c=-xi, loc=mu, scale=sigma, n_samples=-1
+            ),
         )
         self.check_logcdf(
             GenExtreme,
             R,
-            {"mu": R, "sigma": Rplus, "xi": Domain([-1, 1])},
-            lambda value, mu, sigma, xi: sp.genextreme.logcdf(value, c=-xi, loc=mu, scale=sigma),
+            {"mu": R, "sigma": Rplus, "xi": Domain([-1, -1, -0.5, 0, 0.5, 1, 1])},
+            lambda value, mu, sigma, xi: sp.genextreme.logcdf(
+                value, c=-xi, loc=mu, scale=sigma, n_samples=-1
+            ),
         )
 
     def test_logistic(self):

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -2550,17 +2550,15 @@ class TestMatchesScipy:
             GenExtreme,
             R,
             {"mu": R, "sigma": Rplus, "xi": Domain([-1, -1, -0.5, 0, 0.5, 1, 1])},
-            lambda value, mu, sigma, xi: sp.genextreme.logpdf(
-                value, c=-xi, loc=mu, scale=sigma, n_samples=-1
-            ),
+            lambda value, mu, sigma, xi: sp.genextreme.logpdf(value, c=-xi, loc=mu, scale=sigma),
+            n_samples=-1,
         )
         self.check_logcdf(
             GenExtreme,
             R,
             {"mu": R, "sigma": Rplus, "xi": Domain([-1, -1, -0.5, 0, 0.5, 1, 1])},
-            lambda value, mu, sigma, xi: sp.genextreme.logcdf(
-                value, c=-xi, loc=mu, scale=sigma, n_samples=-1
-            ),
+            lambda value, mu, sigma, xi: sp.genextreme.logcdf(value, c=-xi, loc=mu, scale=sigma),
+            n_samples=-1,
         )
 
     def test_logistic(self):

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -548,6 +548,20 @@ class TestExGaussian(BaseTestDistribution):
     ]
 
 
+class TestGenExtreme(BaseTestDistribution):
+    pymc_dist = pm.GenExtreme
+    pymc_dist_params = {"mu": 0, "sigma": 1, "xi": -0.1}
+    expected_rv_op_params = {"mu": 0, "sigma": 1, "xi": -0.1}
+    # Notice, using different parametrization of xi sign to scipy
+    reference_dist_params = {"loc": 0, "scale": 1, "c": 0.1}
+    reference_dist = seeded_scipy_distribution_builder("genextreme")
+    tests_to_run = [
+        "check_pymc_params_match_rv_op",
+        "check_pymc_draws_match_reference",
+        "check_rv_size",
+    ]
+
+
 class TestGumbel(BaseTestDistribution):
     pymc_dist = pm.Gumbel
     pymc_dist_params = {"mu": 1.5, "beta": 3.0}


### PR DESCRIPTION
This PR adds the GEV distribution to Pymc v4. An example notebook is also submitted as PR to pymc-examples: https://github.com/pymc-devs/pymc-examples/pull/241

Docstrings, an example, and tests are added; code is formatted with black.

Considering the complexity of the bounds for this distribution, a careful review of the tensor algebra used in the `logpdf` and `log_cdf` functions would be very welcome.

