### PR TITLE
Update docstring of SkewNormal, Triangular, Gumbel, Logistic, LogitNormal

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3530,6 +3530,7 @@ class Logistic(Continuous):
            \frac{\exp\left(-\frac{x - \mu}{s}\right)}{s \left(1 + \exp\left(-\frac{x - \mu}{s}\right)\right)^2}
 
     .. plot::
+        :context: close-figs
 
         import matplotlib.pyplot as plt
         import numpy as np
@@ -3556,9 +3557,9 @@ class Logistic(Continuous):
 
     Parameters
     ----------
-    mu: float
+    mu : tensor_like of float, default 0
         Mean.
-    s: float
+    s : tensor_like of float, default 1
         Scale (s > 0).
     """
 
@@ -3583,7 +3584,7 @@ class Logistic(Continuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or aesara.tensor
+        value : tensor_like of float
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or Aesara tensor.
 

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3069,6 +3069,7 @@ class SkewNormal(Continuous):
        2 \Phi((x-\mu)\sqrt{\tau}\alpha) \phi(x,\mu,\tau)
 
     .. plot::
+        :context: close-figs
 
         import matplotlib.pyplot as plt
         import numpy as np
@@ -3099,13 +3100,15 @@ class SkewNormal(Continuous):
 
     Parameters
     ----------
-    mu: float
+    mu : tensor_like of float, default 0
         Location parameter.
-    sigma: float
+    sigma : tensor_like of float, optional
         Scale parameter (sigma > 0).
-    tau: float
+        Defaults to 1.
+    tau : tensor_like of float, optional
         Alternative scale parameter (tau > 0).
-    alpha: float
+        Defaults to 1.
+    alpha : tensor_like of float, default 1
         Skewness parameter.
 
     Notes
@@ -3145,9 +3148,9 @@ class SkewNormal(Continuous):
 
         Parameters
         ----------
-        value: numeric
+        value : tensor_like of float
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or Aesara tensor
+            values are desired the values must be provided in a numpy array or Aesara tensor.
 
         Returns
         -------

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3629,6 +3629,7 @@ class LogitNormal(UnitContinuous):
 
 
     .. plot::
+        :context: close-figs
 
         import matplotlib.pyplot as plt
         import numpy as np
@@ -3653,12 +3654,14 @@ class LogitNormal(UnitContinuous):
 
     Parameters
     ----------
-    mu: float
+    mu : tensor_like of float, default 0
         Location parameter.
-    sigma: float
+    sigma : tensor_like of float, optional
         Scale parameter (sigma > 0).
-    tau: float
+        Defaults to 1.
+    tau : tensor_like of float, optional
         Scale parameter (tau > 0).
+        Defaults to 1.
     """
     rv_op = logit_normal
 
@@ -3687,9 +3690,9 @@ class LogitNormal(UnitContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value : tensor_like of float
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or Aesara tensor
+            values are desired the values must be provided in a numpy array or Aesara tensor.
 
         Returns
         -------

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3061,7 +3061,7 @@ class SkewNormal(Continuous):
     r"""
     Univariate skew-normal log-likelihood.
 
-     The pdf of this distribution is
+    The pdf of this distribution is
 
     .. math::
 
@@ -3320,9 +3320,9 @@ class Gumbel(Continuous):
 
     Parameters
     ----------
-    mu : tensor_like of float, optional
+    mu : tensor_like of float
         Location parameter.
-    beta : tensor_like of float, optional
+    beta : tensor_like of float
         Scale parameter (beta > 0).
     """
     rv_op = gumbel

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3168,7 +3168,7 @@ class SkewNormal(Continuous):
 
 class Triangular(BoundedContinuous):
     r"""
-    Continuous Triangular log-likelihood
+    Continuous Triangular log-likelihood.
 
     The pdf of this distribution is
 
@@ -3183,6 +3183,7 @@ class Triangular(BoundedContinuous):
         \end{cases}
 
     .. plot::
+        :context: close-figs
 
         import matplotlib.pyplot as plt
         import numpy as np
@@ -3213,11 +3214,11 @@ class Triangular(BoundedContinuous):
 
     Parameters
     ----------
-    lower: float
+    lower : tensor_like of float, default 0
         Lower limit.
-    c: float
-        mode
-    upper: float
+    c : tensor_like of float, default 0.5
+        Mode.
+    upper : tensor_like of float, default 1
         Upper limit.
     """
 
@@ -3245,7 +3246,7 @@ class Triangular(BoundedContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or aesara.tensor
+        value : tensor_like of float
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or Aesara tensor.
 

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3278,7 +3278,7 @@ class Triangular(BoundedContinuous):
 
 class Gumbel(Continuous):
     r"""
-        Univariate Gumbel log-likelihood
+    Univariate Gumbel log-likelihood.
 
     The pdf of this distribution is
 
@@ -3293,6 +3293,7 @@ class Gumbel(Continuous):
         z = \frac{x - \mu}{\beta}.
 
     .. plot::
+        :context: close-figs
 
         import matplotlib.pyplot as plt
         import numpy as np
@@ -3319,9 +3320,9 @@ class Gumbel(Continuous):
 
     Parameters
     ----------
-    mu: float
+    mu : tensor_like of float, optional
         Location parameter.
-    beta: float
+    beta : tensor_like of float, optional
         Scale parameter (beta > 0).
     """
     rv_op = gumbel
@@ -3359,7 +3360,7 @@ class Gumbel(Continuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or aesara.tensor
+        value : tensor_like of float
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or Aesara tensor.
 


### PR DESCRIPTION
Related to https://github.com/pymc-devs/pymc/issues/5459

This will update the docsting of

[pymc.SkewNormal](https://docs.pymc.io/en/latest/api/distributions/generated/pymc.SkewNormal.html)
[pymc.Triangular](https://docs.pymc.io/en/latest/api/distributions/generated/pymc.Triangular.html)
[pymc.Gumbel](https://docs.pymc.io/en/latest/api/distributions/generated/pymc.Gumbel.html)
[pymc.Logistic](https://docs.pymc.io/en/latest/api/distributions/generated/pymc.Logistic.html)
[pymc.LogitNormal](https://docs.pymc.io/en/latest/api/distributions/generated/pymc.LogitNormal.html)