### PR TITLE
adding nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,10 +1,11 @@
-name: Nightly
+name: nightly
+
 on:
   schedule:
     - cron: "0 0 * * *"
 
 jobs:
-  build_and_publish:
+  build-and-publish-nightly:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
@@ -28,7 +29,7 @@ jobs:
           user: __token__
           password: ${{ secrets.nightly_pypi_secret }}
   test-install-job:
-    needs: release-job
+    needs: build-and-publish-nightly
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,42 @@
+name: Nightly
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  build_and_publish:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install build
+      - name: Build the sdist
+        run: python -m build --sdist .
+        env:
+          BUILD_PYMC_NIGHTLY: true
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.nightly_pypi_secret }}
+  test-install-job:
+    needs: release-job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Give PyPI a chance to update the index
+      run: sleep 240
+    - name: Install from PyPI
+      run: |
+        pip install pymc-nightly==${GITHUB_REF:11}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,4 +40,4 @@ jobs:
       run: sleep 240
     - name: Install from PyPI
       run: |
-        pip install pymc-nightly==${GITHUB_REF:11}
+        pip install pymc-nightly==${GITHUB_REF:11}.dev$(date +"%Y%m%d")

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ AUTHOR = "PyMC Developers"
 AUTHOR_EMAIL = "pymc.devs@gmail.com"
 URL = "http://github.com/pymc-devs/pymc"
 LICENSE = "Apache License, Version 2.0"
+NIGHLTY = "BUILD_PYMC_NIGHTLY" in os.environ
 
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -81,12 +82,10 @@ def get_version(nightly_build=False):
     raise RuntimeError(f"Unable to find version in {version_file}.")
 
 
