### PR TITLE
check for original coords

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1179,16 +1179,17 @@ class Model(WithMemoization, metaclass=ContextMeta):
             # Reject resizing if we already know that it would create shape problems.
             # NOTE: If there are multiple pm.MutableData containers sharing this dim, but the user only
             #       changes the values for one of them, they will run into shape problems nonetheless.
-            length_belongs_to = length_tensor.owner.inputs[0].owner.inputs[0]
-            if not isinstance(length_belongs_to, SharedVariable) and length_changed:
-                raise ShapeError(
-                    f"Resizing dimension '{dname}' with values of length {new_length} would lead to incompatibilities, "
-                    f"because the dimension was initialized from '{length_belongs_to}' which is not a shared variable. "
-                    f"Check if the dimension was defined implicitly before the shared variable '{name}' was created, "
-                    f"for example by a model variable.",
-                    actual=new_length,
-                    expected=old_length,
-                )
+            if original_coords is None:
+                length_belongs_to = length_tensor.owner.inputs[0].owner.inputs[0]
+                if not isinstance(length_belongs_to, SharedVariable) and length_changed:
+                    raise ShapeError(
+                        f"Resizing dimension '{dname}' with values of length {new_length} would lead to incompatibilities, "
+                        f"because the dimension was initialized from '{length_belongs_to}' which is not a shared variable. "
+                        f"Check if the dimension was defined implicitly before the shared variable '{name}' was created, "
+                        f"for example by a model variable.",
+                        actual=new_length,
+                        expected=old_length,
+                    )
             if original_coords is not None and length_changed:
                 if length_changed and new_coords is None:
                     raise ValueError(

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1229,7 +1229,8 @@ class Model(WithMemoization, metaclass=ContextMeta):
                         actual=len(new_coords),
                         expected=new_length,
                     )
-                self._coords[dname] = new_coords
+                # store it as tuple for immutability as in add_coord
+                self._coords[dname] = tuple(new_coords)
 
         shared_object.set_value(values)
 

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1185,7 +1185,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
                         f"Resizing dimension '{dname}' is impossible, because "
                         f"a 'TensorConstant' stores its length. To be able "
                         f"to change the dimension length, 'fixed' in "
-                        f"'model.add_coord' must be passed False."
+                        f"'model.add_coord' must be set to `False`."
                     )
                 if length_tensor.owner is None:
                     # This is the case if the dimension was initialized
@@ -1193,7 +1193,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
                     # stored in TensorConstant e.g by 'fixed' set to False
 
                     warnings.warn(
-                        f"You're changing the shape of a shared variable "
+                        f"You're changing the shape of a variable "
                         f"in the '{dname}' dimension which was initialized "
                         f"from coords. Make sure to update the corresponding "
                         f"coords, otherwise you'll get shape issues.",
@@ -1206,14 +1206,14 @@ class Model(WithMemoization, metaclass=ContextMeta):
                             f"Resizing dimension '{dname}' with values of length {new_length} would lead to incompatibilities, "
                             f"because the dimension was initialized from '{length_belongs_to}' which is not a shared variable. "
                             f"Check if the dimension was defined implicitly before the shared variable '{name}' was created, "
-                            f"for example by a model variable.",
+                            f"for example by another model variable.",
                             actual=new_length,
                             expected=old_length,
                         )
                 if original_coords is not None:
                     if new_coords is None:
                         raise ValueError(
-                            f"The '{name}' variable already had {len(original_coords)} coord values defined for"
+                            f"The '{name}' variable already had {len(original_coords)} coord values defined for "
                             f"its {dname} dimension. With the new values this dimension changes to length "
                             f"{new_length}, so new coord values for the {dname} dimension are required."
                         )

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -46,7 +46,7 @@ from aesara.graph.fg import FunctionGraph
 from aesara.tensor.random.opt import local_subtensor_rv_lift
 from aesara.tensor.random.var import RandomStateSharedVariable
 from aesara.tensor.sharedvar import ScalarSharedVariable
-from aesara.tensor.var import TensorVariable, TensorConstant
+from aesara.tensor.var import TensorConstant, TensorVariable
 
 from pymc.aesaraf import (
     compile_pymc,
@@ -61,7 +61,7 @@ from pymc.data import GenTensorVariable, Minibatch
 from pymc.distributions import joint_logpt
 from pymc.distributions.logprob import _get_scaling
 from pymc.distributions.transforms import _default_transform
-from pymc.exceptions import ImputationWarning, ShapeWarning, SamplingError, ShapeError
+from pymc.exceptions import ImputationWarning, SamplingError, ShapeError, ShapeWarning
 from pymc.initial_point import make_initial_point_fn
 from pymc.math import flatten_list
 from pymc.util import (
@@ -1180,7 +1180,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             # NOTE: If there are multiple pm.MutableData containers sharing this dim, but the user only
             #       changes the values for one of them, they will run into shape problems nonetheless.
             if length_changed:
-                if isinstance(length_tensor,TensorConstant):
+                if isinstance(length_tensor, TensorConstant):
                     raise ShapeError(
                         f"Resizing dimension '{dname}' is impossible, because "
                         f"a 'TensorConstant' stores its length. To be able "
@@ -1221,7 +1221,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
                     # Updating the shared variable resizes dependent nodes that use this dimension for their `size`.
                     length_tensor.set_value(new_length)
 
-
             if new_coords is not None:
                 # Update the registered coord values (also if they were None)
                 if len(new_coords) != new_length:
@@ -1231,7 +1230,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
                         expected=new_length,
                     )
                 self._coords[dname] = new_coords
-
 
         shared_object.set_value(values)
 

--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -317,9 +317,9 @@ class TestData(SeededTest):
         with pm.Model(coords=coords) as pmodel:
             pm.MutableData("observations", data, dims=("rows", "columns"))
             # new data with same shape
-            pm.set_data({"observations":data+1})
+            pm.set_data({"observations": data + 1})
             # new data with same shape and coords
-            pm.set_data({"observations":data},coords=coords)
+            pm.set_data({"observations": data}, coords=coords)
         assert "rows" in pmodel.coords
         assert pmodel.coords["rows"] == ("R1", "R2", "R3", "R4", "R5")
         assert "rows" in pmodel.dim_lengths

--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -316,7 +316,10 @@ class TestData(SeededTest):
         # pass coordinates explicitly, use numpy array in Data container
         with pm.Model(coords=coords) as pmodel:
             pm.MutableData("observations", data, dims=("rows", "columns"))
-
+            # new data with same shape
+            pm.set_data({"observations":data+1})
+            # new data with same shape and coords
+            pm.set_data({"observations":data},coords=coords)
         assert "rows" in pmodel.coords
         assert pmodel.coords["rows"] == ("R1", "R2", "R3", "R4", "R5")
         assert "rows" in pmodel.dim_lengths


### PR DESCRIPTION
This is my quick fix for #5760  . When coords are set manually, `length_tensor` in `set_data` has no owner. That's why it is crashing. In my fix I only check if `original_coords` is not None, meaning they were set explicitly (as far as I understand). However, I am pretty unsure if that's the way to go. Especially since there were a couple of issues in the last time concering `coords`...  