### PR TITLE
Fix nightly upload pypi error (again)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.5.0
         with:
           user: __token__
-          password: ${{ secrets.nightly_pypi_secret }}
+          password: ${{ secrets.PYPI_TOKEN_PYMC_NIGHTLY }}
   test-install-job:
     needs: build-and-publish-nightly
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is for https://github.com/pymc-devs/pymc/issues/5548. Simple change of secret for the nightly uploads. Should do the job @twiecki @fonnesbeck

(That closed PR was because I created a branch from an old branch rather than main, so it had old commits. This should be clean.)
