### PR TITLE
Fix seeding bug in `sample_numpyro_nuts` when more than one chain was sampled

### DIFF
--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -4,8 +4,9 @@ import re
 import sys
 import warnings
 
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List, Optional, Sequence, Union
 
+from pymc.initial_point import StartDict
 from pymc.sampling import _init_jitter
 
 xla_flags = os.getenv("XLA_FLAGS", "")
@@ -130,7 +131,7 @@ def _sample_stats_to_xarray(posterior):
     return data
 
 
-def _get_log_likelihood(model, samples):
+def _get_log_likelihood(model: Model, samples) -> Dict:
     """Compute log-likelihood for all observations"""
     data = {}
     for v in model.observed_RVs:
@@ -142,8 +143,13 @@ def _get_log_likelihood(model, samples):
 
 
 def _get_batched_jittered_initial_points(
-    model, chains, initvals, random_seed, jitter=True, jitter_max_retries=10
-):
+    model: Model,
+    chains: int,
+    initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]],
+    random_seed: int,
+    jitter: bool = True,
+    jitter_max_retries: int = 10,
+) -> Union[np.ndarray, List[np.ndarray]]:
     """Get jittered initial point in format expected by NumPyro MCMC kernel
 
     Returns
@@ -173,19 +179,19 @@ def _get_batched_jittered_initial_points(
 
 
 def sample_numpyro_nuts(
-    draws=1000,
-    tune=1000,
-    chains=4,
-    target_accept=0.8,
-    random_seed=None,
-    initvals=None,
-    model=None,
+    draws: int = 1000,
+    tune: int = 1000,
+    chains: int = 4,
+    target_accept: float = 0.8,
+    random_seed: int = None,
+    initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]] = None,
+    model: Optional[Model] = None,
     var_names=None,
-    progress_bar=True,
-    keep_untransformed=False,
-    chain_method="parallel",
-    idata_kwargs=None,
-    nuts_kwargs=None,
+    progress_bar: bool = True,
+    keep_untransformed: bool = False,
+    chain_method: str = "parallel",
+    idata_kwargs: Optional[Dict] = None,
+    nuts_kwargs: Optional[Dict] = None,
 ):
     from numpyro.infer import MCMC, NUTS
 

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 import os
 import re
 import sys

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -152,10 +152,8 @@ def _get_batched_jittered_initial_points(
         list with one item per variable and number of chains as batch dimension.
         Each item has shape `(chains, *var.shape)`
     """
-    if isinstance(random_seed, (int, np.integer)):
-        random_seed = np.random.default_rng(random_seed).integers(2**30, size=chains)
-    elif not isinstance(random_seed, (list, tuple, np.ndarray)):
-        raise ValueError(f"The `seeds` must be int or array-like. Got {type(random_seed)} instead.")
+
+    random_seed = np.random.default_rng(random_seed).integers(2**30, size=chains)
 
     assert len(random_seed) == chains
 
@@ -213,9 +211,7 @@ def sample_numpyro_nuts(
         dims = {}
 
     if random_seed is None:
-        random_seed = model.rng_seeder.randint(
-            2**30, dtype=np.int64, size=chains if chains > 1 else None
-        )
+        random_seed = model.rng_seeder.randint(2**30, dtype=np.int64)
 
     tic1 = datetime.now()
     print("Compiling...", file=sys.stdout)

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -161,3 +161,32 @@ def test_get_batched_jittered_initial_points():
 
     assert ips[0].shape == (2, 2, 3)
     assert np.all(ips[0][0] != ips[0][1])
+
+
+@pytest.mark.parametrize("random_seed", (None, 123))
+@pytest.mark.parametrize("chains", (1, 2))
+def test_seeding(chains, random_seed):
+    sample_kwargs = dict(
+        tune=100,
+        draws=5,
+        chains=chains,
+        random_seed=random_seed,
+    )
+
+    with pm.Model(rng_seeder=456) as m:
+        pm.Normal("x", mu=0, sigma=1)
+        result1 = sample_numpyro_nuts(**sample_kwargs)
+
+    with pm.Model(rng_seeder=456) as m:
+        pm.Normal("x", mu=0, sigma=1)
+        result2 = sample_numpyro_nuts(**sample_kwargs)
+        result3 = sample_numpyro_nuts(**sample_kwargs)
+
+    assert np.all(result1.posterior["x"] == result2.posterior["x"])
+    expected_equal_result3 = random_seed is not None
+    assert np.all(result2.posterior["x"] == result3.posterior["x"]) == expected_equal_result3
+
+    if chains > 1:
+        assert np.all(result1.posterior["x"].sel(chain=0) != result1.posterior["x"].sel(chain=1))
+        assert np.all(result2.posterior["x"].sel(chain=0) != result2.posterior["x"].sel(chain=1))
+        assert np.all(result3.posterior["x"].sel(chain=0) != result3.posterior["x"].sel(chain=1))


### PR DESCRIPTION
Also adds several type-hints

Closes #5528 