### PR TITLE
Updated pymc.Exponential docstring

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -1461,8 +1461,8 @@ class Exponential(PositiveContinuous):
 
     Parameters
     ----------
-    lam: float
-        Rate or inverse scale (lam > 0)
+    lam : float
+        Rate or inverse scale (`lam` > 0)
     """
     rv_op = exponential
 

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -1433,6 +1433,7 @@ class Exponential(PositiveContinuous):
        f(x \mid \lambda) = \lambda \exp\left\{ -\lambda x \right\}
 
     .. plot::
+        :context: close-figs
 
         import matplotlib.pyplot as plt
         import numpy as np
@@ -1461,8 +1462,8 @@ class Exponential(PositiveContinuous):
 
     Parameters
     ----------
-    lam : float
-        Rate or inverse scale (`lam` > 0)
+    lam : tensor_like of float
+        Rate or inverse scale (``lam`` > 0)
     """
     rv_op = exponential
 


### PR DESCRIPTION
- Added a space before the colon in the Parameter section.
- Put the parameter name `lam` in back ticks.
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
