### PR TITLE
tighten test_normal_scalar bound

### DIFF
--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -508,7 +508,7 @@ class TestSamplePPC(SeededTest):
             assert ppc["a"].shape == (nchains * ndraws,)
             # mu's standard deviation may have changed thanks to a's observed
             _, pval = stats.kstest(ppc["a"] - trace["mu"], stats.norm(loc=0, scale=1).cdf)
-            assert pval > 0.001
+            assert pval > 0.01
 
         # size argument not introduced to fast version [2019/08/20:rpg]
         with model:


### PR DESCRIPTION
Hi,

The test `test_normal_scalar` in `test_sampling.py` has an assertion bound (`assert pval > 0.001`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. Each mutant is generated using simple mutation operators (e.g. > can become < ) on source code covered by the test. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/149836829-f7c3901e-a09b-48b9-8dda-3e2772b04e63.png" width="450">
</p>

Here we see that the bound of `0.001` is too loose since the original distribution (in orange) is higher than `0.001`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are above the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/149836857-b9105fd5-c8d4-4214-87f2-9d00ba06a24c.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `0.001` (red dotted line) has a catch rate of 0.14.

To improve this test, I propose to tighten the bound to `0.01` (the blue dotted line). The new bound has a catch rate of 0.16 (+0.02 increase compare to original) while still has >99 % pass rate (test is not flaky, I ran the updated test 500 times and observed >99 % pass rate). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.7.11
numpy=1.21.4
```

my pymc Experiment SHA:
`19e67f371d4641fd2f9ad7c8a7887361bdaa53d6`

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [ ] important background, or details about the implementation
+ [ ] are the changes—especially new features—covered by tests and docstrings?
+ [ ] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
