### PR TITLE
BART: improve accuracy and other minor fixes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -86,8 +86,9 @@ This includes API changes we did not warn about since at least `3.11.0` (2021-01
 - `pm.DensityDist` can now accept an optional `logcdf` keyword argument to pass in a function to compute the cummulative density function of the distribution (see [5026](https://github.com/pymc-devs/pymc/pull/5026)).
 - `pm.DensityDist` can now accept an optional `get_moment` keyword argument to pass in a function to compute the moment of the distribution (see [5026](https://github.com/pymc-devs/pymc/pull/5026)).
 - New features for BART:
-  -  Added linear response, increased number of trees fitted per step [5044](https://github.com/pymc-devs/pymc3/pull/5044).
-  -  Added partial dependence plots and individual conditional expectation plots [5091](https://github.com/pymc-devs/pymc3/pull/5091).
+  - Added linear response, increased number of trees fitted per step [5044](https://github.com/pymc-devs/pymc3/pull/5044).
+  - Added partial dependence plots and individual conditional expectation plots [5091](https://github.com/pymc-devs/pymc3/pull/5091).
+  - Modify how particle weights are computed. This imporves accuracy of the modeled function (see [5177](https://github.com/pymc-devs/pymc3/pull/5177)).
 - `pm.Data` now passes additional kwargs to `aesara.shared`. [#5098](https://github.com/pymc-devs/pymc/pull/5098)
 - ...
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -88,7 +88,7 @@ This includes API changes we did not warn about since at least `3.11.0` (2021-01
 - New features for BART:
   - Added linear response, increased number of trees fitted per step [5044](https://github.com/pymc-devs/pymc3/pull/5044).
   - Added partial dependence plots and individual conditional expectation plots [5091](https://github.com/pymc-devs/pymc3/pull/5091).
-  - Modify how particle weights are computed. This imporves accuracy of the modeled function (see [5177](https://github.com/pymc-devs/pymc3/pull/5177)).
+  - Modify how particle weights are computed. This improves accuracy of the modeled function (see [5177](https://github.com/pymc-devs/pymc3/pull/5177)).
 - `pm.Data` now passes additional kwargs to `aesara.shared`. [#5098](https://github.com/pymc-devs/pymc/pull/5098)
 - ...
 


### PR DESCRIPTION
The main change introduced in this PR is how particles weights are computed. All particles except for the first one (previous tree) are grown from scratch  and re-weighted at each step. After all particles stop growing we compute the weights of all particles including the previous tree and normalize.  This improve accuracy but at the same time makes the sampler "stickier", in a follow up PR I will introduce better "tree-movements" that should improve sampling.

Just to illustrate, this is an example of fitting a function with 5 covariables related to the output function and then progressively adding more covariables non-related to the output variable (pure noise).
![bart_fit_covariantes_m200](https://user-images.githubusercontent.com/1338958/141416460-22d40ae5-6ba6-4f02-b01f-07aa964c3d7f.png)

and a partial dependant plot for 10 covariables (only the first 5 are related to the output)
![pdp_friedman_200_10](https://user-images.githubusercontent.com/1338958/141416526-7b7a6d4b-6136-4991-b282-e48250c67649.png)


