### PR TITLE
Update docstring in Interpolated, Rice, Moyal, AsymmetricLaplace and PolyaGamma distribution 

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -573,11 +573,7 @@ class Normal(Continuous):
         ----------
         value : tensor_like of float
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or `TensorVariable`.
-        mu : tensor_like of float
-            Mean.
-        sigma : tensor_like of float
-            Standard deviation (sigma > 0).
+            values are desired the values must be provided in a numpy array or Aesara tensor.
 
         Returns
         -------
@@ -2354,7 +2350,7 @@ class Gamma(PositiveContinuous):
         value : tensor_like of float
             Value(s) for which log CDF is calculated. If the log CDF for
             multiple values are desired the values must be provided in a numpy
-            array or `TensorVariable`.
+            array or Aesara tensor.
 
         Returns
         -------
@@ -3417,12 +3413,12 @@ class Rice(PositiveContinuous):
 
     Parameters
     ----------
-    nu : tensor_like of float
-        noncentrality parameter.
+    nu : tensor_like of float, optional
+        Noncentrality parameter (only required if b is not specified).
     sigma : tensor_like of float, default 1
         scale parameter.
-    b : tensor_like of float
-        shape parameter (alternative to nu).
+    b : tensor_like of float, optional
+        Shape parameter (alternative to nu, only required if nu is not specified).
 
     Notes
     -----

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -290,10 +290,10 @@ class Uniform(BoundedContinuous):
 
     Parameters
     ----------
-    lower : float, optional
-        Lower limit. Defaults to 0.
-    upper : float, optional
-        Upper limit. Defaults to 1.
+    lower : tensor_like of float, default 0
+        Lower limit.
+    upper : tensor_like of float, default 1
+        Upper limit.
     """
     rv_op = uniform
     bound_args_indices = (3, 4)  # Lower, Upper
@@ -318,13 +318,9 @@ class Uniform(BoundedContinuous):
 
         Parameters
         ----------
-        value : numeric or ndarray or TensorVariable
+        value : tensor_like of float
             Value(s) for which log CDF is calculated. If the log CDF for multiple
-            values are desired the values must be provided in a numpy array or `TensorVariable`.
-        lower : float, optional
-            Lower limit. Defaults to 0.
-        upper : float, optional
-            Upper limit. Defaults to 1.
+            values are desired the values must be provided in a numpy array or Aesara tensor.
 
         Returns
         -------
@@ -384,7 +380,7 @@ class Flat(Continuous):
         ----------
         value : tensor_like of float
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or Aesara tensor
+            values are desired the values must be provided in a numpy array or Aesara tensor.
 
         Returns
         -------
@@ -452,7 +448,7 @@ class HalfFlat(PositiveContinuous):
         ----------
         value : tensor_like of float
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or Aesara tensor
+            values are desired the values must be provided in a numpy array or Aesara tensor.
 
         Returns
         -------
@@ -1477,7 +1473,7 @@ class Exponential(PositiveContinuous):
     Parameters
     ----------
     lam : tensor_like of float
-        Rate or inverse scale (``lam`` > 0)
+        Rate or inverse scale (``lam`` > 0).
     """
     rv_op = exponential
 
@@ -1658,12 +1654,12 @@ class AsymmetricLaplace(Continuous):
 
     Parameters
     ----------
-    b: float
-        Scale parameter (b > 0)
-    kappa: float
-        Symmetry parameter (kappa > 0)
-    mu: float
-        Location parameter
+    b : tensor_like of float
+        Scale parameter (b > 0).
+    kappa : tensor_like of float
+        Symmetry parameter (kappa > 0).
+    mu : tensor_like of float, default 0
+        Location parameter.
 
     See Also:
     --------
@@ -1698,9 +1694,9 @@ class AsymmetricLaplace(Continuous):
 
         Parameters
         ----------
-        value: numeric
+        value : tensor_like of float
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or Aesara tensor
+            values are desired the values must be provided in a numpy array or Aesara tensor.
 
         Returns
         -------
