### PR TITLE
Pin SciPy to `>=1.7.3,<1.8.0`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,7 @@
 + `pm.Lognormal` is now available as an alias for `pm.Lognormal` (see [#5389](https://github.com/pymc-devs/pymc/pull/5389)).
 
 ### Bugfixes
++ The upper limit for the SciPy version is `<1.8.0` and will most probably remain for all future `3.x.x` releases. For compatibility with newer SciPy versions please update to `pymc>=4.0.0`. Also see [#5448](https://github.com/pymc-devs/pymc/pull/5448).
 + A hotfix is applied on import to remain compatible with NumPy 1.22 (see [#5316](https://github.com/pymc-devs/pymc/pull/5316)).
 
 ## PyMC3 3.11.4 (20 August 2021)

--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -8,9 +8,8 @@ dependencies:
 - libblas=*=*mkl
 - mkl-service
 - nbsphinx>=0.4
-- numpy=1.15
+- numpy>=1.15,<1.22.2
 - numpydoc<1.2
-- pandas=0.24
 - pip
 - pre-commit>=2.8.0
 - pytest-cov>=2.5
@@ -18,7 +17,7 @@ dependencies:
 - python-graphviz
 - python=3.7
 - recommonmark>=0.4
-- scipy=1.2
+- scipy>=1.4.1,<1.8.0
 - sphinx-autobuild>=0.7
 - sphinx>=1.5
 - watermark

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -8,6 +8,7 @@ dependencies:
 - libblas=*=*mkl
 - mkl-service
 - nbsphinx>=0.4
+- numpy>=1.15,<1.22.2
 - numpydoc<1.2
 - pip
 - pre-commit>=2.8.0
@@ -16,6 +17,7 @@ dependencies:
 - python-graphviz
 - python=3.8
 - recommonmark>=0.4
+- scipy>=1.4.1,<1.8.0
 - sphinx-autobuild>=0.7
 - sphinx>=1.5
 - watermark

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -8,6 +8,7 @@ dependencies:
 - libblas=*=*mkl
 - mkl-service
 - nbsphinx>=0.4
+- numpy>=1.15,<1.22.2
 - numpydoc<1.2
 - pip
 - pre-commit>=2.8.0
@@ -16,6 +17,7 @@ dependencies:
 - python-graphviz
 - python=3.9
 - recommonmark>=0.4
+- scipy>=1.4.1,<1.8.0
 - sphinx-autobuild>=0.7
 - sphinx>=1.5
 - watermark

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -16,11 +16,13 @@ dependencies:
 # Extra stuff for dev, testing and docs build
 - ipython>=7.16
 - nbsphinx>=0.4
+- numpy>=1.15,<1.22.2
 - numpydoc<1.2
 - pre-commit>=2.8.0
 - pytest-cov>=2.5
 - pytest>=3.0
 - recommonmark>=0.4
+- scipy>=1.4.1,<1.8.0
 - sphinx-autobuild>=0.7
 - sphinx>=1.5
 - watermark

--- a/pymc3/tests/test_distributions.py
+++ b/pymc3/tests/test_distributions.py
@@ -1082,6 +1082,10 @@ class TestMatchesScipy:
             {"N": NatSmall, "k": NatSmall, "n": NatSmall},
         )
 
+    @pytest.mark.xfail(
+        condition=(theano.config.floatX == "float32"),
+        reason="Fails on float32 due to a float casting problem in the logcdf",
+    )
     def test_negative_binomial(self):
         def scipy_mu_alpha_logpmf(value, mu, alpha):
             return sp.nbinom.logpmf(value, alpha, 1 - mu / (mu + alpha))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ deprecat
 h5py>=2.7
 ipython>=7.16
 nbsphinx>=0.4
+numpy>=1.15,<1.22.2
 numpydoc<1.2
 pre-commit>=2.8.0
 pytest-cov>=2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ cachetools>=4.2.1
 deprecat
 dill
 fastprogress>=0.2.0
-numpy>=1.15.0
+numpy>=1.15.0,<1.22.2
 pandas>=0.24.0
 patsy>=0.5.1
-scipy>=1.2.0
+scipy>=1.7.3,<1.8.0
 semver>=2.13.0
 theano-pymc==1.1.2
 typing-extensions>=3.7.4


### PR DESCRIPTION
Also aligns the SciPy version pins across the testing environments for different Python versions.

See tracking issue #5448.