### PR TITLE
Disable sampling of transformed variables from prior_predictive

### DIFF
--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -1991,8 +1991,7 @@ def sample_prior_predictive(
     model : Model (optional if in ``with`` context)
     var_names : Iterable[str]
         A list of names of variables for which to compute the prior predictive
-        samples. Defaults to both observed and unobserved RVs. Transformed values
-        are not included unless explicitly defined in var_names.
+        samples. Defaults to both observed and unobserved RVs.
     random_seed : int
         Seed for the random number generator.
     mode:
@@ -2038,24 +2037,6 @@ def sample_prior_predictive(
 
     names = get_default_varnames(vars_, include_transformed=False)
     vars_to_sample = [model[name] for name in names]
-
-    # Any variables from var_names that are missing must be transformed variables.
-    # Misspelled variables would have raised a KeyError above.
-    missing_names = vars_.difference(names)
-    for name in missing_names:
-        transformed_value_var = model[name]
-        rv_var = model.values_to_rvs[transformed_value_var]
-        transform = transformed_value_var.tag.transform
-        transformed_rv_var = transform.forward(rv_var, *rv_var.owner.inputs)
-
-        names.append(name)
-        vars_to_sample.append(transformed_rv_var)
-
-        # If the user asked for the transformed variable in var_names, but not the
-        # original RV, we add it manually here
-        if rv_var.name not in names:
-            names.append(rv_var.name)
-            vars_to_sample.append(rv_var)
 
     inputs = [i for i in inputvars(vars_to_sample) if not isinstance(i, (Constant, SharedVariable))]
 


### PR DESCRIPTION
Addressing #5076

Deleted the code that was added to facilitate sampling from the prior as a starting point for SMC.