### PR TITLE
Download arviz_compat and jax_sampling workflows with mamba

### DIFF
--- a/.github/workflows/arviz_compat.yml
+++ b/.github/workflows/arviz_compat.yml
@@ -58,9 +58,13 @@ jobs:
             hashFiles('requirements.txt') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          mamba-version: "*"
           activate-environment: pymc-dev-py39
           channel-priority: strict
           environment-file: conda-envs/environment-dev-py39.yml
+          use-mamba: true
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Install pymc
         run: |

--- a/.github/workflows/jaxtests.yml
+++ b/.github/workflows/jaxtests.yml
@@ -54,9 +54,13 @@ jobs:
             hashFiles('requirements.txt') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          mamba-version: "*"
           activate-environment: pymc-dev-py39
           channel-priority: strict
           environment-file: conda-envs/environment-dev-py39.yml
+          use-mamba: true
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Install pymc
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -134,6 +134,8 @@ jobs:
             hashFiles('requirements.txt') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          mamba-version: "*"
+          use-mamba: true
           activate-environment: pymc-test-py37
           channel-priority: strict
           environment-file: conda-envs/environment-test-py37.yml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -218,9 +218,13 @@ jobs:
             hashFiles('requirements.txt') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          mamba-version: "*"
           activate-environment: pymc-test-py38
           channel-priority: strict
           environment-file: conda-envs/windows-environment-test-py38.yml
+          use-mamba: true
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Install-pymc
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -134,11 +134,13 @@ jobs:
             hashFiles('requirements.txt') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           mamba-version: "*"
-          use-mamba: true
           activate-environment: pymc-test-py37
           channel-priority: strict
           environment-file: conda-envs/environment-test-py37.yml
+          use-mamba: true
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Install-pymc
         run: |


### PR DESCRIPTION
This PR changes the workflows `arviz_compat.yml` and `jaxtests.yml` to build and install with `mamba`. This PR closes the discussion in PR #5387.

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes?
+ [x] important background, or details about the implementation
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [x] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
