### PR TITLE
Removed packaging dependency in data.py

### DIFF
--- a/pymc/data.py
+++ b/pymc/data.py
@@ -31,7 +31,6 @@ from aesara.compile.sharedvalue import SharedVariable
 from aesara.graph.basic import Apply
 from aesara.tensor.type import TensorType
 from aesara.tensor.var import TensorConstant, TensorVariable
-from packaging import version
 
 import pymc as pm
 
@@ -635,8 +634,8 @@ def Data(
     arr = pandas_to_array(value)
 
     if mutable is None:
-        current = version.Version(pm.__version__)
-        mutable = current.major == 4 and current.minor < 1
+        major, minor = [int(v) for v in pm.__version__.split(".")[:2]]
+        mutable = major == 4 and minor < 1
         if mutable:
             warnings.warn(
                 "The `mutable` kwarg was not specified. Currently it defaults to `pm.Data(mutable=True)`,"

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -634,7 +634,7 @@ def Data(
     arr = pandas_to_array(value)
 
     if mutable is None:
-        major, minor = [int(v) for v in pm.__version__.split(".")[:2]]
+        major, minor = (int(v) for v in pm.__version__.split(".")[:2])
         mutable = major == 4 and minor < 1
         if mutable:
             warnings.warn(


### PR DESCRIPTION
This removes the dependency on the `packaging` library, as it is used in a single location to generate a warning for a transient condition. Replaced it with a manual parse of `pm.__version__`

Closes #5342 