### PR TITLE
pass names from RV dims to change_rv_size

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -266,7 +266,9 @@ class Distribution(metaclass=DistributionMeta):
 
         if resize_shape:
             # A batch size was specified through `dims`, or implied by `observed`.
-            rv_out = change_rv_size(rv=rv_out, new_size=resize_shape, expand=True)
+            rv_out = change_rv_size(
+                rv=rv_out, new_size=resize_shape, new_size_dims=dims, expand=True
+            )
 
         rv_out = model.register_rv(
             rv_out,


### PR DESCRIPTION
@canyon289 to resolve #5669, I have made some small changes mainly to aesaraf.py to include the dim names in the new_size tensor (https://github.com/pymc-devs/pymc/commit/6585f9021a17a7f0c9c833bf4700fab240d2164b)

This solves the issue mainly and `test_model` runs without errors. There are a few things that probably need to be addressed.

- do dims passed to `change_rv_size` need to be tested more rigorously?
- is None a good default name for the broadcasting tensor dimension?
- should information if the broadcasting comes from observed or other processes be included in 
the name
- things that I'm not aware of :)

## changes of the PR
- adds argument new_size_dims to change_rv_size in aesaraf.py
- tests if dims is None and wraps in tuple if RV has no dim
- creates new_size_name by adding dim name and decorations
- passes new_size_name as name argument to at.as_tensor method

