### PR TITLE
Add blas dependency temporarily

### DIFF
--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -7,6 +7,7 @@ dependencies:
 - aeppl=0.0.26
 - aesara=2.3.8
 - arviz>=0.11.4
+- blas
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -29,6 +29,7 @@ dependencies:
 - sphinx-notfound-page
 - sphinx>=1.5
 - typing-extensions>=3.7.4
+- watermark
 - pip:
   - polyagamma
   - sphinx-design

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -7,6 +7,7 @@ dependencies:
 - aeppl=0.0.26
 - aesara=2.3.8
 - arviz>=0.11.4
+- blas
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -29,6 +29,7 @@ dependencies:
 - sphinx-notfound-page
 - sphinx>=1.5
 - typing-extensions>=3.7.4
+- watermark
 - pip:
   - polyagamma
   - sphinx-design

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -7,6 +7,7 @@ dependencies:
 - aeppl=0.0.26
 - aesara=2.3.8
 - arviz>=0.11.4
+- blas
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -29,6 +29,7 @@ dependencies:
 - sphinx-notfound-page
 - sphinx>=1.5
 - typing-extensions>=3.7.4
+- watermark
 - pip:
   - polyagamma
   - sphinx-design

--- a/conda-envs/environment-test-py37.yml
+++ b/conda-envs/environment-test-py37.yml
@@ -7,6 +7,7 @@ dependencies:
 - aeppl=0.0.26
 - aesara=2.3.8
 - arviz>=0.11.4
+- blas
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/conda-envs/environment-test-py38.yml
+++ b/conda-envs/environment-test-py38.yml
@@ -7,6 +7,7 @@ dependencies:
 - aeppl=0.0.26
 - aesara=2.3.8
 - arviz>=0.11.4
+- blas
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/conda-envs/environment-test-py39.yml
+++ b/conda-envs/environment-test-py39.yml
@@ -7,6 +7,7 @@ dependencies:
 - aeppl=0.0.26
 - aesara=2.3.8
 - arviz>=0.11.4
+- blas
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -7,6 +7,7 @@ dependencies:
 - aeppl=0.0.26
 - aesara=2.3.8
 - arviz>=0.11.4
+- blas
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/conda-envs/windows-environment-test-py38.yml
+++ b/conda-envs/windows-environment-test-py38.yml
@@ -7,6 +7,7 @@ dependencies:
 - aeppl=0.0.26
 - aesara=2.3.8
 - arviz>=0.11.4
+- blas
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,3 +25,4 @@ sphinx-notfound-page
 sphinx-remove-toctrees
 sphinx>=1.5
 typing-extensions>=3.7.4
+watermark

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -51,6 +51,7 @@ EXCLUDE = {
     "mkl-service",
     "numba",
     "python-graphviz",
+    "blas",
 }
 RENAME = {}
 


### PR DESCRIPTION
This should make sure the docs / conda dev environments work properly for the sprint. We can revert this commit once the next Aesara version is used, as it is part of the Aesara conda-forge recipe: https://github.com/conda-forge/aesara-feedstock/pull/48