### PR TITLE
Temporarily pin upper numpydoc version

### DIFF
--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -14,7 +14,7 @@ dependencies:
 - ipython
 - myst-nb
 - numpy>=1.15
-- numpydoc>=0.9
+- numpydoc<1.2
 - pandas>=0.24
 - pip
 - pre-commit>=2.8.0

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -14,7 +14,7 @@ dependencies:
 - ipython
 - myst-nb
 - numpy>=1.15.0
-- numpydoc>=0.9
+- numpydoc<1.2
 - pandas>=0.24.0
 - pip
 - pre-commit>=2.8.0

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -14,7 +14,7 @@ dependencies:
 - ipython
 - myst-nb
 - numpy>=1.15.0
-- numpydoc>=0.9
+- numpydoc<1.2
 - pandas
 - pip
 - pre-commit>=2.8.0

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -21,7 +21,7 @@ dependencies:
 # Extra stuff for dev, testing and docs build
 - ipython
 - myst-nb
-- numpydoc>=0.9
+- numpydoc<1.2
 - pre-commit>=2.8.0
 - pydata-sphinx-theme
 - pytest-cov>=2.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ h5py>=2.7
 ipython
 myst-nb
 numpy>=1.15.0
-numpydoc>=0.9
+numpydoc<1.2
 pandas
 polyagamma
 pre-commit>=2.8.0


### PR DESCRIPTION
To fix the docs build and unblock open PRs.

Tracking issue https://github.com/pymc-devs/pymc/issues/5401