### PR TITLE
refactor sampling_jax postrocessing to avoid jit

### DIFF
--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -6,8 +6,6 @@ import warnings
 from functools import partial
 from typing import Callable, Dict, List, Optional, Sequence, Union
 
-import aesara
-
 from pymc.initial_point import StartDict
 from pymc.sampling import RandomSeed, _get_seeds_per_chain, _init_jitter
 

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -134,7 +134,7 @@ def _sample_stats_to_xarray(posterior):
 
 def _get_log_likelihood(model: Model, samples, backend=None) -> Dict:
     """Compute log-likelihood for all observations"""
-    elemwise_logpt = [model.logp(v, sum=False)[0] for v in model.observed_RVs]
+    elemwise_logp = model.logp(model.observed_RVs, sum=False)
     jax_fn = get_jaxified_graph(inputs=model.value_vars, outputs=elemwise_logp)
     result = jax.vmap(jax.vmap(jax_fn))(*jax.device_put(samples, jax.devices(backend)[0]))
     return {v.name: r for v, r in zip(model.observed_RVs, result)}

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -135,7 +135,7 @@ def _sample_stats_to_xarray(posterior):
 def _get_log_likelihood(model: Model, samples, backend=None) -> Dict:
     """Compute log-likelihood for all observations"""
     elemwise_logpt = [model.logp(v, sum=False)[0] for v in model.observed_RVs]
-    jax_fn = get_jaxified_graph(inputs=model.value_vars, outputs=elemwise_logpt)
+    jax_fn = get_jaxified_graph(inputs=model.value_vars, outputs=elemwise_logp)
     result = jax.vmap(jax.vmap(jax_fn))(*jax.device_put(samples, jax.devices(backend)[0]))
     return {v.name: r for v, r in zip(model.observed_RVs, result)}
 

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -351,9 +351,13 @@ def sample_blackjax_nuts(
         idata_kwargs = idata_kwargs.copy()
 
     if idata_kwargs.pop("log_likelihood", True):
+        tic5 = datetime.now()
+        print("Computing Log Likelihood...", file=sys.stdout)
         log_likelihood = _get_log_likelihood(
             model, raw_mcmc_samples, backend=postprocessing_backend
         )
+        tic6 = datetime.now()
+        print("Log Likelihood time = ", tic6 - tic5, file=sys.stdout)
     else:
         log_likelihood = None
 
@@ -541,9 +545,13 @@ def sample_numpyro_nuts(
         idata_kwargs = idata_kwargs.copy()
 
     if idata_kwargs.pop("log_likelihood", True):
+        tic5 = datetime.now()
+        print("Computing Log Likelihood...", file=sys.stdout)
         log_likelihood = _get_log_likelihood(
             model, raw_mcmc_samples, backend=postprocessing_backend
         )
+        tic6 = datetime.now()
+        print("Log Likelihood time = ", tic6 - tic5, file=sys.stdout)
     else:
         log_likelihood = None
 

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -350,7 +350,7 @@ def sample_blackjax_nuts(
     else:
         idata_kwargs = idata_kwargs.copy()
 
-    if idata_kwargs.pop("log_likelihood", True):
+    if idata_kwargs.pop("log_likelihood", bool(model.observed_RVs)):
         tic5 = datetime.now()
         print("Computing Log Likelihood...", file=sys.stdout)
         log_likelihood = _get_log_likelihood(
@@ -544,7 +544,7 @@ def sample_numpyro_nuts(
     else:
         idata_kwargs = idata_kwargs.copy()
 
-    if idata_kwargs.pop("log_likelihood", True):
+    if idata_kwargs.pop("log_likelihood", bool(model.observed_RVs)):
         tic5 = datetime.now()
         print("Computing Log Likelihood...", file=sys.stdout)
         log_likelihood = _get_log_likelihood(

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -1,5 +1,6 @@
 import aesara
 import aesara.tensor as at
+import jax
 import numpy as np
 import pytest
 
@@ -27,7 +28,16 @@ from pymc.sampling_jax import (
     ],
 )
 @pytest.mark.parametrize("postprocessing_backend", [None, "cpu"])
-def test_transform_samples(sampler, postprocessing_backend):
+@pytest.mark.parametrize(
+    "chains",
+    [
+        pytest.param(1),
+        pytest.param(
+            2, marks=pytest.mark.skipif(len(jax.devices()) < 2, reason="not enough devices")
+        ),
+    ],
+)
+def test_transform_samples(sampler, postprocessing_backend, chains):
     aesara.config.on_opt_error = "raise"
     np.random.seed(13244)
 
@@ -39,7 +49,7 @@ def test_transform_samples(sampler, postprocessing_backend):
         b = pm.Normal("b", a, sigma=sigma, observed=obs_at)
 
         trace = sampler(
-            chains=1,
+            chains=chains,
             random_seed=1322,
             keep_untransformed=True,
             postprocessing_backend=postprocessing_backend,
@@ -56,7 +66,7 @@ def test_transform_samples(sampler, postprocessing_backend):
     obs_at.set_value(-obs)
     with model:
         trace = sampler(
-            chains=2,
+            chains=chains,
             random_seed=1322,
             keep_untransformed=False,
             postprocessing_backend=postprocessing_backend,
@@ -73,6 +83,7 @@ def test_transform_samples(sampler, postprocessing_backend):
         sample_numpyro_nuts,
     ],
 )
+@pytest.mark.skipif(len(jax.devices()) < 2, reason="not enough devices")
 def test_deterministic_samples(sampler):
     aesara.config.on_opt_error = "raise"
     np.random.seed(13244)
@@ -207,7 +218,15 @@ def test_get_batched_jittered_initial_points():
     ],
 )
 @pytest.mark.parametrize("random_seed", (None, 123))
-@pytest.mark.parametrize("chains", (1, 2))
+@pytest.mark.parametrize(
+    "chains",
+    [
+        pytest.param(1),
+        pytest.param(
+            2, marks=pytest.mark.skipif(len(jax.devices()) < 2, reason="not enough devices")
+        ),
+    ],
+)
 def test_seeding(chains, random_seed, sampler):
     sample_kwargs = dict(
         tune=100,


### PR DESCRIPTION
In #5664 I enabled postprocessing to choose between cpu/gpu or the default device. That time I implemented that using `jax.jit(..., backend=device)` API. However, in some cases jitting is not desirable and causes errors. In this pull request I maintain the functionality but remove jitting.