### PR TITLE
Fix incorrect formula in NormalMixture docstring

### DIFF
--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -510,7 +510,7 @@ class NormalMixture:
     ========  =======================================
     Support   :math:`x \in \mathbb{R}`
     Mean      :math:`\sum_{i = 1}^n w_i \mu_i`
-    Variance  :math:`\sum_{i = 1}^n w_i^2 \sigma^2_i`
+    Variance  :math:`\sum_{i = 1}^n w_i (\sigma^2_i + \mu_i^2) - \left(\sum_{i = 1}^n w_i \mu_i\right)^2`
     ========  =======================================
 
     Parameters


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

The formula for the variance is incorrect in the docstring of the NormalMixture distribution. The correct expression can be found on the Wikipedia page for a [Mixture Distribution](https://en.wikipedia.org/wiki/Mixture_distribution#Moments), or it follows from the moment expressions in section A.2.2 of [The Matrix Cookbook](https://www.math.uwaterloo.ca/~hwolkowi//matrixcookbook.pdf).

The two expressions are not equivalent, as can be verified by checking the case of a mixture of two normal distributions with equal weights, means, and variances. The resulting mixture distribution should be identical to the two individual components, but the expression would give half the variance of the components as written.

...

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Fix the incorrect variance formula in the NormalMixture distribution docstring
