### PR TITLE
Fix error when passing `coords` and `dims` in `sampling_jax`

### DIFF
--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -365,6 +365,7 @@ def sample_blackjax_nuts(
     }
 
     posterior = mcmc_samples
+    # Use 'partial' to set default arguments before passing 'idata_kwargs'
     az_trace = partial(
         az.from_dict,
         posterior=posterior,
@@ -560,6 +561,7 @@ def sample_numpyro_nuts(
     }
 
     posterior = mcmc_samples
+    # Use 'partial' to set default arguments before passing 'idata_kwargs'
     az_trace = partial(
         az.from_dict,
         posterior=posterior,

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -254,7 +254,9 @@ def sample_blackjax_nuts(
     idata_kwargs : dict, optional
         Keyword arguments for :func:`arviz.from_dict`. It also accepts a boolean as value
         for the ``log_likelihood`` key to indicate that the pointwise log likelihood should
-        not be included in the returned object.
+        not be included in the returned object. Values for ``observed_data``, ``constant_data``,
+        ``coords``, and ``dims`` are inferred from the ``model`` argument if not provided
+        in ``idata_kwargs``.
 
     Returns
     -------
@@ -366,16 +368,16 @@ def sample_blackjax_nuts(
 
     posterior = mcmc_samples
     # Use 'partial' to set default arguments before passing 'idata_kwargs'
-    az_trace = partial(
+    to_trace = partial(
         az.from_dict,
-        posterior=posterior,
         log_likelihood=log_likelihood,
         observed_data=find_observations(model),
         constant_data=find_constants(model),
         coords=coords,
         dims=dims,
         attrs=make_attrs(attrs, library=blackjax),
-    )(**idata_kwargs)
+    )
+    az_trace = to_trace(posterior=posterior, **idata_kwargs)
 
     return az_trace
 
@@ -432,7 +434,9 @@ def sample_numpyro_nuts(
     idata_kwargs : dict, optional
         Keyword arguments for :func:`arviz.from_dict`. It also accepts a boolean as value
         for the ``log_likelihood`` key to indicate that the pointwise log likelihood should
-        not be included in the returned object.
+        not be included in the returned object. Values for ``observed_data``, ``constant_data``,
+        ``coords``, and ``dims`` are inferred from the ``model`` argument if not provided
+        in ``idata_kwargs``.
     nuts_kwargs: dict, optional
         Keyword arguments for :func:`numpyro.infer.NUTS`.
 
@@ -562,9 +566,8 @@ def sample_numpyro_nuts(
 
     posterior = mcmc_samples
     # Use 'partial' to set default arguments before passing 'idata_kwargs'
-    az_trace = partial(
+    to_trace = partial(
         az.from_dict,
-        posterior=posterior,
         log_likelihood=log_likelihood,
         observed_data=find_observations(model),
         constant_data=find_constants(model),
@@ -572,6 +575,7 @@ def sample_numpyro_nuts(
         coords=coords,
         dims=dims,
         attrs=make_attrs(attrs, library=numpyro),
-    )(**idata_kwargs)
+    )
+    az_trace = to_trace(posterior=posterior, **idata_kwargs)
 
     return az_trace

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -365,7 +365,8 @@ def sample_blackjax_nuts(
     }
 
     posterior = mcmc_samples
-    az_trace = az.from_dict(
+    az_trace = partial(
+        az.from_dict,
         posterior=posterior,
         log_likelihood=log_likelihood,
         observed_data=find_observations(model),
@@ -373,8 +374,7 @@ def sample_blackjax_nuts(
         coords=coords,
         dims=dims,
         attrs=make_attrs(attrs, library=blackjax),
-        **idata_kwargs,
-    )
+    )(**idata_kwargs)
 
     return az_trace
 
@@ -560,7 +560,8 @@ def sample_numpyro_nuts(
     }
 
     posterior = mcmc_samples
-    az_trace = az.from_dict(
+    az_trace = partial(
+        az.from_dict,
         posterior=posterior,
         log_likelihood=log_likelihood,
         observed_data=find_observations(model),
@@ -569,7 +570,6 @@ def sample_numpyro_nuts(
         coords=coords,
         dims=dims,
         attrs=make_attrs(attrs, library=numpyro),
-        **idata_kwargs,
-    )
+    )(**idata_kwargs)
 
     return az_trace

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -153,6 +153,16 @@ def test_get_jaxified_logp():
     assert not np.isinf(jax_fn((np.array(5000.0), np.array(5000.0))))
 
 
+@pytest.fixture
+def model_test_idata_kwargs(scope="module"):
+    with pm.Model(coords={"x_coord": ["a", "b"], "x_coord2": [1, 2]}) as m:
+        x = pm.Normal("x", shape=(2,), dims=["x_coord"])
+        y = pm.Normal("y", x, observed=[0, 0])
+        pm.ConstantData("constantdata", [1, 2, 3])
+        pm.MutableData("mutabledata", 2)
+    return m
+
+
 @pytest.mark.parametrize(
     "sampler",
     [
@@ -165,15 +175,17 @@ def test_get_jaxified_logp():
     [
         dict(),
         dict(log_likelihood=False),
+        # Overwrite models coords
+        dict(coords={"x_coord": ["x1", "x2"]}),
+        # Overwrite dims from dist specification in model
+        dict(dims={"x": ["x_coord2"]}),
+        # Overwrite both coords and dims
+        dict(coords={"x_coord3": ["A", "B"]}, dims={"x": ["x_coord3"]}),
     ],
 )
 @pytest.mark.parametrize("postprocessing_backend", [None, "cpu"])
-def test_idata_kwargs(sampler, idata_kwargs, postprocessing_backend):
-    with pm.Model() as m:
-        x = pm.Normal("x")
-        y = pm.Normal("y", x, observed=0)
-        pm.ConstantData("constantdata", [1, 2, 3])
-        pm.MutableData("mutabledata", 2)
+def test_idata_kwargs(model_test_idata_kwargs, sampler, idata_kwargs, postprocessing_backend):
+    with model_test_idata_kwargs:
         idata = sampler(
             tune=50,
             draws=50,
@@ -188,6 +200,12 @@ def test_idata_kwargs(sampler, idata_kwargs, postprocessing_backend):
         assert "log_likelihood" in idata
     else:
         assert "log_likelihood" not in idata
+
+    x_dim_expected = idata_kwargs.get("dims", model_test_idata_kwargs.RV_dims)["x"][0]
+    assert idata.posterior.x.dims[-1] == x_dim_expected
+
+    x_coords_expected = idata_kwargs.get("coords", model_test_idata_kwargs.coords)[x_dim_expected]
+    assert list(x_coords_expected) == list(idata.posterior.x.coords[x_dim_expected].values)
 
 
 def test_get_batched_jittered_initial_points():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**Fix #5932 : Allow for passing `coords` and `dims` within `idata_kwargs` in `sample_blackjax_nuts` and `sample_numpyro_nuts`.**

Previously, the arguments `dims` and `coords`  as defined in the sampling function were passed to `az.from_dict` along with `idata_kwargs`. This caused an error when `idata_kwargs` contained keys `coords` and/or `dims` (duplicate keyword arguments), cf #5932.

Proposed solution:
* By using `functools.partial` on `az.from_dict`, new defaults are set first. Only afterwards `idata_kwargs` is passed along. This results in `dims` and `coords` in `idata_kwargs` taking precedence (if given) instead of causing duplicate keyword args.
* Test cases were added to `test_idata_kwargs` for providing `coords` and/or `dims` in `idata_kwargs`.
...

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- Fix #5932 

## Docs / Maintenance
- ...
