### PR TITLE
Fix convert_size failure with 1d symbolic vectors

### DIFF
--- a/demo_try.py
+++ b/demo_try.py
@@ -1,7 +1,0 @@
-import pymc as pm
-import aesara.tensor as at
-x = at.constant(5)
-size = at.stack([x, x])
-pm.Normal.dist(size=size)
-x = at.constant([5, 5])
-pm.Normal.dist(size=x)

--- a/demo_try.py
+++ b/demo_try.py
@@ -1,0 +1,7 @@
+import pymc as pm
+import aesara.tensor as at
+x = at.constant(5)
+size = at.stack([x, x])
+pm.Normal.dist(size=size)
+x = at.constant([5, 5])
+pm.Normal.dist(size=x)

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -450,8 +450,10 @@ def convert_shape(shape: Shape) -> Optional[WeakShape]:
     if shape is None:
         return None
 
-    if isinstance(shape, int) or (isinstance(shape, TensorVariable) and shape.ndim == 0):
-        shape = (shape,)
+    if isinstance(shape, int):
+        shape = shape
+    if isinstance(shape, TensorVariable) and shape.ndim <= 0:
+        shape = tuple(shape)
     elif isinstance(shape, (list, tuple)):
         shape = tuple(shape)
     else:
@@ -473,7 +475,7 @@ def convert_size(size: Size) -> Optional[StrongSize]:
         return None
     if isinstance(size, int):
         size = size
-    elif isinstance(size,TensorVariable):
+    elif isinstance(size, TensorVariable) and size.ndim <= 1:
         size = tuple(size)
     elif isinstance(size, (list, tuple)):
         size = tuple(size)

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -451,7 +451,7 @@ def convert_shape(shape: Shape) -> Optional[WeakShape]:
         return None
     if isinstance(shape, int) or (isinstance(size, TensorVariable) and shape.ndim == 0):
         shape = (shape,)
-    if isinstance(shape, TensorVariable) and shape.ndim == 1:
+    elif isinstance(shape, TensorVariable) and shape.ndim == 1:
         shape = tuple(shape)
     elif isinstance(shape, (list, tuple)):
         shape = tuple(shape)
@@ -459,12 +459,10 @@ def convert_shape(shape: Shape) -> Optional[WeakShape]:
         raise ValueError(
             f"The `shape` parameter must be a tuple, TensorVariable, int or list. Actual: {type(shape)}"
         )
-
     if isinstance(shape, tuple) and any(s == Ellipsis for s in shape[:-1]):
         raise ValueError(
             f"Ellipsis in `shape` may only appear in the last position. Actual: {shape}"
         )
-
     return shape
 
 
@@ -472,7 +470,7 @@ def convert_size(size: Size) -> Optional[StrongSize]:
     """Process a user-provided size variable into None or a valid size object."""
     if size is None:
         return None
-    if isinstance(size, int) or (isinstance(size, TensorVariable) and size.ndim == 0):
+    elif isinstance(size, int) or (isinstance(size, TensorVariable) and size.ndim == 0):
         size = (size,)
     elif isinstance(size, TensorVariable) and size.ndim == 1:
         size = tuple(size)

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -472,8 +472,8 @@ def convert_size(size: Size) -> Optional[StrongSize]:
     if size is None:
         return None
 
-    if isinstance(size, int) or (isinstance(size, TensorVariable) and size.ndim == 0):
-        size = (size,)
+    if isinstance(size, int) or (isinstance(size, TensorVariable) and size.ndim >= 1):
+        size = tuple(size,)
     elif isinstance(size, (list, tuple)):
         size = tuple(size)
     else:

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -449,10 +449,9 @@ def convert_shape(shape: Shape) -> Optional[WeakShape]:
     """Process a user-provided shape variable into None or a valid shape object."""
     if shape is None:
         return None
-
-    if isinstance(shape, int):
-        shape = shape
-    if isinstance(shape, TensorVariable) and shape.ndim <= 0:
+    if isinstance(shape, int) or (isinstance(size, TensorVariable) and shape.ndim == 0):
+        shape = (shape,)
+    if isinstance(shape, TensorVariable) and shape.ndim == 1:
         shape = tuple(shape)
     elif isinstance(shape, (list, tuple)):
         shape = tuple(shape)
@@ -473,9 +472,9 @@ def convert_size(size: Size) -> Optional[StrongSize]:
     """Process a user-provided size variable into None or a valid size object."""
     if size is None:
         return None
-    if isinstance(size, int):
-        size = size
-    elif isinstance(size, TensorVariable) and size.ndim <= 1:
+    if isinstance(size, int) or (isinstance(size, TensorVariable) and size.ndim == 0):
+        size = (size,)
+    elif isinstance(size, TensorVariable) and size.ndim == 1:
         size = tuple(size)
     elif isinstance(size, (list, tuple)):
         size = tuple(size)

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -471,19 +471,18 @@ def convert_size(size: Size) -> Optional[StrongSize]:
     """Process a user-provided size variable into None or a valid size object."""
     if size is None:
         return None
