### PR TITLE
Revert numpy warnings workaround

### DIFF
--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -16,8 +16,6 @@
 __version__ = "4.1.4"
 
 import logging
-import multiprocessing as mp
-import platform
 
 _log = logging.getLogger("pymc")
 

--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -16,7 +16,8 @@
 __version__ = "4.1.4"
 
 import logging
-import sys
+import multiprocessing as mp
+import platform
 
 _log = logging.getLogger("pymc")
 
@@ -25,74 +26,6 @@ if not logging.root.handlers:
     if len(_log.handlers) == 0:
         handler = logging.StreamHandler()
         _log.addHandler(handler)
-
-
-def __suppress_aesara_import_warnings():
-    """This is a workaround to suppress nonlethal NumPy warnings.
-
-    Some more printouts remain. See https://github.com/numpy/numpy/issues/21942
-
-    Remove this once https://github.com/aesara-devs/aesara/pull/980 is merged.
-    """
-    # We need to catch warnings as in some cases NumPy prints
-    # stuff that we don't want the user to see.
-    import io
-    import warnings
-
-    from contextlib import redirect_stderr, redirect_stdout
-
-    import numpy.distutils.system_info
-
-    class NumpyCompatibleStdoutStringIO(io.StringIO):
-        """Used as a temporary replacement of sys.stdout to capture Numpy's output.
-        We want to simply use io.StringIO, but this doesn't work because
-        Numpy expects the .encoding attribute to be a string. For io.StringIO,
-        this attribute is set to None and cannot be modified, hence the need for
-        this subclass.
-        (See forward_bytes_to_stdout in numpy.distutils.exec_command.)
-        """
-
-        encoding = sys.stdout.encoding
-
-    # Known executables which trigger false-positive warnings when not found.
-    # Ref: <https://github.com/conda-forge/aesara-feedstock/issues/54>
-    executables = ["g77", "f77", "ifort", "ifl", "f90", "DF", "efl"]
-
-    # The Numpy function which defines blas_info emits false-positive warnings.
-    # In what follows we capture these warnings and ignore them.
-    with warnings.catch_warnings(record=True):
-        # The warnings about missing executables don't use Python's "warnings"
-        # mechanism, and thus are not filtered by the catch_warnings context
-        # above. On Linux the warnings are printed to stderr, but on Windows
-        # they are printed to stdout. Thus we capture and filter both stdout
-        # and stderr.
-        stdout_sio, stderr_sio = NumpyCompatibleStdoutStringIO(), io.StringIO()
-        with redirect_stdout(stdout_sio), redirect_stderr(stderr_sio):
-            numpy.distutils.system_info.get_info("blas_opt")
-
-        # Print any unfiltered messages to stdout and stderr.
-        # (We hope that, beyond what we filter out, there should have been
-        # no messages printed to stdout or stderr. In case there were messages,
-        # we want to print them for the user to see. In what follows, we print
-        # the stdout messages followed by the stderr messages. This means that
-        # messages will be printed in the wrong order in the case that
-        # there is output to both stdout and stderr, and the stderr output
-        # doesn't come at the end.)
-        for captured_buffer, print_destination in (
-            (stdout_sio, sys.stdout),
-            (stderr_sio, sys.stderr),
-        ):
-            raw_lines = captured_buffer.getvalue().splitlines()
-            filtered_lines = [
-                line
-                for line in raw_lines
-                # Keep a line when none of the warnings are found within
-                # (equiv. when all of the warnings are not found within).
-                if all(f"Could not locate executable {exe}" not in line for exe in executables)
-            ]
-            for line in filtered_lines:
-                print(line, file=print_destination)
-    return
 
 
 def __set_compiler_flags():
@@ -114,8 +47,6 @@ def __set_compiler_flags():
     aesara.config.gcc__cxxflags = augmented
 
 
-if sys.platform == "win32":
-    __suppress_aesara_import_warnings()
 __set_compiler_flags()
 
 from pymc import gp, ode, sampling


### PR DESCRIPTION
This workaround was originally written for Aesara in https://github.com/aesara-devs/aesara/pull/980 to suppress spurious warnings when Aesara loads Numpy under Windows. It was subsequently ported to run here on pymc in https://github.com/pymc-devs/pymc/pull/5956. It has been subsequently fixed upstream in Aesara in a superior way by https://github.com/aesara-devs/aesara/pull/1050. Therefore, this workaround is obsolete, so I'm reverting it.

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
...

**Checklist**
+ [X] Explain important implementation details 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [X] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇

## Major / Breaking Changes
- None (hopefully!)

## Bugfixes / New features
- None

## Docs / Maintenance
- Cleans up unnecessary code :rocket: 

## Tests:
AFAIK there's no test here for warnings. But there is on Conda-Forge, so any problems on a release would be caught very quickly.