### PR TITLE
Bump for `4.0.1` release

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,19 +1,8 @@
 # Release Notes
 
-## PyMC 4.0.1 (vNext)
-+ Fixed an incorrect entry in `pm.Metropolis.stats_dtypes` (see #5582).
-+ Added a check in `Empirical` approximation which does not yet support `InferenceData` inputs (see #5874, #5884).
-+ Fixed bug when sampling discrete variables with SMC (see #5887).
-+ Removed trailing `t` (for tensor) in functions and properties from the model class and from `jointlogpt` (see #5859).
-  + `Model.logpt` → `Model.logp`
-  + `Model.dlogpt` → `Model.dlogp`
-  + `Model.d2logpt` → `Model.d2logp`
-  + `Model.datalogpt` → `Model.datalogp`
-  + `Model.varlogpt` → `Model.varlogp`
-  + `Model.observedlogpt` → `Model.observedlogp`
-  + `Model.potentiallogpt` → `Model.potentiallogp`
-  + `Model.varlogp_nojact` → `Model.varlogp_nojac`
-  + `logprob.joint_logpt` → `logprob.joint_logp`
+:warning: Moving forward we're no longer updating the `RELEASE-NOTES.md` document. :warning:
+
+:warning: Instead, please check the release notes in the [GitHub Releases](https://github.com/pymc-devs/pymc/releases). :warning:
 
 ## PyMC 4.0.0 (2022-06-03)
 

--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # pylint: disable=wildcard-import
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 
 import logging
 import multiprocessing as mp


### PR DESCRIPTION
+ [x] Bumped to `4.0.1`
+ [x] Replaced the `4.0.1` release notes section with a warning message to check the GitHub Releases instead.