### PR TITLE
Raise ValueError if random variables are present in the logp graph

### DIFF
--- a/pymc/tests/test_logprob.py
+++ b/pymc/tests/test_logprob.py
@@ -28,6 +28,7 @@ from aesara.tensor.subtensor import (
     Subtensor,
 )
 
+from pymc import DensityDist
 from pymc.aesaraf import floatX, walk_model
 from pymc.distributions.continuous import HalfFlat, Normal, TruncatedNormal, Uniform
 from pymc.distributions.discrete import Bernoulli
@@ -217,3 +218,12 @@ def test_model_unchanged_logprob_access():
     model.logpt()
     new_inputs = set(aesara.graph.graph_inputs([c]))
     assert original_inputs == new_inputs
+
+
+def test_unexpected_rvs():
+    with Model() as model:
+        x = Normal("x")
+        y = DensityDist("y", logp=lambda *args: x)
+
+    with pytest.raises(ValueError, match="^Random variables detected in the logp graph"):
+        model.logpt()

--- a/pymc/tests/test_parallel_sampling.py
+++ b/pymc/tests/test_parallel_sampling.py
@@ -201,11 +201,11 @@ def test_spawn_densitydist_bound_method():
     N = 100
     with pm.Model() as model:
         mu = pm.Normal("mu", 0, 1)
-        normal_dist = pm.Normal.dist(mu, 1, size=N)
 
-        def logp(x):
+        def logp(x, mu):
+            normal_dist = pm.Normal.dist(mu, 1, size=N)
             out = pm.logp(normal_dist, x)
             return out
 
-        obs = pm.DensityDist("density_dist", logp=logp, observed=np.random.randn(N), size=N)
+        obs = pm.DensityDist("density_dist", mu, logp=logp, observed=np.random.randn(N), size=N)
         pm.sample(draws=10, tune=10, step=pm.Metropolis(), cores=2, mp_ctx="spawn")


### PR DESCRIPTION
Aeppl allows for graphs containing random variables. PyMC models do not generally allow for this, with the current exception of models that include SimulatorRVs.

This PR adds a check to avoid subtle bugs when RandomVariables creep in into the logp unexpectedly, which can happen when mis-using DensityDist or Interval transforms.

Closes #5155 