### PR TITLE
BART: further changes in sampler 

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -95,7 +95,7 @@ This includes API changes we did not warn about since at least `3.11.0` (2021-01
 - New features for BART:
   - Added linear response, increased number of trees fitted per step [5044](https://github.com/pymc-devs/pymc3/pull/5044).
   - Added partial dependence plots and individual conditional expectation plots [5091](https://github.com/pymc-devs/pymc3/pull/5091).
-  - Modify how particle weights are computed. This improves accuracy of the modeled function (see [5177](https://github.com/pymc-devs/pymc3/pull/5177)).
+  - Modify PGBART sampler. Particles are not longer reweighted and the trees are reset from time to time to avoid getting trap in a local mnima. This improves accuracy of the modeled function and improves convergence (see [5223](https://github.com/pymc-devs/pymc3/pull/5223)).
 - `pm.Data` now passes additional kwargs to `aesara.shared`. [#5098](https://github.com/pymc-devs/pymc/pull/5098)
 - ...
 

--- a/pymc/bart/tree.py
+++ b/pymc/bart/tree.py
@@ -38,11 +38,6 @@ class Tree:
         Total number of nodes.
     idx_leaf_nodes : list
         List with the index of the leaf nodes of the tree.
-    idx_prunable_split_nodes : list
-        List with the index of the prunable splitting nodes of the tree. A splitting node is
-        prunable if both its children are leaf nodes.
-    tree_id : int
-        Identifier used to get the previous tree in the ParticleGibbs algorithm used in BART.
     num_observations : int
         Number of observations used to fit BART.
     m : int
@@ -50,16 +45,13 @@ class Tree:
 
     Parameters
     ----------
-    tree_id : int, optional
     num_observations : int, optional
     """
 
-    def __init__(self, tree_id=0, num_observations=0, m=0):
+    def __init__(self, num_observations=0, m=0):
         self.tree_structure = {}
         self.num_nodes = 0
         self.idx_leaf_nodes = []
-        self.idx_prunable_split_nodes = []
-        self.tree_id = tree_id
         self.num_observations = num_observations
         self.m = m
 
@@ -144,12 +136,11 @@ class Tree:
         return current_node, split_variable
 
     @staticmethod
-    def init_tree(tree_id, leaf_node_value, idx_data_points, m):
+    def init_tree(leaf_node_value, idx_data_points, m):
         """
 
         Parameters
         ----------
-        tree_id
         leaf_node_value
         idx_data_points
         m : int
@@ -159,7 +150,7 @@ class Tree:
         -------
 
         """
-        new_tree = Tree(tree_id, len(idx_data_points), m)
+        new_tree = Tree(len(idx_data_points), m)
         new_tree[0] = LeafNode(index=0, value=leaf_node_value, idx_data_points=idx_data_points)
         return new_tree
 

--- a/pymc/bart/tree.py
+++ b/pymc/bart/tree.py
@@ -143,32 +143,6 @@ class Tree:
                 current_node, split_variable = self._traverse_tree(x, right_child, split_variable)
         return current_node, split_variable
 
-    def grow_tree(self, index_leaf_node, new_split_node, new_left_node, new_right_node):
-        """
-        Grow the tree from a particular node.
-
-        Parameters
-        ----------
-        index_leaf_node : int
-        new_split_node : SplitNode
-        new_left_node : LeafNode
-        new_right_node : LeafNode
-        """
-        current_node = self.get_node(index_leaf_node)
-
-        self.delete_node(index_leaf_node)
-        self.set_node(index_leaf_node, new_split_node)
-        self.set_node(new_left_node.index, new_left_node)
-        self.set_node(new_right_node.index, new_right_node)
-
-        # The new SplitNode is a prunable node since it has both children.
-        self.idx_prunable_split_nodes.append(index_leaf_node)
-        # If the parent of the node from which the tree is growing was a prunable node,
-        # remove from the list since one of its children is a SplitNode now
-        parent_index = current_node.get_idx_parent_node()
-        if parent_index in self.idx_prunable_split_nodes:
-            self.idx_prunable_split_nodes.remove(parent_index)
-
     @staticmethod
     def init_tree(tree_id, leaf_node_value, idx_data_points, m):
         """


### PR DESCRIPTION
This introduces several changes in the pgbart sampler. The main motivation was to improve convergence  while keeping a good accuracy.
* Increase the number of trees fitted per step from 20% to 100%
* Reset the sampler after certain number of steps. This prevents the sampler to get stuck in a local minima,
* Particles are no longer re-weighted, we just grow n particles as deep as possible (which is actually not very deep). 

From my tests, using `response="linear"` is less beneficial than before. Nevertheless I decide to keep this feature and runs mores test to determine if we should keep it.

**A note** in case someone wants more info:
Given the other changes introduced in this PR the benefit from re-weighting particles seems negligible. This PR makes BART slower, but accuracy and convergence are good.

Future PRs should explore ways to accelerate BART. Something trivial is finding some intermediate value between 20% to 100% of the trees fitted per step. Additionally there is room to find better hyper-parameters during tuning like the standard deviation for the leaf node values, or when to reset the sampler or the number of trees fitted per step. Also now that there is no particle reweighting, the trees can be build in a more efficient way in one single pass. Another route could be reusing particles.

Also given that the fitted trees are not very deep, we should maybe move away from particles sampler into something like [this](https://projecteuclid.org/journals/bayesian-analysis/volume-11/issue-3/Efficient-MetropolisHastings-Proposal-Mechanisms-for-Bayesian-Regression-Tree-Models/10.1214/16-BA999.full), or maybe a mix. To clarify we use a prior proposed by [Rockova](https://arxiv.org/abs/1810.00787) favouring much shallower trees than the original by Chipman. We should call it Bayesian Additive Regression Bushes (BARB) :-) The particle Gibbs sampler shows good performance with deep trees (something we do not have) and/or high dimensional data. So far my tests for "high-dimensional" data has included only examples were many of the variables are actually unrelated to the response variable and we have a mechanism to focus the sampling on the important variables, so for these cases the effective dimensionality is actually reduced.


Just one example 

Old 
![old](https://user-images.githubusercontent.com/1338958/143256621-58d06ee5-b632-441d-ba6c-4268de0eb22f.png)

New 
![new](https://user-images.githubusercontent.com/1338958/143256650-f389ed3b-7878-4c36-a2dc-35487fa343f3.png)
