### PR TITLE
add Quick links to Contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,15 @@
 # Guidelines for Contributing
 
-The guidelines for contributing to the PyMC project are available
-on [our documentation](https://docs.pymc.io/en/latest/contributing/index.html)
+Thank you for being interested in contributing to PyMC. PyMC is an open source, collective effort, and everyone is welcome to contribute. There are many ways in which you can help make it better. Please check the latest information for contributing to the PyMC project on [this guidelines](https://docs.pymc.io/en/latest/contributing/index.html).
+
+Quick links
+-----------
+
+* [Pull request (PR) step-by-step ](https://docs.pymc.io/en/latest/contributing/pr_tutorial.html)
+* [Pull request (PR) checklist](https://docs.pymc.io/en/latest/contributing/pr_checklist.html)
+* [Python style guide with pre-commit](https://docs.pymc.io/en/latest/contributing/python_style.html)
+* [Running the test suite](https://docs.pymc.io/en/latest/contributing/running_the_test_suite.html)
+* [Submitting a bug report or feature request](https://github.com/pymc-devs/pymc/issues)
 
 <!-- Commented out because our Docker image is outdated/broken.
 ## Developing in Docker


### PR DESCRIPTION
Hi, as in a previous discussion with @OriolAbril, adding a Quick links (similar to [scikit-learn contributing guide](https://github.com/scikit-learn/scikit-learn/edit/main/CONTRIBUTING.md)) could make it easier for new contributors to access different contents in the PyMC Contributing guidelines. Thanks.

cc @ricardoV94 @michaelosthege 