### PR TITLE
Accomodate alternative Aesara backends

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1653,7 +1653,9 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
         return Series(
             {
                 rv.name: np.round(
-                    self.fn(logpt_sum(rv, getattr(rv.tag, "observations", None)))(point),
+                    np.asarray(
+                        self.fn(logpt_sum(rv, getattr(rv.tag, "observations", None)))(point)
+                    ),
                     round_vals,
                 )
                 for rv in self.basic_RVs


### PR DESCRIPTION
This PR tries to disentangle some aspects of the codebase to be more agnostic to Aesara's execution backend, so that we can easily sample with NUMBA or JAX compiled functions as well as the default C backend, by simply changing the `aesara.config.mode` flag.

This now works fine on my machine:

```python
import aesara
aesara.config.mode = "JAX"  # Default is "Mode"

#%%
import pymc as pm
import numpy as np

#%%
rng = np.random.default_rng(seed=42)
prior_idxs = np.repeat(np.arange(4), 25).astype(int)
beta_prior_true = np.abs(rng.normal(size=4))
beta_true = rng.normal(beta_prior_true[prior_idxs])
x = rng.uniform(-5, 5, size=(1000, 100))
y = np.dot(beta_true, x.T)

#%%
with pm.Model(rng_seeder=123) as m:
    beta_prior = pm.HalfNormal('beta_prior', shape=4)
    beta = pm.Normal('beta', beta_prior[prior_idxs], shape=100)
    pm.Normal('y', pm.math.dot(beta, x.T), observed=y)

#%%
pm.model_to_graphviz(m)

#%%
m.point_logps(m.recompute_initial_point(2))

#%%
with m:
    # Model's logp_dlog are compiled to JAX, with potential speedups when running on the GPU
    trace = pm.sample()
```