### PR TITLE
Update `clone_replace` `strict` keyword name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - types-filelock
       - types-setuptools
       - arviz
-      - aesara==2.6.6
+      - aesara==2.7.2
       - aeppl==0.0.31
       always_run: true
       require_serial: true

--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 - aeppl=0.0.31
-- aesara=2.6.6
+- aesara=2.7.2
 - arviz>=0.12.0
 - blas
 - cachetools>=4.2.1

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 - aeppl=0.0.31
-- aesara=2.6.6
+- aesara=2.7.2
 - arviz>=0.12.0
 - blas
 - cachetools>=4.2.1

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 - aeppl=0.0.31
-- aesara=2.6.6
+- aesara=2.7.2
 - arviz>=0.12.0
 - blas
 - cachetools>=4.2.1

--- a/conda-envs/environment-test-py37.yml
+++ b/conda-envs/environment-test-py37.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 - aeppl=0.0.31
-- aesara=2.6.6
+- aesara=2.7.2
 - arviz>=0.12.0
 - blas
 - cachetools>=4.2.1

--- a/conda-envs/environment-test-py38.yml
+++ b/conda-envs/environment-test-py38.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 - aeppl=0.0.31
-- aesara=2.6.6
+- aesara=2.7.2
 - arviz>=0.12.0
 - blas
 - cachetools>=4.2.1

--- a/conda-envs/environment-test-py39.yml
+++ b/conda-envs/environment-test-py39.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 - aeppl=0.0.31
-- aesara=2.6.6
+- aesara=2.7.2
 - arviz>=0.12.0
 - blas
 - cachetools>=4.2.1

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
  # base dependencies (see install guide for Windows)
 - aeppl=0.0.31
-- aesara=2.6.6
+- aesara=2.7.2
 - arviz>=0.12.0
 - blas
 - cachetools>=4.2.1

--- a/conda-envs/windows-environment-test-py38.yml
+++ b/conda-envs/windows-environment-test-py38.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
  # base dependencies (see install guide for Windows)
 - aeppl=0.0.31
-- aesara=2.6.6
+- aesara=2.7.2
 - arviz>=0.12.0
 - blas
 - cachetools>=4.2.1

--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -665,7 +665,7 @@ def join_nonshared_inputs(
 
     replace.update(shared)
 
-    xs_special = [aesara.clone_replace(x, replace, strict=False) for x in xs]
+    xs_special = [aesara.clone_replace(x, replace, rebuild_strict=False) for x in xs]
     return xs_special, inarray
 
 
@@ -693,7 +693,7 @@ class CallableTensor:
         input: TensorVariable
         """
         (oldinput,) = inputvars(self.tensor)
-        return aesara.clone_replace(self.tensor, {oldinput: input}, strict=False)
+        return aesara.clone_replace(self.tensor, {oldinput: input}, rebuild_strict=False)
 
 
 class GeneratorOp(Op):

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -70,7 +70,7 @@ def get_data(filename):
 
 class GenTensorVariable(TensorVariable):
     def __init__(self, op, type, name=None):
-        super().__init__(type=type, name=name)
+        super().__init__(type=type, owner=None, name=name)
         self.op = op
 
     def set_gen(self, gen):

--- a/pymc/smc/smc.py
+++ b/pymc/smc/smc.py
@@ -571,7 +571,7 @@ def _logp_forw(point, out_vars, in_vars, shared):
             else:
                 new_in_vars.append(in_var)
 
-        out_vars = clone_replace(out_vars, replace_int_input, strict=False)
+        out_vars = clone_replace(out_vars, replace_int_input, rebuild_strict=False)
         in_vars = new_in_vars
 
     out_list, inarray0 = join_nonshared_inputs(point, out_vars, in_vars, shared)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # See that file for comments about the need/usage of each dependency.
 
 aeppl==0.0.31
-aesara==2.6.6
+aesara==2.7.2
 arviz>=0.12.0
 cachetools>=4.2.1
 cloudpickle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aeppl==0.0.31
-aesara==2.6.6
+aesara==2.7.2
 arviz>=0.12.0
 cachetools>=4.2.1
 cloudpickle


### PR DESCRIPTION
This PR updates the use of `clone_replace` with the `strict` keyword to use the `rebuild_strict` keyword.