### PR TITLE
Refine trigger filter for both PRs and pushes

### DIFF
--- a/.github/workflows/arviz_compat.yml
+++ b/.github/workflows/arviz_compat.yml
@@ -2,16 +2,22 @@ name: arviz-compatibility
 
 on:
   pull_request:
+    paths:
+      - ".github/workflows/*.yml"
+      - "pymc/**.py"
+      - "*.py"
+      - "conda-envs/**"
+      - "codecov.yml"
+      - "scripts/*.sh"
   push:
     branches: [main]
     paths:
-      - ".github/workflows/*"
-      - "pymc/**"
-      - "setup.py"
-      - "pyproject.toml"
-      - "buildosx"
+      - ".github/workflows/*.yml"
+      - "pymc/**.py"
+      - "*.py"
       - "conda-envs/**"
       - "codecov.yml"
+      - "scripts/*.sh"
 
 jobs:
   pytest:

--- a/.github/workflows/jaxtests.yml
+++ b/.github/workflows/jaxtests.yml
@@ -2,16 +2,22 @@ name: jax-sampling
 
 on:
   pull_request:
+    paths:
+      - ".github/workflows/*.yml"
+      - "pymc/**.py"
+      - "*.py"
+      - "conda-envs/**"
+      - "codecov.yml"
+      - "scripts/*.sh"
   push:
     branches: [main]
     paths:
-      - ".github/workflows/*"
-      - "pymc/**"
-      - "setup.py"
-      - "pyproject.toml"
-      - "buildosx"
+      - ".github/workflows/*.yml"
+      - "pymc/**.py"
+      - "*.py"
       - "conda-envs/**"
       - "codecov.yml"
+      - "scripts/*.sh"
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,16 +2,22 @@ name: pytest
 
 on:
   pull_request:
+    paths:
+      - ".github/workflows/*.yml"
+      - "pymc/**.py"
+      - "*.py"
+      - "conda-envs/**"
+      - "codecov.yml"
+      - "scripts/*.sh"
   push:
     branches: [main]
     paths:
-      - ".github/workflows/*"
-      - "pymc/**"
-      - "setup.py"
-      - "pyproject.toml"
-      - "buildosx"
+      - ".github/workflows/*.yml"
+      - "pymc/**.py"
+      - "*.py"
       - "conda-envs/**"
       - "codecov.yml"
+      - "scripts/*.sh"
 
 
 # Tests are split into multiple jobs to accelerate the CI.


### PR DESCRIPTION
Previously only one of the trigger conditions had the filter.
This is a follow-up to #5364.

Unfortunately, the changes can't be tested on this PR because of how GitHub determines the diff:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#git-diff-comparisons

