### PR TITLE
Do not compare arrays with strings in make_initial_point_expression

### DIFF
--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -269,10 +269,15 @@ def make_initial_point_expression(
         if strategy is None:
             strategy = default_strategy
 
-        if strategy == "moment":
-            value = get_moment(variable)
-        elif strategy == "prior":
-            value = variable
+        if isinstance(strategy, str):
+            if strategy == "moment":
+                value = get_moment(variable)
+            elif strategy == "prior":
+                value = variable
+            else:
+                raise ValueError(
+                    f'Invalid string strategy: {strategy}. It must be one of ["moment", "prior"]'
+                )
         else:
             value = at.as_tensor(strategy, dtype=variable.dtype).astype(variable.dtype)
 

--- a/pymc/tests/test_initial_point.py
+++ b/pymc/tests/test_initial_point.py
@@ -50,6 +50,12 @@ class TestInitvalAssignment:
                 assert not hasattr(rv.tag, "test_value")
         pass
 
+    def test_valid_string_strategy(self):
+        with pm.Model() as pmodel:
+            pm.Uniform("x", 0, 1, size=2, initval="unknown")
+            with pytest.raises(ValueError, match="Invalid string strategy: unknown"):
+                pmodel.recompute_initial_point(seed=0)
+
 
 class TestInitvalEvaluation:
     def test_make_initial_point_fns_per_chain_checks_kwargs(self):


### PR DESCRIPTION
This gets rid of numpy FutureWarnings when we set the initval to an array:

```python
import numpy as np
import pymc as pm

with pm.Model() as m:
  x = pm.Normal('x', size=10, initval=np.arange(10))
m.recompute_initial_point()
```