### PR TITLE
Fix broadcasting via observed and dims

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -209,7 +209,8 @@ class Distribution(metaclass=DistributionMeta):
         rng : optional
             Random number generator to use with the RandomVariable.
         dims : tuple, optional
-            A tuple of dimension names known to the model.
+            A tuple of dimension names known to the model. When shape is not provided,
+            the shape of dims is used to define the shape of the variable.
         initval : optional
             Numeric or symbolic untransformed initial value of matching shape,
             or one of the following initial value strategies: "moment", "prior".
@@ -217,6 +218,8 @@ class Distribution(metaclass=DistributionMeta):
             or moment-based initial values in the transformed space.
         observed : optional
             Observed data to be passed when registering the random variable in the model.
+            When neither shape nor dims is provided, the shape of observed is used to
+            define the shape of the variable.
             See ``Model.register_rv``.
         total_size : float, optional
             See ``Model.register_rv``.
@@ -405,7 +408,8 @@ class SymbolicDistribution:
         name : str
             Name for the new model variable.
         dims : tuple, optional
-            A tuple of dimension names known to the model.
+            A tuple of dimension names known to the model. When shape is not provided,
+            the shape of dims is used to define the shape of the variable.
         initval : optional
             Numeric or symbolic untransformed initial value of matching shape,
             or one of the following initial value strategies: "moment", "prior".
@@ -413,6 +417,8 @@ class SymbolicDistribution:
             symbolic or moment-based initial values in the transformed space.
         observed : optional
             Observed data to be passed when registering the random variable in the model.
+            When neither shape nor dims is provided, the shape of observed is used to
+            define the shape of the variable.
             See ``Model.register_rv``.
         total_size : float, optional
             See ``Model.register_rv``.

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -292,7 +292,7 @@ class Distribution(metaclass=DistributionMeta):
 
         rv_out.logp = _make_nice_attr_error("rv.logp(x)", "pm.logp(rv, x)")
         rv_out.logcdf = _make_nice_attr_error("rv.logcdf(x)", "pm.logcdf(rv, x)")
-        rv_out.random = _make_nice_attr_error("rv.random()", "rv.eval()")
+        rv_out.random = _make_nice_attr_error("rv.random()", "pm.draw(rv)")
         return rv_out
 
     @classmethod
@@ -351,7 +351,7 @@ class Distribution(metaclass=DistributionMeta):
 
         rv_out.logp = _make_nice_attr_error("rv.logp(x)", "pm.logp(rv, x)")
         rv_out.logcdf = _make_nice_attr_error("rv.logcdf(x)", "pm.logcdf(rv, x)")
-        rv_out.random = _make_nice_attr_error("rv.random()", "rv.eval()")
+        rv_out.random = _make_nice_attr_error("rv.random()", "pm.draw(rv)")
         return rv_out
 
 
@@ -488,6 +488,10 @@ class SymbolicDistribution:
             functools.partial(str_for_symbolic_dist, formatting="latex"), rv_out
         )
 
+        rv_out.logp = _make_nice_attr_error("rv.logp(x)", "pm.logp(rv, x)")
+        rv_out.logcdf = _make_nice_attr_error("rv.logcdf(x)", "pm.logcdf(rv, x)")
+        rv_out.random = _make_nice_attr_error("rv.random()", "pm.draw(rv)")
+
         return rv_out
 
     @classmethod
@@ -546,10 +550,9 @@ class SymbolicDistribution:
         # This is needed for resizing from dims in `__new__`
         rv_out.tag.ndim_supp = ndim_supp
 
