### PR TITLE
Fix AttributeError in HMC bad initial energy warning

### DIFF
--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -165,7 +165,7 @@ class BaseHMC(GradientSharedStep):
             self.potential.raise_ok(q0.point_map_info)
             message_energy = (
                 "Bad initial energy, check any log probabilities that "
-                "are inf or -inf, nan or very small:\n{}".format(error_logp.to_string())
+                f"are inf or -inf, nan or very small:\n{error_logp}"
             )
             warning = SamplerWarning(
                 WarningType.BAD_ENERGY,

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -60,7 +60,7 @@ class BaseHMC(GradientSharedStep):
         t0=10,
         adapt_step_size=True,
         step_rand=None,
-        **aesara_kwargs
+        **aesara_kwargs,
     ):
         """Set up Hamiltonian samplers with common structures.
 


### PR DESCRIPTION
**What is this PR about?**
Fixing an `AttributeError: 'numpy.ndarray' object has no attribute 'to_string'`.

This is a bit strange, because as far as I can tell `np.ndarray` never had a `.to_string()` method to beging with.
There's a [`tostring()`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tostring.html) which got deprecated in NumPy 1.19 however.

In any case, the f-string should fix it.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] ~Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))~
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
None

## Bugfixes / New features
Fixes an `AttributeError` in the "Bad initial energy" warning.

## Docs / Maintenance
None
