### PR TITLE
Convert pip-installed dev dependencies to Conda

### DIFF
--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -36,6 +36,5 @@ dependencies:
 - sphinx>=1.5
 - sphinxext-rediraffe
 - watermark
-- pip:
-  - polyagamma
-  - sphinx-remove-toctrees
+- polyagamma
+- sphinx-remove-toctrees

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -34,5 +34,4 @@ dependencies:
 - sphinx-notfound-page
 - sphinx>=1.5
 - watermark
-- pip:
-  - sphinx-remove-toctrees
+- sphinx-remove-toctrees


### PR DESCRIPTION
The package `sphinx-remove-toctrees` was being installed via pip, so I created a Conda package for it, and now it can be installed via Conda. Also, `polygamma` is available through Conda. Thus I modified `[windows-]environment-dev.yml` so that no dependencies are pip installed.

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
...

**Checklist**
+ [X] Explain important implementation details 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Refactor the installation of a few dependencies
