### PR TITLE
Add docker-image workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,9 +41,9 @@ jobs:
           load: true
           tags: ${{ env.CONTAINER_NAME }}
 
-      - name: Test
+      - name: Test importing pymc
         run: |
-           docker run --rm ${{ env.CONTAINER_NAME }} bash
+           docker run --rm build-test conda run -n pymc-dev python -c 'import pymc;print(pymc.__version__)'
 
       - name: Build and push
         uses: docker/build-push-action@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,55 @@
+name: push-docker-image
+
+on:
+  release:
+    types:
+      - created
+
+env:
+  CONTAINER_NAME: build-test
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+                name=pymc/pymc,enable=true
+        tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and load image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: scripts/Dockerfile
+          load: true
+          tags: ${{ env.CONTAINER_NAME }}
+
+      - name: Test
+        run: |
+           docker run --rm ${{ env.CONTAINER_NAME }} bash
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          file: scripts/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->


**What is this PR about?**
It solves #5939 

It add a workflow `docker-image`, The workflow get the labels and tags, build the image, test it and push it to Docker Hub. The workflow will be triggered when there are new releases.

It's needed to have the secrets with the Docker Hub user `DOCKERHUB_USER` and token `DOCKERHUB_TOKEN`.

The workflow was tested using [act](https://github.com/nektos/act). The test image is in a [test image](https://hub.docker.com/repository/docker/symeneses/test) where you can see the tags (latest and version) created. These tags can be modified if needed.

#DataUmbrellaPyMCSprint

...

**Checklist**
+ [ x] Explain important implementation details 👆
+ [x ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ x] Are the changes covered by tests and docstrings?
+ [ x] Fill out the short summary sections 👇

