### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/contributing/developer_guide.md
+++ b/docs/source/contributing/developer_guide.md
@@ -151,7 +151,7 @@ def logp(self, value):
 ```
 
 In the ``logp`` method, parameters and values are either Aesara tensors, or could be converted to tensors.
-It is rather convenient as the evaluation of logp is represented as a tensor (``RV.logpt``), and when we linked different ``logp`` together (e.g., summing all ``RVs.logpt`` to get the model totall logp) the dependence  is taken care of by Aesara when the graph is built and compiled.
+It is rather convenient as the evaluation of logp is represented as a tensor (``RV.logpt``), and when we linked different ``logp`` together (e.g., summing all ``RVs.logpt`` to get the model total logp) the dependence  is taken care of by Aesara when the graph is built and compiled.
 Again, since the compiled function depends on the nodes that already in the graph, whenever you want to generate a new function that takes new input tensors you either need to regenerate the graph with the appropriate dependencies, or replace the node by editing the existing graph.
 In PyMC we use the second approach by using ``aesara.clone_replace()`` when it is needed.
 

--- a/docs/source/contributing/jupyter_style.md
+++ b/docs/source/contributing/jupyter_style.md
@@ -53,7 +53,7 @@ This guide does not teach nor cover MyST extensively, only gives some opinionate
 * Above all, stay consistent with variable names within the notebook. Notebooks using multiple names for the same variable will not be merged.
 * Use meaningful variable names wherever possible. Our users come from different backgrounds and not everyone is familiar with the same naming conventions.
   - Annotate dimensions too. Notebooks are published to be read, so even if the shape is derived
-    from the inputs or you don't like to use named dims and don't use them in your presonal
+    from the inputs or you don't like to use named dims and don't use them in your personal
     code, notebooks must use dims, even if annotating and not setting the shape.
     It makes the code easier to follow, especially for newcomers.
 * Sometimes it makes sense to use Greek letters to refer to variables, for example when writing equations, as this makes them easier to read. In that case, use LaTeX to insert the Greek letter like this `$\theta$` instead of using Unicode like `θ`.

--- a/pymc/step_methods/hmc/hmc.py
+++ b/pymc/step_methods/hmc/hmc.py
@@ -77,7 +77,7 @@ class HamiltonianMC(BaseHMC):
         scaling: array_like, ndim = {1,2}
             The inverse mass, or precision matrix. One dimensional arrays are
             interpreted as diagonal matrices. If `is_cov` is set to True,
-            this will be interpreded as the mass or covariance matrix.
+            this will be interpreted as the mass or covariance matrix.
         is_cov: bool, default=False
             Treat the scaling as mass or covariance matrix.
         potential: Potential, optional

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -158,7 +158,7 @@ class NUTS(BaseHMC):
         scaling: array_like, ndim = {1,2}
             The inverse mass, or precision matrix. One dimensional arrays are
             interpreted as diagonal matrices. If `is_cov` is set to True,
-            this will be interpreded as the mass or covariance matrix.
+            this will be interpreted as the mass or covariance matrix.
         is_cov: bool, default=False
             Treat the scaling as mass or covariance matrix.
         potential: Potential, optional


### PR DESCRIPTION
There are small typos in:
- docs/source/contributing/developer_guide.md
- docs/source/contributing/jupyter_style.md
- pymc/step_methods/hmc/hmc.py
- pymc/step_methods/hmc/nuts.py

Fixes:
- Should read `interpreted` rather than `interpreded`.
- Should read `total` rather than `totall`.
- Should read `personal` rather than `presonal`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md