### PR TITLE
BART: add partial dependence plots and individual conditional expectation plots

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,6 +15,8 @@
 - `pm.DensityDist` no longer accepts the `logp` as its first position argument. It is now an optional keyword argument. If you pass a callable as the first positional argument, a `TypeError` will be raised (see [5026](https://github.com/pymc-devs/pymc3/pull/5026)).
 - `pm.DensityDist` now accepts distribution parameters as positional arguments. Passing them as a dictionary in the `observed` keyword argument is no longer supported and will raise an error (see [5026](https://github.com/pymc-devs/pymc3/pull/5026)).
 - The signature of the `logp` and `random` functions that can be passed into a `pm.DensityDist` has been changed (see [5026](https://github.com/pymc-devs/pymc3/pull/5026)).
+- Generalize BART. A BART variable can be combined with other random variables. The `inv_link` argument has been removed (see [4914](https://github.com/pymc-devs/pymc3/pull/4914)).
+- Move BART to its own module (see [5058](https://github.com/pymc-devs/pymc3/pull/5058)).
 - ...
 
 ### New Features
@@ -32,6 +34,8 @@
 - New experimental mass matrix tuning method jitter+adapt_diag_grad. [#5004](https://github.com/pymc-devs/pymc/pull/5004)
 - `pm.DensityDist` can now accept an optional `logcdf` keyword argument to pass in a function to compute the cummulative density function of the distribution (see [5026](https://github.com/pymc-devs/pymc3/pull/5026)).
 - `pm.DensityDist` can now accept an optional `get_moment` keyword argument to pass in a function to compute the moment of the distribution (see [5026](https://github.com/pymc-devs/pymc3/pull/5026)).
+-  BART: add linear response, increase number of trees fitted per step [5044](https://github.com/pymc-devs/pymc3/pull/5044).
+-  BART: add partial dependence plots and individual conditional expectation plots [5091](https://github.com/pymc-devs/pymc3/pull/5091).
 - ...
 
 ### Maintenance

--- a/pymc/bart/__init__.py
+++ b/pymc/bart/__init__.py
@@ -15,5 +15,6 @@
 
 from pymc.bart.bart import BART
 from pymc.bart.pgbart import PGBART
+from pymc.bart.utils import plot_dependence, predict
 
 __all__ = ["BART", "PGBART"]

--- a/pymc/bart/bart.py
+++ b/pymc/bart/bart.py
@@ -39,35 +39,7 @@ class BARTRV(RandomVariable):
 
     @classmethod
     def rng_fn(cls, rng=np.random.default_rng(), *args, **kwargs):
-        size = kwargs.pop("size", None)
-        X_new = kwargs.pop("X_new", None)
-        all_trees = cls.all_trees
-        if all_trees:
-
-            if size is None:
-                size = ()
-            elif isinstance(size, int):
-                size = [size]
-
-            flatten_size = 1
-            for s in size:
-                flatten_size *= s
-
-            idx = rng.randint(len(all_trees), size=flatten_size)
-
-            if X_new is None:
-                pred = np.zeros((flatten_size, all_trees[0][0].num_observations))
-                for ind, p in enumerate(pred):
-                    for tree in all_trees[idx[ind]]:
-                        p += tree.predict_output()
-            else:
-                pred = np.zeros((flatten_size, X_new.shape[0]))
-                for ind, p in enumerate(pred):
-                    for tree in all_trees[idx[ind]]:
-                        p += np.array([tree.predict_out_of_sample(x, cls.m) for x in X_new])
-            return pred.reshape((*size, -1))
-        else:
-            return np.full_like(cls.Y, cls.Y.mean())
+        return np.full_like(cls.Y, cls.Y.mean())
 
 
 bart = BARTRV()
@@ -115,7 +87,6 @@ class BART(NoDistribution):
         **kwargs,
     ):
 
-        cls.all_trees = []
         X, Y = preprocess_XY(X, Y)
 
         bart_op = type(
@@ -123,7 +94,6 @@ class BART(NoDistribution):
             (BARTRV,),
             dict(
                 name="BART",
-                all_trees=cls.all_trees,
                 inplace=False,
                 initval=Y.mean(),
                 X=X,

--- a/pymc/bart/tree.py
+++ b/pymc/bart/tree.py
@@ -45,7 +45,8 @@ class Tree:
         Identifier used to get the previous tree in the ParticleGibbs algorithm used in BART.
     num_observations : int
         Number of observations used to fit BART.
-
+    m : int
+        Number of trees
 
     Parameters
     ----------
@@ -53,13 +54,14 @@ class Tree:
     num_observations : int, optional
     """
 
-    def __init__(self, tree_id=0, num_observations=0):
+    def __init__(self, tree_id=0, num_observations=0, m=0):
         self.tree_structure = {}
         self.num_nodes = 0
         self.idx_leaf_nodes = []
         self.idx_prunable_split_nodes = []
         self.tree_id = tree_id
         self.num_observations = num_observations
+        self.m = m
 
     def __getitem__(self, index):
         return self.get_node(index)
@@ -94,7 +96,7 @@ class Tree:
 
         return output.astype(aesara.config.floatX)
 
-    def predict_out_of_sample(self, X, m):
+    def predict_out_of_sample(self, X):
         """
         Predict output of tree for an unobserved point x.
 
@@ -102,8 +104,6 @@ class Tree:
         ----------
         X : numpy array
             Unobserved point
-        m : int
-            Number of trees
 
         Returns
         -------
@@ -116,7 +116,7 @@ class Tree:
             return leaf_node.value
         else:
             x = X[split_variable].item()
-            y_x = (linear_params[0] + linear_params[1] * x) / m
+            y_x = (linear_params[0] + linear_params[1] * x) / self.m
             return y_x + linear_params[2]
 
     def _traverse_tree(self, x, node_index=0, split_variable=None):
@@ -170,7 +170,7 @@ class Tree:
             self.idx_prunable_split_nodes.remove(parent_index)
 
     @staticmethod
-    def init_tree(tree_id, leaf_node_value, idx_data_points):
+    def init_tree(tree_id, leaf_node_value, idx_data_points, m):
         """
 
         Parameters
@@ -178,12 +178,14 @@ class Tree:
         tree_id
         leaf_node_value
         idx_data_points
+        m : int
+            number of trees in BART
 
         Returns
         -------
 
         """
-        new_tree = Tree(tree_id, len(idx_data_points))
+        new_tree = Tree(tree_id, len(idx_data_points), m)
         new_tree[0] = LeafNode(index=0, value=leaf_node_value, idx_data_points=idx_data_points)
         return new_tree
 

--- a/pymc/bart/utils.py
+++ b/pymc/bart/utils.py
@@ -1,0 +1,272 @@
+from functools import partial
+
+import arviz as az
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from numpy.random import RandomState
+from scipy.interpolate import griddata
+from scipy.signal import savgol_filter
+
+
+def predict(idata, rng, X_new=None, size=None):
+    """
+    Generate samples from the BART-posterior
+
+    Parameters
+    ----------
+    idata: InferenceData
+        InferenceData containing a collection of BART_trees in sample_stats group
+    rng: NumPy random generator
+    X_new : array-like
+        A new covariate matrix. Use it to obtain out-of-sample predictions
+    size: int or tuple
+        Number of samples.
+    """
+    bart_trees = idata.sample_stats.bart_trees
+    stacked_trees = bart_trees.stack(trees=["chain", "draw"])
+    if size is None:
+        size = ()
+    elif isinstance(size, int):
+        size = [size]
+
+    flatten_size = 1
+    for s in size:
+        flatten_size *= s
+
+    idx = rng.randint(len(stacked_trees.trees), size=flatten_size)
+
+    if X_new is None:
+        pred = np.zeros((flatten_size, stacked_trees[0, 0].item().num_observations))
+        for ind, p in enumerate(pred):
+            for tree in stacked_trees.isel(trees=idx[ind]).values:
+                p += tree.predict_output()
+    else:
+        pred = np.zeros((flatten_size, X_new.shape[0]))
+        for ind, p in enumerate(pred):
+            for tree in stacked_trees.isel(trees=idx[ind]).values:
+                p += np.array([tree.predict_out_of_sample(x) for x in X_new])
+    return pred.reshape((*size, -1))
+
+
+def plot_dependence(
+    bart_trees,
+    X=None,
+    Y=None,
+    kind="pdp",
+    xs_interval="linear",
+    xs_values=None,
+    var_idx=None,
+    samples=50,
+    instances=10,
+    random_seed=None,
+    sharey=True,
+    rug=True,
+    smooth=True,
+    indices=None,
+    grid="long",
+    color="C0",
+    color_mean="C0",
+    alpha=0.1,
+    figsize=None,
+    smooth_kwargs=None,
+    ax=None,
+):
+    """
+    Partial dependence or individual conditional expectation plot
+
+    Parameters
+    ----------
+    bart_trees: DataArray of trees
+        BART trees
+    X : array-like
+        The covariate matrix.
+    Y : array-like
+        The response vector.
+    kind : str
+        Whether to plor a partial dependence plot ("pdp") or an individual conditional expectation
+        plot ("ice"). Defaults to pdp.
+    xs_interval : str
+        Method used to compute the values X used to evaluate the predicted function. "linear",
+        evenly spaced values in the range of X. "quantiles", the evaluation is done at the specified
+        quantiles of X. "insample", the evaluation is done at the values of X.
+    xs_values : int or list
+        Values of X used to evaluate the predicted function. If ``xs_interval="linear"`` number of
+        points in the evenly spaced grid. If ``xs_interval="quantiles"``quantile or sequence of
+        quantiles to compute, which must be between 0 and 1 inclusive.
+        Ignored when ``xs_interval="insample"``.
+    var_idx : list
+        List of the indices of the covariate for which to compute the pdp or ice.
+    samples : int
+        Number of posterior samples used in the predictions. Defaults to 50
+    instances : int
+        Number of instances of X to plot. Only relevant if ice ``kind="ice"`` plots.
+    random_seed : int
+        random_seed used to sample from the posterior. Defaults to None.
+    sharey : bool
+        Controls sharing of properties among y-axes. Defaults to True.
+    rug : bool
+        Whether to include a rugplot. Defaults to True.
+    smooth=True,
+        If True the result will be smoothed by first computing a linear interpolation of the data
+        over a regular grid and then applying the Savitzky-Golay filter to the interpolated data.
+        Defaults to True.
+    grid : str or tuple
+        How to arrange the subplots. Defaults to "long", one subplot below the other.
+        Other options are "wide", one subplot next to eachother or a tuple indicating the number of
+        rows and columns.
+    color : matplotlib valid color
+        Color used to plot the pdp or ice. Defaults to "C0"
+    color_mean : matplotlib valid color
+        Color used to plot the mean pdp or ice. Defaults to "C0",
+    alpha : float
+        Transparency level, should in the interval [0, 1].
+    figsize : tuple
+        Figure size. If None it will be defined automatically.
+    smooth_kwargs : dict
+        Additional keywords modifying the Savitzky-Golay filter.
+        See scipy.signal.savgol_filter() for details.
+    ax : axes
+        Matplotlib axes.
+
+    Returns
+    -------
+    axes: matplotlib axes
+    """
+    if kind not in ["pdp", "ice"]:
+        raise ValueError(f"kind={kind} is not suported. Available option are 'pdp' or 'ice'")
+
+    if xs_interval not in ["insample", "linear", "quantiles"]:
+        raise ValueError(
+            f"""{xs_interval} is not suported.
+                          Available option are 'insample', 'linear' or 'quantiles'"""
+        )
+
+    rng = RandomState(seed=random_seed)
+
+    if isinstance(X, pd.DataFrame):
+        X_names = list(X.columns)
+        X = X.values
+    else:
+        X_names = []
+
+    if isinstance(Y, pd.DataFrame):
+        Y_label = f"Predicted {Y.name}"
+    else:
+        Y_label = "Predicted Y"
+
+    num_observations = X.shape[0]
+    num_covariates = X.shape[1]
+
+    indices = list(range(num_covariates))
+
+    if var_idx is None:
+        var_idx = indices
+
+    if X_names:
+        X_labels = [X_names[idx] for idx in var_idx]
+    else:
+        X_labels = [f"X_{idx}" for idx in var_idx]
+
+    if xs_interval == "linear" and xs_values is None:
+        xs_values = 10
+
+    if xs_interval == "quantiles" and xs_values is None:
+        xs_values = [0.05, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.95]
+
+    if kind == "ice":
+        instances = np.random.choice(range(X.shape[0]), replace=False, size=instances)
+
+    new_Y = []
+    new_X_target = []
+
+    new_X = np.zeros_like(X)
+    idx_s = list(range(X.shape[0]))
+    for i in var_idx:
+        indices_mi = indices[:]
+        indices_mi.pop(i)
+        y_pred = []
+        if kind == "pdp":
+            if xs_interval == "linear":
+                new_X_i = np.linspace(X[:, i].min(), X[:, i].max(), xs_values)
+            elif xs_interval == "quantiles":
+                new_X_i = np.quantile(X[:, i], q=xs_values)
+            elif xs_interval == "insample":
+                new_X_i = X[:, i]
+
+            for x_i in new_X_i:
+                new_X[:, indices_mi] = X[:, indices_mi]
+                new_X[:, i] = x_i
+                y_pred.append(np.mean(predict(bart_trees, rng, X_new=new_X, size=samples), 1))
+            new_X_target.append(new_X_i)
+        else:
+            for instance in instances:
+                new_X = X[idx_s]
+                new_X[:, indices_mi] = X[:, indices_mi][instance]
+                y_pred.append(np.mean(predict(bart_trees, rng, X_new=new_X, size=samples), 0))
+            new_X_target.append(new_X[:, i])
+        new_Y.append(np.array(y_pred).T)
+
+    if ax is None:
+        if grid == "long":
+            fig, axes = plt.subplots(len(var_idx), sharey=sharey, figsize=figsize)
+        elif grid == "wide":
+            fig, axes = plt.subplots(1, len(var_idx), sharey=sharey, figsize=figsize)
+        elif isinstance(grid, tuple):
+            _, axes = plt.subplots(grid[0], grid[1], sharey=sharey, figsize=figsize)
+        axes = np.ravel(axes)
+    else:
+        axes = [ax]
+
+    if rug:
+        lb = np.min(new_Y)
+
+    for i, ax in enumerate(axes):
+        if i >= len(var_idx):
+            ax.set_axis_off()
+        else:
+            if smooth:
+                if smooth_kwargs is None:
+                    smooth_kwargs = {}
+                smooth_kwargs.setdefault("window_length", 55)
+                smooth_kwargs.setdefault("polyorder", 2)
+                x_data = np.linspace(new_X_target[i].min(), new_X_target[i].max(), 200)
+                x_data[0] = (x_data[0] + x_data[1]) / 2
+                if kind == "pdp":
+                    interp = griddata(new_X_target[i], new_Y[i].mean(0), x_data)
+                else:
+                    interp = griddata(new_X_target[i], new_Y[i], x_data)
+
+                y_data = savgol_filter(interp, axis=0, **smooth_kwargs)
+
+                if kind == "pdp":
+                    az.plot_hdi(
+                        new_X_target[i], new_Y[i], color=color, fill_kwargs={"alpha": alpha}, ax=ax
+                    )
+                    ax.plot(x_data, y_data, color=color_mean)
+                else:
+                    ax.plot(x_data, y_data.mean(1), color=color_mean)
+                    ax.plot(x_data, y_data, color=color, alpha=alpha)
+
+            else:
+                idx = np.argsort(new_X_target[i])
+                if kind == "pdp":
+                    az.plot_hdi(
+                        new_X_target[i],
+                        new_Y[i],
+                        smooth=smooth,
+                        fill_kwargs={"alpha": alpha},
+                        ax=ax,
+                    )
+                    ax.plot(new_X_target[i][idx], new_Y[i][idx].mean(0), color=color)
+                else:
+                    ax.plot(new_X_target[i][idx], new_Y[i][idx], color=color, alpha=alpha)
+                    ax.plot(new_X_target[i][idx], new_Y[i][idx].mean(1), color=color_mean)
+
+            if rug:
+                ax.plot(X[:, i], np.full_like(X[:, i], lb), "k|")
+
+            ax.set_xlabel(X_labels[i])
+    ax.get_figure().text(-0.05, 0.5, Y_label, va="center", rotation="vertical", fontsize=15)
+    return axes

--- a/pymc/bart/utils.py
+++ b/pymc/bart/utils.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 import arviz as az
 import matplotlib.pyplot as plt
 import numpy as np

--- a/pymc/bart/utils.py
+++ b/pymc/bart/utils.py
@@ -51,7 +51,7 @@ def predict(idata, rng, X_new=None, size=None):
 
 
 def plot_dependence(
-    bart_trees,
+    idata,
     X=None,
     Y=None,
     kind="pdp",
@@ -78,8 +78,8 @@ def plot_dependence(
 
     Parameters
     ----------
-    bart_trees: DataArray of trees
-        BART trees
+    idata: InferenceData
+        InferenceData containing a collection of BART_trees in sample_stats group
     X : array-like
         The covariate matrix.
     Y : array-like
@@ -144,6 +144,7 @@ def plot_dependence(
         )
 
     rng = RandomState(seed=random_seed)
+    bart_trees = idata.sample_stats.bart_trees
 
     if isinstance(X, pd.DataFrame):
         X_names = list(X.columns)

--- a/pymc/bart/utils.py
+++ b/pymc/bart/utils.py
@@ -144,7 +144,6 @@ def plot_dependence(
         )
 
     rng = RandomState(seed=random_seed)
-    bart_trees = idata.sample_stats.bart_trees
 
     if isinstance(X, pd.DataFrame):
         X_names = list(X.columns)
@@ -199,13 +198,13 @@ def plot_dependence(
             for x_i in new_X_i:
                 new_X[:, indices_mi] = X[:, indices_mi]
                 new_X[:, i] = x_i
-                y_pred.append(np.mean(predict(bart_trees, rng, X_new=new_X, size=samples), 1))
+                y_pred.append(np.mean(predict(idata, rng, X_new=new_X, size=samples), 1))
             new_X_target.append(new_X_i)
         else:
             for instance in instances:
                 new_X = X[idx_s]
                 new_X[:, indices_mi] = X[:, indices_mi][instance]
-                y_pred.append(np.mean(predict(bart_trees, rng, X_new=new_X, size=samples), 0))
+                y_pred.append(np.mean(predict(idata, rng, X_new=new_X, size=samples), 0))
             new_X_target.append(new_X[:, i])
         new_Y.append(np.array(y_pred).T)
 

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -628,6 +628,15 @@ def sample(
                     else:
                         stat["variable_inclusion"] = [np.vstack(stat["variable_inclusion"])]
 
+    if "bart_trees" in trace.stat_names:
+        for strace in trace._straces.values():
+            for stat in strace._stats:
+                if "bart_trees" in stat:
+                    if trace.nchains > 1:
+                        stat["bart_trees"] = np.vstack(stat["bart_trees"])
+                    else:
+                        stat["bart_trees"] = [np.vstack(stat["bart_trees"])]
+
     n_chains = len(trace.chains)
     _log.info(
         f'Sampling {n_chains} chain{"s" if n_chains > 1 else ""} for {n_tune:_d} tune and {n_draws:_d} draw iterations '

--- a/pymc/smc/smc.py
+++ b/pymc/smc/smc.py
@@ -20,6 +20,7 @@ import aesara.tensor as at
 import numpy as np
 
 from aesara.graph.basic import clone_replace
+from arviz import psislw
 from scipy.special import logsumexp
 from scipy.stats import multivariate_normal
 
@@ -236,19 +237,33 @@ class SMC_KERNEL(ABC):
 
         low_beta = old_beta = self.beta
         up_beta = 2.0
-        rN = int(len(self.likelihood_logp) * self.threshold)
 
-        while up_beta - low_beta > 1e-6:
-            new_beta = (low_beta + up_beta) / 2.0
-            log_weights_un = (new_beta - old_beta) * self.likelihood_logp
-            log_weights = log_weights_un - logsumexp(log_weights_un)
-            ESS = int(np.exp(-logsumexp(log_weights * 2)))
-            if ESS == rN:
-                break
-            elif ESS < rN:
-                up_beta = new_beta
-            else:
-                low_beta = new_beta
+        if self.threshold is not None:
+            rN = int(len(self.likelihood_logp) * self.threshold)
+
+            while up_beta - low_beta > 1e-6:
+                new_beta = (low_beta + up_beta) / 2.0
+                log_weights_un = (new_beta - old_beta) * self.likelihood_logp
+                log_weights = log_weights_un - logsumexp(log_weights_un)
+                ESS = int(np.exp(-logsumexp(log_weights * 2)))
+                if ESS == rN:
+                    break
+                elif ESS < rN:
+                    up_beta = new_beta
+                else:
+                    low_beta = new_beta
+        else:
+            rN = int(len(self.likelihood_logp) * 0.5)
+            while up_beta - low_beta > 1e-6:
+                new_beta = (low_beta + up_beta) / 2.0
+                log_weights_un = (new_beta - old_beta) * self.likelihood_logp
+                log_weights = log_weights_un - logsumexp(log_weights_un)
+                log_weights, pareto = psislw(log_weights)
+                ESS = int(np.exp(-logsumexp(log_weights * 2)))
+                if pareto >= 0.5:
+                    up_beta = new_beta
+                else:
+                    break
         if new_beta >= 1:
             new_beta = 1
             log_weights_un = (new_beta - old_beta) * self.likelihood_logp
@@ -366,6 +381,7 @@ class IMH(SMC_KERNEL):
                 max(2, int(np.log(1 - self.p_acc_rate) / np.log(1 - acc_rate))),
             )
             self.proposed = self.draws * self.n_steps
+        print(self.n_steps)
 
         # Update MVNormal proposal based on the mean and covariance of the
         # tempered posterior.
@@ -374,16 +390,18 @@ class IMH(SMC_KERNEL):
         cov += 1e-6 * np.eye(cov.shape[0])
         if np.isnan(cov).any() or np.isinf(cov).any():
             raise ValueError('Sample covariances not valid! Likely "draws" is too small!')
-        mean = np.average(self.tempered_posterior, axis=0)
+        mean = np.mean(self.tempered_posterior, axis=0)
+        self.cov = cov
         self.proposal_dist = multivariate_normal(mean, cov)
 
     def mutate(self):
         """Independent Metropolis-Hastings perturbation."""
         ac_ = np.empty((self.n_steps, self.draws))
-
-        cov = self.proposal_dist.cov
+        cov = self.cov  # self.proposal_dist.cov
         log_R = np.log(np.random.rand(self.n_steps, self.draws))
+        self.old_likelihood_logp = np.copy(self.likelihood_logp)
         for n_step in range(self.n_steps):
+            log_R = np.log(np.random.rand(self.draws))
             # The proposal is independent from the current point.
             # We have to take that into account to compute the Metropolis-Hastings acceptance
             proposal = floatX(self.proposal_dist.rvs(size=self.draws))
@@ -406,7 +424,47 @@ class IMH(SMC_KERNEL):
             self.prior_logp[accepted] = pl[accepted]
             self.likelihood_logp[accepted] = ll[accepted]
 
-        self.acc_rate = np.mean(ac_)
+            # log_weights_un = self.likelihood_logp - self.old_likelihood_logp
+            # log_weights = log_weights_un - logsumexp(log_weights_un)
+            # _, pareto = psislw(log_weights)
+            # if np.isfinite(pareto):# >= 0.7:
+            #    break
+            # print(self.beta, n_step, pareto)
+        # self.acc_rate = np.mean(ac_)
+        self.acc_rate = np.mean(np.sum(ac_, 0) > 0)
+        # print(np.mean(ac_), np.mean(np.sum(ac_, 0) > 0))
+
+    #        ac_ = 0
+    #        cov = self.proposal_dist.cov
+    #        rejected = np.ones(self.draws, dtype=bool)
+    #        itero = 0
+    #        for _ in range(self.n_steps):#while True:
+    #            indi = np.arange(self.draws)
+    #            indi = indi[rejected]
+    #            if len(indi) < 0.1*self.draws:
+    #                break
+    #            propo = floatX(self.proposal_dist.rvs(size=len(indi)))
+    #            propo = propo.reshape(len(propo), -1)
+    #            fw = self.proposal_dist.logpdf(propo)
+    #            bk = multivariate_normal(propo.mean(axis=0), cov).logpdf(self.tempered_posterior[rejected])
+    #            rnd = np.random.rand(len(indi))
+    #            for idx, draw in enumerate(indi):
+    #                proposal = propo[idx]
+    #                forward = fw[idx]
+    #                backward = bk[idx]
+    #                ll = self.likelihood_logp_func(proposal)
+    #                pl = self.prior_logp_func(proposal)
+    #                proposal_logp = pl + ll * self.beta
+    #                accepted = rnd[idx] < ((proposal_logp + backward) - (self.tempered_posterior_logp[draw] + forward))
+    #                rejected[draw] = not accepted
+    #                if accepted:
+    #                    self.tempered_posterior[draw] = proposal
+    #                    self.tempered_posterior_logp[draw] = proposal_logp
+    #                    self.prior_logp[draw] = pl
+    #                    self.likelihood_logp[draw] = ll
+    #                ac_ += accepted
+    #                itero += 1
+    #        self.acc_rate = 1-np.mean(rejected)#ac_/itero
 
     def sample_stats(self):
         stats = super().sample_stats()

--- a/pymc/tests/test_bart.py
+++ b/pymc/tests/test_bart.py
@@ -58,9 +58,9 @@ def test_bart_random():
         idata = pm.sample(random_seed=3415, chains=1)
 
     rng = RandomState(12345)
-    pred_all = mu.owner.op.rng_fn(rng, size=2)
+    pred_all = pm.bart.utils.predict(idata, rng, size=2)
     rng = RandomState(12345)
-    pred_first = mu.owner.op.rng_fn(rng, X_new=X[:10])
+    pred_first = pm.bart.utils.predict(idata, rng, X_new=X[:10])
 
     assert_almost_equal(pred_first, pred_all[0, :10], decimal=4)
     assert pred_all.shape == (2, 50)

--- a/pymc/tests/test_bart.py
+++ b/pymc/tests/test_bart.py
@@ -65,7 +65,7 @@ def test_utils():
     Y = np.random.normal(0, 1, size=50)
 
     with pm.Model() as model:
-        mu = pm.BART("mu", X, Y, m=10)
+        mu = pm.BART("mu", X, Y, m=10, response="mix")
         sigma = pm.HalfNormal("sigma", 1)
         y = pm.Normal("y", mu, sigma, observed=Y)
         idata = pm.sample(random_seed=3415)

--- a/pymc/tests/test_bart.py
+++ b/pymc/tests/test_bart.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from numpy.random import RandomState
 from numpy.testing import assert_almost_equal
@@ -47,26 +48,6 @@ def test_bart_vi():
         assert_almost_equal(var_imp.sum(), 1)
 
 
-def test_bart_random():
-    X = np.random.normal(0, 1, size=(2, 50)).T
-    Y = np.random.normal(0, 1, size=50)
-
-    with pm.Model() as model:
-        mu = pm.BART("mu", X, Y, m=10)
-        sigma = pm.HalfNormal("sigma", 1)
-        y = pm.Normal("y", mu, sigma, observed=Y)
-        idata = pm.sample(random_seed=3415, chains=1)
-
-    rng = RandomState(12345)
-    pred_all = pm.bart.utils.predict(idata, rng, size=2)
-    rng = RandomState(12345)
-    pred_first = pm.bart.utils.predict(idata, rng, X_new=X[:10])
-
-    assert_almost_equal(pred_first, pred_all[0, :10], decimal=4)
-    assert pred_all.shape == (2, 50)
-    assert pred_first.shape == (10,)
-
-
 def test_missing_data():
     X = np.random.normal(0, 1, size=(2, 50)).T
     Y = np.random.normal(0, 1, size=50)
@@ -77,3 +58,37 @@ def test_missing_data():
         sigma = pm.HalfNormal("sigma", 1)
         y = pm.Normal("y", mu, sigma, observed=Y)
         idata = pm.sample(random_seed=3415)
+
+
+def test_utils():
+    X = np.random.normal(0, 1, size=(2, 50)).T
+    Y = np.random.normal(0, 1, size=50)
+
+    with pm.Model() as model:
+        mu = pm.BART("mu", X, Y, m=10)
+        sigma = pm.HalfNormal("sigma", 1)
+        y = pm.Normal("y", mu, sigma, observed=Y)
+        idata = pm.sample(random_seed=3415)
+
+    def test_predict():
+        rng = RandomState(12345)
+        pred_all = pm.bart.utils.predict(idata, rng, size=2)
+        rng = RandomState(12345)
+        pred_first = pm.bart.utils.predict(idata, rng, X_new=X[:10])
+
+        assert_almost_equal(pred_first, pred_all[0, :10], decimal=4)
+        assert pred_all.shape == (2, 50)
+        assert pred_first.shape == (10,)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"kind": "pdp", "xs_interval": "quantiles", "xs_values": [0.25, 0.5, 0.75]},
+            {"kind": "ice", "instances": 5},
+            {"var_idx": 0, "rug": False, "smooth": False, "color": "k"},
+            {"grid": (1, 2), "sharey": "False", "alpha": 1},
+        ],
+    )
+    def test_pdp():
+        pm.bart.utils.plot_dependence(idata, X=None, Y=None, **kwargs)

--- a/pymc/tests/test_bart.py
+++ b/pymc/tests/test_bart.py
@@ -60,7 +60,7 @@ def test_missing_data():
         idata = pm.sample(random_seed=3415)
 
 
-def test_utils():
+class TestUtils:
     X = np.random.normal(0, 1, size=(2, 50)).T
     Y = np.random.normal(0, 1, size=50)
 
@@ -70,11 +70,11 @@ def test_utils():
         y = pm.Normal("y", mu, sigma, observed=Y)
         idata = pm.sample(random_seed=3415)
 
-    def test_predict():
+    def test_predict(self):
         rng = RandomState(12345)
-        pred_all = pm.bart.utils.predict(idata, rng, size=2)
+        pred_all = pm.bart.utils.predict(self.idata, rng, size=2)
         rng = RandomState(12345)
-        pred_first = pm.bart.utils.predict(idata, rng, X_new=X[:10])
+        pred_first = pm.bart.utils.predict(self.idata, rng, X_new=self.X[:10])
 
         assert_almost_equal(pred_first, pred_all[0, :10], decimal=4)
         assert pred_all.shape == (2, 50)
@@ -84,11 +84,16 @@ def test_utils():
         "kwargs",
         [
             {},
-            {"kind": "pdp", "xs_interval": "quantiles", "xs_values": [0.25, 0.5, 0.75]},
-            {"kind": "ice", "instances": 5},
-            {"var_idx": 0, "rug": False, "smooth": False, "color": "k"},
-            {"grid": (1, 2), "sharey": "False", "alpha": 1},
+            {
+                "kind": "pdp",
+                "samples": 2,
+                "xs_interval": "quantiles",
+                "xs_values": [0.25, 0.5, 0.75],
+            },
+            {"kind": "ice", "instances": 2},
+            {"var_idx": [0], "rug": False, "smooth": False, "color": "k"},
+            {"grid": (1, 2), "sharey": "none", "alpha": 1},
         ],
     )
-    def test_pdp():
-        pm.bart.utils.plot_dependence(idata, X=None, Y=None, **kwargs)
+    def test_pdp(self, kwargs):
+        pm.bart.utils.plot_dependence(self.idata, X=self.X, Y=self.Y, **kwargs)


### PR DESCRIPTION
This add functions to compute partial dependence plots and individual conditional expectation plots. It also move the in-sample and out-of-sample function predictions to the function `predict`, also part of `bart.utils`. After this PR is merged I will add an example of  how to use these function and BART in general. 


This is an example of a partial dependence plot, where BART is used to predict the number of rented bikes given 4 covariates.

![index](https://user-images.githubusercontent.com/1338958/138416743-d84a5406-c5bb-4f78-bb13-4e10a4cae1f2.png)


