### PR TITLE
Fix typing errors in `sampling`, `smc`, `hmc` and `nuts`

### DIFF
--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -941,7 +941,9 @@ aesara.compile.optdb["canonicalize"].register(
 )
 
 
-def compile_pymc(inputs, outputs, mode=None, **kwargs):
+def compile_pymc(
+    inputs, outputs, mode=None, **kwargs
+) -> Callable[..., Union[np.ndarray, List[np.ndarray]]]:
     """Use ``aesara.function`` with specialized pymc rewrites always enabled.
 
     Included rewrites

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -7,6 +7,7 @@ from typing import (  # pylint: disable=unused-import
     Any,
     Dict,
     Iterable,
+    Mapping,
     Optional,
     Tuple,
     Union,
@@ -532,8 +533,8 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
 def to_inference_data(
     trace: Optional["MultiTrace"] = None,
     *,
-    prior: Optional[Dict[str, Any]] = None,
-    posterior_predictive: Optional[Dict[str, Any]] = None,
+    prior: Optional[Mapping[str, Any]] = None,
+    posterior_predictive: Optional[Mapping[str, Any]] = None,
     log_likelihood: Union[bool, Iterable[str]] = True,
     coords: Optional[CoordSpec] = None,
     dims: Optional[DimSpec] = None,

--- a/pymc/distributions/logprob.py
+++ b/pymc/distributions/logprob.py
@@ -246,12 +246,6 @@ def joint_logpt(
         logp_var = at.sum([at.sum(factor) for factor in logp_var_dict.values()])
     else:
         logp_var = list(logp_var_dict.values())
-        # TODO: deprecate special behavior when only one variable is requested and
-        #  always return a list. This is here for backwards compatibility as logpt
-        #  started as a replacement to factor.logpt, but it should now be considered an
-        #  internal function reached only via model.logp* methods.
-        if len(logp_var) == 1:
-            logp_var = logp_var[0]
 
     return logp_var
 

--- a/pymc/func_utils.py
+++ b/pymc/func_utils.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import warnings
 
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional, Union
 
 import aesara.tensor as aet
 import numpy as np
@@ -129,6 +129,7 @@ def find_constrained_prior(
     cdf_error = (pm.math.exp(logcdf_upper) - pm.math.exp(logcdf_lower)) - mass
     cdf_error_fn = pm.aesaraf.compile_pymc([dist_params], cdf_error, allow_input_downcast=True)
 
+    jac: Union[str, Callable]
     try:
         aesara_jac = pm.gradient(cdf_error, [dist_params])
         jac = pm.aesaraf.compile_pymc([dist_params], aesara_jac, allow_input_downcast=True)

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1443,8 +1443,9 @@ class Model(WithMemoization, metaclass=ContextMeta):
         if dims is not None:
             if isinstance(dims, str):
                 dims = (dims,)
-            if any(dim not in self.coords and dim is not None for dim in dims):
-                raise ValueError(f"Dimension {dim} is not specified in `coords`.")
+            for dim in dims:
+                if dim not in self.coords and dim is not None:
+                    raise ValueError(f"Dimension {dim} is not specified in `coords`.")
             if any(var.name == dim for dim in dims):
                 raise ValueError(f"Variable `{var.name}` has the same name as its dimension label.")
             self._RV_dims[var.name] = dims

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -749,11 +749,10 @@ class Model(WithMemoization, metaclass=ContextMeta):
                         f"Requested variable {var} not found among the model variables"
                     )
 
-        rv_logps = []
+        rv_logps: List[TensorVariable] = []
         if rv_values:
             rv_logps = joint_logpt(list(rv_values.keys()), rv_values, sum=False, jacobian=jacobian)
-            if not isinstance(rv_logps, list):
-                rv_logps = [rv_logps]
+            assert isinstance(rv_logps, list)
 
         # Replace random variables by their value variables in potential terms
         potential_logps = []

--- a/pymc/smc/smc.py
+++ b/pymc/smc/smc.py
@@ -14,7 +14,7 @@
 import abc
 
 from abc import ABC
-from typing import Dict
+from typing import Dict, cast
 
 import aesara.tensor as at
 import numpy as np
@@ -173,15 +173,15 @@ class SMC_KERNEL(ABC):
         self.resampling_indexes = None
         self.weights = np.ones(self.draws) / self.draws
 
-    def initialize_population(self) -> Dict[str, NDArray]:
+    def initialize_population(self) -> Dict[str, np.ndarray]:
         """Create an initial population from the prior distribution"""
-
-        return sample_prior_predictive(
+        result = sample_prior_predictive(
             self.draws,
             var_names=[v.name for v in self.model.unobserved_value_vars],
             model=self.model,
             return_inferencedata=False,
         )
+        return cast(Dict[str, np.ndarray], result)
 
     def _initialize_kernel(self):
         """Create variables and logp function necessary to run kernel

