### PR TITLE
Make Metropolis cope better with multiple dimensions

### DIFF
--- a/pymc/step_methods/mlda.py
+++ b/pymc/step_methods/mlda.py
@@ -787,11 +787,11 @@ class MLDA(ArrayStepShared):
         if isinstance(self.step_method_below, MLDA):
             self.base_tuning_stats = self.step_method_below.base_tuning_stats
         elif isinstance(self.step_method_below, MetropolisMLDA):
-            self.base_tuning_stats.append({"base_scaling": self.step_method_below.scaling})
+            self.base_tuning_stats.append({"base_scaling": np.mean(self.step_method_below.scaling)})
         elif isinstance(self.step_method_below, DEMetropolisZMLDA):
             self.base_tuning_stats.append(
                 {
-                    "base_scaling": self.step_method_below.scaling,
+                    "base_scaling": np.mean(self.step_method_below.scaling),
                     "base_lambda": self.step_method_below.lamb,
                 }
             )
@@ -799,10 +799,10 @@ class MLDA(ArrayStepShared):
             # Below method is CompoundStep
             for method in self.step_method_below.methods:
                 if isinstance(method, MetropolisMLDA):
-                    self.base_tuning_stats.append({"base_scaling": method.scaling})
+                    self.base_tuning_stats.append({"base_scaling": np.mean(method.scaling)})
                 elif isinstance(method, DEMetropolisZMLDA):
                     self.base_tuning_stats.append(
-                        {"base_scaling": method.scaling, "base_lambda": method.lamb}
+                        {"base_scaling": np.mean(method.scaling), "base_lambda": method.lamb}
                     )
 
         return q_new, [stats] + self.base_tuning_stats


### PR DESCRIPTION
Metropolis now updates each dimension sequentially and tunes a proposal scale parameter per dimension

The performance of the Metropolis sampler with multiple dimensions was incredibly poor as highlighted in this old closed issue https://github.com/pymc-devs/pymc/issues/4223. After these changes, the performance should now be similar between the scalar and batched cases.

Some care had to be taken towards multivariate discrete distributions where we cannot safely update one dimension at a time (e.g., multinomial), because any intermediate change would result in -inf logp. We should probably implement a smarter sampler just for this distribution, but for the time being we avoid doing elemwise updates when multivariate discrete variables are assigned.

