### PR TITLE
Remove unused IS_FLOAT32 and IS_WINDOWS from test_ode

### DIFF
--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -12,8 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import sys
-
 import aesara
 import aesara.tensor as at
 import numpy as np
@@ -27,9 +25,6 @@ import pymc as pm
 from pymc.ode import DifferentialEquation
 from pymc.ode.utils import augment_system
 from pymc.tests.helpers import fast_unstable_sampling_mode
-
-IS_FLOAT32 = aesara.config.floatX == "float32"
-IS_WINDOWS = sys.platform == "win32"
 
 
 def test_gradients():


### PR DESCRIPTION
In the process of convincing myself that https://github.com/conda-forge/pymc-feedstock/pull/60 was a good idea, I checked for `sys.platform` usages, and found these unused variables. :smile: :scissors: 

I don't seem to have labels permissions, but I suggest `no releasenotes` and `tests`

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
...

**Checklist**
+ [ ] Explain important implementation details 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Remove unused IS_FLOAT32 and IS_WINDOWS from test_ode
