### PR TITLE
Default to `pm.Data(mutable=False)`, deprecate `MLDA` and bump to v4.1.0

### DIFF
--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # pylint: disable=wildcard-import
-__version__ = "4.0.1"
+__version__ = "4.1.0"
 
 import logging
 import multiprocessing as mp

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -661,16 +661,14 @@ def Data(
     arr = convert_observed_data(value)
 
     if mutable is None:
-        major, minor = (int(v) for v in pm.__version__.split(".")[:2])
-        mutable = major == 4 and minor < 1
-        if mutable:
-            warnings.warn(
-                "The `mutable` kwarg was not specified. Currently it defaults to `pm.Data(mutable=True)`,"
-                " which is equivalent to using `pm.MutableData()`."
-                " In v4.1.0 the default will change to `pm.Data(mutable=False)`, equivalent to `pm.ConstantData`."
-                " Set `pm.Data(..., mutable=False/True)`, or use `pm.ConstantData`/`pm.MutableData`.",
-                FutureWarning,
-            )
+        warnings.warn(
+            "The `mutable` kwarg was not specified. Before v4.1.0 it defaulted to `pm.Data(mutable=True)`,"
+            " which is equivalent to using `pm.MutableData()`."
+            " In v4.1.0 the default changed to `pm.Data(mutable=False)`, equivalent to `pm.ConstantData`."
+            " Use `pm.ConstantData`/`pm.MutableData` or pass `pm.Data(..., mutable=False/True)` to avoid this warning.",
+            UserWarning,
+        )
+        mutable = False
     if mutable:
         x = aesara.shared(arr, name, **kwargs)
     else:

--- a/pymc/step_methods/mlda.py
+++ b/pymc/step_methods/mlda.py
@@ -365,6 +365,11 @@ class MLDA(ArrayStepShared):
         adaptive_error_model: bool = False,
         **kwargs,
     ) -> None:
+        warnings.warn(
+            "The MLDA stepper will be migrated to the pymc-experimental project!"
+            " See https://github.com/pymc-devs/pymc/issues/5942",
+            DeprecationWarning,
+        )
 
         # this variable is used to identify MLDA objects which are
         # not in the finest level (i.e. child MLDA objects)

--- a/pymc/step_methods/mlda.py
+++ b/pymc/step_methods/mlda.py
@@ -260,7 +260,7 @@ class MLDA(ArrayStepShared):
         sum of the quantity of interest after sampling. In order to use
         variance reduction, the user needs to do the following when defining
         the PyMC model (also demonstrated in the example notebook):
-            - Include a `pm.Data()` variable with the name `Q` in the
+            - Include a `pm.MutableData()` variable with the name `Q` in the
             model description of all levels.
             - Use an Aesara Op to calculate the forward model (or the
             combination of a forward model and a likelihood). This Op
@@ -286,7 +286,7 @@ class MLDA(ArrayStepShared):
             definition at all levels except the finest one, the
             extra variables mu_B and Sigma_B, which will capture
             the bias between different levels. All these variables
-            should be instantiated using the pm.Data method.
+            should be instantiated using the pm.MutableData method.
             - Use an Aesara Op to define the forward model (and
             optionally the likelihood) for all levels. The Op needs
             to store the result of each forward model calculation
@@ -401,12 +401,12 @@ class MLDA(ArrayStepShared):
                     "the variable in the model definition"
                     "for variance reduction to work or"
                     "for storing the fine Q."
-                    "Use pm.Data() to define it."
+                    "Use pm.MutableData() to define it."
                 )
             if not isinstance(self.model.Q, TensorSharedVariable):
                 raise TypeError(
                     "The variable 'Q' in the model definition is not of type "
-                    "'TensorSharedVariable'. Use pm.Data() to define the"
+                    "'TensorSharedVariable'. Use pm.MutableData() to define the"
                     "variable."
                 )
 
@@ -427,7 +427,7 @@ class MLDA(ArrayStepShared):
                     "variable 'mu_B'. You need to include"
                     "the variable in the model definition"
                     "for adaptive error model to work."
