### PR TITLE
Remove `samples` and `keep_size` from `sample_posterior_predictive` 

### DIFF
--- a/pymc/tests/backends/test_arviz.py
+++ b/pymc/tests/backends/test_arviz.py
@@ -89,7 +89,7 @@ class TestDataPyMC:
         with data.model:
             prior = pm.sample_prior_predictive(return_inferencedata=False)
             posterior_predictive = pm.sample_posterior_predictive(
-                data.obj, keep_size=True, return_inferencedata=False
+                data.obj, return_inferencedata=False
             )
 
             idata = to_inference_data(
@@ -111,7 +111,7 @@ class TestDataPyMC:
     ) -> Tuple[InferenceData, Dict[str, np.ndarray]]:
         with data.model:
             posterior_predictive = pm.sample_posterior_predictive(
-                data.obj, keep_size=True, return_inferencedata=False
+                data.obj, return_inferencedata=False
             )
             idata = predictions_to_inference_data(
                 posterior_predictive,
@@ -190,7 +190,7 @@ class TestDataPyMC:
     def test_posterior_predictive_keep_size(self, data, chains, draws, eight_schools_params):
         with data.model:
             posterior_predictive = pm.sample_posterior_predictive(
-                data.obj, keep_size=True, return_inferencedata=False
+                data.obj, return_inferencedata=False
             )
             inference_data = to_inference_data(
                 trace=data.obj,
@@ -203,26 +203,6 @@ class TestDataPyMC:
         assert np.all(
             [obs_s == s for obs_s, s in zip(shape, (chains, draws, eight_schools_params["J"]))]
         )
-
-    def test_posterior_predictive_warning(self, data, eight_schools_params, caplog):
-        with data.model:
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore", ".*smaller than nchains times ndraws.*", UserWarning
-                )
-                posterior_predictive = pm.sample_posterior_predictive(
-                    data.obj, 370, return_inferencedata=False, keep_size=False
-                )
-            with pytest.warns(UserWarning, match="shape of variables"):
-                inference_data = to_inference_data(
-                    trace=data.obj,
-                    posterior_predictive=posterior_predictive,
-                    coords={"school": np.arange(eight_schools_params["J"])},
-                    dims={"theta": ["school"], "eta": ["school"]},
-                )
-
-        shape = inference_data.posterior_predictive.obs.shape
-        assert np.all([obs_s == s for obs_s, s in zip(shape, (1, 370, eight_schools_params["J"]))])
 
     def test_posterior_predictive_thinned(self, data):
         with data.model:

--- a/pymc/tests/distributions/test_mixture.py
+++ b/pymc/tests/distributions/test_mixture.py
@@ -554,10 +554,10 @@ class TestMixture(SeededTest):
         assert prior["like2"].shape == (n_samples, 20)
         assert prior["like3"].shape == (n_samples, 20)
 
-        assert ppc["like0"].shape == (n_samples, 20)
-        assert ppc["like1"].shape == (n_samples, 20)
-        assert ppc["like2"].shape == (n_samples, 20)
-        assert ppc["like3"].shape == (n_samples, 20)
+        assert ppc["like0"].shape == (1, n_samples, 20)
+        assert ppc["like1"].shape == (1, n_samples, 20)
+        assert ppc["like2"].shape == (1, n_samples, 20)
+        assert ppc["like3"].shape == (1, n_samples, 20)
 
     def test_list_mvnormals_predictive_sampling_shape(self):
         N = 100  # number of data points
@@ -594,7 +594,14 @@ class TestMixture(SeededTest):
             ppc = sample_posterior_predictive(
                 n_samples * [self.get_inital_point(model)], return_inferencedata=False
             )
-        assert ppc["x_obs"].shape == (n_samples,) + X.shape
+        assert (
+            ppc["x_obs"].shape
+            == (
+                1,
+                n_samples,
+            )
+            + X.shape
+        )
         assert prior["x_obs"].shape == (n_samples,) + X.shape
         assert prior["mu0"].shape == (n_samples, D)
         assert prior["chol_cov_0"].shape == (n_samples, D * (D + 1) // 2)

--- a/pymc/tests/distributions/test_mixture.py
+++ b/pymc/tests/distributions/test_mixture.py
@@ -546,7 +546,7 @@ class TestMixture(SeededTest):
         with model:
             prior = sample_prior_predictive(samples=n_samples, return_inferencedata=False)
             ppc = sample_posterior_predictive(
-                [self.get_inital_point(model)], samples=n_samples, return_inferencedata=False
+                n_samples * [self.get_inital_point(model)], return_inferencedata=False
             )
 
         assert prior["like0"].shape == (n_samples, 20)
@@ -592,7 +592,7 @@ class TestMixture(SeededTest):
         with model:
             prior = sample_prior_predictive(samples=n_samples, return_inferencedata=False)
             ppc = sample_posterior_predictive(
-                [self.get_inital_point(model)], samples=n_samples, return_inferencedata=False
+                n_samples * [self.get_inital_point(model)], return_inferencedata=False
             )
         assert ppc["x_obs"].shape == (n_samples,) + X.shape
         assert prior["x_obs"].shape == (n_samples,) + X.shape

--- a/pymc/tests/distributions/test_simulator.py
+++ b/pymc/tests/distributions/test_simulator.py
@@ -80,9 +80,7 @@ class TestSimulator(SeededTest):
         with self.SMABC_test:
             trace = pm.sample_smc(draws=1000, chains=1, return_inferencedata=False)
             pr_p = pm.sample_prior_predictive(1000, return_inferencedata=False)
-            po_p = pm.sample_posterior_predictive(
-                trace, keep_size=False, return_inferencedata=False
-            )
+            po_p = pm.sample_posterior_predictive(trace, return_inferencedata=False)
 
         assert abs(self.data.mean() - trace["a"].mean()) < 0.05
         assert abs(self.data.std() - trace["b"].mean()) < 0.05
@@ -91,7 +89,7 @@ class TestSimulator(SeededTest):
         assert abs(0 - pr_p["s"].mean()) < 0.15
         assert abs(1.4 - pr_p["s"].std()) < 0.10
 
-        assert po_p["s"].shape == (1000, 1000)
+        assert po_p["s"].shape == (1, 1000, 1000)
         assert abs(self.data.mean() - po_p["s"].mean()) < 0.10
         assert abs(self.data.std() - po_p["s"].std()) < 0.10
 

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -1269,8 +1269,12 @@ def test_interval_missing_observations():
         )
         assert np.all(np.var(pp_trace["theta1"], 0) > 0.0)
         assert np.all(np.var(pp_trace["theta2"], 0) > 0.0)
-        assert np.mean(pp_trace["theta1"][:, ~obs1.mask] - pp_trace["theta1_observed"]) == 0.0
-        assert np.mean(pp_trace["theta2"][:, ~obs2.mask] - pp_trace["theta2_observed"]) == 0.0
+        assert np.isclose(
+            np.mean(pp_trace["theta1"][:, ~obs1.mask] - pp_trace["theta1_observed"]), 0
+        )
+        assert np.isclose(
+            np.mean(pp_trace["theta2"][:, ~obs2.mask] - pp_trace["theta2_observed"]), 0
+        )
 
 
 def test_double_counting():

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -1263,8 +1263,9 @@ def test_interval_missing_observations():
 
         # Make sure that the observed values are newly generated samples and that
         # the observed and deterministic matche
-        pp_trace = pm.sample_posterior_predictive(
-            trace, return_inferencedata=False, keep_size=False
+        pp_idata = pm.sample_posterior_predictive(trace)
+        pp_trace = pp_idata.posterior_predictive.stack(sample=["chain", "draw"]).transpose(
+            "sample", ...
         )
         assert np.all(np.var(pp_trace["theta1"], 0) > 0.0)
         assert np.all(np.var(pp_trace["theta2"], 0) > 0.0)

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -505,21 +505,6 @@ def test_partial_trace_sample():
         assert "b" not in idata.posterior
 
 
-def test_chain_idx():
-    # see https://github.com/pymc-devs/pymc/issues/4469
-    with pm.Model():
-        mu = pm.Normal("mu")
-        x = pm.Normal("x", mu=mu, sigma=1, observed=np.asarray(3))
-        # note draws-tune must be >100 AND we need an observed RV for this to properly
-        # trigger convergence checks, which is one particular case in which this failed
-        # before
-        idata = pm.sample(draws=150, tune=10, chain_idx=1)
-
-        ppc = pm.sample_posterior_predictive(idata)
-        # TODO FIXME: Assert something.
-        ppc = pm.sample_posterior_predictive(idata)
-
-
 @pytest.mark.parametrize(
     "n_points, tune, expected_length, expected_n_traces",
     [
@@ -655,7 +640,8 @@ class TestSamplePPC(SeededTest):
             assert ppc["a"].shape == (nchains, ndraws)
 
             # test default case
-            ppc = pm.sample_posterior_predictive(trace, var_names=["a"])
+            idata_ppc = pm.sample_posterior_predictive(trace, var_names=["a"])
+            ppc = idata_ppc.posterior_predictive
             assert "a" in ppc
             assert ppc["a"].shape == (nchains, ndraws)
             # mu's standard deviation may have changed thanks to a's observed

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -1396,7 +1396,7 @@ class TestSamplePriorPredictive(SeededTest):
             sim_ppc["obs"].shape
             == (
                 1,
-                20,
+                20
             )
             + mn_data.shape
         )

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -637,7 +637,6 @@ class TestSamplePPC(SeededTest):
             trace = pm.sample(
                 draws=ndraws,
                 chains=nchains,
-                return_inferencedata=False,
             )
 
         with model:
@@ -656,11 +655,13 @@ class TestSamplePPC(SeededTest):
             assert ppc["a"].shape == (nchains, ndraws)
 
             # test default case
-            ppc = pm.sample_posterior_predictive(trace, var_names=["a"], return_inferencedata=False)
+            ppc = pm.sample_posterior_predictive(trace, var_names=["a"])
             assert "a" in ppc
             assert ppc["a"].shape == (nchains, ndraws)
             # mu's standard deviation may have changed thanks to a's observed
-            _, pval = stats.kstest(ppc["a"] - trace["mu"], stats.norm(loc=0, scale=1).cdf)
+            _, pval = stats.kstest(
+                (ppc["a"] - trace.posterior["mu"]).values.flatten(), stats.norm(loc=0, scale=1).cdf
+            )
             assert pval > 0.001
 
     def test_normal_scalar_idata(self):
@@ -754,7 +755,7 @@ class TestSamplePPC(SeededTest):
                 1000,
             )
             scale = np.sqrt(1 + 0.2**2)
-            _, pval = stats.kstest(ppc["b"], stats.norm(scale=scale).cdf)
+            _, pval = stats.kstest(ppc["b"].flatten(), stats.norm(scale=scale).cdf)
             assert pval > 0.001
 
     def test_model_not_drawable_prior(self):

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -658,7 +658,7 @@ class TestSamplePPC(SeededTest):
             # test default case
             ppc = pm.sample_posterior_predictive(trace, var_names=["a"], return_inferencedata=False)
             assert "a" in ppc
-            assert ppc["a"].shape == (nchains * ndraws,)
+            assert ppc["a"].shape == (nchains, ndraws)
             # mu's standard deviation may have changed thanks to a's observed
             _, pval = stats.kstest(ppc["a"] - trace["mu"], stats.norm(loc=0, scale=1).cdf)
             assert pval > 0.001
@@ -804,7 +804,7 @@ class TestSamplePPC(SeededTest):
                 trace, return_inferencedata=False, var_names=["p", "obs"]
             )
 
-        expected_p = np.array([logistic.eval({coeff: val}) for val in trace["x"][:samples]])
+        expected_p = np.array([[logistic.eval({coeff: val}) for val in trace["x"][:samples]]])
         assert post_pred["obs"].shape == (1, samples, 3)
         npt.assert_allclose(post_pred["p"], expected_p)
 
@@ -1392,14 +1392,7 @@ class TestSamplePriorPredictive(SeededTest):
         )
         assert sim_priors["probs"].shape == (20, 6)
         assert sim_priors["obs"].shape == (20,) + mn_data.shape
-        assert (
-            sim_ppc["obs"].shape
-            == (
-                1,
-                20
-            )
-            + mn_data.shape
-        )
+        assert sim_ppc["obs"].shape == (1, 20) + mn_data.shape
 
     def test_layers(self):
         with pm.Model() as model:


### PR DESCRIPTION

# Removed `samples` and `keep_size` from `sample_posterior_predictive` in `sampling.py`

In response to issue #5775, we removed the `samples` and `keep_size` parameters on the `sample_posterior_predictive` function. Consequently, we removed all the calls to these two variables inside the functions and edited the code such that it runs as `keep_size` was always `True` even though the variable is not actually defined. 

Regarding the `samples` parameter, it is defined by the trace object inside the function, so there was no need for it be a function parameter.

Moreover, we edited the all test functions that used these two parameters.

Pre-commit and linting tests were passed.

#DataUmbrellaPyMCSprint
P.D.: Thanks for all the help to @OriolAbril !
cc: @vitaliset @OriolAbril @reshamas 