### PR TITLE
Updated PyPI token to push to the pymc project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release-job:
     runs-on: ubuntu-latest
     env:
-      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN_PYMC }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -39,7 +39,7 @@ jobs:
     - name: Publish to PyPI
       run: |
         twine check dist/*
-        twine upload --repository pypi --username __token__ --password ${PYPI_TOKEN} dist/*
+        twine upload --repository pypi --username __token__ --password ${PYPI_TOKEN_PYMC} dist/*
   test-install-job:
     needs: release-job
     runs-on: ubuntu-latest


### PR DESCRIPTION
Replaced PyPI token to push to the `pymc` project rather than to `pymc3`