### PR TITLE
 Remove automatic normalization in Multinomial and Categorical #5331 

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -145,6 +145,7 @@ This includes API changes we did not warn about since at least `3.11.0` (2021-01
 - `math.log1mexp` and `math.log1mexp_numpy` will expect negative inputs in the future. A `FutureWarning` is now raised unless `negative_input=True` is set (see [#4860](https://github.com/pymc-devs/pymc/pull/4860)).
 - Changed name of `Lognormal` distribution to `LogNormal` to harmonize CamelCase usage for distribution names.
 - Attempt to iterate over MultiTrace will raise NotImplementedError.
+- Removed silent normalisation of `p` parameters in Categorical and Multinomial distributions (see [#5370](https://github.com/pymc-devs/pymc/pull/5370)).
 - ...
 
 

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -2189,19 +2189,43 @@ class TestMatchesScipy:
             lambda value, n, p: scipy.stats.multinomial.logpmf(value, n, p),
         )
 
-    def test_multinomial_invalid(self):
-        # Test non-scalar invalid parameters/values
-        value = np.array([[1, 2, 2], [4, 0, 1]])
-
-        invalid_dist = Multinomial.dist(n=5, p=[-1, 1, 1], size=2)
-        # TODO: Multinomial normalizes p, so it is impossible to trigger p checks
-        # with pytest.raises(ParameterValueError):
-        with does_not_raise():
-            pm.logp(invalid_dist, value).eval()
-
-        value[1] -= 1
+    def test_multinomial_invalid_value(self):
+        # Test passing non-scalar invalid parameters/values to an otherwise valid Multinomial,
+        # evaluates to -inf
+        value = np.array([[1, 2, 2], [3, -1, 0]])
         valid_dist = Multinomial.dist(n=5, p=np.ones(3) / 3)
         assert np.all(np.isfinite(pm.logp(valid_dist, value).eval()) == np.array([True, False]))
+
+    def test_multinomial_negative_p(self):
+        # test passing a list/numpy with negative p raises an immediate error
+        with pytest.raises(ValueError, match="[-1, 1, 1]"):
+            with Model() as model:
+                x = Multinomial("x", n=5, p=[-1, 1, 1])
+
+    def test_multinomial_p_not_normalized(self):
+        # test UserWarning is raised for p vals that sum to more than 1
+        # and normaliation is triggered
+        with pytest.warns(UserWarning, match="[5]"):
+            with pm.Model() as m:
+                x = pm.Multinomial("x", n=5, p=[1, 1, 1, 1, 1])
+        # test stored p-vals have been normalised
+        assert np.isclose(m.x.owner.inputs[4].sum().eval(), 1.0)
+
+    def test_multinomial_negative_p_symbolic(self):
+        # Passing symbolic negative p does not raise an immediate error, but evaluating
+        # logp raises a ParameterValueError
+        with pytest.raises(ParameterValueError):
+            value = np.array([[1, 1, 1]])
+            invalid_dist = pm.Multinomial.dist(n=1, p=at.as_tensor_variable([-1, 0.5, 0.5]))
+            pm.logp(invalid_dist, value).eval()
+
+    def test_multinomial_p_not_normalized_symbolic(self):
+        # Passing symbolic p that do not add up to on does not raise any warning, but evaluating
+        # logp raises a ParameterValueError
+        with pytest.raises(ParameterValueError):
+            value = np.array([[1, 1, 1]])
+            invalid_dist = pm.Multinomial.dist(n=1, p=at.as_tensor_variable([1, 0.5, 0.5]))
+            pm.logp(invalid_dist, value).eval()
 
     @pytest.mark.parametrize("n", [(10), ([10, 11]), ([[5, 6], [10, 11]])])
     @pytest.mark.parametrize(
@@ -2317,12 +2341,22 @@ class TestMatchesScipy:
             np.array([-1, -1, 0, 0]),
         ],
     )
-    def test_categorical_valid_p(self, p):
-        with Model():
-            x = Categorical("x", p=p)
+    def test_categorical_negative_p(self, p):
+        with pytest.raises(ValueError, match=f"{p}"):
+            with Model():
+                x = Categorical("x", p=p)
 
-            with pytest.raises(ParameterValueError):
-                logp(x, 2).eval()
+    def test_categorical_negative_p_symbolic(self):
+        with pytest.raises(ParameterValueError):
+            value = np.array([[1, 1, 1]])
+            invalid_dist = pm.Categorical.dist(p=at.as_tensor_variable([-1, 0.5, 0.5]))
+            pm.logp(invalid_dist, value).eval()
+
+    def test_categorical_p_not_normalized_symbolic(self):
+        with pytest.raises(ParameterValueError):
+            value = np.array([[1, 1, 1]])
+            invalid_dist = pm.Categorical.dist(p=at.as_tensor_variable([2, 2, 2]))
+            pm.logp(invalid_dist, value).eval()
 
     @pytest.mark.parametrize("n", [2, 3, 4])
     def test_categorical(self, n):
@@ -2332,6 +2366,14 @@ class TestMatchesScipy:
             {"p": Simplex(n)},
             lambda value, p: categorical_logpdf(value, p),
         )
+
+    def test_categorical_p_not_normalized(self):
+        # test UserWarning is raised for p vals that sum to more than 1
+        # and normaliation is triggered
+        with pytest.warns(UserWarning, match="[5]"):
+            with pm.Model() as m:
+                x = pm.Categorical("x", p=[1, 1, 1, 1, 1])
+        assert np.isclose(m.x.owner.inputs[3].sum().eval(), 1.0)
 
     @pytest.mark.parametrize("n", [2, 3, 4])
     def test_orderedlogistic(self, n):

--- a/pymc/tests/test_idata_conversion.py
+++ b/pymc/tests/test_idata_conversion.py
@@ -531,6 +531,7 @@ class TestDataPyMC:
         data = np.random.multinomial(20, [0.2, 0.3, 0.5], size=20)
         with pm.Model(coords=coords):
             p = pm.Beta("p", 1, 1, size=(3,))
+            p = p / p.sum()
             pm.Multinomial("y", 20, p, dims=("experiment", "direction"), observed=data)
             idata = pm.sample(draws=50, chains=2, tune=100, return_inferencedata=True)
         test_dict = {


### PR DESCRIPTION
This PR removes the silent normalisation of p-values passed to a distribution. Instead, a UserWarning is raised when p-values do not sum to 1.0 and then normlisation is done. Examples are highlighted below:
```python
with pm.Model() as m:
    x = pm.Multinomial('x', n=5, p=[1,1,1,1,1])
```
> UserWarning: p values sum up to [5], instead of 1.0. They will be automatically rescaled. You can rescale them directly to get rid of this warning.
```python
with pm.Model() as m:
    x = pm.Categorical('x', p=[2,2,2,2,2])
```
> UserWarning: p values sum up to [10], instead of 1.0. They will be automatically rescaled. You can rescale them directly to get rid of this warning.

In addition, after discussion with @ricardoV94 negative p-values now raise a ValueError:

```python
with pm.Model() as model:
    x = pm.Multinomial("x", n = 5, p=[-1, 1, 1])
```
> ValueError: Negative probabilities are not valid

```python
with pm.Model() as model:
    x = pm.Categorical("x", p=[-1, 1, 1])
```
> ValueError: Negative probabilities are not valid

### Changes in this PR
- UserWarning is now raised when p-values passed which do not sum to 1.0. (Both Categorical and Multinomial)
- Normalisation of p-values in Categorical moved out of logp() to dist(). (Categorical only)
- ValueError is now raised when a negative p-value is passed. (Both Categorical and Multinomial)
- Changes to tests_distributions.py:
   - test_categorical_valid_p() and test_multinomial_invalid() now test whether a ValueError is raised using negative p-values during variable creation.
   - Two new tests have been written to check that a UserWarning is raised when using p-values that don't sum to 1.0. 

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes?
+ [x] important background, or details about the implementation
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples) I'm unsure whether this relevant for a PR like this?
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
