### PR TITLE
Remove note that probs are automatically rescaled

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1268,8 +1268,7 @@ class Categorical(Discrete):
     Parameters
     ----------
     p : array of floats
-        p > 0 and the elements of p must sum to 1. They will be automatically
-        rescaled otherwise.
+        p > 0 and the elements of p must sum to 1.
     logit_p : float
         Alternative log odds for the probability of success.
     """

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -516,7 +516,7 @@ class Multinomial(Discrete):
     p : tensor_like of float
         Probability of each one of the different outcomes (0 <= p <= 1). The number of
         categories is given by the length of the last axis. Elements are expected to sum
-        to 1 along the last axis, and they will be automatically rescaled otherwise.
+        to 1 along the last axis.
     """
     rv_op = multinomial
 


### PR DESCRIPTION

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**

This concerns the documentation of the Categorical and Multinomial
distributions.  Probabilities are indeed rescaled, but only when they
are numeric, and with a warning to discourage users from that.
Hence this should not be in the documentation.

See issue #5978.


**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Remove indication that probabilities are automatically rescaled for the Categorical and Multinomial distributions
