### PR TITLE
Use checkout action in nightly workflow test job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,7 @@ jobs:
     needs: build-and-publish-nightly
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
This is for #5570. Add a checkout step so github can see the repo code and find the file `pymc/__init__.py` in the line `grep 'version' pymc/__init__.py`.

(Hopefully the end of the saga... but you never know with things you can't test)
