### PR TITLE
Clean up some warnings from the test suite

### DIFF
--- a/pymc/tests/test_distributions_timeseries.py
+++ b/pymc/tests/test_distributions_timeseries.py
@@ -293,10 +293,25 @@ class TestAR:
         beta_tp = np.random.randn(batch_size, ar_order + int(constant))
         y_tp = np.random.randn(batch_size, steps)
         with Model() as t0:
-            y = AR("y", beta_tp, shape=(batch_size, steps), initval=y_tp, constant=constant)
+            y = AR(
+                "y",
+                beta_tp,
+                shape=(batch_size, steps),
+                initval=y_tp,
+                constant=constant,
+                init_dist=Normal.dist(0, 100, shape=(batch_size, steps)),
+            )
         with Model() as t1:
             for i in range(batch_size):
-                AR(f"y_{i}", beta_tp[i], sigma=1.0, shape=steps, initval=y_tp[i], constant=constant)
+                AR(
+                    f"y_{i}",
+                    beta_tp[i],
+                    sigma=1.0,
+                    shape=steps,
+                    initval=y_tp[i],
+                    constant=constant,
+                    init_dist=Normal.dist(0, 100, shape=steps),
+                )
 
         assert y.owner.op.ar_order == ar_order
 
@@ -402,7 +417,14 @@ class TestAR:
             AR("y", beta_tp, sigma=0.01, init_dist=init_dist, steps=steps, initval=y_tp)
         with Model() as t1:
             for i in range(batch_size):
-                AR(f"y_{i}", beta_tp, sigma=0.01, shape=steps, initval=y_tp[i])
+                AR(
+                    f"y_{i}",
+                    beta_tp,
+                    sigma=0.01,
+                    shape=steps,
+                    initval=y_tp[i],
+                    init_dist=Normal.dist(0, 100, shape=steps),
+                )
 
         np.testing.assert_allclose(
             t0.compile_logp()(t0.initial_point()),

--- a/pymc/tests/test_hmc.py
+++ b/pymc/tests/test_hmc.py
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import logging
+import warnings
 
 import numpy as np
 import numpy.testing as npt
@@ -59,9 +60,11 @@ def test_nuts_tuning():
     with pymc.Model():
         pymc.Normal("mu", mu=0, sigma=1)
         step = pymc.NUTS()
-        idata = pymc.sample(
-            10, step=step, tune=5, discard_tuned_samples=False, progressbar=False, chains=1
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
+            idata = pymc.sample(
+                10, step=step, tune=5, discard_tuned_samples=False, progressbar=False, chains=1
+            )
 
     assert not step.tune
     ss_tuned = idata.warmup_sample_stats["step_size"][0, -1]

--- a/pymc/tests/test_math.py
+++ b/pymc/tests/test_math.py
@@ -148,7 +148,10 @@ def test_log1mexp():
     )
     actual = at.log1mexp(-vals).eval()
     npt.assert_allclose(actual, expected)
-    actual_ = log1mexp_numpy(-vals, negative_input=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "divide by zero encountered in log", RuntimeWarning)
+        warnings.filterwarnings("ignore", "invalid value encountered in log", RuntimeWarning)
+        actual_ = log1mexp_numpy(-vals, negative_input=True)
     npt.assert_allclose(actual_, expected)
     # Check that input was not changed in place
     npt.assert_allclose(vals, vals_)
@@ -193,7 +196,9 @@ def test_log1mexp_deprecation_warnings():
 
 def test_logdiffexp():
     a = np.log([1, 2, 3, 4])
-    b = np.log([0, 1, 2, 3])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "divide by zero encountered in log", RuntimeWarning)
+        b = np.log([0, 1, 2, 3])
 
     assert np.allclose(logdiffexp_numpy(a, b), 0)
     assert np.allclose(logdiffexp(a, b).eval(), 0)

--- a/pymc/tests/test_mixture.py
+++ b/pymc/tests/test_mixture.py
@@ -442,14 +442,16 @@ class TestMixture(SeededTest):
             mu = Gamma("mu", 1.0, 1.0, shape=pois_w.size)
             Mixture("x_obs", w, Poisson.dist(mu), observed=pois_x)
             step = Metropolis()
-            trace = sample(
-                5000,
-                step,
-                random_seed=self.random_seed,
-                progressbar=False,
-                chains=1,
-                return_inferencedata=False,
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "More chains .* than draws.*", UserWarning)
+                trace = sample(
+                    5000,
+                    step,
+                    random_seed=self.random_seed,
+                    progressbar=False,
+                    chains=1,
+                    return_inferencedata=False,
+                )
 
         assert_allclose(np.sort(trace["w"].mean(axis=0)), np.sort(pois_w), rtol=0.1, atol=0.1)
         assert_allclose(np.sort(trace["mu"].mean(axis=0)), np.sort(pois_mu), rtol=0.1, atol=0.1)
