### PR TITLE
Switch GitHub Actions to install environments with mamba #5375

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -134,6 +134,8 @@ jobs:
             hashFiles('requirements.txt') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          mamba-version: "*"
+          use-mamba: true
           activate-environment: pymc-test-py37
           channel-priority: strict
           environment-file: conda-envs/environment-test-py37.yml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -218,9 +218,13 @@ jobs:
             hashFiles('requirements.txt') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          mamba-version: "*"
           activate-environment: pymc-test-py38
           channel-priority: strict
           environment-file: conda-envs/windows-environment-test-py38.yml
+          use-mamba: true
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Install-pymc
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -134,11 +134,13 @@ jobs:
             hashFiles('requirements.txt') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           mamba-version: "*"
-          use-mamba: true
           activate-environment: pymc-test-py37
           channel-priority: strict
           environment-file: conda-envs/environment-test-py37.yml
+          use-mamba: true
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Install-pymc
         run: |


### PR DESCRIPTION
This PR makes the Github actions to install conda environments using `mamba` for both `windows` and `ubuntu` builds.
Solves the issue #5375.

**Changes in this PR**
- Used `Mambaforge` to do the job `conda-incubator/setup-miniconda@v2` in ubuntu and windows build.
- In `pytest.yml`, added the below code in both ubuntu and windows build.
```
- uses: conda-incubator/setup-miniconda@v2
        with:
          miniforge-variant: Mambaforge
          miniforge-version: latest
          mamba-version: "*"
          activate-environment: pymc-test-py37
          channel-priority: strict
          environment-file: conda-envs/environment-test-py37.yml
          use-mamba: true
          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
```
- This change downloads and installs the environment around 30 to 40 seconds faster in both builds.
- The build times after these changes can be viewed at https://github.com/parthb83/pymc/actions/runs/1745581196

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes?
+ [x] important background, or details about the implementation
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [x] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
