### PR TITLE
Do not issue warning when default transform of Mixture is None

### DIFF
--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -444,7 +444,7 @@ def marginal_mixture_default_transform(op, rv):
     def transform_warning():
         warnings.warn(
             f"No safe default transform found for Mixture distribution {rv}. This can "
-            "happen when compoments have different supports or default transforms.\n"
+            "happen when components have different supports or default transforms.\n"
             "If appropriate, you can specify a custom transform for more efficient sampling.",
             MixtureTransformWarning,
             stacklevel=2,
@@ -462,6 +462,9 @@ def marginal_mixture_default_transform(op, rv):
         return None
 
     default_transform = default_transforms[0]
+
+    if default_transform is None:
+        return None
 
     if not isinstance(default_transform, allowed_default_mixture_transforms):
         transform_warning()

--- a/pymc/tests/test_mixture.py
+++ b/pymc/tests/test_mixture.py
@@ -1322,3 +1322,9 @@ class TestMixtureDefaultTransforms:
             with pytest.warns(None) as rec:
                 Mixture("mix5", w=[0.5, 0.5], comp_dists=comp_dists, observed=1)
             assert not rec
+
+            # Case where the appropriate default transform is None
+            comp_dists = [Normal.dist(), Normal.dist()]
+            with pytest.warns(None) as rec:
+                Mixture("mix6", w=[0.5, 0.5], comp_dists=comp_dists)
+            assert not rec


### PR DESCRIPTION
Also fixes typo in warning message.

Reported by @cluhmann 