### PR TITLE
Adding log_likelihood, observed_data, and sample_stats to numpyro sampler

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -25,7 +25,7 @@ import pymc
 
 from pymc.aesaraf import extract_obs_data
 from pymc.distributions import logpt
-from pymc.model import modelcontext, Model
+from pymc.model import Model, modelcontext
 from pymc.util import get_default_varnames
 
 if TYPE_CHECKING:
@@ -216,7 +216,6 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
 
         self.density_dist_obs = density_dist_obs
         self.observations = find_observations(self.model)
-
 
     def split_trace(self) -> Tuple[Union[None, "MultiTrace"], Union[None, "MultiTrace"]]:
         """Split MultiTrace object into posterior and warmup.

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -25,13 +25,14 @@ import pymc
 
 from pymc.aesaraf import extract_obs_data
 from pymc.distributions import logpt
-from pymc.model import Model, modelcontext
+from pymc.model import modelcontext
 from pymc.util import get_default_varnames
 
 if TYPE_CHECKING:
     from typing import Set  # pylint: disable=ungrouped-imports
 
     from pymc.backends.base import MultiTrace  # pylint: disable=invalid-name
+    from pymc.model import Model
 
 ___all__ = [""]
 
@@ -41,7 +42,7 @@ _log = logging.getLogger("pymc")
 Var = Any  # pylint: disable=invalid-name
 
 
-def find_observations(model: Model) -> Optional[Dict[str, Var]]:
+def find_observations(model: Optional["Model"]) -> Optional[Dict[str, Var]]:
     """If there are observations available, return them as a dictionary."""
     if model is None:
         return None

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -4,7 +4,7 @@ import re
 import sys
 import warnings
 
-from typing import Callable, List, Dict, Optional, Any
+from typing import Any, Callable, Dict, List, Optional
 
 from aesara.graph import optimize_graph
 from aesara.tensor import TensorVariable

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -4,7 +4,7 @@ import re
 import sys
 import warnings
 
-from typing import Any, Callable, Dict, List, Optional
+from typing import Callable, List
 
 from aesara.graph import optimize_graph
 from aesara.tensor import TensorVariable
@@ -26,7 +26,7 @@ from aesara.graph.fg import FunctionGraph
 from aesara.link.jax.dispatch import jax_funcify
 
 from pymc import Model, modelcontext
-from pymc.aesaraf import compile_rv_inplace, extract_obs_data
+from pymc.aesaraf import compile_rv_inplace
 from pymc.backends.arviz import find_observations
 from pymc.util import get_default_varnames
 

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -27,6 +27,7 @@ from aesara.link.jax.dispatch import jax_funcify
 
 from pymc import Model, modelcontext
 from pymc.aesaraf import compile_rv_inplace, extract_obs_data
+from pymc.backends.arviz import find_observations
 from pymc.util import get_default_varnames
 
 warnings.warn("This module is experimental.")
@@ -93,24 +94,6 @@ def get_jaxified_logp(model: Model) -> Callable:
         return -res
 
     return logp_fn_wrap
-
-
-# Adopted from pm.to_inference_data
-def find_observations(model: Model) -> Dict[str, Any]:
-    """If there are observations available, return them as a dictionary."""
-    observations = {}
-    for obs in model.observed_RVs:
-        aux_obs = getattr(obs.tag, "observations", None)
-        if aux_obs is not None:
-            try:
-                obs_data = extract_obs_data(aux_obs)
-                observations[obs.name] = obs_data
-            except TypeError:
-                warnings.warn(f"Could not extract data from symbolic observation {obs}")
-        else:
-            warnings.warn(f"No data for observation {obs}")
-
-    return observations
 
 
 # Adopted from arviz numpyro extractor

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -174,6 +174,7 @@ def sample_numpyro_nuts(
 
     if chains == 1:
         init_params=init_state
+        map_seed = seed
     else:
         init_params=init_state_batched
 

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -173,10 +173,10 @@ def sample_numpyro_nuts(
     map_seed = jax.random.split(seed, chains)
 
     if chains == 1:
-        init_params=init_state
+        init_params = init_state
         map_seed = seed
     else:
-        init_params=init_state_batched
+        init_params = init_state_batched
 
     pmap_numpyro.run(
         map_seed,

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -62,7 +62,7 @@ def test_deterministic_samples():
     assert np.allclose(trace.posterior["b"].values, trace.posterior["a"].values / 2)
 
 
-def test_get_log_log_likelihood():
+def test_get_log_likelihood():
     obs = np.random.normal(10, 2, size=100)
     obs_at = aesara.shared(obs, borrow=True, name="obs")
     with pm.Model() as model:

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -70,12 +70,12 @@ def test_get_log_log_likelihood():
         sigma = pm.HalfNormal("sigma")
         b = pm.Normal("b", a, sigma=sigma, observed=obs_at)
 
-        trace = pm.sample(chains=1, random_seed=1322)
+        trace = pm.sample(tune=10, draws=10, chains=2, random_seed=1322)
 
     b_true = trace.log_likelihood.b.values
     a = np.array(trace.posterior.a)
     sigma_log_ = np.log(np.array(trace.posterior.sigma))
-    b_jax = _get_log_likelihood(model, [a, sigma_log_])["b"][0]
+    b_jax = _get_log_likelihood(model, [a, sigma_log_])["b"]
 
     assert np.allclose(b_jax.reshape(-1), b_true.reshape(-1))
 

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -12,6 +12,7 @@ from pymc.sampling_jax import (
     get_jaxified_logp,
     replace_shared_variables,
     sample_numpyro_nuts,
+    _get_log_likelihood,
 )
 
 
@@ -59,6 +60,24 @@ def test_deterministic_samples():
 
     assert 8 < trace.posterior["a"].mean() < 11
     assert np.allclose(trace.posterior["b"].values, trace.posterior["a"].values / 2)
+
+
+def test_get_log_log_likelihood():
+    obs = np.random.normal(10, 2, size=100)
+    obs_at = aesara.shared(obs, borrow=True, name="obs")
+    with pm.Model() as model:
+        a = pm.Normal("a", 0, 2)
+        sigma = pm.HalfNormal("sigma")
+        b = pm.Normal("b", a, sigma=sigma, observed=obs_at)
+
+        trace = pm.sample(chains=1, random_seed=1322)
+
+    b_true = trace.log_likelihood.b.values
+    a = np.array(trace.posterior.a)
+    sigma_log_ = np.log(np.array(trace.posterior.sigma))
+    b_jax = _get_log_likelihood(model, [a, sigma_log_])["b"][0]
+
+    assert np.allclose(b_jax.reshape(-1), b_true.reshape(-1))
 
 
 def test_replace_shared_variables():

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -9,10 +9,10 @@ from aesara.graph import graph_inputs
 import pymc as pm
 
 from pymc.sampling_jax import (
+    _get_log_likelihood,
     get_jaxified_logp,
     replace_shared_variables,
     sample_numpyro_nuts,
-    _get_log_likelihood,
 )
 
 


### PR DESCRIPTION
This adds more fields to the trace object returned from `sample_numpyro_nuts` addressing some of the concerns in #5121
