### PR TITLE
Stack array stats if possible

### DIFF
--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -204,10 +204,18 @@ class BaseTrace(ABC):
         vals = np.stack(
             [self._get_sampler_stats(stat_name, i, burn, thin) for i in sampler_idxs], axis=-1
         )
+
         if vals.shape[-1] == 1:
-            return vals[..., 0]
-        else:
-            return vals
+            vals = vals[..., 0]
+
+        if vals.dtype == np.dtype(object):
+            try:
+                vals = np.vstack(vals)
+            except ValueError:
+                # Most likely due to non-identical shapes. Just stick with the object-array.
+                pass
+
+        return vals
 
     def _get_sampler_stats(self, stat_name, sampler_idx, burn, thin):
         """Get sampler statistics."""

--- a/pymc/tests/test_step.py
+++ b/pymc/tests/test_step.py
@@ -1750,13 +1750,13 @@ class TestMLDA:
                 Q_mean_vr, Q_se_vr = extract_Q_estimate(trace, 3)
 
                 # check that returned values are floats and finite.
-                assert isinstance(Q_mean_standard, float)
+                assert isinstance(Q_mean_standard, np.floating)
                 assert np.isfinite(Q_mean_standard)
-                assert isinstance(Q_mean_vr, float)
+                assert isinstance(Q_mean_vr, np.floating)
                 assert np.isfinite(Q_mean_vr)
-                assert isinstance(Q_se_standard, float)
+                assert isinstance(Q_se_standard, np.floating)
                 assert np.isfinite(Q_se_standard)
-                assert isinstance(Q_se_vr, float)
+                assert isinstance(Q_se_vr, np.floating)
                 assert np.isfinite(Q_se_vr)
 
                 # check consistency of QoI across levels.


### PR DESCRIPTION
BART (that now lives in pymc-experimental) stores 2 stats which at each point are arrays. Variable importance and bart_trees. For example variable importance is a vector with the position encoding a given covariate and an integer encoding the number of times that covariate was used in the trees. 

We used to have this to stack those stats https://github.com/pymc-devs/pymc/pull/5566/files#diff-7b3470589153c7c90a2c05fc86402f9acf65555200d90f01b51a47ccef592628L637-L654 but that code is BART-specific, so here I am proposing as alternative a more general solution. 