### PR TITLE
Return an empty string for empty model representation

### DIFF
--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -58,6 +58,9 @@ def str_for_dist(rv: TensorVariable, formatting: str = "plain", include_params: 
 def str_for_model(model: Model, formatting: str = "plain", include_params: bool = True) -> str:
     """Make a human-readable string representation of Model, listing all random variables
     and their distributions, optionally including parameter values."""
+    if len(model.unobserved_RVs) + len(model.observed_RVs) + len(model.potentials) == 0:
+        return ""
+
     all_rv = itertools.chain(model.unobserved_RVs, model.observed_RVs, model.potentials)
 
     rv_reprs = [rv.str_repr(formatting=formatting, include_params=include_params) for rv in all_rv]

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -58,13 +58,13 @@ def str_for_dist(rv: TensorVariable, formatting: str = "plain", include_params: 
 def str_for_model(model: Model, formatting: str = "plain", include_params: bool = True) -> str:
     """Make a human-readable string representation of Model, listing all random variables
     and their distributions, optionally including parameter values."""
-    if len(model.unobserved_RVs) + len(model.observed_RVs) + len(model.potentials) == 0:
-        return ""
-
     all_rv = itertools.chain(model.unobserved_RVs, model.observed_RVs, model.potentials)
 
     rv_reprs = [rv.str_repr(formatting=formatting, include_params=include_params) for rv in all_rv]
     rv_reprs = [rv_repr for rv_repr in rv_reprs if "TransformedDistribution()" not in rv_repr]
+
+    if not rv_reprs:
+        return ""
     if "latex" in formatting:
         rv_reprs = [
             rv_repr.replace(r"\sim", r"&\sim &").strip("$")

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -753,3 +753,7 @@ def test_deterministic():
 
     assert model.y == y
     assert model["y"] == y
+
+
+def test_empty_model_representation():
+    assert pm.Model().str_repr() == ""


### PR DESCRIPTION
… instead of raising an error

Should fix #5568 

**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [ ] important background, or details about the implementation
+ [ ] are the changes—especially new features—covered by tests and docstrings?
+ [x] [linting/style checks have been run](https://docs.pymc.io/en/latest/contributing/python_style.html)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
