### PR TITLE
Bump aesara dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - types-filelock
       - types-setuptools
       - arviz
-      - aesara==2.7.5
+      - aesara==2.7.7
       - aeppl==0.0.32
       always_run: true
       require_serial: true

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 # Base dependencies
 - aeppl=0.0.32
-- aesara=2.7.5
+- aesara=2.7.7
 - arviz>=0.12.0
 - blas
 - cachetools>=4.2.1

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 # Base dependencies
 - aeppl=0.0.32
-- aesara=2.7.5
+- aesara=2.7.7
 - arviz>=0.12.0
 - blas
 - cachetools>=4.2.1

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 # Base dependencies (see install guide for Windows)
 - aeppl=0.0.32
-- aesara=2.7.5
+- aesara=2.7.7
 - arviz>=0.12.0
 - blas
 - cachetools>=4.2.1

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 # Base dependencies (see install guide for Windows)
 - aeppl=0.0.32
-- aesara=2.7.5
+- aesara=2.7.7
 - arviz>=0.12.0
 - blas
 - cachetools>=4.2.1

--- a/pymc/ode/ode.py
+++ b/pymc/ode/ode.py
@@ -158,11 +158,11 @@ class DifferentialEquation(Op):
             )
 
         # convert inputs to tensors (and check their types)
-        y0 = at.cast(at.unbroadcast(at.as_tensor_variable(y0), 0), floatX)
-        theta = at.cast(at.unbroadcast(at.as_tensor_variable(theta), 0), floatX)
+        y0 = at.cast(at.as_tensor_variable(y0), floatX)
+        theta = at.cast(at.as_tensor_variable(theta), floatX)
         inputs = [y0, theta]
         for i, (input_val, itype) in enumerate(zip(inputs, self._itypes)):
-            if not input_val.type.in_same_class(itype):
+            if not itype.is_super(input_val.type):
                 raise ValueError(
                     f"Input {i} of type {input_val.type} does not have the expected type of {itype}"
                 )

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1030,7 +1030,7 @@ class Group(WithMemoization):
         """
         node = self.to_flat_input(node)
         random = self.symbolic_random.astype(self.symbolic_initial.dtype)
-        random = at.patternbroadcast(random, self.symbolic_initial.broadcastable)
+        random = at.specify_shape(random, self.symbolic_initial.type.shape)
 
         def sample(post, node):
             return aesara.clone_replace(node, {self.input: post})
@@ -1065,7 +1065,7 @@ class Group(WithMemoization):
         dict with replacements for initial
         """
         initial = self._new_initial(s, d, more_replacements)
-        initial = at.patternbroadcast(initial, self.symbolic_initial.broadcastable)
+        initial = at.specify_shape(initial, self.symbolic_initial.type.shape)
         if more_replacements:
             initial = aesara.clone_replace(initial, more_replacements)
         return {self.symbolic_initial: initial}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # See that file for comments about the need/usage of each dependency.
 
 aeppl==0.0.32
-aesara==2.7.5
+aesara==2.7.7
 arviz>=0.12.0
 cachetools>=4.2.1
 cloudpickle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aeppl==0.0.32
-aesara==2.7.5
+aesara==2.7.7
 arviz>=0.12.0
 cachetools>=4.2.1
 cloudpickle


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Bumping aesara from 2.7.5

The reason is that pypi is able to properly extract the dependencies of aesara >=2.7.6, but not of 2.7.5, [see this ticket for more info](https://github.com/aesara-devs/aesara/pull/1048). So AFAICT with this change pymc and all it's dependencies will be properly added to our pypi-mirror by just adding pymc to it and will be installable with just `pip install pymc` :D 

Thanks for the awesome library! 


...

**Checklist**
+ [ ] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Bump aesara dependency to 2.7.7
