### PR TITLE
Add a method to compile an aesara forward sampling function

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -139,6 +139,7 @@ This includes API changes we did not warn about since at least `3.11.0` (2021-01
 - `pymc.sampling_jax` samplers support `log_likelihood`, `observed_data`, and `sample_stats` in returned InferenceData object (see [#5189](https://github.com/pymc-devs/pymc/pull/5189))
 - Adding support for `pm.Deterministic` in `pymc.sampling_jax` (see [#5182](https://github.com/pymc-devs/pymc/pull/5182))
 - Added an alternative parametrization, `logit_p` to `pm.Binomial` and `pm.Categorical` distributions (see [5637](https://github.com/pymc-devs/pymc/pull/5637)).
+- Added the low level `compile_forward_sampling_function` method to compile the aesara function responsible for generating forward samples (see [#5759](https://github.com/pymc-devs/pymc/pull/5759)).
 - ...
 
 


### PR DESCRIPTION
Closes #5302

This PR adds a low level method to compile the aesara function responsible for generating forward samples. It introduces the notion of **volatile** variables in a graph, which allows it to determine which values it should take from an inferred posterior during forward sampling. Volatile variables are variables whose values could change between a run of `pm.sample` and future calls to `pm.sample_posterior_predictive`. These are:

- Variables in the outputs list (the ones that should actually be returned by the compiled function)
- SharedVariable instances
- RandomVariable instances that have volatile parameters
- RandomVariables that are not in the ``vars_in_trace`` list (this means that they don't have values in the inferred posterior, so they should be drawn from their a priori assumed distribution)
- Variables in the `givens_dict`, because setting values through `givens` is considered disruptive with respect to the values the variable could have taken during `pm.sample`.
- Any other type of variable that depends on volatile variables.

Tasks that remain before this PR is ready to merge:

- [x] Use `compile_forward_sampling_function` in `sample_prior_predictive`
~~- [ ] Use `compile_forward_sampling_function` in `sample_posterior_predictive_w`~~