### PR TITLE
Fix 'model' and 'aesara_config' kwargs for pm.Model

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -542,7 +542,11 @@ class Model(WithMemoization, metaclass=ContextMeta):
         name="",
         coords=None,
         check_bounds=True,
+        *,
+        aesara_config=None,
+        model=None,
     ):
+        del aesara_config, model  # used in __new__
         self.name = self._validate_name(name)
         self.check_bounds = check_bounds
 

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -1014,3 +1014,20 @@ def test_compile_fn():
     result_expect = func(state)
 
     np.testing.assert_allclose(result_compute, result_expect)
+
+
+def test_model_aesara_config():
+    assert aesara.config.mode != "JAX"
+    with pm.Model(aesara_config=dict(mode="JAX")) as model:
+        assert aesara.config.mode == "JAX"
+    assert aesara.config.mode != "JAX"
+
+
+def test_model_parent_set_programmatically():
+    with pm.Model() as model:
+        x = pm.Normal("x")
+
+    with pm.Model(model=model):
+        y = pm.Normal("y")
+
+    assert "y" in model.named_vars


### PR DESCRIPTION
Fixes

```python
with pm.Model(aesara_config=dict(mode="JAX")):
    ...
```

and 

```python
with pm.Model(model=parent):
    ...
```