### PR TITLE
Fix bug in Slice sampler and speedup `test_step.py`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -148,8 +148,7 @@ This includes API changes we did not warn about since at least `3.11.0` (2021-01
 - Added the low level `compile_forward_sampling_function` method to compile the aesara function responsible for generating forward samples (see [#5759](https://github.com/pymc-devs/pymc/pull/5759)).
 - ...
 
-
-## Documentation
+### Documentation
 - Switched to the [pydata-sphinx-theme](https://pydata-sphinx-theme.readthedocs.io/en/latest/)
 - Updated our documentation tooling to use [MyST](https://myst-parser.readthedocs.io/en/latest/), [MyST-NB](https://myst-nb.readthedocs.io/en/latest/), sphinx-design, notfound.extension,
   sphinx-copybutton and sphinx-remove-toctrees.
@@ -157,7 +156,8 @@ This includes API changes we did not warn about since at least `3.11.0` (2021-01
 - Restructured the documentation to facilitate learning paths
 - Updated API docs to document objects at the path users should use to import them
 
-### Internal changes
+### Maintenance
+- ⚠ Fixed old-time bug in Slice sampler that resulted in biased samples (see [#5816](https://github.com/pymc-devs/pymc/pull/5816)).
 - ⚠ PyMC now requires Scipy version `>= 1.4.1` (see [4857](https://github.com/pymc-devs/pymc/pull/4857)).
 - Removed float128 dtype support (see [#4514](https://github.com/pymc-devs/pymc/pull/4514)).
 - Logp method of `Uniform` and `DiscreteUniform` no longer depends on `pymc.distributions.dist_math.bound` for proper evaluation (see [#4541](https://github.com/pymc-devs/pymc/pull/4541)).

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -33,6 +33,9 @@ class CompoundStep:
         for method in self.methods:
             if method.generates_stats:
                 self.stats_dtypes.extend(method.stats_dtypes)
+        self.name = (
+            f"Compound[{', '.join(getattr(m, 'name', 'UNNAMED_STEP') for m in self.methods)}]"
+        )
 
     def step(self, point):
         if self.generates_stats:

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -66,37 +66,42 @@ class Slice(ArrayStep):
     def astep(self, q0, logp):
         q0_val = q0.data
         self.w = np.resize(self.w, len(q0_val))  # this is a repmat
-        q = np.copy(q0_val)  # TODO: find out if we need this
+
+        q = np.copy(q0_val)
         ql = np.copy(q0_val)  # l for left boundary
         qr = np.copy(q0_val)  # r for right boudary
-        for i in range(len(q0_val)):
+
+        # The points are not copied, so it's fine to update them inplace in the
+        # loop below
+        q_ra = RaveledVars(q, q0.point_map_info)
+        ql_ra = RaveledVars(ql, q0.point_map_info)
+        qr_ra = RaveledVars(qr, q0.point_map_info)
+
+        for i, wi in enumerate(self.w):
             # uniformly sample from 0 to p(q), but in log space
-            q_ra = RaveledVars(q, q0.point_map_info)
             y = logp(q_ra) - nr.standard_exponential()
 
             # Create initial interval
-            ql[i] = q[i] - nr.uniform() * self.w[i]  # q[i] + r * w
-            qr[i] = ql[i] + self.w[i]  # Equivalent to q[i] + (1-r) * w
+            ql[i] = q[i] - nr.uniform() * wi  # q[i] + r * w
+            qr[i] = ql[i] + wi  # Equivalent to q[i] + (1-r) * w
 
             # Stepping out procedure
             cnt = 0
-            while y <= logp(
-                RaveledVars(ql, q0.point_map_info)
-            ):  # changed lt to leq  for locally uniform posteriors
-                ql[i] -= self.w[i]
+            while y <= logp(ql_ra):  # changed lt to leq  for locally uniform posteriors
+                ql[i] -= wi
                 cnt += 1
                 if cnt > self.iter_limit:
                     raise RuntimeError(LOOP_ERR_MSG % self.iter_limit)
             cnt = 0
-            while y <= logp(RaveledVars(qr, q0.point_map_info)):
-                qr[i] += self.w[i]
+            while y <= logp(qr_ra):
+                qr[i] += wi
                 cnt += 1
                 if cnt > self.iter_limit:
                     raise RuntimeError(LOOP_ERR_MSG % self.iter_limit)
 
             cnt = 0
             q[i] = nr.uniform(ql[i], qr[i])
-            while logp(q_ra) < y:  # Changed leq to lt, to accomodate for locally flat posteriors
+            while y > logp(q_ra):  # Changed leq to lt, to accomodate for locally flat posteriors
                 # Sample uniformly from slice
                 if q[i] > q0_val[i]:
                     qr[i] = q[i]
@@ -110,7 +115,7 @@ class Slice(ArrayStep):
             if self.tune:
                 # I was under impression from MacKays lectures that slice width can be tuned without
                 # breaking markovianness. Can we do it regardless of self.tune?(@madanh)
-                self.w[i] = self.w[i] * (self.n_tunes / (self.n_tunes + 1)) + (qr[i] - ql[i]) / (
+                self.w[i] = wi * (self.n_tunes / (self.n_tunes + 1)) + (qr[i] - ql[i]) / (
                     self.n_tunes + 1
                 )
 
@@ -119,6 +124,7 @@ class Slice(ArrayStep):
 
         if self.tune:
             self.n_tunes += 1
+
         return q
 
     @staticmethod

--- a/pymc/tests/test_step.py
+++ b/pymc/tests/test_step.py
@@ -221,6 +221,16 @@ class TestCompoundStep:
                     assert not isinstance(sampler_instance, CompoundStep)
                     assert isinstance(sampler_instance, sampler)
 
+    def test_name(self):
+        with Model() as m:
+            c1 = HalfNormal("c1")
+            c2 = HalfNormal("c2")
+
+            step1 = NUTS([c1])
+            step2 = Slice([c2])
+            step = CompoundStep([step1, step2])
+        assert step.name == "Compound[nuts, slice]"
+
 
 class TestAssignStepMethods:
     def test_bernoulli(self):


### PR DESCRIPTION
Closes #5815 

I changed the logic when creating the initial interval according to MacKay (2005, page 375) [[pdf](https://www.inference.org.uk/itprnn/book.pdf)].

![image](https://user-images.githubusercontent.com/28983449/170834162-f05db517-64a9-4510-8d45-af69cf5de746.png)

### Before

```python
ql[i] = q[i] - nr.uniform(0, self.w[i])
qr[i] = q[i] + self.w[i]
```

### After
```python
r = nr.uniform()
ql[i] = q[i] - r * self.w[i]
qr[i] = q[i] + (1 - r) * self.w[i]
```

I think the previous was causing the proposals to be systematically biased towards higher values (right).

Also made sure that we set the boundaries of previous variables to the accepted values, which probably by mistake was only being done during tuning.

```
# Set qr and ql to the accepted points (they matter for subsequent iterations)
qr[i] = ql[i] = q[i]
```

If someone more familiar with these can confirm my changes to `Slice` make sense that would be great. 

The sampler now converges in the multivariate example in #5815, and does an increasingly better job with more samples.

***

Also did some other minor changes, see individual commits for more details.