-                    "Use pm.Data() to define it."
+                    "Use pm.MutableData() to define it."
                 )
             if not hasattr(self.model_below, "Sigma_B"):
                 raise AttributeError(
@@ -435,7 +435,7 @@ class MLDA(ArrayStepShared):
                     "variable 'Sigma_B'. You need to include"
                     "the variable in the model definition"
                     "for adaptive error model to work."
-                    "Use pm.Data() to define it."
+                    "Use pm.MutableData() to define it."
                 )
             if not (
                 isinstance(self.model_below.mu_B, TensorSharedVariable)
@@ -444,7 +444,7 @@ class MLDA(ArrayStepShared):
                 raise TypeError(
                     "At least one of the variables 'mu_B' and 'Sigma_B' "
                     "in the definition of the below model is not of type "
-                    "'TensorSharedVariable'. Use pm.Data() to define those "
+                    "'TensorSharedVariable'. Use pm.MutableData() to define those "
                     "variables."
                 )
 

--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -18,7 +18,6 @@ import numpy as np
 import pytest
 
 from aesara import shared
-from aesara.compile.sharedvalue import SharedVariable
 from aesara.tensor import TensorConstant
 from aesara.tensor.var import TensorVariable
 
@@ -431,9 +430,9 @@ class TestData(SeededTest):
 
     def test_data_mutable_default_warning(self):
         with pm.Model():
-            with pytest.warns(FutureWarning, match="`mutable` kwarg was not specified"):
+            with pytest.warns(UserWarning, match="`mutable` kwarg was not specified"):
                 data = pm.Data("x", [1, 2, 3])
-            assert isinstance(data, SharedVariable)
+            assert isinstance(data, TensorConstant)
         pass
 
 

--- a/pymc/tests/test_step.py
+++ b/pymc/tests/test_step.py
@@ -29,7 +29,7 @@ from aesara.graph.op import Op
 import pymc as pm
 
 from pymc.aesaraf import floatX
-from pymc.data import Data
+from pymc.data import Data, MutableData
 from pymc.distributions import (
     Bernoulli,
     Beta,
@@ -1109,7 +1109,7 @@ class TestMLDA:
                 intercept = inputs[0][0]
                 x_coeff = inputs[0][1]
 
-                temp = intercept + x_coeff * x + self.pymc_model.bias.get_value()
+                temp = intercept + x_coeff * x + self.pymc_model.bias.data
                 with self.pymc_model:
                     set_data({"model_output": temp})
                 outputs[0][0] = np.array(temp)
@@ -1120,9 +1120,9 @@ class TestMLDA:
 
         with Model() as coarse_model_0:
             bias = Data("bias", 3.5 * np.ones(y.shape, dtype=p))
-            mu_B = Data("mu_B", -1.3 * np.ones(y.shape, dtype=p))
-            Sigma_B = Data("Sigma_B", np.zeros((y.shape[0], y.shape[0]), dtype=p))
-            model_output = Data("model_output", np.zeros(y.shape, dtype=p))
+            mu_B = MutableData("mu_B", -1.3 * np.ones(y.shape, dtype=p))
+            Sigma_B = MutableData("Sigma_B", np.zeros((y.shape[0], y.shape[0]), dtype=p))
+            model_output = MutableData("model_output", np.zeros(y.shape, dtype=p))
             Sigma_e = Data("Sigma_e", s)
 
             # Define priors
@@ -1140,9 +1140,9 @@ class TestMLDA:
 
         with Model() as coarse_model_1:
             bias = Data("bias", 2.2 * np.ones(y.shape, dtype=p))
-            mu_B = Data("mu_B", -2.2 * np.ones(y.shape, dtype=p))
-            Sigma_B = Data("Sigma_B", np.zeros((y.shape[0], y.shape[0]), dtype=p))
-            model_output = Data("model_output", np.zeros(y.shape, dtype=p))
+            mu_B = MutableData("mu_B", -2.2 * np.ones(y.shape, dtype=p))
+            Sigma_B = MutableData("Sigma_B", np.zeros((y.shape[0], y.shape[0]), dtype=p))
+            model_output = MutableData("model_output", np.zeros(y.shape, dtype=p))
             Sigma_e = Data("Sigma_e", s)
 
             # Define priors
@@ -1161,7 +1161,7 @@ class TestMLDA:
         # fine model and inference
         with Model() as model:
             bias = Data("bias", np.zeros(y.shape, dtype=p))
-            model_output = Data("model_output", np.zeros(y.shape, dtype=p))
+            model_output = MutableData("model_output", np.zeros(y.shape, dtype=p))
             Sigma_e = Data("Sigma_e", s)
 
             # Define priors
@@ -1268,9 +1268,9 @@ class TestMLDA:
 
             with Model() as coarse_model_0:
                 if aesara.config.floatX == "float32":
-                    Q = Data("Q", np.float32(0.0))
+                    Q = MutableData("Q", np.float32(0.0))
                 else:
-                    Q = Data("Q", np.float64(0.0))
+                    Q = MutableData("Q", np.float64(0.0))
 
                 # Define priors
                 intercept = Normal("Intercept", true_intercept, sigma=1)
@@ -1285,9 +1285,9 @@ class TestMLDA:
 
             with Model() as coarse_model_1:
                 if aesara.config.floatX == "float32":
-                    Q = Data("Q", np.float32(0.0))
+                    Q = MutableData("Q", np.float32(0.0))
                 else:
-                    Q = Data("Q", np.float64(0.0))
+                    Q = MutableData("Q", np.float64(0.0))
 
                 # Define priors
                 intercept = Normal("Intercept", true_intercept, sigma=1)
@@ -1302,9 +1302,9 @@ class TestMLDA:
 
             with Model() as model:
                 if aesara.config.floatX == "float32":
-                    Q = Data("Q", np.float32(0.0))
+                    Q = MutableData("Q", np.float32(0.0))
                 else:
-                    Q = Data("Q", np.float64(0.0))
+                    Q = MutableData("Q", np.float64(0.0))
 
                 # Define priors
                 intercept = Normal("Intercept", true_intercept, sigma=1)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
When attempting to bump the version to `4.1.0`, I ran into a change f the `pm.Data(mutable=...)` default setting that we had already announced to happen in `4.1.0`.

Consequently, I made that change and adapted tests accordingly.

I also sneaked in a `DeprecationWarning` about moving `MLDA` over to `pymc-experimental` (#5942).

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- `pm.Data()` now defaults to `mutable=False` (use `pm.ConstantData`/`pm.MutableData` or pass `mutable=True/False` to avoid a warning).

## Bugfixes / New features
None

## Docs / Maintenance
- Added a `DeprecationWarning` about moving `MLDA` to `pymc-experimental`.
- `__version__` was incremented to `"4.1.0"`