### PR TITLE
Fix model graph node name to remove RV from end only and not the start

### DIFF
--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -135,8 +135,10 @@ class ModelGraph:
                 style = "filled"
             else:
                 shape = "ellipse"
-                syle = None
-            symbol = v.owner.op.__class__.__name__.strip("RV")
+                style = None
+            symbol = v.owner.op.__class__.__name__
+            if symbol.endswith("RV"):
+                symbol = symbol[:-2]
             label = f"{var_name}\n~\n{symbol}"
         else:
             shape = "box"


### PR DESCRIPTION
The model graph (graphviz) output currently strips the leading "V" from a "VonMises" random variable node. The reason is that the current code uses `.strip("RV")` to remove characters which is too aggressive. It has been replaced with a check to see if the node name ends with "RV" and to remove those two characters if it does.

There is also a minor typo where `style = None` was written as `syle = None` (the `t` is missing) but this has no impact since `style` is set to `None` earlier in the code anyway.

## Bugfixes
- Fixed model graph node names to remove RV from end only and not the start.