### PR TITLE
Rename cov_func/cov to scale_func/scale for TP/MvStudentT

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -368,13 +368,13 @@ class MvStudentT(Continuous):
 
     @classmethod
     def dist(cls, nu, Sigma=None, mu=None, scale=None, tau=None, chol=None, lower=True, **kwargs):
-        if kwargs.get('cov') is not None:
+        if kwargs.get("cov") is not None:
             warnings.warn(
                 "Use the scale argument to specify the scale matrix."
                 "cov will be removed in future versions.",
                 DeprecationWarning,
             )
-            scale = kwargs.get('cov')
+            scale = kwargs.get("cov")
         if Sigma is not None:
             if scale is not None:
                 raise ValueError("Specify only one of scale and Sigma")

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -15,6 +15,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from asyncio import Future
 import warnings
 
 from functools import reduce
@@ -372,7 +373,7 @@ class MvStudentT(Continuous):
             warnings.warn(
                 "Use the scale argument to specify the scale matrix."
                 "cov will be removed in future versions.",
-                DeprecationWarning,
+                FutureWarning,
             )
             scale = kwargs.pop("cov")
         if Sigma is not None:

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -371,7 +371,7 @@ class MvStudentT(Continuous):
         if kwargs.get('cov') is not None:
             warnings.warn(
                 "Use the scale argument to specify the scale matrix."
-                "cov will be removed in future versions."
+                "cov will be removed in future versions.",
                 DeprecationWarning,
             )
             scale = kwargs.get('cov')

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -15,7 +15,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from asyncio import Future
 import warnings
 
 from functools import reduce

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -374,7 +374,7 @@ class MvStudentT(Continuous):
                 "cov will be removed in future versions.",
                 DeprecationWarning,
             )
-            scale = kwargs.get("cov")
+            scale = kwargs.pop("cov")
         if Sigma is not None:
             if scale is not None:
                 raise ValueError("Specify only one of scale and Sigma")

--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -270,7 +270,7 @@ class TP(Latent):
         if cov_func is not None:
             warnings.warn(
                 "Use the scale_func argument to specify the scale function."
-                "cov_func will be removed in future versions."
+                "cov_func will be removed in future versions.",
                 DeprecationWarning,
             )
             scale_func = cov_func

--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -271,7 +271,7 @@ class TP(Latent):
             warnings.warn(
                 "Use the scale_func argument to specify the scale function."
                 "cov_func will be removed in future versions.",
-                DeprecationWarning,
+                FutureWarning,
             )
             scale_func = cov_func
         self.nu = nu

--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -251,8 +251,8 @@ class TP(Latent):
 
     Parameters
     ----------
-    cov_func : None, 2D array, or instance of Covariance
-        The covariance function.  Defaults to zero.
+    scale_func : None, 2D array, or instance of Covariance
+        The scale function.  Defaults to zero.
     mean_func : None, instance of Mean
         The mean function.  Defaults to zero.
     nu : float
@@ -264,11 +264,18 @@ class TP(Latent):
         Processes as Alternatives to Gaussian Processes.  arXiv preprint arXiv:1402.4306.
     """
 
-    def __init__(self, *, mean_func=Zero(), cov_func=Constant(0.0), nu=None):
+    def __init__(self, *, mean_func=Zero(), scale_func=Constant(0.0), cov_func=None, nu=None):
         if nu is None:
             raise ValueError("Student's T process requires a degrees of freedom parameter, 'nu'")
+        if cov_func is not None:
+            warnings.warn(
+                "Use the scale_func argument to specify the scale function."
+                "cov_func will be removed in future versions."
+                DeprecationWarning,
+            )
+            scale_func = cov_func
         self.nu = nu
-        super().__init__(mean_func=mean_func, cov_func=cov_func)
+        super().__init__(mean_func=mean_func, cov_func=scale_func)
 
     def __add__(self, other):
         raise TypeError("Student's T processes aren't additive")

--- a/pymc/tests/test_gp.py
+++ b/pymc/tests/test_gp.py
@@ -1068,8 +1068,8 @@ class TestTP:
 
     def testTPvsLatent(self):
         with pm.Model() as model:
-            cov_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
-            tp = pm.gp.TP(cov_func=cov_func, nu=self.nu)
+            scale_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
+            tp = pm.gp.TP(scale_func=scale_func, nu=self.nu)
             f = tp.prior("f", self.X, reparameterize=False)
             p = tp.conditional("p", self.Xnew)
         assert tuple(f.shape.eval()) == (self.X.shape[0],)
@@ -1079,22 +1079,22 @@ class TestTP:
 
     def testTPvsLatentReparameterized(self):
         with pm.Model() as model:
-            cov_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
-            tp = pm.gp.TP(cov_func=cov_func, nu=self.nu)
+            scale_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
+            tp = pm.gp.TP(scale_func=scale_func, nu=self.nu)
             f = tp.prior("f", self.X, reparameterize=True)
             p = tp.conditional("p", self.Xnew)
         assert tuple(f.shape.eval()) == (self.X.shape[0],)
         assert tuple(p.shape.eval()) == (self.Xnew.shape[0],)
-        chol = np.linalg.cholesky(cov_func(self.X).eval())
+        chol = np.linalg.cholesky(scale_func(self.X).eval())
         f_rotated = np.linalg.solve(chol, self.y)
         tp_logp = model.compile_logp()({"f_rotated_": f_rotated, "p": self.pnew})
         npt.assert_allclose(self.gp_latent_logp, tp_logp, atol=0, rtol=1e-2)
 
     def testAdditiveTPRaises(self):
         with pm.Model() as model:
-            cov_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
-            gp1 = pm.gp.TP(cov_func=cov_func, nu=10)
-            gp2 = pm.gp.TP(cov_func=cov_func, nu=10)
+            scale_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
+            gp1 = pm.gp.TP(scale_func=scale_func, nu=10)
+            gp2 = pm.gp.TP(scale_func=scale_func, nu=10)
             with pytest.raises(Exception) as e_info:
                 gp1 + gp2
 


### PR DESCRIPTION
The scale matrix/function in the `MvStudentT` distribution and the `TP` have to date been called `cov` and `cov_func`, respectively. This is confusing because these are not covariance matrices/functions, but rather scale matrices/functions that only become covariances as a function of the `nu` parameter. This PR renames `cov` and `cov_func` to `scale` and `scale_func`, respectively, but still allows `cov` and `cov_func` for backward compatibility, with a deprecation warning.

Closes #2865 


**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Bugfixes / New features
- fixes #2865 

