### PR TITLE
Remove deprecated functions

### DIFF
--- a/pymc/backends/tracetab.py
+++ b/pymc/backends/tracetab.py
@@ -15,51 +15,8 @@
 """Functions for converting traces into a table-like format
 """
 
-import warnings
 
 import numpy as np
-import pandas as pd
-
-from pymc.util import get_default_varnames
-
-__all__ = ["trace_to_dataframe"]
-
-
-def trace_to_dataframe(trace, chains=None, varnames=None, include_transformed=False):
-    """Convert trace to pandas DataFrame.
-
-    Parameters
-    ----------
-    trace: NDarray trace
-    chains: int or list of ints
-        Chains to include. If None, all chains are used. A single
-        chain value can also be given.
-    varnames: list of variable names
-        Variables to be included in the DataFrame, if None all variable are
-        included.
-    include_transformed: boolean
-        If true transformed variables will be included in the resulting
-        DataFrame.
-    """
-    warnings.warn(
-        "The `trace_to_dataframe` function will soon be removed. "
-        "Please use ArviZ to save traces. "
-        "If you have good reasons for using the `trace_to_dataframe` function, file an issue and tell us about them. ",
-        FutureWarning,
-    )
-    var_shapes = trace._straces[0].var_shapes
-
-    if varnames is None:
-        varnames = get_default_varnames(var_shapes.keys(), include_transformed=include_transformed)
-
-    flat_names = {v: create_flat_names(v, var_shapes[v]) for v in varnames}
-
-    var_dfs = []
-    for v in varnames:
-        vals = trace.get_values(v, combine=True, chains=chains)
-        flat_vals = vals.reshape(vals.shape[0], -1)
-        var_dfs.append(pd.DataFrame(flat_vals, columns=flat_names[v]))
-    return pd.concat(var_dfs, axis=1)
 
 
 def create_flat_names(varname, shape):

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -767,9 +767,10 @@ class TestSamplePPC(SeededTest):
                 return_inferencedata=False,
                 compute_convergence_checks=False,
             )
-            ppc_trace = pm.trace_to_dataframe(
-                trace, varnames=[n for n in trace.varnames if n != "out"]
-            ).to_dict("records")
+            varnames = [v for v in trace.varnames if v != "out"]
+            ppc_trace = [
+                dict(zip(varnames, row)) for row in zip(*(trace.get_values(v) for v in varnames))
+            ]
             ppc = pm.sample_posterior_predictive(
                 return_inferencedata=False,
                 model=model,

--- a/pymc/tests/test_tracetab.py
+++ b/pymc/tests/test_tracetab.py
@@ -12,53 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import numpy.testing as npt
-
-from pymc.backends import ndarray
 from pymc.backends import tracetab as ttab
-from pymc.tests import backend_fixtures as bf
-
-
-class TestTraceToDf(bf.ModelBackendSampledTestCase):
-    backend = ndarray.NDArray
-    name = "text-db"
-    shape = (2, 3)
-
-    def test_trace_to_dataframe(self):
-        mtrace = self.mtrace
-        df = ttab.trace_to_dataframe(mtrace)
-        assert len(mtrace) * mtrace.nchains == df.shape[0]
-
-        checked = False
-        for varname in self.test_point.keys():
-            vararr = mtrace.get_values(varname)
-            # With `shape` above, only one variable has to have that
-            # `shape`.
-            if vararr.shape[1:] != self.shape:
-                continue
-            npt.assert_equal(vararr[:, 0, 0], df[varname + "__0_0"].values)
-            npt.assert_equal(vararr[:, 1, 0], df[varname + "__1_0"].values)
-            npt.assert_equal(vararr[:, 1, 2], df[varname + "__1_2"].values)
-            checked = True
-        assert checked
-
-    def test_trace_to_dataframe_chain_arg(self):
-        mtrace = self.mtrace
-        df = ttab.trace_to_dataframe(mtrace, chains=0)
-        assert len(mtrace) == df.shape[0]
-
-        checked = False
-        for varname in self.test_point.keys():
-            vararr = mtrace.get_values(varname, chains=0)
-            # With `shape` above, only one variable has to have that
-            # `shape`.
-            if vararr.shape[1:] != self.shape:
-                continue
-            npt.assert_equal(vararr[:, 0, 0], df[varname + "__0_0"].values)
-            npt.assert_equal(vararr[:, 1, 0], df[varname + "__1_0"].values)
-            npt.assert_equal(vararr[:, 1, 2], df[varname + "__1_2"].values)
-            checked = True
-        assert checked
 
 
 def test_create_flat_names_0d():

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 
 import functools
-import warnings
 
 from typing import Dict, List, Tuple, Union
 
@@ -229,16 +228,6 @@ def biwrap(wrapper):
             return newwrapper
 
     return enhanced
-
-
-# FIXME: this function is poorly named, because it returns a LIST of
-# points, not a dictionary of points.
-def dataset_to_point_dict(ds: xarray.Dataset) -> List[Dict[str, np.ndarray]]:
-    warnings.warn(
-        "dataset_to_point_dict was renamed to dataset_to_point_list and will be removed!",
-        FutureWarning,
-    )
-    return dataset_to_point_list(ds)
 
 
 def dataset_to_point_list(ds: xarray.Dataset) -> List[Dict[str, np.ndarray]]:


### PR DESCRIPTION
This PR closes https://github.com/pymc-devs/pymc/issues/5124, to remove deprecated functions.

Should we also remove an `if statement` with a `FutureWarning` in it? For example this line:

```python
def invlogit(x, eps=None):
    """The inverse of the logit function, 1 / (1 + exp(-x))."""
    if eps is not None:
        warnings.warn(
            "pymc.math.invlogit no longer supports the ``eps`` argument and it will be ignored.",
            FutureWarning,
            stacklevel=2,
        )
    return at.sigmoid(x)
```

If that's the case, I think we need to remove the related argument(s).