@@ -463,14 +465,16 @@ class TestMixture(SeededTest):
             w = Dirichlet("w", floatX(np.ones_like(pois_w)), shape=pois_w.shape)
             mu = Gamma("mu", 1.0, 1.0, shape=pois_w.size)
             Mixture("x_obs", w, [Poisson.dist(mu[0]), Poisson.dist(mu[1])], observed=pois_x)
-            trace = sample(
-                5000,
-                chains=1,
-                step=Metropolis(),
-                random_seed=self.random_seed,
-                progressbar=False,
-                return_inferencedata=False,
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "More chains .* than draws.*", UserWarning)
+                trace = sample(
+                    5000,
+                    chains=1,
+                    step=Metropolis(),
+                    random_seed=self.random_seed,
+                    progressbar=False,
+                    return_inferencedata=False,
+                )
 
         assert_allclose(np.sort(trace["w"].mean(axis=0)), np.sort(pois_w), rtol=0.1, atol=0.1)
         assert_allclose(np.sort(trace["mu"].mean(axis=0)), np.sort(pois_mu), rtol=0.1, atol=0.1)
@@ -491,14 +495,16 @@ class TestMixture(SeededTest):
                 [Normal.dist(mu[0], tau=tau[0]), Normal.dist(mu[1], tau=tau[1])],
                 observed=norm_x,
             )
-            trace = sample(
-                5000,
-                chains=1,
-                step=Metropolis(),
-                random_seed=self.random_seed,
-                progressbar=False,
-                return_inferencedata=False,
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "More chains .* than draws.*", UserWarning)
+                trace = sample(
+                    5000,
+                    chains=1,
+                    step=Metropolis(),
+                    random_seed=self.random_seed,
+                    progressbar=False,
+                    return_inferencedata=False,
+                )
 
         assert_allclose(np.sort(trace["w"].mean(axis=0)), np.sort(norm_w), rtol=0.1, atol=0.1)
         assert_allclose(np.sort(trace["mu"].mean(axis=0)), np.sort(norm_mu), rtol=0.1, atol=0.1)
@@ -747,14 +753,16 @@ class TestNormalMixture(SeededTest):
             tau = Gamma("tau", 1.0, 1.0, shape=norm_w.size)
             NormalMixture("x_obs", w, mu, tau=tau, observed=norm_x)
             step = Metropolis()
-            trace = sample(
-                5000,
-                step,
-                random_seed=self.random_seed,
-                progressbar=False,
-                chains=1,
-                return_inferencedata=False,
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "More chains .* than draws.*", UserWarning)
+                trace = sample(
+                    5000,
+                    step,
+                    random_seed=self.random_seed,
+                    progressbar=False,
+                    chains=1,
+                    return_inferencedata=False,
+                )
 
         assert_allclose(np.sort(trace["w"].mean(axis=0)), np.sort(norm_w), rtol=0.1, atol=0.1)
         assert_allclose(np.sort(trace["mu"].mean(axis=0)), np.sort(norm_mu), rtol=0.1, atol=0.1)

--- a/pymc/tests/test_model_graph.py
+++ b/pymc/tests/test_model_graph.py
@@ -22,6 +22,7 @@ from aesara.tensor.var import TensorConstant
 
 import pymc as pm
 
+from pymc.exceptions import ImputationWarning
 from pymc.model_graph import ModelGraph, model_to_graphviz, model_to_networkx
 from pymc.tests.helpers import SeededTest
 
@@ -138,7 +139,8 @@ def model_with_imputations():
 
     with pm.Model() as model:
         a = pm.Normal("a")
