### PR TITLE
Fix dim lengths created from coords or ConstantData #5751 

### DIFF
--- a/pymc/data.py
+++ b/pymc/data.py
@@ -704,6 +704,7 @@ def Data(
                     # Note: Coordinate values can't be taken from
                     # the value, because it could be N-dimensional.
                     values=coords.get(dname, None),
+                    mutable=mutable,
                     length=xshape[d],
                 )
 

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1072,7 +1072,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         name: str,
         values: Optional[Sequence] = None,
         *,
-        length: Optional[Variable] = None,
+        length: Optional[Union[int, Variable]] = None,
     ):
         """Registers a dimension coordinate with the model.
 
@@ -1085,7 +1085,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             Coordinate values or ``None`` (for auto-numbering).
             If ``None`` is passed, a ``length`` must be specified.
         length : optional, scalar
-            A symbolic scalar of the dimensions length.
+            A scalar of the dimensions length.
             Defaults to ``aesara.shared(len(values))``.
         """
         if name in {"draw", "chain", "__sample__"}:
@@ -1097,7 +1097,9 @@ class Model(WithMemoization, metaclass=ContextMeta):
             raise ValueError(
                 f"Either `values` or `length` must be specified for the '{name}' dimension."
             )
-        if length is not None and not isinstance(length, Variable):
+        if isinstance(length, int):
+            length = at.constant(length)
+        elif length is not None and not isinstance(length, Variable):
             raise ValueError(
                 f"The `length` passed for the '{name}' coord must be an Aesara Variable or None."
             )
@@ -1116,7 +1118,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         self,
         coords: Dict[str, Optional[Sequence]],
         *,
-        lengths: Optional[Dict[str, Union[Variable, None]]] = None,
+        lengths: Optional[Dict[str, Optional[Union[int, Variable]]]] = None,
     ):
         """Vectorized version of ``Model.add_coord``."""
         if coords is None:

--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -332,6 +332,22 @@ class TestData(SeededTest):
         assert isinstance(pmodel.dim_lengths["columns"], ScalarSharedVariable)
         assert pmodel.dim_lengths["columns"].eval() == 7
 
+    def test_set_coords_through_pmdata(self):
+        with pm.Model() as pmodel:
+            pm.ConstantData(
+                "population", [100, 200], dims="city", coords={"city": ["Tinyvil", "Minitown"]}
+            )
+            pm.MutableData(
+                "temperature",
+                [[15, 20, 22, 17], [18, 22, 21, 12]],
+                dims=("city", "season"),
+                coords={"season": ["winter", "spring", "summer", "fall"]},
+            )
+        assert "city" in pmodel.coords
+        assert "season" in pmodel.coords
+        assert pmodel.coords["city"] == ("Tinyvil", "Minitown")
+        assert pmodel.coords["season"] == ("winter", "spring", "summer", "fall")
+
     def test_symbolic_coords(self):
         """
         In v4 dimensions can be created without passing coordinate values.

--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -19,7 +19,7 @@ import pytest
 
 from aesara import shared
 from aesara.compile.sharedvalue import SharedVariable
-from aesara.tensor.sharedvar import ScalarSharedVariable
+from aesara.tensor import TensorConstant
 from aesara.tensor.var import TensorVariable
 
 import pymc as pm
@@ -315,21 +315,22 @@ class TestData(SeededTest):
         }
         # pass coordinates explicitly, use numpy array in Data container
         with pm.Model(coords=coords) as pmodel:
+            # Dims created from coords are constant by default
+            assert isinstance(pmodel.dim_lengths["rows"], TensorConstant)
+            assert isinstance(pmodel.dim_lengths["columns"], TensorConstant)
             pm.MutableData("observations", data, dims=("rows", "columns"))
-            # new data with same shape
+            # new data with same (!) shape
             pm.set_data({"observations": data + 1})
-            # new data with same shape and coords
+            # new data with same (!) shape and coords
             pm.set_data({"observations": data}, coords=coords)
         assert "rows" in pmodel.coords
         assert pmodel.coords["rows"] == ("R1", "R2", "R3", "R4", "R5")
         assert "rows" in pmodel.dim_lengths
-        assert isinstance(pmodel.dim_lengths["rows"], ScalarSharedVariable)
         assert pmodel.dim_lengths["rows"].eval() == 5
         assert "columns" in pmodel.coords
         assert pmodel.coords["columns"] == ("C1", "C2", "C3", "C4", "C5", "C6", "C7")
         assert pmodel.RV_dims == {"observations": ("rows", "columns")}
         assert "columns" in pmodel.dim_lengths
-        assert isinstance(pmodel.dim_lengths["columns"], ScalarSharedVariable)
         assert pmodel.dim_lengths["columns"].eval() == 7
 
     def test_set_coords_through_pmdata(self):
@@ -354,6 +355,7 @@ class TestData(SeededTest):
         Their lengths are then automatically linked to the corresponding Tensor dimension.
         """
         with pm.Model() as pmodel:
+            # Dims created from MutableData are TensorVariables linked to the SharedVariable.shape
             intensity = pm.MutableData("intensity", np.ones((2, 3)), dims=("row", "column"))
             assert "row" in pmodel.dim_lengths
             assert "column" in pmodel.dim_lengths


### PR DESCRIPTION
Closes #5751. Fixes dimensions created by add_coord by making dimension length a TensorConstant. I have also added a test for this using some code from #5181. 

I'm setting as WIP as @canyon289 suggested this PR is required for other work to become unblocked and I'm having problems with some failing tests (which could just be due to me running things locally with an incorrect set-up?). So it's worth seeing if they fail on here and then look at fixes, which will be faster than me trying to figure things out on my own!

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes?
+ [x] important background, or details about the implementation
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [x] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
