### PR TITLE
Move the NumPyro sampling time to the sample_stats group

### DIFF
--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -262,7 +262,7 @@ def sample_numpyro_nuts(
         sample_stats=_sample_stats_to_xarray(pmap_numpyro),
         coords=coords,
         dims=dims,
-        attrs={"sampling_time": (tic3 - tic2).total_seconds()},
+        sample_stats_attrs={"sampling_time": (tic3 - tic2).total_seconds()},
         **idata_kwargs,
     )
 


### PR DESCRIPTION
`sampling_time` should be an attribute of the `sample_stats` group, not the top-level `InferenceData` object.