### PR TITLE
Fix the Minibatch deprecated warnings

### DIFF
--- a/pymc/data.py
+++ b/pymc/data.py
@@ -321,7 +321,7 @@ class Minibatch(TensorVariable):
         else:
             data = np.asarray(data, dtype)
         in_memory_slc = self.make_static_slices(in_memory_size)
-        self.shared = aesara.shared(data[in_memory_slc])
+        self.shared = aesara.shared(data[tuple(in_memory_slc)])
         self.update_shared_f = update_shared_f
         self.random_slc = self.make_random_slices(self.shared.shape, batch_size, random_seed)
         minibatch = self.shared[self.random_slc]

--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import io
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -403,3 +405,8 @@ def test_data_naming():
         y = pm.Normal("y")
     assert y.name == "named_model_y"
     assert x.name == "named_model_x"
+
+
+def test_get_data():
+    data = pm.get_data("radon.csv")
+    assert type(data) == io.BytesIO

--- a/pymc/tests/test_minibatches.py
+++ b/pymc/tests/test_minibatches.py
@@ -317,21 +317,18 @@ class TestMinibatch:
         mb = pm.Minibatch(self.data, [(10, 42), (4, 42)])
         assert mb.eval().shape == (10, 4, 40, 10, 50)
 
-    def test_special1(self):
-        mb = pm.Minibatch(self.data, [(10, 42), None, (4, 42)])
-        assert mb.eval().shape == (10, 10, 4, 10, 50)
-
-    def test_special2(self):
-        mb = pm.Minibatch(self.data, [(10, 42), Ellipsis, (4, 42)])
-        assert mb.eval().shape == (10, 10, 40, 10, 4)
-
-    def test_special3(self):
-        mb = pm.Minibatch(self.data, [(10, 42), None, Ellipsis, (4, 42)])
-        assert mb.eval().shape == (10, 10, 40, 10, 4)
-
-    def test_special4(self):
-        mb = pm.Minibatch(self.data, [10, None, Ellipsis, (4, 42)])
-        assert mb.eval().shape == (10, 10, 40, 10, 4)
+    @pytest.mark.parametrize(
+        "batch_size, expected",
+        [
+            ([(10, 42), None, (4, 42)], (10, 10, 4, 10, 50)),
+            ([(10, 42), Ellipsis, (4, 42)], (10, 10, 40, 10, 4)),
+            ([(10, 42), None, Ellipsis, (4, 42)], (10, 10, 40, 10, 4)),
+            ([10, None, Ellipsis, (4, 42)], (10, 10, 40, 10, 4)),
+        ],
+    )
+    def test_special_batch_size(self, batch_size, expected):
+        mb = pm.Minibatch(self.data, batch_size)
+        assert mb.eval().shape == expected
 
     def test_cloning_available(self):
         gop = pm.Minibatch(np.arange(100), 1)


### PR DESCRIPTION
This PR is used to fix the Minibatch deprecated warnings in the issue #4664 

Also add minor improvements:
- Simplify several tests for Minibatch in `TestMinibatch`
- Add a test for `get_data` function to improve test coverage of `data.py` a little bit

This PR will replace the previous PR #5463 due to my incorrect rebase.

Please let's me know if it need to change anything.

Thanks a lot :D