-        pm.Normal("L", a, 1.0, observed=x)
+        with pytest.warns(ImputationWarning):
+            pm.Normal("L", a, 1.0, observed=x)
 
     compute_graph = {
         "a": set(),

--- a/pymc/tests/test_ode.py
+++ b/pymc/tests/test_ode.py
@@ -11,6 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import warnings
 
 import aesara
 import aesara.tensor as at
@@ -363,7 +364,9 @@ class TestDiffEqModel:
             y = pm.LogNormal("y", mu=pm.math.log(forward), sigma=sigma, observed=yobs)
 
             with aesara.config.change_flags(mode=fast_unstable_sampling_mode):
-                idata = pm.sample(50, tune=0, chains=1)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
+                    idata = pm.sample(50, tune=0, chains=1)
 
         assert idata.posterior["alpha"].shape == (1, 50)
         assert idata.posterior["y0"].shape == (1, 50)
@@ -394,7 +397,9 @@ class TestDiffEqModel:
             y = pm.LogNormal("y", mu=pm.math.log(forward), sigma=sigma, observed=yobs)
 
             with aesara.config.change_flags(mode=fast_unstable_sampling_mode):
-                idata = pm.sample(50, tune=0, chains=1)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
+                    idata = pm.sample(50, tune=0, chains=1)
 
         assert idata.posterior["alpha"].shape == (1, 50)
         assert idata.posterior["beta"].shape == (1, 50)
@@ -436,7 +441,9 @@ class TestDiffEqModel:
             y = pm.LogNormal("y", mu=pm.math.log(forward), sigma=sigma, observed=yobs)
 
             with aesara.config.change_flags(mode=fast_unstable_sampling_mode):
-                idata = pm.sample(50, tune=0, chains=1)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
+                    idata = pm.sample(50, tune=0, chains=1)
 
         assert idata.posterior["R"].shape == (1, 50)
         assert idata.posterior["sigma"].shape == (1, 50, 2)
@@ -477,7 +484,9 @@ class TestDiffEqModel:
             y = pm.LogNormal("y", mu=pm.math.log(forward), sigma=sigma, observed=yobs)
 
             with aesara.config.change_flags(mode=fast_unstable_sampling_mode):
-                idata = pm.sample(50, tune=0, chains=1)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
+                    idata = pm.sample(50, tune=0, chains=1)
 
         assert idata.posterior["beta"].shape == (1, 50)
         assert idata.posterior["gamma"].shape == (1, 50)

--- a/pymc/tests/test_parallel_sampling.py
+++ b/pymc/tests/test_parallel_sampling.py
@@ -14,6 +14,7 @@
 import multiprocessing
 import os
 import platform
+import warnings
 
 import aesara
 import aesara.tensor as at
@@ -34,7 +35,9 @@ def test_context():
     with pm.Model():
         pm.Normal("x")
         ctx = multiprocessing.get_context("spawn")
-        pm.sample(tune=2, draws=2, chains=2, cores=2, mp_ctx=ctx)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
+            pm.sample(tune=2, draws=2, chains=2, cores=2, mp_ctx=ctx)
 
 
 class NoUnpickle:
@@ -194,7 +197,9 @@ def test_spawn_densitydist_function():
             return -2 * (x**2).sum()
 
         obs = pm.DensityDist("density_dist", logp=func, observed=np.random.randn(100))
-        pm.sample(draws=10, tune=10, step=pm.Metropolis(), cores=2, mp_ctx="spawn")
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
+            pm.sample(draws=10, tune=10, step=pm.Metropolis(), cores=2, mp_ctx="spawn")
 
 
 def test_spawn_densitydist_bound_method():
@@ -208,4 +213,6 @@ def test_spawn_densitydist_bound_method():
             return out
 
         obs = pm.DensityDist("density_dist", mu, logp=logp, observed=np.random.randn(N), size=N)
-        pm.sample(draws=10, tune=10, step=pm.Metropolis(), cores=2, mp_ctx="spawn")
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
+            pm.sample(draws=10, tune=10, step=pm.Metropolis(), cores=2, mp_ctx="spawn")

--- a/pymc/tests/test_sampling_jax.py
+++ b/pymc/tests/test_sampling_jax.py
@@ -16,17 +16,18 @@ from numpyro.infer import MCMC
 
 import pymc as pm
 
-from pymc.sampling_jax import (
-    _get_batched_jittered_initial_points,
-    _get_log_likelihood,
-    _numpyro_nuts_defaults,
-    _replace_shared_variables,
-    _update_numpyro_nuts_kwargs,
-    get_jaxified_graph,
-    get_jaxified_logp,
-    sample_blackjax_nuts,
-    sample_numpyro_nuts,
-)
+with pytest.warns(UserWarning, match="module is experimental"):
+    from pymc.sampling_jax import (
+        _get_batched_jittered_initial_points,
+        _get_log_likelihood,
+        _numpyro_nuts_defaults,
+        _replace_shared_variables,
+        _update_numpyro_nuts_kwargs,
+        get_jaxified_graph,
+        get_jaxified_logp,
+        sample_blackjax_nuts,
+        sample_numpyro_nuts,
+    )
 
 
 @pytest.mark.parametrize(
@@ -129,7 +130,9 @@ def test_get_log_likelihood():
         sigma = pm.HalfNormal("sigma")
         b = pm.Normal("b", a, sigma=sigma, observed=obs_at)
 
-        trace = pm.sample(tune=10, draws=10, chains=2, random_seed=1322)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
+            trace = pm.sample(tune=10, draws=10, chains=2, random_seed=1322)
 
     b_true = trace.log_likelihood.b.values
     a = np.array(trace.posterior.a)

--- a/pymc/tests/test_starting.py
+++ b/pymc/tests/test_starting.py
@@ -26,6 +26,7 @@ from pymc import (
     Uniform,
     find_MAP,
 )
+from pymc.exceptions import ImputationWarning
 from pymc.tests.checks import close_to
 from pymc.tests.helpers import select_by_precision
 from pymc.tests.models import non_normal, simple_arbitrary_det, simple_model
@@ -127,7 +128,8 @@ def test_find_MAP_issue_5923():
 def test_find_MAP_issue_4488():
     # Test for https://github.com/pymc-devs/pymc/issues/4488
     with Model() as m:
-        x = Gamma("x", alpha=3, beta=10, observed=np.array([1, np.nan]))
+        with pytest.warns(ImputationWarning):
+            x = Gamma("x", alpha=3, beta=10, observed=np.array([1, np.nan]))
         y = Deterministic("y", x + 1)
         map_estimate = find_MAP()
 

--- a/pymc/tests/test_tuning.py
+++ b/pymc/tests/test_tuning.py
@@ -11,6 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import warnings
 
 import numpy as np
 import pytest
@@ -24,7 +25,9 @@ from pymc.tuning import find_MAP, scaling
 
 def test_adjust_precision():
     a = np.array([-10, -0.01, 0, 10, 1e300, -inf, inf])
-    a1 = scaling.adjust_precision(a)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "divide by zero encountered in log", RuntimeWarning)
+        a1 = scaling.adjust_precision(a)
     assert all((a1 > 0) & (a1 < 1e200))
 
 

--- a/pymc/tests/test_types.py
+++ b/pymc/tests/test_types.py
@@ -11,6 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import warnings
 
 from copy import copy
 
@@ -45,7 +46,9 @@ class TestType:
 
         for sampler in self.samplers:
             with model:
-                sample(draws=10, tune=10, chains=1, step=sampler())
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
+                    sample(draws=10, tune=10, chains=1, step=sampler())
 
     @aesara.config.change_flags({"floatX": "float32", "warn_float64": "warn"})
     def test_float32(self):
@@ -58,4 +61,6 @@ class TestType:
 
         for sampler in self.samplers:
             with model:
-                sample(draws=10, tune=10, chains=1, step=sampler())
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
+                    sample(draws=10, tune=10, chains=1, step=sampler())

--- a/pymc/tests/test_variational_inference.py
+++ b/pymc/tests/test_variational_inference.py
@@ -11,7 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-
 import functools
 import io
 import operator
@@ -517,7 +516,11 @@ def inference_spec(request):
     def init_(**kw):
         k = init.copy()
         k.update(kw)
-        return cls(**k)
+        if cls == ASVGD:
+            with pytest.warns(UserWarning, match="experimental inference Operator"):
+                return cls(**k)
+        else:
+            return cls(**k)
 
     init_.cls = cls
     return init_
@@ -641,11 +644,19 @@ def fit_method_with_object(request, another_simple_model):
 )
 def test_fit_fn_text(method, kwargs, error, another_simple_model):
     with another_simple_model:
