### PR TITLE
update the default value of jitter to JITTER_DEFAULT

### DIFF
--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -160,7 +160,7 @@ class Latent(Base):
             variable by the Cholesky factor of the covariance matrix.
         jitter: scalar
             A small correction added to the diagonal of positive semi-definite
-            covariance matrices to ensure numerical stability.  Default value is 1e-6.
+            covariance matrices to ensure numerical stability.
         **kwargs
             Extra keyword arguments that are passed to distribution constructor.
         """
@@ -196,7 +196,7 @@ class Latent(Base):
         cov = Kss - at.dot(at.transpose(A), A)
         return mu, cov
 
-    def conditional(self, name, Xnew, given=None, jitter=0.0, **kwargs):
+    def conditional(self, name, Xnew, given=None, jitter=JITTER_DEFAULT, **kwargs):
         R"""
         Returns the conditional distribution evaluated over new input
         locations `Xnew`.
@@ -223,8 +223,7 @@ class Latent(Base):
             models in PyMC for more information.
         jitter: scalar
             A small correction added to the diagonal of positive semi-definite
-            covariance matrices to ensure numerical stability.  For conditionals
-            the default value is 0.0.
+            covariance matrices to ensure numerical stability.
         **kwargs
             Extra keyword arguments that are passed to `MvNormal` distribution
             constructor.
@@ -324,7 +323,7 @@ class TP(Latent):
         covT = (self.nu + beta - 2) / (nu2 - 2) * cov
         return nu2, mu, covT
 
-    def conditional(self, name, Xnew, jitter=0.0, **kwargs):
+    def conditional(self, name, Xnew, jitter=JITTER_DEFAULT, **kwargs):
         R"""
         Returns the conditional distribution evaluated over new input
         locations `Xnew`.
@@ -341,8 +340,7 @@ class TP(Latent):
             Function input values.
         jitter: scalar
             A small correction added to the diagonal of positive semi-definite
-            covariance matrices to ensure numerical stability.  For conditionals
-            the default value is 0.0.
+            covariance matrices to ensure numerical stability.
         **kwargs
             Extra keyword arguments that are passed to `MvNormal` distribution
             constructor.
@@ -407,7 +405,9 @@ class Marginal(Base):
         cov = Kxx + Knx
         return mu, stabilize(cov, jitter)
 
-    def marginal_likelihood(self, name, X, y, noise, jitter=0.0, is_observed=True, **kwargs):
+    def marginal_likelihood(
+        self, name, X, y, noise, jitter=JITTER_DEFAULT, is_observed=True, **kwargs
+    ):
         R"""
         Returns the marginal likelihood distribution, given the input
         locations `X` and the data `y`.
@@ -433,7 +433,7 @@ class Marginal(Base):
             non-white noise.
         jitter: scalar
             A small correction added to the diagonal of positive semi-definite
-            covariance matrices to ensure numerical stability.  Default value is 0.0.
+            covariance matrices to ensure numerical stability.
         **kwargs
             Extra keyword arguments that are passed to `MvNormal` distribution
             constructor.
@@ -497,7 +497,9 @@ class Marginal(Base):
                 cov += noise(Xnew)
             return mu, cov if pred_noise else stabilize(cov, jitter)
 
-    def conditional(self, name, Xnew, pred_noise=False, given=None, jitter=0.0, **kwargs):
+    def conditional(
+        self, name, Xnew, pred_noise=False, given=None, jitter=JITTER_DEFAULT, **kwargs
+    ):
         R"""
         Returns the conditional distribution evaluated over new input
         locations `Xnew`.
@@ -527,8 +529,7 @@ class Marginal(Base):
             models in PyMC for more information.
         jitter: scalar
             A small correction added to the diagonal of positive semi-definite
-            covariance matrices to ensure numerical stability.  For conditionals
-            the default value is 0.0.
+            covariance matrices to ensure numerical stability.
         **kwargs
             Extra keyword arguments that are passed to `MvNormal` distribution
             constructor.
@@ -539,7 +540,14 @@ class Marginal(Base):
         return pm.MvNormal(name, mu=mu, cov=cov, **kwargs)
 
     def predict(
-        self, Xnew, point=None, diag=False, pred_noise=False, given=None, jitter=0.0, model=None
+        self,
+        Xnew,
+        point=None,
+        diag=False,
+        pred_noise=False,
+        given=None,
+        jitter=JITTER_DEFAULT,
+        model=None,
     ):
         R"""
         Return the mean vector and covariance matrix of the conditional
