### PR TITLE
Fix numpydoc in pm.Data, pm.MutableData, pm.ConstantData

### DIFF
--- a/pymc/data.py
+++ b/pymc/data.py
@@ -577,7 +577,7 @@ def Data(
     ----------
     name : str
         The name for this variable.
-    value : array_like or pd.Series, pd.Dataframe
+    value : array_like or pandas.Series, pandas.Dataframe
         A value to associate with this variable.
     dims : str or tuple of str, optional
         Dimension names of the random variables (as opposed to the shapes of these

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -614,7 +614,7 @@ def Data(
     :func:`pymc.Model.set_data`.
 
     For more information, take a look at this example notebook
-    https://docs.pymc.io/notebooks/data_container.html
+    https://docs.pymc.io/projects/examples/en/latest/pymc3_howto/data_container.html
     """
     if isinstance(value, list):
         value = np.array(value)

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -571,8 +571,7 @@ def Data(
     To set the value of the data container variable, check out
     :func:`pymc.Model.set_data`.
 
-    For more information, take a look at this example notebook
-    https://docs.pymc.io/projects/examples/en/latest/pymc3_howto/data_container.html
+    For more information, take a look at this example notebook :ref:`nb:data_container`
 
     Parameters
     ----------

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -565,6 +565,12 @@ def Data(
     is registered as a ``SharedVariable``, enabling it to be altered
     in value and shape, but NOT in dimensionality using ``pm.set_data()``.
 
+    To set the value of the data container variable, check out
+    :func:`pymc.Model.set_data`.
+
+    For more information, take a look at this example notebook
+    https://docs.pymc.io/projects/examples/en/latest/pymc3_howto/data_container.html
+
     Parameters
     ----------
     name : str
@@ -590,7 +596,6 @@ def Data(
 
     Examples
     --------
-
     >>> import pymc as pm
     >>> import numpy as np
     >>> # We generate 10 datasets
@@ -609,12 +614,6 @@ def Data(
     ...         # Switch out the observed dataset
     ...         model.set_data('data', data_vals)
     ...         idatas.append(pm.sample())
-
-    To set the value of the data container variable, check out
-    :func:`pymc.Model.set_data`.
-
-    For more information, take a look at this example notebook
-    https://docs.pymc.io/projects/examples/en/latest/pymc3_howto/data_container.html
     """
     if isinstance(value, list):
         value = np.array(value)

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -567,25 +567,25 @@ def Data(
 
     Parameters
     ----------
-    name: str
+    name : str
         The name for this variable
-    value: {List, np.ndarray, pd.Series, pd.Dataframe}
+    value : {List, np.ndarray, pd.Series, pd.Dataframe}
         A value to associate with this variable
     mutable : bool, optional
         Switches between creating a ``SharedVariable`` (``mutable=True``, default)
         vs. creating a ``TensorConstant`` (``mutable=False``).
         Consider using ``pm.ConstantData`` or ``pm.MutableData`` as less verbose
         alternatives to ``pm.Data(..., mutable=...)``.
-    dims: {str, tuple of str}, optional, default=None
+    dims : {str, tuple of str}, optional, default=None
         Dimension names of the random variables (as opposed to the shapes of these
         random variables). Use this when `value` is a pandas Series or DataFrame. The
         `dims` will then be the name of the Series / DataFrame's columns. See ArviZ
         documentation for more information about dimensions and coordinates:
         :ref:`arviz:quickstart`.
-    export_index_as_coords: bool, optional, default=False
+    export_index_as_coords : bool, optional, default=False
         If True, the `Data` container will try to infer what the coordinates should be
         if there is an index in `value`.
-    **kwargs: dict, optional
+    **kwargs : dict, optional
         Extra arguments passed to :func:`aesara.shared`.
 
     Examples

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -569,20 +569,20 @@ def Data(
     ----------
     name : str
         The name for this variable
-    value : {List, np.ndarray, pd.Series, pd.Dataframe}
+    value : list or ndarray or pd.Series, pd.Dataframe
         A value to associate with this variable
     mutable : bool, optional
         Switches between creating a ``SharedVariable`` (``mutable=True``, default)
         vs. creating a ``TensorConstant`` (``mutable=False``).
         Consider using ``pm.ConstantData`` or ``pm.MutableData`` as less verbose
         alternatives to ``pm.Data(..., mutable=...)``.
-    dims : {str, tuple of str}, optional, default=None
+    dims : str or tuple of str, optional, default=None
         Dimension names of the random variables (as opposed to the shapes of these
         random variables). Use this when `value` is a pandas Series or DataFrame. The
         `dims` will then be the name of the Series / DataFrame's columns. See ArviZ
         documentation for more information about dimensions and coordinates:
         :ref:`arviz:quickstart`.
-    export_index_as_coords : bool, optional, default=False
+    export_index_as_coords : bool, default=False
         If True, the `Data` container will try to infer what the coordinates should be
         if there is an index in `value`.
     **kwargs : dict, optional

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -562,8 +562,9 @@ def Data(
     """Data container that registers a data variable with the model.
 
     Depending on the ``mutable`` setting (default: True), the variable
-    is registered as a ``SharedVariable``, enabling it to be altered
-    in value and shape, but NOT in dimensionality using ``pm.set_data()``.
+    is registered as a :class:`~aesara.compile.sharedvalue.SharedVariable`,
+    enabling it to be altered in value and shape, but NOT in dimensionality using
+    :func:`pymc.set_data`.
 
     To set the value of the data container variable, check out
     :func:`pymc.Model.set_data`.

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -568,9 +568,9 @@ def Data(
     Parameters
     ----------
     name : str
-        The name for this variable
+        The name for this variable.
     value : list or ndarray or pd.Series, pd.Dataframe
-        A value to associate with this variable
+        A value to associate with this variable.
     mutable : bool, optional
         Switches between creating a ``SharedVariable`` (``mutable=True``, default)
         vs. creating a ``TensorConstant`` (``mutable=False``).

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -577,11 +577,6 @@ def Data(
         The name for this variable.
     value : list or ndarray or pd.Series, pd.Dataframe
         A value to associate with this variable.
-    mutable : bool, optional
-        Switches between creating a ``SharedVariable`` (``mutable=True``, default)
-        vs. creating a ``TensorConstant`` (``mutable=False``).
-        Consider using ``pm.ConstantData`` or ``pm.MutableData`` as less verbose
-        alternatives to ``pm.Data(..., mutable=...)``.
     dims : str or tuple of str, optional, default=None
         Dimension names of the random variables (as opposed to the shapes of these
         random variables). Use this when `value` is a pandas Series or DataFrame. The
@@ -591,6 +586,11 @@ def Data(
     export_index_as_coords : bool, default=False
         If True, the `Data` container will try to infer what the coordinates should be
         if there is an index in `value`.
+    mutable : bool, optional
+        Switches between creating a ``SharedVariable`` (``mutable=True``, default)
+        vs. creating a ``TensorConstant`` (``mutable=False``).
+        Consider using ``pm.ConstantData`` or ``pm.MutableData`` as less verbose
+        alternatives to ``pm.Data(..., mutable=...)``.
     **kwargs : dict, optional
         Extra arguments passed to :func:`aesara.shared`.
 

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -578,7 +578,7 @@ def Data(
     ----------
     name : str
         The name for this variable.
-    value : list or ndarray or pd.Series, pd.Dataframe
+    value : array_like or pd.Series, pd.Dataframe
         A value to associate with this variable.
     dims : str or tuple of str, optional
         Dimension names of the random variables (as opposed to the shapes of these

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -578,20 +578,26 @@ def Data(
         The name for this variable.
     value : list or ndarray or pd.Series, pd.Dataframe
         A value to associate with this variable.
-    dims : str or tuple of str, optional, default=None
+    dims : str or tuple of str, optional
         Dimension names of the random variables (as opposed to the shapes of these
         random variables). Use this when ``value`` is a pandas Series or DataFrame. The
         ``dims`` will then be the name of the Series / DataFrame's columns. See ArviZ
         documentation for more information about dimensions and coordinates:
         :ref:`arviz:quickstart`.
+        If this parameter is not specified, the random variables will not have dimension
+        names.
     export_index_as_coords : bool, default=False
         If True, the ``Data`` container will try to infer what the coordinates should be
         if there is an index in ``value``.
     mutable : bool, optional
-        Switches between creating a ``SharedVariable`` (``mutable=True``, default)
-        vs. creating a ``TensorConstant`` (``mutable=False``).
-        Consider using ``pm.ConstantData`` or ``pm.MutableData`` as less verbose
-        alternatives to ``pm.Data(..., mutable=...)``.
+        Switches between creating a :class:`~aesara.compile.sharedvalue.SharedVariable`
+        (``mutable=True``) vs. creating a :class:`~aesara.tensor.TensorConstant`
+        (``mutable=False``).
+        Consider using :class:`pymc.ConstantData` or :class:`pymc.MutableData` as less
+        verbose alternatives to ``pm.Data(..., mutable=...)``.
+        If this parameter is not specified, the value it takes will depend on the
+        version of the package. Since ``v4.1.0`` the default value is
+        ``mutable=False``, with previous versions having ``mutable=True``.
     **kwargs : dict, optional
         Extra arguments passed to :func:`aesara.shared`.
 

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -571,7 +571,7 @@ def Data(
     To set the value of the data container variable, check out
     :func:`pymc.Model.set_data`.
 
-    For more information, read the notebook :ref:`nb:data_container`
+    For more information, read the notebook :ref:`nb:data_container`.
 
     Parameters
     ----------

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -571,7 +571,7 @@ def Data(
     To set the value of the data container variable, check out
     :func:`pymc.Model.set_data`.
 
-    For more information, take a look at this example notebook :ref:`nb:data_container`
+    For more information, read the notebook :ref:`nb:data_container`
 
     Parameters
     ----------

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -516,7 +516,8 @@ def ConstantData(
 ) -> TensorConstant:
     """Alias for ``pm.Data(..., mutable=False)``.
 
-    Registers the ``value`` as a ``TensorConstant`` with the model.
+    Registers the ``value`` as a :class:`~aesara.tensor.TensorConstant` with the model.
+    For more information, please reference :class:`pymc.Data`.
     """
     return Data(
         name,
@@ -538,7 +539,8 @@ def MutableData(
 ) -> SharedVariable:
     """Alias for ``pm.Data(..., mutable=True)``.
 
-    Registers the ``value`` as a ``SharedVariable`` with the model.
+    Registers the ``value`` as a :class:`~aesara.compile.sharedvalue.SharedVariable`
+    with the model. For more information, please reference :class:`pymc.Data`.
     """
     return Data(
         name,

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -611,7 +611,7 @@ def Data(
     ...         idatas.append(pm.sample())
 
     To set the value of the data container variable, check out
-    :func:`pymc.model.set_data()`.
+    :func:`pymc.Model.set_data`.
 
     For more information, take a look at this example notebook
     https://docs.pymc.io/notebooks/data_container.html

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -579,13 +579,13 @@ def Data(
         A value to associate with this variable.
     dims : str or tuple of str, optional, default=None
         Dimension names of the random variables (as opposed to the shapes of these
-        random variables). Use this when `value` is a pandas Series or DataFrame. The
-        `dims` will then be the name of the Series / DataFrame's columns. See ArviZ
+        random variables). Use this when ``value`` is a pandas Series or DataFrame. The
+        ``dims`` will then be the name of the Series / DataFrame's columns. See ArviZ
         documentation for more information about dimensions and coordinates:
         :ref:`arviz:quickstart`.
     export_index_as_coords : bool, default=False
-        If True, the `Data` container will try to infer what the coordinates should be
-        if there is an index in `value`.
+        If True, the ``Data`` container will try to infer what the coordinates should be
+        if there is an index in ``value``.
     mutable : bool, optional
         Switches between creating a ``SharedVariable`` (``mutable=True``, default)
         vs. creating a ``TensorConstant`` (``mutable=False``).


### PR DESCRIPTION
Addresses #5459.

This PR:
- Add space between colon in parameters
- Fix link to Model.set_data function in documentation
- Fix docstring parameters type
- Fix link to example notebook
- Move information to extended description
- Add punctuation to parameter description
- Move parameter description to respect parameters order
- Add double ticks for code references in docstrings
- Link function in pymc
- Add default behaviour of optional parameters
- Add reference to pm.Data in pm.ConstantData and pm.MutableData

The `value` parameter still references pandas objects (`pd.Series`, `pd.Dataframe`).
How should we handle them?

On the other hand, I think the [reference notebook](https://docs.pymc.io/projects/examples/en/latest/pymc3_howto/data_container.html) remains to be translated to the new version. I don't know if we should leave a comment to remember to change it once it is updated or not.

#DataUmbrellaPyMCSprint