### PR TITLE
Fix command to render documentation in build_docs

### DIFF
--- a/docs/source/contributing/build_docs.md
+++ b/docs/source/contributing/build_docs.md
@@ -6,7 +6,7 @@ To build the docs, run these commands at pymc repository root:
 $ pip install -r requirements-dev.txt  # Make sure the dev requirements are installed
 $ make clean  # clean built docs from previous runs and intermediate outputs
 $ make html   # Build docs
-$ python -m http.server --directory ../_build/  # Render docs
+$ python -m http.server --directory docs/_build/  # Render docs
 ```
 
 Check the printed url where docs are being served and open it.


### PR DESCRIPTION
Fix `build_docs.md` with the path to the built documentation.
Getting ready for the DataUmbrella sprint :nerd_face: 