### PR TITLE
Raises error when dims match the variable name

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1441,6 +1441,9 @@ class Model(WithMemoization, metaclass=ContextMeta):
             if isinstance(dims, str):
                 dims = (dims,)
             assert all(dim in self.coords or dim is None for dim in dims)
+            assert all(
+                var.name != dim for dim in dims
+            ), f"Variable `{var.name}` has the same name as its dimension label."
             self._RV_dims[var.name] = dims
 
         self.named_vars[var.name] = var

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1444,7 +1444,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
                 raise ValueError(f"Dimension {dim} is not specified in `coords`.")
             if any(var.name == dim for dim in dims):
                 raise ValueError(f"Variable `{var.name}` has the same name as its dimension label.")
-
             self._RV_dims[var.name] = dims
 
         self.named_vars[var.name] = var

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1440,16 +1440,10 @@ class Model(WithMemoization, metaclass=ContextMeta):
         if dims is not None:
             if isinstance(dims, str):
                 dims = (dims,)
-
-            for dim in dims:
-                if dim in self.coords:
-                    raise ValueError(f"Dimension {dim} is already specified in `coords`.")
-                if dim is None:
-                    raise ValueError("Empty dimension name.")
-                if var.name != dim:
-                    raise ValueError(
-                        f"Variable `{var.name}` has the same name as its dimension label."
-                    )
+            if any(dim not in self.coords and dim is not None for dim in dims):
+                raise ValueError(f"Dimension {dim} is not specified in `coords`.")
+            if any(var.name == dim for dim in dims):
+                raise ValueError(f"Variable `{var.name}` has the same name as its dimension label.")
 
             self._RV_dims[var.name] = dims
 

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1440,10 +1440,17 @@ class Model(WithMemoization, metaclass=ContextMeta):
         if dims is not None:
             if isinstance(dims, str):
                 dims = (dims,)
-            assert all(dim in self.coords or dim is None for dim in dims)
-            assert all(
-                var.name != dim for dim in dims
-            ), f"Variable `{var.name}` has the same name as its dimension label."
+
+            for dim in dims:
+                if dim in self.coords:
+                    raise ValueError(f"Dimension {dim} is already specified in `coords`.")
+                if dim is None:
+                    raise ValueError("Empty dimension name.")
+                if var.name != dim:
+                    raise ValueError(
+                        f"Variable `{var.name}` has the same name as its dimension label."
+                    )
+
             self._RV_dims[var.name] = dims
 
         self.named_vars[var.name] = var

--- a/pymc/tests/test_idata_conversion.py
+++ b/pymc/tests/test_idata_conversion.py
@@ -2,6 +2,7 @@
 
 from typing import Dict, Tuple
 
+import aesara.tensor as at
 import numpy as np
 import pandas as pd
 import pytest
@@ -603,11 +604,10 @@ class TestDataPyMC:
             assert isinstance(converter.coords["city"], pd.MultiIndex)
 
     def test_variable_dimension_name_collision(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="same name as its dimension"):
             with pm.Model() as pmodel:
-                pm.ConstantData("time", np.ones(9), dims="time")
-                pm.Normal("a")
-                idata = pm.sample(chains=1)
+                var = at.as_tensor([1, 2, 3])
+                pmodel.register_rv(var, name="time", dims=("time",))
 
 
 class TestPyMCWarmupHandling:

--- a/pymc/tests/test_idata_conversion.py
+++ b/pymc/tests/test_idata_conversion.py
@@ -602,6 +602,15 @@ class TestDataPyMC:
             )
             assert isinstance(converter.coords["city"], pd.MultiIndex)
 
+    @pytest.mark.xfail(
+        reason="Xarray doesn't support labeling dimensions with the same name as the variable"
+    )
+    def test_variable_dimension_name_collision(self):
+        with pm.Model() as pmodel:
+            pm.ConstantData("time", np.ones(9), dims="time")
+            pm.Normal("a")
+            idata = pm.sample(chains=1)
+
 
 class TestPyMCWarmupHandling:
     @pytest.mark.parametrize("save_warmup", [False, True])

--- a/pymc/tests/test_idata_conversion.py
+++ b/pymc/tests/test_idata_conversion.py
@@ -602,14 +602,12 @@ class TestDataPyMC:
             )
             assert isinstance(converter.coords["city"], pd.MultiIndex)
 
-    @pytest.mark.xfail(
-        reason="Xarray doesn't support labeling dimensions with the same name as the variable"
-    )
     def test_variable_dimension_name_collision(self):
-        with pm.Model() as pmodel:
-            pm.ConstantData("time", np.ones(9), dims="time")
-            pm.Normal("a")
-            idata = pm.sample(chains=1)
+        with pytest.raises(ValueError):
+            with pm.Model() as pmodel:
+                pm.ConstantData("time", np.ones(9), dims="time")
+                pm.Normal("a")
+                idata = pm.sample(chains=1)
 
 
 class TestPyMCWarmupHandling:

--- a/pymc/tests/test_model_graph.py
+++ b/pymc/tests/test_model_graph.py
@@ -104,7 +104,7 @@ def model_with_dims():
 
         population = pm.HalfNormal("population", sd=5, dims=("city"))
 
-        time = pm.ConstantData("year", [2014, 2015, 2016], dims="year")
+        time = pm.ConstantData("time", [2014, 2015, 2016], dims="year")
 
         n = pm.Deterministic(
             "tax revenue", economics * population[None, :] * time[:, None], dims=("year", "city")
@@ -116,15 +116,15 @@ def model_with_dims():
     compute_graph = {
         "economics": set(),
         "population": set(),
-        "year": set(),
-        "tax revenue": {"economics", "population", "year"},
+        "time": set(),
+        "tax revenue": {"economics", "population", "time"},
         "L": {"tax revenue"},
         "observed": {"L"},
     }
     plates = {
         "1": {"economics"},
         "city (4)": {"population"},
-        "year (3)": {"year"},
+        "year (3)": {"time"},
         "year (3) x city (4)": {"tax revenue"},
         "3 x 4": {"L", "observed"},
     }


### PR DESCRIPTION
Fixes #5309 , where a data variable misses when its name collides with its dimensions.

- Added an assertion that checks if all dimension labels are different from the variable name.
- Added a test that checks if an error is raised when a variable name collides with its dimension labels.