### PR TITLE
Fix problems with specifying target_accept and nuts kwargs

### DIFF
--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -479,7 +479,7 @@ def sample(
                 "`target_accept` was defined twice. Please specify it either as a direct keyword argument or in the `nuts` kwarg."
             )
         if "nuts" in kwargs:
-            kwargs["nuts"].update({"target_accept": kwargs.pop("target_accept")})
+            kwargs["nuts"]["target_accept"] = kwargs.pop("target_accept")
         else:
             kwargs = {"nuts": {"target_accept": kwargs.pop("target_accept")}}
 

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -474,7 +474,14 @@ def sample(
         )
         initvals = kwargs.pop("start")
     if "target_accept" in kwargs:
-        kwargs.setdefault("nuts", {"target_accept": kwargs.pop("target_accept")})
+        if "nuts" in kwargs and "target_accept" in kwargs["nuts"]:
+            raise ValueError(
+                "`target_accept` was defined twice. Please specify it either as a direct keyword argument or in the `nuts` kwarg."
+            )
+        if "nuts" in kwargs:
+            kwargs["nuts"].update({"target_accept": kwargs.pop("target_accept")})
+        else:
+            kwargs = {"nuts": {"target_accept": kwargs.pop("target_accept")}}
 
     model = modelcontext(model)
     if not model.free_RVs:

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -1450,9 +1450,14 @@ def test_step_args():
         a = pm.Normal("a")
         idata0 = pm.sample(target_accept=0.5, random_seed=1410)
         idata1 = pm.sample(nuts={"target_accept": 0.5}, random_seed=1410 * 2)
+        idata2 = pm.sample(target_accept=0.5, nuts={"max_treedepth": 10}, random_seed=1410)
+
+        with pytest.raises(ValueError):
+            pm.sample(target_accept=0.5, nuts={"target_accept": 0.95}, random_seed=1410)
 
     npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
     npt.assert_almost_equal(idata1.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
+    npt.assert_almost_equal(idata2.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
 
     with pm.Model() as model:
         a = pm.Normal("a")

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -1452,7 +1452,7 @@ def test_step_args():
         idata1 = pm.sample(nuts={"target_accept": 0.5}, random_seed=1410 * 2)
         idata2 = pm.sample(target_accept=0.5, nuts={"max_treedepth": 10}, random_seed=1410)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="`target_accept` was defined twice."):
             pm.sample(target_accept=0.5, nuts={"target_accept": 0.95}, random_seed=1410)
 
     npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)


### PR DESCRIPTION
This PR addresses #6009.


## Major / Breaking Changes
 
None

## Bugfixes / New features

- Fixes the problem that target_accept is overwritten if nuts kwargs are specified, i.e., this case
    `pm.sample(nuts={"max_treedepth": 15}, target_accept=0.99)`
- Raises an error when target_accept is specified twice; directly and in nuts kwargs, i.e. this case
    `pm.sample(nuts={"target_accept": 0.9}, target_accept=0.99)`

To this end, I slightly modified the code in `pm.sample()` such that
- We first check whether `nuts` is defined in `kwargs` and if yes, update that dictionary, and if not, create it. Before, the `setdefault()` method was used which meant that `target_accept` was just dropped if `nuts` was already defined in `kwargs`.
-  it is explicitly checked whether `target_accept` is defined twice.


## Docs / Maintenance
 I added two new test cases to the `test_step_args()` test.
