### PR TITLE
Add chain_method kwarg to sample_numpyro_nuts

### DIFF
--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -141,6 +141,7 @@ def sample_numpyro_nuts(
     var_names=None,
     progress_bar=True,
     keep_untransformed=False,
+    chain_method="parallel",
 ):
     from numpyro.infer import MCMC, NUTS
 
@@ -188,7 +189,7 @@ def sample_numpyro_nuts(
         num_samples=draws,
         num_chains=chains,
         postprocess_fn=None,
-        chain_method="parallel",
+        chain_method=chain_method,
         progress_bar=progress_bar,
     )
 


### PR DESCRIPTION
Hi all,

welcome to a tiny pull request!

*Motivation*: I've been using the JAX backend in PyMC v4 with the GPU. When only a single GPU is available, setting `chain_method="parallel"`, as is the default, is a bit inefficient because only one chain is run at a time. numpyro also provides the `chain_method="vectorized"`, which is able to run all chains at the same time on a single GPU. I've found this to be quite a bit faster. 

*Changes*: This just adds a keyword argument to `sample_numpyro_nuts` which allows users to specify the `chain_method` rather than hard-coding it to `parallel`. Default behaviour is the same as before.

Hope this all makes sense -- let me know if you need more information!

Best wishes,
Martin
