### PR TITLE
Batched MvNormal distribution

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -237,11 +237,11 @@ class MvNormal(Continuous):
         mu = at.as_tensor_variable(mu)
         cov = quaddist_matrix(cov, chol, tau, lower)
 
-        distribution_shape = at.broadcast_shape(mu.shape, cov.shape[:-1], arrays_are_shapes=True)
+        distribution_shape = at.stack(at.broadcast_shape(mu, cov[..., -1]))
         mu = at.broadcast_to(mu, distribution_shape)
 
-        event_shape = distribution_shape[-1]
-        cov_shape = at.broadcast_shape(mu[..., None].shape, event_shape, arrays_are_shapes=True)
+        event_shape = [distribution_shape[-1]]
+        cov_shape = at.concatenate((distribution_shape, event_shape))
 
         cov = at.broadcast_to(cov, cov_shape)
         return super().dist([mu, cov], **kwargs)

--- a/pymc/distributions/multivariate_utils.py
+++ b/pymc/distributions/multivariate_utils.py
@@ -1,0 +1,76 @@
+import numpy as np
+
+from aesara.graph.basic import Apply
+from aesara.graph.op import Op
+from aesara.tensor import swapaxes
+from aesara.tensor.basic import as_tensor_variable
+
+
+class BatchedMatrixInverse(Op):
+    """Computes the inverse of a matrix.
+
+    `aesara.tensor.nlinalg.matrix_inverse` can only inverse square matrices.
+    This Op can inverse batches of square matrices.
+    """
+
+    __props__ = ()
+
+    def __init__(self):
+        pass
+
+    def make_node(self, x):
+        x = as_tensor_variable(x)
+        return Apply(self, [x], [x.type()])
+
+    def perform(self, node, inputs, outputs):
+        (x,) = inputs
+        (z,) = outputs
+        z[0] = np.linalg.inv(x).astype(x.dtype)
+
+    def grad(self, inputs, g_outputs):
+        """
+        Checkout Page 10 of Matrix Cookbook:
+        https://www.math.uwaterloo.ca/~hwolkowi/matrixcookbook.pdf
+        """
+        (x,) = inputs
+        xi = self(x)
+        (gz,) = g_outputs
+
+        # Take transpose of last two dimensions
+        gz_transpose = swapaxes(gz, -1, -2)
+
+        output = xi * gz_transpose * xi
+
+        output_transpose = swapaxes(output, -1, -2)
+        return [-output_transpose]
+
+    def R_op(self, inputs, eval_points):
+        r"""The gradient function should return
+
+            .. math:: \frac{\partial X^{-1}}{\partial X}V,
+
+        where :math:`V` corresponds to ``g_outputs`` and :math:`X` to
+        ``inputs``. Using the `matrix cookbook
+        <http://www2.imm.dtu.dk/pubdb/views/publication_details.php?id=3274>`_,
+        one can deduce that the relation corresponds to
+
+            .. math:: X^{-1} \cdot V \cdot X^{-1}.
+
+        """
+        (x,) = inputs
+        xi = self(x)
+        (ev,) = eval_points
+        if ev is None:
+            return [None]
+        return [-xi * ev * xi]
+
+    def infer_shape(self, fgraph, node, shapes):
+        return shapes
+
+
+batched_matrix_inverse = BatchedMatrixInverse()
+# import aesara.tensor as at
+
+# array = np.stack([np.eye(3), np.eye(3)])
+# array_tensor = at.as_tensor_variable(array)
+# at.grad(batched_matrix_inverse(array_tensor).mean(), array_tensor)

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1094,9 +1094,9 @@ class TestMvNormalCov(BaseTestDistributionRandom):
         assert mu.eval().shape == (10, 3)
 
         # Cov is artificually limited to being 2D
-        # x = pm.MvNormal.dist(mu=np.ones((10, 1)), cov=np.full((2, 3, 3), np.eye(3)))
-        # mu = x.owner.inputs[3]
-        # assert mu.eval().shape == (10, 2, 3)
+        x = pm.MvNormal.dist(mu=np.ones((10, 1, 1)), cov=np.full((2, 3, 3), np.eye(3)))
+        mu = x.owner.inputs[3]
+        assert mu.eval().shape == (10, 2, 3)
 
 
 class TestMvNormalChol(BaseTestDistributionRandom):


### PR DESCRIPTION
**Thank your for opening a PR!**

Initializing the work on https://github.com/pymc-devs/pymc/issues/5383 

~Blocked by https://github.com/aesara-devs/aesara/issues/798~
EDIT: Now, I am correctly using `at.broadcast_shape` function.

Depending on what your PR does, here are a few things you might want to address in the description:
+ [X] what are the (breaking) changes that this PR makes?
This PR generalizes the MvNormal distribution. 

The parameters `mu` and `cov` were restricted to 2d. To remove this restriction, I created a custom `Op` that operates on batches of square matrices to compute their inverses in vectorized fashion. 

With the changes in this PR, I think that random variable object for MvNormal distribution can be created and random samples can be drawn. The `logp` computations still need to be sorted out. So, this PR is WIP.

+ [ ] important background, or details about the implementation
+ [ ] are the changes—especially new features—covered by tests and docstrings?
Will add them soon.
+ [X] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
