### PR TITLE
Supress warning SMC initialization

### DIFF
--- a/pymc/smc/smc.py
+++ b/pymc/smc/smc.py
@@ -14,6 +14,7 @@
 import abc
 
 from abc import ABC
+import sys
 from typing import Dict, cast
 import warnings
 
@@ -176,7 +177,7 @@ class SMC_KERNEL(ABC):
 
     def initialize_population(self) -> Dict[str, np.ndarray]:
         """Create an initial population from the prior distribution"""
-        print()
+        sys.stdout.write(" ")
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", category=UserWarning, message="The effect of Potentials"

--- a/pymc/smc/smc.py
+++ b/pymc/smc/smc.py
@@ -177,7 +177,7 @@ class SMC_KERNEL(ABC):
 
     def initialize_population(self) -> Dict[str, np.ndarray]:
         """Create an initial population from the prior distribution"""
-        sys.stdout.write(" ")
+        sys.stdout.write(" ")  # see issue #5828
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", category=UserWarning, message="The effect of Potentials"

--- a/pymc/smc/smc.py
+++ b/pymc/smc/smc.py
@@ -15,6 +15,7 @@ import abc
 
 from abc import ABC
 from typing import Dict, cast
+import warnings
 
 import aesara.tensor as at
 import numpy as np
@@ -175,12 +176,18 @@ class SMC_KERNEL(ABC):
 
     def initialize_population(self) -> Dict[str, np.ndarray]:
         """Create an initial population from the prior distribution"""
-        result = sample_prior_predictive(
-            self.draws,
-            var_names=[v.name for v in self.model.unobserved_value_vars],
-            model=self.model,
-            return_inferencedata=False,
-        )
+        print()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", category=UserWarning, message="The effect of Potentials"
+            )
+
+            result = sample_prior_predictive(
+                self.draws,
+                var_names=[v.name for v in self.model.unobserved_value_vars],
+                model=self.model,
+                return_inferencedata=False,
+            )
         return cast(Dict[str, np.ndarray], result)
 
     def _initialize_kernel(self):

--- a/pymc/smc/smc.py
+++ b/pymc/smc/smc.py
@@ -12,11 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import abc
+import sys
+import warnings
 
 from abc import ABC
-import sys
 from typing import Dict, cast
-import warnings
 
 import aesara.tensor as at
 import numpy as np


### PR DESCRIPTION
This is a little bit weird. Catching the warning makes the progressbar not progress. But it seems this is not related to the warning itself, manually removing the warning from `sample_prior_predictive` has the same effect. Additionally it works when core=1, i.e. not parallel sampling and it also works if we add a print statement.  So I guess is related to  something going on here https://github.com/pymc-devs/pymc/blob/5703a9d24ca01da8b81363874e023e59cd18688d/pymc/smc/sample_smc.py#L398-L417 @ricardoV94 any guess?