### PR TITLE
Latex representation for SymbolicDistributions

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -42,7 +42,7 @@ from pymc.distributions.dist_math import (
     normal_lccdf,
     normal_lcdf,
 )
-from pymc.distributions.distribution import Discrete
+from pymc.distributions.distribution import Discrete, set_print_name
 from pymc.distributions.logprob import logp
 from pymc.distributions.mixture import Mixture
 from pymc.distributions.shape_utils import rv_size_is_none
@@ -1411,7 +1411,7 @@ class Constant(Discrete):
         )
 
 
-def _zero_inflated_mixture(*, name, nonzero_p, nonzero_dist, **kwargs):
+def _zero_inflated_mixture(*, cls, name, nonzero_p, nonzero_dist, **kwargs):
     """Helper function to create a zero-inflated mixture
 
     If name is `None`, this function returns an unregistered variable
@@ -1423,9 +1423,14 @@ def _zero_inflated_mixture(*, name, nonzero_p, nonzero_dist, **kwargs):
         nonzero_dist,
     ]
     if name is not None:
-        return Mixture(name, weights, comp_dists, **kwargs)
+        rv_out = Mixture(name, weights, comp_dists, **kwargs)
     else:
-        return Mixture.dist(weights, comp_dists, **kwargs)
+        rv_out = Mixture.dist(weights, comp_dists, **kwargs)
+
+    # overriding Mixture _print_name
+    set_print_name(cls, rv_out)
+
+    return rv_out
 
 
 class ZeroInflatedPoisson:
@@ -1481,13 +1486,13 @@ class ZeroInflatedPoisson:
 
     def __new__(cls, name, psi, mu, **kwargs):
         return _zero_inflated_mixture(
-            name=name, nonzero_p=psi, nonzero_dist=Poisson.dist(mu=mu), **kwargs
+            cls=cls, name=name, nonzero_p=psi, nonzero_dist=Poisson.dist(mu=mu), **kwargs
         )
 
     @classmethod
     def dist(cls, psi, mu, **kwargs):
         return _zero_inflated_mixture(
-            name=None, nonzero_p=psi, nonzero_dist=Poisson.dist(mu=mu), **kwargs
+            cls=cls, name=None, nonzero_p=psi, nonzero_dist=Poisson.dist(mu=mu), **kwargs
         )
 
 
@@ -1545,13 +1550,13 @@ class ZeroInflatedBinomial:
 
     def __new__(cls, name, psi, n, p, **kwargs):
         return _zero_inflated_mixture(
-            name=name, nonzero_p=psi, nonzero_dist=Binomial.dist(n=n, p=p), **kwargs
+            cls=cls, name=name, nonzero_p=psi, nonzero_dist=Binomial.dist(n=n, p=p), **kwargs
         )
 
     @classmethod
     def dist(cls, psi, n, p, **kwargs):
         return _zero_inflated_mixture(
-            name=None, nonzero_p=psi, nonzero_dist=Binomial.dist(n=n, p=p), **kwargs
+            cls=cls, name=None, nonzero_p=psi, nonzero_dist=Binomial.dist(n=n, p=p), **kwargs
         )
 
 
@@ -1638,6 +1643,7 @@ class ZeroInflatedNegativeBinomial:
 
     def __new__(cls, name, psi, mu=None, alpha=None, p=None, n=None, **kwargs):
         return _zero_inflated_mixture(
+            cls=cls,
             name=name,
             nonzero_p=psi,
             nonzero_dist=NegativeBinomial.dist(mu=mu, alpha=alpha, p=p, n=n),
@@ -1647,6 +1653,7 @@ class ZeroInflatedNegativeBinomial:
     @classmethod
     def dist(cls, psi, mu=None, alpha=None, p=None, n=None, **kwargs):
         return _zero_inflated_mixture(
+            cls=cls,
             name=None,
             nonzero_p=psi,
             nonzero_dist=NegativeBinomial.dist(mu=mu, alpha=alpha, p=p, n=n),

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -484,7 +484,9 @@ class SymbolicDistribution:
             initval=initval,
         )
 
+        # TODO: if rv_out is a cloned variable, the line below wouldn't work
         set_print_name(cls, rv_out)
+
         rv_out.str_repr = types.MethodType(str_for_symbolic_dist, rv_out)
         rv_out._repr_latex_ = types.MethodType(
             functools.partial(str_for_symbolic_dist, formatting="latex"), rv_out

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -47,7 +47,7 @@ from pymc.distributions.shape_utils import (
     resize_from_dims,
     resize_from_observed,
 )
-from pymc.printing import str_for_dist
+from pymc.printing import str_for_dist, str_for_symbolic_dist
 from pymc.util import UNSET
 from pymc.vartypes import string_types
 
@@ -484,15 +484,11 @@ class SymbolicDistribution:
             initval=initval,
         )
 
-        # TODO: Refactor this
-        # add in pretty-printing support
-        rv_out.str_repr = lambda *args, **kwargs: name
-        rv_out._repr_latex_ = f"\\text{name}"
-        # rv_out.str_repr = types.MethodType(str_for_dist, rv_out)
-        # rv_out._repr_latex_ = types.MethodType(
-        #     functools.partial(str_for_dist, formatting="latex"), rv_out
-        # )
-
+        set_print_name(cls, rv_out)
+        rv_out.str_repr = types.MethodType(str_for_symbolic_dist, rv_out)
+        rv_out._repr_latex_ = types.MethodType(
+            functools.partial(str_for_symbolic_dist, formatting="latex"), rv_out
+        )
         return rv_out
 
     @classmethod
@@ -521,7 +517,6 @@ class SymbolicDistribution:
         -------
         var : TensorVariable
         """
