### PR TITLE
Add additional compiler flag to work around GCC bug.

### DIFF
--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -82,10 +82,16 @@ def __set_compiler_flags():
     # Workarounds for Theano compiler problems on various platforms
     current = theano.config.gcc__cxxflags
     augmented = f"{current} -Wno-c++11-narrowing"
+
     # Work around compiler bug in GCC < 8.4 related to structured exception
     # handling registers on Windows.
     # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782 for details.
-    augmented = f"{augmented} -fno-asynchronous-unwind-tables"
+    # First disable C++ exception handling altogether since it's not needed
+    # for the C extensions that we generate.
+    augmented = f"{augmented} -fno-exceptions"
+    # Now disable the generation of stack unwinding tables.
+    augmented = f"{augmented} -fno-unwind-tables -fno-asynchronous-unwind-tables"
+
     theano.config.gcc__cxxflags = augmented
 
 

--- a/pymc3/__init__.py
+++ b/pymc3/__init__.py
@@ -81,7 +81,12 @@ def _check_backend_version():
 def __set_compiler_flags():
     # Workarounds for Theano compiler problems on various platforms
     current = theano.config.gcc__cxxflags
-    theano.config.gcc__cxxflags = f"{current} -Wno-c++11-narrowing"
+    augmented = f"{current} -Wno-c++11-narrowing"
+    # Work around compiler bug in GCC < 8.4 related to structured exception
+    # handling registers on Windows.
+    # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782 for details.
+    augmented = f"{augmented} -fno-asynchronous-unwind-tables"
+    theano.config.gcc__cxxflags = augmented
 
 
 def _hotfix_theano_printing():


### PR DESCRIPTION
Work around compiler bug in GCC < 8.4 related to structured exception handling registers on Windows.
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782 for details.

Addresses compiler failure issues as described in #4937. This change is applied to the v3 branch.

This fix was tested on an Intel Xeon W-2125 processor where previous compile errors were observed with GCC 5.3.0. This fix resolved the compile errors.
