### PR TITLE
Option to create non-shared `pm.Data`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -113,7 +113,10 @@ This includes API changes we did not warn about since at least `3.11.0` (2021-01
   - Added partial dependence plots and individual conditional expectation plots [5091](https://github.com/pymc-devs/pymc3/pull/5091).
   - Modify how particle weights are computed. This improves accuracy of the modeled function (see [5177](https://github.com/pymc-devs/pymc3/pull/5177)).
   - Improve sampling, increase default number of particles [5229](https://github.com/pymc-devs/pymc3/pull/5229).
-- `pm.Data` now passes additional kwargs to `aesara.shared`. [#5098](https://github.com/pymc-devs/pymc/pull/5098)
+- New features for `pm.Data` containers:
+  - With `pm.Data(..., mutable=True/False)`, or by using `pm.MutableData` vs. `pm.ConstantData` one can now create `TensorConstant` data variables. They can be more performant and compatible in situtations where a variable doesn't need to be changed via `pm.set_data()`. See [#5295](https://github.com/pymc-devs/pymc/pull/5295).
+  - New named dimensions can be introduced to the model via `pm.Data(..., dims=...)`. For mutable data variables (see above) the lengths of these dimensions are symbolic, so they can be re-sized via `pm.set_data()`.
+  - `pm.Data` now passes additional kwargs to `aesara.shared`/`at.as_tensor`. [#5098](https://github.com/pymc-devs/pymc/pull/5098).
 - ...
 
 

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -454,7 +454,7 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
         """Convert constant data to xarray."""
         # For constant data, we are concerned only with deterministics and
         # data.  The constant data vars must be either pm.Data
-        # (TensorSharedVariable) or pm.Deterministic
+        # (TensorConstant/SharedVariable) or pm.Deterministic
         constant_data_vars = {}  # type: Dict[str, Var]
 
         def is_data(name, var) -> bool:

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1114,7 +1114,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
     ):
         """Changes the values of a data variable in the model.
 
-        In contrast to pm.Data().set_value, this method can also
+        In contrast to pm.MutableData().set_value, this method can also
         update the corresponding coordinates.
 
         Parameters
@@ -1131,7 +1131,8 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
         shared_object = self[name]
         if not isinstance(shared_object, SharedVariable):
             raise TypeError(
-                f"The variable `{name}` must be a `SharedVariable` (e.g. `pymc.Data`) to allow updating. "
+                f"The variable `{name}` must be a `SharedVariable`"
+                " (created through `pm.MutableData()` or `pm.Data(mutable=True)`) to allow updating. "
                 f"The current type is: {type(shared_object)}"
             )
 
@@ -1156,7 +1157,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
             length_changed = new_length != old_length
 
             # Reject resizing if we already know that it would create shape problems.
-            # NOTE: If there are multiple pm.Data containers sharing this dim, but the user only
+            # NOTE: If there are multiple pm.MutableData containers sharing this dim, but the user only
             #       changes the values for one of them, they will run into shape problems nonetheless.
             length_belongs_to = length_tensor.owner.inputs[0].owner.inputs[0]
             if not isinstance(length_belongs_to, SharedVariable) and length_changed:
@@ -1735,8 +1736,8 @@ def set_data(new_data, model=None):
 
         >>> import pymc as pm
         >>> with pm.Model() as model:
-        ...     x = pm.Data('x', [1., 2., 3.])
-        ...     y = pm.Data('y', [1., 2., 3.])
+        ...     x = pm.MutableData('x', [1., 2., 3.])
+        ...     y = pm.MutableData('y', [1., 2., 3.])
         ...     beta = pm.Normal('beta', 0, 1)
         ...     obs = pm.Normal('obs', x * beta, 1, observed=y)
         ...     idata = pm.sample(1000, tune=1000)

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -20,7 +20,7 @@ from aesara import function
 from aesara.compile.sharedvalue import SharedVariable
 from aesara.graph.basic import walk
 from aesara.tensor.random.op import RandomVariable
-from aesara.tensor.var import TensorVariable
+from aesara.tensor.var import TensorConstant, TensorVariable
 
 import pymc as pm
 
@@ -133,7 +133,7 @@ class ModelGraph:
             shape = "octagon"
             style = "filled"
             label = f"{var_name}\n~\nPotential"
-        elif isinstance(v, SharedVariable):
+        elif isinstance(v, (SharedVariable, TensorConstant)):
             shape = "box"
             style = "rounded, filled"
             label = f"{var_name}\n~\nData"

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -133,10 +133,14 @@ class ModelGraph:
             shape = "octagon"
             style = "filled"
             label = f"{var_name}\n~\nPotential"
-        elif isinstance(v, (SharedVariable, TensorConstant)):
+        elif isinstance(v, TensorConstant):
             shape = "box"
             style = "rounded, filled"
-            label = f"{var_name}\n~\nData"
+            label = f"{var_name}\n~\nConstantData"
+        elif isinstance(v, SharedVariable):
+            shape = "box"
+            style = "rounded, filled"
+            label = f"{var_name}\n~\nMutableData"
         elif v.owner and isinstance(v.owner.op, RandomVariable):
             shape = "ellipse"
             if hasattr(v.tag, "observations"):

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -31,6 +31,7 @@ import numpy as np
 import xarray
 
 from aesara.compile.mode import Mode
+from aesara.graph.basic import Constant
 from aesara.tensor.sharedvar import SharedVariable
 from arviz import InferenceData
 from fastprogress.fastprogress import progress_bar
@@ -1715,7 +1716,7 @@ def sample_posterior_predictive(
             for rv in walk_model(vars_to_sample, walk_past_rvs=True)
             if rv not in vars_to_sample
             and rv in model.named_vars.values()
-            and not isinstance(rv, SharedVariable)
+            and not isinstance(rv, (Constant, SharedVariable))
         ]
         if inputs_and_names:
             inputs, input_names = zip(*inputs_and_names)
@@ -1726,7 +1727,7 @@ def sample_posterior_predictive(
         input_names = [
             n
             for n in _trace.varnames
-            if n not in output_names and not isinstance(model[n], SharedVariable)
+            if n not in output_names and not isinstance(model[n], (Constant, SharedVariable))
         ]
         inputs = [model[n] for n in input_names]
 
@@ -2054,7 +2055,7 @@ def sample_prior_predictive(
             names.append(rv_var.name)
             vars_to_sample.append(rv_var)
 
-    inputs = [i for i in inputvars(vars_to_sample) if not isinstance(i, SharedVariable)]
+    inputs = [i for i in inputvars(vars_to_sample) if not isinstance(i, (Constant, SharedVariable))]
 
     sampler_fn = compile_pymc(
         inputs, vars_to_sample, allow_input_downcast=True, accept_inplace=True, mode=mode

--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -71,8 +71,8 @@ class TestData(SeededTest):
 
     def test_sample_posterior_predictive_after_set_data(self):
         with pm.Model() as model:
-            x = pm.Data("x", [1.0, 2.0, 3.0])
-            y = pm.Data("y", [1.0, 2.0, 3.0])
+            x = pm.MutableData("x", [1.0, 2.0, 3.0])
+            y = pm.ConstantData("y", [1.0, 2.0, 3.0])
             beta = pm.Normal("beta", 0, 10.0)
             pm.Normal("obs", beta * x, np.sqrt(1e-2), observed=y)
             trace = pm.sample(

--- a/pymc/tests/test_idata_conversion.py
+++ b/pymc/tests/test_idata_conversion.py
@@ -255,7 +255,7 @@ class TestDataPyMC:
             )
 
             data_dims = ("date", "city")
-            data = pm.Data("data", df_data, dims=data_dims)
+            data = pm.ConstantData("data", df_data, dims=data_dims)
             _ = pm.Normal("likelihood", mu=city_temperature, sd=0.5, observed=data, dims=data_dims)
 
             trace = pm.sample(
@@ -281,14 +281,14 @@ class TestDataPyMC:
         np.testing.assert_array_equal(idata.observed_data.coords["city"], coords["city"])
 
     def test_ovewrite_model_coords_dims(self):
-        """Check coords and dims from model object can be partially overwrited."""
+        """Check coords and dims from model object can be partially overwritten."""
         dim1 = ["a", "b"]
         new_dim1 = ["c", "d"]
         coords = {"dim1": dim1, "dim2": ["c1", "c2"]}
         x_data = np.arange(4).reshape((2, 2))
         y = x_data + np.random.normal(size=(2, 2))
         with pm.Model(coords=coords):
-            x = pm.Data("x", x_data, dims=("dim1", "dim2"))
+            x = pm.ConstantData("x", x_data, dims=("dim1", "dim2"))
             beta = pm.Normal("beta", 0, 1, dims="dim1")
             _ = pm.Normal("obs", x * beta, 1, observed=y, dims=("dim1", "dim2"))
             trace = pm.sample(100, tune=100, return_inferencedata=False)
@@ -466,8 +466,8 @@ class TestDataPyMC:
     def test_constant_data(self, use_context):
         """Test constant_data group behaviour."""
         with pm.Model() as model:
-            x = pm.Data("x", [1.0, 2.0, 3.0])
-            y = pm.Data("y", [1.0, 2.0, 3.0])
+            x = pm.ConstantData("x", [1.0, 2.0, 3.0])
+            y = pm.MutableData("y", [1.0, 2.0, 3.0])
             beta = pm.Normal("beta", 0, 1)
             obs = pm.Normal("obs", x * beta, 1, observed=y)  # pylint: disable=unused-variable
             trace = pm.sample(100, chains=2, tune=100, return_inferencedata=False)
@@ -483,8 +483,8 @@ class TestDataPyMC:
 
     def test_predictions_constant_data(self):
         with pm.Model():
-            x = pm.Data("x", [1.0, 2.0, 3.0])
-            y = pm.Data("y", [1.0, 2.0, 3.0])
+            x = pm.ConstantData("x", [1.0, 2.0, 3.0])
+            y = pm.MutableData("y", [1.0, 2.0, 3.0])
             beta = pm.Normal("beta", 0, 1)
             obs = pm.Normal("obs", x * beta, 1, observed=y)  # pylint: disable=unused-variable
             trace = pm.sample(100, tune=100, return_inferencedata=False)
@@ -495,8 +495,8 @@ class TestDataPyMC:
         assert not fails
 
         with pm.Model():
-            x = pm.Data("x", [1.0, 2.0])
-            y = pm.Data("y", [1.0, 2.0])
+            x = pm.MutableData("x", [1.0, 2.0])
+            y = pm.ConstantData("y", [1.0, 2.0])
             beta = pm.Normal("beta", 0, 1)
             obs = pm.Normal("obs", x * beta, 1, observed=y)  # pylint: disable=unused-variable
             predictive_trace = pm.sample_posterior_predictive(
@@ -519,8 +519,8 @@ class TestDataPyMC:
 
     def test_no_trace(self):
         with pm.Model() as model:
-            x = pm.Data("x", [1.0, 2.0, 3.0])
-            y = pm.Data("y", [1.0, 2.0, 3.0])
+            x = pm.ConstantData("x", [1.0, 2.0, 3.0])
+            y = pm.MutableData("y", [1.0, 2.0, 3.0])
             beta = pm.Normal("beta", 0, 1)
             obs = pm.Normal("obs", x * beta, 1, observed=y)  # pylint: disable=unused-variable
             idata = pm.sample(100, tune=100)
@@ -553,8 +553,8 @@ class TestDataPyMC:
     def test_priors_separation(self, use_context):
         """Test model is enough to get prior, prior predictive and observed_data."""
         with pm.Model() as model:
-            x = pm.Data("x", [1.0, 2.0, 3.0])
-            y = pm.Data("y", [1.0, 2.0, 3.0])
+            x = pm.MutableData("x", [1.0, 2.0, 3.0])
+            y = pm.ConstantData("y", [1.0, 2.0, 3.0])
             beta = pm.Normal("beta", 0, 1)
             obs = pm.Normal("obs", x * beta, 1, observed=y)  # pylint: disable=unused-variable
             prior = pm.sample_prior_predictive(return_inferencedata=False)

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -549,7 +549,7 @@ class TestShapeEvaluation:
                 "city": ["Sydney", "Las Vegas", "Düsseldorf"],
             }
         ) as pmodel:
-            pm.Data("budget", [1, 2, 3, 4], dims="year")
+            pm.MutableData("budget", [1, 2, 3, 4], dims="year")
             pm.Normal("untransformed", size=(1, 2))
             pm.Uniform("transformed", size=(7,))
             obs = pm.Uniform("observed", size=(3,), observed=[0.1, 0.2, 0.3])

--- a/pymc/tests/test_model_graph.py
+++ b/pymc/tests/test_model_graph.py
@@ -44,9 +44,9 @@ def radon_model():
 
         # Anonymous SharedVariables don't show up
         floor_measure = aesara.shared(floor_measure)
-        floor_measure_offset = pm.Data("floor_measure_offset", 1)
+        floor_measure_offset = pm.MutableData("floor_measure_offset", 1)
         y_hat = a + b * floor_measure + floor_measure_offset
-        log_radon = pm.Data("log_radon", np.random.normal(1, 1, size=n_homes))
+        log_radon = pm.MutableData("log_radon", np.random.normal(1, 1, size=n_homes))
         y_like = pm.Normal("y_like", mu=y_hat, sigma=sigma_y, observed=log_radon)
 
     compute_graph = {
@@ -104,13 +104,13 @@ def model_with_dims():
 
         population = pm.HalfNormal("population", sd=5, dims=("city"))
 
-        time = pm.Data("year", [2014, 2015, 2016], dims="year")
+        time = pm.ConstantData("year", [2014, 2015, 2016], dims="year")
 
         n = pm.Deterministic(
             "tax revenue", economics * population[None, :] * time[:, None], dims=("year", "city")
         )
 
-        yobs = pm.Data("observed", np.ones((3, 4)))
+        yobs = pm.MutableData("observed", np.ones((3, 4)))
         L = pm.Normal("L", n, observed=yobs)
 
     compute_graph = {

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -955,7 +955,7 @@ class TestSamplePriorPredictive(SeededTest):
         observed = np.random.normal(10, 1, size=200)
         with pm.Model():
             # Use a prior that's way off to show we're ignoring the observed variables
-            observed_data = pm.Data("observed_data", observed)
+            observed_data = pm.MutableData("observed_data", observed)
             mu = pm.Normal("mu", mu=-100, sigma=1)
             positive_mu = pm.Deterministic("positive_mu", np.abs(mu))
             z = -1 - positive_mu

--- a/pymc/tests/test_shape_handling.py
+++ b/pymc/tests/test_shape_handling.py
@@ -315,7 +315,7 @@ class TestShapeDimsSize:
     @pytest.mark.xfail(reason="Simultaneous use of size and dims is not implemented")
     def test_data_defined_size_dimension_can_register_dimname(self):
         with pm.Model() as pmodel:
-            x = pm.Data("x", [[1, 2, 3, 4]], dims=("first", "second"))
+            x = pm.ConstantData("x", [[1, 2, 3, 4]], dims=("first", "second"))
             assert "first" in pmodel.dim_lengths
             assert "second" in pmodel.dim_lengths
             # two dimensions are implied; a "third" dimension is created
@@ -325,7 +325,7 @@ class TestShapeDimsSize:
 
     def test_can_resize_data_defined_size(self):
         with pm.Model() as pmodel:
-            x = pm.Data("x", [[1, 2, 3, 4]], dims=("first", "second"))
+            x = pm.MutableData("x", [[1, 2, 3, 4]], dims=("first", "second"))
             y = pm.Normal("y", mu=0, dims=("first", "second"))
             z = pm.Normal("z", mu=y, observed=np.ones((1, 4)))
             assert x.eval().shape == (1, 4)


### PR DESCRIPTION
Until now `pm.Data` always created a `SharedVariable`, even though most uses of `pm.Data` are not because it's mutable, but because it registers the variable in the model.

With `pm.Data(..., mutable=False/True)`, this PR adds the option to create non-shared data variables (`TensorConstant`) that possibly improve performance (via optimizations available for `TensorConstant`) and can also be used in places where a `SharedVariable` is not supported.

I also refactored `pm.Data` from a class into a function. I'm not 100 % sure why it was a class in the first place, but if I understand it correctly our use of `__new__` actually violates its intended signature, since we're not returning an instance of the correct type(?).

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes? The `pm.Data.get_coord` staticmethod was refactored to `pm.data.determine_coords`, but this is just internal API.
+ [x] important background, or details about the implementation. See above.
+ [x] are the changes—especially new features—covered by tests and docstrings? Yes.
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples) 👉 Do we want to add a deprecation warning when `mutable` is not specified? We could also make `mutable=None` by default and warn that the default will change in the future?
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md

Closes #5105