--- a/pymc/step_methods/arraystep.py
+++ b/pymc/step_methods/arraystep.py
@@ -50,7 +50,7 @@ class Competence(IntEnum):
 class BlockedStep(ABC):
 
     generates_stats = False
-    stats_dtypes: List[Dict[str, np.dtype]] = []
+    stats_dtypes: List[Dict[str, type]] = []
     vars: List[Variable] = []
 
     def __new__(cls, *args, **kwargs):

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -2780,19 +2780,19 @@ class TestBound:
             UpperPoisson = Bound("upper", dist, upper=[np.inf, 10], transform=None)
             BoundedPoisson = Bound("bounded", dist, lower=[1, 2], upper=[9, 10], transform=None)
 
-        first, second = joint_logpt(LowerPoisson, [0, 0], sum=False).eval()
+        first, second = joint_logpt(LowerPoisson, [0, 0], sum=False)[0].eval()
         assert first == -np.inf
         assert second != -np.inf
 
-        first, second = joint_logpt(UpperPoisson, [11, 11], sum=False).eval()
+        first, second = joint_logpt(UpperPoisson, [11, 11], sum=False)[0].eval()
         assert first != -np.inf
         assert second == -np.inf
 
-        first, second = joint_logpt(BoundedPoisson, [1, 1], sum=False).eval()
+        first, second = joint_logpt(BoundedPoisson, [1, 1], sum=False)[0].eval()
         assert first != -np.inf
         assert second == -np.inf
 
-        first, second = joint_logpt(BoundedPoisson, [10, 10], sum=False).eval()
+        first, second = joint_logpt(BoundedPoisson, [10, 10], sum=False)[0].eval()
         assert first == -np.inf
         assert second != -np.inf
 
@@ -3282,7 +3282,7 @@ def test_density_dist_multivariate_logp(size):
     a_val = np.random.normal(loc=mu_val, scale=1, size=to_tuple(size) + (supp_shape,)).astype(
         aesara.config.floatX
     )
-    log_densityt = joint_logpt(a, a.tag.value_var, sum=False)
+    log_densityt = joint_logpt(a, a.tag.value_var, sum=False)[0]
     assert log_densityt.eval(
         {a.tag.value_var: a_val, mu.tag.value_var: mu_val},
     ).shape == to_tuple(size)

--- a/pymc/tests/test_logprob.py
+++ b/pymc/tests/test_logprob.py
@@ -60,7 +60,7 @@ def test_joint_logpt_basic():
 
     b_logp = joint_logpt(b, b_value_var, sum=False)
 
-    res_ancestors = list(walk_model((b_logp,), walk_past_rvs=True))
+    res_ancestors = list(walk_model(b_logp, walk_past_rvs=True))
     res_rv_ancestors = [
         v for v in res_ancestors if v.owner and isinstance(v.owner.op, RandomVariable)
     ]
@@ -104,7 +104,7 @@ def test_joint_logpt_incsubtensor(indices, size):
 
     a_idx_logp = joint_logpt(a_idx, {a_idx: a_value_var}, sum=False)
 
