### PR TITLE
Variable selection for graphviz visualization via kwarg

### DIFF
--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -29,14 +29,33 @@ from pymc.aesaraf import change_rv_size
 from pymc.distributions import transforms
 from pymc.distributions.continuous import Normal, get_tau_sigma
 from pymc.distributions.dist_math import check_parameters
-from pymc.distributions.distribution import SymbolicDistribution, _moment, moment
-from pymc.distributions.logprob import ignore_logprob, logcdf, logp
+from pymc.distributions.distribution import (
+    SymbolicDistribution,
+    _moment,
+    moment,
+)
+from pymc.distributions.logprob import logcdf, logp
 from pymc.distributions.shape_utils import to_tuple
 from pymc.distributions.transforms import _default_transform
 from pymc.util import check_dist_not_registered
 from pymc.vartypes import continuous_types, discrete_types
 
 __all__ = ["Mixture", "NormalMixture"]
+
+
+def all_same_type(comp_dists):
+    """
+    Determine if the distributions in comp_dists are all discrete or continuous
+    """
+
+    if len(comp_dists) == 1:
+        # should return True for either check_discrete=True or False
+        return comp_dists[0] in continuous_types | discrete_types
+    else:
+        all_continuous = all([comp_dist in continuous_types for comp_dist in comp_dists])
+        all_discrete = all([comp_dist in discrete_types for comp_dist in comp_dists])
+
+        return all_continuous or all_discrete
 
 
 class MarginalMixtureRV(OpFromGraph):
@@ -173,15 +192,11 @@ class Mixture(SymbolicDistribution):
                 UserWarning,
             )
 
-        if len(comp_dists) > 1:
-            if not (
-                all(comp_dist.dtype in continuous_types for comp_dist in comp_dists)
-                or all(comp_dist.dtype in discrete_types for comp_dist in comp_dists)
-            ):
-                raise ValueError(
-                    "All distributions in comp_dists must be either discrete or continuous.\n"
-                    "See the following issue for more information: https://github.com/pymc-devs/pymc/issues/4511."
-                )
+        if not all_same_type(comp_dists):
+            raise ValueError(
+                "All distributions in comp_dists must be either discrete or continuous.\n"
+                "See the following issue for more information: https://github.com/pymc-devs/pymc/issues/4511."
+            )
 
         # Check that components are not associated with a registered variable in the model
         components_ndim_supp = set()

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -29,30 +29,14 @@ from pymc.aesaraf import change_rv_size
 from pymc.distributions import transforms
 from pymc.distributions.continuous import Normal, get_tau_sigma
 from pymc.distributions.dist_math import check_parameters
-from pymc.distributions.distribution import (
-    Discrete,
-    Distribution,
-    SymbolicDistribution,
-    _moment,
-    moment,
-)
-from pymc.distributions.logprob import logcdf, logp
+from pymc.distributions.distribution import SymbolicDistribution, _moment, moment
+from pymc.distributions.logprob import ignore_logprob, logcdf, logp
 from pymc.distributions.shape_utils import to_tuple
 from pymc.distributions.transforms import _default_transform
 from pymc.util import check_dist_not_registered
-from pymc.vartypes import discrete_types
+from pymc.vartypes import continuous_types, discrete_types
 
 __all__ = ["Mixture", "NormalMixture"]
-
-
-def all_discrete(comp_dists):
-    """
-    Determine if all distributions in comp_dists are discrete
-    """
-    if isinstance(comp_dists, Distribution):
-        return isinstance(comp_dists, Discrete)
-    else:
-        return all(isinstance(comp_dist, Discrete) for comp_dist in comp_dists)
 
 
 class MarginalMixtureRV(OpFromGraph):
@@ -188,6 +172,16 @@ class Mixture(SymbolicDistribution):
                 "To disable this warning do not wrap the single component inside a list or tuple",
                 UserWarning,
             )