-        # TODO: Create new attr error stating that these are not available for DerivedDistribution
-        # rv_out.logp = _make_nice_attr_error("rv.logp(x)", "pm.logp(rv, x)")
-        # rv_out.logcdf = _make_nice_attr_error("rv.logcdf(x)", "pm.logcdf(rv, x)")
-        # rv_out.random = _make_nice_attr_error("rv.random()", "rv.eval()")
+        rv_out.logp = _make_nice_attr_error("rv.logp(x)", "pm.logp(rv, x)")
+        rv_out.logcdf = _make_nice_attr_error("rv.logcdf(x)", "pm.logcdf(rv, x)")
+        rv_out.random = _make_nice_attr_error("rv.random()", "pm.draw(rv)")
         return rv_out
 
 

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -18,15 +18,13 @@ A collection of common shape operations needed for broadcasting
 samples from probability distributions for stochastic nodes in PyMC.
 """
 
-from typing import Optional, Sequence, Tuple, Union, cast
+from typing import Optional, Sequence, Tuple, Union
 
 import numpy as np
 
 from aesara.graph.basic import Variable
 from aesara.tensor.var import TensorVariable
 from typing_extensions import TypeAlias
-
-from pymc.aesaraf import convert_observed_data
 
 __all__ = [
     "to_tuple",
@@ -471,74 +469,46 @@ def convert_size(size: Size) -> Optional[StrongSize]:
     return size
 
 
-def resize_from_dims(dims: Dims, ndim_implied: int, model) -> Tuple[StrongSize, StrongDims]:
-    """Determines a potential resize shape from a `dims` tuple.
+def shape_from_dims(
+    dims: StrongDims, shape_implied: Sequence[TensorVariable], model
+) -> StrongShape:
+    """Determines shape from a `dims` tuple.
 
     Parameters
     ----------
     dims : array-like
         A vector of dimension names or None.
-    ndim_implied : int
-        Number of RV dimensions that were implied from its inputs alone.
+    shape_implied : tensor_like of int
+        Shape of RV implied from its inputs alone.
     model : pm.Model
         The current model on stack.
 
     Returns
     -------
-    resize_shape : array-like
-        Shape of new dimensions that should be prepended.
     dims : tuple of (str or None)
-        Names or None for all dimensions after resizing.
+        Names or None for all RV dimensions.
     """
-    sdims = cast(StrongDims, dims)
+    ndim_resize = len(dims) - len(shape_implied)
 
-    ndim_resize = len(sdims) - ndim_implied
-
-    # All resize dims must be known already (numerically or symbolically).
-    unknowndim_resize_dims = set(sdims[:ndim_resize]) - set(model.dim_lengths)
+    # Dims must be known already or be inferrable from implied dimensions of the RV
+    unknowndim_resize_dims = set(dims[:ndim_resize]) - set(model.dim_lengths)
     if unknowndim_resize_dims:
         raise KeyError(
             f"Dimensions {unknowndim_resize_dims} are unknown to the model and cannot be used to specify a `size`."
         )
 
     # The numeric/symbolic resize tuple can be created using model.RV_dim_lengths
-    resize_shape: Tuple[Variable, ...] = tuple(
-        model.dim_lengths[dname] for dname in sdims[:ndim_resize]
+    return tuple(
+        model.dim_lengths[dname] if dname in model.dim_lengths else shape_implied[i]
+        for i, dname in enumerate(dims)
     )
-    return resize_shape, sdims
-
-
-def resize_from_observed(
-    observed, ndim_implied: int
-) -> Tuple[StrongSize, Union[np.ndarray, Variable]]:
-    """Determines a potential resize shape from observations.
-
-    Parameters
-    ----------
-    observed : scalar, array-like
-        The value of the `observed` kwarg to the RV creation.
-    ndim_implied : int
-        Number of RV dimensions that were implied from its inputs alone.
-
-    Returns
-    -------
-    resize_shape : array-like
-        Shape of new dimensions that should be prepended.
-    observed : scalar, array-like
-        Observations as numpy array or `Variable`.
-    """
-    if not hasattr(observed, "shape"):
-        observed = convert_observed_data(observed)
-    ndim_resize = observed.ndim - ndim_implied
-    resize_shape = tuple(observed.shape[d] for d in range(ndim_resize))
-    return resize_shape, observed
 
 
 def find_size(
     shape: Optional[StrongShape],
     size: Optional[StrongSize],
     ndim_supp: int,
-) -> Tuple[Optional[StrongSize], Optional[int], Optional[int], int]:
+) -> Optional[StrongSize]:
     """Determines the size keyword argument for creating a Distribution.
 
     Parameters
@@ -553,30 +523,19 @@ def find_size(
 
     Returns
     -------
-    create_size : int, optional
-        The size argument to be passed to the distribution
-    ndim_expected : int, optional
-        Number of dimensions expected after distribution was created
-    ndim_batch : int, optional
-        Number of batch dimensions
-    ndim_supp : int
-        Number of support dimensions
+    size : tuble of int or TensorVariable, optional
+        The size argument for creating the Distribution
     """
 
