### PR TITLE
Replace point vmap with point map

### DIFF
--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -256,7 +256,7 @@ def sample_blackjax_nuts(
         Include untransformed variables in the posterior samples. Defaults to False.
     chain_method : str, default "parallel"
         Specify how samples should be drawn. The choices include "parallel", and "vectorized".
-    postprocessing_backend : Optional[str]
+    postprocessing_backend : str, optional
         Specify how postprocessing should be computed. gpu or cpu
     idata_kwargs : dict, optional
         Keyword arguments for :func:`arviz.from_dict`. It also accepts a boolean as value

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -138,7 +138,7 @@ def _get_log_likelihood(model: Model, samples) -> Dict:
     for v in model.observed_RVs:
         v_elemwise_logpt = model.logpt(v, sum=False)
         jax_fn = get_jaxified_graph(inputs=model.value_vars, outputs=v_elemwise_logpt)
-        result = jax.jit(jax.vmap(jax.vmap(jax_fn)))(*samples)[0]
+        result = jax.jit(jax.vmap(partial(jax.lax.map, jax_fn)))(samples)[0]
         data[v.name] = result
     return data
 
@@ -341,7 +341,7 @@ def sample_blackjax_nuts(
     mcmc_samples = {}
     for v in vars_to_sample:
         jax_fn = get_jaxified_graph(inputs=model.value_vars, outputs=[v])
-        result = jax.vmap(jax.vmap(jax_fn))(*raw_mcmc_samples)[0]
+        result = jax.jit(jax.vmap(partial(jax.lax.map, jax_fn)))(raw_mcmc_samples)[0]
         mcmc_samples[v.name] = result
 
     tic4 = datetime.now()
@@ -525,7 +525,7 @@ def sample_numpyro_nuts(
     mcmc_samples = {}
     for v in vars_to_sample:
         jax_fn = get_jaxified_graph(inputs=model.value_vars, outputs=[v])
-        result = jax.vmap(jax.vmap(jax_fn))(*raw_mcmc_samples)[0]
+        result = jax.jit(jax.vmap(partial(jax.lax.map, jax_fn)))(raw_mcmc_samples)[0]
         mcmc_samples[v.name] = result
 
     tic4 = datetime.now()

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -26,8 +26,8 @@ from pymc.sampling_jax import (
         sample_numpyro_nuts,
     ],
 )
-@pytest.mark.parametrize("postprocessing_method", ["sequential", "vectorized"])
-def test_transform_samples(sampler, postprocessing_method):
+@pytest.mark.parametrize("postprocessing_backend", [None, "cpu"])
+def test_transform_samples(sampler, postprocessing_backend):
     aesara.config.on_opt_error = "raise"
     np.random.seed(13244)
 
@@ -42,7 +42,7 @@ def test_transform_samples(sampler, postprocessing_method):
             chains=1,
             random_seed=1322,
             keep_untransformed=True,
-            postprocessing_method=postprocessing_method,
+            postprocessing_backend=postprocessing_backend,
         )
 
     log_vals = trace.posterior["sigma_log__"].values
@@ -59,7 +59,7 @@ def test_transform_samples(sampler, postprocessing_method):
             chains=2,
             random_seed=1322,
             keep_untransformed=False,
-            postprocessing_method=postprocessing_method,
+            postprocessing_backend=postprocessing_backend,
         )
 
     assert -11 < trace.posterior["a"].mean() < -8
@@ -156,8 +156,8 @@ def test_get_jaxified_logp():
         dict(log_likelihood=False),
     ],
 )
-@pytest.mark.parametrize("postprocessing_method", ["sequential", "vectorized"])
-def test_idata_kwargs(sampler, idata_kwargs, postprocessing_method):
+@pytest.mark.parametrize("postprocessing_backend", [None, "cpu"])
+def test_idata_kwargs(sampler, idata_kwargs, postprocessing_backend):
     with pm.Model() as m:
         x = pm.Normal("x")
         z = pm.Normal("z")
@@ -167,7 +167,7 @@ def test_idata_kwargs(sampler, idata_kwargs, postprocessing_method):
             draws=50,
             chains=1,
             idata_kwargs=idata_kwargs,
-            postprocessing_method=postprocessing_method,
+            postprocessing_backend=postprocessing_backend,
         )
 
     if idata_kwargs.get("log_likelihood", True):

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -148,6 +148,7 @@ def test_get_jaxified_logp():
 def test_idata_kwargs(sampler, idata_kwargs):
     with pm.Model() as m:
         x = pm.Normal("x")
+        z = pm.Normal("z")
         y = pm.Normal("y", x, observed=0)
         idata = sampler(
             tune=50,


### PR DESCRIPTION
Resolves #5656

I've changed `jax.vmap(jax_fn)` with `partial(jax.lax.map, jax_fn)`. The reason is that `vmap` does the computation all at once. Sometimes it causes OOM. `jax.lax.map` is more memory friendly and, basically, does the computation in a loop.
