### PR TITLE
Add version string to conda install command.

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -6,7 +6,7 @@ We recommend using [Anaconda](https://www.anaconda.com/) (or [Miniforge](https:/
 Once you have installed one of the above, PyMC can be installed into a new conda environment as follows:
 
 ```console
-conda create -c conda-forge -n pymc_env pymc
+conda create -c conda-forge -n pymc_env "pymc>=4"
 conda activate pymc_env
 ```
 If you like, replace the name `pymc_env` with whatever environment name you prefer.
@@ -23,7 +23,7 @@ pip install numpyro
 Similarly, to use BlackJAX for sampling it should be installed via `pip`:
 
 ```console
-pip install jax jaxlib blackjax
+pip install blackjax
 ```
 
 Note that JAX is not directly supported on Windows systems at the moment.


### PR DESCRIPTION
Closes #5943.

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
conda sometimes pulls in `pymc 2.x` when running `conda install -c conda-forge pymc`. If we specify `pymc>=4` the problem goes away. 

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Update installation instructions to specify version string
- Remove jax and jaxlib from blackjax pip install command
