### PR TITLE
Adding `StickBreakingWeights` distribution class

### DIFF
--- a/docs/source/api/distributions/multivariate.rst
+++ b/docs/source/api/distributions/multivariate.rst
@@ -19,3 +19,4 @@ Multivariate
    MatrixNormal
    KroneckerNormal
    CAR
+   StickBreakingWeights

--- a/pymc/distributions/__init__.py
+++ b/pymc/distributions/__init__.py
@@ -95,6 +95,7 @@ from pymc.distributions.multivariate import (
     MvNormal,
     MvStudentT,
     OrderedMultinomial,
+    StickBreakingWeights,
     Wishart,
     WishartBartlett,
 )

--- a/pymc/distributions/__init__.py
+++ b/pymc/distributions/__init__.py
@@ -160,6 +160,7 @@ __all__ = [
     "KroneckerNormal",
     "MvStudentT",
     "Dirichlet",
+    "StickBreakingWeights",
     "Multinomial",
     "DirichletMultinomial",
     "OrderedMultinomial",

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2237,6 +2237,36 @@ stickbreakingweights = StickBreakingWeightsRV()
 
 
 class StickBreakingWeights(Continuous):
+    r"""
+    Likelihood of truncated stick-breaking weights. The weights are generated
+
+    .. math:
+
+
+        f(\mathbf{x}|\alpha, K) = 
+
+    ========  ===============================================
+    Support   :math:`x_i \in (0, 1)` for :math:`i \in \{1, \ldots, K+1\}`
+              such that :math:`\sum x_i = 1`
+    Mean      :math:`\dfrac{a_i}{\sum a_i}`
+    Variance  :math:`\dfrac{a_i - \sum a_0}{a_0^2 (a_0 + 1)}`
+              where :math:`a_0 = \sum a_i`
+    ========  ===============================================
+
+    Parameters
+    ----------
+    alpha: float
+        Concentration parameters (alpha > 0).
+    K: int
+        The number of "sticks" to break off from an initial one-unit stick. The length
+        of categories is K + 1, where the last weight is one minus the sum of all the first sticks.
+
+    References
+    ----------
+    .. [1] Ishwaran James
+
+    .. [2] Peter Mueller
+    """
     rv_op = stickbreakingweights
 
     def __new__(cls, name, *args, **kwargs):
@@ -2277,6 +2307,19 @@ class StickBreakingWeights(Continuous):
         return moment
 
     def logp(value, alpha, K):
+        """
+        Calculate log-probability of the distribution induced from the stick-breaking process
+        at specified value.
+
+        Parameters
+        ----------
+        value: numeric
+            Value for which log-probability is calculated.
+
+        Returns
+        -------
+        TensorVariable
+        """
         logp = -at.sum(
             at.log(
                 at.cumsum(

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2242,7 +2242,7 @@ class StickBreakingWeights(Continuous):
     Likelihood of truncated stick-breaking weights. The weights are generated from a
     stick-breaking proceduce where :math:`x_k = v_k \prod_{\ell < k} (1 - v_\ell)` for
     :math:`k \in \{1, \ldots, K\}` and :math:`x_K = \prod_{\ell = 1}^{K} (1 - v_\ell) = 1 - \sum_{\ell=1}^K x_\ell`
-    with `v_k \stackrel{\text{i.i.d.}}{\sim} \text{Beta}(1, \alpha)`.
+    with :math:`v_k \stackrel{\text{i.i.d.}}{\sim} \text{Beta}(1, \alpha)`.
 
     .. math:
 

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2194,7 +2194,7 @@ class StickBreakingWeightsRV(RandomVariable):
     @classmethod
     def rng_fn(cls, rng, alpha, K, size):
         if K < 0:
-            raise ValueError("K needs to be a positive integer.")
+            raise ValueError(f"K needs to be a positive integer, but K = {K}.")
 
         if np.ndim(alpha) > 0:
             raise ValueError("The concentration parameter needs to be a scalar.")
@@ -2252,10 +2252,12 @@ class StickBreakingWeights(Continuous):
         return super().dist([alpha, K], **kwargs)
 
     def get_moment(rv, size, alpha, K):
-        moment = (alpha / (1 + alpha)) ** at.arange(K + 1)
+        moment = (alpha / (1 + alpha)) ** at.arange(K)
         moment *= 1 / (1 + alpha)
+        moment = at.concatenate([moment, [(alpha / (1 + alpha)) ** K]], axis=-1)
         if not rv_size_is_none(size):
             moment = at.full(*size + (K + 1,), moment)
+
         return moment
 
     def logp(value, alpha, K):

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2265,6 +2265,9 @@ class StickBreakingWeights(Continuous):
         if at.lt(alpha, 0).eval():
             raise ValueError("alpha needs to be a positive.")
 
+        if not at.allclose(value.sum(axis=-1), 1).eval():
+            raise ValueError("weights need to sum to 1.")
+
         logp = -at.sum(
             at.log(
                 at.cumsum(
@@ -2274,7 +2277,7 @@ class StickBreakingWeights(Continuous):
             ),
             axis=-1,
         )
-        logp += -K * betaln(1, alpha)
+        logp += -(K - 1) * betaln(1, alpha)
         logp += alpha * at.log(value[..., -1])  # check this
 
         return bound(

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2188,9 +2188,6 @@ class StickBreakingWeightsRV(RandomVariable):
         alpha = at.as_tensor_variable(alpha)
         K = at.as_tensor_variable(intX(K))
 
-        if K.eval() < 0:
-            raise ValueError("K needs to be positive.")
-
         if alpha.ndim > 0:
             raise ValueError("The concentration parameter needs to be a scalar.")
 
@@ -2205,6 +2202,9 @@ class StickBreakingWeightsRV(RandomVariable):
 
     @classmethod
     def rng_fn(cls, rng, alpha, K, size):
+        if K < 0:
+            raise ValueError("K needs to be positive.")
+
         if size is None:
             size = (K,)
         elif isinstance(size, int):
@@ -2352,5 +2352,5 @@ class StickBreakingWeights(Continuous):
             logp,
             alpha > 0,
             K > 0,
-            msg="alpha > 0, K > 0, 0 <= value <= 1, sum(value) == 1",
+            msg="alpha > 0, K > 0",
         )

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2261,7 +2261,7 @@ class StickBreakingWeights(Continuous):
     alpha: float
         Concentration parameter (alpha > 0).
     K: int
-        The number of "sticks" to break off from an initial one-unit stick. The length of the weight 
+        The number of "sticks" to break off from an initial one-unit stick. The length of the weight
         vector is K + 1, where the last weight is one minus the sum of all the first sticks.
 
     References

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2259,15 +2259,6 @@ class StickBreakingWeights(Continuous):
         return moment
 
     def logp(value, alpha, K):
-        if at.lt(K, 0).eval():
-            raise ValueError("K needs to be a positive integer.")
-
-        if at.lt(alpha, 0).eval():
-            raise ValueError("alpha needs to be a positive.")
-
-        if not at.allclose(value.sum(axis=-1), 1).eval():
-            raise ValueError("weights need to sum to 1.")
-
         logp = -at.sum(
             at.log(
                 at.cumsum(
@@ -2283,6 +2274,8 @@ class StickBreakingWeights(Continuous):
         return bound(
             logp,
             alpha > 0,
+            K > 0,
             at.all(value >= 0),
             at.all(value <= 1),
+            at.allclose(value.sum(axis=-1), 1),
         )

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2241,7 +2241,8 @@ class StickBreakingWeights(Continuous):
     r"""
     Likelihood of truncated stick-breaking weights. The weights are generated from a
     stick-breaking proceduce where :math:`x_k = v_k \prod_{\ell < k} (1 - v_\ell)` for
-    :math:`k \in \{1, \ldots, K\}` and :math
+    :math:`k \in \{1, \ldots, K\}` and :math:`x_K = \prod_{\ell = 1}^{K} (1 - v_\ell) = 1 - \sum_{\ell=1}^K x_\ell`
+    with `v_k \stackrel{\text{i.i.d.}}{\sim} \text{Beta}(1, \alpha)`.
 
     .. math:
 
@@ -2252,7 +2253,7 @@ class StickBreakingWeights(Continuous):
     Support   :math:`x_k \in (0, 1)` for :math:`k \in \{1, \ldots, K+1\}`
               such that :math:`\sum x_k = 1`
     Mean      :math:`\mathbb{E}[x_k] = \dfrac{1}{1 + \alpha}\left(\dfrac{\alpha}{1 + \alpha}\right)^{k - 1}`
-              for :math:`k \in \{1, \ldots, K\}` and `\mathbb{E}[x_{K+1}] = \left(\dfrac{\alpha}{1 + \alpha}\right)^{K}`
+              for :math:`k \in \{1, \ldots, K\}` and :math:`\mathbb{E}[x_{K+1}] = \left(\dfrac{\alpha}{1 + \alpha}\right)^{K}`
     ========  ===============================================
 
     Parameters
@@ -2260,8 +2261,8 @@ class StickBreakingWeights(Continuous):
     alpha: float
         Concentration parameter (alpha > 0).
     K: int
-        The number of "sticks" to break off from an initial one-unit stick. The length
-        of categories is K + 1, where the last weight is one minus the sum of all the first sticks.
+        The number of "sticks" to break off from an initial one-unit stick. The length of the weight 
+        vector is K + 1, where the last weight is one minus the sum of all the first sticks.
 
     References
     ----------

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2191,6 +2191,9 @@ class StickBreakingWeightsRV(RandomVariable):
         if alpha.ndim > 0:
             raise ValueError("The concentration parameter needs to be a scalar.")
 
+        if K.ndim > 0:
+            raise ValueError("K must be a scalar.")
+
         return super().make_node(rng, size, dtype, alpha, K)
 
     def _infer_shape(self, size, dist_params, param_shapes=None):
@@ -2278,12 +2281,6 @@ class StickBreakingWeights(Continuous):
     def dist(cls, alpha, K, *args, **kwargs):
         alpha = at.as_tensor_variable(floatX(alpha))
         K = at.as_tensor_variable(intX(K))
-
-        if alpha.ndim > 0:
-            raise ValueError("alpha must be a scalar.")
-
-        if K.ndim > 0:
-            raise ValueError("K must be a scalar.")
 
         assert_negative_support(alpha, "alpha", "StickBreakingWeights")
         assert_negative_support(K, "K", "StickBreakingWeights")

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -44,11 +44,13 @@ import pymc as pm
 from pymc.aesaraf import floatX, intX
 from pymc.distributions import transforms
 from pymc.distributions.continuous import ChiSquared, Normal, assert_negative_support
-<<<<<<< HEAD
-from pymc.distributions.dist_math import check_parameters, factln, logpow, multigammaln
-=======
-from pymc.distributions.dist_math import betaln, bound, factln, logpow, multigammaln
->>>>>>> 36c8fe0b (Moment and random tests failing...)
+from pymc.distributions.dist_math import (
+    betaln,
+    check_parameters,
+    factln,
+    logpow,
+    multigammaln,
+)
 from pymc.distributions.distribution import Continuous, Discrete
 from pymc.distributions.shape_utils import (
     broadcast_dist_samples_to,
@@ -2256,7 +2258,15 @@ class StickBreakingWeights(Continuous):
         moment *= 1 / (1 + alpha)
         moment = at.concatenate([moment, [(alpha / (1 + alpha)) ** K]], axis=-1)
         if not rv_size_is_none(size):
-            moment = at.full(*size + (K + 1,), moment)
+            moment_size = at.concatenate(
+                [
+                    size,
+                    [
+                        K + 1,
+                    ],
+                ]
+            )
+            moment = at.full(moment_size, moment)
 
         return moment
 
@@ -2273,7 +2283,7 @@ class StickBreakingWeights(Continuous):
         logp += -(K - 1) * betaln(1, alpha)
         logp += alpha * at.log(value[..., -1])  # check this
 
-        return bound(
+        return check_parameters(
             logp,
             alpha > 0,
             K > 0,

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -173,7 +173,6 @@ def make_initial_point_fn(
         default_strategy=default_strategy,
         return_transformed=return_transformed,
     )
-    # print("make_initial_point_fn", initial_values[0].eval())
 
     # Replace original rng shared variables so that we don't mess with them
     # when calling the final seeded function

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -173,6 +173,7 @@ def make_initial_point_fn(
         default_strategy=default_strategy,
         return_transformed=return_transformed,
     )
+    # print("make_initial_point_fn", initial_values[0].eval())
 
     # Replace original rng shared variables so that we don't mess with them
     # when calling the final seeded function

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -474,9 +474,6 @@ def _dirichlet_logpdf(value, a):
 
 dirichlet_logpdf = np.vectorize(_dirichlet_logpdf, signature="(n),(n)->()")
 
-def stickbreakingweights_logpdf(value, alpha):
-    return floatX(1)
-
 def categorical_logpdf(value, p):
     if value >= 0 and value <= len(p):
         return floatX(np.log(np.moveaxis(p, -1, 0)[value]))
@@ -2127,7 +2124,12 @@ class TestMatchesScipy:
 
     @pytest.mark.parametrize("n", [1, 2, 3])
     def test_stickbreakingweights(self, n):
-        self.check_logp(StickBreakingWeights, Simplex(n), {"alpha": Rplus}, sbw_logpdf)
+        self.check_logp(
+            StickBreakingWeights, # pymc_dist
+            Simplex(n), # domain
+            {"alpha": Rplus}, # paramdomains
+            sbw_logpdf, # precompute values as in ex-gaussian dist
+        )
 
     def test_stickbreakingweights_shape(self):
         alpha = at.as_tensor_variable(np.r_[1, 2])

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -2144,11 +2144,13 @@ class TestMatchesScipy:
             err_msg=str(pt),
         )
 
-    @pytest.mark.parametrize("n", [2, 3])
-    def test_multinomial(self, n):
-        self.check_logp(
-            Multinomial, Vector(Nat, n), {"p": Simplex(n), "n": Nat}, multinomial_logpdf
-        )
+    def test_stickbreakingweights_invalid(self):
+        sbw = pm.StickBreakingWeights.dist(3.0, 3)
+        sbw_wrong_K = pm.StickBreakingWeights.dist(3.0, 7)
+        assert pm.logp(sbw, np.array([0.4, 0.3, 0.2, 0.15])).eval() == -np.inf
+        assert pm.logp(sbw, np.array([1.1, 0.3, 0.2, 0.1])).eval() == -np.inf
+        assert pm.logp(sbw, np.array([0.4, 0.3, 0.2, -0.1])).eval() == -np.inf
+        assert pm.logp(sbw_wrong_K, np.array([0.4, 0.3, 0.2, 0.1])).eval() == -np.inf
 
     @pytest.mark.parametrize(
         "a",

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -2127,18 +2127,24 @@ class TestMatchesScipy:
     @pytest.mark.parametrize(
         "value,alpha,K,logp",
         [
-            (np.array([5, 4, 3, 2, 1]) / 15, 0.5, 4, 2.2057773112876893),
-            (np.tile(1, 13) / 13, 2, 12, 13.286898065112881),
-            (np.array([0.001] * 10 + [0.99]), 0.1, 10, -20.66907735582068),
-            (np.append(0.5 ** np.arange(1, 20), 0.5 ** 20), 5, 19, 92.59518981534681),
+            (np.array([5, 4, 3, 2, 1]) / 15, 0.5, 4, 1.5126301307277439),
+            (np.tile(1, 13) / 13, 2, 12, 13.980045245672827),
+            (np.array([0.001] * 10 + [0.99]), 0.1, 10, -22.971662448814723),
+            (np.append(0.5 ** np.arange(1, 20), 0.5 ** 20), 5, 19, 94.20462772778092),
+            (
+                (np.array([[7, 5, 3, 2], [19, 17, 13, 11]]) / np.array([[17], [60]])),
+                2.5,
+                3,
+                np.array([1.29317672, 1.50126157]),
+            ),
         ],
     )
-    def test_stickbreakingweights(self, value, alpha, K, logp):
+    def test_stickbreakingweights_logp(self, value, alpha, K, logp):
         with Model() as model:
-            StickBreakingWeights("sbw", alpha=alpha, K=K, transform=None)
+            sbw = StickBreakingWeights("sbw", alpha=alpha, K=K, transform=None)
         pt = {"sbw": value}
         assert_almost_equal(
-            model.compile_logp()(pt),
+            pm.logp(sbw, value).eval(),
             logp,
             decimal=select_by_precision(float64=6, float32=2),
             err_msg=str(pt),

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -109,6 +109,7 @@ from pymc.distributions import (
     Poisson,
     Rice,
     SkewNormal,
+    StickBreakingWeights,
     StudentT,
     Triangular,
     TruncatedNormal,
@@ -2132,21 +2133,21 @@ class TestMatchesScipy:
             sbw_logpdf,  # precompute values as in ex-gaussian dist
         )
 
-    def test_stickbreakingweights_shape(self):
-        alpha = at.as_tensor_variable(np.r_[1, 2])
-        sbw_rv = StickBreakingWeights.dist(alpha)
-        assert sbw_rv.shape.eval() == (2,)
+    # def test_stickbreakingweights_shape(self):
+    #     alpha = at.as_tensor_variable(np.r_[1, 2])
+    #     sbw_rv = StickBreakingWeights.dist(alpha)
+    #     assert sbw_rv.shape.eval() == (2,)
 
-        with pytest.warns(DeprecationWarning), aesara.change_flags(compute_test_value="ignore"):
-            sbw_rv = StickBreakingWeights.dist(at.vector())
+    #     with pytest.warns(DeprecationWarning), aesara.change_flags(compute_test_value="ignore"):
+    #         sbw_rv = StickBreakingWeights.dist(at.vector())
 
-    def test_dirichlet_2D(self):
-        self.check_logp(
-            StickBreakingWeights,
-            MultiSimplex(2, 2),
-            {"alpha": Vector(Vector(Rplus, 2), 2)},
-            dirichlet_logpdf,
-        )
+    # def test_dirichlet_2D(self):
+    #     self.check_logp(
+    #         StickBreakingWeights,
+    #         MultiSimplex(2, 2),
+    #         {"alpha": Vector(Vector(Rplus, 2), 2)},
+    #         dirichlet_logpdf,
+    #     )
 
     @pytest.mark.parametrize("n", [2, 3])
     def test_multinomial(self, n):

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -474,6 +474,7 @@ def _dirichlet_logpdf(value, a):
 
 dirichlet_logpdf = np.vectorize(_dirichlet_logpdf, signature="(n),(n)->()")
 
+
 def categorical_logpdf(value, p):
     if value >= 0 and value <= len(p):
         return floatX(np.log(np.moveaxis(p, -1, 0)[value]))
@@ -2125,10 +2126,10 @@ class TestMatchesScipy:
     @pytest.mark.parametrize("n", [1, 2, 3])
     def test_stickbreakingweights(self, n):
         self.check_logp(
-            StickBreakingWeights, # pymc_dist
-            Simplex(n), # domain
-            {"alpha": Rplus}, # paramdomains
-            sbw_logpdf, # precompute values as in ex-gaussian dist
+            StickBreakingWeights,  # pymc_dist
+            Simplex(n),  # domain
+            {"alpha": Rplus},  # paramdomains
+            sbw_logpdf,  # precompute values as in ex-gaussian dist
         )
 
     def test_stickbreakingweights_shape(self):

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -2133,22 +2133,6 @@ class TestMatchesScipy:
             sbw_logpdf,  # precompute values as in ex-gaussian dist
         )
 
-    # def test_stickbreakingweights_shape(self):
-    #     alpha = at.as_tensor_variable(np.r_[1, 2])
-    #     sbw_rv = StickBreakingWeights.dist(alpha)
-    #     assert sbw_rv.shape.eval() == (2,)
-
-    #     with pytest.warns(DeprecationWarning), aesara.change_flags(compute_test_value="ignore"):
-    #         sbw_rv = StickBreakingWeights.dist(at.vector())
-
-    # def test_dirichlet_2D(self):
-    #     self.check_logp(
-    #         StickBreakingWeights,
-    #         MultiSimplex(2, 2),
-    #         {"alpha": Vector(Vector(Rplus, 2), 2)},
-    #         dirichlet_logpdf,
-    #     )
-
     @pytest.mark.parametrize("n", [2, 3])
     def test_multinomial(self, n):
         self.check_logp(

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -2138,7 +2138,7 @@ class TestMatchesScipy:
             StickBreakingWeights("sbw", alpha=alpha, K=K, transform=None)
         pt = {"sbw": value}
         assert_almost_equal(
-            model.fastlogp(pt),
+            model.compile_logp()(pt),
             logp,
             decimal=select_by_precision(float64=6, float32=2),
             err_msg=str(pt),

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -1092,7 +1092,27 @@ def test_rice_moment(nu, sigma, size, expected):
 
 @pytest.mark.parametrize(
     "alpha, K, size, expected",
-    [(3, 11, None, np.append((3 / 4) ** np.arange(11) * 1 / 4, (3 / 4) ** 11))],
+    [
+        (3, 11, None, np.append((3 / 4) ** np.arange(11) * 1 / 4, (3 / 4) ** 11)),
+        (5, 19, None, np.append((5 / 6) ** np.arange(19) * 1 / 6, (5 / 6) ** 19)),
+        (
+            1,
+            7,
+            (13,),
+            np.full(
+                shape=(13, 8), fill_value=np.append((1 / 2) ** np.arange(7) * 1 / 2, (1 / 2) ** 7)
+            ),
+        ),
+        (
+            0.5,
+            5,
+            (3, 5, 7),
+            np.full(
+                shape=(3, 5, 7, 6),
+                fill_value=np.append((1 / 3) ** np.arange(5) * 2 / 3, (1 / 3) ** 5),
+            ),
+        ),
+    ],
 )
 def test_stickbreakingweights_moment(alpha, K, size, expected):
     with Model() as model:

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -1088,6 +1088,9 @@ def test_matrixnormal_moment(mu, rowchol, colchol, size, expected):
 def test_rice_moment(nu, sigma, size, expected):
     with Model() as model:
         Rice("x", nu=nu, sigma=sigma, size=size)
+
+
+@pytest.mark.parametrize(
     "alpha, K, size, expected", [(3, 11, None, (3 / 4) ** np.arange(12) * 1 / 3)]
 )
 def test_stickbreakingweights_moment(alpha, K, size, expected):

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -1091,7 +1091,8 @@ def test_rice_moment(nu, sigma, size, expected):
 
 
 @pytest.mark.parametrize(
-    "alpha, K, size, expected", [(3, 11, None, (3 / 4) ** np.arange(12) * 1 / 3)]
+    "alpha, K, size, expected",
+    [(3, 11, None, np.append((3 / 4) ** np.arange(11) * 1 / 4, (3 / 4) ** 11))],
 )
 def test_stickbreakingweights_moment(alpha, K, size, expected):
     with Model() as model:

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -52,6 +52,7 @@ from pymc.distributions import (
     Rice,
     Simulator,
     SkewNormal,
+    StickBreakingWeights,
     StudentT,
     Triangular,
     TruncatedNormal,
@@ -1087,6 +1088,11 @@ def test_matrixnormal_moment(mu, rowchol, colchol, size, expected):
 def test_rice_moment(nu, sigma, size, expected):
     with Model() as model:
         Rice("x", nu=nu, sigma=sigma, size=size)
+    "alpha, K, size, expected", [(3, 11, None, (3 / 4) ** np.arange(12) * 1 / 3)]
+)
+def test_stickbreakingweights_moment(alpha, K, size, expected):
+    with Model() as model:
+        StickBreakingWeights("x", alpha=alpha, K=K, size=size)
     assert_moment_is_expected(model, expected)
 
 

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1193,7 +1193,21 @@ class TestStickBreakingWeights(BaseTestDistribution):
     tests_to_run = [
         "check_pymc_params_match_rv_op",
         "check_rv_size",
+        "check_basic_properties",
     ]
+
+    def check_basic_properties(self):
+        default_rng = aesara.shared(np.random.default_rng(1234))
+        draws = pm.StickBreakingWeights.dist(
+            alpha=3.5,
+            K=19,
+            size=(2, 3, 5),
+            rng=default_rng,
+        )
+
+        assert np.allclose(draws.sum(-1).eval(), 1)
+        assert np.all(draws.eval() >= 0)
+        assert np.all(draws.eval() <= 1)
 
 
 class TestMultinomial(BaseTestDistribution):

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1176,6 +1176,19 @@ class TestDirichlet(BaseTestDistribution):
     ]
 
 
+class TestStickBreakingWeights(BaseTestDistribution):
+    print(pm.StickBreakingWeights.dist(2., 19, size=[3,]).eval().shape)
+    pymc_dist = pm.StickBreakingWeights
+    pymc_dist_params = {"alpha": 2., "K": 19}
+    expected_rv_op_params = {"alpha": 2., "K": 19}
+    sizes_to_check = [None, (5,), (11, 5), (3, 13, 5)]
+    sizes_expected = [(20,), (20,), (11, 5, 20), (3, 13, 5, 20)]
+    tests_to_run = [
+        "check_pymc_params_match_rv_op",
+        "check_rv_size",
+    ]
+
+
 class TestMultinomial(BaseTestDistribution):
     pymc_dist = pm.Multinomial
     pymc_dist_params = {"n": 85, "p": np.array([0.28, 0.62, 0.10])}

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1204,8 +1204,7 @@ class TestStickBreakingWeights(BaseTestDistribution):
             K=19,
             size=(2, 3, 5),
             rng=default_rng,
-        )
-        draws = draws.eval()
+        ).eval()
 
         assert np.allclose(draws.sum(-1), 1)
         assert np.all(draws >= 0)

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1177,12 +1177,19 @@ class TestDirichlet(BaseTestDistribution):
 
 
 class TestStickBreakingWeights(BaseTestDistribution):
-    print(pm.StickBreakingWeights.dist(2., 19, size=[3,]).eval().shape)
     pymc_dist = pm.StickBreakingWeights
-    pymc_dist_params = {"alpha": 2., "K": 19}
-    expected_rv_op_params = {"alpha": 2., "K": 19}
+    pymc_dist_params = {"alpha": 2.0, "K": 19}
+    expected_rv_op_params = {"alpha": 2.0, "K": 19}
     sizes_to_check = [None, (5,), (11, 5), (3, 13, 5)]
-    sizes_expected = [(20,), (20,), (11, 5, 20), (3, 13, 5, 20)]
+    sizes_expected = [
+        (20,),
+        (
+            5,
+            20,
+        ),
+        (11, 5, 20),
+        (3, 13, 5, 20),
+    ]
     tests_to_run = [
         "check_pymc_params_match_rv_op",
         "check_rv_size",

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1180,9 +1180,10 @@ class TestStickBreakingWeights(BaseTestDistribution):
     pymc_dist = pm.StickBreakingWeights
     pymc_dist_params = {"alpha": 2.0, "K": 19}
     expected_rv_op_params = {"alpha": 2.0, "K": 19}
-    sizes_to_check = [None, (5,), (11, 5), (3, 13, 5)]
+    sizes_to_check = [None, 17, (5,), (11, 5), (3, 13, 5)]
     sizes_expected = [
         (20,),
+        (17, 20),
         (
             5,
             20,

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1205,10 +1205,11 @@ class TestStickBreakingWeights(BaseTestDistribution):
             size=(2, 3, 5),
             rng=default_rng,
         )
+        draws = draws.eval()
 
-        assert np.allclose(draws.sum(-1).eval(), 1)
-        assert np.all(draws.eval() >= 0)
-        assert np.all(draws.eval() <= 1)
+        assert np.allclose(draws.sum(-1), 1)
+        assert np.all(draws >= 0)
+        assert np.all(draws <= 1)
 
 
 class TestMultinomial(BaseTestDistribution):


### PR DESCRIPTION
This pull request adds a class for truncated stick-breaking weights which are vital in the construction of Dirichlet Processes, which I hope to work on soon. See section 1.1 in [Ishwaran and James (2001)](http://people.ee.duke.edu/~lcarin/Yuting3.3.06.pdf). My previous attempt as a PR is #4971 .

Some tests are failing, will have to resolve them first.

CC: @ricardoV94 @AustinRochford @fonnesbeck 