### PR TITLE
Updated convert_shape and convert_size

### DIFF
--- a/.github/workflows/arviz_compat.yml
+++ b/.github/workflows/arviz_compat.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           conda activate pymc-test-py39
           pip uninstall arviz -y
-          pip install git+git://github.com/arviz-devs/arviz.git
+          pip install git+https://github.com/arviz-devs/arviz
       - name: Run tests
         run: |
           python -m pytest -vv --cov=pymc --cov-report=xml --cov-report term --durations=50 $TEST_SUBSET

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -458,16 +458,16 @@ def convert_shape(shape: Shape) -> Optional[WeakShape]:
     """Process a user-provided shape variable into None or a valid shape object."""
     if shape is None:
         return None
-
-    if isinstance(shape, int) or (isinstance(shape, TensorVariable) and shape.ndim == 0):
+    elif isinstance(shape, int) or (isinstance(shape, TensorVariable) and shape.ndim == 0):
         shape = (shape,)
+    elif isinstance(shape, TensorVariable) and shape.ndim == 1:
+        shape = tuple(shape)
     elif isinstance(shape, (list, tuple)):
         shape = tuple(shape)
     else:
         raise ValueError(
             f"The `shape` parameter must be a tuple, TensorVariable, int or list. Actual: {type(shape)}"
         )
-
     if isinstance(shape, tuple) and any(s == Ellipsis for s in shape[:-1]):
         raise ValueError(
             f"Ellipsis in `shape` may only appear in the last position. Actual: {shape}"
@@ -480,16 +480,16 @@ def convert_size(size: Size) -> Optional[StrongSize]:
     """Process a user-provided size variable into None or a valid size object."""
     if size is None:
         return None
-
-    if isinstance(size, int) or (isinstance(size, TensorVariable) and size.ndim == 0):
+    elif isinstance(size, int) or (isinstance(size, TensorVariable) and size.ndim == 0):
         size = (size,)
+    elif isinstance(size, TensorVariable) and size.ndim == 1:
+        size = tuple(size)
     elif isinstance(size, (list, tuple)):
         size = tuple(size)
     else:
         raise ValueError(
             f"The `size` parameter must be a tuple, TensorVariable, int or list. Actual: {type(size)}"
         )
-
     if isinstance(size, tuple) and Ellipsis in size:
         raise ValueError(f"The `size` parameter cannot contain an Ellipsis. Actual: {size}")
 


### PR DESCRIPTION
this is another PR for #5417  which I got closed because of deletion of my forked repo

```convert_size```  wrongly assumes symbolic sizes have to be scalars
```
import pymc as pm
import aesara.tensor as at

s = at.scalar('s')
size = at.stack([s, s])
x = at.random.normal(size=size)
x.eval({s: 2})
# array([[-0.66285345,  0.97341598],
#        [ 0.05158132,  2.03399059]])

pm.Normal.dist(size=size)
# ValueError: The `size` parameter must be a tuple, TensorVariable, int or list. Actual: <class 'aesara.tensor.var.TensorVariable'>
```

fixed by changing code in 
https://github.com/pymc-devs/pymc/blob/915592235ea6920689f89bece48e2d679e8ed4f1/pymc/distributions/shape_utils.py#L475

by accepting ```size.ndim == 1``` as well as ```size.ndim == 0```

Closes #5394 