### PR TITLE
Create helper pm.draw() to take draws for a given variable

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -33,9 +33,8 @@ All of the above apply to:
 - ⚠ Theano-PyMC has been replaced with Aesara, so all external references to `theano`, `tt`, and `pymc3.theanof` need to be replaced with `aesara`, `at`, and `pymc.aesaraf` (see [4471](https://github.com/pymc-devs/pymc/pull/4471)).
 - `pm.Distribution(...).logp(x)` is now `pm.logp(pm.Distribution(...), x)`.
 - `pm.Distribution(...).logcdf(x)` is now `pm.logcdf(pm.Distribution(...), x)`.
-- `pm.Distribution(...).random()` is now `pm.Distribution(...).eval()`.
-- `pm.draw(...)` is added to draw samples of a variable or a list of variables.
-- `pm.draw_values(...)` and `pm.generate_samples(...)` were removed. The tensors can now be evaluated with `pm.draw(x)` instead of `x.eval()`.
+- `pm.Distribution(...).random(size=x)` is now `pm.draw(pm.Distribution(...), draws=x)`.
+- `pm.draw_values(...)` and `pm.generate_samples(...)` were removed.
 - `pm.fast_sample_posterior_predictive` was removed.
 - `pm.sample_prior_predictive`, `pm.sample_posterior_predictive` and `pm.sample_posterior_predictive_w` now return an `InferenceData` object by default, instead of a dictionary (see [#5073](https://github.com/pymc-devs/pymc/pull/5073)).
 - `pm.sample_prior_predictive` no longer returns transformed variable values by default. Pass them by name in `var_names` if you want to obtain these draws (see [4769](https://github.com/pymc-devs/pymc/pull/4769)).

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -31,10 +31,11 @@ All of the above apply to:
 
 - ⚠ The library is now named, installed and imported as "pymc". For example: `pip install pymc`.
 - ⚠ Theano-PyMC has been replaced with Aesara, so all external references to `theano`, `tt`, and `pymc3.theanof` need to be replaced with `aesara`, `at`, and `pymc.aesaraf` (see [4471](https://github.com/pymc-devs/pymc/pull/4471)).
-- `pm.Distribution(...).logp(x)` is now `pm.logp(pm.Distribution(...), x)`
-- `pm.Distribution(...).logcdf(x)` is now `pm.logcdf(pm.Distribution(...), x)`
-- `pm.Distribution(...).random()` is now `pm.Distribution(...).eval()`
-- `pm.draw_values(...)` and `pm.generate_samples(...)` were removed. The tensors can now be evaluated with `.eval()`.
+- `pm.Distribution(...).logp(x)` is now `pm.logp(pm.Distribution(...), x)`.
+- `pm.Distribution(...).logcdf(x)` is now `pm.logcdf(pm.Distribution(...), x)`.
+- `pm.Distribution(...).random()` is now `pm.Distribution(...).eval()`.
+- `pm.draw(...)` is added to draw samples of a variable or a list of variables.
+- `pm.draw_values(...)` and `pm.generate_samples(...)` were removed. The tensors can now be evaluated with `pm.draw(x)` instead of `x.eval()`.
 - `pm.fast_sample_posterior_predictive` was removed.
 - `pm.sample_prior_predictive`, `pm.sample_posterior_predictive` and `pm.sample_posterior_predictive_w` now return an `InferenceData` object by default, instead of a dictionary (see [#5073](https://github.com/pymc-devs/pymc/pull/5073)).
 - `pm.sample_prior_predictive` no longer returns transformed variable values by default. Pass them by name in `var_names` if you want to obtain these draws (see [4769](https://github.com/pymc-devs/pymc/pull/4769)).

--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -967,7 +967,7 @@ def compile_pymc(inputs, outputs, mode=None, **kwargs):
 
     # Set the default update of a NoDistribution RNG so that it is automatically
     # updated after every function call
-    output_to_list = outputs if isinstance(outputs, list) else [outputs]
+    output_to_list = outputs if isinstance(outputs, (list, tuple)) else [outputs]
     for rv in (
         node
         for node in walk_model(output_to_list, walk_past_rvs=True)

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -2094,14 +2094,9 @@ def sample_prior_predictive(
     return pm.to_inference_data(prior=prior, **ikwargs)
 
 
-def draw(
-    vars,
-    draws=500,
-    mode=None,
-    **kwargs
-) -> Dict[str, np.ndarray]:
+def draw(vars, draws=500, mode=None, **kwargs) -> Dict[str, np.ndarray]:
     """Draw samples for one variable or a list of variables
-    
+
     Parameters
     ----------
     vars : Iterable[TensorVariable]
@@ -2110,18 +2105,18 @@ def draw(
         Number of samples needed to draw. Detaults to 500.
     mode:
         The mode used by ``aesara.function`` to compile the graph.
-    kwargs: 
+    kwargs:
         Keyword arguments for :func:`pymc.aesara.compile_pymc`
 
     Returns
     -------
     Dict[str, np.ndarray]
         A dictionary with variable names as keys and drawn samples as numpy arrays.
-    
+
     Examples
     --------
-    .. code-block:: python    
-        # Draw samples for one variable 
+    .. code-block:: python
+        # Draw samples for one variable
         with pm.Model():
             x = pm.Normal("x")
         x_draws = pm.draw(x)
@@ -2139,7 +2134,7 @@ def draw(
         assert draws["y"].shape == (num_draws, 10)
         assert draws["z"].shape == (num_draws, 5)
     """
-    
+
     if vars is None:
         raise AssertionError("Must include at least one variable")
 
@@ -2149,7 +2144,7 @@ def draw(
         vars = [vars]
 
     draw_fn = compile_pymc(inputs=[], outputs=vars, mode=mode, **kwargs)
-    
+
     values = zip(*(draw_fn() for _ in range(draws)))
 
     names = [var.name for var in vars]

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -2142,9 +2142,6 @@ def draw(
         assert draws[2].shape == (num_draws, 5)
     """
 
-    if vars is None:
-        raise AssertionError("Must include at least one variable")
-
     if not isinstance(vars, (list, tuple)):
         vars = [vars]
 

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -2147,16 +2147,13 @@ def draw(
         vars = [vars]
 
     draw_fn = compile_pymc(inputs=[], outputs=vars, mode=mode, **kwargs)
-
     drawn_values = zip(*(draw_fn() for _ in range(draws)))
-
-    drawn_data = [np.stack(v) for v in drawn_values]
+    drawn_values = [np.stack(v) for v in drawn_values]
 
     # If only one variable, return the numpy array instead of a list of numpy arrays
-    if len(drawn_data) == 1:
-        return drawn_data[0]
-
-    return drawn_data
+    if draws == 1:
+        return drawn_values[0]
+    return drawn_values
 
 
 def _init_jitter(

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -96,6 +96,7 @@ __all__ = [
     "sample_posterior_predictive_w",
     "init_nuts",
     "sample_prior_predictive",
+    "draw",
 ]
 
 STEP_METHODS = (

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -2114,8 +2114,31 @@ def draw(
 
     Returns
     -------
+    Dict[str, np.ndarray]
         A dictionary with variable names as keys and drawn samples as numpy arrays.
+    
+    Examples
+    --------
+    .. code-block:: python    
+        # Draw samples for one variable 
+        with pm.Model():
+            x = pm.Normal("x")
+        x_draws = pm.draw(x)
+        assert x_draws["x"].shape == (500,)
+
+        # Draw 1000 samples for several variables
+        with pm.Model():
+            x = pm.Normal("x")
+            y = pm.Normal("y", shape=10)
+            z = pm.Uniform("z", shape=5)
+
+        num_draws = 1000
+        draws = pm.draw([x, y, z], draws=num_draws)
+        assert draws["x"].shape == (num_draws,)
+        assert draws["y"].shape == (num_draws, 10)
+        assert draws["z"].shape == (num_draws, 5)
     """
+    
     if vars is None:
         raise AssertionError("Must include at least one variable")
 

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -2104,13 +2104,13 @@ def draw(
 
     Parameters
     ----------
-    vars : Union[Variable, Sequence[Variable]]
+    vars
         A variable or a list of variables for which to draw samples.
     draws : int
         Number of samples needed to draw. Detaults to 500.
-    mode : Optional[Union[str, Mode]]
+    mode
         The mode used by ``aesara.function`` to compile the graph.
-    kwargs:
+    **kwargs
         Keyword arguments for :func:`pymc.aesara.compile_pymc`
 
     Returns
@@ -2120,26 +2120,27 @@ def draw(
 
     Examples
     --------
-    .. code-block:: python
-        import pymc as pm
+        .. code-block:: python
 
-        # Draw samples for one variable
-        with pm.Model():
-            x = pm.Normal("x")
-        x_draws = pm.draw(x, draws=100)
-        print(x_draws.shape)
+            import pymc as pm
 
-        # Draw 1000 samples for several variables
-        with pm.Model():
-            x = pm.Normal("x")
-            y = pm.Normal("y", shape=10)
-            z = pm.Uniform("z", shape=5)
-        num_draws = 1000
-        # Draw samples of a list variables
-        draws = pm.draw([x, y, z], draws=num_draws)
-        assert draws[0].shape == (num_draws,)
-        assert draws[1].shape == (num_draws, 10)
-        assert draws[2].shape == (num_draws, 5)
+            # Draw samples for one variable
+            with pm.Model():
+                x = pm.Normal("x")
+            x_draws = pm.draw(x, draws=100)
+            print(x_draws.shape)
+
+            # Draw 1000 samples for several variables
+            with pm.Model():
+                x = pm.Normal("x")
+                y = pm.Normal("y", shape=10)
+                z = pm.Uniform("z", shape=5)
+            num_draws = 1000
+            # Draw samples of a list variables
+            draws = pm.draw([x, y, z], draws=num_draws)
+            assert draws[0].shape == (num_draws,)
+            assert draws[1].shape == (num_draws, 10)
+            assert draws[2].shape == (num_draws, 5)
     """
 
     if not isinstance(vars, (list, tuple)):

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -2096,10 +2096,10 @@ def sample_prior_predictive(
 
 def draw(
     vars: Union[Variable, Sequence[Variable]],
-    draws=1,
+    draws: int = 1,
     mode: Optional[Union[str, Mode]] = None,
     **kwargs,
-) -> List[np.ndarray]:
+) -> Union[np.ndarray, List[np.ndarray]]:
     """Draw samples for one variable or a list of variables
 
     Parameters

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -2143,17 +2143,19 @@ def draw(
             assert draws[2].shape == (num_draws, 5)
     """
 
-    if not isinstance(vars, (list, tuple)):
-        vars = [vars]
-
     draw_fn = compile_pymc(inputs=[], outputs=vars, mode=mode, **kwargs)
-    drawn_values = zip(*(draw_fn() for _ in range(draws)))
-    drawn_values = [np.stack(v) for v in drawn_values]
 
-    # If only one variable, return the numpy array instead of a list of numpy arrays
     if draws == 1:
-        return drawn_values[0]
-    return drawn_values
+        return draw_fn()
+
+    # Single variable output
+    if not isinstance(vars, (list, tuple)):
+        drawn_values = (draw_fn() for _ in range(draws))
+        return np.stack(drawn_values)
+
+    # Multiple variable output
+    drawn_values = zip(*(draw_fn() for _ in range(draws)))
+    return [np.stack(v) for v in drawn_values]
 
 
 def _init_jitter(

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -27,6 +27,7 @@ import pytest
 from aesara import shared
 from arviz import InferenceData
 from arviz import from_dict as az_from_dict
+from numpy.testing._private.utils import assert_array_equal
 from scipy import stats
 
 import pymc as pm
@@ -1216,25 +1217,21 @@ def test_sample_deterministic():
 
 class TestDraw(SeededTest):
     def test_draw_one_variable(self):
-
-        with pm.Model() as model:
+        with pm.Model():
             x = pm.Normal("x")
 
         x_draws = pm.draw(x)
-        assert x_draws["x"].shape == (500,)
+        assert x_draws.shape == (1,)
 
-    def test_draw_one_variable_with_number_draws(self):
-
-        with pm.Model() as model:
+        with pm.Model():
             x = pm.Normal("x")
 
         num_draws = 100
         x_draws = pm.draw(x, draws=num_draws)
-        assert x_draws["x"].shape == (num_draws,)
+        assert x_draws.shape == (num_draws,)
 
-    def test_draw_variables(self):
-
-        with pm.Model() as model:
+    def test_draw_several_variables(self):
+        with pm.Model():
             x = pm.Normal("x")
             y = pm.Normal("y", shape=10)
             z = pm.Uniform("z", shape=5)
@@ -1242,28 +1239,28 @@ class TestDraw(SeededTest):
         num_draws = 1000
         # Draw samples of a list variables
         draws = pm.draw([x, y, z], draws=num_draws)
-        assert draws["x"].shape == (num_draws,)
-        assert draws["y"].shape == (num_draws, 10)
-        assert draws["z"].shape == (num_draws, 5)
+        assert draws[0].shape == (num_draws,)
+        assert draws[1].shape == (num_draws, 10)
+        assert draws[2].shape == (num_draws, 5)
 
         # Draw samples of a tuple variables
         draws = pm.draw((x, y, z), draws=num_draws)
-        assert draws["x"].shape == (num_draws,)
-        assert draws["y"].shape == (num_draws, 10)
-        assert draws["z"].shape == (num_draws, 5)
+        assert draws[0].shape == (num_draws,)
+        assert draws[1].shape == (num_draws, 10)
+        assert draws[2].shape == (num_draws, 5)
 
     def test_multivariate(self):
-        with pm.Model() as model:
+        with pm.Model():
             mln = pm.Multinomial("mln", n=5, p=np.array([0.25, 0.25, 0.25, 0.25]))
 
         mln_draws = pm.draw(mln, draws=100)
-        assert mln_draws != (100, 4)
+        assert mln_draws.shape == (100, 4)
 
-    def test_shape_edgecase(self):
+    def test_draw_different_samples(self):
         with pm.Model():
-            mu = pm.Normal("mu", size=5)
-            sd = pm.Uniform("sd", lower=2, upper=3)
-            x = pm.Normal("x", mu=mu, sigma=sd, size=5)
+            x = pm.Normal("x")
 
-        x_draws = pm.draw(x, draws=50)
-        assert x_draws["x"].shape == (50, 5)
+        x_draws_1 = pm.draw(x, 100)
+        x_draws_2 = pm.draw(x, 100)
+        # Check if the draw function will draw different samples each time
+        npt.assert_raises(AssertionError, assert_array_equal, x_draws_1, x_draws_2)

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -1215,7 +1215,6 @@ def test_sample_deterministic():
 
 
 class TestDraw(SeededTest):
-
     def test_draw_one_variable(self):
 
         with pm.Model() as model:
@@ -1224,16 +1223,14 @@ class TestDraw(SeededTest):
         x_draws = pm.draw(x)
         assert x_draws["x"].shape == (500,)
 
-
     def test_draw_one_variable_with_number_draws(self):
 
         with pm.Model() as model:
             x = pm.Normal("x")
 
-        num_draws = 100            
+        num_draws = 100
         x_draws = pm.draw(x, draws=num_draws)
         assert x_draws["x"].shape == (num_draws,)
-
 
     def test_draw_variables(self):
 
@@ -1243,33 +1240,30 @@ class TestDraw(SeededTest):
             z = pm.Uniform("z", shape=5)
 
         num_draws = 1000
-        # Draw samples of a list variables            
+        # Draw samples of a list variables
         draws = pm.draw([x, y, z], draws=num_draws)
         assert draws["x"].shape == (num_draws,)
         assert draws["y"].shape == (num_draws, 10)
         assert draws["z"].shape == (num_draws, 5)
 
-        # Draw samples of a tuple variables            
+        # Draw samples of a tuple variables
         draws = pm.draw((x, y, z), draws=num_draws)
         assert draws["x"].shape == (num_draws,)
         assert draws["y"].shape == (num_draws, 10)
         assert draws["z"].shape == (num_draws, 5)
 
-
     def test_multivariate(self):
         with pm.Model() as model:
             mln = pm.Multinomial("mln", n=5, p=np.array([0.25, 0.25, 0.25, 0.25]))
-            
+
         mln_draws = pm.draw(mln, draws=100)
         assert mln_draws != (100, 4)
-
 
     def test_shape_edgecase(self):
         with pm.Model():
             mu = pm.Normal("mu", size=5)
             sd = pm.Uniform("sd", lower=2, upper=3)
             x = pm.Normal("x", mu=mu, sigma=sd, size=5)
-        
+
         x_draws = pm.draw(x, draws=50)
         assert x_draws["x"].shape == (50, 5)
-

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -27,7 +27,6 @@ import pytest
 from aesara import shared
 from arviz import InferenceData
 from arviz import from_dict as az_from_dict
-from numpy.testing._private.utils import assert_array_equal
 from scipy import stats
 
 import pymc as pm
@@ -1223,13 +1222,6 @@ class TestDraw(SeededTest):
         x_draws = pm.draw(x)
         assert x_draws.shape == (1,)
 
-        with pm.Model():
-            x = pm.Normal("x")
-
-        num_draws = 100
-        x_draws = pm.draw(x, draws=num_draws)
-        assert x_draws.shape == (num_draws,)
-
     def test_draw_several_variables(self):
         with pm.Model():
             x = pm.Normal("x")
@@ -1263,4 +1255,4 @@ class TestDraw(SeededTest):
         x_draws_1 = pm.draw(x, 100)
         x_draws_2 = pm.draw(x, 100)
         # Check if the draw function will draw different samples each time
-        npt.assert_raises(AssertionError, assert_array_equal, x_draws_1, x_draws_2)
+        assert not np.all(np.isclose(x_draws_1, x_draws_2))


### PR DESCRIPTION
Hi @ricardoV94 

I have created helper pm.draw() to take draws for a given variable or several variables, to address the issue #5311 
The draw function is stored in pymc/sampling.py along with docstring and examples.
The test cases are added in class TestDraw in pymc/tests/tests_sampling.py

Please let me know if there is anything needed to update.

Thank you.

Closes #5311