### PR TITLE
Align advertised `Metropolis` `stats_dtypes` with changes from 1e7d91f

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,10 @@
 # Release Notes
 
-## PyMC 4.0.0
+## PyMC 4.0.1 (vNext)
++ Fixed an incorrect entry in `pm.Metropolis.stats_dtypes` (see #5582).
++ ...
+
+## PyMC 4.0.0 (2022-06-03)
 
 **If you want a description of the highlights of this release, check out the [release announcement](https://www.pymc.io/blog/v4_announcement.html) on our [new website](https://www.pymc.io)**.
 Feel free to read it, print it out, and give it to people on the street -- because _everybody_ has to know PyMC 4.0 is officially out 🍾

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -120,7 +120,7 @@ class Metropolis(ArrayStepShared):
     stats_dtypes = [
         {
             "accept": np.float64,
-            "accepted": bool,
+            "accepted": np.float64,
             "tune": bool,
             "scaling": np.float64,
         }


### PR DESCRIPTION
In https://github.com/michaelosthege/mcbackend/pull/27 I tried to upgrade to `4.0.0` but the CI failed.

The reason for the failure is an incorrect `stats_dtypes["accepted"]` which was not updated with the changes in 1e7d91f.

------

+ [x] No breaks
+ [x] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
