### PR TITLE
Allow for batched `alpha` in `StickBreakingWeights`

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2277,9 +2277,10 @@ class StickBreakingWeights(SimplexContinuous):
         return super().dist([alpha, K], **kwargs)
 
     def moment(rv, size, alpha, K):
+        alpha = alpha[..., np.newaxis]
         moment = (alpha / (1 + alpha)) ** at.arange(K)
         moment *= 1 / (1 + alpha)
-        moment = at.concatenate([moment, [(alpha / (1 + alpha)) ** K]], axis=-1)
+        moment = at.concatenate([moment, (alpha / (1 + alpha)) ** K], axis=-1)
         if not rv_size_is_none(size):
             moment_size = at.concatenate(
                 [

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2206,10 +2206,12 @@ class StickBreakingWeightsRV(RandomVariable):
         if K < 0:
             raise ValueError("K needs to be positive.")
 
-        size = to_tuple(size)
-        size = np.broadcast_shapes(alpha.shape, size) + (K,)
+        if size is None:
+            size = alpha.shape + (K,)
+            alpha = alpha[..., np.newaxis]
+        else:
+            size = size + (K,)
 
-        alpha = alpha[..., np.newaxis]
         betas = rng.beta(1, alpha, size=size)
 
         sticks = np.concatenate(

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2206,11 +2206,9 @@ class StickBreakingWeightsRV(RandomVariable):
         if K < 0:
             raise ValueError("K needs to be positive.")
 
-        if size is None:
-            size = alpha.shape + (K,)
-            alpha = alpha[..., np.newaxis]
-        else:
-            size = size + (K,)
+        size = size if size is not None else alpha.shape
+        size = size + (K,)
+        alpha = alpha[..., np.newaxis]
 
         betas = rng.beta(1, alpha, size=size)
 

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2192,9 +2192,6 @@ class StickBreakingWeightsRV(RandomVariable):
         alpha = at.as_tensor_variable(alpha)
         K = at.as_tensor_variable(intX(K))
 
-        if alpha.ndim > 0:
-            raise ValueError("The concentration parameter needs to be a scalar.")
-
         if K.ndim > 0:
             raise ValueError("K must be a scalar.")
 
@@ -2205,20 +2202,17 @@ class StickBreakingWeightsRV(RandomVariable):
 
         size = tuple(size)
 
-        return size + (K + 1,)
+        return size + tuple(alpha.shape) + (K + 1,)
 
     @classmethod
     def rng_fn(cls, rng, alpha, K, size):
         if K < 0:
             raise ValueError("K needs to be positive.")
 
-        if size is None:
-            size = (K,)
-        elif isinstance(size, int):
-            size = (size,) + (K,)
-        else:
-            size = tuple(size) + (K,)
+        distribution_shape = alpha.shape + (K,)
+        size = to_tuple(size) + distribution_shape
 
+        alpha = alpha[..., np.newaxis]
         betas = rng.beta(1, alpha, size=size)
 
         sticks = np.concatenate(
@@ -2262,7 +2256,7 @@ class StickBreakingWeights(SimplexContinuous):
 
     Parameters
     ----------
-    alpha : tensor_like of float
+    alpha: float or array_like of floats
         Concentration parameter (alpha > 0).
     K : tensor_like of int
         The number of "sticks" to break off from an initial one-unit stick. The length of the weight

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2197,20 +2197,17 @@ class StickBreakingWeightsRV(RandomVariable):
 
         return super().make_node(rng, size, dtype, alpha, K)
 
-    def _infer_shape(self, size, dist_params, param_shapes=None):
-        alpha, K = dist_params
-
-        size = tuple(size)
-
-        return size + tuple(alpha.shape) + (K + 1,)
+    def _supp_shape_from_params(self, dist_params, **kwargs):
+        K = dist_params[1]
+        return (K + 1,)
 
     @classmethod
     def rng_fn(cls, rng, alpha, K, size):
         if K < 0:
             raise ValueError("K needs to be positive.")
 
-        distribution_shape = alpha.shape + (K,)
-        size = to_tuple(size) + distribution_shape
+        size = to_tuple(size)
+        size = np.broadcast_shapes(alpha.shape, size) + (K,)
 
         alpha = alpha[..., np.newaxis]
         betas = rng.beta(1, alpha, size=size)
@@ -2256,7 +2253,7 @@ class StickBreakingWeights(SimplexContinuous):
 
     Parameters
     ----------
-    alpha: float or array_like of floats
+    alpha : tensor_like of float
         Concentration parameter (alpha > 0).
     K : tensor_like of int
         The number of "sticks" to break off from an initial one-unit stick. The length of the weight

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2206,7 +2206,7 @@ class StickBreakingWeightsRV(RandomVariable):
         if K < 0:
             raise ValueError("K needs to be positive.")
 
-        size = size if size is not None else alpha.shape
+        size = to_tuple(size) if size is not None else alpha.shape
         size = size + (K,)
         alpha = alpha[..., np.newaxis]
 

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -953,6 +953,15 @@ def test_hierarchical_obs_logp():
     assert not any(isinstance(o, RandomVariable) for o in ops)
 
 
+@pytest.fixture(scope="module")
+def _compile_stickbreakingweights_logpdf():
+    _value = at.vector()
+    _alpha = at.scalar()
+    _k = at.iscalar()
+    _logp = logp(StickBreakingWeights.dist(_alpha, _k), _value)
+    return compile_pymc([_value, _alpha, _k], _logp)
+
+
 class TestMatchesScipy:
     def test_uniform(self):
         check_logp(
@@ -2280,27 +2289,25 @@ class TestMatchesScipy:
         )
 
     @pytest.mark.parametrize(
-        "value,alpha,K,logp",
+        "alpha,K",
         [
-            (np.array([5, 4, 3, 2, 1]) / 15, 0.5, 4, 1.5126301307277439),
-            (np.tile(1, 13) / 13, 2, 12, 13.980045245672827),
-            (np.array([0.001] * 10 + [0.99]), 0.1, 10, -22.971662448814723),
-            (np.append(0.5 ** np.arange(1, 20), 0.5**20), 5, 19, 94.20462772778092),
-            (
-                (np.array([[7, 5, 3, 2], [19, 17, 13, 11]]) / np.array([[17], [60]])),
-                2.5,
-                3,
-                np.array([1.29317672, 1.50126157]),
-            ),
+            (0.5, 4),
+            (2, 12),
+            (np.array([0.5, 1.0, 2.0]), 3),
+            (np.arange(1, 7, dtype="float64").reshape(2, 3), 5),
         ],
     )
-    def test_stickbreakingweights_logp(self, value, alpha, K, logp):
-        with Model() as model:
+    def test_stickbreakingweights_logp(self, alpha, K, _compile_stickbreakingweights_logpdf):
+        stickbreakingweights_logpdf = np.vectorize(
+            _compile_stickbreakingweights_logpdf, signature="(n),(),()->()"
+        )
+        value = pm.StickBreakingWeights.dist(alpha, K).eval()
+        with Model():
             sbw = StickBreakingWeights("sbw", alpha=alpha, K=K, transform=None)
         pt = {"sbw": value}
         assert_almost_equal(
             pm.logp(sbw, value).eval(),
-            logp,
+            stickbreakingweights_logpdf(value, alpha, K),
             decimal=select_by_precision(float64=6, float32=2),
             err_msg=str(pt),
         )
@@ -2312,37 +2319,6 @@ class TestMatchesScipy:
         assert pm.logp(sbw, np.array([1.1, 0.3, 0.2, 0.1])).eval() == -np.inf
         assert pm.logp(sbw, np.array([0.4, 0.3, 0.2, -0.1])).eval() == -np.inf
         assert pm.logp(sbw_wrong_K, np.array([0.4, 0.3, 0.2, 0.1])).eval() == -np.inf
-
-    @pytest.mark.parametrize(
-        "value, alpha, K",
-        [
-            (np.array([5, 4, 3, 2, 1]) / 15, [0.5, 1.0, 2.0], 4),
-            (
-                np.append(0.5 ** np.arange(1, 20), 0.5**20),
-                np.arange(1, 7, dtype="float64").reshape(2, 3),
-                19,
-            ),
-        ],
-    )
-    def test_stickbreakingweights_vectorized(self, value, alpha, K):
-        _value = at.vector()
-        _alpha = at.scalar()
-        _k = at.iscalar()
-        _logp = logp(StickBreakingWeights.dist(_alpha, _k), _value)
-        _stickbreakingweights_logpdf = compile_pymc([_value, _alpha, _k], _logp)
-        stickbreakingweights_logpdf = np.vectorize(
-            _stickbreakingweights_logpdf, signature="(n),(),()->()"
-        )
-
-        with Model():
-            sbw = StickBreakingWeights("sbw", alpha=alpha, K=K, transform=None)
-        pt = {"sbw": value}
-        assert_almost_equal(
-            pm.logp(sbw, value).eval(),
-            stickbreakingweights_logpdf(value, alpha, K),
-            decimal=select_by_precision(float64=6, float32=2),
-            err_msg=str(pt),
-        )
 
     @aesara.config.change_flags(compute_test_value="raise")
     def test_categorical_bounds(self):

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -2291,6 +2291,24 @@ class TestMatchesScipy:
                 3,
                 np.array([1.29317672, 1.50126157]),
             ),
+            (
+                np.array([5, 4, 3, 2, 1]) / 15,
+                np.array([0.5, 1, 2], dtype="float64"),
+                4,
+                np.array([1.51263013, 2.93119375, 2.99573227]),
+            ),
+            (
+                np.array([5, 4, 3, 2, 1]) / 15,
+                np.arange(1, 10, dtype="float64").reshape(3, 3),
+                4,
+                np.array(
+                    [
+                        [2.93119375, 2.99573227, 1.9095425],
+                        [0.35222059, -1.4632554, -3.44201938],
+                        [-5.53346686, -7.70739149, -9.94430955],
+                    ]
+                ),
+            ),
         ],
     )
     def test_stickbreakingweights_logp(self, value, alpha, K, logp):

--- a/pymc/tests/test_distributions_moments.py
+++ b/pymc/tests/test_distributions_moments.py
@@ -1166,6 +1166,32 @@ def test_rice_moment(nu, sigma, size, expected):
                 fill_value=np.append((1 / 3) ** np.arange(5) * 2 / 3, (1 / 3) ** 5),
             ),
         ),
