### PR TITLE
Constrain priors with symmetric mass distribution

### DIFF
--- a/pymc/func_utils.py
+++ b/pymc/func_utils.py
@@ -107,7 +107,7 @@ def find_constrained_prior(
             fixed_params={"nu": 7},
         )
 
-    Under some circumstances, you might not want to have the same cummulative
+    Under some circumstances, you might not want to have the same cumulative
     probability below the ``lower`` threshold and above the ``upper`` threshold.
     For example, you might want to constrain an Exponential distribution to
     find the parameter that yields 90% of the mass below the ``upper`` bound,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
The `find_constrained_prior` function was optimising the difference between the upper and lower cdf values so that it matched a particular mass. This can be very brittle since there are multiple lower and upper cdf values that produce exactly the same mass. For example, [0.01, 0.96] will have 0.95 mass but [0.025, 0.975] will have it too. This PR proposes to use a different optimisation target so that the prior will be constrained to have the desired mass, and that the lower and upper cdf bounds will be symmetric.

**Checklist**
+ [X] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇

## Bugfixes / New features
- find_constrained_prior now attempts to find the parameters that lead to the desired mass between the lower and upper bounds, but also forces the lower and upper cdf values to be symmetric.
