### PR TITLE
Workaround for #5310: theano import error with recent NumPy

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,9 @@
 + The `pm.Distribution(testval=...)` kwarg was deprecated and will be replaced by `pm.Distribution(initval=...)`in `pymc >=4` (see [#5226](https://github.com/pymc-devs/pymc/pulls/5226)).
 + The `pm.sample(start=...)` kwarg was deprecated and will be replaced by `pm.sample(initvals=...)`in `pymc >=4` (see [#5226](https://github.com/pymc-devs/pymc/pulls/5226)).
 
+### Bugfixes
++ A hotfix is applied on import to remain compatible with NumPy 1.22 (see [#5316](https://github.com/pymc-devs/pymc/pull/5316)).
+
 ## PyMC3 3.11.4 (20 August 2021)
 
 ### New Features


### PR DESCRIPTION
Importing Theano with NumPy>=1.22.0 installed raises an exception as it accesses an undefined variable in NumPy's `__config__` module. This PR implements a workaround as suggested in https://github.com/pymc-devs/pymc/issues/5310#issuecomment-1006044281

+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md