### PR TITLE
Add testimonials to docs homepage

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -77,6 +77,59 @@ Donate
 
 ::::
 
+# Testimonials
+
+::::{card-carousel} 3
+
+:::{card}
+:class-body: small
+**[SpaceX](https://www.spacex.com/)**
+^^^
+> At SpaceX PyMC helped us estimate supplier delivery uncertainty and quantify which suppliers were consistent in sending us rocket parts and which suppliers we needed to partner with to understand how we could reduce variability
+
+_Ravin Kumar_
+:::
+
+:::{card}
+:class-body: small
+**[Salesforce](http://www.salesforce.com)**
+^^^
+> PyMC is my primary tool for statistical modeling at Salesforce. I use it to combine disparate sources of information and pretty much anywhere that quantifying uncertainty is important. We've also been experimenting with gaussian processes to model time series data for forecasting.
+
+_Eddie Landesberg. Manager, Data Scientist_
+:::
+
+:::{card}
+:class-body: small
+**[Novartis Institutes for Biomedical Research](https://www.novartis.com/our-science/novartis-institutes-biomedical-research)**
+^^^
+> At the Novartis Institutes for Biomedical Research, we use PyMC for a wide variety of scientific and business use cases. The API is incredible, making it easy to express probabilistic models of our scientific experimental data and business processes, such as models of electrophysiology and molecular dose response.
+
+_Eric J. Ma_
+:::
+
+:::{card}
+:class-body: small
+**[Intercom](https://www.intercom.com)**
+^^^
+> At Intercom, we've adopted PyMC as part of our A/B testing framework. The API made it easy to integrate into our existing experimentation framework and the methodology has made communication of experiment results much more straightforward for non technical stakeholders.
+
+_Louis Ryan_
+:::
+
+:::{card}
+:class-body: small
+**[Channel 4](http://www.channel4.co.uk)**
+^^^
+> Used in research code at Channel 4 for developing internal forecasting tools.
+
+_Peader Coyle_
+:::
+
+::::
+
+More testimonials can be found on our [Testimonials Wiki](https://github.com/pymc-devs/pymc/wiki/Testimonials).
+
 # Citing PyMC
 
 Use this to cite the library:


### PR DESCRIPTION
Adding some testimonials to the homepage of the PyMC Docs and a link to the testimonials wiki.

![image](https://user-images.githubusercontent.com/4202651/139533119-14d11f37-64af-416a-9d0e-5c2f3be28408.png)

