### PR TITLE
Small improvements to early nuts behaviour

### DIFF
--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -236,6 +236,7 @@ class BaseHMC(GradientSharedStep):
 
         stats.update(hmc_step.stats)
         stats.update(self.step_adapt.stats())
+        stats.update(self.potential.stats())
 
         return hmc_step.end.q, [stats]
 

--- a/pymc/step_methods/hmc/hmc.py
+++ b/pymc/step_methods/hmc/hmc.py
@@ -51,6 +51,8 @@ class HamiltonianMC(BaseHMC):
             "process_time_diff": np.float64,
             "perf_counter_diff": np.float64,
             "perf_counter_start": np.float64,
+            "largest_eigval": np.float64,
+            "smallest_eigval": np.float64,
         }
     ]
 
@@ -162,7 +164,16 @@ class HamiltonianMC(BaseHMC):
             "model_logp": state.model_logp,
         }
         # Retrieve State q and p data from respective RaveledVars
-        end = State(end.q.data, end.p.data, end.v, end.q_grad, end.energy, end.model_logp)
+        end = State(
+            end.q.data,
+            end.p.data,
+            end.v,
+            end.q_grad,
+            end.energy,
+            end.model_logp,
+            end.index_in_trajectory,
+        )
+        stats.update(self.potential.stats())
         return HMCStepData(end, accept_stat, div_info, stats)
 
     @staticmethod

--- a/pymc/step_methods/hmc/integration.py
+++ b/pymc/step_methods/hmc/integration.py
@@ -114,4 +114,12 @@ class CpuLeapfrogIntegrator:
         kinetic = pot.velocity_energy(p_new.data, v_new)
         energy = kinetic - logp
 
-        return State(q_new, p_new, v_new, q_new_grad, energy, logp, state.index_in_trajectory + int(np.sign(epsilon)))
+        return State(
+            q_new,
+            p_new,
+            v_new,
+            q_new_grad,
+            energy,
+            logp,
+            state.index_in_trajectory + int(np.sign(epsilon)),
+        )

--- a/pymc/step_methods/hmc/integration.py
+++ b/pymc/step_methods/hmc/integration.py
@@ -20,7 +20,7 @@ from scipy import linalg
 
 from pymc.blocking import RaveledVars
 
-State = namedtuple("State", "q, p, v, q_grad, energy, model_logp")
+State = namedtuple("State", "q, p, v, q_grad, energy, model_logp, index_in_trajectory")
 
 
 class IntegrationError(RuntimeError):
@@ -49,7 +49,7 @@ class CpuLeapfrogIntegrator:
         v = self._potential.velocity(p.data)
         kinetic = self._potential.energy(p.data, velocity=v)
         energy = kinetic - logp
