### PR TITLE
fixed Gamma docstring or -> of

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2279,13 +2279,13 @@ class Gamma(PositiveContinuous):
 
     Parameters
     ----------
-    alpha : tensor_like or float, optional
+    alpha : tensor_like of float, optional
         Shape parameter (alpha > 0).
-    beta : tensor_like or float, optional
+    beta : tensor_like of float, optional
         Rate parameter (beta > 0).
-    mu : tensor_like or float, optional
+    mu : tensor_like of float, optional
         Alternative shape parameter (mu > 0).
-    sigma : tensor_like or float, optional
+    sigma : tensor_like of float, optional
         Alternative scale parameter (sigma > 0).
     """
     rv_op = gamma


### PR DESCRIPTION
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md

This fixes my previous mistake in the Gamma distributionwhere I wrote tensor_like or float. For issue https://github.com/pymc-devs/pymc/issues/5459