### PR TITLE
Updated pymc.Bound docstring

### DIFF
--- a/pymc/distributions/bound.py
+++ b/pymc/distributions/bound.py
@@ -145,12 +145,12 @@ class Bound:
 
     Parameters
     ----------
-    dist: PyMC unnamed distribution
+    dist : PyMC unnamed distribution
         Distribution to be transformed into a bounded distribution created via the
         `.dist()` API.
-    lower: float or array like, optional
+    lower : float or array like, optional
         Lower bound of the distribution.
-    upper: float or array like, optional
+    upper : float or array like, optional
         Upper bound of the distribution.
 
     Examples


### PR DESCRIPTION
I've only made a small change to catch the sight of the merging process, since perhaps these issues should be saved for the sprint.

Let me know if I should update more of the docstrings in distributions/bound.py or update the docstrings for other objects yet.

+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