@@ -2655,7 +2651,7 @@ class Weibull(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or aesara.tensor
+        value : tensor_like of float
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or Aesara tensor.
 
@@ -3394,6 +3390,7 @@ class Rice(PositiveContinuous):
        \left({\frac  {-(x^{2}+\nu ^{2})}{2\sigma ^{2}}}\right)I_{0}\left({\frac  {x\nu }{\sigma ^{2}}}\right),
 
     .. plot::
+        :context: close-figs
 
         import matplotlib.pyplot as plt
         import numpy as np
@@ -3420,11 +3417,11 @@ class Rice(PositiveContinuous):
 
     Parameters
     ----------
-    nu: float
+    nu : tensor_like of float
         noncentrality parameter.
-    sigma: float
+    sigma : tensor_like of float, default 1
         scale parameter.
-    b: float
+    b : tensor_like of float
         shape parameter (alternative to nu).
 
     Notes
@@ -3489,9 +3486,9 @@ class Rice(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value : tensor_like of float
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or Aesara tensor
+            values are desired the values must be provided in a numpy array or Aesara tensor.
 
         Returns
         -------
@@ -3752,6 +3749,7 @@ class Interpolated(BoundedContinuous):
     plain array-like objects, so they are constant and cannot be sampled.
 
     .. plot::
+        :context: close-figs
 
         import matplotlib.pyplot as plt
         import numpy as np
@@ -3779,11 +3777,11 @@ class Interpolated(BoundedContinuous):
 
     Parameters
     ----------
-    x_points: array-like
-        A monotonically growing list of values. Must be non-symbolic
-    pdf_points: array-like
+    x_points : array_like
+        A monotonically growing list of values. Must be non-symbolic.
+    pdf_points : array_like
         Probability density function evaluated on lattice ``x_points``. Must
-        be non-symbolic
+        be non-symbolic.
     """
 
     rv_op = interpolated
@@ -3833,9 +3831,9 @@ class Interpolated(BoundedContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value : tensor_like of float
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or Aesara tensor
+            values are desired the values must be provided in a numpy array or Aesara tensor.
 
         Returns
         -------
@@ -3888,6 +3886,7 @@ class Moyal(Continuous):
        z = \frac{x-\mu}{\sigma}.
 
     .. plot::
+        :context: close-figs
 
         import matplotlib.pyplot as plt
         import numpy as np
@@ -3913,9 +3912,9 @@ class Moyal(Continuous):
 
     Parameters
     ----------
-    mu: float
+    mu : tensor_like of float, default 0
         Location parameter.
-    sigma: float
+    sigma : tensor_like of float, default 1
         Scale parameter (sigma > 0).
     """
     rv_op = moyal
@@ -3942,9 +3941,9 @@ class Moyal(Continuous):
 
         Parameters
         ----------
-        value: numeric
+        value : tensor_like of float
             Value(s) for which log-probability is calculated. If the log probabilities for multiple
-            values are desired the values must be provided in a numpy array or Aesara tensor
+            values are desired the values must be provided in a numpy array or Aesara tensor.
 
         Returns
         -------
@@ -3961,7 +3960,7 @@ class Moyal(Continuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or aesara.tensor
+        value : tensor_like of float
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array or Aesara tensor.
 
@@ -4072,6 +4071,7 @@ class PolyaGamma(PositiveContinuous):
     random variable with shape  parameter ``h`` and scale parameter ``1``.
 
     .. plot::
+        :context: close-figs
 
         import matplotlib.pyplot as plt
         import numpy as np
@@ -4096,9 +4096,9 @@ class PolyaGamma(PositiveContinuous):
 
     Parameters
     ----------
-    h: float, optional
+    h : tensor_like of float, default 1
         The shape parameter of the distribution (h > 0).
-    z: float, optional
+    z : tensor_like of float, default 0
         The exponential tilting parameter of the distribution.
 
     Examples
@@ -4119,7 +4119,7 @@ class PolyaGamma(PositiveContinuous):
            108.504 (2013): 1339-1349.
     .. [2] Windle, Jesse, Nicholas G. Polson, and James G. Scott.
            "Sampling Polya-Gamma random variates: alternate and approximate
-           techniques." arXiv preprint arXiv:1405.0506 (2014)
+           techniques." arXiv preprint arXiv:1405.0506 (2014).
     .. [3] Luc Devroye. "On exact simulation algorithms for some distributions
            related to Jacobi theta functions." Statistics & Probability Letters,
            Volume 79, Issue 21, (2009): 2251-2259.
@@ -4154,7 +4154,7 @@ class PolyaGamma(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric
+        value : tensor_like of float
             Value(s) for which log-probability is calculated. If the log
             probabilities for multiple values are desired the values must be
             provided in a numpy array.
@@ -4182,7 +4182,7 @@ class PolyaGamma(PositiveContinuous):
 
         Parameters
         ----------
-        value: numeric or np.ndarray or `TensorVariable`
+        value : tensor_like of float
             Value(s) for which log CDF is calculated. If the log CDF for multiple
             values are desired the values must be provided in a numpy array.
 


### PR DESCRIPTION
Related to https://github.com/pymc-devs/pymc/issues/5459

This will update the docsting of

[pymc.Interpolated](https://docs.pymc.io/en/latest/api/distributions/generated/pymc.Interpolated.html)
[pymc.Rice](https://docs.pymc.io/en/latest/api/distributions/generated/pymc.Rice.html)
[pymc.Moyal](https://docs.pymc.io/en/latest/api/distributions/generated/pymc.Moyal.html)
[pymc.AsymmetricLaplace](https://docs.pymc.io/en/latest/api/distributions/generated/pymc.AsymmetricLaplace.html)
[pymc.PolyaGamma](https://docs.pymc.io/en/latest/api/distributions/generated/pymc.PolyaGamma.html)

Also did a 2nd review of previous PRs under  https://github.com/pymc-devs/pymc/issues/5459

This PR will complete the docstring for 

[Distributions](https://pymc--5595.org.readthedocs.build/en/5595/api/distributions.html)
- [Continuous](https://pymc--5595.org.readthedocs.build/en/5595/api/distributions/continuous.html)

![image](https://user-images.githubusercontent.com/42216008/158480192-0f0e7e87-b1d2-4a12-a1cf-44b7b6746209.png)
