### PR TITLE
NegativeBinomial, ZeroInflatedPoisson, ZeroInflatedBinomial moments

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1323,10 +1323,10 @@ class ZeroInflatedPoisson(Discrete):
         return super().dist([psi, theta], *args, **kwargs)
 
     def get_moment(rv, size, psi, theta):
-        mu = at.floor(psi * theta)
+        mean = at.floor(psi * theta)
         if not rv_size_is_none(size):
-            mu = at.full(size, mu)
-        return mu
+            mean = at.full(size, mean)
+        return mean
 
     def logp(value, psi, theta):
         r"""

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -716,6 +716,12 @@ class NegativeBinomial(Discrete):
 
         return n, p
 
+    def get_moment(rv, size, n, p):
+        mu = at.floor(n * (1 - p) / p)
+        if not rv_size_is_none(size):
+            mu = at.full(size, mu)
+        return mu
+
     def logp(value, n, p):
         r"""
         Calculate log-probability of NegativeBinomial distribution at specified value.

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1449,6 +1449,12 @@ class ZeroInflatedBinomial(Discrete):
         p = at.as_tensor_variable(floatX(p))
         return super().dist([psi, n, p], *args, **kwargs)
 
+    def get_moment(rv, size, psi, n, p):
+        mean = at.round((1 - psi) * n * p)
+        if not rv_size_is_none(size):
+            mean = at.full(size, mean)
+        return mean
+
     def logp(value, psi, n, p):
         r"""
         Calculate log-probability of ZeroInflatedBinomial distribution at specified value.

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1322,6 +1322,12 @@ class ZeroInflatedPoisson(Discrete):
         theta = at.as_tensor_variable(floatX(theta))
         return super().dist([psi, theta], *args, **kwargs)
 
+    def get_moment(rv, size, psi, theta):
+        mu = at.floor(psi * theta)
+        if not rv_size_is_none(size):
+            mu = at.full(size, mu)
+        return mu
+
     def logp(value, psi, theta):
         r"""
         Calculate log-probability of ZeroInflatedPoisson distribution at specified value.

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -22,6 +22,7 @@ from pymc.distributions import (
     Poisson,
     StudentT,
     Weibull,
+    ZeroInflatedBinomial,
 )
 from pymc.distributions.shape_utils import rv_size_is_none
 from pymc.initial_point import make_initial_point_fn

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -406,9 +406,6 @@ def test_poisson_moment(mu, size, expected):
 
 
 @pytest.mark.parametrize(
-<<<<<<< HEAD
-    "c, size, expected",
-=======
     "n, p, size, expected",
     [
         (10, 0.7, None, 4),
@@ -424,6 +421,20 @@ def test_negative_binomial_moment(n, p, size, expected):
 
 
 @pytest.mark.parametrize(
+    "c, size, expected",
+    [
+        (1, None, 1),
+        (1, 5, np.full(5, 1)),
+        (np.arange(1, 6), None, np.arange(1, 6)),
+    ],
+)
+def test_constant_moment(c, size, expected):
+    with Model() as model:
+        Constant("x", c=c, size=size)
+    assert_moment_is_expected(model, expected)
+
+
+@pytest.mark.parametrize(
     "psi, theta, size, expected",
     [
         (0.9, 3.0, None, 2),
@@ -435,21 +446,21 @@ def test_negative_binomial_moment(n, p, size, expected):
 def test_zero_inflated_poisson_moment(psi, theta, size, expected):
     with Model() as model:
         ZeroInflatedPoisson("x", psi=psi, theta=theta, size=size)
-    assert_moment_is_expected(model, expected)   
+    assert_moment_is_expected(model, expected)
 
 
 @pytest.mark.parametrize(
     "psi, n, p, size, expected",
->>>>>>> 2eb37150 (negative binomial moment)
     [
-        (1, None, 1),
-        (1, 5, np.full(5, 1)),
-        (np.arange(1, 6), None, np.arange(1, 6)),
+        (0.2, 7, 0.7, None, 4),
+        (0.2, 7, 0.3, 5, np.full(5, 2)),
+        (0.6, 25, np.arange(1, 6) / 10, None, np.arange(1, 6)),
+        (0.6, 25, np.arange(1, 6) / 10, (2, 5), np.full((2, 5), np.arange(1, 6))),
     ],
 )
-def test_constant_moment(c, size, expected):
+def test_zero_inflated_binomial_moment(psi, n, p, size, expected):
     with Model() as model:
-        Constant("x", c=c, size=size)
+        ZeroInflatedBinomial("x", psi=psi, n=n, p=p, size=size)
     assert_moment_is_expected(model, expected)
 
 

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -24,6 +24,7 @@ from pymc.distributions import (
     StudentT,
     Weibull,
     ZeroInflatedBinomial,
+    ZeroInflatedPoisson,
 )
 from pymc.distributions.shape_utils import rv_size_is_none
 from pymc.initial_point import make_initial_point_fn
@@ -420,6 +421,21 @@ def test_negative_binomial_moment(n, p, size, expected):
     with Model() as model:
         NegativeBinomial("x", n=n, p=p, size=size)
     assert_moment_is_expected(model, expected)
+
+
+@pytest.mark.parametrize(
+    "psi, theta, size, expected",
+    [
+        (0.9, 3.0, None, 2),
+        (0.8, 2.9, 5, np.full(5, 2)),
+        (0.2, np.arange(1, 5) * 5, None, np.arange(1, 5)),
+        (0.2, np.arange(1, 5) * 5, (2, 4), np.full((2, 4), np.arange(1, 5))),
+    ],
+)
+def test_zero_inflated_poisson_moment(psi, theta, size, expected):
+    with Model() as model:
+        ZeroInflatedPoisson("x", psi=psi, theta=theta, size=size)
+    assert_moment_is_expected(model, expected)   
 
 
 @pytest.mark.parametrize(

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -19,6 +19,7 @@ from pymc.distributions import (
     Laplace,
     Logistic,
     LogNormal,
+    NegativeBinomial,
     Poisson,
     StudentT,
     Weibull,
@@ -404,7 +405,26 @@ def test_poisson_moment(mu, size, expected):
 
 
 @pytest.mark.parametrize(
+<<<<<<< HEAD
     "c, size, expected",
+=======
+    "n, p, size, expected",
+    [
+        (10, 0.7, None, 4),
+        (10, 0.7, 5, np.full(5, 4)),
+        (np.full(3, 10), np.arange(1, 4) / 10, None, np.array([90, 40, 23])),
+        (10, np.arange(1, 4) / 10, (2, 3), np.full((2, 3), np.array([90, 40, 23]))),
+    ],
+)
+def test_negative_binomial_moment(n, p, size, expected):
+    with Model() as model:
+        NegativeBinomial("x", n=n, p=p, size=size)
+    assert_moment_is_expected(model, expected)
+
+
+@pytest.mark.parametrize(
+    "psi, n, p, size, expected",
+>>>>>>> 2eb37150 (negative binomial moment)
     [
         (1, None, 1),
         (1, 5, np.full(5, 1)),


### PR DESCRIPTION
Add moments and tests for the below distributions as part of #5078:

- pymc.distributions.Discrete.NegativeBinomial
- pymc.distributions.Discrete.ZeroInflatedPoisson
- pymc.distributions.Discrete.ZeroInflatedBinomial

This is my first PR (first time with pytest, rebasing etc – ah the bliss life of the end user) so __please check carefully__. 
