### PR TITLE
Prior predictions constant data

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -468,7 +468,7 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
             default_dims=[],
         )
 
-    @requires(["trace", "predictions","prior_predictions"])
+    @requires(["trace", "predictions", "prior_predictions"])
     @requires("model")
     def constant_data_to_xarray(self):
         """Convert constant data to xarray."""

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -169,6 +169,10 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
             self.nchains = self.ndraws = 0
 
         self.prior = prior
+        self.prior_predictions = None
+        if self.prior is not None:
+            self.prior_predictions = True
+
         self.posterior_predictive = posterior_predictive
         self.log_likelihood = log_likelihood
         self.predictions = predictions
@@ -464,7 +468,7 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
             default_dims=[],
         )
 
-    @requires(["trace", "predictions"])
+    @requires(["trace", "predictions","prior_predictions"])
     @requires("model")
     def constant_data_to_xarray(self):
         """Convert constant data to xarray."""

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -169,10 +169,6 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
             self.nchains = self.ndraws = 0
 
         self.prior = prior
-        self.prior_predictions = None
-        if self.prior is not None:
-            self.prior_predictions = True
-
         self.posterior_predictive = posterior_predictive
         self.log_likelihood = log_likelihood
         self.predictions = predictions
@@ -468,7 +464,6 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
             default_dims=[],
         )
 
-    @requires(["trace", "predictions", "prior_predictions"])
     @requires("model")
     def constant_data_to_xarray(self):
         """Convert constant data to xarray."""

--- a/pymc/tests/test_idata_conversion.py
+++ b/pymc/tests/test_idata_conversion.py
@@ -502,7 +502,7 @@ class TestDataPyMC:
 
     @pytest.mark.parametrize("use_context", [True, False])
     def test_priors_separation(self, use_context):
-        """Test model is enough to get prior, prior predictive and observed_data."""
+        """Test model is enough to get prior, prior predictive, constant_data and observed_data."""
         with pm.Model() as model:
             x = pm.MutableData("x", [1.0, 2.0, 3.0])
             y = pm.ConstantData("y", [1.0, 2.0, 3.0])
@@ -514,6 +514,7 @@ class TestDataPyMC:
             "prior": ["beta", "~obs"],
             "observed_data": ["obs"],
             "prior_predictive": ["obs"],
+            "constant_data": ["x", "y"],
         }
         if use_context:
             with model:

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -1042,6 +1042,28 @@ def point_list_arg_bug_fixture() -> Tuple[pm.Model, pm.backends.base.MultiTrace]
 
 
 class TestSamplePriorPredictive(SeededTest):
+    def test_idata_output(self):
+        """This test controls that returned idata
+        contains all expected groups"""
+
+        with pm.Model() as model:
+            x = pm.MutableData("x", [1, 2, 3])
+            y = pm.MutableData("y", [1.1, 1.9, 3.1])
+            a = pm.Normal("a", mu=1, sigma=1)
+            b = pm.Normal("b", mu=0, sigma=1)
+            mu = pm.Deterministic("mu", var=a * x + b)
+            obs = pm.Normal("obs", mu=mu, sigma=1, observed=y)
+            idata = pm.sample_prior_predictive(samples=10)
+
+        test_dict = {
+            "prior": ["a", "b", "mu"],
+            "prior_predictive": ["obs"],
+            "observed_data": ["obs"],
+            "constant_data": ["x", "y"],
+        }
+        fails = check_multiple_attrs(test_dict, idata)
+        assert not fails
+
     def test_ignores_observed(self):
         observed = np.random.normal(10, 1, size=200)
         with pm.Model():

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -1042,28 +1042,6 @@ def point_list_arg_bug_fixture() -> Tuple[pm.Model, pm.backends.base.MultiTrace]
 
 
 class TestSamplePriorPredictive(SeededTest):
-    def test_idata_output(self):
-        """This test controls that returned idata
-        contains all expected groups"""
-
-        with pm.Model() as model:
-            x = pm.MutableData("x", [1, 2, 3])
-            y = pm.MutableData("y", [1.1, 1.9, 3.1])
-            a = pm.Normal("a", mu=1, sigma=1)
-            b = pm.Normal("b", mu=0, sigma=1)
-            mu = pm.Deterministic("mu", var=a * x + b)
-            obs = pm.Normal("obs", mu=mu, sigma=1, observed=y)
-            idata = pm.sample_prior_predictive(samples=10)
-
-        test_dict = {
-            "prior": ["a", "b", "mu"],
-            "prior_predictive": ["obs"],
-            "observed_data": ["obs"],
-            "constant_data": ["x", "y"],
-        }
-        fails = check_multiple_attrs(test_dict, idata)
-        assert not fails
-
     def test_ignores_observed(self):
         observed = np.random.normal(10, 1, size=200)
         with pm.Model():


### PR DESCRIPTION
This is my suggestion for issue  #5722
With this minor changes, pm.sample_prior_predictive() returns an InferenceData object, that
contains the `constant_data` group, useful for e.g. plotting purposes of prior predictions before sampling.
