### PR TITLE
Warnings of theano and pymc3 has been deleted

### DIFF
--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -18,7 +18,8 @@ __version__ = "4.0.0b1"
 import logging
 import multiprocessing as mp
 import platform
-
+import theano
+import pymc3
 _log = logging.getLogger("pymc")
 
 if not logging.root.handlers:
@@ -26,39 +27,6 @@ if not logging.root.handlers:
     if len(_log.handlers) == 0:
         handler = logging.StreamHandler()
         _log.addHandler(handler)
-
-
-def _check_install_compatibilitites():
-    try:
-        import theano
-
-        _log.warning(
-            "!" * 60
-            + f"\nYour Python environment has Theano(-PyMC) {theano.__version__} installed, "
-            + f"but you are importing PyMC {__version__} which uses Aesara as its backend."
-            + f"\nFor PyMC {__version__} to work as expected you should uninstall Theano(-PyMC)."
-            + "\nSee https://github.com/pymc-devs/pymc/wiki for update instructions.\n"
-            + "!" * 60
-        )
-    except ImportError:
-        pass
-
-    try:
-        import pymc3
-
-        _log.warning(
-            "!" * 60
-            + f"\nYou are importing PyMC {__version__}, but your environment also has"
-            + f" the legacy version PyMC3 {pymc3.__version__} installed."
-            + f"\nFor PyMC {__version__} to work as expected you should uninstall PyMC3."
-            + "\nSee https://github.com/pymc-devs/pymc/wiki for update instructions.\n"
-            + "!" * 60
-        )
-    except ImportError:
-        pass
-
-
-_check_install_compatibilitites()
 
 
 def __set_compiler_flags():

--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -18,8 +18,7 @@ __version__ = "4.0.0b1"
 import logging
 import multiprocessing as mp
 import platform
-import theano
-import pymc3
+
 _log = logging.getLogger("pymc")
 
 if not logging.root.handlers:


### PR DESCRIPTION
#5312 
1.I have deleted the warnings of importing theano and pymc3

2.This PR is the solution to the issue[#5312](https://github.com/pymc-devs/pymc/issues/5312)


