### PR TITLE
Fix Poisson logcdf

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -635,12 +635,10 @@ class Poisson(Discrete):
         safe_mu = at.switch(at.lt(mu, 0), 0, mu)
         safe_value = at.switch(at.lt(value, 0), 0, value)
 
-        res = (
-            at.switch(
-                at.lt(value, 0),
-                -np.inf,
-                at.log(at.gammaincc(safe_value + 1, safe_mu)),
-            ),
+        res = at.switch(
+            at.lt(value, 0),
+            -np.inf,
+            at.log(at.gammaincc(safe_value + 1, safe_mu)),
         )
 
         return check_parameters(res, 0 <= mu, msg="mu >= 0")


### PR DESCRIPTION
This showed up in #5231, the evalution of a scalar logcdf was returning a 1D result, because of a silly comma :D

Didn't add tests, because we are not checking this for any other distribution...