### PR TITLE
Add `model_to_networkx` function

### DIFF
--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -15,6 +15,7 @@ dependencies:
 - ipython>=7.16
 - jax
 - myst-nb
+- networkx
 - numpy>=1.15.0
 - numpydoc<1.2
 - pandas>=0.24.0

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -15,6 +15,7 @@ dependencies:
 - ipython>=7.16
 - jax
 - myst-nb
+- networkx
 - numpy>=1.15.0
 - numpydoc<1.2
 - pandas>=0.24.0

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -15,6 +15,7 @@ dependencies:
 - ipython>=7.16
 - jax
 - myst-nb
+- networkx
 - numpy>=1.15.0
 - numpydoc<1.2
 - pandas>=0.24.0

--- a/conda-envs/environment-test-py37.yml
+++ b/conda-envs/environment-test-py37.yml
@@ -16,6 +16,7 @@ dependencies:
 - jax
 - libblas=*=*mkl
 - mkl-service
+- networkx
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pre-commit>=2.8.0

--- a/conda-envs/environment-test-py38.yml
+++ b/conda-envs/environment-test-py38.yml
@@ -16,6 +16,7 @@ dependencies:
 - jax
 - libblas=*=*mkl
 - mkl-service
+- networkx
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pre-commit>=2.8.0

--- a/conda-envs/environment-test-py39.yml
+++ b/conda-envs/environment-test-py39.yml
@@ -16,6 +16,7 @@ dependencies:
 - jax
 - libblas=*=*mkl
 - mkl-service
+- networkx
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pre-commit>=2.8.0

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -12,6 +12,7 @@ dependencies:
 - cloudpickle
 - fastprogress>=0.2.0
 - h5py>=2.7
+- networkx
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip

--- a/conda-envs/windows-environment-test-py38.yml
+++ b/conda-envs/windows-environment-test-py38.yml
@@ -16,6 +16,7 @@ dependencies:
 - mkl==2020.4
 - mkl-service==2.3.0
 - m2w64-toolchain
+- networkx
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip

--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -67,7 +67,7 @@ from pymc.math import (
     probit,
 )
 from pymc.model import *
-from pymc.model_graph import model_to_graphviz
+from pymc.model_graph import model_to_graphviz, model_to_networkx
 from pymc.plots import *
 from pymc.printing import *
 from pymc.sampling import *

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ fastprogress>=0.2.0
 h5py>=2.7
 ipython>=7.16
 myst-nb
+networkx
 numpy>=1.15.0
 numpydoc<1.2
 pandas>=0.24.0


### PR DESCRIPTION
This implements the new `pm.model_to_networkx` feature from #5677 to the `main` branch.


+ [x] what are the (breaking) changes that this PR makes? No breaking changes
+ [ ] important background, or details about the implementation
+ [ ] are the changes—especially new features—covered by tests and docstrings?
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
