### PR TITLE
Create arrow to observation nodes subject to arbitrary `dtype` casting in `pm.model_to_graphviz`

### DIFF
--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -100,6 +100,8 @@ class ModelGraph:
             input_map[var_name] = input_map[var_name].union(parent_name)
 
             while True:
+                # loop created so that the elif block can go through this again
+                # and remove any intermediate ops, notably dtype casting, to observations
                 if hasattr(var.tag, "observations"):
                     obs_node = var.tag.observations
                     obs_name = obs_node.name
@@ -108,11 +110,15 @@ class ModelGraph:
                         input_map[obs_name] = input_map[obs_name].union({var_name})
                         break
                     elif (
+                        # for cases where observations are cast to a certain dtype
+                        # see issue 5795: https://github.com/pymc-devs/pymc/issues/5795
                         obs_node.owner
                         and isinstance(obs_node.owner.op, Elemwise)
                         and isinstance(obs_node.owner.inputs[0].owner.op.scalar_op, Cast)
                     ):
                         # go to the beginning of the loop
+                        # this comment is going up the graph to retrieve the node, i.e.
+                        # observations here, is subject to dtype casting
                         var.tag.observations = obs_node.owner.inputs[0].owner.inputs[0]
                     else:
                         break

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -118,9 +118,7 @@ class ModelGraph:
                         and isinstance(obs_node.owner.op, Elemwise)
                         and isinstance(obs_node.owner.op.scalar_op, Cast)
                     ):
-                        # go to the beginning of the loop
-                        # this comment is going up the graph to retrieve the node, i.e.
-                        # observations here, is subject to dtype casting
+                        # we can retrieve the observation node by going up the graph
                         obs_node = obs_node.owner.inputs[0]
                     else:
                         break

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -107,11 +107,15 @@ class ModelGraph:
                         input_map[var_name] = input_map[var_name].difference({obs_name})
                         input_map[obs_name] = input_map[obs_name].union({var_name})
                         break
-                    elif isinstance(obs_node.owner.op, Elemwise) and isinstance(
-                        obs_node.owner.inputs[0].owner.op.scalar_op, Cast
+                    elif (
+                        obs_node.owner
+                        and isinstance(obs_node.owner.op, Elemwise)
+                        and isinstance(obs_node.owner.inputs[0].owner.op.scalar_op, Cast)
                     ):
                         # go to the beginning of the loop
                         var.tag.observations = obs_node.owner.inputs[0].owner.inputs[0]
+                    else:
+                        break
                 else:
                     break
 


### PR DESCRIPTION
Closes #5795.

As described in the issue, when casting data to another `dtype`, a casting operation is performed and ignored by the `pm.model_to_graphviz` functionality.

However, without investigating further, I believe that this PR covers the scope of #5795, but there is an [important example](https://github.com/pymc-devs/pymc/issues/5795#issuecomment-1184236854) of another problem which seems to be caused by a different issue. I hope to have a look at the latter this Wednesday.

CC @drbenvincent 