### PR TITLE
Community gov update

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -664,7 +664,7 @@ Team:
 * Documentation team members are given permissions to [pymc-examples](https://github.com/pymc-devs/pymc-examples)
   and [resources](https://github.com/pymc-devs/resources) repositories.
 
-In addition, Council members are given admin rights to all repositories within
+In addition, Council members are given administrative rights to all repositories within
 the [pymc-devs](https://github.com/pymc-devs) organization.
 
 #### Discourse
@@ -709,7 +709,7 @@ provide examples on how to assign permissions:
   * Added to all private communication channels
   * Write permissions on pymc-examples and resources repositories, triage permissions
     to pymc and pymc-experimental repositories
-  * Admin access to ReadTheDocs accounts
+  * Administrative access to ReadTheDocs accounts
 
 - Dolors, core contributor, dev and community teams
   * Added to the Community PyMC_team and given "leader" trust level,

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -640,7 +640,7 @@ core contributor membership sections.
 All tasks related to the project that are not specifically listed in the
 description of a dedicated team are the responsibility of the PyMC team
 as a whole. At the time of writing, this includes but is not limited to:
-enforcing this governance  and the [PyMC code of conduct](https://github.com/pymc-devs/pymc/blob/main/CODE_OF_CONDUCT.md), developing project-related grants, soliciting of project sponsorships, decisions regarding the allocation of project-related funds, planning of the project roadmap, and triaging of GitHub issues.
+enforcing this governance and the [PyMC code of conduct](https://github.com/pymc-devs/pymc/blob/main/CODE_OF_CONDUCT.md), developing project-related grants, soliciting of project sponsorships, decisions regarding the allocation of project-related funds, planning of the project roadmap, or triaging of GitHub issues.
 
 ### Team structure in practice
 This section describes how members of the PyMC team are given
@@ -672,10 +672,11 @@ Similar to the above section, Discourse permissions are also mapped to the commu
 and the two contributor roles.
 
 Role:
-- Recurring Contributors are added to the [PyMC_team](https://discourse.pymc.io/g/PyMC_devs)
-  group and are given the "leader" trust level.
-- Core Contributors are given [moderator permissions](https://discourse.pymc.io/g/moderators)
-  if possible.
+- Recurring Contributors are given no special permissions
+- Core Contributors are added to the [PyMC_core](https://discourse.pymc.io/g/PyMC_core)
+  group independently of the teams they are part of.
+  Core Contributors in the community team are also added to the
+  [Community Team](https://discourse.pymc.io/g/Community_Team) group.
 
 #### Accounts and services ownership and administration
 The PyMC Project also has accounts and hosts services on several platforms
@@ -694,7 +695,7 @@ provide examples on how to assign permissions:
 <details><summary>See permission examples</summary>
 
 - Arnau, recurrent contributor, community team
-  * Added to the Community PyMC_team and given "leader" trust level
+  * No permissions on Discourse
   * Added to all private communication channels
   * Triage permissions on the pymcon, pymc-data-umbrella, and other "event" repositories
 
@@ -705,24 +706,25 @@ provide examples on how to assign permissions:
     of the pymc-devs organization
 
 - Carme, core contributor, doc team
-  * Added to the community PyMC_team and given "leader" trust level
+  * Added to the community PyMC_core group on Discourse
   * Added to all private communication channels
   * Write permissions on pymc-examples and resources repositories, triage permissions
     to pymc and pymc-experimental repositories
   * Administrative access to ReadTheDocs accounts
 
 - Dolors, core contributor, dev and community teams
-  * Added to the Community PyMC_team and given "leader" trust level,
-    given moderator permissions on Discourse (such permissions may rotate and not always be active)
+  * Added to the Community Team and PyMC_core Discourse groups.
+    Part of the rotation of administrative permissions on Discourse
+    (Discourse allows only 3 admins on our current plan).
   * Added to all private communication channels
   * Write permissions on pymc, pymc-experimental, pymcon, pymc-data-umbrella, and other "event" repositories, triage permissions
     on pymc-examples and resources repositories
 
 - Eudald, core contributor, no dedicated team membership
-  * Added to the Community PyMC_team and given "leader" trust level
+  * Added to the PyMC_core Discourse group
   * Added to all private communication channels
   * Triage permissions on all repositories
-  * Access to pymc gmail, drive and grant application platforms (i.e. CZI slack) as they are the main grant writing coordinator
+  * Access to PyMC gmail, drive and grant application platforms (i.e. CZI slack) as they are the main grant writing coordinator
 
 </details>
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -722,7 +722,7 @@ provide examples on how to assign permissions:
   * Added to the Community PyMC_team and given "leader" trust level
   * Added to all private communication channels
   * Triage permissions on all repositories
-  * Access to pymc_devs twitter account as they are the main manager
+  * Access to pymc gmail, drive and grant application platforms (i.e. CZI slack) as they are the main grant writing coordinator
 
 </details>
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -79,7 +79,7 @@ also members of all the groups listed above:
 Recurring Contributors comprise what we understand as the PyMC Team.
 The Team will generally act as a single unit, except for some specific
 questions where dedicated teams will prevail.
-The PyMC project currently has Developer, Documentation and Discourse teams.
+The PyMC project currently has Developer, Documentation and Community teams.
 Team members can be part of one, some or none of these dedicated teams.
 The diagram below should help illustrate this idea.
 
@@ -191,24 +191,24 @@ Contributors don't need to be part of any dedicated team.
 * Bill Engels (dev)
 * Brandon T. Willard (dev)
 * Chris Fonnesbeck (dev, docs)
-* Christian Luhmann (discourse)
+* Christian Luhmann (community)
 * Colin Carroll (dev)
 * Eelke Spaak (dev)
 * Eric Ma (dev - PyMC Labs)
 * George Ho (dev)
-* Junpeng Lao (dev, discourse)
+* Junpeng Lao (dev, community)
 * Luciano Paz (dev - PyMC Labs)
 * Martina Cantaro (docs)
 * Maxim Kochurov (dev - PyMC Labs)
 * Meenal Jhajharia (docs)
 * Michael Osthege (dev)
-* Oriol Abril-Pla (docs, discourse)
+* Oriol Abril-Pla (docs, community)
 * Osvaldo Martin (dev, docs)
-* Ravin Kumar (dev, discourse, docs)
-* Ricardo Vieira (dev, discourse)
+* Ravin Kumar (dev, community, docs)
+* Ricardo Vieira (dev, community)
 * Robert P. Goldman (dev)
 * Sayam Kumar (dev, docs)
-* Thomas Wiecki (dev, discourse - PyMC Labs)
+* Thomas Wiecki (dev, community - PyMC Labs)
 
 ## Steering Council
 
@@ -253,10 +253,10 @@ In particular, the Council may:
 The current Steering Council membership comprises:
 
 - Chris Fonnesbeck (dev, docs)
-- Junpeng Lao (dev, discourse)
-- Oriol Abril-Pla (docs, discourse)
-- Ravin Kumar (dev, discourse, docs)
-- Thomas Wiecki (dev, discourse - PyMC Labs)
+- Junpeng Lao (dev, community)
+- Oriol Abril-Pla (docs, community)
+- Ravin Kumar (dev, community, docs)
+- Thomas Wiecki (dev, community - PyMC Labs)
 
 Note that as explained in the [community architecture section](#community-and-team-architecture)
 and as indicated again in the description of the Steering Council above,
@@ -604,7 +604,7 @@ The dedicated teams are work units with two main objectives: better
 distributing the work related to The Project, and to better showcase all the different tasks
 involved in The Project to attract more diverse Contributors.
 
-The PyMC project currently has Developer, Documentation and Discourse teams.
+The PyMC project currently has Developer, Documentation and Community teams.
 Team members can be part of one, some or none of these dedicated teams.
 
 Team members are expected to participate and join these dedicated teams
@@ -630,10 +630,10 @@ write all the documentation for the PyMC library.
 For current members of the documentation team, refer to the recurrent and
 core contributor membership sections.
 
-### Discourse team
-The focus of the Discourse team is managing and energizing the PyMC Discourse.
+### Community team
+The focus of the Community team is activities intended to nuture, energize, and grow the community of PyMC users and contributors.
 
-For current members of the discourse team, refer to the recurrent and
+For current members of the community team, refer to the recurrent and
 core contributor membership sections.
 
 ### "No-team" tasks
@@ -668,7 +668,7 @@ In addition, Council members are given admin rights to all repositories within
 the [pymc-devs](https://github.com/pymc-devs) organization.
 
 #### Discourse
-Similarly to the above section, Discourse permissions are also mapped to the discourse team
+Similarly to the above section, Discourse permissions are also mapped to the community team
 and the two contributor roles.
 
 Role:
@@ -679,13 +679,13 @@ Role:
 
 #### Accounts and services ownership and administration
 The PyMC Project also has accounts and hosts services on several platforms
-such as GitHub, Discourse, Twitter, ReadTheDocs or Medium.
+such as GitHub, Discourse, Twitter, ReadTheDocs, and Medium.
 
 If possible, all Council Members and relevant Core Contributors should have
-admin rights on those platforms.
-If this were not possible, admin rights should be distributed between
+administrative rights on those platforms.
+If this is not possible, administrative rights should be distributed among
 Council Members and relevant Core Contributors and establish a rotation
-of the admin rights every 1-2 years.
+of the administrative rights every 1-2 years.
 
 #### Permission examples
 This section lists some imaginary contributors with their teams and roles to
@@ -693,8 +693,8 @@ provide examples on how to assign permissions:
 
 <details><summary>See permission examples</summary>
 
-- Arnau, recurrent contributor, discourse team
-  * Added to the Discourse PyMC_team and given "leader" trust level
+- Arnau, recurrent contributor, community team
+  * Added to the Community PyMC_team and given "leader" trust level
   * Added to all private communication channels
   * No permissions on any GitHub
 
@@ -705,21 +705,21 @@ provide examples on how to assign permissions:
     of the pymc-devs organization
 
 - Carme, core contributor, doc team
-  * Added to the Discourse PyMC_team and given "leader" trust level
+  * Added to the community PyMC_team and given "leader" trust level
   * Added to all private communication channels
   * Write permissions on pymc-examples and resources repositories, triage permissions
     to pymc and pymc-experimental repositories
   * Admin access to ReadTheDocs accounts
 
-- Dolors, core contributor, dev and discourse teams
-  * Added to the Discourse PyMC_team and given "leader" trust level,
+- Dolors, core contributor, dev and community teams
+  * Added to the Community PyMC_team and given "leader" trust level,
     given moderator permissions on Discourse (that might be rotating and not always active)
   * Added to all private communication channels
   * Write permissions on pymc and pymc-experimental repositories, triage permissions
     to pymc-examples and resources repositories
 
 - Eudald, core contributor, no dedicated team membership
-  * Added to the Discourse PyMC_team and given "leader" trust level
+  * Added to the Community PyMC_team and given "leader" trust level
   * Added to all private communication channels
   * Triage permissions on all repositories
   * Access to pymc_devs twitter account as they are the main manager

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -200,7 +200,7 @@ Contributors don't need to be part of any dedicated team.
 * Luciano Paz (dev - PyMC Labs)
 * Martina Cantaro (docs)
 * Maxim Kochurov (dev - PyMC Labs)
-* Meenal Jhajharia (docs)
+* Meenal Jhajharia (docs, community)
 * Michael Osthege (dev)
 * Oriol Abril-Pla (docs, community)
 * Osvaldo Martin (dev, docs)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -631,7 +631,7 @@ For current members of the documentation team, refer to the recurrent and
 core contributor membership sections.
 
 ### Community team
-The focus of the Community team is activities intended to nuture, energize, and grow the community of PyMC users and contributors.
+The focus of the Community team is activities intended to nurture, energize, and grow the community of PyMC users and contributors.  These activities include moderation of and participation in the discussions on the PyMC Discourse, planning and organization of events such as PyMCon and sprints, and coordination of presence on various social networks.  These activites are not intended to be the sole responsibility of the Community team.  Instead, the Community team provides leadership in these efforts, but recruits other contributors and community members as needed, thus encourging participation and fostering a healthy, self-sustaining community.
 
 For current members of the community team, refer to the recurrent and
 core contributor membership sections.
@@ -640,8 +640,7 @@ core contributor membership sections.
 All tasks related to the project that are not specifically listed in the
 description of a dedicated team are the responsibility of the PyMC team
 as a whole. At the time of writing, this includes but is not limited to:
-fundraising, issue triaging, running PyMC related events like PyMCon or
-sprints, outreach, or presence on social networks.
+enforcing this governance  and the [PyMC code of conduct](https://github.com/pymc-devs/pymc/blob/main/CODE_OF_CONDUCT.md), developing project-related grants, soliciting of project sponsorships, decisions regarding the allocation of project-related funds, planning of the project roadmap, and triaging of GitHub issues.
 
 ### Team structure in practice
 This section describes how members of the PyMC team are given
@@ -663,12 +662,13 @@ Team:
   and [pymc-experimental](https://github.com/pymc-devs/pymc-experimental) repository.
 * Documentation team members are given permissions to [pymc-examples](https://github.com/pymc-devs/pymc-examples)
   and [resources](https://github.com/pymc-devs/resources) repositories.
+* Community team members are given permissions to [PyMCon](https://github.com/pymc-devs/pymcon), [PyMC Data Umbrella](https://github.com/pymc-devs/pymc-data-umbrella), and other event- and community-related repositories.
 
 In addition, Council members are given administrative rights to all repositories within
 the [pymc-devs](https://github.com/pymc-devs) organization.
 
 #### Discourse
-Similarly to the above section, Discourse permissions are also mapped to the community team
+Similar to the above section, Discourse permissions are also mapped to the community team
 and the two contributor roles.
 
 Role:
@@ -696,7 +696,7 @@ provide examples on how to assign permissions:
 - Arnau, recurrent contributor, community team
   * Added to the Community PyMC_team and given "leader" trust level
   * Added to all private communication channels
-  * No permissions on any GitHub
+  * Triage permissions on the pymcon, pymc-data-umbrella, and other "event" repositories
 
 - Berta, recurrent contributor, dev and doc teams
   * No permissions on Discourse
@@ -713,10 +713,10 @@ provide examples on how to assign permissions:
 
 - Dolors, core contributor, dev and community teams
   * Added to the Community PyMC_team and given "leader" trust level,
-    given moderator permissions on Discourse (that might be rotating and not always active)
+    given moderator permissions on Discourse (such permissions may rotate and not always be active)
   * Added to all private communication channels
-  * Write permissions on pymc and pymc-experimental repositories, triage permissions
-    to pymc-examples and resources repositories
+  * Write permissions on pymc, pymc-experimental, pymcon, pymc-data-umbrella, and other "event" repositories, triage permissions
+    on pymc-examples and resources repositories
 
 - Eudald, core contributor, no dedicated team membership
   * Added to the Community PyMC_team and given "leader" trust level


### PR DESCRIPTION
This PR updates the governance document to reflect recent discussions regarding the mission and naming of PyMC's community team as requested by @OriolAbril.  As with other recent updates to the document, the diagram illustrating the organization of the various teams (docs/community_diagram.png) does not reflect the current update.