### PR TITLE
Change tests included in arviz_compat workflow

### DIFF
--- a/.github/workflows/arviz_compat.yml
+++ b/.github/workflows/arviz_compat.yml
@@ -20,11 +20,18 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         floatx: [float64]
         test-subset:
-          - pymc/tests/test_distributions.py
+          - |
+            pymc/tests/test_parallel_sampling.py
+            pymc/tests/test_posteriors.py
+            pymc/tests/test_sampling.py
 
           - |
-            pymc/tests/test_distributions_random.py
-            pymc/tests/test_sampling.py
+            pymc/tests/test_data_container.py
+            pymc/tests/test_idata_conversion.py
+            pymc/tests/test_missing.py
+            pymc/tests/test_model.py
+            pymc/tests/test_shape_handling.py
+            pymc/tests/test_shared.py
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
The macOS machines in Github actions seem incredibly slow (see #5410), so I am proposing to remove the computationally heavier tests in favor of something more integration-like (which should also be more relevant for the "arviz_compat" part).

Currently this is a draft to check what the new Runtime might look like.

***

Chose a set of tests that are more related to sampling + arviz, while dropping the slow test_distributions and test_distributions_random that have nothing to do with arviz

Closes #5410