-nightly = "BUILD_PYMC_NIGHTLY" in os.environ
-
 if __name__ == "__main__":
     setup(
-        name=get_distname(nightly),
-        version=get_version(nightly),
+        name=get_distname(NIGHLTY),
+        version=get_version(NIGHLTY),
         maintainer=AUTHOR,
         maintainer_email=AUTHOR_EMAIL,
         description=DESCRIPTION,

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ import os
 import re
 
 from codecs import open
+from datetime import datetime, timezone
 from os.path import dirname, join, realpath
 
 from setuptools import find_packages, setup
 
-DISTNAME = "pymc"
 DESCRIPTION = "Probabilistic Programming in Python: Bayesian Modeling and Probabilistic Machine Learning with Aesara"
 AUTHOR = "PyMC Developers"
 AUTHOR_EMAIL = "pymc.devs@gmail.com"
@@ -55,9 +55,17 @@ with open(REQUIREMENTS_FILE) as f:
 test_reqs = ["pytest", "pytest-cov"]
 
 
+def get_distname(nightly_build=False):
+    distname = "pymc"
+    if nightly_build:
+        distname = "{}{}".format(distname, "-nightly")
+
+    return distname
+
+
 def get_version(nightly_build=False):
-    VERSIONFILE = join("pymc", "__init__.py")
-    lines = open(VERSIONFILE).readlines()
+    version_file = join("pymc", "__init__.py")
+    lines = open(version_file).readlines()
     version_regex = r"^__version__ = ['\"]([^'\"]*)['\"]"
     for line in lines:
         mo = re.search(version_regex, line, re.M)
@@ -65,27 +73,20 @@ def get_version(nightly_build=False):
             version = mo.group(1)
 
             if nightly_build:
-                from datetime import datetime, timezone
-
                 suffix = datetime.now(timezone.utc).strftime(r".dev%Y%m%d")
-                version += suffix
+                version = f"{version}{suffix}"
 
             return version
 
-    raise RuntimeError(f"Unable to find version in {VERSIONFILE}.")
+    raise RuntimeError(f"Unable to find version in {version_file}.")
 
 
-if "BUILD_PYMC_NIGHTLY" in os.environ:
-    nightly = True
-    DISTNAME += "-nightly"
-    VERSION = get_version(nightly_build=True)
-else:
-    VERSION = get_version()
+nightly = "BUILD_PYMC_NIGHTLY" in os.environ
 
 if __name__ == "__main__":
     setup(
-        name=DISTNAME,
-        version=VERSION,
+        name=get_distname(nightly),
+        version=get_version(nightly),
         maintainer=AUTHOR,
         maintainer_email=AUTHOR_EMAIL,
         description=DESCRIPTION,

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import os
 import re
 
 from codecs import open
@@ -65,10 +66,26 @@ def get_version():
     raise RuntimeError(f"Unable to find version in {VERSIONFILE}.")
 
 
+VERSION = get_version()
+
+if "BUILD_PYMC_NIGHTLY" in os.environ:
+    nightly = True
+    DISTNAME += "-nightly"
+
+    def get_versions():
+        from datetime import datetime, timezone
+
+        suffix = datetime.now(timezone.utc).strftime(r".dev%Y%m%d")
+        versions = get_version()
+        versions += suffix
+        return versions
+
+    VERSION = get_versions()
+
 if __name__ == "__main__":
     setup(
         name=DISTNAME,
-        version=get_version(),
+        version=VERSION,
         maintainer=AUTHOR,
         maintainer_email=AUTHOR_EMAIL,
         description=DESCRIPTION,

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ test_reqs = ["pytest", "pytest-cov"]
 def get_distname(nightly_build=False):
     distname = "pymc"
     if nightly_build:
-        distname = "{}{}".format(distname, "-nightly")
+        distname = f"{distname}-nightly"
 
     return distname
 

--- a/setup.py
+++ b/setup.py
@@ -55,32 +55,32 @@ with open(REQUIREMENTS_FILE) as f:
 test_reqs = ["pytest", "pytest-cov"]
 
 
-def get_version():
+def get_version(nightly_build=False):
     VERSIONFILE = join("pymc", "__init__.py")
     lines = open(VERSIONFILE).readlines()
     version_regex = r"^__version__ = ['\"]([^'\"]*)['\"]"
     for line in lines:
         mo = re.search(version_regex, line, re.M)
         if mo:
-            return mo.group(1)
+            version = mo.group(1)
+
+            if nightly_build:
+                from datetime import datetime, timezone
+
+                suffix = datetime.now(timezone.utc).strftime(r".dev%Y%m%d")
+                version += suffix
+
+            return version
+
     raise RuntimeError(f"Unable to find version in {VERSIONFILE}.")
 
-
-VERSION = get_version()
 
 if "BUILD_PYMC_NIGHTLY" in os.environ:
     nightly = True
     DISTNAME += "-nightly"
-
-    def get_versions():
-        from datetime import datetime, timezone
-
-        suffix = datetime.now(timezone.utc).strftime(r".dev%Y%m%d")
-        versions = get_version()
-        versions += suffix
-        return versions
-
-    VERSION = get_versions()
+    VERSION = get_version(nightly_build=True)
+else:
+    VERSION = get_version()
 
 if __name__ == "__main__":
     setup(


### PR DESCRIPTION
This PR closes #5144. It adds support for building a "nightly" release, pushing it to the pymc-nightly PyPI package.

I have taken it mostly from [aesara-devs/aesara/pull/656](https://github.com/aesara-devs/aesara/pull/656), copying the relevant nightly.yml and setup.py files.

If the environment variable BUILD_PYMC_NIGHTLY is present, the name of the package in setup.py gets renamed and the VERSION variable is changed to return the current base version with the date appended.

Differences between aesara PR and questions:
- this is "pymc" not "aesara"
- pymc has it's own `get_version()` rather than using `versioneer`. The aesara versioneer code uses `versions["version"] = versions["version"].split("+")[0] + suffix` and I just use `+ suffix`, which in my environment gives `VERSION="4.0.0b2.dev20220218"`
- I added a test to `nightly.yml` for the nightly install. Aesara doesn't have this. No idea what `${GITHUB_REF:11}` means
- Are the secrets. correct?
- Am I okay using `python -m build --sdist` rather than `twine wheel`

There's no way of testing this... so check carefully

Cheers
