### PR TITLE
add subsections inside community section

### DIFF
--- a/docs/source/community.md
+++ b/docs/source/community.md
@@ -27,4 +27,17 @@ Learn how the PyMC project is governed and how to become a member of PyMC [here]
 
 ## Code of Conduct
 
-In order to foster a welcoming environment, participation in our project and community is guided by this [code of conduct](https://github.com/pymc-devs/pymc/blob/main/CODE_OF_CONDUCT.md).
+In order to foster a welcoming environment, participation in our project and community is guided by the {ref}`code_of_conduct`.
+
+:::{toctree}
+:caption: Discourse resources
+
+community/how_to_ask_on_discourse
+:::
+
+:::{toctree}
+:caption: General resources
+
+community/code_of_conduct
+Blog <https://www.pymc.io/blog.html>
+:::

--- a/docs/source/community/code_of_conduct.md
+++ b/docs/source/community/code_of_conduct.md
@@ -1,0 +1,3 @@
+(code_of_conduct)=
+```{include} ../../../CODE_OF_CONDUCT.md
+```

--- a/docs/source/community/how_to_ask_on_discourse.md
+++ b/docs/source/community/how_to_ask_on_discourse.md
@@ -1,0 +1,4 @@
+(how_to_ask_on_discourse)=
+# How to ask a question on Discourse
+
+**Placeholder page**

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -249,7 +249,7 @@ html_context = {
 }
 # this controls which sidebar sections are available in which pages. [] removes the left sidebar
 html_sidebars = {
-    "community": ["twitter"],
+    "community": ["sidebar-nav-bs.html", "twitter"],
     "**": ["sidebar-nav-bs.html"],
 }
 


### PR DESCRIPTION
+ [x] important background, or details about the implementation
  - Extends the community section to make it easier for other contributors to add
    more documentation about it.

    In general, all sections but the "contributing" one have pymc _users_ as intended audience,
    things that have contributors as expected audience so far have gone inside the
    "contributing" section (so "how to set up office hours" page would go there).
    We can change that and add its own contributing inside the community section
    but I think it is good to have the guides of all types of contributions
    in the same place so that hosting office hours, building docs or writing code are
    perceived as similar and same level contributions.

cc @cluhmann  @reshamas 
