### PR TITLE
start private API section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tags
 # Sphinx
 _build
 docs/jupyter_execute
+docs/.jupyter_cache
 docs/**/generated/*
 
 # Merge tool

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf $(SOURCEDIR)/api/**/generated
+	rm -rf $(SOURCEDIR)/api/**/classmethods
+	rm -rf $(SOURCEDIR)/contributing/private_api/**/generated
+	rm -rf $(SOURCEDIR)/contributing/private_api/**/classmethods
 	rm -rf docs/jupyter_execute
 
 html:

--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -81,6 +81,7 @@ running_the_test_suite
 :maxdepth: 1
 :caption: Reference content
 
+private_api/index
 python_style
 jupyter_style
 pr_checklist

--- a/docs/source/contributing/private_api/index.md
+++ b/docs/source/contributing/private_api/index.md
@@ -1,0 +1,17 @@
+# Private API
+
+:::{warning}
+The private API pages reference parts of the PyMC API that are developer
+facing only but still benefit from having their docstrings rendered here
+to help both contributors and members of the PyMC team.
+
+If you are a PyMC user you should try to avoid using these objects.
+As part of the private API, their changes may not appear in the release
+notes and they can be modified or removed without warning at any time.
+:::
+
+:::{toctree}
+:maxdepth: 2
+
+tests
+:::

--- a/docs/source/contributing/private_api/tests.rst
+++ b/docs/source/contributing/private_api/tests.rst
@@ -1,0 +1,17 @@
+***************
+Testing helpers
+***************
+
+Fixtures
+--------
+These fixtures are used to configure test functions.
+
+.. currentmodule:: pymc.tests.conftest
+
+.. autosummary::
+  :toctree: generated/
+
+  aesara_config
+  exception_verbosity
+  strict_float32
+  seeded_test


### PR DESCRIPTION
Starts a private api section and fills an example page.
Still not sure what should be documented there and the goal is not to add more things,
only to show how it is done so other people can take over.
Related to #5539

+ [x] what are the (breaking) changes that this PR makes? **None**
+ [x] important background, or details about the implementation: see above
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
