### PR TITLE
Cleanup trace initialization and type hints

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -32,6 +32,7 @@ from aesara.tensor.elemwise import Elemwise
 from aesara.tensor.random.op import RandomVariable
 from aesara.tensor.random.var import RandomStateSharedVariable
 from aesara.tensor.var import TensorVariable
+from typing_extensions import TypeAlias
 
 from pymc.aesaraf import change_rv_size
 from pymc.distributions.shape_utils import (
@@ -61,7 +62,7 @@ __all__ = [
     "NoDistribution",
 ]
 
-DIST_PARAMETER_TYPES = Union[np.ndarray, int, float, TensorVariable]
+DIST_PARAMETER_TYPES: TypeAlias = Union[np.ndarray, int, float, TensorVariable]
 
 vectorized_ppc = contextvars.ContextVar(
     "vectorized_ppc", default=None

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -21,12 +21,13 @@ samples from probability distributions for stochastic nodes in PyMC.
 import warnings
 
 from functools import partial
-from typing import Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
 from aesara.graph.basic import Constant, Variable
 from aesara.tensor.var import TensorVariable
+from typing_extensions import TypeAlias
 
 from pymc.aesaraf import change_rv_size, pandas_to_array
 from pymc.exceptions import ShapeError, ShapeWarning
@@ -412,19 +413,31 @@ def broadcast_dist_samples_to(to_shape, samples, size=None):
     return [np.broadcast_to(o, to_shape) for o in samples]
 
 
+# Workaround to annotate the Ellipsis type, posted by the BDFL himself.
+# See https://github.com/python/typing/issues/684#issuecomment-548203158
+if TYPE_CHECKING:
+    from enum import Enum
+
+    class ellipsis(Enum):
+        Ellipsis = "..."
+
+    Ellipsis = ellipsis.Ellipsis
+else:
+    ellipsis = type(Ellipsis)
+
 # User-provided can be lazily specified as scalars
-Shape = Union[int, TensorVariable, Sequence[Union[int, TensorVariable, type(Ellipsis)]]]
-Dims = Union[str, Sequence[Union[str, None, type(Ellipsis)]]]
-Size = Union[int, TensorVariable, Sequence[Union[int, TensorVariable]]]
+Shape: TypeAlias = Union[int, TensorVariable, Sequence[Union[int, TensorVariable, ellipsis]]]
+Dims: TypeAlias = Union[str, Sequence[Optional[Union[str, ellipsis]]]]
+Size: TypeAlias = Union[int, TensorVariable, Sequence[Union[int, TensorVariable]]]
 
 # After conversion to vectors
-WeakShape = Union[TensorVariable, Tuple[Union[int, TensorVariable, type(Ellipsis)], ...]]
-WeakDims = Tuple[Union[str, None, type(Ellipsis)], ...]
+WeakShape: TypeAlias = Union[TensorVariable, Tuple[Union[int, TensorVariable, ellipsis], ...]]
+WeakDims: TypeAlias = Tuple[Optional[Union[str, ellipsis]], ...]
 
 # After Ellipsis were substituted
-StrongShape = Union[TensorVariable, Tuple[Union[int, TensorVariable], ...]]
-StrongDims = Sequence[Union[str, None]]
-StrongSize = Union[TensorVariable, Tuple[Union[int, TensorVariable], ...]]
+StrongShape: TypeAlias = Union[TensorVariable, Tuple[Union[int, TensorVariable], ...]]
+StrongDims: TypeAlias = Sequence[Optional[str]]
+StrongSize: TypeAlias = Union[TensorVariable, Tuple[Union[int, TensorVariable], ...]]
 
 
 def convert_dims(dims: Optional[Dims]) -> Optional[WeakDims]:

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -734,10 +734,10 @@ def _sample_many(
 
     Returns
     -------
-    trace: MultiTrace
+    mtrace: MultiTrace
         Contains samples of all chains
     """
-    traces: List[Backend] = []
+    traces: List[BaseTrace] = []
     for i in range(chains):
         trace = _sample(
             draws=draws,
@@ -837,7 +837,7 @@ def _sample(
     model: Optional[Model] = None,
     callback=None,
     **kwargs,
-) -> MultiTrace:
+) -> BaseTrace:
     """Main iteration for singleprocess sampling.
 
     Multiple step methods are supported via compound step methods.
@@ -867,8 +867,8 @@ def _sample(
 
     Returns
     -------
-    strace : MultiTrace
-        A ``MultiTrace`` object that contains the samples for this chain.
+    strace : BaseTrace
+        A ``BaseTrace`` object that contains the samples for this chain.
     """
     skip_first = kwargs.get("skip_first", 0)
 
@@ -961,7 +961,7 @@ def _iter_sample(
     model=None,
     random_seed=None,
     callback=None,
-) -> Iterator[Tuple[Backend, bool]]:
+) -> Iterator[Tuple[BaseTrace, bool]]:
     """Generator for sampling one chain. (Used in singleprocess sampling.)
 
     Parameters
@@ -998,7 +998,7 @@ def _iter_sample(
     if draws < 1:
         raise ValueError("Argument `draws` must be greater than 0.")
 
-    strace = _choose_backend(trace, model=model)
+    strace: BaseTrace = _choose_backend(trace, model=model)
 
     try:
         step = CompoundStep(step)
@@ -1265,7 +1265,7 @@ def _prepare_iter_population(
     # 5. a PopulationStepper is configured for parallelized stepping
 
     # 1. prepare a BaseTrace for each chain
-    traces = [_choose_backend(None, model=model) for chain in chains]
+    traces: List[BaseTrace] = [_choose_backend(None, model=model) for chain in chains]
 
     # 2. create a population (points) that tracks each chain
     # it is updated as the chains are advanced
@@ -1364,7 +1364,7 @@ def _iter_population(
                 steppers[c].report._finalize(strace)
 
 
-def _choose_backend(trace: Optional[Union[BaseTrace, List[str]]], **kwds) -> Backend:
+def _choose_backend(trace: Optional[Union[BaseTrace, List[str]]], **kwds) -> BaseTrace:
     """Selects or creates a NDArray trace backend for a particular chain.
 
     Parameters
@@ -1454,7 +1454,7 @@ def _mp_sample(
     # We did draws += tune in pm.sample
     draws -= tune
 
-    traces = []
+    traces: List[BaseTrace] = []
     for idx in range(chain, chain + chains):
         if trace is not None:
             strace = _choose_backend(copy(trace), model=model)

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -769,7 +769,7 @@ def _sample_population(
     start: Sequence[PointType],
     random_seed,
     step,
-    tune,
+    tune: int,
     model,
     progressbar: bool = True,
     parallelize=False,
@@ -791,8 +791,8 @@ def _sample_population(
         A list is accepted if more if ``cores`` is greater than one.
     step : function
         Step function (should be or contain a population step method)
-    tune : int, optional
-        Number of iterations to tune, if applicable (defaults to None)
+    tune : int
+        Number of iterations to tune.
     model : Model (optional if in ``with`` context)
     progressbar : bool
         Show progress bars? (defaults to True)
@@ -826,6 +826,7 @@ def _sample_population(
 
 
 def _sample(
+    *,
     chain: int,
     progressbar: bool,
     random_seed,
@@ -833,7 +834,7 @@ def _sample(
     draws: int,
     step=None,
     trace: Optional[Union[BaseTrace, List[str]]] = None,
-    tune=None,
+    tune: int,
     model: Optional[Model] = None,
     callback=None,
     **kwargs,
@@ -861,8 +862,8 @@ def _sample(
     trace : backend or list
         This should be a backend instance, or a list of variables to track.
         If None or a list of variables, the NDArray backend is used.
-    tune : int, optional
-        Number of iterations to tune, if applicable (defaults to None)
+    tune : int
+        Number of iterations to tune.
     model : Model (optional if in ``with`` context)
 
     Returns
@@ -898,7 +899,7 @@ def iter_sample(
     start: PointType,
     trace=None,
     chain=0,
-    tune: Optional[int] = None,
+    tune: int = 0,
     model: Optional[Model] = None,
     random_seed: Optional[Union[int, List[int]]] = None,
     callback=None,
@@ -923,7 +924,7 @@ def iter_sample(
         Chain number used to store sample in backend. If ``cores`` is greater than one, chain numbers
         will start here.
     tune : int, optional
-        Number of iterations to tune, if applicable (defaults to None)
+        Number of iterations to tune (defaults to 0).
     model : Model (optional if in ``with`` context)
     random_seed : int or list of ints, optional
         A list is accepted if more if ``cores`` is greater than one.
@@ -957,7 +958,7 @@ def _iter_sample(
     start: PointType,
     trace: Optional[Union[BaseTrace, List[str]]] = None,
     chain=0,
-    tune=None,
+    tune: int = 0,
     model=None,
     random_seed=None,
     callback=None,
@@ -980,7 +981,7 @@ def _iter_sample(
         Chain number used to store sample in backend. If ``cores`` is greater than one, chain numbers
         will start here.
     tune : int, optional
-        Number of iterations to tune, if applicable (defaults to None)
+        Number of iterations to tune (defaults to 0).
     model : Model (optional if in ``with`` context)
     random_seed : int or list of ints, optional
         A list is accepted if more if ``cores`` is greater than one.
@@ -1217,7 +1218,7 @@ def _prepare_iter_population(
     step,
     start: Sequence[PointType],
     parallelize: bool,
-    tune=None,
+    tune: int,
     model=None,
     random_seed=None,
     progressbar=True,
@@ -1236,8 +1237,8 @@ def _prepare_iter_population(
         Start points for each chain
     parallelize : bool
         Setting for multiprocess parallelization
-    tune : int, optional
-        Number of iterations to tune, if applicable (defaults to None)
+    tune : int
+        Number of iterations to tune.
     model : Model (optional if in ``with`` context)
     random_seed : int or list of ints, optional
         A list is accepted if more if ``cores`` is greater than one.
@@ -1417,7 +1418,7 @@ def _mp_sample(
     draws : int
         The number of samples to draw
     tune : int
-        Number of iterations to tune, if applicable (defaults to None)
+        Number of iterations to tune.
     step : function
         Step function
     chains : int
@@ -1517,7 +1518,7 @@ def _mp_sample(
             strace.close()
 
 
-def _choose_chains(traces: Sequence[BaseTrace], tune: Optional[int]) -> Tuple[List[BaseTrace], int]:
+def _choose_chains(traces: Sequence[BaseTrace], tune: int) -> Tuple[List[BaseTrace], int]:
     """
     Filter and slice traces such that (n_traces * len(shortest_trace)) is maximized.
 
@@ -1526,9 +1527,6 @@ def _choose_chains(traces: Sequence[BaseTrace], tune: Optional[int]) -> Tuple[Li
     traces such that (number of traces) * (length of shortest trace)
     is maximised.
     """
-    if tune is None:
-        tune = 0
-
     if not traces:
         raise ValueError("No traces to slice.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,9 @@ exclude_lines = [
 isort = 1
 black = 1
 pyupgrade = 1
+
+[tool.mypy]
+exclude = [
+  "^pymc/tests",
+]
+ignore_missing_imports = true


### PR DESCRIPTION
This PR refactors the code and type hints in `sampling.py` that are related to trace backend initialization and related type hints.

I found several type hints that were too loose or even wrong.
* In multiple places `tune` was advertised as `int | None` but the code inside assumed it to be `int`.
* Similarly, multiple `trace` kwargs were advertised as `BaseTrace | MultiTrace` but the code inside called methods that are only available with `BaseTrace`.
* After tightening the input types, I fixed the return type hints in a similar fashion.

Finally, this tightening enabled a consolidation of the trace initialization (`_choose_backend()` + `strace.setup()`) such that now all of `_iter_sample`, `_mp_sample`, `_prepare_iter_population` make the same call to `_init_trace`.