### PR TITLE
WIP Improve scoped models

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         exclude: ^requirements-dev\.txt$
     -   id: trailing-whitespace
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.940
+  rev: v0.941
   hooks:
     - id: mypy
       name: Run static type checks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         exclude: ^requirements-dev\.txt$
     -   id: trailing-whitespace
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.941
+  rev: v0.940
   hooks:
     - id: mypy
       name: Run static type checks

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -473,7 +473,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
                 # 3) you can create variables with Var method
                 self.Var('v1', Normal.dist(mu=mean, sigma=sd))
-                # this will create variable named like '{prefix_}v1'
+                # this will create variable named like '{prefix/}v1'
                 # and assign attribute 'v1' to instance created
                 # variable can be accessed with self.v1 or self['v1']
 
@@ -514,6 +514,8 @@ class Model(WithMemoization, metaclass=ContextMeta):
         with Model() as model:
             CustomModel(mean=1, name='first')
             CustomModel(mean=2, name='second')
+
+        # variables inside both scopes will be named like `first/*`, `second/*`
 
     """
 
@@ -1456,7 +1458,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
     @property
     def prefix(self):
-        return f"{self.name}_" if self.name else ""
+        return f"{self.name}/" if self.name else ""
 
     def name_for(self, name):
         """Checks if name has prefix and adds if needed"""

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -14,6 +14,7 @@
 
 import collections
 import functools
+import os.path
 import threading
 import types
 import warnings
@@ -1458,25 +1459,17 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
     @property
     def prefix(self) -> str:
-        parts = []
-        model = self
-        while True:
-            if model.name:
-                parts.append(model.name)
-            if model.isroot:
-                break
-            else:
-                model = model.parent
-        name = "/".join(reversed(parts))
-        if name:
-            name += "/"
-        return name
+        if self.isroot:
+            name = self.name
+        else:
+            name = os.path.join(self.parent.prefix, self.name)
+        return name.strip("/")
 
     def name_for(self, name):
         """Checks if name has prefix and adds if needed"""
         if self.prefix:
             if not name.startswith(self.prefix):
-                return f"{self.prefix}{name}"
+                return os.path.join(self.prefix, name)
             else:
                 return name
         else:
@@ -1486,8 +1479,8 @@ class Model(WithMemoization, metaclass=ContextMeta):
         """Checks if name has prefix and deletes if needed"""
         if not self.prefix or not name:
             return name
-        elif name.startswith(self.prefix):
-            return name[len(self.prefix) :]
+        elif name.startswith(self.prefix + "/"):
+            return name[len(self.prefix) + 1 :]
         else:
             return name
 

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -14,7 +14,6 @@
 
 import collections
 import functools
-import os.path
 import threading
 import types
 import warnings
@@ -1459,17 +1458,17 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
     @property
     def prefix(self) -> str:
-        if self.isroot:
+        if self.isroot or not self.parent.prefix:
             name = self.name
         else:
-            name = os.path.join(self.parent.prefix, self.name)
+            name = f"{self.parent.prefix}/{self.name}"
         return name.strip("/")
 
     def name_for(self, name):
         """Checks if name has prefix and adds if needed"""
         if self.prefix:
             if not name.startswith(self.prefix):
-                return os.path.join(self.prefix, name)
+                return f"{self.prefix}/{name}"
             else:
                 return name
         else:

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1457,8 +1457,20 @@ class Model(WithMemoization, metaclass=ContextMeta):
             setattr(self, self.name_of(var.name), var)
 
     @property
-    def prefix(self):
-        return f"{self.name}/" if self.name else ""
+    def prefix(self) -> str:
+        parts = []
+        model = self
+        while True:
+            if model.name:
+                parts.append(model.name)
+            if model.isroot:
+                break
+            else:
+                model = model.parent
+        name = "/".join(reversed(parts))
+        if name:
+            name += "/"
+        return name
 
     def name_for(self, name):
         """Checks if name has prefix and adds if needed"""

--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -403,8 +403,8 @@ def test_data_naming():
     with pm.Model("named_model") as model:
         x = pm.ConstantData("x", [1.0, 2.0, 3.0])
         y = pm.Normal("y")
-    assert y.name == "named_model_y"
-    assert x.name == "named_model_x"
+    assert y.name == "named_model/y"
+    assert x.name == "named_model/x"
 
 
 def test_get_data():

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -163,7 +163,7 @@ class TestNested:
                 b = pm.Normal("var")
         assert {"sub/var", "sub/sub/var"} == set(model.named_vars.keys())
 
-    def test_multi_scoping1(self):
+    def test_nested_named_model(self):
         with pm.Model("sub1") as model:
             b = pm.Normal("var")
             with pm.Model("sub2"):

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -95,20 +95,20 @@ class TestBaseModel:
                 usermodel2.register_rv(pm.Normal.dist(), "v3")
                 pm.Normal("v4")
                 # this variable is created in parent model too
-        assert "another_v2" in model.named_vars
-        assert "another_v3" in model.named_vars
-        assert "another_v3" in usermodel2.named_vars
-        assert "another_v4" in model.named_vars
-        assert "another_v4" in usermodel2.named_vars
+        assert "another/v2" in model.named_vars
+        assert "another/v3" in model.named_vars
+        assert "another/v3" in usermodel2.named_vars
+        assert "another/v4" in model.named_vars
+        assert "another/v4" in usermodel2.named_vars
         assert hasattr(usermodel2, "v3")
         assert hasattr(usermodel2, "v2")
         assert hasattr(usermodel2, "v4")
         # When you create a class based model you should follow some rules
         with model:
             m = NewModel("one_more")
-        assert m.d is model["one_more_d"]
-        assert m["d"] is model["one_more_d"]
-        assert m["one_more_d"] is model["one_more_d"]
+        assert m.d is model["one_more/d"]
+        assert m["d"] is model["one_more/d"]
+        assert m["one_more/d"] is model["one_more/d"]
 
 
 class TestNested:
@@ -124,8 +124,8 @@ class TestNested:
     def test_named_context(self):
         with pm.Model() as m:
             NewModel(name="new")
-        assert "new_v1" in m.named_vars
-        assert "new_v2" in m.named_vars
+        assert "new/v1" in m.named_vars
+        assert "new/v2" in m.named_vars
 
     def test_docstring_example1(self):
         usage1 = DocstringModel()
@@ -138,10 +138,10 @@ class TestNested:
     def test_docstring_example2(self):
         with pm.Model() as model:
             DocstringModel(name="prefix")
-        assert "prefix_v1" in model.named_vars
-        assert "prefix_v2" in model.named_vars
-        assert "prefix_v3" in model.named_vars
-        assert "prefix_v3_sq" in model.named_vars
+        assert "prefix/v1" in model.named_vars
+        assert "prefix/v2" in model.named_vars
+        assert "prefix/v3" in model.named_vars
+        assert "prefix/v3_sq" in model.named_vars
         assert len(model.potentials), 1
 
     def test_duplicates_detection(self):

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -156,7 +156,7 @@ class TestNested:
             with pm.Model() as sub:
                 assert model is sub.root
 
-    def test_multi_scoping(self):
+    def test_nested_named_model_repeated(self):
         with pm.Model("sub") as model:
             b = pm.Normal("var")
             with pm.Model("sub"):

--- a/pymc/tests/test_smc.py
+++ b/pymc/tests/test_smc.py
@@ -530,9 +530,9 @@ class TestSimulator(SeededTest):
             s = pm.Simulator("s", self.normal_sim, a, b, observed=self.data)
 
             trace = pm.sample_smc(draws=10, chains=2, return_inferencedata=False)
-            assert f"{name}_a" in trace.varnames
-            assert f"{name}_b" in trace.varnames
-            assert f"{name}_b_log__" in trace.varnames
+            assert f"{name}/a" in trace.varnames
+            assert f"{name}/b" in trace.varnames
+            assert f"{name}/b_log__" in trace.varnames
 
 
 class TestMHKernel(SeededTest):


### PR DESCRIPTION
resolves #5599, #5341
## Breaking changes
### Use `/` separator for model scopes
<table>
  <tr>
    <td>Before</td><td>After</td>
  </tr>
  <tr>
   <td>
<pre>
with pm.Model("sub") as model:
    b = pm.Normal("var")
model.named_vars.keys()
# dict_keys(['sub_var'])
</pre>
   </td>
<td>
<pre>
with pm.Model("sub") as model:
    b = pm.Normal("var")
model.named_vars.keys()
# dict_keys(['sub/var'])
</pre>
</td>
  </tr>
</table>

### Fix an error for nesting

<table>
  <tr>
    <td>Before</td><td>After</td>
  </tr>
  <tr>
   <td>
<pre>
with pm.Model("sub") as model:
    b = pm.Normal("var")
    with pm.Model("sub") as model:
        b = pm.Normal("var")
# Error
</pre>
   </td>
<td>
<pre>
with pm.Model("sub") as model:
    b = pm.Normal("var")
    with pm.Model("sub") as sub_model:
        b = pm.Normal("var")
model.named_vars.keys()
# dict_keys(['sub/var', 'sub/sub/var'])
</pre>
</td>
  </tr>
</table>

## Background
A long time ago nesting models were implemented as an experimental feature in #1525. It proved to be partially useful since that time.
* Name scoping is extremely useful for model factory functions
* Class-based approach is still rarely used and less intuitive, but it is an east-to-support feature.

The initial implementation had bugs that were only visible in real applications where scoping is critical to create many model instances and run a single inference. The PR solves that use-case and improves the UI of the output 