-
-    if isinstance(size, int) or (isinstance(size, TensorVariable) and size.ndim==1 or size.ndim==0):
-        size = tuple(size,)
+    if isinstance(size, int):
+        size = size
+    elif isinstance(size,TensorVariable):
+        size = tuple(size)
     elif isinstance(size, (list, tuple)):
         size = tuple(size)
     else:
         raise ValueError(
             f"The `size` parameter must be a tuple, TensorVariable, int or list. Actual: {type(size)}"
         )
-
     if isinstance(size, tuple) and Ellipsis in size:
         raise ValueError(f"The `size` parameter cannot contain an Ellipsis. Actual: {size}")
-
     return size
 
 

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -449,20 +449,16 @@ def convert_shape(shape: Shape) -> Optional[WeakShape]:
     """Process a user-provided shape variable into None or a valid shape object."""
     if shape is None:
         return None
-    if isinstance(shape, int) or (isinstance(size, TensorVariable) and shape.ndim == 0):
+    elif isinstance(shape, int) or (isinstance(size, TensorVariable) and shape.ndim == 0):
         shape = (shape,)
     elif isinstance(shape, TensorVariable) and shape.ndim == 1:
         shape = tuple(shape)
     elif isinstance(shape, (list, tuple)):
         shape = tuple(shape)
     else:
-        raise ValueError(
-            f"The `shape` parameter must be a tuple, TensorVariable, int or list. Actual: {type(shape)}"
-        )
+        raise ValueError(f"The `shape` parameter must be a tuple, TensorVariable, int or list. Actual: {type(shape)}")
     if isinstance(shape, tuple) and any(s == Ellipsis for s in shape[:-1]):
-        raise ValueError(
-            f"Ellipsis in `shape` may only appear in the last position. Actual: {shape}"
-        )
+        raise ValueError(f"Ellipsis in `shape` may only appear in the last position. Actual: {shape}")
     return shape
 
 
@@ -477,9 +473,7 @@ def convert_size(size: Size) -> Optional[StrongSize]:
     elif isinstance(size, (list, tuple)):
         size = tuple(size)
     else:
-        raise ValueError(
-            f"The `size` parameter must be a tuple, TensorVariable, int or list. Actual: {type(size)}"
-        )
+        raise ValueError(f"The `size` parameter must be a tuple, TensorVariable, int or list. Actual: {type(size)}")
     if isinstance(size, tuple) and Ellipsis in size:
         raise ValueError(f"The `size` parameter cannot contain an Ellipsis. Actual: {size}")
     return size

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -472,7 +472,7 @@ def convert_size(size: Size) -> Optional[StrongSize]:
     if size is None:
         return None
 
-    if isinstance(size, int) or (isinstance(size, TensorVariable) and size.ndim >= 1):
+    if isinstance(size, int) or (isinstance(size, TensorVariable) and size.ndim==1 or size.ndim==0):
         size = tuple(size,)
     elif isinstance(size, (list, tuple)):
         size = tuple(size)

--- a/pymc/tests/test_shape_handling.py
+++ b/pymc/tests/test_shape_handling.py
@@ -466,6 +466,10 @@ class TestShapeDimsSize:
             convert_size(size="notasize")
         with pytest.raises(ValueError, match="cannot contain"):
             convert_size(size=(3, ...))
+        x = at.constant(5)
+        assert convert_size(x) ==(5,)
+        x = at.constant([5, 5])
+        assert convert_size(x) ==([5,5],)
 
     def test_lazy_flavors(self):
         assert pm.Uniform.dist(2, [4, 5], size=[3, 2]).eval().shape == (3, 2)

--- a/pymc/tests/test_shape_handling.py
+++ b/pymc/tests/test_shape_handling.py
@@ -467,9 +467,9 @@ class TestShapeDimsSize:
         with pytest.raises(ValueError, match="cannot contain"):
             convert_size(size=(3, ...))
         x = at.constant(5)
-        assert convert_size(x) ==(5,)
+        assert convert_size(x) == (5,)
         x = at.constant([5, 5])
-        assert convert_size(x) ==([5,5],)
+        assert convert_size(x) == ([5, 5],)
 
     def test_lazy_flavors(self):
         assert pm.Uniform.dist(2, [4, 5], size=[3, 2]).eval().shape == (3, 2)


### PR DESCRIPTION
```convert_size```  wrongly assumes symbolic sizes have to be scalars
```
import pymc as pm
import aesara.tensor as at

s = at.scalar('s')
size = at.stack([s, s])
x = at.random.normal(size=size)
x.eval({s: 2})
# array([[-0.66285345,  0.97341598],
#        [ 0.05158132,  2.03399059]])

pm.Normal.dist(size=size)
# ValueError: The `size` parameter must be a tuple, TensorVariable, int or list. Actual: <class 'aesara.tensor.var.TensorVariable'>
```

fixed by changing code in 
https://github.com/pymc-devs/pymc/blob/915592235ea6920689f89bece48e2d679e8ed4f1/pymc/distributions/shape_utils.py#L475

by accepting ```size.ndim == 1``` as well as ```size.ndim == 0```

Closes #5394 