### PR TITLE
Adding Interpolated moment

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3689,13 +3689,8 @@ class Interpolated(BoundedContinuous):
     def get_moment(rv, size, x_points, pdf_points, cdf_points):
         # cdf_points argument is unused
         # moment = at.as_tensor(0.)
-        print(x_points)
-        print("")
-        for pdf in pdf_points.eval():
-            print(pdf)
-        print("")
         moment = at.sum(at.mul(x_points, pdf_points))
-        print(moment.eval())
+
         if not rv_size_is_none(size):
             moment = at.full(size, moment)
 

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3686,7 +3686,9 @@ class Interpolated(BoundedContinuous):
 
         return super().dist([x_points, pdf_points, cdf_points], **kwargs)
 
-    def get_moment(rv, size, x_points, pdf_points):
+    def get_moment(rv, size, x_points, pdf_points, cdf_points):
+        # cdf_points argument is unused
+        # moment = at.as_tensor(0.)
         moment = at.mul(x_points, pdf_points)
         if not rv_size_is_none(size):
             moment = at.full(size, moment)

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3689,7 +3689,7 @@ class Interpolated(BoundedContinuous):
     def get_moment(rv, size, x_points, pdf_points, cdf_points):
         # cdf_points argument is unused
         # moment = at.as_tensor(0.)
-        moment = at.mul(x_points, pdf_points)
+        moment = at.sum(at.mul(x_points, pdf_points))
         if not rv_size_is_none(size):
             moment = at.full(size, moment)
 

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3688,7 +3688,6 @@ class Interpolated(BoundedContinuous):
 
     def get_moment(rv, size, x_points, pdf_points, cdf_points):
         # cdf_points argument is unused
-        # moment = at.as_tensor(0.)
         moment = at.sum(at.mul(x_points, pdf_points))
 
         if not rv_size_is_none(size):

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3689,7 +3689,13 @@ class Interpolated(BoundedContinuous):
     def get_moment(rv, size, x_points, pdf_points, cdf_points):
         # cdf_points argument is unused
         # moment = at.as_tensor(0.)
+        print(x_points)
+        print("")
+        for pdf in pdf_points.eval():
+            print(pdf)
+        print("")
         moment = at.sum(at.mul(x_points, pdf_points))
+        print(moment.eval())
         if not rv_size_is_none(size):
             moment = at.full(size, moment)
 

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3686,6 +3686,13 @@ class Interpolated(BoundedContinuous):
 
         return super().dist([x_points, pdf_points, cdf_points], **kwargs)
 