-        if error is not None:
-            with pytest.raises(error):
-                fit(10, method=method, **kwargs)
+        if method == "asvgd":
+            with pytest.warns(UserWarning, match="experimental inference Operator"):
+                if error is not None:
+                    with pytest.raises(error):
+                        fit(10, method=method, **kwargs)
+                else:
+                    fit(10, method=method, **kwargs)
         else:
-            fit(10, method=method, **kwargs)
+            if error is not None:
+                with pytest.raises(error):
+                    fit(10, method=method, **kwargs)
+            else:
+                fit(10, method=method, **kwargs)
 
 
 @pytest.fixture(scope="module")

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -142,10 +142,11 @@ def find_MAP(
         )
         method = "Powell"
 
-    if compute_gradient:
+    if compute_gradient and method != "Powell":
         cost_func = CostFuncWrapper(maxeval, progressbar, logp_func, dlogp_func)
     else:
         cost_func = CostFuncWrapper(maxeval, progressbar, logp_func)
+        compute_gradient = False
 
     try:
         opt_result = minimize(


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**

This PR removes 200 warnings from the 678 generated by the test suite. This de-clutters the output of the tests and makes it easier to spot if something is wrong. Also, but I am not sure if this is significant, the whole test suite ran 10% faster on my computer after the cleanup. I will check if it also makes the github runners faster.

I think that the ones that I fixed are the less controversial ones.

A good proportion if not the majority of the remaining warnings comes from a numpy deprecation in aesara which I will also address.

The rest are less easy to fix, or potential legit indications of problems (when I was not sure, I left them alone).

If there is interest, I can make a second pass later and try to tackle the rest.

I can breakup this huge commit into smaller thematic ones, let me know if this would be easier to review.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Clean up some warnings generated by the test suite