-
         if "testval" in kwargs:
             kwargs.pop("testval")
             warnings.warn(
@@ -848,3 +843,7 @@ def default_moment(rv, size, *rv_inputs, rv_name=None, has_fallback=False, ndim_
             f"Please provide a moment function when instantiating the {rv_name} "
             "random variable."
         )
+
+
+def set_print_name(cls, rv):
+    setattr(rv.owner.op, "_print_name", (f"{cls.__name__}", f"\\operatorname{{{cls.__name__}}}"))

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -93,10 +93,9 @@ def str_for_symbolic_dist(
         elif "Censored" in rv.owner.op._print_name[0]:
             start_idx_para = 2
         else:
-            raise ValueError(
-                "Latex printing not yet implemented for this SymbolicDistribution\n"
-                "Please update the str_for_symbolic_dist in pymc/printing.py file."
-            )
+            # Latex representation for the SymbolicDistribution has not been implemented.
+            # Hoping for the best here!
+            start_idx_para = 2
 
         dist_args = [
             dispatch_comp_str(dist_para, formatting=formatting, include_params=include_params)

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -26,6 +26,7 @@ from pymc.model import Model
 
 __all__ = [
     "str_for_dist",
+    "str_for_symbolic_dist",
     "str_for_model",
     "str_for_potential_or_deterministic",
 ]
@@ -35,6 +36,37 @@ def str_for_dist(rv: TensorVariable, formatting: str = "plain", include_params: 
     """Make a human-readable string representation of a RandomVariable in a model, either
     LaTeX or plain, optionally with distribution parameter values included."""
 
+    if include_params:
+        # first 3 args are always (rng, size, dtype), rest is relevant for distribution
+        dist_args = [_str_for_input_var(x, formatting=formatting) for x in rv.owner.inputs[3:]]
+
+    print_name = rv.name if rv.name is not None else "<unnamed>"
+    if "latex" in formatting:
+        print_name = r"\text{" + _latex_escape(print_name) + "}"
+        dist_name = rv.owner.op._print_name[1]
+        if include_params:
+            return r"${} \sim {}({})$".format(print_name, dist_name, ",~".join(dist_args))
+        else:
+            return rf"${print_name} \sim {dist_name}$"
+    else:  # plain
+        dist_name = rv.owner.op._print_name[0]
+        if include_params:
+            return r"{} ~ {}({})".format(print_name, dist_name, ", ".join(dist_args))
+        else:
+            return rf"{print_name} ~ {dist_name}"
+
+
+def str_for_symbolic_dist(
+    rv: TensorVariable, formatting: str = "plain", include_params: bool = True
+) -> str:
+
+    # code would look something like this:
+    # if "ZeroInflated" in rv.owner.op._print_name[0]:
+    #     return
+    # if "Mixture" in rv.owner.op._print_name[0]:
+    #     return
+
+    # below is copy-pasted from str_for_dist
     if include_params:
         # first 3 args are always (rng, size, dtype), rest is relevant for distribution
         dist_args = [_str_for_input_var(x, formatting=formatting) for x in rv.owner.inputs[3:]]


### PR DESCRIPTION
Closes #5616.

This PR adds Latex presentation to `SymbolicDistribution`s which does not construct `rv_op`s like regular `Distribution`s, hence why the Latex representation is currently broken.

I would like some advice on how to carry this out. Dispatching was recommended, but the initial class which was called does not seem to be encoded in `TensorVariable`s for `SymbolicDistribution`s. I currently set it up so that a new `str_for_symbolic_dist` function would be called for `SymbolicDistribution`s for `_print_name`s which can be automatically initialized for such distributions (except for zero-inflated ones because they are created via `pm.Mixture`). Here are the internal changes that I came up with, but I'm happy to hear discussion about these points:

- `cls` is now passed in `_zero_inflated_mixture` so they don't come out as "Mixture"
- Akin to [`str_for_dist`](https://github.com/pymc-devs/pymc/blob/main/pymc/printing.py#L34), `str_for_symbolic_dist` is created in `printing.py` in which pattern matching can be used to determine how to print the corresponding distribution. I have yet to address this and perhaps this is where dispatching would be useful?
- `_print_name` attributes initialized for `SymbolicDistribution`s

Some printing references that have been provided: [AePPL printing](https://github.com/aesara-devs/aeppl/blob/main/aeppl/printing.py) and [symbolic-pymc printing](https://github.com/pymc-devs/symbolic-pymc/blob/84e8d612c714f502f8d188c1766498f4ff7beecf/symbolic_pymc/tensorflow/printing.py). Both of which use dispatching, but only the latter uses `singledispatch`.