### PR TITLE
docs: Fix Examples link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ algorithms. Its flexibility and extensibility make it applicable to a
 large suite of problems.
 
 Check out the `PyMC overview <https://docs.pymc.io/en/latest/learn/core_notebooks/pymc_overview.html>`__,  or
-one of `the many examples <https://docs.pymc.io/projects/examples/en/latest/>`__!
+one of `the many examples <https://www.pymc.io/projects/examples/en/latest/gallery.html>`__!
 For questions on PyMC, head on over to our `PyMC Discourse <https://discourse.pymc.io/>`__ forum.
 
 Features
@@ -41,7 +41,7 @@ If you already know about Bayesian statistics:
 
 -  `API quickstart guide <https://docs.pymc.io/en/stable/pymc-examples/examples/pymc3_howto/api_quickstart.html>`__
 -  The `PyMC tutorial <https://docs.pymc.io/en/latest/learn/core_notebooks/pymc_overview.html>`__
--  `PyMC examples <https://docs.pymc.io/projects/examples/en/latest/>`__ and the `API reference <https://docs.pymc.io/en/stable/api.html>`__
+-  `PyMC examples <https://www.pymc.io/projects/examples/en/latest/gallery.html>`__ and the `API reference <https://docs.pymc.io/en/stable/api.html>`__
 
 Learn Bayesian statistics with a book together with PyMC
 --------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>


The current Example link goes to a `docs` cname which appears to have been changed to www. 

Also, `https://www.pymc.io/projects/examples/en/latest/` has: `<meta http-equiv="refresh" content="0; url=gallery.html"/>`

Plugged in the final destination link in the README.
