### PR TITLE
Updates to pymc.Hypergeometric docstrings

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -971,11 +971,11 @@ class HyperGeometric(Discrete):
 
     Parameters
     ----------
-    N : integer
+    N : integer, array_like or TensorVariable
         Total size of the population (N > 0)
-    k : integer
+    k : integer, array_like or TensorVariable
         Number of successful individuals in the population (0 <= k <= N)
-    n : integer
+    n : integer, array_like or TensorVariable
         Number of samples drawn from the population (0 <= n <= N)
     """
 

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -972,11 +972,11 @@ class HyperGeometric(Discrete):
     Parameters
     ----------
     N : integer
-        Total size of the population
+        Total size of the population (N > 0)
     k : integer
-        Number of successful individuals in the population
+        Number of successful individuals in the population (0 <= k <= N)
     n : integer
-        Number of samples drawn from the population
+        Number of samples drawn from the population (0 <= n <= N)
     """
 
     rv_op = hypergeometric

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1004,6 +1004,10 @@ class HyperGeometric(Discrete):
         value : numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or Aesara tensor
+        good : integer
+            Number of successful individuals in the population. Alias for parameter :math:`k`.
+        bad : integer
+            Number of unsuccessful individuals in the population. Alias for :math:`N-k`.
 
         Returns
         -------
@@ -1042,8 +1046,14 @@ class HyperGeometric(Discrete):
 
         Parameters
         ----------
-        value: numeric
+        value : numeric
             Value for which log CDF is calculated.
+        good : integer
+            Number of successful individuals in the population. Alias for parameter :math:`k`.
+        bad : integer
+            Number of unsuccessful individuals in the population. Alias for :math:`N-k`.
+        n : integer
+            Number of samples drawn from the population (0 <= n <= N)
 
         Returns
         -------

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -971,11 +971,11 @@ class HyperGeometric(Discrete):
 
     Parameters
     ----------
-    N : integer, array_like or TensorVariable
+    N : tensor_like of integer
         Total size of the population (N > 0)
-    k : integer, array_like or TensorVariable
+    k : tensor_like of integer
         Number of successful individuals in the population (0 <= k <= N)
-    n : integer, array_like or TensorVariable
+    n : tensor_like of integer
         Number of samples drawn from the population (0 <= n <= N)
     """
 

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1004,9 +1004,9 @@ class HyperGeometric(Discrete):
         value : numeric
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
             values are desired the values must be provided in a numpy array or Aesara tensor
-        good : integer
+        good : integer, array_like or TensorVariable
             Number of successful individuals in the population. Alias for parameter :math:`k`.
-        bad : integer
+        bad : integer, array_like or TensorVariable
             Number of unsuccessful individuals in the population. Alias for :math:`N-k`.
 
         Returns


### PR DESCRIPTION
As part of the work of #5459:

- Added the bounds to the parameters N, k, and n in the parameters section of pymc.Hypergeometric.
- Added docstrings for parameters "good" and "bad" in `logp` and `logcdf`. These parameters are different than the ones used in `__init__`, which is odd to me. They transform the `N` and `k` parameters to `bad` (which is `N - k`) and `good` (which is `k`), but this transformation could happen inside `logp` and `logcdf`. Would it make sense to always use N, k? 

#DataUmbrellaPyMCSprint