### PR TITLE
Remove size from Distribution signatures

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -344,7 +344,7 @@ class FlatRV(RandomVariable):
     _print_name = ("Flat", "\\operatorname{Flat}")
 
     @classmethod
-    def rng_fn(cls, rng, size):
+    def rng_fn(cls, rng, *args):
         raise NotImplementedError("Cannot sample from flat variable")
 
 
@@ -364,8 +364,8 @@ class Flat(Continuous):
         return super().__new__(cls, *args, **kwargs)
 
     @classmethod
-    def dist(cls, *, size=None, **kwargs):
-        res = super().dist([], size=size, **kwargs)
+    def dist(cls, **kwargs):
+        res = super().dist([], **kwargs)
         return res
 
     def moment(rv, size):
@@ -415,7 +415,7 @@ class HalfFlatRV(RandomVariable):
     _print_name = ("HalfFlat", "\\operatorname{HalfFlat}")
 
     @classmethod
-    def rng_fn(cls, rng, size):
+    def rng_fn(cls, rng, *args):
         raise NotImplementedError("Cannot sample from half_flat variable")
 
 
@@ -432,8 +432,8 @@ class HalfFlat(PositiveContinuous):
         return super().__new__(cls, *args, **kwargs)
 
     @classmethod
-    def dist(cls, *, size=None, **kwargs):
-        res = super().dist([], size=size, **kwargs)
+    def dist(cls, **kwargs):
+        res = super().dist([], **kwargs)
         return res
 
     def moment(rv, size):

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -344,7 +344,7 @@ class FlatRV(RandomVariable):
     _print_name = ("Flat", "\\operatorname{Flat}")
 
     @classmethod
-    def rng_fn(cls, rng, *args):
+    def rng_fn(cls, rng, size):
         raise NotImplementedError("Cannot sample from flat variable")
 
 
@@ -415,7 +415,7 @@ class HalfFlatRV(RandomVariable):
     _print_name = ("HalfFlat", "\\operatorname{HalfFlat}")
 
     @classmethod
-    def rng_fn(cls, rng, *args):
+    def rng_fn(cls, rng, size):
         raise NotImplementedError("Cannot sample from half_flat variable")
 
 

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -226,8 +226,8 @@ class Distribution(metaclass=DistributionMeta):
         transform : optional
             See ``Model.register_rv``.
         **kwargs
-            Keyword arguments that will be forwarded to ``.dist()``.
-            Most prominently: ``shape`` and ``size``
+            Keyword arguments that will be forwarded to ``.dist()`` or the Aesara RV Op.
+            Most prominently: ``shape`` for ``.dist()`` and ``size`` or ``dtype`` for the Op.
 
         Returns
         -------
@@ -298,7 +298,6 @@ class Distribution(metaclass=DistributionMeta):
         dist_params,
         *,
         shape: Optional[Shape] = None,
-        size: Optional[Size] = None,
         **kwargs,
     ) -> RandomVariable:
         """Creates a RandomVariable corresponding to the `cls` distribution.
@@ -312,8 +311,9 @@ class Distribution(metaclass=DistributionMeta):
 
             An Ellipsis (...) may be inserted in the last position to short-hand refer to
             all the dimensions that the RV would get if no shape/size/dims were passed at all.
-        size : int, tuple, Variable, optional
-            For creating the RV like in Aesara/NumPy.
+        **kwargs
+            Keyword arguments that will be forwarded to the Aesara RV Op.
+            Most prominently: ``size`` or ``dtype``.
 
         Returns
         -------
@@ -337,6 +337,7 @@ class Distribution(metaclass=DistributionMeta):
 
         if "dims" in kwargs:
             raise NotImplementedError("The use of a `.dist(dims=...)` API is not supported.")
+        size = kwargs.pop("size", None)
         if shape is not None and size is not None:
             raise ValueError(
                 f"Passing both `shape` ({shape}) and `size` ({size}) is not supported!"

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -227,7 +227,7 @@ class Distribution(metaclass=DistributionMeta):
             See ``Model.register_rv``.
         **kwargs
             Keyword arguments that will be forwarded to ``.dist()`` or the Aesara RV Op.
-            Most prominently: ``shape`` for ``.dist()`` and ``size`` or ``dtype`` for the Op.
+            Most prominently: ``shape`` for ``.dist()`` or ``dtype`` for the Op.
 
         Returns
         -------


### PR DESCRIPTION
This PR implements how I propose to resolve #5754.

It kicks the argument from the signature, but continues to support it for internal use & to maintain API continuity with Aesara & aeppl.

I made the corresponding changes for `Flat`, `HalfFlat`, but I don't know how to go about `Bound` which has multiple other kwargs from the Distribution API in it's signature.
Also the GaussianRandomWalk has a `size` kwarg that I wasn't sure how to remove without having to starting thinking.

Anybody please feel free to take over the branch.