### PR TITLE
Remove logcdfpt and simplify logp and logcdf helpers

### DIFF
--- a/pymc/distributions/__init__.py
+++ b/pymc/distributions/__init__.py
@@ -13,10 +13,8 @@
 #   limitations under the License.
 
 from pymc.distributions.logprob import (  # isort:skip
-    _logcdf,
     logcdf,
     logp,
-    logcdfpt,
     logp_transform,
     logpt,
     logpt_sum,
@@ -195,6 +193,5 @@ __all__ = [
     "logp",
     "logp_transform",
     "logcdf",
-    "_logcdf",
     "logpt_sum",
 ]

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -23,14 +23,13 @@ from typing import Callable, Optional, Sequence
 
 import aesara
 
-from aeppl.logprob import _logprob
+from aeppl.logprob import _logcdf, _logprob
 from aesara.tensor.basic import as_tensor_variable
 from aesara.tensor.random.op import RandomVariable
 from aesara.tensor.random.var import RandomStateSharedVariable
 from aesara.tensor.var import TensorVariable
 
 from pymc.aesaraf import change_rv_size
-from pymc.distributions import _logcdf
 from pymc.distributions.shape_utils import (
     Dims,
     Shape,
@@ -98,18 +97,18 @@ class DistributionMeta(ABCMeta):
             if class_logp:
 
                 @_logprob.register(rv_type)
-                def logp(op, value_var_list, *dist_params, **kwargs):
-                    _dist_params = dist_params[3:]
-                    value_var = value_var_list[0]
-                    return class_logp(value_var, *_dist_params)
+                def logp(op, values, *dist_params, **kwargs):
+                    dist_params = dist_params[3:]
+                    (value,) = values
+                    return class_logp(value, *dist_params)
 
             class_logcdf = clsdict.get("logcdf")
             if class_logcdf:
 
                 @_logcdf.register(rv_type)
-                def logcdf(op, var, rvs_to_values, *dist_params, **kwargs):
-                    value_var = rvs_to_values.get(var, var)
-                    return class_logcdf(value_var, *dist_params, **kwargs)
+                def logcdf(op, value, *dist_params, **kwargs):
+                    dist_params = dist_params[3:]
+                    return class_logcdf(value, *dist_params)
 
             class_initval = clsdict.get("get_moment")
             if class_initval:

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2095,7 +2095,7 @@ class CAR(Continuous):
         TensorVariable
         """
 
-        sparse = isinstance(W, aesara.sparse.SparseConstant)
+        sparse = isinstance(W, (aesara.sparse.SparseConstant, aesara.sparse.SparseVariable))
 
         if sparse:
             D = sp_sum(W, axis=0)

--- a/pymc/tests/test_parallel_sampling.py
+++ b/pymc/tests/test_parallel_sampling.py
@@ -204,7 +204,7 @@ def test_spawn_densitydist_bound_method():
         normal_dist = pm.Normal.dist(mu, 1, size=N)
 
         def logp(x):
-            out = pm.logp(normal_dist, x, transformed=False)
+            out = pm.logp(normal_dist, x)
             return out
 
         obs = pm.DensityDist("density_dist", logp=logp, observed=np.random.randn(N), size=N)

--- a/pymc/tests/test_smc.py
+++ b/pymc/tests/test_smc.py
@@ -408,12 +408,12 @@ class TestSimulator(SeededTest):
         # Check that the logps use the correct methods
         a_val = m.rvs_to_values[a]
         sim1_val = m.rvs_to_values[sim1]
-        logp_sim1 = pm.logp(sim1, sim1_val)
+        logp_sim1 = pm.logpt(sim1, sim1_val)
         logp_sim1_fn = aesara.function([sim1_val, a_val], logp_sim1)
 
         b_val = m.rvs_to_values[b]
         sim2_val = m.rvs_to_values[sim2]
-        logp_sim2 = pm.logp(sim2, sim2_val)
+        logp_sim2 = pm.logpt(sim2, sim2_val)
         logp_sim2_fn = aesara.function([sim2_val, b_val], logp_sim2)
 
         assert any(


### PR DESCRIPTION
These methods will only retrieve the RV logp and logcdf terms, and no longer attempt to replace any potential RVs in their arguments.

This also lifts the constraint that the RV whose logp or logcdf term is requested must have the right dimensions, as long as the respective expression broadcasts properly. Since these terms will not be used as inputs to anything else, it seems safe to allow this.

Therefore it is now possible to do the following, more in line with V3:
```python
x = Normal.dist(0, 1)
x_logp = logp(x, [0, 1])
```

**However the following is now also possible:**
```python
x = pm.Normal.dist()
y = pm.Normal.dist(x)
pm.logp(y, 0.5).eval()
```
And the logp term evaluation will depend on a stochastic value of `x` (or it's first draw). You could also do this before the PR, but would at least get warning:
```
UserWarning: Found a random variable that was neither among the observations nor the conditioned variables
```

This would have failed in V3, because `pm.Normal.dist` would be a `pymc3.distributions.continuous.Normal` which could NOT be used as input to other distributions.

To have a logprob of `y` that depends on an input for `x` the user should have done the following:
```python
x = at.scalar('x')
y = pm.Normal.dist(x)
pm.logp(y, 0.5).eval({x: 0})
```

During normal usage in a model context, where a logp or logcdf call only affect the model through a Potential this is not an issue because the RVs in the graph of `y` would be replaced by the respective value variable, via a call to `rvs_to_value_vars` that happens at the end of `model.potentiallogpt`:

```python
with pm.Model() as m:
  x = pm.Normal('x')
  y = pm.Normal.dist(x)
  pm.Potential('y_logprob', pm.logp(y, 0.5))
```

