### PR TITLE
Set default updates for all graph RandomVariables in compile_pymc

### DIFF
--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -961,17 +961,14 @@ def compile_pymc(inputs, outputs, mode=None, **kwargs):
         this function is called within a model context and the model `check_bounds` flag
         is set to False.
     """
-
-    # Avoid circular dependency
-    from pymc.distributions import NoDistribution
-
-    # Set the default update of a NoDistribution RNG so that it is automatically
+    # Set the default update of RandomVariable's RNG so that it is automatically
     # updated after every function call
+    # TODO: This won't work for variables with InnerGraphs (Scan and OpFromGraph)
     output_to_list = outputs if isinstance(outputs, (list, tuple)) else [outputs]
     for rv in (
         node
         for node in walk_model(output_to_list, walk_past_rvs=True)
-        if node.owner and isinstance(node.owner.op, NoDistribution)
+        if node.owner and isinstance(node.owner.op, RandomVariable)
     ):
         rng = rv.owner.inputs[0]
         if not hasattr(rng, "default_update"):

--- a/pymc/tests/test_aesaraf.py
+++ b/pymc/tests/test_aesaraf.py
@@ -574,3 +574,11 @@ def test_check_bounds_flag():
     m.check_bounds = True
     with m:
         assert np.all(compile_pymc([], bound)() == -np.inf)
+
+
+def test_compile_pymc_sets_default_updates():
+    rng = aesara.shared(np.random.default_rng(0))
+    x = pm.Normal.dist(rng=rng)
+    assert x.owner.inputs[0] is rng
+    f = compile_pymc([], x)
+    assert not np.isclose(f(), f())


### PR DESCRIPTION
This PR makes `compile_pymc` set `default_updates` for any RandomVariables found in the graph. Previously this logic was limited to NoDistribution to accommodate the special case of `pm.Simulator`.

With this change the following code now produces the "expected" behavior (i.e., different draws of `x`):
```python
with pm.Model() as m:
  pm.Deterministic("x", pm.Normal.dist())
  prior = pm.sample_prior_predictive()
```

With this change we may also consider removing this responsibility from `pm.Distribution` which was doing this for registered (named) variables, which should facilitate https://github.com/pymc-devs/pymc/issues/5308

https://github.com/pymc-devs/pymc/blob/ea776d6f69f7eb62c7ef51759bd8e2a0559cace5/pymc/distributions/distribution.py#L366-L381

***

This is likely to be all reevaluated soon, as Aesara is in the process of refining the API for seeding of RandomVariables