### PR TITLE
Fixing the version number for the test in nightly.yml

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,4 +40,4 @@ jobs:
       run: sleep 240
     - name: Install from PyPI
       run: |
-        pip install pymc-nightly==${GITHUB_REF:11}.dev$(date +"%Y%m%d")
+        pip install pymc-nightly==$(grep 'version' pymc/__init__.py | awk '{print $3}' | tr -d '"').dev$(date +"%Y%m%d")


### PR DESCRIPTION
This is for #5570. cc @twiecki @michaelosthege 

`grep 'version' pymc/__init__.py` pulls out the line `__version__ = "4.0.0b3"`

 `awk '{print $3}'` takes `"4.0.0b3"`

`tr -d '"` trims to `4.0.0b3`.

Note this only works if `__init__.py` stays in its current format.
