### PR TITLE
Review docstrings checkmarcked as best practice

### DIFF
--- a/docs/source/api/aesaraf.rst
+++ b/docs/source/api/aesaraf.rst
@@ -6,6 +6,7 @@ Aesara utils
 .. autosummary::
    :toctree: generated/
 
+   compile_pymc
    gradient
    hessian
    hessian_diag

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,7 +81,8 @@ numpydoc_xref_aliases = {
     "SMC_kernel": ":ref:`SMC Kernel <smc_kernels>`",
     "Aesara_Op": ":class:`Aesara Op <aesara.graph.op.Op>`",
     "tensor_like": ":term:`tensor_like`",
-    "numpy_Generator": ":class:`~numpy.random.Generator`"
+    "numpy_Generator": ":class:`~numpy.random.Generator`",
+    "Distribution": ":ref:`Distribution <api_distributions>`",
 }
 
 # Show the documentation of __init__ and the class docstring

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,6 +81,7 @@ numpydoc_xref_aliases = {
     "SMC_kernel": ":ref:`SMC Kernel <smc_kernels>`",
     "Aesara_Op": ":class:`Aesara Op <aesara.graph.op.Op>`",
     "tensor_like": ":term:`tensor_like`",
+    "numpy_Generator": ":class:`~numpy.random.Generator`"
 }
 
 # Show the documentation of __init__ and the class docstring

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -1653,10 +1653,6 @@ class AsymmetricLaplace(Continuous):
         Location parameter.
     b : tensor_like of float
         Scale parameter (b > 0).
-
-    See Also:
-    --------
-    `Reference <https://en.wikipedia.org/wiki/Asymmetric_Laplace_distribution>`_
     """
     rv_op = asymmetriclaplace
 

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -988,11 +988,11 @@ class HyperGeometric(Discrete):
 
     Parameters
     ----------
-    N : tensor_like of integer
+    N : tensor_like of int
         Total size of the population (N > 0)
-    k : tensor_like of integer
+    k : tensor_like of int
         Number of successful individuals in the population (0 <= k <= N)
-    n : tensor_like of integer
+    n : tensor_like of int
         Number of samples drawn from the population (0 <= n <= N)
     """
 

--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -231,7 +231,7 @@ class GaussianRandomWalk(distribution.Continuous):
 
         .. warning:: init will be cloned, rendering them independent of the ones passed as input.
 
-    steps : tensor_like of int, optional
+    steps : int, optional
         Number of steps in Gaussian Random Walk (steps > 0). Only needed if shape is not
         provided.
     """

--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -217,20 +217,21 @@ gaussianrandomwalk = GaussianRandomWalkRV()
 
 
 class GaussianRandomWalk(distribution.Continuous):
-    r"""Random Walk with Normal innovations
+    r"""Random Walk with Normal innovations.
 
     Parameters
     ----------
-    mu : tensor_like of float
-        innovation drift, defaults to 0.0
-    sigma : tensor_like of float, optional
-        sigma > 0, innovation standard deviation, defaults to 1.0
-    init_dist : unnamed distribution
-        Univariate distribution of the initial value, created with the `.dist()` API.
+    mu : tensor_like of float, default 0
+        innovation drift
+    sigma : tensor_like of float, default 1
+        sigma > 0, innovation standard deviation.
+    init_dist : Distribution
+        Unnamed univariate distribution of the initial value. Unnamed refers to distributions
+         created with the ``.dist()`` API.
 
         .. warning:: init will be cloned, rendering them independent of the ones passed as input.
 
-    steps : int, optional
+    steps : tensor_like of int, optional
         Number of steps in Gaussian Random Walk (steps > 0). Only needed if shape is not
         provided.
     """

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -2277,14 +2277,14 @@ def draw(
 
     Parameters
     ----------
-    vars : Variable or iterable of Variable
+    vars : RandomVariable or iterable of RandomVariable
         A variable or a list of variables for which to draw samples.
     draws : int, default 1
         Number of samples needed to draw.
-    random_seed : int, RandomState or Generator, optional
+    random_seed : int, RandomState or numpy_Generator, optional
         Seed for the random number generator.
     **kwargs : dict, optional
-        Keyword arguments for :func:`pymc.aesara.compile_pymc`.
+        Keyword arguments for :func:`pymc.aesaraf.compile_pymc`.
 
     Returns
     -------

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -2277,7 +2277,7 @@ def draw(
 
     Parameters
     ----------
-    vars : RandomVariable or iterable of RandomVariable
+    vars : TensorVariable or iterable of TensorVariable
         A variable or a list of variables for which to draw samples.
     draws : int, default 1
         Number of samples needed to draw.


### PR DESCRIPTION
Minor fixes to docstrings marked as best practices already so they can serve as example in the coming open source working sessions. 