### PR TITLE
Remove rng seeder

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,7 +25,10 @@ Also check out the [milestones](https://github.com/pymc-devs/pymc/milestones) fo
 
 All of the above apply to:
 
-Signature and default parameters changed for several distributions:
+⚠ Random seeding behavior changed!
+    - Sampling results will differ from those of V3 when passing the same random_state as before. They will be consitent across subsequent V4 releases unless mentioned otherwise.
+    - Sampling functions no longer respect user-specified global seeding! Always pass `random_seed` to ensure reproducible behavior.
+- Signature and default parameters changed for several distributions:
     - `pm.StudentT` now requires either `sigma` or `lam` as kwarg (see [#5628](https://github.com/pymc-devs/pymc/pull/5628))
     - `pm.StudentT` now requires `nu` to be specified (no longer defaults to 1) (see [#5628](https://github.com/pymc-devs/pymc/pull/5628))
     - `pm.AsymmetricLaplace` positional arguments re-ordered (see [#5628](https://github.com/pymc-devs/pymc/pull/5628))

--- a/benchmarks/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks/benchmarks.py
@@ -174,13 +174,16 @@ class NUTSInitSuite:
         """How long does it take to run the initialization."""
         with glm_hierarchical_model():
             pm.init_nuts(
-                init=init, chains=self.chains, progressbar=False, seeds=np.arange(self.chains)
+                init=init,
+                chains=self.chains,
+                progressbar=False,
+                random_seed=np.arange(self.chains),
             )
 
     def track_glm_hierarchical_ess(self, init):
         with glm_hierarchical_model():
             start, step = pm.init_nuts(
-                init=init, chains=self.chains, progressbar=False, seeds=np.arange(self.chains)
+                init=init, chains=self.chains, progressbar=False, random_seed=np.arange(self.chains)
             )
             t0 = time.time()
             idata = pm.sample(
@@ -201,7 +204,7 @@ class NUTSInitSuite:
         model, start = mixture_model()
         with model:
             _, step = pm.init_nuts(
-                init=init, chains=self.chains, progressbar=False, seeds=np.arange(self.chains)
+                init=init, chains=self.chains, progressbar=False, random_seed=np.arange(self.chains)
             )
             start = [{k: v for k, v in start.items()} for _ in range(self.chains)]
             t0 = time.time()

--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -929,9 +929,28 @@ def reseed_rngs(
 
 
 def compile_pymc(
-    inputs, outputs, mode=None, **kwargs
+    inputs,
+    outputs,
+    random_seed: SeedSequenceSeed = None,
+    mode=None,
+    **kwargs,
 ) -> Callable[..., Union[np.ndarray, List[np.ndarray]]]:
     """Use ``aesara.function`` with specialized pymc rewrites always enabled.
+
+    This function also ensures shared RandomState/Generator used by RandomVariables
+    in the graph are updated across calls, to ensure independent draws.
+
+    Parameters
+    ----------
+    inputs: list of TensorVariables, optional
+        Inputs of the compiled Aesara function
+    outputs: list of TensorVariables, optional
+        Outputs of the compiled Aesara function
+    random_seed: int, array-like of int or SeedSequence, optional
+        Seed used to override any RandomState/Generator shared variables in the graph.
+        If not specified, the value of original shared variables will still be overwritten.
+    mode: optional
+        Aesara mode used to compile the function
 
     Included rewrites
     -----------------
@@ -952,7 +971,6 @@ def compile_pymc(
     """
     # Create an update mapping of RandomVariable's RNG so that it is automatically
     # updated after every function call
-    # TODO: This won't work for variables with InnerGraphs (Scan and OpFromGraph)
     rng_updates = {}
     output_to_list = outputs if isinstance(outputs, (list, tuple)) else [outputs]
     for random_var in (
@@ -966,10 +984,16 @@ def compile_pymc(
             rng = random_var.owner.inputs[0]
             if not hasattr(rng, "default_update"):
                 rng_updates[rng] = random_var.owner.outputs[0]
+            else:
+                rng_updates[rng] = rng.default_update
         else:
             update_fn = getattr(random_var.owner.op, "update", None)
             if update_fn is not None:
                 rng_updates.update(update_fn(random_var.owner))
+
+    # We always reseed random variables as this provides RNGs with no chances of collision
+    if rng_updates:
+        reseed_rngs(rng_updates.keys(), random_seed)
 
     # If called inside a model context, see if check_bounds flag is set to False
     try:

--- a/pymc/distributions/censored.py
+++ b/pymc/distributions/censored.py
@@ -86,15 +86,11 @@ class Censored(SymbolicDistribution):
         return super().dist([dist, lower, upper], **kwargs)
 
     @classmethod
-    def num_rngs(cls, *args, **kwargs):
-        return 1
-
-    @classmethod
     def ndim_supp(cls, *dist_params):
         return 0
 
     @classmethod
-    def rv_op(cls, dist, lower=None, upper=None, size=None, rngs=None):
+    def rv_op(cls, dist, lower=None, upper=None, size=None):
 
         lower = at.constant(-np.inf) if lower is None else at.as_tensor_variable(lower)
         upper = at.constant(np.inf) if upper is None else at.as_tensor_variable(upper)
@@ -112,20 +108,7 @@ class Censored(SymbolicDistribution):
         rv_out.tag.lower = lower
         rv_out.tag.upper = upper
 
-        if rngs is not None:
-            rv_out = cls._change_rngs(rv_out, rngs)
-
         return rv_out
-
-    @classmethod
-    def _change_rngs(cls, rv, new_rngs):
-        (new_rng,) = new_rngs
-        dist_node = rv.tag.dist.owner
-        lower = rv.tag.lower
-        upper = rv.tag.upper
-        olg_rng, size, dtype, *dist_params = dist_node.inputs
-        new_dist = dist_node.op.make_node(new_rng, size, dtype, *dist_params).default_output()
-        return cls.rv_op(new_dist, lower, upper)
 
     @classmethod
     def change_size(cls, rv, new_size, expand=False):

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -19,7 +19,7 @@ import warnings
 
 from abc import ABCMeta
 from functools import singledispatch
-from typing import Callable, Iterable, Optional, Sequence, Tuple, Union, cast
+from typing import Callable, Optional, Sequence, Tuple, Union, cast
 
 import aesara
 import numpy as np
@@ -258,13 +258,10 @@ class Distribution(metaclass=DistributionMeta):
         if not isinstance(name, string_types):
             raise TypeError(f"Name needs to be a string but got: {name}")
 
-        if rng is None:
-            rng = model.next_rng()
-
         # Create the RV and process dims and observed to determine
         # a shape by which the created RV may need to be resized.
         rv_out, dims, observed, resize_shape = _make_rv_and_resize_shape(
-            cls=cls, dims=dims, model=model, observed=observed, args=args, rng=rng, **kwargs
+            cls=cls, dims=dims, model=model, observed=observed, args=args, **kwargs
         )
 
         if resize_shape:
@@ -383,9 +380,6 @@ class SymbolicDistribution:
         to a canonical parametrization. It should call `super().dist()`, passing a
         list with the default parameters as the first and only non keyword argument,
         followed by other keyword arguments like size and rngs, and return the result
-    cls.num_rngs
-        Returns the number of rngs given the same arguments passed by the user when
-        calling the distribution
     cls.ndim_supp
         Returns the support of the symbolic distribution, given the default set of
         parameters. This may not always be constant, for instance if the symbolic
@@ -402,7 +396,6 @@ class SymbolicDistribution:
         cls,
         name: str,
         *args,
-        rngs: Optional[Iterable] = None,
         dims: Optional[Dims] = None,
         initval=None,
         observed=None,
@@ -419,8 +412,6 @@ class SymbolicDistribution:
             A distribution class that inherits from SymbolicDistribution.
         name : str
             Name for the new model variable.
-        rngs : optional
-            Random number generator to use for the RandomVariable(s) in the graph.
         dims : tuple, optional
             A tuple of dimension names known to the model.
         initval : optional
@@ -468,17 +459,10 @@ class SymbolicDistribution:
         if not isinstance(name, string_types):
             raise TypeError(f"Name needs to be a string but got: {name}")
 
-        if rngs is None:
-            # Instead of passing individual RNG variables we could pass a RandomStream
-            # and let the classes create as many RNGs as they need
-            rngs = [model.next_rng() for _ in range(cls.num_rngs(*args, **kwargs))]
-        elif not isinstance(rngs, (list, tuple)):
-            rngs = [rngs]
-
         # Create the RV and process dims and observed to determine
         # a shape by which the created RV may need to be resized.
         rv_out, dims, observed, resize_shape = _make_rv_and_resize_shape(
-            cls=cls, dims=dims, model=model, observed=observed, args=args, rngs=rngs, **kwargs
+            cls=cls, dims=dims, model=model, observed=observed, args=args, **kwargs
         )
 
         if resize_shape:

--- a/pymc/parallel_sampling.py
+++ b/pymc/parallel_sampling.py
@@ -21,7 +21,7 @@ import time
 import traceback
 
 from collections import namedtuple
-from typing import Dict, List, Sequence
+from typing import TYPE_CHECKING, Dict, List, Sequence
 
 import cloudpickle
 import numpy as np
@@ -31,6 +31,10 @@ from fastprogress.fastprogress import progress_bar
 from pymc import aesaraf
 from pymc.blocking import DictToArrayBijection
 from pymc.exceptions import SamplingError
+
+# Avoid circular import
+if TYPE_CHECKING:
+    from pymc.sampling import RandomSeed
 
 logger = logging.getLogger("pymc")
 
@@ -389,7 +393,7 @@ class ParallelSampler:
         tune: int,
         chains: int,
         cores: int,
-        seeds: list,
+        seeds: Sequence["RandomSeed"],
         start_points: Sequence[Dict[str, np.ndarray]],
         step_method,
         start_chain_num: int = 0,

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -2531,7 +2531,9 @@ def init_nuts(
             progressbar=progressbar,
             obj_optimizer=pm.adagrad_window,
         )
-        approx_sample = approx.sample(draws=chains, return_inferencedata=False)
+        approx_sample = approx.sample(
+            draws=chains, random_seed=random_seed_list[0], return_inferencedata=False
+        )
         initial_points = [approx_sample[i] for i in range(chains)]
         std_apoint = approx.std.eval()
         cov = std_apoint**2
@@ -2549,7 +2551,9 @@ def init_nuts(
             progressbar=progressbar,
             obj_optimizer=pm.adagrad_window,
         )
-        approx_sample = approx.sample(draws=chains, return_inferencedata=False)
+        approx_sample = approx.sample(
+            draws=chains, random_seed=random_seed_list[0], return_inferencedata=False
+        )
         initial_points = [approx_sample[i] for i in range(chains)]
         cov = approx.std.eval() ** 2
         potential = quadpotential.QuadPotentialDiag(cov)
@@ -2564,7 +2568,9 @@ def init_nuts(
             progressbar=progressbar,
             obj_optimizer=pm.adagrad_window,
         )
-        approx_sample = approx.sample(draws=chains, return_inferencedata=False)
+        approx_sample = approx.sample(
+            draws=chains, random_seed=random_seed_list[0], return_inferencedata=False
+        )
         initial_points = [approx_sample[i] for i in range(chains)]
         cov = approx.std.eval() ** 2
         potential = quadpotential.QuadPotentialDiag(cov)

--- a/pymc/tests/models.py
+++ b/pymc/tests/models.py
@@ -189,7 +189,7 @@ def simple_normal(bounded_prior=False):
     sigma = 1.0
     a, b = (9, 12)  # bounds for uniform RV, need non-symmetric to reproduce issue
 
-    with pm.Model(rng_seeder=2482) as model:
+    with pm.Model() as model:
         if bounded_prior:
             mu_i = pm.Uniform("mu_i", a, b)
         else:

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1682,14 +1682,14 @@ class TestMatrixNormal(BaseTestDistributionRandom):
         def ref_rand(mu, rowcov, colcov):
             return st.matrix_normal.rvs(mean=mu, rowcov=rowcov, colcov=colcov)
 
-        with pm.Model(rng_seeder=1):
+        with pm.Model():
             matrixnormal = pm.MatrixNormal(
                 "matnormal",
                 mu=np.random.random((3, 3)),
                 rowcov=np.eye(3),
                 colcov=np.eye(3),
             )
-            check = pm.sample_prior_predictive(n_fails, return_inferencedata=False)
+            check = pm.sample_prior_predictive(n_fails, return_inferencedata=False, random_seed=1)
 
         ref_smp = ref_rand(mu=np.random.random((3, 3)), rowcov=np.eye(3), colcov=np.eye(3))
 
@@ -2328,10 +2328,10 @@ def test_car_rng_fn(sparse):
     if sparse:
         W = aesara.sparse.csr_from_dense(W)
 
-    with pm.Model(rng_seeder=1):
+    with pm.Model():
         car = pm.CAR("car", mu, W, alpha, tau, size=size)
         mn = pm.MvNormal("mn", mu, cov, size=size)
-        check = pm.sample_prior_predictive(n_fails, return_inferencedata=False)
+        check = pm.sample_prior_predictive(n_fails, return_inferencedata=False, random_seed=1)
 
     p, f = delta, n_fails
     while p <= delta and f > 0:

--- a/pymc/tests/test_mixture.py
+++ b/pymc/tests/test_mixture.py
@@ -232,12 +232,8 @@ class TestMixture(SeededTest):
     @pytest.mark.parametrize("size", [None, (4,), (5, 4)])
     def test_single_multivariate_component_deterministic_weights(self, weights, component, size):
         # This test needs seeding to avoid repetitions
-        rngs = [
-            aesara.shared(np.random.default_rng(seed))
-            for seed in self.get_random_state().randint(2**30, size=2)
-        ]
-        mix = Mixture.dist(weights, component, size=size, rngs=rngs)
-        mix_eval = mix.eval()
+        mix = Mixture.dist(weights, component, size=size)
+        mix_eval = draw(mix, random_seed=self.get_random_state())
 
         # Test shape
         # component shape is either (4, 2, 3), (2, 3)
@@ -853,7 +849,7 @@ class TestMixtureVsLatent(SeededTest):
         # [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
         mus = at.constant(np.full((nd, npop), np.arange(npop)))
 
-        with Model(rng_seeder=self.get_random_state()) as model:
+        with Model() as model:
             m = NormalMixture(
                 "m",
                 w=np.ones(npop) / npop,
@@ -867,8 +863,8 @@ class TestMixtureVsLatent(SeededTest):
             latent_m = Normal("latent_m", mu=mu, sigma=1e-5, shape=nd)
 
         size = 100
-        m_val = draw(m, draws=size)
-        latent_m_val = draw(latent_m, draws=size)
+        m_val = draw(m, draws=size, random_seed=self.get_random_state())
+        latent_m_val = draw(latent_m, draws=size, random_seed=self.get_random_state())
 
         assert m_val.shape == latent_m_val.shape
         # Test that each element in axis = -1 can come from independent
@@ -888,7 +884,7 @@ class TestMixtureVsLatent(SeededTest):
         # [[0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]]
         mus = at.constant(np.full((nd, npop), np.arange(npop)))
 
-        with Model(rng_seeder=self.get_random_state()) as model:
+        with Model() as model:
             m = Mixture(
                 "m",
                 w=np.ones(npop) / npop,
@@ -900,8 +896,8 @@ class TestMixtureVsLatent(SeededTest):
             latent_m = Normal("latent_m", mu=mus[..., z], sigma=1e-5, shape=nd)
 
         size = 100
-        m_val = draw(m, draws=size)
-        latent_m_val = draw(latent_m, draws=size)
+        m_val = draw(m, draws=size, random_seed=998)
+        latent_m_val = draw(latent_m, draws=size, random_seed=998 * 2)
         assert m_val.shape == latent_m_val.shape
         # Test that each element in axis = -1 comes from the same mixture
         # component

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -657,7 +657,7 @@ def test_set_initval():
     # generating initial values
     rng = np.random.RandomState(392)
 
-    with pm.Model(rng_seeder=rng) as model:
+    with pm.Model() as model:
         eta = pm.Uniform("eta", 1.0, 2.0, size=(1, 1))
         mu = pm.Normal("mu", sigma=eta, initval=[[100]])
         alpha = pm.HalfNormal("alpha", initval=100)

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -100,11 +100,6 @@ class TestSample(SeededTest):
         allequal = np.all(tr1["x"] == tr2["x"])
         if seeds is None:
             assert not allequal
-        # TODO: ADVI init methods are not correctly seeded, as they rely on the state of
-        #  the model RandomState/Generators which is updated in place when the function
-        #  is compiled and evaluated. This elif branch must be removed once this is fixed
-        elif init == "advi":
-            assert not allequal
         else:
             assert allequal
 

--- a/pymc/tests/test_step.py
+++ b/pymc/tests/test_step.py
@@ -1183,7 +1183,7 @@ class TestMLDA:
 
             rng = np.random.RandomState(seed)
 
-            with Model(rng_seeder=rng) as coarse_model_0:
+            with Model() as coarse_model_0:
                 if aesara.config.floatX == "float32":
                     Q = Data("Q", np.float32(0.0))
                 else:
@@ -1202,7 +1202,7 @@ class TestMLDA:
 
             rng = np.random.RandomState(seed)
 
-            with Model(rng_seeder=rng) as coarse_model_1:
+            with Model() as coarse_model_1:
                 if aesara.config.floatX == "float32":
                     Q = Data("Q", np.float32(0.0))
                 else:
@@ -1221,7 +1221,7 @@ class TestMLDA:
 
             rng = np.random.RandomState(seed)
 
-            with Model(rng_seeder=rng) as model:
+            with Model() as model:
                 if aesara.config.floatX == "float32":
                     Q = Data("Q", np.float32(0.0))
                 else:

--- a/pymc/tests/test_step.py
+++ b/pymc/tests/test_step.py
@@ -523,7 +523,7 @@ class TestNutsCheckTrace:
             b = at.slinalg.solve(floatX(np.eye(2)), a, check_finite=False)
             Normal("c", mu=b, size=2, initval=floatX(np.r_[0.0, 0.0]))
             caplog.clear()
-            trace = sample(20, tune=5, chains=2, return_inferencedata=False)
+            trace = sample(20, tune=5, chains=2, return_inferencedata=False, random_seed=526)
             warns = [msg.msg for msg in caplog.records]
             assert np.any(trace["diverging"])
             assert (

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -107,8 +107,6 @@ def find_MAP(
         return_transformed=True,
         overrides=start,
     )
-    if seed is None:
-        seed = model.rng_seeder.randint(2**30, dtype=np.int64)
     start = ipfn(seed)
     model.check_start_vals(start)
 

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -846,6 +846,7 @@ class Group(WithMemoization):
         self._vfam = vfam
         self._local = local
         self._batched = rowwise
+        self.rng = np.random.default_rng(random_seed)
         self._rng = at_rng(random_seed)
         model = modelcontext(model)
         self.model = model
@@ -867,7 +868,7 @@ class Group(WithMemoization):
             jitter_rvs={},
             return_transformed=True,
         )
-        start = ipfn(self.model.rng_seeder.randint(2**30, dtype=np.int64))
+        start = ipfn(self.rng.integers(2**30, dtype=np.int64))
         group_vars = {self.model.rvs_to_values[v].name for v in self.group}
         start = {k: v for k, v in start.items() if k in group_vars}
         if self.batched:

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -57,11 +57,20 @@ from aesara.graph.basic import Variable
 
 import pymc as pm
 
-from pymc.aesaraf import at_rng, compile_pymc, identity, rvs_to_value_vars
+from pymc.aesaraf import (
+    SeedSequenceSeed,
+    at_rng,
+    compile_pymc,
+    find_rng_nodes,
+    identity,
+    reseed_rngs,
+    rvs_to_value_vars,
+)
 from pymc.backends import NDArray
 from pymc.blocking import DictToArrayBijection
 from pymc.initial_point import make_initial_point_fn
 from pymc.model import modelcontext
+from pymc.sampling import RandomState, _get_seeds_per_chain
 from pymc.util import WithMemoization, locally_cachedmethod
 from pymc.variational.updates import adagrad_window
 from pymc.vartypes import discrete_types
@@ -1641,22 +1650,30 @@ class Approximation(WithMemoization):
         sampled = [self.rslice(name) for name in names]
         sampled = self.set_size_and_deterministic(sampled, s, 0)
         sample_fn = compile_pymc([s], sampled)
+        rng_nodes = find_rng_nodes(sampled)
 
-        def inner(draws=100):
+        def inner(draws=100, *, random_seed: SeedSequenceSeed = None):
+            if random_seed is not None:
+                reseed_rngs(rng_nodes, random_seed)
             _samples = sample_fn(draws)
+
             return {v_: s_ for v_, s_ in zip(names, _samples)}
 
         return inner
 
-    def sample(self, draws=500, return_inferencedata=True, **kwargs):
+    def sample(
+        self, draws=500, *, random_seed: RandomState = None, return_inferencedata=True, **kwargs
+    ):
         """Draw samples from variational posterior.
 
         Parameters
         ----------
-        draws: `int`
+        draws : int
             Number of random samples.
-        return_inferencedata: `bool`
-            Return trace in Arviz format
+        random_seed : int, RandomState or Generator, optional
+            Seed for the random number generator.
+        return_inferencedata : bool
+            Return trace in Arviz format.
 
         Returns
         -------
@@ -1666,7 +1683,9 @@ class Approximation(WithMemoization):
         # TODO: add tests for include_transformed case
         kwargs["log_likelihood"] = False
 
-        samples = self.sample_dict_fn(draws)  # type: dict
+        if random_seed is not None:
+            (random_seed,) = _get_seeds_per_chain(random_seed, 1)
+        samples = self.sample_dict_fn(draws, random_seed=random_seed)  # type: dict
         points = ({name: records[i] for name, records in samples.items()} for i in range(draws))
 
         trace = NDArray(


### PR DESCRIPTION
This PR removes the `Model(rng_seeder=seed)` API as discussed in #5785 and instead makes use of the `random_seed` kwarg in all sampling functions. One big breaking change done on purpose (but not strictly needed) is that these functions will not care/respect user defined external global seeding.

```python
import pymc as pm
import numpy as np

with pm.Model() as m:
  x = pm.Normal("x")
  np.random.seed(0)  # DOES NOT MATTER!
  always_different = pm.sample()
  always_the_same = pm.sample(random_seed=0)
```

This is done so that default seeding quality can be "as good as possible", as suggested by NumPy best practice: https://numpy.org/doc/stable/reference/random/bit_generators/generated/numpy.random.SeedSequence.html#numpy.random.SeedSequence

```Python
# Global seeding is ignored by numpy default_rng, 
# and that's why our PyMC sampling functions now do the same:
import numpy as np

np.random.seed(0)
print(np.random.default_rng(None).random())  # 0.7166779009481196
np.random.seed(0)
print(np.random.default_rng(None).random())  # 0.6145552524375484
```
Is everyone okay with this change?

Also allowed passing RandomState or Generators to all sampling functions for user convenience.
```python
rng = np.random.default_rng()
with pm.Model() as m:
  x = pm.Normal("x")
  pm.sample(random_seed=rng)
```

Closes #5785 
Closes #5733
Closes #5784
Closes #4301