### PR TITLE
include :: in name prefix check

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1568,7 +1568,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         """Checks if name has prefix and adds if needed"""
         name = self._validate_name(name)
         if self.prefix:
-            if not name.startswith(self.prefix):
+            if not name.startswith(self.prefix + "::"):
                 return f"{self.prefix}::{name}"
             else:
                 return name

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -159,6 +159,11 @@ class TestNested:
             with pm.Model() as sub:
                 assert model is sub.root
 
+    def test_prefix_add_uses_separator(self):
+        with pm.Model("foo"):
+            foobar = pm.Normal("foobar")
+            assert foobar.name == "foo::foobar"
+
     def test_nested_named_model_repeated(self):
         with pm.Model("sub") as model:
             b = pm.Normal("var")


### PR DESCRIPTION
```
import pymc as pm
with pm.Model("foo"):
    print(pm.Normal("foobar"), pm.Normal("baz"))
```

before: `foobar foo::baz`
after: `foo::foobar foo::baz`

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
...

**Checklist**
+ [ ] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- The model name did not show up in the first RV name

## Docs / Maintenance
- ...
