### PR TITLE
Obtain timeseries step information from dims or observed

### DIFF
--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -81,16 +81,13 @@ __all__ = [
     "set_at_rng",
     "at_rng",
     "take_along_axis",
-    "pandas_to_array",
+    "convert_observed_data",
 ]
 
 
-def pandas_to_array(data):
-    """Convert a pandas object to a NumPy array.
+def convert_observed_data(data):
+    """Convert user provided dataset to accepted formats."""
 
-    XXX: When `data` is a generator, this will return an Aesara tensor!
-
-    """
     if hasattr(data, "to_numpy") and hasattr(data, "isnull"):
         # typically, but not limited to pandas objects
         vals = data.to_numpy()

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -33,7 +33,7 @@ from aesara.tensor.var import TensorConstant, TensorVariable
 
 import pymc as pm
 
-from pymc.aesaraf import pandas_to_array
+from pymc.aesaraf import convert_observed_data
 
 __all__ = [
     "get_data",
@@ -636,9 +636,9 @@ def Data(
         )
     name = model.name_for(name)
 
-    # `pandas_to_array` takes care of parameter `value` and
+    # `convert_observed_data` takes care of parameter `value` and
     # transforms it to something digestible for Aesara.
-    arr = pandas_to_array(value)
+    arr = convert_observed_data(value)
 
     if mutable is None:
         major, minor = (int(v) for v in pm.__version__.split(".")[:2])

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -26,7 +26,7 @@ from aesara.graph.basic import Variable
 from aesara.tensor.var import TensorVariable
 from typing_extensions import TypeAlias
 
-from pymc.aesaraf import pandas_to_array
+from pymc.aesaraf import convert_observed_data
 
 __all__ = [
     "to_tuple",
@@ -558,7 +558,7 @@ def resize_from_observed(
         Observations as numpy array or `Variable`.
     """
     if not hasattr(observed, "shape"):
-        observed = pandas_to_array(observed)
+        observed = convert_observed_data(observed)
     ndim_resize = observed.ndim - ndim_implied
     resize_shape = tuple(observed.shape[d] for d in range(ndim_resize))
     return resize_shape, observed

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -50,10 +50,10 @@ from aesara.tensor.var import TensorVariable
 
 from pymc.aesaraf import (
     compile_pymc,
+    convert_observed_data,
     gradient,
     hessian,
     inputvars,
-    pandas_to_array,
     rvs_to_value_vars,
 )
 from pymc.blocking import DictToArrayBijection, RaveledVars
@@ -1158,7 +1158,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         if isinstance(values, list):
             values = np.array(values)
-        values = pandas_to_array(values)
+        values = convert_observed_data(values)
         dims = self.RV_dims.get(name, None) or ()
         coords = coords or {}
 
@@ -1290,7 +1290,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         """
         name = rv_var.name
-        data = pandas_to_array(data).astype(rv_var.dtype)
+        data = convert_observed_data(data).astype(rv_var.dtype)
 
         if data.ndim != rv_var.ndim:
             raise ShapeError(

--- a/pymc/tests/test_aesaraf.py
+++ b/pymc/tests/test_aesaraf.py
@@ -38,8 +38,8 @@ from pymc.aesaraf import (
     _conversion_map,
     change_rv_size,
     compile_pymc,
+    convert_observed_data,
     extract_obs_data,
-    pandas_to_array,
     rvs_to_value_vars,
     take_along_axis,
     walk_model,
@@ -413,9 +413,9 @@ def test_extract_obs_data():
 
 
 @pytest.mark.parametrize("input_dtype", ["int32", "int64", "float32", "float64"])
-def test_pandas_to_array(input_dtype):
+def test_convert_observed_data(input_dtype):
     """
-    Ensure that pandas_to_array returns the dense array, masked array,
+    Ensure that convert_observed_data returns the dense array, masked array,
     graph variable, TensorVariable, or sparse matrix as appropriate.
     """
     pd = pytest.importorskip("pandas")
@@ -437,7 +437,7 @@ def test_pandas_to_array(input_dtype):
     square_generator = (np.array([i**2], dtype=int) for i in range(100))
 
     # Alias the function to be tested
-    func = pandas_to_array
+    func = convert_observed_data
 
     #####
     # Perform the various tests
@@ -496,7 +496,7 @@ def test_pandas_to_array(input_dtype):
 def test_pandas_to_array_pandas_index():
     pd = pytest.importorskip("pandas")
     data = pd.Index([1, 2, 3])
-    result = pandas_to_array(data)
+    result = convert_observed_data(data)
     expected = np.array([1, 2, 3])
     np.testing.assert_array_equal(result, expected)
 

--- a/pymc/tests/test_distributions_timeseries.py
+++ b/pymc/tests/test_distributions_timeseries.py
@@ -363,7 +363,7 @@ class TestAR:
         beta_tp.set_value(np.zeros((ar_order,)))  # Should always be close to zero
         sigma_tp = np.full(batch_size, [0.01, 0.1, 1, 10, 100])
         y_eval = t0["y"].eval({t0["sigma"]: sigma_tp})
-        assert y_eval.shape == (*batch_size, steps)
+        assert y_eval.shape == (*batch_size, steps + ar_order)
         assert np.allclose(y_eval.std(axis=(0, 2)), [0.01, 0.1, 1, 10, 100], rtol=0.1)
 
     def test_batched_init_dist(self):
@@ -389,7 +389,7 @@ class TestAR:
         init_dist = t0["y"].owner.inputs[2]
         init_dist_tp = np.full((batch_size, ar_order), (np.arange(batch_size) * 100)[:, None])
         y_eval = t0["y"].eval({init_dist: init_dist_tp})
-        assert y_eval.shape == (batch_size, steps)
+        assert y_eval.shape == (batch_size, steps + ar_order)
         assert np.allclose(
             y_eval[:, -10:].mean(-1), np.arange(batch_size) * 100, rtol=0.1, atol=0.5
         )
@@ -429,7 +429,7 @@ class TestAR:
     def test_moment(self, size, expected):
         with Model() as model:
             init_dist = Constant.dist([[1.0, 2.0], [3.0, 4.0]])
-            AR("x", rho=[0, 0], init_dist=init_dist, steps=7, size=size)
+            AR("x", rho=[0, 0], init_dist=init_dist, steps=5, size=size)
         assert_moment_is_expected(model, expected, check_finite_logp=False)
 
 


### PR DESCRIPTION
Follow up to #5690 so that steps can also be retrieved from observed and dims when possible.

Other changes:
* Renamed `pandas_to_array` to `convert_observed_data`
* Made AR `steps` more consistent with expectation / GRW