### PR TITLE
Allow passing `compile_pymc` kwargs to sampling functions

### DIFF
--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -121,7 +121,7 @@ class TestData(SeededTest):
 
         assert pp_trace.posterior_predictive["obs"].shape == (1, 1000, 3)
         np.testing.assert_allclose(
-            new_y, pp_trace.posterior_predictive["obs"].mean(("chain", "draw")), atol=0.015
+            new_y, pp_trace.posterior_predictive["obs"].mean(("chain", "draw")), atol=1e-1
         )
 
     def test_shared_data_as_index(self):


### PR DESCRIPTION
This is needed for sampling of `RandomVariables` within `Scan`s among other things