### PR TITLE
make vi (posterior) mean and std accessible as a structured xarray

### DIFF
--- a/pymc/tests/test_variational_inference.py
+++ b/pymc/tests/test_variational_inference.py
@@ -571,6 +571,14 @@ def test_fit_oo(inference, fit_kwargs, simple_model_data):
     np.testing.assert_allclose(np.std(trace.posterior["mu"]), np.sqrt(1.0 / d), rtol=0.2)
 
 
+def test_fit_data(inference, fit_kwargs, simple_model_data):
+    fitted = inference.fit(**fit_kwargs)
+    mu_post = simple_model_data["mu_post"]
+    d = simple_model_data["d"]
+    np.testing.assert_allclose(fitted.mean_data["mu"].values, mu_post, rtol=0.05)
+    np.testing.assert_allclose(fitted.std_data["mu"], np.sqrt(1.0 / d), rtol=0.2)
+
+
 def test_profile(inference):
     inference.run_profiling(n=100).summary()
 

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1126,13 +1126,13 @@ class Group(WithMemoization):
     def var_to_data(self, shared):
         shared = shared.eval()
         result = dict()
-        for name, s, shape, _ in self.ordering.values():
+        for name, s, shape, dtype in self.ordering.values():
             dims = self.model.RV_dims.get(name, None)
             if dims is not None:
                 coords = {d: np.array(self.model.coords[d]) for d in dims}
             else:
                 coords = None
-            values = np.array(shared[s]).reshape(shape)
+            values = np.array(shared[s]).reshape(shape).astype(dtype)
             result[name] = xarray.DataArray(values, coords=coords, dims=dims, name=name)
         return xarray.Dataset(result)
 

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1110,14 +1110,17 @@ class Group(WithMemoization):
 
     @node_property
     def std(self):
+        """Standard deviation of the latent variables as an unstructured 1-dimensional Aesara variable"""
         raise NotImplementedError
 
     @node_property
     def cov(self):
+        """Covariance between the latent variables as an unstructured 2-dimensional Aesara variable"""
         raise NotImplementedError
 
     @node_property
     def mean(self):
+        """Mean of the latent variables as an unstructured 1-dimensional Aesara variable"""
         raise NotImplementedError
 
     def var_to_data(self, shared):
@@ -1135,10 +1138,12 @@ class Group(WithMemoization):
 
     @property
     def mean_data(self):
+        """Mean of the latent variables as an xarray Dataset"""
         return self.var_to_data(self.mean)
 
     @property
     def std_data(self):
+        """Standard deviation of the latent variables as an xarray Dataset"""
         return self.var_to_data(self.std)
 
 

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1124,6 +1124,11 @@ class Group(WithMemoization):
         raise NotImplementedError
 
     def var_to_data(self, shared):
+        """Takes a flat 1-dimensional Aesara variable and maps it to an xarray data set based on the information in
+        `self.ordering`.
+        """
+        # This is somewhat similar to `DictToArrayBijection.rmap`, which doesn't work here since we don't have
+        # `RaveledVars` and need to take the information from `self.ordering` instead
         shared = shared.eval()
         result = dict()
         for name, s, shape, dtype in self.ordering.values():


### PR DESCRIPTION
**What is this PR about?**
For VI the mean and std of approximations is currently only available as an unstructured flat Aesara Variable. This leads to frequent questions on how to extract these properties from the posterior. This PR creates two new properties which evaluate the Aesara Variables and transforms them into a structured xarray Dataset using the available `coords`.

See also:
https://discourse.pymc.io/t/quality-of-life-improvements-to-advi/10254

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- None

## Bugfixes / New features
- new feature: get mean and std as xarray data set

## Docs / Maintenance
- Included doc strings for existing `mean`, `std`, and `cov` properties
