### PR TITLE
Adding check to prevent mixing of discrete and continuous distributions

### DIFF
--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -177,7 +177,7 @@ class Mixture(SymbolicDistribution):
             if not (
                 all(comp_dist.dtype in continuous_types for comp_dist in comp_dists)
                 or all(comp_dist.dtype in discrete_types for comp_dist in comp_dists)
-                ):
+            ):
                 # Determine if the distributions in comp_dists are all discrete or continuous
                 raise ValueError(
                     "All distributions in comp_dists must be either discrete or continuous.\n"

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -174,7 +174,6 @@ class Mixture(SymbolicDistribution):
                 all(comp_dist.dtype in continuous_types for comp_dist in comp_dists)
                 or all(comp_dist.dtype in discrete_types for comp_dist in comp_dists)
             ):
-                # Determine if the distributions in comp_dists are all discrete or continuous
                 raise ValueError(
                     "All distributions in comp_dists must be either discrete or continuous.\n"
                     "See the following issue for more information: https://github.com/pymc-devs/pymc/issues/4511."

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -43,21 +43,6 @@ from pymc.vartypes import continuous_types, discrete_types
 __all__ = ["Mixture", "NormalMixture"]
 
 
-def all_same_type(comp_dists):
-    """
-    Determine if the distributions in comp_dists are all discrete or continuous
-    """
-
-    if len(comp_dists) == 1:
-        # should return True for either check_discrete=True or False
-        return comp_dists[0] in continuous_types | discrete_types
-    else:
-        all_continuous = all([comp_dist in continuous_types for comp_dist in comp_dists])
-        all_discrete = all([comp_dist in discrete_types for comp_dist in comp_dists])
-
-        return all_continuous or all_discrete
-
-
 class MarginalMixtureRV(OpFromGraph):
     """A placeholder used to specify a log-likelihood for a mixture sub-graph."""
 
@@ -185,11 +170,16 @@ class Mixture(SymbolicDistribution):
                 UserWarning,
             )
 
-        if not all_same_type(comp_dists):
-            raise ValueError(
-                "All distributions in comp_dists must be either discrete or continuous.\n"
-                "See the following issue for more information: https://github.com/pymc-devs/pymc/issues/4511."
-            )
+        if len(comp_dists) > 1:
+            all_continuous = all([comp_dist.dtype in continuous_types for comp_dist in comp_dists])
+            all_discrete = all([comp_dist.dtype in discrete_types for comp_dist in comp_dists])
+
+            if not (all_continuous or all_discrete):
+                # Determine if the distributions in comp_dists are all discrete or continuous
+                raise ValueError(
+                    "All distributions in comp_dists must be either discrete or continuous.\n"
+                    "See the following issue for more information: https://github.com/pymc-devs/pymc/issues/4511."
+                )
 
         # Check that components are not associated with a registered variable in the model
         components_ndim_supp = set()

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -30,8 +30,6 @@ from pymc.distributions import transforms
 from pymc.distributions.continuous import Normal, get_tau_sigma
 from pymc.distributions.dist_math import check_parameters
 from pymc.distributions.distribution import (
-    Discrete,
-    Distribution,
     SymbolicDistribution,
     _moment,
     moment,
@@ -40,19 +38,24 @@ from pymc.distributions.logprob import logcdf, logp
 from pymc.distributions.shape_utils import to_tuple
 from pymc.distributions.transforms import _default_transform
 from pymc.util import check_dist_not_registered
-from pymc.vartypes import discrete_types
+from pymc.vartypes import continuous_types, discrete_types
 
 __all__ = ["Mixture", "NormalMixture"]
 
 
-def all_discrete(comp_dists):
+def all_same_type(comp_dists):
     """
-    Determine if all distributions in comp_dists are discrete
+    Determine if the distributions in comp_dists are all discrete or continuous
     """
-    if isinstance(comp_dists, Distribution):
-        return isinstance(comp_dists, Discrete)
+
+    if len(comp_dists) == 1:
+        # should return True for either check_discrete=True or False
+        return comp_dists[0] in continuous_types | discrete_types
     else:
-        return all(isinstance(comp_dist, Discrete) for comp_dist in comp_dists)
+        all_continuous = all([comp_dist in continuous_types for comp_dist in comp_dists])
+        all_discrete = all([comp_dist in discrete_types for comp_dist in comp_dists])
+
+        return all_continuous or all_discrete
 
 
 class MarginalMixtureRV(OpFromGraph):
@@ -180,6 +183,12 @@ class Mixture(SymbolicDistribution):
                 "Single component will be treated as a mixture across the last size dimension.\n"
                 "To disable this warning do not wrap the single component inside a list or tuple",
                 UserWarning,
+            )
+
+        if not all_same_type(comp_dists):
+            raise ValueError(
+                "All distributions in comp_dists must be either discrete or continuous.\n"
+                "See the following issue for more information: https://github.com/pymc-devs/pymc/issues/4511."
             )
 
         # Check that components are not associated with a registered variable in the model

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -29,11 +29,7 @@ from pymc.aesaraf import change_rv_size
 from pymc.distributions import transforms
 from pymc.distributions.continuous import Normal, get_tau_sigma
 from pymc.distributions.dist_math import check_parameters
