### PR TITLE
raise not implemented error for non refactored distributions and functions

### DIFF
--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -648,6 +648,13 @@ class GARCH11(distribution.Continuous):
         initial_vol >= 0, initial volatility, sigma_0
     """
 
+    def __new__(cls, *args, **kwargs):
+        raise NotImplementedError(f"{cls.__name__} has not yet been ported to PyMC 4.0.")
+
+    @classmethod
+    def dist(cls, *args, **kwargs):
+        raise NotImplementedError(f"{cls.__name__} has not yet been ported to PyMC 4.0.")
+
     def __init__(self, omega, alpha_1, beta_1, initial_vol, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -705,6 +712,13 @@ class EulerMaruyama(distribution.Continuous):
         parameters of the SDE, passed as ``*args`` to ``sde_fn``
     """
 
+    def __new__(cls, *args, **kwargs):
+        raise NotImplementedError(f"{cls.__name__} has not yet been ported to PyMC 4.0.")
+
+    @classmethod
+    def dist(cls, *args, **kwargs):
+        raise NotImplementedError(f"{cls.__name__} has not yet been ported to PyMC 4.0.")
+
     def __init__(self, dt, sde_fn, sde_pars, *args, **kwds):
         super().__init__(*args, **kwds)
         self.dt = dt = at.as_tensor_variable(dt)
@@ -756,6 +770,13 @@ class MvGaussianRandomWalk(distribution.Continuous):
     Only one of cov, tau or chol is required.
 
     """
+
+    def __new__(cls, *args, **kwargs):
+        raise NotImplementedError(f"{cls.__name__} has not yet been ported to PyMC 4.0.")
+
+    @classmethod
+    def dist(cls, *args, **kwargs):
+        raise NotImplementedError(f"{cls.__name__} has not yet been ported to PyMC 4.0.")
 
     def __init__(
         self, mu=0.0, cov=None, tau=None, chol=None, lower=True, init=None, *args, **kwargs
@@ -878,6 +899,13 @@ class MvStudentTRandomWalk(MvGaussianRandomWalk):
     init: distribution
         distribution for initial value (Defaults to Flat())
     """
+
+    def __new__(cls, *args, **kwargs):
+        raise NotImplementedError(f"{cls.__name__} has not yet been ported to PyMC 4.0.")
+
+    @classmethod
+    def dist(cls, *args, **kwargs):
+        raise NotImplementedError(f"{cls.__name__} has not yet been ported to PyMC 4.0.")
 
     def __init__(self, nu, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -2032,6 +2032,8 @@ def sample_posterior_predictive_w(
         weighted models (default), or a dictionary with variable names as keys, and samples as
         numpy arrays.
     """
+    raise NotImplementedError(f"sample_posterior_predictive_w has not yet been ported to PyMC 4.0.")
+
     if isinstance(traces[0], InferenceData):
         n_samples = [
             trace.posterior.sizes["chain"] * trace.posterior.sizes["draw"] for trace in traces

--- a/pymc/tests/test_distributions_timeseries.py
+++ b/pymc/tests/test_distributions_timeseries.py
@@ -435,7 +435,7 @@ class TestAR:
         assert_moment_is_expected(model, expected, check_finite_logp=False)
 
 
-@pytest.mark.xfail(reason="Timeseries not refactored")
+@pytest.mark.xfail(reason="Timeseries not refactored", raises=NotImplementedError)
 def test_GARCH11():
     # test data ~ N(0, 1)
     data = np.array(
@@ -496,7 +496,7 @@ def _gen_sde_path(sde, pars, dt, n, x0):
     return np.array(xs)
 
 
-@pytest.mark.xfail(reason="Timeseries not refactored")
+@pytest.mark.xfail(reason="Timeseries not refactored", raises=NotImplementedError)
 def test_linear():
     lam = -0.78
     sig2 = 5e-3

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -935,8 +935,10 @@ class TestSamplePPC(SeededTest):
         assert np.all(np.abs(ppc.posterior_predictive.c + 4) <= 0.1)
 
 
+@pytest.mark.xfail(
+    reason="sample_posterior_predictive_w not refactored for v4", raises=NotImplementedError
+)
 class TestSamplePPCW(SeededTest):
-    @pytest.mark.xfail(reason="sample_posterior_predictive_w not refactored for v4")
     def test_sample_posterior_predictive_w(self):
         data0 = np.random.normal(0, 1, size=50)
         warning_msg = "The number of samples is too small to check convergence reliably"
@@ -986,7 +988,6 @@ class TestSamplePPCW(SeededTest):
         ):
             pm.sample_posterior_predictive_w([trace_0, trace_2], 100, [model_0, model_2])
 
-    @pytest.mark.xfail(reason="sample_posterior_predictive_w not refactored for v4")
     def test_potentials_warning(self):
         warning_msg = "The effect of Potentials on other parameters is ignored during"
         with pm.Model() as m:


### PR DESCRIPTION
Closes #5676

* The PR raises a `NotImplemented` error on attempt to create not yet refactored timeseries distributions or sample_posterior_predctive_w
* Also refactored tests to catch the correct error is passed to the user side