### PR TITLE
Provide a fix for `sample_blackjax_nuts` failing with `chains=1` with prior parameters of different shapes

### DIFF
--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -298,8 +298,7 @@ def sample_blackjax_nuts(
     )
 
     if chains == 1:
-        init_params = [np.stack(init_params)]
-        init_params = [np.stack(init_state) for init_state in zip(*init_params)]
+        init_params = [np.stack(init_state) for init_state in zip(init_params)]
 
     logprob_fn = get_jaxified_logp(model)
 

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -45,8 +45,8 @@ def test_transform_samples(sampler, postprocessing_backend, chains):
     obs_at = aesara.shared(obs, borrow=True, name="obs")
     with pm.Model() as model:
         a = pm.Uniform("a", -20, 20)
-        sigma = pm.HalfNormal("sigma")
-        b = pm.Normal("b", a, sigma=sigma, observed=obs_at)
+        sigma = pm.HalfNormal("sigma", shape=(2,))
+        b = pm.Normal("b", a, sigma=sigma.mean(), observed=obs_at)
 
         trace = sampler(
             chains=chains,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

The PR addresses #5954, which reported that calling `sample_blackjax_nuts` failed with `chains=1` when prior parameters had different shapes. A fix is provided by:
* A change in [sampling_jax.py](https://github.com/pymc-devs/pymc/blob/ab40dcc194ac9a358c690f0532841235b6cde13b/pymc/sampling_jax.py)  so that `init_params` has the same structure for `chains=1` as for `chains>1`
* Modification of the test case in [test_sampling_jax.py](https://github.com/pymc-devs/pymc/blob/ab40dcc194ac9a358c690f0532841235b6cde13b/pymc/tests/test_sampling_jax.py) so that it covers parameters with different shapes.
...

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- Fix bug in `sampling_jax.sample_blackjax_nuts` failing when called for one chain and prior parameters of different shape

## Docs / Maintenance
- ...
