### PR TITLE
Update docstrings of pm.set_data and model.Data

### DIFF
--- a/pymc/data.py
+++ b/pymc/data.py
@@ -592,12 +592,12 @@ def Data(
     :func:`pymc.set_data`.
 
     To set the value of the data container variable, check out
-    :func:`pymc.Model.set_data`.
+    :meth:`pymc.Model.set_data`.
 
     When making predictions or doing posterior predictive sampling, the shape of the
     registered data variable will most likely need to be changed.  If you encounter an
     Aesara shape mismatch error, refer to the documentation for
-    :func:`pymc.model.set_data`.
+    :meth:`pymc.model.set_data`.
 
     For more information, read the notebook :ref:`nb:data_container`.
 

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -594,6 +594,11 @@ def Data(
     To set the value of the data container variable, check out
     :func:`pymc.Model.set_data`.
 
+    When making predictions or doing posterior predictive sampling, the shape of the
+    registered data variable will most likely need to be changed.  If you encounter an
+    Aesara shape mismatch error, refer to the documentation for
+    :func:`pymc.model.set_data`.
+
     For more information, read the notebook :ref:`nb:data_container`.
 
     Parameters

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1849,6 +1849,13 @@ Model._context_class = Model
 def set_data(new_data, model=None, *, coords=None):
     """Sets the value of one or more data container variables.
 
+    When doing prediction or posterior predictive sampling, make sure that
+    the random variable acting as the likelihood (`observed` is True) is dynamically
+    resized when the data is updated.  Set the `shape` argument of the random
+    variable acting as the likelihood to the shape of the relevant
+    :class:`pymc.data.MutableData` object, as shown in the example below
+    (the `shape=x.shape` of `obs`).
+
     Parameters
     ----------
     new_data: dict
@@ -1867,7 +1874,7 @@ def set_data(new_data, model=None, *, coords=None):
         ...     x = pm.MutableData('x', [1., 2., 3.])
         ...     y = pm.MutableData('y', [1., 2., 3.])
         ...     beta = pm.Normal('beta', 0, 1)
-        ...     obs = pm.Normal('obs', x * beta, 1, observed=y)
+        ...     obs = pm.Normal('obs', x * beta, 1, observed=y, shape=x.shape)
         ...     idata = pm.sample(1000, tune=1000)
 
     Set the value of `x` to predict on new data.
@@ -1875,10 +1882,10 @@ def set_data(new_data, model=None, *, coords=None):
     .. code:: ipython
 
         >>> with model:
-        ...     pm.set_data({'x': [5., 6., 9.]})
+        ...     pm.set_data({'x': [5., 6., 9., 12., 15.]})
         ...     y_test = pm.sample_posterior_predictive(idata)
         >>> y_test.posterior_predictive['obs'].mean(('chain', 'draw'))
-        array([4.6088569 , 5.54128318, 8.32953844])
+        array([4.6088569 , 5.54128318, 8.32953844, 11.14044852, 13.94178173])
     """
     model = modelcontext(model)
 


### PR DESCRIPTION
Adds docstrings describing how to track changing shape of `MutableData` in the likelihood.  Meant to address issue #5987.   The recommended solution is then to set the `shape=x.shape`, like this:

```python
import pymc as pm                                                                       
with pm.Model() as model:                                                               
    x = pm.MutableData('x', [1., 2., 3.])                                               
    y = pm.MutableData('y', [1., 2., 3.])                                               
    beta = pm.Normal('beta', 0, 1)                                                      
    obs = pm.Normal('obs', x * beta, 1, observed=y, shape=x.shape) # <--- here                      
    idata = pm.sample(1000, tune=1000)   

with model:                                                                             
    pm.set_data({'x': [5., 6., 9., 12., 15.]})                                               
    y_test = pm.sample_posterior_predictive(idata)                                      
y_test.posterior_predictive['obs'].mean(('chain', 'draw'))
```

## Major / Breaking Changes
None

## Bugfixes / New features
None

## Docs / Maintenance
Add recommendation to docstrings relevant to prediction and posterior predictive sampling.
