### PR TITLE
reset TestSamplePPC bound to original value

### DIFF
--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -508,7 +508,7 @@ class TestSamplePPC(SeededTest):
             assert ppc["a"].shape == (nchains * ndraws,)
             # mu's standard deviation may have changed thanks to a's observed
             _, pval = stats.kstest(ppc["a"] - trace["mu"], stats.norm(loc=0, scale=1).cdf)
-            assert pval > 0.01
+            assert pval > 0.001
 
         # size argument not introduced to fast version [2019/08/20:rpg]
         with model:


### PR DESCRIPTION
The bound for `TestSamplePPC` is reset to 0.001 (original value). Address Issue #5411

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [ ] important background, or details about the implementation
+ [ ] are the changes—especially new features—covered by tests and docstrings?
+ [ ] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