+
+        if len(comp_dists) > 1:
+            if not (
+                all(comp_dist.dtype in continuous_types for comp_dist in comp_dists)
+                or all(comp_dist.dtype in discrete_types for comp_dist in comp_dists)
+            ):
+                raise ValueError(
+                    "All distributions in comp_dists must be either discrete or continuous.\n"
+                    "See the following issue for more information: https://github.com/pymc-devs/pymc/issues/4511."
+                )
 
         # Check that components are not associated with a registered variable in the model
         components_ndim_supp = set()

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -30,6 +30,8 @@ from pymc.distributions import transforms
 from pymc.distributions.continuous import Normal, get_tau_sigma
 from pymc.distributions.dist_math import check_parameters
 from pymc.distributions.distribution import (
+    Discrete,
+    Distribution,
     SymbolicDistribution,
     _moment,
     moment,
@@ -38,9 +40,19 @@ from pymc.distributions.logprob import logcdf, logp
 from pymc.distributions.shape_utils import to_tuple
 from pymc.distributions.transforms import _default_transform
 from pymc.util import check_dist_not_registered
-from pymc.vartypes import continuous_types, discrete_types
+from pymc.vartypes import discrete_types
 
 __all__ = ["Mixture", "NormalMixture"]
+
+
+def all_discrete(comp_dists):
+    """
+    Determine if all distributions in comp_dists are discrete
+    """
+    if isinstance(comp_dists, Distribution):
+        return isinstance(comp_dists, Discrete)
+    else:
+        return all(isinstance(comp_dist, Discrete) for comp_dist in comp_dists)
 
 
 class MarginalMixtureRV(OpFromGraph):
@@ -176,17 +188,6 @@ class Mixture(SymbolicDistribution):
                 "To disable this warning do not wrap the single component inside a list or tuple",
                 UserWarning,
             )
-
-        if len(comp_dists) > 1:
-            all_continuous = all([comp_dist.dtype in continuous_types for comp_dist in comp_dists])
-            all_discrete = all([comp_dist.dtype in discrete_types for comp_dist in comp_dists])
-
-            if not (all_continuous or all_discrete):
-                # Determine if the distributions in comp_dists are all discrete or continuous
-                raise ValueError(
-                    "All distributions in comp_dists must be either discrete or continuous.\n"
-                    "See the following issue for more information: https://github.com/pymc-devs/pymc/issues/4511."
-                )
 
         # Check that components are not associated with a registered variable in the model
         components_ndim_supp = set()

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -118,7 +118,7 @@ class ModelGraph:
                     if model_var.tag.observations == self.model[var_name]:
                         selected_names.add(model_var.name)
 
