### PR TITLE
Fix linting link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,6 @@ Depending on what your PR does, here are a few things you might want to address 
 + [ ] what are the (breaking) changes that this PR makes?
 + [ ] important background, or details about the implementation
 + [ ] are the changes—especially new features—covered by tests and docstrings?
-+ [ ] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
++ [ ] [linting/style checks have been run](https://docs.pymc.io/en/latest/contributing/python_style.html)
 + [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
 + [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md


### PR DESCRIPTION
The current link to the linting page points to a [deprecated wiki page](https://github.com/pymc-devs/pymc/wiki/PyMC3-Python-Code-Style).
This, in turn, points to [another deprecated wiki page](https://github.com/pymc-devs/pymc/wiki/Python-Code-Style).
The current link is https://docs.pymc.io/en/latest/contributing/python_style.html