### PR TITLE
Fix `pm.distributions.transforms.ordered` fails on >1 dimension

### DIFF
--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -82,7 +82,7 @@ class Ordered(RVTransform):
         return y
 
     def log_jac_det(self, value, *inputs):
-        return at.sum(value[..., 1:], axis=-1)
+        return at.sum(value[..., 1:], axis=-1, keepdims=True)
 
 
 class SumTo1(RVTransform):
@@ -102,7 +102,7 @@ class SumTo1(RVTransform):
 
     def log_jac_det(self, value, *inputs):
         y = at.zeros(value.shape)
-        return at.sum(y, axis=-1)
+        return at.sum(y, axis=-1, keepdims=True)
 
 
 class CholeskyCovPacked(RVTransform):

--- a/pymc/tests/test_transforms.py
+++ b/pymc/tests/test_transforms.py
@@ -557,3 +557,19 @@ def test_interval_transform_raises():
         tr.Interval(at.constant(5) + 1, None)
 
     assert tr.Interval(at.constant(5), None)
+
+
+def test_transforms_ordered():
+    COORDS = {"question": np.arange(10), "thresholds": np.arange(4)}
+
+    with pm.Model(coords=COORDS) as model:
+        kappa = pm.Normal(
+            "kappa",
+            mu=[-3, -1, 1, 2],
+            sigma=1,
+            dims=["question", "thresholds"],
+            transform=pm.distributions.transforms.ordered,
+        )
+
+    log_prob = model.point_logps()
+    np.testing.assert_allclose(list(log_prob.values()), np.array([18.69]))

--- a/pymc/tests/test_transforms.py
+++ b/pymc/tests/test_transforms.py
@@ -560,16 +560,28 @@ def test_interval_transform_raises():
 
 
 def test_transforms_ordered():
-    COORDS = {"question": np.arange(10), "thresholds": np.arange(4)}
-
-    with pm.Model(coords=COORDS) as model:
-        kappa = pm.Normal(
-            "kappa",
+    with pm.Model() as model:
+        pm.Normal(
+            "x",
             mu=[-3, -1, 1, 2],
             sigma=1,
-            dims=["question", "thresholds"],
+            size=(10, 4),
             transform=pm.distributions.transforms.ordered,
         )
-
+        
     log_prob = model.point_logps()
     np.testing.assert_allclose(list(log_prob.values()), np.array([18.69]))
+
+
+def test_transforms_sumto1():
+    with pm.Model() as model:
+        pm.Normal(
+            "x",
+            mu=[-3, -1, 1, 2],
+            sigma=1,
+            size=(10, 4),
+            transform=pm.distributions.transforms.sum_to_1,
+        )
+        
+    log_prob = model.point_logps()
+    np.testing.assert_allclose(list(log_prob.values()), np.array([-56.76]))

--- a/pymc/tests/test_transforms.py
+++ b/pymc/tests/test_transforms.py
@@ -568,7 +568,7 @@ def test_transforms_ordered():
             size=(10, 4),
             transform=pm.distributions.transforms.ordered,
         )
-        
+
     log_prob = model.point_logps()
     np.testing.assert_allclose(list(log_prob.values()), np.array([18.69]))
 
@@ -582,6 +582,6 @@ def test_transforms_sumto1():
             size=(10, 4),
             transform=pm.distributions.transforms.sum_to_1,
         )
-        
+
     log_prob = model.point_logps()
     np.testing.assert_allclose(list(log_prob.values()), np.array([-56.76]))


### PR DESCRIPTION
Addressing #5659

Kept the original dims in the log_jac_det by changing
```
def log_jac_det(self, value, *inputs): 
     return at.sum(value[..., 1:], axis=-1)
```
to 
```
def log_jac_det(self, value, *inputs):
    return at.sum(value[..., 1:], axis=-1, keepdims=True)
```