### PR TITLE
Update conda environment name when running docker with jupyter notebook

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -27,4 +27,4 @@ RUN echo "conda activate pymc-dev" >> ~/.bashrc && \
 
 # For running from jupyter notebook
 EXPOSE 8888
-CMD ["conda", "run", "--no-capture-output", "-n", "pymc-dev-py39", "jupyter","notebook","--ip=0.0.0.0","--port=8888","--no-browser"]
+CMD ["conda", "run", "--no-capture-output", "-n", "pymc-dev", "jupyter","notebook","--ip=0.0.0.0","--port=8888","--no-browser"]


### PR DESCRIPTION
Hi, I am trying to build a Pymc docker image to push it into dockerhub, by using the command in our docs: https://docs.pymc.io/en/latest/contributing/docker_container.html

The building process works, and the docker container can run in bash. However, running docker with jupyter notebook using this command `bash scripts/docker_container.sh jupyter` will fail.

Turn out in https://github.com/pymc-devs/pymc/pull/5911, we also need to update the name of conda environment in the last line in dockerfile. So I've updated the conda environment name in this PR, and checked it with jupyter notebook.

Thank you.