### PR TITLE
preserve chain and draw dims in posterior predictive

### DIFF
--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - aeppl=0.0.27
 - aesara=2.5.1
-- arviz>=0.11.4
+- arviz>=0.12.0
 - blas
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - aeppl=0.0.27
 - aesara=2.5.1
-- arviz>=0.11.4
+- arviz>=0.12.0
 - blas
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - aeppl=0.0.27
 - aesara=2.5.1
-- arviz>=0.11.4
+- arviz>=0.12.0
 - blas
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/environment-test-py37.yml
+++ b/conda-envs/environment-test-py37.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - aeppl=0.0.27
 - aesara=2.5.1
-- arviz>=0.11.4
+- arviz>=0.12.0
 - blas
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/environment-test-py38.yml
+++ b/conda-envs/environment-test-py38.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - aeppl=0.0.27
 - aesara=2.5.1
-- arviz>=0.11.4
+- arviz>=0.12.0
 - blas
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/environment-test-py39.yml
+++ b/conda-envs/environment-test-py39.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - aeppl=0.0.27
 - aesara=2.5.1
-- arviz>=0.11.4
+- arviz>=0.12.0
 - blas
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -6,7 +6,7 @@ dependencies:
  # base dependencies (see install guide for Windows)
 - aeppl=0.0.27
 - aesara=2.5.1
-- arviz>=0.11.4
+- arviz>=0.12.0
 - blas
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/windows-environment-test-py38.yml
+++ b/conda-envs/windows-environment-test-py38.yml
@@ -6,7 +6,7 @@ dependencies:
  # base dependencies (see install guide for Windows)
 - aeppl=0.0.27
 - aesara=2.5.1
-- arviz>=0.11.4
+- arviz>=0.12.0
 - blas
 - cachetools>=4.2.1
 - cloudpickle

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -1627,13 +1627,13 @@ def sample_posterior_predictive(
     if "coords" not in idata_kwargs:
         idata_kwargs["coords"] = {}
     if isinstance(trace, InferenceData):
-        idata_kwargs["coords"].setdefault("draw", trace.posterior.draw)
-        idata_kwargs["coords"].setdefault("chain", trace.posterior.chain)
+        idata_kwargs["coords"].setdefault("draw", trace["posterior"]["draw"])
+        idata_kwargs["coords"].setdefault("chain", trace["posterior"]["chain"])
         _trace = dataset_to_point_list(trace["posterior"])
         nchain, len_trace = chains_and_samples(trace)
     elif isinstance(trace, xarray.Dataset):
-        idata_kwargs["coords"].setdefault("draw", trace.draw)
-        idata_kwargs["coords"].setdefault("chain", trace.chain)
+        idata_kwargs["coords"].setdefault("draw", trace["draw"])
+        idata_kwargs["coords"].setdefault("chain", trace["chain"])
         _trace = dataset_to_point_list(trace)
         nchain, len_trace = chains_and_samples(trace)
     elif isinstance(trace, MultiTrace):

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -1620,10 +1620,20 @@ def sample_posterior_predictive(
 
     _trace: Union[MultiTrace, PointList]
     nchain: int
+    if idata_kwargs is None:
+        idata_kwargs = {}
+    else:
+        idata_kwargs = idata_kwargs.copy()
+    if "coords" not in idata_kwargs:
+        idata_kwargs["coords"] = {}
     if isinstance(trace, InferenceData):
+        idata_kwargs["coords"].setdefault("draw", trace.posterior.draw)
+        idata_kwargs["coords"].setdefault("chain", trace.posterior.chain)
         _trace = dataset_to_point_list(trace["posterior"])
         nchain, len_trace = chains_and_samples(trace)
     elif isinstance(trace, xarray.Dataset):
+        idata_kwargs["coords"].setdefault("draw", trace.draw)
+        idata_kwargs["coords"].setdefault("chain", trace.chain)
         _trace = dataset_to_point_list(trace)
         nchain, len_trace = chains_and_samples(trace)
     elif isinstance(trace, MultiTrace):
@@ -1782,9 +1792,7 @@ def sample_posterior_predictive(
 
     if not return_inferencedata:
         return ppc_trace
-    ikwargs: Dict[str, Any] = dict(model=model)
-    if idata_kwargs:
-        ikwargs.update(idata_kwargs)
+    ikwargs: Dict[str, Any] = dict(model=model, **idata_kwargs)
     if predictions:
         if extend_inferencedata:
             ikwargs.setdefault("idata_orig", trace)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 
 aeppl==0.0.27
 aesara==2.5.1
-arviz>=0.11.4
+arviz>=0.12.0
 cachetools>=4.2.1
 cloudpickle
 fastprogress>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aeppl==0.0.27
 aesara==2.5.1
-arviz>=0.11.4
+arviz>=0.12.0
 cachetools>=4.2.1
 cloudpickle
 fastprogress>=0.2.0


### PR DESCRIPTION
+ [x] what are the (breaking) changes that this PR makes? None that I can think of
+ [x] important background, or details about the implementation
  - This is mostly relevant when thinning the posterior to generate posterior predictive samples
    for only a subset of it (if pp sampling is expensive for example), but can also
    be an issue if someone uses non standard coordinate values.
  - It depends on https://github.com/arviz-devs/arviz/pull/2001 and an ArviZ release before the
    specific test can pass. Should I use a skipif to request arviz>0.11.4 so it can be merged
    before that? (not sure when next ArviZ release will be)
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [x] [linting/style checks have been run](https://docs.pymc.io/en/latest/contributing/python_style.html)
+ [x] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples): Updating the golf putting notebook that samples posterior predictive on a thinned posterior only.
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
