### PR TITLE
Marginalapprox fix

### DIFF
--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -685,17 +685,12 @@ class MarginalApprox(Marginal):
         super().__init__(mean_func=mean_func, cov_func=cov_func)
 
     def __add__(self, other):
-        # new_gp will default to FITC approx
         new_gp = super().__add__(other)
-        # make sure new gp has correct approx
         if not self.approx == other.approx:
             raise TypeError("Cannot add GPs with different approximations")
         new_gp.approx = self.approx
         return new_gp
 
-    # Use y as first argument, so that we can use functools.partial
-    # in marginal_likelihood instead of lambda. This makes pickling
-    # possible.
     def _build_marginal_likelihood_logp(self, y, X, Xu, sigma, jitter):
         sigma2 = at.square(sigma)
         Kuu = self.cov_func(Xu)
@@ -765,7 +760,7 @@ class MarginalApprox(Marginal):
             self.sigma = noise
 
         approx_logp = self._build_marginal_likelihood_logp(y, X, Xu, noise, JITTER_DEFAULT)
-        pm.Potential("marginalapprox_logp_" + name, approx_logp)
+        pm.Potential(f"marginalapprox_logp_{name}", approx_logp)
 
     def _build_conditional(
         self, Xnew, pred_noise, diag, X, Xu, y, sigma, cov_total, mean_total, jitter

--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -763,7 +763,7 @@ class MarginalApprox(Marginal):
             raise ValueError("noise argument must be specified")
         else:
             self.sigma = noise
-            
+
         approx_logp = self._build_marginal_likelihood_logp(y, X, Xu, noise, JITTER_DEFAULT)
         pm.Potential("marginalapprox_logp_" + name, approx_logp)
 

--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -691,7 +691,7 @@ class MarginalApprox(Marginal):
         new_gp.approx = self.approx
         return new_gp
 
-    def _build_marginal_likelihood_logp(self, y, X, Xu, sigma, jitter):
+    def _build_marginal_likelihood_loglik(self, y, X, Xu, sigma, jitter):
         sigma2 = at.square(sigma)
         Kuu = self.cov_func(Xu)
         Kuf = self.cov_func(Xu, X)
@@ -720,9 +720,7 @@ class MarginalApprox(Marginal):
         quadratic = 0.5 * (at.dot(r, r_l) - at.dot(c, c))
         return -1.0 * (constant + logdet + quadratic + trace)
 
-    def marginal_likelihood(
-        self, name, X, Xu, y, noise=None, is_observed=True, jitter=JITTER_DEFAULT, **kwargs
-    ):
+    def marginal_likelihood(self, name, X, Xu, y, noise=None, jitter=JITTER_DEFAULT, **kwargs):
         R"""
         Returns the approximate marginal likelihood distribution, given the input
         locations `X`, inducing point locations `Xu`, data `y`, and white noise
@@ -759,8 +757,8 @@ class MarginalApprox(Marginal):
         else:
             self.sigma = noise
 
-        approx_logp = self._build_marginal_likelihood_logp(y, X, Xu, noise, JITTER_DEFAULT)
-        pm.Potential(f"marginalapprox_logp_{name}", approx_logp)
+        approx_loglik = self._build_marginal_likelihood_loglik(y, X, Xu, noise, jitter)
+        pm.Potential(f"marginalapprox_loglik_{name}", approx_loglik, **kwargs)
 
     def _build_conditional(
         self, Xnew, pred_noise, diag, X, Xu, y, sigma, cov_total, mean_total, jitter

--- a/pymc/tests/test_gp.py
+++ b/pymc/tests/test_gp.py
@@ -852,7 +852,7 @@ class TestMarginalVsMarginalApprox:
     def setup_method(self):
         self.sigma = 0.1
         self.x = np.linspace(-5, 5, 30)
-        self.y = 0.25 * self.x + self.sigma * np.random.randn(len(self.x))
+        self.y = np.random.normal(0.25 * self.x, self.sigma)
         with pm.Model() as model:
             cov_func = pm.gp.cov.Linear(1, c=0.0)
             c = pm.Normal("c", mu=20.0, sigma=100.0)  # far from true value

--- a/pymc/tests/test_gp.py
+++ b/pymc/tests/test_gp.py
@@ -843,72 +843,10 @@ class TestMarginalVsLatent:
         latent_logp = model.compile_logp()({"f_rotated_": y_rotated, "p": self.pnew})
         npt.assert_allclose(latent_logp, self.logp, atol=5)
 
-
+                            
 class TestMarginalVsMarginalApprox:
     R"""
-    Compare logp of models Marginal and MarginalApprox.
-    Should be nearly equal when inducing points are same as inputs.
-    """
-
-    def setup_method(self):
-        X = np.random.randn(50, 3)
-        y = np.random.randn(50)
-        Xnew = np.random.randn(60, 3)
-        pnew = np.random.randn(60)
-        with pm.Model() as model:
-            cov_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
-            mean_func = pm.gp.mean.Constant(0.5)
-            gp = pm.gp.Marginal(mean_func=mean_func, cov_func=cov_func)
-            sigma = 0.1
-            f = gp.marginal_likelihood("f", X, y, noise=sigma)
-            p = gp.conditional("p", Xnew)
-        self.logp = model.compile_logp()({"p": pnew})
-        self.X = X
-        self.Xnew = Xnew
-        self.y = y
-        self.sigma = sigma
-        self.pnew = pnew
-        self.gp = gp
-        
-    @pytest.mark.parametrize("approx", ["FITC", "VFE", "DTC"])
-    def testApproximations(self, approx):
-        with pm.Model() as model:
-            cov_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
-            mean_func = pm.gp.mean.Constant(0.5)
-            gp = pm.gp.MarginalApprox(mean_func=mean_func, cov_func=cov_func, approx=approx)
-            f = gp.marginal_likelihood("f", self.X, self.X, self.y, self.sigma)
-            p = gp.conditional("p", self.Xnew)
-        approx_logp = model.compile_logp()({"p": self.pnew})
-        npt.assert_allclose(approx_logp, self.logp, atol=1e-2, rtol=1e-2)
-
-    @pytest.mark.parametrize("approx", ["FITC", "VFE", "DTC"])
-    def testPredictVar(self, approx):
-        with pm.Model() as model:
-            cov_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
-            mean_func = pm.gp.mean.Constant(0.5)
-            gp = pm.gp.MarginalApprox(mean_func=mean_func, cov_func=cov_func, approx=approx)
-            f = gp.marginal_likelihood("f", self.X, self.X, self.y, self.sigma)
-            mu1, var1 = self.gp.predict(self.Xnew, diag=True)
-            mu2, var2 = gp.predict(self.Xnew, diag=True)
-        npt.assert_allclose(mu1, mu2, atol=1e-2, rtol=1e-2)
-        npt.assert_allclose(var1, var2, atol=1e-2, rtol=1e-2)
-
-    def testPredictCov(self):
-        with pm.Model() as model:
-            cov_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
-            mean_func = pm.gp.mean.Constant(0.5)
-            gp = pm.gp.MarginalApprox(mean_func=mean_func, cov_func=cov_func, approx="DTC")
-            f = gp.marginal_likelihood("f", self.X, self.X, self.y, self.sigma)
-            mu1, cov1 = self.gp.predict(self.Xnew, pred_noise=True)
-            mu2, cov2 = gp.predict(self.Xnew, pred_noise=True)
-        npt.assert_allclose(mu1, mu2, atol=1e-2, rtol=1e-2)
-        npt.assert_allclose(cov1, cov2, atol=1e-2, rtol=1e-2)
-
-                            
-class TestMarginalVsMarginalApproxFit:
-    R"""
     Compare test fits of models Marginal and MarginalApprox.
-    Should be nearly equal when inducing points are same as inputs.
     """
     def setup_method(self):
         self.sigma = 0.1
@@ -918,22 +856,56 @@ class TestMarginalVsMarginalApproxFit:
             cov_func = pm.gp.cov.Linear(1, c=0.0)
             c = pm.Normal("c", mu=20.0, sigma=100.0) # far from true value
             mean_func = pm.gp.mean.Constant(c)
-            gp = pm.gp.Marginal(mean_func=mean_func, cov_func=cov_func)
-            gp.marginal_likelihood("lik", self.x[:, None], self.y, self.sigma)
-            map_full = pm.find_MAP(method="bfgs")
-        self.c_full = map_full["c"]
+            self.gp = pm.gp.Marginal(mean_func=mean_func, cov_func=cov_func)
+            sigma = pm.HalfNormal("sigma", sigma=100)
+            self.gp.marginal_likelihood("lik", self.x[:, None], self.y, sigma)
+            self.map_full = pm.find_MAP(method="bfgs") # bfgs seems to work much better than lbfgsb
+        
+        self.x_new = np.linspace(-6, 6, 20)
+        with model:
+            self.pred_mu, self.pred_var = self.gp.predict(
+                self.x_new[:, None], point=self.map_full, pred_noise=True, diag=True
+            )
+        
+        with model:
+            self.pred_mu, self.pred_covar = self.gp.predict(
+                self.x_new[:, None], point=self.map_full, pred_noise=False, diag=False
+            )
 
     @pytest.mark.parametrize("approx", ["FITC", "VFE", "DTC"])
-    def test_fits(self, approx):
+    def test_fits_and_preds(self, approx):
+        # check logp & dlogp, optimization gets approximately correct result
         with pm.Model() as model:
             cov_func = pm.gp.cov.Linear(1, c=0.0)
-            c = pm.Normal("c", mu=20.0, sigma=100.0)
+            c = pm.Normal("c", mu=20.0, sigma=100.0, initval=-500.0)
             mean_func = pm.gp.mean.Constant(c)
             gp = pm.gp.MarginalApprox(mean_func=mean_func, cov_func=cov_func, approx="VFE")
-            gp.marginal_likelihood("lik", self.x[:, None], self.x[:, None], self.y, self.sigma)
+            sigma = pm.HalfNormal("sigma", sigma=100, initval=50.0)
+            gp.marginal_likelihood("lik", self.x[:, None], self.x[:, None], self.y, sigma)
             map_approx = pm.find_MAP(method="bfgs")
-        npt.assert_allclose(self.c_full, map_approx["c"], atol=0.1, rtol=0.01)
-                            
+            
+        # use wide tolerances (but narrow relative to initial values of unknown parameters) because
+        # test is likely flakey
+        npt.assert_allclose(self.map_full["c"], map_approx["c"], atol=0.01, rtol=0.1)
+        npt.assert_allclose(self.map_full["sigma"], map_approx["sigma"], atol=0.01, rtol=0.1)
+          
+        # check that predict (and conditional) work, include noise, with diagonal non-full pred var
+        with model:
+            pred_mu_approx, pred_var_approx = gp.predict(
+                self.x_new[:, None], point=map_approx, pred_noise=True, diag=True
+            )
+        npt.assert_allclose(self.pred_mu, pred_mu_approx, atol=0.0, rtol=0.1)
+        npt.assert_allclose(self.pred_var, pred_var_approx, atol=0.0, rtol=0.1)
+        
+        # check that predict (and conditional) work, no noise, full pred covariance
+        with model:
+            pred_mu_approx, pred_var_approx = gp.predict(
+                self.x_new[:, None], point=map_approx, pred_noise=True, diag=True
+            )
+        npt.assert_allclose(self.pred_mu, pred_mu_approx, atol=0.0, rtol=0.1)
+        npt.assert_allclose(self.pred_var, pred_var_approx, atol=0.0, rtol=0.1)
+    
+    
 
 class TestGPAdditive:
     def setup_method(self):

--- a/pymc/tests/test_gp.py
+++ b/pymc/tests/test_gp.py
@@ -843,30 +843,31 @@ class TestMarginalVsLatent:
         latent_logp = model.compile_logp()({"f_rotated_": y_rotated, "p": self.pnew})
         npt.assert_allclose(latent_logp, self.logp, atol=5)
 
-                            
+
 class TestMarginalVsMarginalApprox:
     R"""
     Compare test fits of models Marginal and MarginalApprox.
     """
+
     def setup_method(self):
         self.sigma = 0.1
         self.x = np.linspace(-5, 5, 30)
-        self.y = 0.25 * self.x + self.sigma*np.random.randn(len(self.x))
+        self.y = 0.25 * self.x + self.sigma * np.random.randn(len(self.x))
         with pm.Model() as model:
             cov_func = pm.gp.cov.Linear(1, c=0.0)
-            c = pm.Normal("c", mu=20.0, sigma=100.0) # far from true value
+            c = pm.Normal("c", mu=20.0, sigma=100.0)  # far from true value
             mean_func = pm.gp.mean.Constant(c)
             self.gp = pm.gp.Marginal(mean_func=mean_func, cov_func=cov_func)
             sigma = pm.HalfNormal("sigma", sigma=100)
             self.gp.marginal_likelihood("lik", self.x[:, None], self.y, sigma)
-            self.map_full = pm.find_MAP(method="bfgs") # bfgs seems to work much better than lbfgsb
-        
+            self.map_full = pm.find_MAP(method="bfgs")  # bfgs seems to work much better than lbfgsb
+
         self.x_new = np.linspace(-6, 6, 20)
         with model:
             self.pred_mu, self.pred_var = self.gp.predict(
                 self.x_new[:, None], point=self.map_full, pred_noise=True, diag=True
             )
-        
+
         with model:
             self.pred_mu, self.pred_covar = self.gp.predict(
                 self.x_new[:, None], point=self.map_full, pred_noise=False, diag=False
@@ -883,12 +884,12 @@ class TestMarginalVsMarginalApprox:
             sigma = pm.HalfNormal("sigma", sigma=100, initval=50.0)
             gp.marginal_likelihood("lik", self.x[:, None], self.x[:, None], self.y, sigma)
             map_approx = pm.find_MAP(method="bfgs")
-            
+
         # use wide tolerances (but narrow relative to initial values of unknown parameters) because
         # test is likely flakey
         npt.assert_allclose(self.map_full["c"], map_approx["c"], atol=0.01, rtol=0.1)
         npt.assert_allclose(self.map_full["sigma"], map_approx["sigma"], atol=0.01, rtol=0.1)
-          
+
         # check that predict (and conditional) work, include noise, with diagonal non-full pred var
         with model:
             pred_mu_approx, pred_var_approx = gp.predict(
@@ -896,7 +897,7 @@ class TestMarginalVsMarginalApprox:
             )
         npt.assert_allclose(self.pred_mu, pred_mu_approx, atol=0.0, rtol=0.1)
         npt.assert_allclose(self.pred_var, pred_var_approx, atol=0.0, rtol=0.1)
-        
+
         # check that predict (and conditional) work, no noise, full pred covariance
         with model:
             pred_mu_approx, pred_var_approx = gp.predict(
@@ -904,8 +905,7 @@ class TestMarginalVsMarginalApprox:
             )
         npt.assert_allclose(self.pred_mu, pred_mu_approx, atol=0.0, rtol=0.1)
         npt.assert_allclose(self.pred_var, pred_var_approx, atol=0.0, rtol=0.1)
-    
-    
+
 
 class TestGPAdditive:
     def setup_method(self):


### PR DESCRIPTION
This PR is meant to fix #5922 and possibly also #6069, but not 100% sure about the last one.

Ended up having to use `pm.Potential` instead of `pm.DenisityDist` to get `pm.MarginalApprox.marginal_likelihood` working properly.   Using `pm.DensityDist` it seems would involve introspecting the lazily evaluated covariance and mean functions for any random variables and their dims.

I also tried to clean up the tests a bit for `MarginalApprox`, because the reason #5922 took a while to be caught was because `find_MAP` or other any other methods weren't tested.  #6069 does look to just be due to tolerances -- the results still look correct so I increased those a bit. 

Hopefully this PR can close #6069 and close #5922.