### PR TITLE
explicit error about empirical approx

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,7 @@
 
 ## PyMC 4.0.1 (vNext)
 + Fixed an incorrect entry in `pm.Metropolis.stats_dtypes` (see #5582).
++ Added a check in `Empirical` approximation which does not yet support `InferenceData` inputs (see #5874, #5884).
 + ...
 
 ## PyMC 4.0.0 (2022-06-03)

--- a/pymc/tests/test_variational_inference.py
+++ b/pymc/tests/test_variational_inference.py
@@ -795,9 +795,8 @@ def test_empirical_does_not_support_inference_data(another_simple_model):
     with another_simple_model:
         step = pm.Metropolis()
         trace = pm.sample(100, step=step, chains=1, tune=0, return_inferencedata=True)
-        with pytest.raises(NotImplementedError) as e:
-            emp = Empirical(trace)
-        assert e.match("use return_inferencedata=False")
+        with pytest.raises(NotImplementedError, match="return_inferencedata=False"):
+            Empirical(trace)
 
 
 @pytest.mark.parametrize("score", [True, False])

--- a/pymc/tests/test_variational_inference.py
+++ b/pymc/tests/test_variational_inference.py
@@ -791,6 +791,15 @@ def test_empirical_from_trace(another_simple_model):
         assert emp.histogram.shape[0].eval() == 400
 
 
+def test_empirical_does_not_support_inference_data(another_simple_model):
+    with another_simple_model:
+        step = pm.Metropolis()
+        trace = pm.sample(100, step=step, chains=1, tune=0, return_inferencedata=True)
+        with pytest.raises(NotImplementedError) as e:
+            emp = Empirical(trace)
+        assert e.match("use return_inferencedata=False")
+
+
 @pytest.mark.parametrize("score", [True, False])
 def test_fit_with_nans(score):
     X_mean = pm.floatX(np.linspace(0, 10, 10))

--- a/pymc/variational/approximations.py
+++ b/pymc/variational/approximations.py
@@ -198,10 +198,6 @@ class EmpiricalGroup(Group):
                 # Initialize particles
                 histogram = np.tile(start, (size, 1))
                 histogram += pm.floatX(np.random.normal(0, jitter, histogram.shape))
-        elif isinstance(trace, InferenceData):
-            raise NotImplementedError(
-                "InferenceData is not supported, use return_inference_data=False"
-            )
         else:
             histogram = np.empty((len(trace) * len(trace.chains), self.ddim))
             i = 0
@@ -213,7 +209,11 @@ class EmpiricalGroup(Group):
 
     def _check_trace(self):
         trace = self._kwargs.get("trace", None)
-        if trace is not None and not all(
+        if isinstance(trace, InferenceData):
+            raise NotImplementedError(
+                "InferenceData is not supported, use return_inferencedata=False"
+            )
+        elif trace is not None and not all(
             [self.model.rvs_to_values[var].name in trace.varnames for var in self.group]
         ):
             raise ValueError("trace has not all free RVs in the group")

--- a/pymc/variational/approximations.py
+++ b/pymc/variational/approximations.py
@@ -18,7 +18,7 @@ import numpy as np
 from aesara import tensor as at
 from aesara.graph.basic import Variable
 from aesara.tensor.var import TensorVariable
-
+from arviz import InferenceData
 import pymc as pm
 
 from pymc.blocking import DictToArrayBijection
@@ -198,7 +198,10 @@ class EmpiricalGroup(Group):
                 # Initialize particles
                 histogram = np.tile(start, (size, 1))
                 histogram += pm.floatX(np.random.normal(0, jitter, histogram.shape))
-
+        elif isinstance(trace, InferenceData):
+            raise NotImplementedError(
+                "InferenceData is not supported, use return_inference_data=False"
+            )
         else:
             histogram = np.empty((len(trace) * len(trace.chains), self.ddim))
             i = 0

--- a/pymc/variational/approximations.py
+++ b/pymc/variational/approximations.py
@@ -19,6 +19,7 @@ from aesara import tensor as at
 from aesara.graph.basic import Variable
 from aesara.tensor.var import TensorVariable
 from arviz import InferenceData
+
 import pymc as pm
 
 from pymc.blocking import DictToArrayBijection
@@ -211,7 +212,9 @@ class EmpiricalGroup(Group):
         trace = self._kwargs.get("trace", None)
         if isinstance(trace, InferenceData):
             raise NotImplementedError(
-                "InferenceData is not supported, use return_inferencedata=False"
+                "The `Empirical` approximation does not yet support `InferenceData` inputs."
+                " Pass `pm.sample(return_inferencedata=False)` to get a `MultiTrace` to use with `Empirical`."
+                " Please help us to refactor: https://github.com/pymc-devs/pymc/issues/5884"
             )
         elif trace is not None and not all(
             [self.model.rvs_to_values[var].name in trace.varnames for var in self.group]


### PR DESCRIPTION
Currently the Empirical approximation is impossible initialize with inference data. This happens due to missing variables in the output. While histogram requires transformed variables (e.g. `a_log__`), inference data only has untransformed ones (e.g. `a`). This PR makes this error explicit with a recommendation to solve the issue.