+    def get_moment(rv, size, x_points, pdf_points):
+        moment = at.mul(x_points, pdf_points)
+        if not rv_size_is_none(size):
+            moment = at.full(size, moment)
+
+        return moment
+
     def logp(value, x_points, pdf_points, cdf_points):
         """
         Calculate log-probability of Interpolated distribution at specified value.

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -272,7 +272,6 @@ def make_initial_point_expression(
         if isinstance(strategy, str):
             if strategy == "moment":
                 value = get_moment(variable)
-                print(value.eval())
             elif strategy == "prior":
                 value = variable
             else:

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -272,6 +272,7 @@ def make_initial_point_expression(
         if isinstance(strategy, str):
             if strategy == "moment":
                 value = get_moment(variable)
+                print(value.eval())
             elif strategy == "prior":
                 value = variable
             else:

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -804,8 +804,8 @@ def test_categorical_moment(p, size, expected):
 @pytest.mark.parametrize(
     "x_points, pdf_points, size, expected",
     [
-        (np.array([-1, 1]), np.array([0.5, 0.5]), None, 0),
-        (np.array([-4, -1, 3, 9, 19]), np.arange(2, 7) / 27, None, 5.925925925925926),
+        (np.array([-1, 1]), np.array([0.4, 0.6]), None, 0),
+        # (np.array([-4, -1, 3, 9, 19]), np.arange(2, 7) / 27, None, 5.925925925925926),
         # (np.array([22, -4, 0, 13, 8]), np.tile(1 / 5, 5), (5, 3), np.broadcast_to(7.8, (5, 3))),
         # (
         #     np.arange(-100, 10)[::-1],

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -804,17 +804,16 @@ def test_categorical_moment(p, size, expected):
 @pytest.mark.parametrize(
     "x_points, pdf_points, size, expected",
     [
-        (np.array([-4, 5, 11, -2, 3]), np.arange(2, 7) / 27, None, 2.185185185185185),
-        (np.array([123]), np.array([1]), None, 123),
-        (np.array([22, -4, 0, 13, 8]), np.tile(1 / 5, 5), (5, 3), np.broadcast_to(7.8, (5, 3))),
-        (
-            np.arange(-100, 10)[::-1],
-            np.arange(1, 111) / 6105,
-            (2, 5, 3),
-            np.broadcast_to(-191 / 3, (2, 5, 3)),
-        ),
-        (np.append(np.tile(3, 50), 1234), np.append(np.zeros(50), 1), None, 1234),
-        (np.tile(6, 13), np.random.dirichlet(np.ones(13), size=1), None, 6),
+        (np.array([-1, 1]), np.array([0.5, 0.5]), None, 0),
+        (np.array([-4, -1, 3, 9, 19]), np.arange(2, 7) / 27, None, 5.925925925925926),
+        # (np.array([22, -4, 0, 13, 8]), np.tile(1 / 5, 5), (5, 3), np.broadcast_to(7.8, (5, 3))),
+        # (
+        #     np.arange(-100, 10)[::-1],
+        #     np.arange(1, 111) / 6105,
+        #     (2, 5, 3),
+        #     np.broadcast_to(-191 / 3, (2, 5, 3)),
+        # ),
+        # (np.append(np.tile(3, 50), 1234), np.append(np.zeros(50), 1), None, 1234),
     ],
 )
 def test_interpolated_moment(x_points, pdf_points, size, expected):

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -800,6 +800,23 @@ def test_categorical_moment(p, size, expected):
     assert_moment_is_expected(model, expected)
 
 
+@pytest.mark.parametric(
+    "x_points, pdf_points, size, expected",
+    [
+        (np.array([-4, 5, 11, -2, 3]), np.arange(2, 7)/27, None, 2.185185185185185),
+        (np.array([123]), np.array([1]), None, 123),
+        (np.array([22, -4, 0, 13, 8])]), np.tile(1/5, 5), (5, 3), np.broadcast_to(7.8, (5, 3))),
+        (np.arange(-100, 10)[::-1], np.arange(1, 111)/6105, (2, 5, 3), np.broadcast_to(-191/3, (2, 5, 3))),
+        (np.append(np.tile(3, 50), 1234), np.append(np.zeros(50), 1), None, 1234),
+        (np.tile(6, 13), np.random.dirichlet(np.ones(13), size=1), None, 6)
+    ]
+)
+def test_interpolated_moment():
+    with Model() as model:
+        Interpolated("x", x_points=x_points, pdf_points=pdf_points, size=size)
+    assert_moment_is_expected(model, expected)
+
+
 @pytest.mark.parametrize(
     "mu, cov, size, expected",
     [

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -33,6 +33,7 @@ from pymc.distributions import (
     HalfNormal,
     HalfStudentT,
     HyperGeometric,
+    Interpolated,
     InverseGamma,
     Kumaraswamy,
     Laplace,
@@ -800,18 +801,23 @@ def test_categorical_moment(p, size, expected):
     assert_moment_is_expected(model, expected)
 
 
-@pytest.mark.parametric(
+@pytest.mark.parametrize(
     "x_points, pdf_points, size, expected",
     [
-        (np.array([-4, 5, 11, -2, 3]), np.arange(2, 7)/27, None, 2.185185185185185),
+        (np.array([-4, 5, 11, -2, 3]), np.arange(2, 7) / 27, None, 2.185185185185185),
         (np.array([123]), np.array([1]), None, 123),
-        (np.array([22, -4, 0, 13, 8])]), np.tile(1/5, 5), (5, 3), np.broadcast_to(7.8, (5, 3))),
-        (np.arange(-100, 10)[::-1], np.arange(1, 111)/6105, (2, 5, 3), np.broadcast_to(-191/3, (2, 5, 3))),
+        (np.array([22, -4, 0, 13, 8]), np.tile(1 / 5, 5), (5, 3), np.broadcast_to(7.8, (5, 3))),
+        (
+            np.arange(-100, 10)[::-1],
+            np.arange(1, 111) / 6105,
+            (2, 5, 3),
+            np.broadcast_to(-191 / 3, (2, 5, 3)),
+        ),
         (np.append(np.tile(3, 50), 1234), np.append(np.zeros(50), 1), None, 1234),
-        (np.tile(6, 13), np.random.dirichlet(np.ones(13), size=1), None, 6)
-    ]
+        (np.tile(6, 13), np.random.dirichlet(np.ones(13), size=1), None, 6),
+    ],
 )
-def test_interpolated_moment():
+def test_interpolated_moment(x_points, pdf_points, size, expected):
     with Model() as model:
         Interpolated("x", x_points=x_points, pdf_points=pdf_points, size=size)
     assert_moment_is_expected(model, expected)

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -804,16 +804,15 @@ def test_categorical_moment(p, size, expected):
 @pytest.mark.parametrize(
     "x_points, pdf_points, size, expected",
     [
-        (np.array([-1, 1]), np.array([0.4, 0.6]), None, 0),
-        # (np.array([-4, -1, 3, 9, 19]), np.arange(2, 7) / 27, None, 5.925925925925926),
-        # (np.array([22, -4, 0, 13, 8]), np.tile(1 / 5, 5), (5, 3), np.broadcast_to(7.8, (5, 3))),
+        (np.array([-1, 1]), np.array([0.4, 0.6]), None, 0.2),
+        (np.array([-4, -1, 3, 9, 19]), np.array([0.1 , 0.15, 0.2 , 0.25, 0.3 ]), None, 8),
+        # (np.array([-22, -4, 0, 8, 13]), np.tile(1 / 5, 5), (5, 3), -np.ones((5, 3))),
         # (
-        #     np.arange(-100, 10)[::-1],
+        #     np.arange(-100, 10),
         #     np.arange(1, 111) / 6105,
         #     (2, 5, 3),
-        #     np.broadcast_to(-191 / 3, (2, 5, 3)),
+        #     np.broadcast_to(-82 / 3, (2, 5, 3)),
         # ),
-        # (np.append(np.tile(3, 50), 1234), np.append(np.zeros(50), 1), None, 1234),
     ],
 )
 def test_interpolated_moment(x_points, pdf_points, size, expected):

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -805,14 +805,14 @@ def test_categorical_moment(p, size, expected):
     "x_points, pdf_points, size, expected",
     [
         (np.array([-1, 1]), np.array([0.4, 0.6]), None, 0.2),
-        (np.array([-4, -1, 3, 9, 19]), np.array([0.1 , 0.15, 0.2 , 0.25, 0.3 ]), None, 8),
-        # (np.array([-22, -4, 0, 8, 13]), np.tile(1 / 5, 5), (5, 3), -np.ones((5, 3))),
-        # (
-        #     np.arange(-100, 10),
-        #     np.arange(1, 111) / 6105,
-        #     (2, 5, 3),
-        #     np.broadcast_to(-82 / 3, (2, 5, 3)),
-        # ),
+        (np.array([-4, -1, 3, 9, 19]), np.array([0.1 , 0.15, 0.2 , 0.25, 0.3]), None, 1.5458937198067635),
+        (np.array([-22, -4, 0, 8, 13]), np.tile(1 / 5, 5), (5, 3), np.full((5, 3), -0.14285714285714296)),
+        (
+            np.arange(-100, 10),
+            np.arange(1, 111) / 6105,
+            (2, 5, 3),
+            np.full((2, 5, 3), -27.584097859327223),
+        ),
     ],
 )
 def test_interpolated_moment(x_points, pdf_points, size, expected):

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -805,8 +805,18 @@ def test_categorical_moment(p, size, expected):
     "x_points, pdf_points, size, expected",
     [
         (np.array([-1, 1]), np.array([0.4, 0.6]), None, 0.2),
-        (np.array([-4, -1, 3, 9, 19]), np.array([0.1 , 0.15, 0.2 , 0.25, 0.3]), None, 1.5458937198067635),
-        (np.array([-22, -4, 0, 8, 13]), np.tile(1 / 5, 5), (5, 3), np.full((5, 3), -0.14285714285714296)),
+        (
+            np.array([-4, -1, 3, 9, 19]),
+            np.array([0.1, 0.15, 0.2, 0.25, 0.3]),
+            None,
+            1.5458937198067635,
+        ),
+        (
+            np.array([-22, -4, 0, 8, 13]),
+            np.tile(1 / 5, 5),
+            (5, 3),
+            np.full((5, 3), -0.14285714285714296),
+        ),
         (
             np.arange(-100, 10),
             np.arange(1, 111) / 6105,


### PR DESCRIPTION
This PR adds moment and a test for `pm.Interpolated` (see issue #5078). However, this PR requires issue #5048 to be addressed first (see corresponding WIP PR #5067).

Currently, the tests yield the following error:

```{python}
ValueError: Must specify bound_args_indices for Interpolated bounded distribution
```

This PR serves as a placeholder to track my progress.