### PR TITLE
Change initial_point default strategy from "prior" to "moment"

### DIFF
--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 - aeppl=0.0.18
-- aesara>=2.2.6
+- aesara=2.3.2
 - arviz>=0.11.4
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 - aeppl=0.0.18
-- aesara>=2.2.6
+- aesara=2.3.2
 - arviz>=0.11.4
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 - aeppl=0.0.18
-- aesara>=2.2.6
+- aesara=2.3.2
 - arviz>=0.11.4
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/environment-test-py37.yml
+++ b/conda-envs/environment-test-py37.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 - aeppl=0.0.18
-- aesara>=2.2.6
+- aesara=2.3.2
 - arviz>=0.11.4
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/environment-test-py38.yml
+++ b/conda-envs/environment-test-py38.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 - aeppl=0.0.18
-- aesara>=2.2.6
+- aesara=2.3.2
 - arviz>=0.11.4
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/environment-test-py39.yml
+++ b/conda-envs/environment-test-py39.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 - aeppl=0.0.18
-- aesara>=2.2.6
+- aesara=2.3.2
 - arviz>=0.11.4
 - cachetools
 - cloudpickle

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
  # base dependencies (see install guide for Windows)
 - aeppl=0.0.18
-- aesara>=2.2.6
+- aesara=2.3.2
 - arviz>=0.11.4
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/windows-environment-test-py38.yml
+++ b/conda-envs/windows-environment-test-py38.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
  # base dependencies (see install guide for Windows)
 - aeppl=0.0.18
-- aesara>=2.2.6
+- aesara=2.3.2
 - arviz>=0.11.2
 - cachetools
 - cloudpickle

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -717,16 +717,16 @@ class TruncatedNormal(BoundedContinuous):
     def get_moment(rv, size, mu, sigma, lower, upper):
         mu, _, lower, upper = at.broadcast_arrays(mu, sigma, lower, upper)
         moment = at.switch(
-            at.isinf(lower),
+            at.eq(lower, -np.inf),
             at.switch(
-                at.isinf(upper),
+                at.eq(upper, np.inf),
                 # lower = -inf, upper = inf
                 mu,
                 # lower = -inf, upper = x
                 upper - 1,
             ),
             at.switch(
-                at.isinf(upper),
+                at.eq(upper, np.inf),
                 # lower = x, upper = inf
                 lower + 1,
                 # lower = x, upper = x

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -131,7 +131,7 @@ def make_initial_point_fn(
     model,
     overrides: Optional[StartDict] = None,
     jitter_rvs: Optional[Set[TensorVariable]] = None,
-    default_strategy: str = "prior",
+    default_strategy: str = "moment",
     return_transformed: bool = True,
 ) -> Callable:
     """Create seeded function that computes initial values for all free model variables.
@@ -226,7 +226,7 @@ def make_initial_point_expression(
     rvs_to_values: Dict[TensorVariable, TensorVariable],
     initval_strategies: Dict[TensorVariable, Optional[Union[np.ndarray, Variable, str]]],
     jitter_rvs: Set[TensorVariable] = None,
-    default_strategy: str = "prior",
+    default_strategy: str = "moment",
     return_transformed: bool = False,
 ) -> List[TensorVariable]:
     """Creates the tensor variables that need to be evaluated to obtain an initial point.

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import functools
+import warnings
 
 from typing import Callable, Dict, List, Optional, Sequence, Set, Union
 
@@ -269,7 +270,19 @@ def make_initial_point_expression(
 
         if isinstance(strategy, str):
             if strategy == "moment":
-                value = get_moment(variable)
+                try:
+                    value = get_moment(variable)
+                except NotImplementedError:
+                    warnings.warn(
+                        f"Moment not defined for variable {variable} of type "
+                        f"{variable.owner.op.__class__.__name__}, defaulting to "
+                        f"a draw from the prior. This can lead to difficulties "
+                        f"during tuning. You can manually define an initval or "
+                        f"implement a get_moment dispatched function for this "
+                        f"distribution.",
+                        UserWarning,
+                    )
+                    value = variable
             elif strategy == "prior":
                 value = variable
             else:

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -249,14 +249,13 @@ def test_halfstudentt_moment(nu, sigma, size, expected):
     assert_moment_is_expected(model, expected)
 
 
-@pytest.mark.skip(reason="aeppl interval transform fails when both edges are None")
 @pytest.mark.parametrize(
     "mu, sigma, lower, upper, size, expected",
     [
-        (0.9, 1, -1, 1, None, 0),
-        (0.9, 1, -np.inf, np.inf, 5, np.full(5, 0.9)),
+        (0.9, 1, -5, 5, None, 0),
+        (1, np.ones(5), -10, np.inf, None, np.full(5, -9)),
         (np.arange(5), 1, None, 10, (2, 5), np.full((2, 5), 9)),
-        (1, np.ones(5), -10, np.inf, None, np.full((2, 5), -9)),
+        (1, 1, [-np.inf, -np.inf, -np.inf], 10, None, np.full(3, 9)),
     ],
 )
 def test_truncatednormal_moment(mu, sigma, lower, upper, size, expected):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # See that file for comments about the need/usage of each dependency.
 
 aeppl==0.0.18
-aesara>=2.2.6
+aesara==2.3.2
 arviz>=0.11.4
 cachetools>=4.2.1
 cloudpickle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aeppl==0.0.18
-aesara>=2.2.6
+aesara==2.3.2
 arviz>=0.11.4
 cachetools>=4.2.1
 cloudpickle


### PR DESCRIPTION
This PR adds a check that we have moments for all distributions and changes the default initial point strategy from `"prior"` to `"moment"`

Also added a check in the default test moments that the logp of the provided moment is finite.

Closes #5009 
Related to #5078 

We also need to decide whether we default to a draw from the prior if a distribution does not have a `get_moment` implemented or if we just fail in that case (which is what is happening now). It would be trivial to allow this with a try/except block