### PR TITLE
Fixing keyword args in top-level pm.compile_fn

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1825,7 +1825,7 @@ def compile_fn(outs, mode=None, point_fn=True, model=None, **kwargs):
     Compiled Aesara function as point function.
     """
     model = modelcontext(model)
-    return model.compile_fn(outs, mode, point_fn=point_fn, **kwargs)
+    return model.compile_fn(outs, mode=mode, point_fn=point_fn, **kwargs)
 
 
 def Point(*args, filter_model_vars=False, **kwargs) -> Dict[str, np.ndarray]:

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -975,8 +975,13 @@ def test_compile_fn():
 
     test_vals = np.array([0.0, -1.0])
     state = {"x": test_vals, "y_log__": test_vals}
-    result_expect = m.compile_fn([x, y])(state)
-    with m:
-        result_compute = pm.compile_fn([x, y])(state)
-    for a, b in zip(result_compute, result_expect):
-        np.testing.assert_allclose(a, b)
+
+    for target in [x, y]:
+        with m:
+            func = pm.compile_fn(target)
+            result_compute = func(state)
+
+        func = m.compile_fn(target)
+        result_expect = func(state)
+
+        np.testing.assert_allclose(result_compute, result_expect)

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -966,3 +966,16 @@ def test_deterministic():
 
 def test_empty_model_representation():
     assert pm.Model().str_repr() == ""
+
+
+def test_compile_fn():
+    with pm.Model() as m:
+        x = pm.Normal("x", 0, 1, size=2)
+        y = pm.LogNormal("y", 0, 1, size=2)
+
+    test_vals = np.array([0.0, -1.0])
+    state = {"x": test_vals, "y_log__": test_vals}
+    result_expect = m.compile_fn([x, y])(state)
+    result_compute = pm.compile_fn([x, y])(state)
+    for a, b in zip(result_compute, result_expect):
+        np.testing.assert_allclose(a, b)

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -976,6 +976,7 @@ def test_compile_fn():
     test_vals = np.array([0.0, -1.0])
     state = {"x": test_vals, "y_log__": test_vals}
     result_expect = m.compile_fn([x, y])(state)
-    result_compute = pm.compile_fn([x, y])(state)
+    with m:
+        result_compute = pm.compile_fn([x, y])(state)
     for a, b in zip(result_compute, result_expect):
         np.testing.assert_allclose(a, b)


### PR DESCRIPTION
`Model.compile_fn` requires all parameters except `outs` to be keyword arguments so the top level `compile_fn` didn't work as written.


**Thank your for opening a PR!**

Before you proceed, please make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [ ] important background, or details about the implementation
+ [ ] are the changes—especially new features—covered by tests and docstrings?
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
