### PR TITLE
DOC Adding "Git Bash command" to install virtual enviroment

### DIFF
--- a/docs/source/contributing/pr_tutorial.md
+++ b/docs/source/contributing/pr_tutorial.md
@@ -42,6 +42,12 @@ The preferred workflow for contributing to PyMC is to fork the [GitHub repositor
    conda env create -f .\conda-envs\windows-environment-dev.yml
    ```
    :::
+   :::{tab-item} Windows (Git Bash)
+
+   ```bash
+   conda env create -f conda-envs/windows-environment-dev.yml
+   ```
+   :::
    ::::
 
    ```bash


### PR DESCRIPTION
You can run many common Linux/Bash commands using the Git Bash application on Windows. When someone is following the (really useful) [Pull request step-by-step](https://docs.pymc.io/en/latest/contributing/pr_tutorial.html) tutorial it can be tricky to understand the error you get when you run "the Linux version" of creating the virtual environment using Git Bash on Windows.

The problem is that it is pointing to a different yml file (`environment-dev.yml`, instead of `windows-environment-dev.yml`).

Once you revisit the tutorial you can probably figure it out, but I don't find it is obvious just by looking at the terminal so I think we should explicitly make a new tab for it. 

What do you folks think? As it is quite straightforward to update, I did this PR, but "no hard feelings" if you think it should not be added! 🚀