### PR TITLE
Add SpecifyShape decorator to jax_funcify_Assert

### DIFF
--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -28,6 +28,7 @@ from aesara.link.jax.dispatch import jax_funcify
 from aesara.raise_op import Assert
 from aesara.tensor import TensorVariable
 from arviz.data.base import make_attrs
+from aesara.tensor.shape import SpecifyShape
 
 from pymc import Model, modelcontext
 from pymc.backends.arviz import find_constants, find_observations
@@ -38,6 +39,7 @@ warnings.warn("This module is experimental.")
 
 @jax_funcify.register(Assert)
 @jax_funcify.register(CheckParameterValue)
+@jax_funcify.register(SpecifyShape)
 def jax_funcify_Assert(op, **kwargs):
     # Jax does not allow assert whose values aren't known during JIT compilation
     # within it's JIT-ed code. Hence we need to make a simple pass through

--- a/pymc/sampling_jax.py
+++ b/pymc/sampling_jax.py
@@ -27,8 +27,8 @@ from aesara.graph.fg import FunctionGraph
 from aesara.link.jax.dispatch import jax_funcify
 from aesara.raise_op import Assert
 from aesara.tensor import TensorVariable
-from arviz.data.base import make_attrs
 from aesara.tensor.shape import SpecifyShape
+from arviz.data.base import make_attrs
 
 from pymc import Model, modelcontext
 from pymc.backends.arviz import find_constants, find_observations


### PR DESCRIPTION
**What is this PR about?**
This PR addresses the problem raised in https://github.com/pymc-devs/pymc/issues/6050 and implements the fix suggested by @ricardoV94 . It consists of only two lines, so it is not a major change.

Closes #6050

## Major / Breaking Changes
* ...

## Bugfixes / New features
* Ignore `SpecifyShape` nodes when sampling with JAX (fixes https://github.com/pymc-devs/pymc/issues/6050).

## Docs / Maintenance
* ...