### PR TITLE
Updated docstrings to inform users that ODE solution may be slow.

### DIFF
--- a/pymc/ode/__init__.py
+++ b/pymc/ode/__init__.py
@@ -1,7 +1,10 @@
 """
 This submodule contains tools used to perform inference on ordinary differential equations.
-Due to the nature of the model (as well as included solvers), this may perform slowly.
-A library based on PyMC--sunode--has implemented Adams' method and BDF (backward differentation formula).  More information about sunode is available at: https://github.com/aseyboldt/sunode.
+
+Due to the nature of the model (as well as included solvers), ODE solution may perform slowly.
+Another library based on PyMC--sunode--has implemented Adams' method and BDF (backward differentation formula) using the very fast SUNDIALS suite of ODE and PDE solvers.
+It is much faster than the ``pm.ode`` implementation.
+More information about ``sunode`` is available at: https://github.com/aseyboldt/sunode.
 """
 #   Copyright 2020 The PyMC Developers
 #
@@ -16,7 +19,6 @@ A library based on PyMC--sunode--has implemented Adams' method and BDF (backward
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-
 
 from pymc.ode import utils
 from pymc.ode.ode import DifferentialEquation

--- a/pymc/ode/__init__.py
+++ b/pymc/ode/__init__.py
@@ -1,4 +1,8 @@
-"""This submodule contains tools used to perform inference on ordinary differential equations."""
+"""
+This submodule contains tools used to perform inference on ordinary differential equations.
+Due to the nature of the model (as well as included solvers), this may perform slowly.
+A library based on PyMC--sunode--has implemented Adams' method and BDF (backward differentation formula).  More information about sunode is available at: https://github.com/aseyboldt/sunode.
+"""
 #   Copyright 2020 The PyMC Developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +16,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
 
 from pymc.ode import utils
 from pymc.ode.ode import DifferentialEquation

--- a/pymc/ode/ode.py
+++ b/pymc/ode/ode.py
@@ -64,6 +64,9 @@ class DifferentialEquation(Op):
         times = np.arange(0.5, 5, 0.5)
 
         ode_model = DifferentialEquation(func=odefunc, times=times, n_states=1, n_theta=1, t0=0)
+
+    Due to the nature of the model (as well as included solvers), the process of ODE solution may perform slowly.
+    A faster alternative library based on PyMC--sunode--has implemented Adams' method and BDF (backward differentation formula).  More information about sunode is available at: https://github.com/aseyboldt/sunode.
     """
     _itypes = [
         TensorType(floatX, (False,)),  # y0 as 1D floatX vector

--- a/pymc/ode/ode.py
+++ b/pymc/ode/ode.py
@@ -34,6 +34,9 @@ class DifferentialEquation(Op):
     r"""
     Specify an ordinary differential equation
 
+    Due to the nature of the model (as well as included solvers), the process of ODE solution may perform slowly.  A faster alternative library based on PyMC--sunode--has implemented Adams' method and BDF (backward differentation formula).  More information about sunode is available at: https://github.com/aseyboldt/sunode.
+
+
     .. math::
         \dfrac{dy}{dt} = f(y,t,p) \quad y(t_0) = y_0
 
@@ -65,8 +68,6 @@ class DifferentialEquation(Op):
 
         ode_model = DifferentialEquation(func=odefunc, times=times, n_states=1, n_theta=1, t0=0)
 
-    Due to the nature of the model (as well as included solvers), the process of ODE solution may perform slowly.
-    A faster alternative library based on PyMC--sunode--has implemented Adams' method and BDF (backward differentation formula).  More information about sunode is available at: https://github.com/aseyboldt/sunode.
     """
     _itypes = [
         TensorType(floatX, (False,)),  # y0 as 1D floatX vector


### PR DESCRIPTION
Updated docstrings for [__init.py__](https://github.com/pymc-devs/pymc/blob/main/pymc/ode/__init__.py) and [pymc.ode.DifferentialEquation](https://www.pymc.io/projects/docs/en/stable/api/generated/pymc.ode.DifferentialEquation.html#pymc.ode.DifferentialEquation)

Docstrings now provide additional information that ODE solution performance may be slow and provide a link to the sunode library (based on PyMC).

@reshamas 
#DataUmbrellaPyMCSprint