-    logp_vals = a_idx_logp.eval({a_value_var: a_val})
+    logp_vals = a_idx_logp[0].eval({a_value_var: a_val})
 
     # The indices that were set should all have the same log-likelihood values,
     # because the values they were set to correspond to the unique means along

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -635,7 +635,7 @@ class TestSamplePPC(SeededTest):
 
             # test wrong type argument
             bad_trace = {"mu": stats.norm.rvs(size=1000)}
-            with pytest.raises(TypeError):
+            with pytest.raises(TypeError, match="type for `trace`"):
                 ppc = pm.sample_posterior_predictive(bad_trace)
 
     def test_vector_observed(self):

--- a/pymc/tests/test_transforms.py
+++ b/pymc/tests/test_transforms.py
@@ -296,7 +296,7 @@ class TestElementWiseLogp(SeededTest):
         x_val_untransf = at.constant(test_array_untransf).type()
 
         jacob_det = transform.log_jac_det(test_array_transf, *x.owner.inputs)
-        assert joint_logpt(x, sum=False).ndim == x.ndim == jacob_det.ndim
+        assert joint_logpt(x, sum=False)[0].ndim == x.ndim == jacob_det.ndim
 
         v1 = joint_logpt(x, x_val_transf, jacobian=False).eval({x_val_transf: test_array_transf})
         v2 = joint_logpt(x, x_val_untransf, transformed=False).eval(
@@ -319,10 +319,10 @@ class TestElementWiseLogp(SeededTest):
         jacob_det = transform.log_jac_det(test_array_transf, *x.owner.inputs)
         # Original distribution is univariate
         if x.owner.op.ndim_supp == 0:
-            assert joint_logpt(x, sum=False).ndim == x.ndim == (jacob_det.ndim + 1)
+            assert joint_logpt(x, sum=False)[0].ndim == x.ndim == (jacob_det.ndim + 1)
         # Original distribution is multivariate
         else:
-            assert joint_logpt(x, sum=False).ndim == (x.ndim - 1) == jacob_det.ndim
+            assert joint_logpt(x, sum=False)[0].ndim == (x.ndim - 1) == jacob_det.ndim
 
         a = joint_logpt(x, x_val_transf, jacobian=False).eval({x_val_transf: test_array_transf})
         b = joint_logpt(x, x_val_untransf, transformed=False).eval(

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -50,15 +50,19 @@ pymc/ode/ode.py
 pymc/ode/utils.py
 pymc/parallel_sampling.py
 pymc/plots/__init__.py
+pymc/sampling.py
 pymc/smc/__init__.py
 pymc/smc/sample_smc.py
+pymc/smc/smc.py
 pymc/stats/__init__.py
 pymc/step_methods/__init__.py
 pymc/step_methods/compound.py
 pymc/step_methods/elliptical_slice.py
 pymc/step_methods/hmc/__init__.py
 pymc/step_methods/hmc/base_hmc.py
+pymc/step_methods/hmc/hmc.py
 pymc/step_methods/hmc/integration.py
+pymc/step_methods/hmc/nuts.py
 pymc/step_methods/hmc/quadpotential.py
 pymc/step_methods/slicer.py
 pymc/step_methods/step_sizes.py
@@ -159,6 +163,9 @@ def check_no_unexpected_results(mypy_lines: Iterator[str]):
         print(f"{len(unexpected_passing)} files unexpectedly passed the type checks:")
         print("\n".join(sorted(map(str, unexpected_passing))))
         print("This is good news! Go to scripts/run-mypy.py and add them to the list.")
+        if all_files.issubset(passing):
+            print("WOW! All files are passing the mypy type checks!")
+            print("scripts\\run_mypy.py may no longer be needed.")
         sys.exit(1)
     return
 


### PR DESCRIPTION
In some places I renamed local variables to have fewer typing conflicts.

In other places, I simplified if/else branching based on stronger typing.