### PR TITLE
Remove `nan_is_num` and `nan_is_high` limiters from `find_MAP`.

### DIFF
--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -25,7 +25,7 @@ import aesara.gradient as tg
 import numpy as np
 
 from fastprogress.fastprogress import ProgressBar, progress_bar
-from numpy import isfinite, nan_to_num
+from numpy import isfinite
 from scipy.optimize import minimize
 
 import pymc as pm
@@ -181,10 +181,6 @@ def allfinite(x):
     return np.all(isfinite(x))
 
 
-def nan_to_high(x):
-    return np.where(isfinite(x), x, 1.0e100)
-
-
 def allinmodel(vars, model):
     notin = [v for v in vars if v not in model.value_vars]
     if notin:
@@ -214,12 +210,12 @@ class CostFuncWrapper:
 
     def __call__(self, x):
         neg_value = np.float64(self.logp_func(pm.floatX(x)))
-        value = -1.0 * nan_to_high(neg_value)
+        value = -1.0 * neg_value
         if self.use_gradient:
             neg_grad = self.dlogp_func(pm.floatX(x))
             if np.all(np.isfinite(neg_grad)):
                 self.previous_x = x
-            grad = nan_to_num(-1.0 * neg_grad)
+            grad = -1.0 * neg_grad
             grad = grad.astype(np.float64)
         else:
             self.previous_x = x


### PR DESCRIPTION
This commit removes the `nan_is_num` and `nan_is_high` calls in `find_MAP`. Generally speaking, I've found that this improves performance when the actual MAP value is on the edge of the prior/far from the starting point.

These limiters seem to be in place because `scipy.optimize.minimize` often had trouble with non-finite values in earlier versions of SciPy. However, this seems to have been addressed upstream for most SciPy optimizers around version 1.3.2/1.4, which are older versions than the minimum PyMC currently requires. Also, `nan_is_num` and `nan_is_high` seem to make the optimizer perform worse, because they introduce discontinuities in the functions being limited, and in particular produce unrealistically small values in the gradient when the gradient is producing NaN due to overflows.

My main concern here is that the test I've added is a bit janky; this is the only small and easily reproducible example I have on hand of a model where the `nan_is_*` limiters make a big difference, but it's kind of arbitrary-looking, and I haven't tried to formally calculate the chance that it produces a false positive/false negative. (That said, it fails pretty consistently when using the old code, and it hasn't failed after running it over a hundred times on the new code, so it looks good from that perspective.)