### PR TITLE
Remove self-directing arrow in observed nodes

### DIFF
--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -100,7 +100,7 @@ class ModelGraph:
             if hasattr(var.tag, "observations"):
                 try:
                     obs_name = var.tag.observations.name
-                    if obs_name:
+                    if obs_name and obs_name != var_name:
                         input_map[var_name] = input_map[var_name].difference({obs_name})
                         input_map[obs_name] = input_map[obs_name].union({var_name})
                 except AttributeError:


### PR DESCRIPTION
Closes #5892.

One question in the code review and some tests in `tests/test_model_graph.py` relocated in the same file.