### PR TITLE
Update contributing guide with etiquette section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,11 @@
 
 **Thank your for opening a PR!**
 
+Before you proceed, please make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+
 Depending on what your PR does, here are a few things you might want to address in the description:
 + [ ] what are the (breaking) changes that this PR makes?
 + [ ] important background, or details about the implementation
 + [ ] are the changes—especially new features—covered by tests and docstrings?
-+ [ ] [linting/style checks have been run](https://docs.pymc.io/en/latest/contributing/python_style.html)
 + [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
 + [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,17 @@ Please verify that your issue is not being currently addressed by other issues o
 
 Filter on the ["beginner friendly"](https://github.com/pymc-devs/pymc/issues?q=is%3Aopen+is%3Aissue+label%3A%22beginner+friendly%22) label for issues which are good for new contributors.
 
-# Contributing code via pull requests
+## Etiquiette for code contributions
+* When you start working working on an issue, open a `Draft` pull request as soon as you're doing the first steps (see steps below).
+* Before opening a PR with a new feature, please propose it in an [Issue](https://github.com/pymc-devs/pymc/issues) or [Discussion](https://github.com/pymc-devs/pymc/discussions) with the maintainers. Depending on the proposal we might direct you to other places such as [`pymc-experimental`](https://github.com/pymc-devs/pymc-experimental) or [`pymc-examples`](https://github.com/pymc-devs/pymc-examples).
+* Any issue without an open pull request is available for work.
+   * If a pull request has no recent activity it may be closed, or taken over by someone else.
+   * The specific timeframe for "recent" is hard to define as it depends on the contributor the specific code change, and other contextual factors. As a rule of thumb in a normal pull request with no other blockers there is typically activity every couple of days.
+   * The core devs will make their best judgement when opting to close PRs.
+* In accordance with the previous point, please don't make unrealistic "_I want to work on this issue_" pledges.
+* It's okay if priorities change, but please communicate if you can't get a PR to the finish line, or that you're taking a break. Depending on the change (urgent bugfix vs. new feature) others might want to take over to get the work done.
+
+## Contributing code via pull requests
 
 While issue reporting is valuable, we strongly encourage users who are inclined to do so to submit patches for new or existing issues via pull requests. This is particularly the case for simple fixes, such as typos or tweaks to documentation, which do not require a heavy investment of time and attention.
 
@@ -26,6 +36,8 @@ Contributors are also encouraged to contribute new code to enhance PyMC's functi
 The preferred workflow for contributing to PyMC is to fork the [GitHub repository](https://github.com/pymc-devs/pymc/), clone it to your local machine, and develop on a feature branch.
 
 ### Steps
+
+1. Read the [Contributing etiquette section](#etiquiette-for-code-contributions).
 
 1. Fork the [project repository](https://github.com/pymc-devs/pymc/) by clicking on the 'Fork' button near the top right of the main repository page. This creates a copy of the code under your GitHub user account.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,15 +17,15 @@ Please verify that your issue is not being currently addressed by other issues o
 
 Filter on the ["beginner friendly"](https://github.com/pymc-devs/pymc/issues?q=is%3Aopen+is%3Aissue+label%3A%22beginner+friendly%22) label for issues which are good for new contributors.
 
-## Etiquiette for code contributions
-* When you start working working on an issue, open a `Draft` pull request as soon as you're doing the first steps (see steps below).
-* Before opening a PR with a new feature, please propose it in an [Issue](https://github.com/pymc-devs/pymc/issues) or [Discussion](https://github.com/pymc-devs/pymc/discussions) with the maintainers. Depending on the proposal we might direct you to other places such as [`pymc-experimental`](https://github.com/pymc-devs/pymc-experimental) or [`pymc-examples`](https://github.com/pymc-devs/pymc-examples).
+## Etiquette for code contributions
+* When you start working working on an issue, open a `Draft` pull request as soon as you make your first commit (see steps below).
+* Before opening a PR with a new feature, please make a proposal by opening an [issue](https://github.com/pymc-devs/pymc/issues) or [Discussion](https://github.com/pymc-devs/pymc/discussions) with the maintainers. Depending on the proposal we might direct you to other places such as [`pymc-experimental`](https://github.com/pymc-devs/pymc-experimental) or [`pymc-examples`](https://github.com/pymc-devs/pymc-examples).
 * Any issue without an open pull request is available for work.
    * If a pull request has no recent activity it may be closed, or taken over by someone else.
    * The specific timeframe for "recent" is hard to define as it depends on the contributor the specific code change, and other contextual factors. As a rule of thumb in a normal pull request with no other blockers there is typically activity every couple of days.
-   * The core devs will make their best judgement when opting to close PRs.
-* In accordance with the previous point, please don't make unrealistic "_I want to work on this issue_" pledges.
-* It's okay if priorities change, but please communicate if you can't get a PR to the finish line, or that you're taking a break. Depending on the change (urgent bugfix vs. new feature) others might want to take over to get the work done.
+   * The core devs will make their best judgement when opting to close PRs or reassign them to others.
+* If unsure if an issue ticket is available feel free to ask in the issue ticket. Note however, that per the previous point an open pull request is way to claim an issue ticket. Please do not make unrealistic pledges in the issue tickets.
+* It's okay if you are delayed or need to take a break, but please leave a comment in the pull request if you cannot get it to a state where it can be merged. Depending on the change (urgent bugfix vs. new feature) the core devs can determine if the PR needs to be reassigned to get the work done.
 
 ## Contributing code via pull requests
 
@@ -37,7 +37,7 @@ The preferred workflow for contributing to PyMC is to fork the [GitHub repositor
 
 ### Steps
 
-1. Read the [Contributing etiquette section](#etiquiette-for-code-contributions).
+1. Read the [Etiquette for code contributions](#etiquette-for-code-contributions).
 
 1. Fork the [project repository](https://github.com/pymc-devs/pymc/) by clicking on the 'Fork' button near the top right of the main repository page. This creates a copy of the code under your GitHub user account.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ There are 4 main ways of contributing to the PyMC project (in descending order o
 * Contributing or improving the documentation (`docs`) or examples (`pymc/examples`)
 * Submitting issues related to bugs or desired enhancements
 
-# Opening issues
+## Opening issues
 
 We appreciate being notified of problems with the existing PyMC code. We prefer that issues be filed the on [Github Issue Tracker](https://github.com/pymc-devs/pymc/issues), rather than on social media or by direct email to the developers.
 
@@ -25,66 +25,81 @@ Contributors are also encouraged to contribute new code to enhance PyMC's functi
 
 The preferred workflow for contributing to PyMC is to fork the [GitHub repository](https://github.com/pymc-devs/pymc/), clone it to your local machine, and develop on a feature branch.
 
-## Steps:
+### Steps
 
 1. Fork the [project repository](https://github.com/pymc-devs/pymc/) by clicking on the 'Fork' button near the top right of the main repository page. This creates a copy of the code under your GitHub user account.
 
-2. Clone your fork of the PyMC repo from your GitHub account to your local disk, and add the base repository as a remote:
+1. Clone your fork of the PyMC repo from your GitHub account to your local disk, and add the base repository as a remote:
 
    ```bash
-   $ git clone git@github.com:<your GitHub handle>/pymc.git
-   $ cd pymc
-   $ git remote add upstream git@github.com:pymc-devs/pymc.git
+   git clone git@github.com:<your GitHub handle>/pymc.git
+   cd pymc
+   git remote add upstream git@github.com:pymc-devs/pymc.git
    ```
 
-3. Create a ``feature`` branch to hold your development changes:
+1. Create a ``feature`` branch to hold your development changes:
 
    ```bash
-   $ git checkout -b my-feature
+   git checkout -b my-feature
    ```
 
    Always use a ``feature`` branch. It's good practice to never routinely work on the ``main`` branch of any repository.
 
-4. Project requirements are in ``requirements.txt``, and libraries used for development are in ``requirements-dev.txt``. The easiest (and recommended) way to set up a development environment is via [miniconda](https://docs.conda.io/en/latest/miniconda.html):
+1. Project requirements are in ``requirements.txt``, and libraries used for development are in ``requirements-dev.txt``. The easiest (and recommended) way to set up a development environment is via [miniconda](https://docs.conda.io/en/latest/miniconda.html):
 
    ```bash
-   $ conda env create -f conda-envs/environment-dev-py37.yml  # or py38 or py39
-   $ conda activate pymc-dev-py37
-   $ pip install -e .
+   conda env create -f conda-envs/environment-dev-py39.yml  # or py38 or py37
+   conda activate pymc-dev-py39
+   pip install -e .
    ```
 
    _Alternatively_ you may (probably in a [virtual environment](https://docs.python-guide.org/dev/virtualenvs/)) run:
 
    ```bash
-   $ pip install -e .
-   $ pip install -r requirements-dev.txt
+   pip install -e .
+   pip install -r requirements-dev.txt
+   ```
+<!-- Commented out because our Docker image is outdated/broken.
+   Yet another alternative is to create a docker environment for development. See: [Developing in Docker](#Developing-in-Docker).
+-->
+
+1. Develop the feature on your feature branch.
+   ```bash
+   git checkout -b my-cool-bugfix
    ```
 
-   Yet another alternative is to create a docker environment for development. See: [Developing in Docker](#Developing-in-Docker).
-
-5. Develop the feature on your feature branch. Add changed files using ``git add`` and then ``git commit`` files:
-
+1. Before committing, please run `pre-commit` checks.
    ```bash
-   $ git add modified_files
-   $ git commit
+   pip install pre-commit
+   pre-commit run --all      # 👈 to run it manually
+   pre-commit install        # 👈 to run it automatically before each commit
+   ```
+
+1. Add changed files using ``git add`` and then ``git commit`` files:
+   ```bash
+   git checkout -b my-cool-bugfix
+   git add modified_files
+   git commit
    ```
 
    to record your changes locally.
-   After committing, it is a good idea to sync with the base repository in case there have been any changes:
+
+1. After committing, sync with the base repository in case there have been any changes:
    ```bash
-   $ git fetch upstream
-   $ git rebase upstream/main
+   git fetch upstream
+   git rebase upstream/main
    ```
 
-   Then push the changes to your GitHub account with:
+   Then push the changes to the fork in your GitHub account with:
 
    ```bash
-   $ git push -u origin my-feature
+   git push -u origin my-cool-bugfix
    ```
 
-6. Go to the GitHub web page of your fork of the PyMC repo. Click the 'Pull request' button to send your changes to the project's maintainers for review. This will send an email to the committers.
+1. Go to the GitHub web page of your fork of the PyMC repo. Click the 'Pull request' button to open a pull request to the main project. Our CI pipeline will start running tests* and project maintainers can start reviewing your changes.
+   <sup>*If this is your first contribution, the start of some CI jobs will have to be approved by a maintainer.</sup>
 
-## Pull request checklist
+### Pull request checklist
 
 We recommended that your contribution complies with the following guidelines before you submit a pull request:
 
@@ -92,29 +107,31 @@ We recommended that your contribution complies with the following guidelines bef
 
 *  All public methods must have informative docstrings with sample usage when appropriate.
 
-*  Please prefix the title of incomplete contributions with `[WIP]` (to indicate a work in progress). WIPs may be useful to (1) indicate you are working on something to avoid duplicated work, (2) request broad review of functionality or API, or (3) seek collaborators.
+*  Please select "Create draft pull request" in the dropdown menu when opening your pull request to indicate a work in progress. This is to avoid duplicated work, to get early input on implementation details or API/functionality, or to seek collaborators.
 
-*  All other tests pass when everything is rebuilt from scratch.  See
-[Developing in Docker](#Developing-in-Docker) for information on running the test suite locally.
-
-*  When adding additional functionality, provide at least one example script or Jupyter Notebook in the ``pymc/examples/`` folder. Have a look at other examples for reference. Examples should demonstrate why the new functionality is useful in practice and, if possible, compare it to other methods available in PyMC.
+<!-- Commented out because our Docker image is outdated/broken.
+See [Developing in Docker](#Developing-in-Docker) for information on running the test suite locally.
+-->
 
 * Documentation and high-coverage tests are necessary for enhancements to be accepted.
 
-* Run any of the pre-existing examples in ``docs/source/notebooks`` that contain analyses that would be affected by your changes to ensure that nothing breaks. This is a useful opportunity to not only check your work for bugs that might not be revealed by unit test, but also to show how your contribution improves PyMC for end users.
+*  Depending on the functionality, please consider contributing an example Jupyter Notebook to [`pymc-examples`](https://github.com/pymc-devs/pymc-examples). Examples should demonstrate why the new functionality is useful in practice and, if possible, compare it to other methods available in PyMC.
 
-You can also check for common programming errors with the following
-tools:
+* __No `pre-commit` errors:__ see the [Python code style](https://github.com/pymc-devs/pymc/wiki/Python-Code-Style) and [Jupyter Notebook style](https://github.com/pymc-devs/pymc/wiki/PyMC-Jupyter-Notebook-Style-Guide) page from our Wiki on how to install and run it.
 
-* Code with good test **coverage** (at least 80%), check with:
+In addition to running `pre-commit`, please also run tests:
 
-  ```bash
-  $ pip install pytest pytest-cov coverage
-  $ pytest --cov=pymc pymc/tests/<name of test>.py
-  ```
+```bash
+pip install pytest pytest-cov coverage
 
-* No `pre-commit` errors: see the [Python code style](https://github.com/pymc-devs/pymc/wiki/Python-Code-Style) and [Jupyter Notebook style](https://github.com/pymc-devs/pymc/wiki/PyMC-Jupyter-Notebook-Style-Guide) page from our Wiki on how to install and run it.
+# To run a subset of tests
+pytest --verbose pymc/tests/<name of test>.py
 
+# To get a coverage report
+pytest --verbose --cov=pymc --cov-report term-missing pymc/tests/<name of test>.py
+```
+
+<!-- Commented out because our Docker image is outdated/broken.
 ## Developing in Docker
 
 We have provided a Dockerfile which helps for isolating build problems, and local development.
@@ -142,6 +159,7 @@ accessed with
 ```
 docker exec -it pymc jupyter notebook list
 ```
+-->
 
 ## Style guide
 
@@ -150,6 +168,6 @@ We encourage you to configure the pre-commit hook as described in the [PyMC Pyth
 
 Similarly, consult the [PyMC's Jupyter Notebook Style](https://docs.pymc.io/en/latest/contributing/jupyter_style.html) guides for notebooks.
 
-For documentation strings, we *prefer* [numpy style](https://numpydoc.readthedocs.io/en/latest/format.html) to comply with the style that predominates in our upstream dependencies.
+For documentation strings, we use [numpy style](https://numpydoc.readthedocs.io/en/latest/format.html) to comply with the style that predominates in our upstream dependencies.
 
-#### This guide was derived from the [scikit-learn guide to contributing](https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md)
+__This guide was derived from the [scikit-learn guide to contributing](https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md)__


### PR DESCRIPTION
Lately we have seen several examples where people asked for permission or commented that they wanted to work on an issue, but did not follow up with a pull request within several __weeks__ or at all.

Because this is blocking other people from getting the work done, and thereby slowing the overall progress, I'm proposing to add a corresponding section to our `CONTRIBUTING.md`.

The gist of it is:
+ We value _getting work done_ over pledges.
+ We ask people to open `Draft` PRs as soon as they start working on it.
+ We reserve the right to take over or close PRs when authors go unresponsive.

I think the risk of doing work twice is really low.

Also among high-frequency contributors pledges are rare - if happening at all they are usually more of the kind "I can do this after these two other things are merged".

And in the rare event of two people picking up the same issue at the same time (within 1-3 days) they can help out each other and decide which PR to go for.

-----------

Why are the tests triggering? I thought they only run if there are changes in `.py` files?
(I cancelled them to save resources.)