### PR TITLE
Pin NumPy to <1.22.0 temporarily

### DIFF
--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -13,7 +13,7 @@ dependencies:
 - h5py>=2.7
 - ipython
 - myst-nb
-- numpy>=1.15
+- numpy>=1.15.0,<1.22.0
 - numpydoc>=0.9
 - pandas>=0.24
 - pre-commit>=2.8.0

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -13,7 +13,7 @@ dependencies:
 - h5py>=2.7
 - ipython
 - myst-nb
-- numpy>=1.15.0
+- numpy>=1.15.0,<1.22.0
 - numpydoc>=0.9
 - pandas>=0.24.0
 - pre-commit>=2.8.0

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -13,7 +13,7 @@ dependencies:
 - h5py>=2.7
 - ipython
 - myst-nb
-- numpy>=1.15.0
+- numpy>=1.15.0,<1.22.0
 - numpydoc>=0.9
 - pandas
 - pre-commit>=2.8.0

--- a/conda-envs/environment-test-py37.yml
+++ b/conda-envs/environment-test-py37.yml
@@ -14,7 +14,7 @@ dependencies:
 - ipython
 - libblas=*=*mkl
 - mkl-service
-- numpy>=1.15.0
+- numpy>=1.15.0,<1.22.0
 - pandas>=0.24
 - pre-commit>=2.8.0
 - pytest-cov>=2.5

--- a/conda-envs/environment-test-py38.yml
+++ b/conda-envs/environment-test-py38.yml
@@ -14,7 +14,7 @@ dependencies:
 - ipython
 - libblas=*=*mkl
 - mkl-service
-- numpy>=1.15.0
+- numpy>=1.15.0,<1.22.0
 - pandas
 - pre-commit>=2.8.0
 - pytest-cov>=2.5

--- a/conda-envs/environment-test-py39.yml
+++ b/conda-envs/environment-test-py39.yml
@@ -14,7 +14,7 @@ dependencies:
 - ipython>=7.16
 - libblas=*=*mkl
 - mkl-service
-- numpy>=1.15.0
+- numpy>=1.15.0,<1.22.0
 - pandas
 - pre-commit>=2.8.0
 - pytest-cov>=2.5

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -11,7 +11,7 @@ dependencies:
 - cloudpickle
 - fastprogress>=0.2.0
 - h5py
-- numpy>=1.15.0
+- numpy>=1.15.0,<1.22.0
 - pandas
 - pip
 - python=3.8

--- a/conda-envs/windows-environment-test-py38.yml
+++ b/conda-envs/windows-environment-test-py38.yml
@@ -15,7 +15,7 @@ dependencies:
 - mkl==2020.4
 - mkl-service==2.3.0
 - m2w64-toolchain
-- numpy>=1.15.0
+- numpy>=1.15.0,<1.22.0
 - pandas
 - pip
 - python=3.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ fastprogress>=0.2.0
 h5py>=2.7
 ipython
 myst-nb
-numpy>=1.15.0
+numpy>=1.15.0,<1.22.0
 numpydoc>=0.9
 pandas
 pre-commit>=2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ arviz>=0.11.4
 cachetools>=4.2.1
 cloudpickle
 fastprogress>=0.2.0
-numpy>=1.15.0
+numpy>=1.15.0,<1.22.0
 pandas>=0.24.0
 scipy>=1.4.1
 typing-extensions>=3.7.4


### PR DESCRIPTION
Tracker issue #5321 until we can upgrade to Aesara >= 2.3.4 and unpin again.