+        (
+            np.array([1, 3]),
+            11,
+            None,
+            np.array(
+                [
+                    np.append((1 / 2) ** np.arange(11) * 1 / 2, (1 / 2) ** 11),
+                    np.append((3 / 4) ** np.arange(11) * 1 / 4, (3 / 4) ** 11),
+                ]
+            ),
+        ),
+        (
+            np.array([1, 3, 5]),
+            9,
+            (5, 3),
+            np.full(
+                shape=(5, 3, 10),
+                fill_value=np.array(
+                    [
+                        np.append((1 / 2) ** np.arange(9) * 1 / 2, (1 / 2) ** 9),
+                        np.append((3 / 4) ** np.arange(9) * 1 / 4, (3 / 4) ** 9),
+                        np.append((5 / 6) ** np.arange(9) * 1 / 6, (5 / 6) ** 9),
+                    ]
+                ),
+            ),
+        ),
     ],
 )
 def test_stickbreakingweights_moment(alpha, K, size, expected):

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1321,6 +1321,18 @@ class TestStickBreakingWeights(BaseTestDistributionRandom):
         assert np.all(draws <= 1)
 
 
+class TestStickBreakingWeights_1D_alpha(BaseTestDistributionRandom):
+    pymc_dist = pm.StickBreakingWeights
+    pymc_dist_params = {"alpha": [1.0, 2.0, 3.0], "K": 19}
+    expected_rv_op_params = {"alpha": [1.0, 2.0, 3.0], "K": 19}
+    sizes_to_check = [None]
+    sizes_expected = [(3, 20)]
+    checks_to_run = [
+        "check_pymc_params_match_rv_op",
+        "check_rv_size",
+    ]
+
+
 class TestCategorical(BaseTestDistributionRandom):
     pymc_dist = pm.Categorical
     pymc_dist_params = {"p": np.array([0.28, 0.62, 0.10])}

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1325,8 +1325,8 @@ class TestStickBreakingWeights_1D_alpha(BaseTestDistributionRandom):
     pymc_dist = pm.StickBreakingWeights
     pymc_dist_params = {"alpha": [1.0, 2.0, 3.0], "K": 19}
     expected_rv_op_params = {"alpha": [1.0, 2.0, 3.0], "K": 19}