-        return State(q, p, v, dlogp, energy, logp)
+        return State(q, p, v, dlogp, energy, logp, 0)
 
     def step(self, epsilon, state):
         """Leapfrog integrator step.
@@ -114,4 +114,4 @@ class CpuLeapfrogIntegrator:
         kinetic = pot.velocity_energy(p_new.data, v_new)
         energy = kinetic - logp
 
-        return State(q_new, p_new, v_new, q_new_grad, energy, logp)
+        return State(q_new, p_new, v_new, q_new_grad, energy, logp, state.index_in_trajectory + int(np.sign(epsilon)))

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -351,9 +351,7 @@ class _Tree:
                     right.model_logp,
                     right.index_in_trajectory,
                 )
-                tree = Subtree(
-                    right, right, right.p.data, proposal, log_size
-                )
+                tree = Subtree(right, right, right.p.data, proposal, log_size)
                 return tree, None, False
             else:
                 error_msg = f"Energy change in leapfrog step is too large: {energy_change}."

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -78,6 +78,12 @@ class NUTS(BaseHMC):
       by the python standard library `time.perf_counter` (wall time).
     - `perf_counter_start`: The value of `time.perf_counter` at the beginning
       of the computation of the draw.
+    - `index_in_trajectory`: This is usually only interesting for debugging
+      purposes. This indicates the position of the posterior draw in the
+      trajectory. Eg a -4 would indicate that the draw was the result of the
+      fourth leapfrog step in negative direction.
+    - `largest_eigval` and `smallest_eigval`: Experimental statistics for
+      some mass matrix adaptation algorithms. This is nan if it is not used.
 
     References
     ----------

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -339,7 +339,7 @@ class _Tree:
 
             if np.abs(energy_change) > np.abs(self.max_energy_change):
                 self.max_energy_change = energy_change
-            if np.abs(energy_change) < self.Emax:
+            if energy_change < self.Emax:
                 # Acceptance statistic
                 # e^{H(q_0, p_0) - H(q_n, p_n)} max(1, e^{H(q_0, p_0) - H(q_n, p_n)})
                 # Saturated Metropolis accept probability with Boltzmann weight

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -105,6 +105,9 @@ class NUTS(BaseHMC):
             "process_time_diff": np.float64,
             "perf_counter_diff": np.float64,
             "perf_counter_start": np.float64,
+            "largest_eigval": np.float64,
+            "smallest_eigval": np.float64,
+            "index_in_trajectory": np.int64,
         }
     ]
 
@@ -219,7 +222,7 @@ class NUTS(BaseHMC):
 
 
 # A proposal for the next position
-Proposal = namedtuple("Proposal", "q, q_grad, energy, logp")
+Proposal = namedtuple("Proposal", "q, q_grad, energy, logp, index_in_trajectory")
 
 # A subtree of the binary tree built by nuts.
 Subtree = namedtuple(
@@ -252,7 +255,7 @@ class _Tree:
         self.start_energy = np.array(start.energy)
 
         self.left = self.right = start
-        self.proposal = Proposal(start.q.data, start.q_grad, start.energy, start.model_logp)
+        self.proposal = Proposal(start.q.data, start.q_grad, start.energy, start.model_logp, 0)
         self.depth = 0
         self.log_size = 0
         self.log_accept_sum = -np.inf
@@ -346,6 +349,7 @@ class _Tree:
                     right.q_grad,
                     right.energy,
                     right.model_logp,
+                    right.index_in_trajectory,
                 )
                 tree = Subtree(
                     right, right, right.p.data, proposal, log_size
@@ -406,4 +410,5 @@ class _Tree:
             "tree_size": self.n_proposals,
             "max_energy_error": self.max_energy_change,
             "model_logp": self.proposal.logp,
+            "index_in_trajectory": self.proposal.index_in_trajectory,
         }

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -282,7 +282,7 @@ class _Tree:
             )
             leftmost_begin, leftmost_end = self.left, self.right
             rightmost_begin, rightmost_end = tree.left, tree.right
-            leftmost_p_sum = self.p_sum
+            leftmost_p_sum = self.p_sum.copy()
             rightmost_p_sum = tree.p_sum
             self.right = tree.right
         else:
@@ -292,7 +292,7 @@ class _Tree:
             leftmost_begin, leftmost_end = tree.right, tree.left
             rightmost_begin, rightmost_end = self.left, self.right
             leftmost_p_sum = tree.p_sum
-            rightmost_p_sum = self.p_sum
+            rightmost_p_sum = self.p_sum.copy()
             self.left = tree.right
 
         self.depth += 1

--- a/pymc/step_methods/hmc/quadpotential.py
+++ b/pymc/step_methods/hmc/quadpotential.py
@@ -254,6 +254,7 @@ class QuadPotentialDiagAdapt(QuadPotential):
 
     def _update_from_weightvar(self, weightvar):
         weightvar.current_variance(out=self._var)
+        self._var = np.clip(self._var, 1e-12, 1e12)
         np.sqrt(self._var, out=self._stds)
         np.divide(1, self._stds, out=self._inv_stds)
         self._var_aesara.set_value(self._var)

--- a/pymc/step_methods/hmc/quadpotential.py
+++ b/pymc/step_methods/hmc/quadpotential.py
@@ -136,6 +136,9 @@ class QuadPotential:
     def reset(self):
         pass
 
+    def stats(self):
+        return {"largest_eigval": np.nan, "smallest_eigval": np.nan}
+
 
 def isquadpotential(value):
     """Check whether an object might be a QuadPotential object."""

--- a/pymc/tests/test_step.py
+++ b/pymc/tests/test_step.py
@@ -595,6 +595,9 @@ class TestNutsCheckTrace:
             "perf_counter_diff",
             "perf_counter_start",
             "process_time_diff",
+            "index_in_trajectory",
+            "largest_eigval",
+            "smallest_eigval",
         }
         assert trace.stat_names == expected_stat_names
         for varname in trace.stat_names:


### PR DESCRIPTION
Step size adaptation:
Currently, we compute the acceptance rate of a draw only in that part of the trajectory that is accepted at the end. This way we discard some additional information about energy errors in the remaining discarded part. After this PR we compute the mean acceptance rate over all leapfrog steps we take.

Divergences:
Currently we count large derivations from the initial energy as a divergence regardless of the direction of the energy error.
This PR changes this so that only large energy errors that correspond to a low acceptance probability are considered a divergence. I think this helps with some model in the initial phase of sampling, were with the old behavior we stop promising trajectories that are *too good*, leading to worse performance.

Also a little bit of housekeeping:
This introduces an additional sampler statistic: `index_in_trajectory`. I don't see much of a use-case for this other than teaching and debugging, but it proved useful while comparing the sampler to other implementations.

I also introduced some array copies for the integrated momentum array. I thought I saw bugs while comparing sampler behavior to nuts-rs, but somehow I can't reproduce those now. Still, I think it's better to be safe.