### PR TITLE
Deterministic group order of Approximations

### DIFF
--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1337,6 +1337,7 @@ class Approximation(WithMemoization):
                     raise GroupError("Found duplicates in groups")
                 seen.update(g.group)
                 self.groups.append(g)
+        # List iteration to preserve order for reproducibility between runs
         unseen_free_RVs = [var for var in model.free_RVs if var not in seen]
         if unseen_free_RVs:
             if rest is None:

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1337,11 +1337,12 @@ class Approximation(WithMemoization):
                     raise GroupError("Found duplicates in groups")
                 seen.update(g.group)
                 self.groups.append(g)
-        if set(model.free_RVs) - seen:
+        unseen_free_RVs = [ver for var in model.free_RVs if var not in seen]
+        if unseen_free_RVs:
             if rest is None:
                 raise GroupError("No approximation is specified for the rest variables")
             else:
-                rest.__init_group__(list(set(model.free_RVs) - seen))
+                rest.__init_group__(unseen_free_RVs)
                 self.groups.append(rest)
         self.model = model
 

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1337,7 +1337,7 @@ class Approximation(WithMemoization):
                     raise GroupError("Found duplicates in groups")
                 seen.update(g.group)
                 self.groups.append(g)
-        unseen_free_RVs = [ver for var in model.free_RVs if var not in seen]
+        unseen_free_RVs = [var for var in model.free_RVs if var not in seen]
         if unseen_free_RVs:
             if rest is None:
                 raise GroupError("No approximation is specified for the rest variables")


### PR DESCRIPTION
In the `__init__` of the `Approximation` class, there is an issue with `list(set(...))` makes the order of elements not deterministic, and it varies between runs. This means runs are not reproducible even when fixing random seeds.

This PR fixes the issue, and make sure that the order of variables in the group is the same is the order is `model.free_RVs`