### PR TITLE
Disable C++ exception handling

### DIFF
--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -34,10 +34,16 @@ def __set_compiler_flags():
 
     current = aesara.config.gcc__cxxflags
     augmented = f"{current} -Wno-c++11-narrowing"
+
     # Work around compiler bug in GCC < 8.4 related to structured exception
     # handling registers on Windows.
     # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782 for details.
-    augmented = f"{augmented} -fno-asynchronous-unwind-tables"
+    # First disable C++ exception handling altogether since it's not needed
+    # for the C extensions that we generate.
+    augmented = f"{augmented} -fno-exceptions"
+    # Now disable the generation of stack unwinding tables.
+    augmented = f"{augmented} -fno-unwind-tables -fno-asynchronous-unwind-tables"
+
     aesara.config.gcc__cxxflags = augmented
 
 


### PR DESCRIPTION
Update GCC compiler options to disable C++ exception handling altogether.
Also disable the creation of stack unwinding tables since these will not be
required without exceptions enabled.

This should be considered an interim solution to the compiler bugs on Windows until a better C++ compiler situation can be found. It should make it much simpler for new Windows users to get a working PyMC by allowing `conda` to install the MinGW C++ compiler.

Addresses #4937, specifically https://github.com/pymc-devs/pymc/issues/4937#issuecomment-1021352178, for the main branch.
