### PR TITLE
Limit model graph nodes to named model variables

### DIFF
--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -47,7 +47,12 @@ class ModelGraph:
                 return reversed(x.owner.inputs)
             return []
 
-        parents = {get_var_name(x) for x in walk(nodes=var.owner.inputs, expand=_expand) if x.name}
+        parents = {
+            get_var_name(x)
+            for x in walk(nodes=var.owner.inputs, expand=_expand)
+            # Only consider nodes that are in the named model variables.
+            if x.name and x.name in self._all_var_names
+        }
 
         return parents
 


### PR DESCRIPTION
Some nodes such as `NoneConst` in an Aesara graph are named, but aren't model variables
that the user is interested in.

Prior to this fix, the model graph would print nodes like this:

![grafik](https://user-images.githubusercontent.com/5894642/170316131-c712b7f6-7b1a-4d9b-9631-fbd1db08718f.png)