-    ndim_expected: Optional[int] = None
-    ndim_batch: Optional[int] = None
-    create_size: Optional[StrongSize] = None
+    if size is not None:
+        return size
 
     if shape is not None:
         ndim_expected = len(tuple(shape))
         ndim_batch = ndim_expected - ndim_supp
-        create_size = tuple(shape)[:ndim_batch]
-    elif size is not None:
-        ndim_expected = ndim_supp + len(tuple(size))
-        ndim_batch = ndim_expected - ndim_supp
-        create_size = size
+        return tuple(shape)[:ndim_batch]
 
-    return create_size, ndim_expected, ndim_batch, ndim_supp
+    return None
 
 
 def rv_size_is_none(size: Variable) -> bool:

--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -45,7 +45,7 @@ class TestData(SeededTest):
         with pm.Model():
             x_shared = pm.MutableData("x_shared", x)
             b = pm.Normal("b", 0.0, 10.0)
-            pm.Normal("obs", b * x_shared, np.sqrt(1e-2), observed=y)
+            pm.Normal("obs", b * x_shared, np.sqrt(1e-2), observed=y, shape=x_shared.shape)
 
             prior_trace0 = pm.sample_prior_predictive(1000)
             idata = pm.sample(1000, tune=1000, chains=1)

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -3145,7 +3145,7 @@ def test_distinct_rvs():
     [
         ("logp", r"pm.logp\(rv, x\)"),
         ("logcdf", r"pm.logcdf\(rv, x\)"),
-        ("random", r"rv.eval\(\)"),
+        ("random", r"pm.draw\(rv\)"),
     ],
 )
 def test_logp_gives_migration_instructions(method, newcode):

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1905,7 +1905,6 @@ class TestDensityDist:
                 mu,
                 random=lambda mu, rng=None, size=None: rng.normal(loc=mu, scale=1, size=size),
                 observed=np.random.randn(100, *size),
-                size=size,
             )
 
         assert obs.eval().shape == (100,) + size
@@ -1937,7 +1936,6 @@ class TestDensityDist:
                     mean=mu, cov=np.eye(len(mu)), size=size
                 ),
                 observed=np.random.randn(100, *size, supp_shape),
-                size=size,
                 ndims_params=[1],
                 ndim_supp=1,
             )

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -1606,7 +1606,7 @@ class TestCompileForwardSampler:
             beta = pm.Normal("beta", 0, 0.1)
             mu = pm.Deterministic("mu", alpha + beta * x)
             sigma = pm.HalfNormal("sigma", 0.1)
