### PR TITLE
Fix UserWarning always being printed

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -386,12 +386,13 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
             else:
                 data[k] = np.expand_dims(ary, 0)
                 warning_vars.append(k)
-        warnings.warn(
-            f"The shape of variables {', '.join(warning_vars)} in {kind} group is not compatible "
-            "with number of chains and draws. The automatic dimension naming might not have worked. "
-            "This can also mean that some draws or even whole chains are not represented.",
-            UserWarning,
-        )
+        if warning_vars:
+            warnings.warn(
+                f"The shape of variables {', '.join(warning_vars)} in {kind} group is not compatible "
+                "with number of chains and draws. The automatic dimension naming might not have worked. "
+                "This can also mean that some draws or even whole chains are not represented.",
+                UserWarning,
+            )
         return dict_to_dataset(data, library=pymc, coords=self.coords, dims=self.dims)
 
     @requires(["posterior_predictive"])


### PR DESCRIPTION
I noticed that #5268 introduced a small bug that always printed a warning. Now fixed. (@michaelosthege)
I'd be happy to run linting, but the linting/style checks link below from the PR template takes me to a blank page?

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [ ] important background, or details about the implementation
+ [ ] are the changes—especially new features—covered by tests and docstrings?
+ [ ] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