-    sizes_to_check = [None]
-    sizes_expected = [(3, 20)]
+    sizes_to_check = [None, (3,), (5, 3)]
+    sizes_expected = [(3, 20), (3, 20), (5, 3, 20)]
     checks_to_run = [
         "check_pymc_params_match_rv_op",
         "check_rv_size",

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1287,26 +1287,25 @@ class TestDirichletMultinomial_1D_n_2D_a(BaseTestDistributionRandom):
 
 
 class TestStickBreakingWeights(BaseTestDistributionRandom):
-    parameters = [
-        (np.array(3.5), 19),
-        (np.array([1, 2, 3], dtype="float64"), 17),
-        (np.arange(1, 10, dtype="float64").reshape(3, 3), 15),
-        (np.arange(1, 25, dtype="float64").reshape(2, 3, 4), 5),
+    pymc_dist = pm.StickBreakingWeights
+    pymc_dist_params = {"alpha": 2.0, "K": 19}
+    expected_rv_op_params = {"alpha": 2.0, "K": 19}
+    sizes_to_check = [None, 17, (5,), (11, 5), (3, 13, 5)]
+    sizes_expected = [
+        (20,),
+        (17, 20),
+        (
+            5,
+            20,
+        ),
+        (11, 5, 20),
+        (3, 13, 5, 20),
     ]
-    for alpha, K in parameters:
-        pymc_dist = pm.StickBreakingWeights
-        pymc_dist_params = {"alpha": alpha, "K": K}
-        expected_rv_op_params = {"alpha": alpha, "K": K}
-        sizes_to_check = [None, 17, (5,), (11, 5), (3, 13, 5)]
-        sizes_expected = []
-        for size in sizes_to_check:
-            sizes_expected.append(to_tuple(size) + alpha.shape + (K + 1,))
-
-        checks_to_run = [
-            "check_pymc_params_match_rv_op",
-            "check_rv_size",
-            "check_basic_properties",
-        ]
+    checks_to_run = [
+        "check_pymc_params_match_rv_op",
+        "check_rv_size",
+        "check_basic_properties",
+    ]
 
     def check_basic_properties(self):
         default_rng = aesara.shared(np.random.default_rng(1234))

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1287,25 +1287,26 @@ class TestDirichletMultinomial_1D_n_2D_a(BaseTestDistributionRandom):
 
 
 class TestStickBreakingWeights(BaseTestDistributionRandom):
-    pymc_dist = pm.StickBreakingWeights
-    pymc_dist_params = {"alpha": 2.0, "K": 19}
-    expected_rv_op_params = {"alpha": 2.0, "K": 19}
-    sizes_to_check = [None, 17, (5,), (11, 5), (3, 13, 5)]
-    sizes_expected = [
-        (20,),
-        (17, 20),
-        (
-            5,
-            20,
-        ),
-        (11, 5, 20),
-        (3, 13, 5, 20),
+    parameters = [
+        (np.array(3.5), 19),
+        (np.array([1, 2, 3], dtype="float64"), 17),
+        (np.arange(1, 10, dtype="float64").reshape(3, 3), 15),
+        (np.arange(1, 25, dtype="float64").reshape(2, 3, 4), 5),
     ]
-    checks_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_rv_size",
-        "check_basic_properties",
-    ]
+    for alpha, K in parameters:
+        pymc_dist = pm.StickBreakingWeights
+        pymc_dist_params = {"alpha": alpha, "K": K}
+        expected_rv_op_params = {"alpha": alpha, "K": K}
+        sizes_to_check = [None, 17, (5,), (11, 5), (3, 13, 5)]
+        sizes_expected = []
+        for size in sizes_to_check:
+            sizes_expected.append(to_tuple(size) + alpha.shape + (K + 1,))
+
+        checks_to_run = [
+            "check_pymc_params_match_rv_op",
+            "check_rv_size",
+            "check_basic_properties",
+        ]
 
     def check_basic_properties(self):
         default_rng = aesara.shared(np.random.default_rng(1234))


### PR DESCRIPTION
**What is this PR about?**
Addressing #5383
This enables `StickBreakingWeight`'s `alpha` to accept batched data (>2D), make the `infer_shape` work with batched data, and fix the `rng_fn` by broadcasting alpha to K.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
* ...

## Bugfixes / New features
- `StickBreakingWeights` now supports batched `alpha` parameters

## Docs / Maintenance
* ...