### PR TITLE
Adding Deterministic for sampling_numpyro

### DIFF
--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -168,10 +168,10 @@ def sample_numpyro_nuts(
 
     for i in range(draws):
         for c in range(chains):
-            draw = dict(
-                (value_var.name, raw_samples[c, i])
+            draw = {
+                value_var.name: raw_samples[c, i]
                 for value_var, raw_samples in zip(model.value_vars, raw_mcmc_samples)
-            )
+            }
             sample = fn(draw)
             for vi, v in enumerate(vars_to_sample):
                 mcmc_samples[v.name].append(sample[vi])

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -116,7 +116,6 @@ def sample_numpyro_nuts(
     vars_to_sample = list(get_default_varnames(var_names, include_transformed=keep_untransformed))
     inputs = [model.rvs_to_values[i] for i in model.free_RVs]
 
-
     tic1 = pd.Timestamp.now()
     print("Compiling...", file=sys.stdout)
 

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -114,7 +114,6 @@ def sample_numpyro_nuts(
         var_names = model.unobserved_value_vars
 
     vars_to_sample = list(get_default_varnames(var_names, include_transformed=keep_untransformed))
-    inputs = [model.rvs_to_values[i] for i in model.free_RVs]
 
     tic1 = pd.Timestamp.now()
     print("Compiling...", file=sys.stdout)
@@ -164,7 +163,7 @@ def sample_numpyro_nuts(
     print("Transforming variables...", file=sys.stdout)
     mcmc_samples = {}
     for v in vars_to_sample:
-        fgraph = FunctionGraph(inputs, [v], clone=False)
+        fgraph = FunctionGraph(model.value_vars, [v], clone=False)
         jax_fn = jax_funcify(fgraph)
         result = jax.vmap(jax.vmap(jax_fn))(*raw_mcmc_samples)[0]
         mcmc_samples[v.name] = result

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -58,7 +58,7 @@ def test_deterministic_samples():
         trace = sample_numpyro_nuts(chains=2, random_seed=1322, keep_untransformed=True)
 
     assert 8 < trace.posterior["a"].mean() < 11
-    assert 4 < trace.posterior["b"].mean() < 6
+    assert np.allclose(trace.posterior["b"].values, trace.posterior["a"].values / 2)
 
 
 def test_replace_shared_variables():

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -44,6 +44,23 @@ def test_transform_samples():
     assert 1.5 < trace.posterior["sigma"].mean() < 2.5
 
 
+def test_deterministic_samples():
+    aesara.config.on_opt_error = "raise"
+    np.random.seed(13244)
+
+    obs = np.random.normal(10, 2, size=100)
+    obs_at = aesara.shared(obs, borrow=True, name="obs")
+    with pm.Model() as model:
+        a = pm.Normal("a", 0, 1)
+        b = pm.Deterministic("b", a / 2.0)
+        c = pm.Normal("c", a, sigma=1.0, observed=obs_at)
+
+        trace = sample_numpyro_nuts(chains=2, random_seed=1322, keep_untransformed=True)
+
+    assert 8 < trace.posterior["a"].mean() < 11
+    assert 4 < trace.posterior["b"].mean() < 6
+
+
 def test_replace_shared_variables():
     x = aesara.shared(5, name="shared_x")
 

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -51,7 +51,7 @@ def test_deterministic_samples():
     obs = np.random.normal(10, 2, size=100)
     obs_at = aesara.shared(obs, borrow=True, name="obs")
     with pm.Model() as model:
-        a = pm.Normal("a", 0, 1)
+        a = pm.Uniform("a", -20, 20)
         b = pm.Deterministic("b", a / 2.0)
         c = pm.Normal("c", a, sigma=1.0, observed=obs_at)
 


### PR DESCRIPTION
This addresses #5100 and passes tests. My only concern is that this is likely not the fastest way to get deterministic variables as iterating per sample and per chain in pure python takes away much of the speed of this method.
