### PR TITLE
Added blas to conda dev envs

### DIFF
--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -7,6 +7,7 @@ dependencies:
 - aeppl=0.0.18
 - aesara=2.3.6
 - arviz>=0.11.4
+- blas
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -7,6 +7,7 @@ dependencies:
 - aeppl=0.0.18
 - aesara=2.3.6
 - arviz>=0.11.4
+- blas
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -7,6 +7,7 @@ dependencies:
 - aeppl=0.0.18
 - aesara=2.3.6
 - arviz>=0.11.4
+- blas
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0


### PR DESCRIPTION
Running 4.0.0b2 on Linux generates a warning about missing blas header. It even appears on [the current overview notebook on the rendered docs](https://docs.pymc.io/en/latest/learn/examples/pymc_overview.html).

![image](https://user-images.githubusercontent.com/81476/151242663-10388128-68e6-47ed-a988-6958f8643856.png)

Installing blas from conda resolves the issue for me, so I'm adding it to the dev conda envs.