### PR TITLE
doc: add `nuts_kwargs` to `sample_numpyro_nuts` docstring

### DIFF
--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -435,6 +435,8 @@ def sample_numpyro_nuts(
         Keyword arguments for :func:`arviz.from_dict`. It also accepts a boolean as value
         for the ``log_likelihood`` key to indicate that the pointwise log likelihood should
         not be included in the returned object.
+    nuts_kwargs: dict, optional
+        Keyword arguments for :func:`numpyro.infer.NUTS`.
 
     Returns
     -------


### PR DESCRIPTION
The `nuts_kwargs` argument is currently missing from the docstring of `sample_numpyro_nuts`. This just adds a simple statement to indicate that the keyword arguments are passed to `numpyro.infer.NUTS()`.

**Thank your for opening a PR!**

Before you proceed, please make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes?
+ [ x important background, or details about the implementation
+ [x] are the changes—especially new features—covered by tests and docstrings?
+ [x] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