@@ -563,15 +571,14 @@ class Marginal(Base):
             Same as `conditional` method.
         jitter: scalar
             A small correction added to the diagonal of positive semi-definite
-            covariance matrices to ensure numerical stability.  For conditionals
-            the default value is 0.0.
+            covariance matrices to ensure numerical stability.
         """
         if given is None:
             given = {}
         mu, cov = self._predict_at(Xnew, diag, pred_noise, given, jitter)
         return replace_with_values([mu, cov], replacements=point, model=model)
 
-    def _predict_at(self, Xnew, diag=False, pred_noise=False, given=None, jitter=0.0):
+    def _predict_at(self, Xnew, diag=False, pred_noise=False, given=None, jitter=JITTER_DEFAULT):
         R"""
         Return the mean vector and covariance matrix of the conditional
         distribution as symbolic variables.
@@ -712,7 +719,7 @@ class MarginalApprox(Marginal):
         return -1.0 * (constant + logdet + quadratic + trace)
 
     def marginal_likelihood(
-        self, name, X, Xu, y, noise=None, is_observed=True, jitter=0.0, **kwargs
+        self, name, X, Xu, y, noise=None, is_observed=True, jitter=JITTER_DEFAULT, **kwargs
     ):
         R"""
         Returns the approximate marginal likelihood distribution, given the input
@@ -738,7 +745,7 @@ class MarginalApprox(Marginal):
             Default is `True`.
         jitter: scalar
             A small correction added to the diagonal of positive semi-definite
-            covariance matrices to ensure numerical stability.  Default value is 0.0.
+            covariance matrices to ensure numerical stability.
         **kwargs
             Extra keyword arguments that are passed to `MvNormal` distribution
             constructor.
@@ -836,7 +843,9 @@ class MarginalApprox(Marginal):
             X, Xu, y, sigma = self.X, self.Xu, self.y, self.sigma
         return X, Xu, y, sigma, cov_total, mean_total
 
-    def conditional(self, name, Xnew, pred_noise=False, given=None, jitter=0.0, **kwargs):
+    def conditional(
+        self, name, Xnew, pred_noise=False, given=None, jitter=JITTER_DEFAULT, **kwargs
+    ):
         R"""
         Returns the approximate conditional distribution of the GP evaluated over
         new input locations `Xnew`.
@@ -857,8 +866,7 @@ class MarginalApprox(Marginal):
             models in PyMC for more information.
         jitter: scalar
             A small correction added to the diagonal of positive semi-definite
-            covariance matrices to ensure numerical stability.  For conditionals
-            the default value is 0.0.
+            covariance matrices to ensure numerical stability.
         **kwargs
             Extra keyword arguments that are passed to `MvNormal` distribution
             constructor.
@@ -968,7 +976,7 @@ class LatentKron(Base):
             `cartesian(*Xs)`.
         jitter: scalar
             A small correction added to the diagonal of positive semi-definite
-            covariance matrices to ensure numerical stability.  Default value is 1e-6.
+            covariance matrices to ensure numerical stability.
         **kwargs
             Extra keyword arguments that are passed to the `KroneckerNormal`
             distribution constructor.
@@ -998,7 +1006,7 @@ class LatentKron(Base):
         cov = stabilize(Kss - at.dot(at.transpose(A), A), jitter)
         return mu, cov
 
-    def conditional(self, name, Xnew, jitter=0.0, **kwargs):
+    def conditional(self, name, Xnew, jitter=JITTER_DEFAULT, **kwargs):
         """
         Returns the conditional distribution evaluated over new input
         locations `Xnew`.
@@ -1027,8 +1035,7 @@ class LatentKron(Base):
             vector with shape `(n, 1)`.
         jitter: scalar
             A small correction added to the diagonal of positive semi-definite
-            covariance matrices to ensure numerical stability.  For conditionals
-            the default value is 0.0.
+            covariance matrices to ensure numerical stability.
         **kwargs
             Extra keyword arguments that are passed to `MvNormal` distribution
             constructor.


### PR DESCRIPTION
This PR makes a minor change in gp models by setting the default value of `jitter` to `JITTER_DEFAULT`, instead of `0.0`. 

This could reduce the number of errors (like positive definite errors) when calling `conditional` functions.

I am not sure, but I'm not aware if there is any cases that the default jitter of `0.0` will be useful for end users. Please confirm if I'm wrong. Thank you.