### PR TITLE
Bump for 4.0.0b2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ focusing on advanced Markov chain Monte Carlo (MCMC) and variational inference (
 algorithms. Its flexibility and extensibility make it applicable to a
 large suite of problems.
 
-Check out the `PyMC overview <https://docs.pymc.io/en/stable/learn/examples/pymc_overview.html>`__,  or
+Check out the `PyMC overview <https://docs.pymc.io/en/latest/learn/examples/pymc_overview.html>`__,  or
 `interact with live examples <https://mybinder.org/v2/gh/pymc-devs/pymc/main?filepath=%2Fdocs%2Fsource%2Fnotebooks>`__
 using Binder!
 For questions on PyMC, head on over to our `PyMC Discourse <https://discourse.pymc.io/>`__ forum.
@@ -29,7 +29,7 @@ Features
    for large data sets.
 -  Relies on `Aesara <https://aesara.readthedocs.io/en/latest/>`__ which provides:
     *  Computation optimization and dynamic C or JAX compilation
-    *  Numpy broadcasting and advanced indexing
+    *  NumPy broadcasting and advanced indexing
     *  Linear algebra operators
     *  Simple extensibility
 -  Transparent support for missing value imputation
@@ -41,7 +41,7 @@ If you already know about Bayesian statistics:
 ----------------------------------------------
 
 -  `API quickstart guide <https://docs.pymc.io/en/stable/pymc-examples/examples/pymc3_howto/api_quickstart.html>`__
--  The `PyMC tutorial <https://docs.pymc.io/en/stable/learn/examples/pymc_overview.html>`__
+-  The `PyMC tutorial <https://docs.pymc.io/en/latest/learn/examples/pymc_overview.html>`__
 -  `PyMC examples <https://docs.pymc.io/nb_examples/index.html>`__ and the `API reference <https://docs.pymc.io/en/stable/api.html>`__
 
 Learn Bayesian statistics with a book together with PyMC

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,7 +7,7 @@ Instead update the vNext section until 4.0.0 is out.
 ⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠
 -->
 
-## PyMC vNext (4.0.0b1 → 4.0.0b2 → 4.0.0)
+## PyMC vNext (4.0.0b1 → 4.0.0b2 → 4.0.0b3 → 4.0.0)
 ⚠ The changes below are the delta between the upcoming releases `v3.11.5` →...→ `v4.0.0`.
 
 ### No-yet working features

--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # pylint: disable=wildcard-import
-__version__ = "4.0.0b1"
+__version__ = "4.0.0b2"
 
 import logging
 import multiprocessing as mp


### PR DESCRIPTION
I fixed two links in the readme that were broken.

⚠ The links in the readme point to a mix between v3 and v4 documentation, but for the ones I changed I didn't find good v3 targets.