### PR TITLE
Upgrade all cache actions to v3

### DIFF
--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: Cache multiple paths
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pre-commit

--- a/.github/workflows/dispatched_pre-commit.yml
+++ b/.github/workflows/dispatched_pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
           ref: ${{github.event.client_payload.pull_request.head.ref}}
           token: ${{ secrets.ACTION_TRIGGER_TOKEN }}
       - name: Cache multiple paths
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pre-commit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if environment-test-py37.yml has not changed
           CACHE_NUMBER: 0
@@ -95,7 +95,7 @@ jobs:
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('conda-envs/environment-test-py37.yml') }}
       - name: Cache multiple paths
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if requirements.txt has not changed
           CACHE_NUMBER: 0
@@ -154,7 +154,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if conda-envs/environment-test-py38.yml has not changed
           CACHE_NUMBER: 0
@@ -163,7 +163,7 @@ jobs:
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('conda-envs/windows-environment-test-py38.yml') }}
       - name: Cache multiple paths
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if requirements.txt has not changed
           CACHE_NUMBER: 0
@@ -230,7 +230,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if environment-test-py39.yml has not changed
           CACHE_NUMBER: 0
@@ -239,7 +239,7 @@ jobs:
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('conda-envs/environment-test-py39.yml') }}
       - name: Cache multiple paths
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if requirements.txt has not changed
           CACHE_NUMBER: 0
@@ -292,7 +292,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if environment-test-py39.yml has not changed
           CACHE_NUMBER: 0
@@ -301,7 +301,7 @@ jobs:
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('conda-envs/environment-test-py39.yml') }}
       - name: Cache multiple paths
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if requirements.txt has not changed
           CACHE_NUMBER: 0
@@ -359,7 +359,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if conda-envs/environment-test-py38.yml has not changed
           CACHE_NUMBER: 0
@@ -368,7 +368,7 @@ jobs:
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('conda-envs/windows-environment-test-py38.yml') }}
       - name: Cache multiple paths
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if requirements.txt has not changed
           CACHE_NUMBER: 0


### PR DESCRIPTION
According to their [release notes](https://github.com/actions/cache/releases), there were performance improvements and security fixes in v2.

The v3 bump had a breaking change for users of (outdated) custom runners which does not apply to us.

Notice that in the CI run of this PR the caching did not work - most probably because of the update.
But in the last run on `main` it worked for all three OSes.