### PR TITLE
tighten test_sample_after_set_data bound

### DIFF
--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -122,7 +122,7 @@ class TestData(SeededTest):
 
         assert pp_trace.posterior_predictive["obs"].shape == (1, 1000, 3)
         np.testing.assert_allclose(
-            new_y, pp_trace.posterior_predictive["obs"].mean(("chain", "draw")), atol=1e-1
+            new_y, pp_trace.posterior_predictive["obs"].mean(("chain", "draw")), atol=0.015
         )
 
     def test_shared_data_as_index(self):


### PR DESCRIPTION
Hi,

The test `test_sample_after_set_data` in `test_data_container.py` has an assertion bound (`np.testing.assert_allclose(new_y, pp_trace.posterior_predictive["obs"].mean(("chain", "draw")), atol=1e-1)`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/146660428-16c0d33b-1104-422d-ba43-6c4c0bde1aa5.png" width="450">
</p>

Here we see that the bound of `0.1` is too loose since the original distribution (in orange) is much less than `0.1`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are below the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/146660437-221e194c-843b-4f3d-8c76-03f53d509388.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `0.1` (red dotted line) has a catch rate of 0.09.

To improve this test, I propose to tighten the bound to `0.015` (the blue dotted line). The new bound has a catch rate of 0.21 (+0.12 increase compare to original) while still has >99 % pass rate (test is not flaky, I ran the updated test 500 times and observed >99 % pass rate). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.7.11
numpy=1.21.4
```

my pymc Experiment SHA:
`19e67f371d4641fd2f9ad7c8a7887361bdaa53d6`

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [ ] important background, or details about the implementation
+ [ ] are the changes—especially new features—covered by tests and docstrings?
+ [ ] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
