### PR TITLE
fix: check the output type of ode_func

### DIFF
--- a/pymc/ode/utils.py
+++ b/pymc/ode/utils.py
@@ -108,7 +108,9 @@ def augment_system(ode_func, n_states, n_theta):
     else:
         # Stack the results of the ode_func into a single tensor variable
         if not isinstance(yhat, (list, tuple)):
-            yhat = (yhat,)
+            raise TypeError(
+                f"Unexpected type, {type(yhat)}, returned by ode_func. TensorVariable, list or tuple is expected."
+            )
         t_yhat = at.stack(yhat, axis=0)
     if t_yhat.ndim > 1:
         raise ValueError(

--- a/pymc/ode/utils.py
+++ b/pymc/ode/utils.py
@@ -110,7 +110,9 @@ def augment_system(ode_func, n_states, n_theta):
         else:
             t_yhat = yhat
     elif isinstance(yhat, np.ndarray):
-        t_yhat = at.shared(yhat)
+        msg = f'Invalid Output type for odefunc: {type(yhat)}.\n'
+        msg += 'Valid output types are list, tuple, or at.TensorVariable.'
+        raise TypeError(msg)
     else:
         # Stack the results of the ode_func into a single tensor variable
         if not isinstance(yhat, (list, tuple)):

--- a/pymc/ode/utils.py
+++ b/pymc/ode/utils.py
@@ -107,11 +107,15 @@ def augment_system(ode_func, n_states, n_theta):
         if yhat.ndim == 0:
             # Convert yhat from scalar to array
             t_yhat = at.stack((yhat,), axis=0)
-        else:
+        elif yhat.ndim == 1:
             t_yhat = yhat
+        else:
+            raise ValueError(
+                f"The odefunc returned a {yhat.ndim}-dimensional tensor, but 0 or 1 dimensions were expected."
+            )
     elif isinstance(yhat, np.ndarray):
-        msg = f'Invalid Output type for odefunc: {type(yhat)}.\n'
-        msg += 'Valid output types are list, tuple, or at.TensorVariable.'
+        msg = f"Invalid Output type for odefunc: {type(yhat)}.\n"
+        msg += "Valid output types are list, tuple, or at.TensorVariable."
         raise TypeError(msg)
     else:
         # Stack the results of the ode_func into a single tensor variable

--- a/pymc/ode/utils.py
+++ b/pymc/ode/utils.py
@@ -105,15 +105,15 @@ def augment_system(ode_func, n_states, n_theta):
     yhat = ode_func(t_y, t_t, t_p[n_states:])
     if isinstance(yhat, at.TensorVariable):
         t_yhat = at.atleast_1d(yhat)
-        if t_yhat.ndim > 1:
-            raise ValueError(
-                f"The odefunc returned a {yhat.ndim}-dimensional tensor, but 0 or 1 dimensions were expected."
-            )
     else:
         # Stack the results of the ode_func into a single tensor variable
         if not isinstance(yhat, (list, tuple)):
             yhat = (yhat,)
         t_yhat = at.stack(yhat, axis=0)
+    if t_yhat.ndim > 1:
+        raise ValueError(
+            f"The odefunc returned a {yhat.ndim}-dimensional tensor, but 0 or 1 dimensions were expected."
+        )
 
     # Now compute gradients
     J = at.jacobian(t_yhat, t_y)

--- a/pymc/ode/utils.py
+++ b/pymc/ode/utils.py
@@ -103,10 +103,15 @@ def augment_system(ode_func, n_states, n_theta):
 
     # Get symbolic representation of the ODEs by passing tensors for y, t and theta
     yhat = ode_func(t_y, t_t, t_p[n_states:])
-    # Stack the results of the ode_func into a single tensor variable
-    if not isinstance(yhat, (list, tuple)):
-        yhat = (yhat,)
-    t_yhat = at.stack(yhat, axis=0)
+    if isinstance(yhat, at.TensorVariable):
+        t_yhat = yhat
+    elif isinstance(yhat, np.ndarray):
+        t_yhat = at.shared(yhat)
+    else:
+        # Stack the results of the ode_func into a single tensor variable
+        if not isinstance(yhat, (list, tuple)):
+            yhat = (yhat,)
+        t_yhat = at.stack(yhat, axis=0)
 
     # Now compute gradients
     J = at.jacobian(t_yhat, t_y)

--- a/pymc/ode/utils.py
+++ b/pymc/ode/utils.py
@@ -112,7 +112,7 @@ def augment_system(ode_func, n_states, n_theta):
         t_yhat = at.stack(yhat, axis=0)
     if t_yhat.ndim > 1:
         raise ValueError(
-            f"The odefunc returned a {yhat.ndim}-dimensional tensor, but 0 or 1 dimensions were expected."
+            f"The odefunc returned a {t_yhat.ndim}-dimensional tensor, but 0 or 1 dimensions were expected."
         )
 
     # Now compute gradients

--- a/pymc/ode/utils.py
+++ b/pymc/ode/utils.py
@@ -113,10 +113,6 @@ def augment_system(ode_func, n_states, n_theta):
             raise ValueError(
                 f"The odefunc returned a {yhat.ndim}-dimensional tensor, but 0 or 1 dimensions were expected."
             )
-    elif isinstance(yhat, np.ndarray):
-        msg = f"Invalid Output type for odefunc: {type(yhat)}.\n"
-        msg += "Valid output types are list, tuple, or at.TensorVariable."
-        raise TypeError(msg)
     else:
         # Stack the results of the ode_func into a single tensor variable
         if not isinstance(yhat, (list, tuple)):

--- a/pymc/ode/utils.py
+++ b/pymc/ode/utils.py
@@ -104,7 +104,11 @@ def augment_system(ode_func, n_states, n_theta):
     # Get symbolic representation of the ODEs by passing tensors for y, t and theta
     yhat = ode_func(t_y, t_t, t_p[n_states:])
     if isinstance(yhat, at.TensorVariable):
-        t_yhat = yhat
+        if yhat.ndim == 0:
+            # Convert yhat from scalar to array
+            t_yhat = at.stack((yhat,), axis=0)
+        else:
+            t_yhat = yhat
     elif isinstance(yhat, np.ndarray):
         t_yhat = at.shared(yhat)
     else:

--- a/pymc/ode/utils.py
+++ b/pymc/ode/utils.py
@@ -104,12 +104,8 @@ def augment_system(ode_func, n_states, n_theta):
     # Get symbolic representation of the ODEs by passing tensors for y, t and theta
     yhat = ode_func(t_y, t_t, t_p[n_states:])
     if isinstance(yhat, at.TensorVariable):
-        if yhat.ndim == 0:
-            # Convert yhat from scalar to array
-            t_yhat = at.stack((yhat,), axis=0)
-        elif yhat.ndim == 1:
-            t_yhat = yhat
-        else:
+        t_yhat = at.atleast_1d(yhat)
+        if t_yhat.ndim > 1:
             raise ValueError(
                 f"The odefunc returned a {yhat.ndim}-dimensional tensor, but 0 or 1 dimensions were expected."
             )

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -165,7 +165,9 @@ class TestSensitivityInitialCondition:
             return at.concatenate([ds, di], axis=0)
 
         # Instantiate ODE model
-        model4_t = DifferentialEquation(func=ode_func_4_t, t0=0, times=self.t, n_states=2, n_theta=2)
+        model4_t = DifferentialEquation(
+            func=ode_func_4_t, t0=0, times=self.t, n_states=2, n_theta=2
+        )
 
         model4_sens_ic_t = np.array([1, 0, 0, 0, 0, 1, 0, 0])
 

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -234,7 +234,6 @@ class TestErrors:
 
     times = np.arange(0, 9)
 
-    print(type(system))
     ode_model = DifferentialEquation(func=system.__func__, t0=0, times=times, n_states=1, n_theta=1)
 
     @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -280,7 +280,7 @@ class TestErrors:
         return [[s,s], [s,s]]
 
     def test_list_shape(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="returned a 2-dimensional tensor"):
             DifferentialEquation(func=self.system_2d_list, t0=0, times=self.times, n_states=1, n_theta=0)
 
 

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -267,15 +267,6 @@ class TestErrors:
         with pytest.raises(ValueError):
             DifferentialEquation(func=self.system, t0=0, times=self.times, n_states=1, n_theta=0)
 
-    def system_2(y, t, p):
-        return np.array(np.exp(-t) - p[0] * y[0])
-
-    ode_model_2 = DifferentialEquation(func=system, t0=0, times=times, n_states=1, n_theta=1)
-
-    def test_output_numpy(self):
-        with pytest.raises(TypeError):
-            DifferentialEquation(func=self.system_2, t0=0, times=self.times, n_states=1, n_theta=1)
-
 
 class TestDiffEqModel:
     def test_op_equality(self):

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -231,9 +231,12 @@ class TestErrors:
     def setup_method(self, method):
         def system(y, t, p):
             return np.exp(-t) - p[0] * y[0]
+
         self.system = system
         self.times = np.arange(0, 9)
-        self.ode_model = DifferentialEquation(func=system, t0=0, times=self.times, n_states=1, n_theta=1)
+        self.ode_model = DifferentialEquation(
+            func=system, t0=0, times=self.times, n_states=1, n_theta=1
+        )
 
     @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_many_params(self):
@@ -271,15 +274,11 @@ class TestErrors:
 
     def test_number_of_states(self):
         with pytest.raises(ValueError, match="Argument n_states must be at least 1."):
-            DifferentialEquation(
-                func=self.system, t0=0, times=self.times, n_states=0, n_theta=1
-            )
+            DifferentialEquation(func=self.system, t0=0, times=self.times, n_states=0, n_theta=1)
 
     def test_number_of_params(self):
         with pytest.raises(ValueError, match="Argument n_theta must be positive"):
-            DifferentialEquation(
-                func=self.system, t0=0, times=self.times, n_states=1, n_theta=0
-            )
+            DifferentialEquation(func=self.system, t0=0, times=self.times, n_states=1, n_theta=0)
 
     def test_tensor_shape(self):
         with pytest.raises(ValueError, match="returned a 2-dimensional tensor"):

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -228,13 +228,12 @@ def test_logp_scalar_ode():
 class TestErrors:
     """Test running model for a scalar ODE with 1 parameter"""
 
-    @staticmethod
-    def system(y, t, p):
-        return np.exp(-t) - p[0] * y[0]
-
-    times = np.arange(0, 9)
-
-    ode_model = DifferentialEquation(func=system.__func__, t0=0, times=times, n_states=1, n_theta=1)
+    def setup_method(self, method):
+        def system(y, t, p):
+            return np.exp(-t) - p[0] * y[0]
+        self.system = system
+        self.times = np.arange(0, 9)
+        self.ode_model = DifferentialEquation(func=system, t0=0, times=self.times, n_states=1, n_theta=1)
 
     @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_many_params(self):
@@ -273,13 +272,13 @@ class TestErrors:
     def test_number_of_states(self):
         with pytest.raises(ValueError, match="Argument n_states must be at least 1."):
             DifferentialEquation(
-                func=TestErrors.system, t0=0, times=self.times, n_states=0, n_theta=1
+                func=self.system, t0=0, times=self.times, n_states=0, n_theta=1
             )
 
     def test_number_of_params(self):
         with pytest.raises(ValueError, match="Argument n_theta must be positive"):
             DifferentialEquation(
-                func=TestErrors.system, t0=0, times=self.times, n_states=1, n_theta=0
+                func=self.system, t0=0, times=self.times, n_states=1, n_theta=0
             )
 
     def test_tensor_shape(self):

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -272,7 +272,7 @@ class TestErrors:
         return at.stack((s, s, s, s)).reshape((2,2))
 
     def test_tensor_shape(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="returned a 2-dimensional tensor"):
             DifferentialEquation(func=self.system_2d_tensor, t0=0, times=self.times, n_states=1, n_theta=0)
 
     def system_2d_list(y, t, p):

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -238,22 +238,32 @@ class TestErrors:
 
     @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_many_params(self):
-        with pytest.raises(pm.ShapeError, match="Length of theta is wrong. \\(actual \\(2,\\) != expected \\(1,\\)\\)"):
+        with pytest.raises(
+            pm.ShapeError,
+            match="Length of theta is wrong. \\(actual \\(2,\\) != expected \\(1,\\)\\)",
+        ):
             self.ode_model(theta=[1, 1], y0=[0])
 
     @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_many_y0(self):
-        with pytest.raises(pm.ShapeError, match="Length of y0 is wrong. \\(actual \\(2,\\) != expected \\(1,\\)\\)"):
+        with pytest.raises(
+            pm.ShapeError, match="Length of y0 is wrong. \\(actual \\(2,\\) != expected \\(1,\\)\\)"
+        ):
             self.ode_model(theta=[1], y0=[0, 0])
 
     @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_few_params(self):
-        with pytest.raises(pm.ShapeError, match="Length of theta is wrong. \\(actual \\(0,\\) != expected \\(1,\\)\\)"):
+        with pytest.raises(
+            pm.ShapeError,
+            match="Length of theta is wrong. \\(actual \\(0,\\) != expected \\(1,\\)\\)",
+        ):
             self.ode_model(theta=[], y0=[1])
 
     @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_few_y0(self):
-        with pytest.raises(pm.ShapeError, match="Length of y0 is wrong. \\(actual \\(0,\\) != expected \\(1,\\)\\)"):
+        with pytest.raises(
+            pm.ShapeError, match="Length of y0 is wrong. \\(actual \\(0,\\) != expected \\(1,\\)\\)"
+        ):
             self.ode_model(theta=[1], y0=[])
 
     def test_func_callable(self):
@@ -262,31 +272,39 @@ class TestErrors:
 
     def test_number_of_states(self):
         with pytest.raises(ValueError, match="Argument n_states must be at least 1."):
-            DifferentialEquation(func=TestErrors.system, t0=0, times=self.times, n_states=0, n_theta=1)
+            DifferentialEquation(
+                func=TestErrors.system, t0=0, times=self.times, n_states=0, n_theta=1
+            )
 
     def test_number_of_params(self):
         with pytest.raises(ValueError, match="Argument n_theta must be positive"):
-            DifferentialEquation(func=TestErrors.system, t0=0, times=self.times, n_states=1, n_theta=0)
+            DifferentialEquation(
+                func=TestErrors.system, t0=0, times=self.times, n_states=1, n_theta=0
+            )
 
     def test_tensor_shape(self):
         with pytest.raises(ValueError, match="returned a 2-dimensional tensor"):
+
             def system_2d_tensor(y, t, p):
                 s0 = np.exp(-t) - p[0] * y[0]
                 s1 = np.exp(-t) - p[0] * y[1]
                 s2 = np.exp(-t) - p[0] * y[2]
                 s3 = np.exp(-t) - p[0] * y[3]
-                return at.stack((s0, s1, s2, s3)).reshape((2,2))
+                return at.stack((s0, s1, s2, s3)).reshape((2, 2))
 
-            DifferentialEquation(func=system_2d_tensor, t0=0, times=self.times, n_states=4, n_theta=1)
+            DifferentialEquation(
+                func=system_2d_tensor, t0=0, times=self.times, n_states=4, n_theta=1
+            )
 
     def test_list_shape(self):
         with pytest.raises(ValueError, match="returned a 2-dimensional tensor"):
+
             def system_2d_list(y, t, p):
                 s0 = np.exp(-t) - p[0] * y[0]
                 s1 = np.exp(-t) - p[0] * y[1]
                 s2 = np.exp(-t) - p[0] * y[2]
                 s3 = np.exp(-t) - p[0] * y[3]
-                return [[s0,s1], [s2,s3]]
+                return [[s0, s1], [s2, s3]]
 
             DifferentialEquation(func=system_2d_list, t0=0, times=self.times, n_states=4, n_theta=1)
 

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -228,12 +228,14 @@ def test_logp_scalar_ode():
 class TestErrors:
     """Test running model for a scalar ODE with 1 parameter"""
 
+    @staticmethod
     def system(y, t, p):
         return np.exp(-t) - p[0] * y[0]
 
     times = np.arange(0, 9)
 
-    ode_model = DifferentialEquation(func=system, t0=0, times=times, n_states=1, n_theta=1)
+    print(type(system))
+    ode_model = DifferentialEquation(func=system.__func__, t0=0, times=times, n_states=1, n_theta=1)
 
     @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_many_params(self):
@@ -267,27 +269,27 @@ class TestErrors:
         with pytest.raises(ValueError, match="Argument n_theta must be positive"):
             DifferentialEquation(func=TestErrors.system, t0=0, times=self.times, n_states=1, n_theta=0)
 
-    def system_2d_tensor(y, t, p):
-        s0 = np.exp(-t) - p[0] * y[0]
-        s1 = np.exp(-t) - p[0] * y[1]
-        s2 = np.exp(-t) - p[0] * y[2]
-        s3 = np.exp(-t) - p[0] * y[3]
-        return at.stack((s0, s1, s2, s3)).reshape((2,2))
-
     def test_tensor_shape(self):
         with pytest.raises(ValueError, match="returned a 2-dimensional tensor"):
-            DifferentialEquation(func=TestErrors.system_2d_tensor, t0=0, times=self.times, n_states=4, n_theta=1)
+            def system_2d_tensor(y, t, p):
+                s0 = np.exp(-t) - p[0] * y[0]
+                s1 = np.exp(-t) - p[0] * y[1]
+                s2 = np.exp(-t) - p[0] * y[2]
+                s3 = np.exp(-t) - p[0] * y[3]
+                return at.stack((s0, s1, s2, s3)).reshape((2,2))
 
-    def system_2d_list(y, t, p):
-        s0 = np.exp(-t) - p[0] * y[0]
-        s1 = np.exp(-t) - p[0] * y[1]
-        s2 = np.exp(-t) - p[0] * y[2]
-        s3 = np.exp(-t) - p[0] * y[3]
-        return [[s0,s1], [s2,s3]]
+            DifferentialEquation(func=system_2d_tensor, t0=0, times=self.times, n_states=4, n_theta=1)
 
     def test_list_shape(self):
         with pytest.raises(ValueError, match="returned a 2-dimensional tensor"):
-            DifferentialEquation(func=TestErrors.system_2d_list, t0=0, times=self.times, n_states=4, n_theta=1)
+            def system_2d_list(y, t, p):
+                s0 = np.exp(-t) - p[0] * y[0]
+                s1 = np.exp(-t) - p[0] * y[1]
+                s2 = np.exp(-t) - p[0] * y[2]
+                s3 = np.exp(-t) - p[0] * y[3]
+                return [[s0,s1], [s2,s3]]
+
+            DifferentialEquation(func=system_2d_list, t0=0, times=self.times, n_states=4, n_theta=1)
 
 
 class TestDiffEqModel:

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -268,20 +268,26 @@ class TestErrors:
             DifferentialEquation(func=self.system, t0=0, times=self.times, n_states=1, n_theta=0)
 
     def system_2d_tensor(y, t, p):
-        s = np.exp(-t) - p[0] * y[0]
-        return at.stack((s, s, s, s)).reshape((2,2))
+        s0 = np.exp(-t) - p[0] * y[0]
+        s1 = np.exp(-t) - p[0] * y[1]
+        s2 = np.exp(-t) - p[0] * y[2]
+        s3 = np.exp(-t) - p[0] * y[3]
+        return at.stack((s0, s1, s2, s3)).reshape((2,2))
 
     def test_tensor_shape(self):
         with pytest.raises(ValueError, match="returned a 2-dimensional tensor"):
-            DifferentialEquation(func=self.system_2d_tensor, t0=0, times=self.times, n_states=1, n_theta=0)
+            DifferentialEquation(func=TestErrors.system_2d_tensor, t0=0, times=self.times, n_states=4, n_theta=1)
 
     def system_2d_list(y, t, p):
-        s = np.exp(-t) - p[0] * y[0]
-        return [[s,s], [s,s]]
+        s0 = np.exp(-t) - p[0] * y[0]
+        s1 = np.exp(-t) - p[0] * y[1]
+        s2 = np.exp(-t) - p[0] * y[2]
+        s3 = np.exp(-t) - p[0] * y[3]
+        return [[s0,s1], [s2,s3]]
 
     def test_list_shape(self):
         with pytest.raises(ValueError, match="returned a 2-dimensional tensor"):
-            DifferentialEquation(func=self.system_2d_list, t0=0, times=self.times, n_states=1, n_theta=0)
+            DifferentialEquation(func=TestErrors.system_2d_list, t0=0, times=self.times, n_states=4, n_theta=1)
 
 
 class TestDiffEqModel:

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -237,35 +237,35 @@ class TestErrors:
 
     @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_many_params(self):
-        with pytest.raises(pm.ShapeError):
+        with pytest.raises(pm.ShapeError, match="Length of theta is wrong. \\(actual \\(2,\\) != expected \\(1,\\)\\)"):
             self.ode_model(theta=[1, 1], y0=[0])
 
     @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_many_y0(self):
-        with pytest.raises(pm.ShapeError):
+        with pytest.raises(pm.ShapeError, match="Length of y0 is wrong. \\(actual \\(2,\\) != expected \\(1,\\)\\)"):
             self.ode_model(theta=[1], y0=[0, 0])
 
     @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_few_params(self):
-        with pytest.raises(pm.ShapeError):
+        with pytest.raises(pm.ShapeError, match="Length of theta is wrong. \\(actual \\(0,\\) != expected \\(1,\\)\\)"):
             self.ode_model(theta=[], y0=[1])
 
     @pytest.mark.xfail(condition=(IS_FLOAT32 and IS_WINDOWS), reason="Fails on float32 on Windows")
     def test_too_few_y0(self):
-        with pytest.raises(pm.ShapeError):
+        with pytest.raises(pm.ShapeError, match="Length of y0 is wrong. \\(actual \\(0,\\) != expected \\(1,\\)\\)"):
             self.ode_model(theta=[1], y0=[])
 
     def test_func_callable(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Argument func must be callable."):
             DifferentialEquation(func=1, t0=0, times=self.times, n_states=1, n_theta=1)
 
     def test_number_of_states(self):
-        with pytest.raises(ValueError):
-            DifferentialEquation(func=self.system, t0=0, times=self.times, n_states=0, n_theta=1)
+        with pytest.raises(ValueError, match="Argument n_states must be at least 1."):
+            DifferentialEquation(func=TestErrors.system, t0=0, times=self.times, n_states=0, n_theta=1)
 
     def test_number_of_params(self):
-        with pytest.raises(ValueError):
-            DifferentialEquation(func=self.system, t0=0, times=self.times, n_states=1, n_theta=0)
+        with pytest.raises(ValueError, match="Argument n_theta must be positive"):
+            DifferentialEquation(func=TestErrors.system, t0=0, times=self.times, n_states=1, n_theta=0)
 
     def system_2d_tensor(y, t, p):
         s0 = np.exp(-t) - p[0] * y[0]

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -306,6 +306,26 @@ class TestErrors:
 
             DifferentialEquation(func=system_2d_list, t0=0, times=self.times, n_states=4, n_theta=1)
 
+    def test_unexpected_return_type_set(self):
+        with pytest.raises(
+            TypeError, match="Unexpected type, <class 'set'>, returned by ode_func."
+        ):
+
+            def system_set(y, t, p):
+                return {np.exp(-t) - p[0] * y[0]}
+
+            DifferentialEquation(func=system_set, t0=0, times=self.times, n_states=4, n_theta=1)
+
+    def test_unexpected_return_type_dict(self):
+        with pytest.raises(
+            TypeError, match="Unexpected type, <class 'dict'>, returned by ode_func."
+        ):
+
+            def system_dict(y, t, p):
+                return {"rhs": np.exp(-t) - p[0] * y[0]}
+
+            DifferentialEquation(func=system_dict, t0=0, times=self.times, n_states=4, n_theta=1)
+
 
 class TestDiffEqModel:
     def test_op_equality(self):

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -265,6 +265,15 @@ class TestErrors:
         with pytest.raises(ValueError):
             DifferentialEquation(func=self.system, t0=0, times=self.times, n_states=1, n_theta=0)
 
+    def system_2(y, t, p):
+        return np.array(np.exp(-t) - p[0] * y[0])
+
+    ode_model_2 = DifferentialEquation(func=system, t0=0, times=times, n_states=1, n_theta=1)
+
+    def test_output_numpy(self):
+        with pytest.raises(TypeError):
+            DifferentialEquation(func=self.system_2, t0=0, times=self.times, n_states=1, n_theta=1)
+
 
 class TestDiffEqModel:
     def test_op_equality(self):

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -267,6 +267,22 @@ class TestErrors:
         with pytest.raises(ValueError):
             DifferentialEquation(func=self.system, t0=0, times=self.times, n_states=1, n_theta=0)
 
+    def system_2d_tensor(y, t, p):
+        s = np.exp(-t) - p[0] * y[0]
+        return at.stack((s, s, s, s)).reshape((2,2))
+
+    def test_tensor_shape(self):
+        with pytest.raises(ValueError):
+            DifferentialEquation(func=self.system_2d_tensor, t0=0, times=self.times, n_states=1, n_theta=0)
+
+    def system_2d_list(y, t, p):
+        s = np.exp(-t) - p[0] * y[0]
+        return [[s,s], [s,s]]
+
+    def test_list_shape(self):
+        with pytest.raises(ValueError):
+            DifferentialEquation(func=self.system_2d_list, t0=0, times=self.times, n_states=1, n_theta=0)
+
 
 class TestDiffEqModel:
     def test_op_equality(self):

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -15,6 +15,7 @@
 import sys
 
 import aesara
+import aesara.tensor as at
 import numpy as np
 import pytest
 
@@ -153,6 +154,22 @@ class TestSensitivityInitialCondition:
         model4_sens_ic = np.array([1, 0, 0, 0, 0, 1, 0, 0])
 
         np.testing.assert_array_equal(model4_sens_ic, model4._sens_ic)
+
+    def test_sens_ic_vector_2_param_tensor(self):
+        # Vector ODE 2 Param with return type at.TensorVariable
+        def ode_func_4_t(y, t, p):
+            # Make sure that ds and di are vectors by slicing
+            ds = -p[0:1] * y[0:1] * y[1:]
+            di = p[0:1] * y[0:1] * y[1:] - p[1:] * y[1:]
+
+            return at.concatenate([ds, di], axis=0)
+
+        # Instantiate ODE model
+        model4_t = DifferentialEquation(func=ode_func_4_t, t0=0, times=self.t, n_states=2, n_theta=2)
+
+        model4_sens_ic_t = np.array([1, 0, 0, 0, 0, 1, 0, 0])
+
+        np.testing.assert_array_equal(model4_sens_ic_t, model4_t._sens_ic)
 
     def test_sens_ic_vector_3_params(self):
         # Big System with Many Parameters


### PR DESCRIPTION
This PR addresses the issue discussed here https://discourse.pymc.io/t/return-value-for-2n-dimensional-ode-system/4141?u=mirko-m .

When estimating the parameters of a system of ODEs we need to define a a function called `ode_func` which returns the right hand side of the ODE system. It is not clear what the return type of `ode_func` is. In some of the examples it is a list, but for some ODE systems the user may prefer to return a  `TensorVariable` or a `numpy.ndarray`. The changes in this PR check for the return type of `ode_func` and then convert to a `TensorVariable`.

I am not sure if using `at.shared()` is the best method for casting a`numpy.ndarray`  to a `TensorVariable` .

I do not have a test for the changes I made, but it should be possible to adapt one of the existing examples. Let me know if you need me to do this.