### PR TITLE
MNT Removes pandas Series from point_logps

### DIFF
--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -157,8 +157,9 @@ class BaseHMC(GradientSharedStep):
 
         if not np.isfinite(start.energy):
             model = self._model
-            check_test_point = model.point_logps()
-            error_logp = check_test_point.loc[
+            check_test_point_dict = model.point_logps()
+            check_test_point = np.asarray(list(check_test_point_dict.values()))
+            error_logp = check_test_point[
                 (np.abs(check_test_point) >= 1e20) | np.isnan(check_test_point)
             ]
             self.potential.raise_ok(q0.point_map_info)

--- a/pymc/tests/test_transforms.py
+++ b/pymc/tests/test_transforms.py
@@ -233,7 +233,7 @@ def test_interval_near_boundary():
         pm.Uniform("x", initval=x0, lower=lb, upper=ub)
 
     log_prob = model.point_logps()
-    np.testing.assert_allclose(log_prob, np.array([-52.68]))
+    np.testing.assert_allclose(list(log_prob.values()), np.array([-52.68]))
 
 
 def test_circular():


### PR DESCRIPTION
Address some of https://github.com/pymc-devs/pymc/issues/5469

Changing the return type of `point_logps` is a breaking change. For example, `BaseHMC.astep` needed to be adjusted to support the dictionary.

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes?
+ [x] important background, or details about the implementation
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [x] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