-            obs = pm.Normal("obs", mu, sigma, observed=y)
+            obs = pm.Normal("obs", mu, sigma, observed=y, shape=x.shape)
 
         f = compile_forward_sampling_function(
             [obs],
@@ -1624,7 +1624,7 @@ class TestCompileForwardSampler:
             beta = pm.Normal("beta", 0, 0.1)
             mu = pm.Deterministic("mu", alpha + beta * x)
             sigma = pm.HalfNormal("sigma", 0.1)
-            obs = pm.Normal("obs", mu, sigma, observed=y)
+            obs = pm.Normal("obs", mu, sigma, observed=y, shape=x.shape)
 
         f = compile_forward_sampling_function(
             [obs],
@@ -1644,7 +1644,7 @@ class TestCompileForwardSampler:
             beta = pm.Normal("beta", 0, 0.1, size=p.shape)
             mu = pm.Deterministic("mu", beta[category])
             sigma = pm.HalfNormal("sigma", 0.1)
-            pm.Normal("obs", mu, sigma, observed=y)
+            pm.Normal("obs", mu, sigma, observed=y, shape=mu.shape)
 
         f = compile_forward_sampling_function(
             outputs=model.observed_RVs,
@@ -1675,7 +1675,7 @@ class TestCompileForwardSampler:
             mu = pm.Normal("mu", 0, 1)
             nested_mu = pm.Normal("nested_mu", mu, 1, size=10)
             sigma = pm.HalfNormal("sigma", 1)
-            pm.Normal("obs", nested_mu, sigma, observed=y)
+            pm.Normal("obs", nested_mu, sigma, observed=y, shape=nested_mu.shape)
 
         f = compile_forward_sampling_function(
             outputs=model.observed_RVs,

--- a/pymc/tests/test_shape_handling.py
+++ b/pymc/tests/test_shape_handling.py
@@ -320,6 +320,21 @@ class TestShapeDimsSize:
             # The change should propagate all the way through
             assert effect.eval().shape == (4,)
 
+    def test_define_dims_on_the_fly_from_observed(self):
+        with pm.Model() as pmodel:
+            data = aesara.shared(np.zeros((4, 5)))
+            x = pm.Normal("x", observed=data, dims=("patient", "trials"))
+            assert pmodel.dim_lengths["patient"].eval() == 4
+            assert pmodel.dim_lengths["trials"].eval() == 5
+
+            # Use dim to create a new RV
+            x_noisy = pm.Normal("x_noisy", 0, dims=("patient", "trials"))
+            assert x_noisy.eval().shape == (4, 5)
+
+            # Change data patient dims
+            data.set_value(np.zeros((10, 6)))
+            assert x_noisy.eval().shape == (10, 6)
+
     def test_can_resize_data_defined_size(self):
         with pm.Model() as pmodel:
             x = pm.MutableData("x", [[1, 2, 3, 4]], dims=("first", "second"))

--- a/pymc/tests/test_shared.py
+++ b/pymc/tests/test_shared.py
@@ -41,7 +41,7 @@ class TestShared(SeededTest):
 
         with pm.Model() as model:
             b = pm.Normal("b", 0.0, 10.0)
-            pm.Normal("obs", b * x_shared, np.sqrt(1e-2), observed=y)
+            pm.Normal("obs", b * x_shared, np.sqrt(1e-2), observed=y, shape=x_shared.shape)
             prior_trace0 = pm.sample_prior_predictive(1000)
 
             idata = pm.sample(1000, tune=1000, chains=1)


### PR DESCRIPTION
Fixes #5993 

This PR also removes the support of ellipsis in dims and shape. This feature was not very advertised so hopefully this won't cause too much pain.

These tests illustrate the bug fix

```python
    def test_broadcast_by_dims(self):
        with pm.Model(coords={"broadcast_dim": range(3)}) as m:
            x = pm.Normal("x", mu=np.zeros((1,)), dims=("broadcast_dim",))
            assert x.eval().shape == (3,)

    def test_broadcast_by_observed(self):
        with pm.Model() as m:
            x = pm.Normal("x", mu=np.zeros((1,)), observed=np.zeros((3,)))
            assert x.eval().shape == (3,)
```

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- When shape is not provided, dims or observed are used to define the shape of a variable. If you want a variable that has dims or is observed to automatically resize when its inputs change, you must specify that explicitly via the shape argument. For example, `pm.Normal("likelihood", mu=mu, sigma=sigma, observed=data, dims="data", shape=mu.shape)`
- Remove support of Ellipsis (`...`) in shape and dims

## Bugfixes / New features
- Fix bug where distribution shape would not be broadcasted by dims or observed
- Allow specifying dims on the fly from observed
- Do not show shape-related dependencies of RandomVariables in `model_graph`

## Docs / Maintenance
- Update `_make_nice_attr_error` to suggest `pm.draw` instead of `.eval()`
- Add `_make_nice_attr_error` to `SymbolicDistribution`s
