### PR TITLE
Conditionally depend on pandas in tests

### DIFF
--- a/pymc/tests/test_aesaraf.py
+++ b/pymc/tests/test_aesaraf.py
@@ -19,7 +19,6 @@ import aesara.tensor as at
 import numpy as np
 import numpy.ma as ma
 import numpy.testing as npt
-import pandas as pd
 import pytest
 import scipy.sparse as sps
 
@@ -377,6 +376,7 @@ def test_pandas_to_array(input_dtype):
     Ensure that pandas_to_array returns the dense array, masked array,
     graph variable, TensorVariable, or sparse matrix as appropriate.
     """
+    pd = pytest.importorskip("pandas")
     # Create the various inputs to the function
     sparse_input = sps.csr_matrix(np.eye(3)).astype(input_dtype)
     dense_input = np.arange(9).reshape((3, 3)).astype(input_dtype)
@@ -452,6 +452,7 @@ def test_pandas_to_array(input_dtype):
 
 
 def test_pandas_to_array_pandas_index():
+    pd = pytest.importorskip("pandas")
     data = pd.Index([1, 2, 3])
     result = pandas_to_array(data)
     expected = np.array([1, 2, 3])

--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -15,7 +15,6 @@
 import io
 
 import numpy as np
-import pandas as pd
 import pytest
 
 from aesara import shared

--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -342,6 +342,7 @@ class TestData(SeededTest):
                 pmodel.set_data("inhabitants", [1, 2, 3, 4])
 
     def test_implicit_coords_series(self):
+        pd = pytest.importorskip("pandas")
         ser_sales = pd.Series(
             data=np.random.randint(low=0, high=30, size=22),
             index=pd.date_range(start="2020-05-01", periods=22, freq="24H", name="date"),
@@ -355,6 +356,7 @@ class TestData(SeededTest):
         assert pmodel.RV_dims == {"sales": ("date",)}
 
     def test_implicit_coords_dataframe(self):
+        pd = pytest.importorskip("pandas")
         N_rows = 5
         N_cols = 7
         df_data = pd.DataFrame()

--- a/pymc/tests/test_idata_conversion.py
+++ b/pymc/tests/test_idata_conversion.py
@@ -4,7 +4,6 @@ from typing import Dict, Tuple
 
 import aesara.tensor as at
 import numpy as np
-import pandas as pd
 import pytest
 
 from aesara.tensor.subtensor import AdvancedIncSubtensor, AdvancedIncSubtensor1
@@ -240,6 +239,7 @@ class TestDataPyMC:
 
     @pytest.mark.parametrize("use_context", [True, False])
     def test_autodetect_coords_from_model(self, use_context):
+        pd = pytest.importorskip("pandas")
         df_data = pd.DataFrame(columns=["date"]).set_index("date")
         dates = pd.date_range(start="2020-05-01", end="2020-05-20")
         for city, mu in {"Berlin": 15, "San Marino": 18, "Paris": 16}.items():
@@ -573,6 +573,7 @@ class TestDataPyMC:
             np.testing.assert_array_equal(ds[dname].values, cvals)
 
     def test_issue_5043_autoconvert_coord_values(self):
+        pd = pytest.importorskip("pandas")
         coords = {"city": pd.Series(["Bonn", "Berlin"])}
         with pm.Model(coords=coords) as pmodel:
             # The model tracks coord values as (immutable) tuples

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -22,7 +22,6 @@ import cloudpickle
 import numpy as np
 import numpy.ma as ma
 import numpy.testing as npt
-import pandas as pd
 import pytest
 import scipy.sparse as sps
 import scipy.stats as st
@@ -216,6 +215,7 @@ def test_duplicate_vars():
 
 
 def test_empty_observed():
+    pd = pytest.importorskip("pandas")
     data = pd.DataFrame(np.ones((2, 3)) / 3)
     data.values[:] = np.nan
     with pm.Model():

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ cachetools>=4.2.1
 cloudpickle
 fastprogress>=0.2.0
 numpy>=1.15.0
-pandas>=0.24.0
 scipy>=1.4.1
 typing-extensions>=3.7.4


### PR DESCRIPTION
Closes https://github.com/pymc-devs/pymc/issues/5469

This PR updates the tests to conditionally dependent on pandas. With this PR the only code that uses pandas are maintenance, benchmark scripts, and two notebooks:

- scripts/check_all_tests_are_covered.py
- scripts/run_mypy.py
- benchmarks/benchmarks/benchmarks.py
- docs/source/learn/examples/GLM_linear.ipynb
- docs/source/learn/examples/pymc_overview.ipynb