### PR TITLE
improve total_size

### DIFF
--- a/pymc/distributions/logprob.py
+++ b/pymc/distributions/logprob.py
@@ -103,7 +103,7 @@ def _get_scaling(total_size: Optional[Union[int, Sequence[int]]], shape, ndim: i
         coef = at.prod(coefs)
     elif isinstance(total_size, (np.ndarray, at.TensorVariable)):
         coef = total_size
-        warnings.warn("Using array as scaling that is experimental", UserWarning)
+        warnings.warn("Using an array for total_size is experimental.", UserWarning)
     else:
         raise TypeError(
             "Unrecognized `total_size` type, expected int or list of ints, got %r" % total_size

--- a/pymc/distributions/logprob.py
+++ b/pymc/distributions/logprob.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import warnings
+
 from collections.abc import Mapping
 from typing import Dict, List, Optional, Sequence, Union
 
@@ -99,6 +101,9 @@ def _get_scaling(total_size: Optional[Union[int, Sequence[int]]], shape, ndim: i
         end_coef = [floatX(t) / floatX(shp_end[i]) for i, t in enumerate(end) if t is not None]
         coefs = begin_coef + end_coef
         coef = at.prod(coefs)
+    elif isinstance(total_size, (np.ndarray, at.TensorVariable)):
+        coef = total_size
+        warnings.warn("Using array as scaling that is experimental", UserWarning)
     else:
         raise TypeError(
             "Unrecognized `total_size` type, expected int or list of ints, got %r" % total_size

--- a/pymc/tests/test_minibatches.py
+++ b/pymc/tests/test_minibatches.py
@@ -304,6 +304,16 @@ class TestScaling:
         assert p4() == p5(pm.floatX([[1]]))
         assert p4() == p5(pm.floatX([[1, 1], [1, 1]]))
 
+    def test_scaling_histogram_per_observation(self):
+        with pm.Model() as model6:
+            Normal("n", observed=[1, 1, 2])
+            p6 = aesara.function([], model6.logpt())
+
+        with pm.Model() as model7:
+            n = Normal("n", observed=[1, 2], total_size=np.array([2, 1]))
+            p7 = aesara.function([], model7.logpt())
+        assert p6() == p7()
+
 
 @pytest.mark.usefixtures("strict_float32")
 class TestMinibatch:

--- a/pymc/tests/test_minibatches.py
+++ b/pymc/tests/test_minibatches.py
@@ -312,7 +312,11 @@ class TestScaling:
         with pm.Model() as model7:
             n = Normal("n", observed=[1, 2], total_size=np.array([2, 1]))
             p7 = aesara.function([], model7.logpt())
-        assert p6() == p7()
+
+        with pm.Model() as model8:
+            n = Normal("n", observed=[1, 2], total_size=at.as_tensor(np.array([2, 1])))
+            p8 = aesara.function([], model7.logpt())
+        assert p6() == p7() == p8()
 
 
 @pytest.mark.usefixtures("strict_float32")


### PR DESCRIPTION
Improving total_size API for observed variables to implement histogram trick

```python
values = np.random.randn(10)
counts = np.random.randint(1, 100, size=10)
```

<table>
  <tr>
    <td>Before</td><td>After</td>
  </tr>
  <tr>
   <td>
<pre>
with pm.Model():
    a = pm.Potential("obs", pm.logp(pm.Normal.dist(), values) * counts)
</pre>
   </td>
<td>
<pre>
with pm.Model():
    pm.Normal("obs", observed=values, total_size=counts)
</pre>
</td>
  </tr>
</table>
It also adds a warning

```
/home/ferres/dev/pymc3/pymc/distributions/logprob.py:104: UserWarning: Using array as scaling that is experimental
warnings.warn("Using array as scaling that is experimental", UserWarning)
```