-from pymc.distributions.distribution import (
-    SymbolicDistribution,
-    _moment,
-    moment,
-)
+from pymc.distributions.distribution import SymbolicDistribution, _moment, moment
 from pymc.distributions.logprob import logcdf, logp
 from pymc.distributions.shape_utils import to_tuple
 from pymc.distributions.transforms import _default_transform

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -171,10 +171,13 @@ class Mixture(SymbolicDistribution):
             )
 
         if len(comp_dists) > 1:
-            all_continuous = all([comp_dist.dtype in continuous_types for comp_dist in comp_dists])
-            all_discrete = all([comp_dist.dtype in discrete_types for comp_dist in comp_dists])
+            all_continuous = all(comp_dist.dtype in continuous_types for comp_dist in comp_dists)
+            all_discrete = all(comp_dist.dtype in discrete_types for comp_dist in comp_dists)
 
-            if not (all_continuous or all_discrete):
+            if not (
+                all(comp_dist.dtype in continuous_types for comp_dist in comp_dists)
+                or all(comp_dist.dtype in discrete_types for comp_dist in comp_dists)
+                ):
                 # Determine if the distributions in comp_dists are all discrete or continuous
                 raise ValueError(
                     "All distributions in comp_dists must be either discrete or continuous.\n"

--- a/pymc/tests/test_mixture.py
+++ b/pymc/tests/test_mixture.py
@@ -729,14 +729,6 @@ class TestMixture(SeededTest):
                 Categorical.dist(np.tile(1 / 3, 3)),
                 Normal.dist(np.ones(3), 3),
             ),
-            (
-                Binomial.dist(n=10, p=0.5),
-                Normal.dist(),
-            ),
-            (
-                Categorical.dist(np.broadcast_to(1 / 3, (5, 2, 3))),
-                MvNormal.dist(np.ones(3), np.eye(3), shape=(5, 2)),
-            ),
         ],
     )
     def test_preventing_mixing_cont_and_discrete(self, comp_dists):

--- a/pymc/tests/test_mixture.py
+++ b/pymc/tests/test_mixture.py
@@ -721,22 +721,20 @@ class TestMixture(SeededTest):
             assert isinstance(comp_dist.owner.op, RandomVariable)
             assert tuple(comp_dist.shape.eval()) == expected_shape
 
-    @pytest.mark.parametrize(
-        "comp_dists",
-        [
-            (
-                Categorical.dist(np.tile(1 / 3, 3)),
-                Normal.dist(np.ones(3), 3),
-            ),
-        ],
-    )
     def test_preventing_mixing_cont_and_discrete(self, comp_dists):
         with pytest.raises(
             ValueError,
             match="All distributions in comp_dists must be either discrete or continuous.",
         ):
             with Model() as model:
-                mix = Mixture("x", w=[0.5, 0.3, 0.2], comp_dists=comp_dists)
+                mix = Mixture(
+                    "x", 
+                    w=[0.5, 0.3, 0.2], 
+                    comp_dists=[
+                        Categorical.dist(np.tile(1 / 3, 3)),
+                        Normal.dist(np.ones(3), 3),
+                    ],
+                )
 
 
 class TestNormalMixture(SeededTest):

--- a/pymc/tests/test_mixture.py
+++ b/pymc/tests/test_mixture.py
@@ -721,7 +721,7 @@ class TestMixture(SeededTest):
             assert isinstance(comp_dist.owner.op, RandomVariable)
             assert tuple(comp_dist.shape.eval()) == expected_shape
 
-    def test_preventing_mixing_cont_and_discrete(self, comp_dists):
+    def test_preventing_mixing_cont_and_discrete(self):
         with pytest.raises(
             ValueError,
             match="All distributions in comp_dists must be either discrete or continuous.",

--- a/pymc/tests/test_mixture.py
+++ b/pymc/tests/test_mixture.py
@@ -728,8 +728,8 @@ class TestMixture(SeededTest):
         ):
             with Model() as model:
                 mix = Mixture(
-                    "x", 
-                    w=[0.5, 0.3, 0.2], 
+                    "x",
+                    w=[0.5, 0.3, 0.2],
                     comp_dists=[
                         Categorical.dist(np.tile(1 / 3, 3)),
                         Normal.dist(np.ones(3), 3),

--- a/pymc/tests/test_mixture.py
+++ b/pymc/tests/test_mixture.py
@@ -29,7 +29,6 @@ from scipy.special import logsumexp
 
 from pymc.aesaraf import floatX
 from pymc.distributions import (
-    Binomial,
     Categorical,
     Dirichlet,
     DirichletMultinomial,


### PR DESCRIPTION
Closes #4511. `all_discrete` in `mixture.py` has also been removed

Is there a test that should be added?