### PR TITLE
Bump version for b6 release

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,7 +7,7 @@ Instead update the vNext section until 4.0.0 is out.
 ⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠⚠
 -->
 
-## PyMC vNext (4.0.0b1 → ... → 4.0.0b5 → 4.0.0)
+## PyMC vNext (4.0.0b1 → ... → 4.0.0b6 → 4.0.0)
 ⚠ The changes below are the delta between the releases `v3.11.5` →...→ `v4.0.0`.
 
 ### Not-yet working features

--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # pylint: disable=wildcard-import
-__version__ = "4.0.0b5"
+__version__ = "4.0.0b6"
 
 import logging
 import multiprocessing as mp


### PR DESCRIPTION
We fixed this critical bug: https://github.com/pymc-devs/pymc/issues/5653 which affected prior and posterior predictive for variables whose size was defined from `dims` or `observed` alone.

We should merge #5670 first