### PR TITLE
Use Random Generator in SMC instead of global seeding

### DIFF
--- a/pymc/smc/sample_smc.py
+++ b/pymc/smc/sample_smc.py
@@ -42,7 +42,7 @@ def sample_smc(
     *,
     start=None,
     model=None,
-    random_seed=-1,
+    random_seed=None,
     chains=None,
     cores=None,
     compute_convergence_checks=True,
@@ -191,15 +191,19 @@ def sample_smc(
         cores = min(chains, cores)
 
     if random_seed == -1:
+        raise FutureWarning(
+            f"random_seed should be a non-negative integer or None, got: {random_seed}"
+            "This will raise a ValueError in the Future"
+        )
         random_seed = None
-    if chains == 1 and isinstance(random_seed, int):
-        random_seed = [random_seed]
-    if random_seed is None or isinstance(random_seed, int):
-        if random_seed is not None:
-            np.random.seed(random_seed)
-        random_seed = [np.random.randint(2 ** 30) for _ in range(chains)]
-    if not isinstance(random_seed, Iterable):
-        raise TypeError("Invalid value for `random_seed`. Must be tuple, list or int")
+    if isinstance(random_seed, int) or random_seed is None:
+        rng = np.random.default_rng(seed=random_seed)
+        random_seed = list(rng.integers(2 ** 30, size=chains))
+    elif isinstance(random_seed, Iterable):
+        if len(random_seed) != chains:
+            raise ValueError(f"Length of seeds ({len(seeds)}) must match number of chains {chains}")
+    else:
+        raise TypeError("Invalid value for `random_seed`. Must be tuple, list, int or None")
 
     model = modelcontext(model)
 

--- a/pymc/smc/smc.py
+++ b/pymc/smc/smc.py
@@ -189,7 +189,7 @@ class SMC_KERNEL(ABC):
 
         """
         # Create dictionary that stores original variables shape and size
-        initial_point = self.model.initial_point
+        initial_point = self.model.recompute_initial_point(seed=self.rng.integers(2 ** 30))
         for v in self.variables:
             self.var_info[v.name] = (initial_point[v.name].shape, initial_point[v.name].size)
 

--- a/pymc/tests/helpers.py
+++ b/pymc/tests/helpers.py
@@ -17,6 +17,7 @@ import contextlib
 from logging.handlers import BufferingHandler
 
 import aesara
+import numpy as np
 import numpy.random as nr
 
 from aesara.gradient import verify_grad as at_verify_grad
@@ -123,3 +124,11 @@ def verify_grad(op, pt, n_tests=2, rng=None, *args, **kwargs):
     if rng is None:
         rng = nr.RandomState(411342)
     at_verify_grad(op, pt, n_tests, rng, *args, **kwargs)
+
+
+def assert_random_state_equal(state1, state2):
+    for field1, field2 in zip(state1, state2):
+        if isinstance(field1, np.ndarray):
+            np.testing.assert_array_equal(field1, field2)
+        else:
+            assert field1 == field2


### PR DESCRIPTION
Closes #4938 

Other changes:
1. Use model.recompute_initial_point instead of deprecated model.initial_point.
2. Update Metropolis Proposal classes to accept a Numpy Random Generator in `__call__`