### PR TITLE
Fix default update bug

### DIFF
--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -142,7 +142,7 @@ def pandas_to_array(data):
 
 
 def change_rv_size(
-    rv_var: TensorVariable,
+    rv: TensorVariable,
     new_size: PotentialShapeType,
     expand: Optional[bool] = False,
 ) -> TensorVariable:
@@ -150,8 +150,8 @@ def change_rv_size(
 
     Parameters
     ==========
-    rv_var
-        The `RandomVariable` output.
+    rv
+        The old `RandomVariable` output.
     new_size
         The new size.
     expand:
@@ -166,32 +166,32 @@ def change_rv_size(
         new_size = (new_size,)
 
     # Extract the RV node that is to be resized, together with its inputs, name and tag
-    if isinstance(rv_var.owner.op, SpecifyShape):
-        rv_var = rv_var.owner.inputs[0]
-    rv_node = rv_var.owner
+    if isinstance(rv.owner.op, SpecifyShape):
+        rv = rv.owner.inputs[0]
+    rv_node = rv.owner
     rng, size, dtype, *dist_params = rv_node.inputs
-    name = rv_var.name
-    tag = rv_var.tag
+    name = rv.name
+    tag = rv.tag
 
     if expand:
-        old_shape = tuple(rv_node.op._infer_shape(size, dist_params))
-        old_size = old_shape[: len(old_shape) - rv_node.op.ndim_supp]
-        new_size = tuple(new_size) + tuple(old_size)
+        shape = tuple(rv_node.op._infer_shape(size, dist_params))
+        size = shape[: len(shape) - rv_node.op.ndim_supp]
+        new_size = tuple(new_size) + tuple(size)
 
     # Make sure the new size is a tensor. This dtype-aware conversion helps
     # to not unnecessarily pick up a `Cast` in some cases (see #4652).
     new_size = at.as_tensor(new_size, ndim=1, dtype="int64")
 
     new_rv_node = rv_node.op.make_node(rng, new_size, dtype, *dist_params)
-    rv_var = new_rv_node.outputs[-1]
-    rv_var.name = name
+    new_rv = new_rv_node.outputs[-1]
+    new_rv.name = name
     for k, v in tag.__dict__.items():
-        rv_var.tag.__dict__.setdefault(k, v)
+        new_rv.tag.__dict__.setdefault(k, v)
 
     if config.compute_test_value != "off":
         compute_test_value(new_rv_node)
 
-    return rv_var
+    return new_rv
 
 
 def extract_rv_and_value_vars(

--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -39,9 +39,9 @@ from aesara.graph.basic import (
     Apply,
     Constant,
     Variable,
-    ancestors,
     clone_get_equiv,
     graph_inputs,
+    vars_between,
     walk,
 )
 from aesara.graph.fg import FunctionGraph
@@ -971,8 +971,8 @@ def compile_pymc(
     output_to_list = outputs if isinstance(outputs, (list, tuple)) else [outputs]
     for rv in (
         node
-        for node in ancestors(output_to_list)
-        if node.owner and isinstance(node.owner.op, RandomVariable)
+        for node in vars_between(inputs, output_to_list)
+        if node.owner and isinstance(node.owner.op, RandomVariable) and node not in inputs
     ):
         rng = rv.owner.inputs[0]
         if not hasattr(rng, "default_update"):

--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -188,6 +188,11 @@ def change_rv_size(
     for k, v in tag.__dict__.items():
         new_rv.tag.__dict__.setdefault(k, v)
 
+    # Update "traditional" rng default_update, if that was set for old RV
+    default_update = getattr(rng, "default_update", None)
+    if default_update is not None and default_update is rv_node.outputs[0]:
+        rng.default_update = new_rv_node.outputs[0]
+
     if config.compute_test_value != "off":
         compute_test_value(new_rv_node)
 

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -269,7 +269,7 @@ class Distribution(metaclass=DistributionMeta):
 
         if resize_shape:
             # A batch size was specified through `dims`, or implied by `observed`.
-            rv_out = change_rv_size(rv_var=rv_out, new_size=resize_shape, expand=True)
+            rv_out = change_rv_size(rv=rv_out, new_size=resize_shape, expand=True)
 
         rv_out = model.register_rv(
             rv_out,
@@ -355,7 +355,7 @@ class Distribution(metaclass=DistributionMeta):
         # Replicate dimensions may be prepended via a shape with Ellipsis as the last element:
         if shape is not None and Ellipsis in shape:
             replicate_shape = cast(StrongShape, shape[:-1])
-            rv_out = change_rv_size(rv_var=rv_out, new_size=replicate_shape, expand=True)
+            rv_out = change_rv_size(rv=rv_out, new_size=replicate_shape, expand=True)
 
         rv_out.logp = _make_nice_attr_error("rv.logp(x)", "pm.logp(rv, x)")
         rv_out.logcdf = _make_nice_attr_error("rv.logcdf(x)", "pm.logcdf(rv, x)")

--- a/pymc/tests/test_aesaraf.py
+++ b/pymc/tests/test_aesaraf.py
@@ -94,6 +94,28 @@ def test_change_rv_size():
     assert tuple(rv_newer.shape.eval()) == (2,)
 
 
+def test_change_rv_size_default_update():
+    rng = aesara.shared(np.random.default_rng(0))
+    x = normal(rng=rng)
+
+    # Test that "traditional" default_update is updated
+    rng.default_update = x.owner.outputs[0]
+    new_x = change_rv_size(x, new_size=(2,))
+    assert rng.default_update is not x.owner.outputs[0]
+    assert rng.default_update is new_x.owner.outputs[0]
+
+    # Test that "non-traditional" default_update is left unchanged
+    next_rng = aesara.shared(np.random.default_rng(1))
+    rng.default_update = next_rng
+    new_x = change_rv_size(x, new_size=(2,))
+    assert rng.default_update is next_rng
+
+    # Test that default_update is not set if there was none before
+    del rng.default_update
+    new_x = change_rv_size(x, new_size=(2,))
+    assert not hasattr(rng, "default_update")
+
+
 class TestBroadcasting:
     def test_make_shared_replacements(self):
         """Check if pm.make_shared_replacements preserves broadcasting."""

--- a/pymc/tests/test_aesaraf.py
+++ b/pymc/tests/test_aesaraf.py
@@ -628,3 +628,29 @@ def test_compile_pymc_missing_default_explicit_updates():
     # And again, it should be overridden by an explicit update
     f = compile_pymc([], x, updates={rng: x.owner.outputs[0]})
     assert f() != f()
+
+
+def test_compile_pymc_updates_inputs():
+    """Test that compile_pymc does not include rngs updates of variables that are inputs
+    or ancestors to inputs
+    """
+    x = at.random.normal()
+    y = at.random.normal(x)
+    z = at.random.normal(y)
+
+    for inputs, rvs_in_graph in (
+        ([], 3),
+        ([x], 2),
+        ([y], 1),
+        ([z], 0),
+        ([x, y], 1),
+        ([x, y, z], 0),
+    ):
+        fn = compile_pymc(inputs, z, on_unused_input="ignore")
+        fn_fgraph = fn.maker.fgraph
+        # Each RV adds a shared input for its rng
+        assert len(fn_fgraph.inputs) == len(inputs) + rvs_in_graph
+        # If the output is an input, the graph has a DeepCopyOp
+        assert len(fn_fgraph.apply_nodes) == max(rvs_in_graph, 1)
+        # Each RV adds a shared output for its rng
+        assert len(fn_fgraph.outputs) == 1 + rvs_in_graph


### PR DESCRIPTION
Two changes:

1. No longer set `rng.default_update` when creating RVs via PyMC distributions
2. Just to be on the safe-side, update the `rng.default_update` in `change_rv_size`, when it followed the old "traditional" update rule

Closes #5653 