-        selected_ancestors = set(
+        selected_ancestors = g(
             filter(
                 lambda rv: rv.name in self._all_var_names,
                 list(ancestors([self.model[var_name] for var_name in selected_names])),

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -14,7 +14,7 @@
 import warnings
 
 from collections import defaultdict, deque
-from typing import Dict, Iterator, List, NewType, Optional, Set
+from typing import Dict, Iterable, Iterator, List, NewType, Optional, Set
 
 from aesara import function
 from aesara.compile.sharedvalue import SharedVariable
@@ -108,7 +108,8 @@ class ModelGraph:
 
         selected_names = set(var_names)
 
-        for var_name in selected_names:
+        # .copy() because sets cannot change in size during iteration
+        for var_name in selected_names.copy():
             if var_name not in self._all_var_names:
                 raise ValueError(f"{var_name} is not in this model.")
 
@@ -124,7 +125,7 @@ class ModelGraph:
             )
         )
 
-        for var in selected_ancestors:
+        for var in selected_ancestors.copy():
             if hasattr(var.tag, "observations"):
                 selected_ancestors.add(var.tag.observations)
 

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -13,15 +13,15 @@
 #   limitations under the License.
 import warnings
 
-from collections import defaultdict, deque
-from typing import Dict, Iterable, Iterator, List, NewType, Optional, Set
+from collections import defaultdict
+from typing import Dict, Iterable, List, NewType, Optional, Set
 
 from aesara import function
 from aesara.compile.sharedvalue import SharedVariable
 from aesara.graph import Apply
 from aesara.graph.basic import ancestors, walk
 from aesara.tensor.random.op import RandomVariable
-from aesara.tensor.var import TensorConstant, TensorVariable
+from aesara.tensor.var import TensorConstant
 
 import pymc as pm
 
@@ -47,7 +47,7 @@ class ModelGraph:
                 return reversed(x.owner.inputs)
             return []
 
-        parents = [x.name for x in walk(nodes=var.owner.inputs, expand=_expand) if x.name]
+        parents = [get_var_name(x) for x in walk(nodes=var.owner.inputs, expand=_expand) if x.name]
 
         return parents
 

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -118,7 +118,7 @@ class ModelGraph:
                     if model_var.tag.observations == self.model[var_name]:
                         selected_names.add(model_var.name)
 
-        selected_ancestors = g(
+        selected_ancestors = set(
             filter(
                 lambda rv: rv.name in self._all_var_names,
                 list(ancestors([self.model[var_name] for var_name in selected_names])),

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -241,10 +241,7 @@ class ModelGraph:
         for child, parents in self.make_compute_graph(selected_vars=selected_vars).items():
             # parents is a set of rv names that preceed child rv nodes
             for parent in parents:
-                try:
-                    graph.edge(parent.replace(":", "&"), child.replace(":", "&"))
-                except AttributeError:
-                    print(child, parent)
+                graph.edge(parent.replace(":", "&"), child.replace(":", "&"))
 
         return graph
 

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -85,7 +85,7 @@ class ModelGraph:
         self, var_names: Optional[Iterable[VarName]] = None
     ) -> Dict[VarName, Set[VarName]]:
         """Get map of var_name -> set(input var names) for the model"""
-        input_map = defaultdict(set)  # type: Dict[VarName, Set[VarName]]
+        input_map: Dict[VarName, Set[VarName]] = defaultdict(set)
 
         for var_name in self.vars_to_plot(var_names):
             var = self.model[var_name]
@@ -149,7 +149,9 @@ class ModelGraph:
     def _eval(self, var):
         return function([], var, mode="FAST_COMPILE")()
 
-    def get_plates(self, var_names: Optional[Iterable[VarName]] = None):
+    def get_plates(
+        self, var_names: Optional[Iterable[VarName]] = None
+    ) -> Dict[str, Set[VarName]]:
         """Rough but surprisingly accurate plate detection.
 
         Just groups by the shape of the underlying distribution.  Will be wrong
@@ -157,7 +159,8 @@ class ModelGraph:
 
         Returns
         -------
-        dict: VarName -> set(VarName)
+        dict
+            Maps plate labels to the set of ``VarName``s inside the plate.
         """
         plates = defaultdict(set)
 

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -109,10 +109,14 @@ class ModelGraph:
             all_selected_ancestors = set()
 
             for selected_var_name in selected_vars:
-                var_ancestors = self._get_ancestors(self.model[selected_var_name], self.model[selected_var_name])
+                var_ancestors = self._get_ancestors(
+                    self.model[selected_var_name], self.model[selected_var_name]
+                )
                 all_selected_ancestors = all_selected_ancestors.union(var_ancestors)
 
-            vars_on_graph = all_selected_ancestors.union(set(self.model[selected_var_name] for selected_var_name in selected_vars))
+            vars_on_graph = all_selected_ancestors.union(
+                {self.model[selected_var_name] for selected_var_name in selected_vars}
+            )
             vars_on_graph = {var.name for var in vars_on_graph}
 
             # ordering of self.var_names is important

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -149,9 +149,7 @@ class ModelGraph:
     def _eval(self, var):
         return function([], var, mode="FAST_COMPILE")()
 
-    def get_plates(
-        self, var_names: Optional[Iterable[VarName]] = None
-    ) -> Dict[str, Set[VarName]]:
+    def get_plates(self, var_names: Optional[Iterable[VarName]] = None) -> Dict[str, Set[VarName]]:
         """Rough but surprisingly accurate plate detection.
 
         Just groups by the shape of the underlying distribution.  Will be wrong

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -38,7 +38,7 @@ class ModelGraph:
 
     def get_parent_names(self, var):
         if var.owner is None or var.owner.inputs is None:
-            return []
+            return set()
 
         def _expand(x):
             if x.name:
@@ -47,7 +47,7 @@ class ModelGraph:
                 return reversed(x.owner.inputs)
             return []
 
-        parents = [get_var_name(x) for x in walk(nodes=var.owner.inputs, expand=_expand) if x.name]
+        parents = {get_var_name(x) for x in walk(nodes=var.owner.inputs, expand=_expand) if x.name}
 
         return parents
 

--- a/pymc/tests/test_model_graph.py
+++ b/pymc/tests/test_model_graph.py
@@ -206,7 +206,8 @@ class TestVariableSelection(BaseModelGraphTest):
     model_func = model_with_different_descendants
 
     def check_subgraph(var_names):
-
+        # To be done sooon!
+        pass
 
 
 class TestImputationModel(BaseModelGraphTest):

--- a/pymc/tests/test_model_graph.py
+++ b/pymc/tests/test_model_graph.py
@@ -143,7 +143,7 @@ class BaseModelGraphTest(SeededTest):
     def test_inputs(self):
         for child, parents_in_plot in self.compute_graph.items():
             var = self.model[child]
-            parents_in_graph = self.model_graph.get_parents(var)
+            parents_in_graph = self.model_graph.get_parent_names(var)
             if isinstance(var, SharedVariable):
                 # observed data also doesn't have parents in the compute graph!
                 # But for the visualization we like them to become decendants of the

--- a/pymc/tests/test_model_graph.py
+++ b/pymc/tests/test_model_graph.py
@@ -202,6 +202,23 @@ def model_with_different_descendants():
     return pmodel2
 
 
+class TestParents:
+    @pytest.mark.parametrize(
+        "var_name, parent_names",
+        [
+            ("L", {"pred"}),
+            ("pred", {"intermediate"}),
+            ("intermediate", {"a", "b"}),
+            ("c", {"a", "b"}),
+            ("a", set()),
+            ("b", set()),
+        ],
+    )
+    def test_get_parent_names(self, var_name, parent_names):
+        mg = ModelGraph(model_with_different_descendants())
+        mg.get_parent_names(mg.model[var_name]) == parent_names
+
+
 class TestVariableSelection:
     @pytest.mark.parametrize(
         "var_names, vars_to_plot, compute_graph",

--- a/pymc/tests/test_model_graph.py
+++ b/pymc/tests/test_model_graph.py
@@ -203,8 +203,6 @@ def model_with_different_descendants():
 
 
 class TestVariableSelection:
-    mg = ModelGraph(model_with_different_descendants())
-
     @pytest.mark.parametrize(
         "var_names, vars_to_plot, compute_graph",
         [
@@ -236,12 +234,13 @@ class TestVariableSelection:
             # selecting ["c", "L"] is akin to selecting the entire graph
             (
                 ["c", "L"],
-                mg.vars_to_plot(),
-                mg.make_compute_graph(),
+                ModelGraph(model_with_different_descendants()).vars_to_plot(),
+                ModelGraph(model_with_different_descendants()).make_compute_graph(),
             ),
         ],
     )
-    def check_subgraph(self, var_names, vars_to_plot, compute_graph):
+    def test_subgraph(self, var_names, vars_to_plot, compute_graph):
+        mg = ModelGraph(model_with_different_descendants())
         assert set(mg.vars_to_plot(var_names=var_names)) == set(vars_to_plot)
         assert mg.make_compute_graph(var_names=var_names) == compute_graph
 

--- a/pymc/tests/test_model_graph.py
+++ b/pymc/tests/test_model_graph.py
@@ -183,6 +183,32 @@ class TestRadonModel(BaseModelGraphTest):
             model_to_graphviz(self.model, formatting="plain_with_params")
 
 
+def model_with_different_descendants():
+    """
+    Model proposed by Michael to test variable selection functionality
+    See: https://github.com/pymc-devs/pymc/pull/5634#pullrequestreview-916297509
+    """
+    with pm.Model() as pmodel2:
+        a = pm.Normal("a")
+        b = pm.Normal("b")
+        pm.Normal("c", a * b)
+        intermediate = pm.Deterministic("intermediate", a + b)
+        pred = pm.Deterministic("pred", intermediate * 3)
+
+        obs = pm.ConstantData("obs", 1.75)
+
+        L = pm.Normal("L", mu=1 + 0.5 * pred, observed=obs)
+
+    return pmodel2
+
+
+class TestVariableSelection(BaseModelGraphTest):
+    model_func = model_with_different_descendants
+
+    def check_subgraph(var_names):
+
+
+
 class TestImputationModel(BaseModelGraphTest):
     model_func = model_with_imputations
 


### PR DESCRIPTION
Fixes #5527. Some elements are hackish and currently need more work.

+ [x] Do not plot all descendants when specifying an intermediate rv unless the variable is observed (plot observed node)
+ [x] Add `var_names` as kwarg
+ [x] Rename previous `var_names` class instance by `_all_var_names`