### PR TITLE
adds beta-binomial mean and test cases

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -238,6 +238,12 @@ class BetaBinomial(Discrete):
         beta = at.as_tensor_variable(floatX(beta))
         n = at.as_tensor_variable(intX(n))
         return super().dist([n, alpha, beta], **kwargs)
+    
+    def get_moment(rv, size, n, alpha, beta):
+        mean = (n * alpha) / (alpha + beta)
+        if not rv_size_is_none(size):
+            mean = at.full(size, mean)
+        return mean
 
     def logp(value, n, alpha, beta):
         r"""

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -238,7 +238,7 @@ class BetaBinomial(Discrete):
         beta = at.as_tensor_variable(floatX(beta))
         n = at.as_tensor_variable(intX(n))
         return super().dist([n, alpha, beta], **kwargs)
-    
+
     def get_moment(rv, size, n, alpha, beta):
         mean = (n * alpha) / (alpha + beta)
         if not rv_size_is_none(size):

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -240,7 +240,7 @@ class BetaBinomial(Discrete):
         return super().dist([n, alpha, beta], **kwargs)
 
     def get_moment(rv, size, n, alpha, beta):
-        mean = (n * alpha) / (alpha + beta)
+        mean = at.round((n * alpha) / (alpha + beta))
         if not rv_size_is_none(size):
             mean = at.full(size, mean)
         return mean

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -6,6 +6,7 @@ from scipy import special
 from pymc.distributions import (
     Bernoulli,
     Beta,
+    BetaBinomial,
     Binomial,
     Cauchy,
     ChiSquared,
@@ -206,6 +207,21 @@ def test_bernoulli_moment(p, size, expected):
 def test_beta_moment(alpha, beta, size, expected):
     with Model() as model:
         Beta("x", alpha=alpha, beta=beta, size=size)
+    assert_moment_is_expected(model, expected)
+
+
+@pytest.mark.parametrize(
+    "n, alpha, beta, size, expected",
+    [
+        (10, 1, 1, None, 5),
+        (10, 1, 1, 5, np.full(5, 5)),
+        (10, 1, np.arange(1, 6), None, np.floor(10 / np.arange(2, 7))),
+        (10, 1, np.arange(1, 6), (2, 5), np.full((2, 5), np.floor(10 / np.arange(2, 7)))),
+    ],
+)
+def test_beta_binomial_moment(alpha, beta, n, size, expected):
+    with Model() as model:
+        BetaBinomial("x", alpha=alpha, beta=beta, n=n, size=size)
     assert_moment_is_expected(model, expected)
 
 

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -215,8 +215,8 @@ def test_beta_moment(alpha, beta, size, expected):
     [
         (10, 1, 1, None, 5),
         (10, 1, 1, 5, np.full(5, 5)),
-        (10, 1, np.arange(1, 6), None, np.floor(10 / np.arange(2, 7))),
-        (10, 1, np.arange(1, 6), (2, 5), np.full((2, 5), np.floor(10 / np.arange(2, 7)))),
+        (10, 1, np.arange(1, 6), None, np.round(10 / np.arange(2, 7))),
+        (10, 1, np.arange(1, 6), (2, 5), np.full((2, 5), np.round(10 / np.arange(2, 7)))),
     ],
 )
 def test_beta_binomial_moment(alpha, beta, n, size, expected):


### PR DESCRIPTION
Note that the get_moment method returns an integer value (rounding the mean down to the nearest integer) in this implementation. Probably due to multiplying an integer with floats.. 

This is made clear in two of the test cases, where np.floor is applied to the expected output. This is similar to the implementation of the Binomial mean (also a integer multiplied with a float, and where the test cases are also rounded to integer values) so I figured it would be OK. Let me know otherwise!


**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [ ] important background, or details about the implementation
+ [ ] are the changes—especially new features—covered by tests and docstrings?
+ [ ] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
