### PR TITLE
remove self from core devs list

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -198,7 +198,6 @@ Contributors don't need to be part of any dedicated team.
 * George Ho (dev)
 * Junpeng Lao (dev, discourse)
 * Luciano Paz (dev - PyMC Labs)
-* Marco E. Gorelli (dev, docs)
 * Martina Cantaro (docs)
 * Maxim Kochurov (dev - PyMC Labs)
 * Meenal Jhajharia (docs)


### PR DESCRIPTION
Hey y'all :wave: 

I just saw my name in the governance doc under "core devs" - I hadn't realise I'd been added (I'd originally been invited to join as triager)

Although I'd like to think I've been helpful, I don't think anything I've done warrants being made core dev. Furthermore, I've not been active in the core codebase for > 1 year

I'd like to emphasise that I'm still happy to help out with occasional reviews and docs, and that I have a huge amount of respect for the PyMC project and its community - I just don't think I belong on this list


**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [ ] important background, or details about the implementation
+ [ ] are the changes—especially new features—covered by tests and docstrings?
+ [ ] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
