### PR TITLE
Update GOVERNANCE.md for PyMCon_2022 planning repo

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -654,7 +654,8 @@ In addition, Council members are given administrative rights to all repositories
 the [pymc-devs](https://github.com/pymc-devs) organization.
 
 ##### Communication Focused Repositroes
-Some repositories on Github may be used primarily for internal knowledge store and communication, rather than as codebases that are packaged and deployed. 
+Some repositories on Github may be used primarily for internal knowledge store and communication, rather than content tha tis curated, published, or released _by the project_ for external users. 
+
 The permissions of such repositories will be set in order to allow the same participation and access levels we use on private project communication channels like Slack. 
 Therefore, similarly to slack, these repositories will be private and write permissions will be given to all recurrent contributors (that is, anyone with access to slack).
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -653,6 +653,9 @@ Team:
 In addition, Council members are given administrative rights to all repositories within
 the [pymc-devs](https://github.com/pymc-devs) organization.
 
+##### Communication Focused Repositroes
+Some repositories on Github may be used primarily for internal knowledge store and communication, rather than as codebases that are packaged and deployd. In this case permissions, such as write permissions, will be granted in a manner more like other communication platforms such as slack.
+
 #### Discourse
 Similar to the above section, Discourse permissions are also mapped to the community team
 and the two contributor roles.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -653,10 +653,10 @@ Team:
 In addition, Council members are given administrative rights to all repositories within
 the [pymc-devs](https://github.com/pymc-devs) organization.
 
-##### Communication Focused Repositroes
-Some repositories on Github may be used primarily for internal knowledge store and communication, rather than content tha tis curated, published, or released _by the project_ for external users. 
+##### Communication Focused Repositories
+Some repositories on Github may be used primarily for internal knowledge store and communication, rather than content tha tis curated, published, or released _by the project_ for external users.
 
-The permissions of such repositories will be set in order to allow the same participation and access levels we use on private project communication channels like Slack. 
+The permissions of such repositories will be set in order to allow the same participation and access levels we use on private project communication channels like Slack.
 Therefore, similarly to slack, these repositories will be private and write permissions will be given to all recurrent contributors (that is, anyone with access to slack).
 
 #### Discourse

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -654,7 +654,9 @@ In addition, Council members are given administrative rights to all repositories
 the [pymc-devs](https://github.com/pymc-devs) organization.
 
 ##### Communication Focused Repositroes
-Some repositories on Github may be used primarily for internal knowledge store and communication, rather than as codebases that are packaged and deployd. In this case permissions, such as write permissions, will be granted in a manner more like other communication platforms such as slack.
+Some repositories on Github may be used primarily for internal knowledge store and communication, rather than as codebases that are packaged and deployed. 
+The permissions of such repositories will be set in order to allow the same participation and access levels we use on private project communication channels like Slack. 
+Therefore, similarly to slack, these repositories will be private and write permissions will be given to all recurrent contributors (that is, anyone with access to slack).
 
 #### Discourse
 Similar to the above section, Discourse permissions are also mapped to the community team


### PR DESCRIPTION
@OriolAbril let me know if I got this right. If so we can have the other steering committee members review it.

Additionally I can remove all single member additions to the pymcon_2022 repo and instead grant view and commit permissions to all named groups in the pymc-devs organization. This way anyone in those groups can participate in the pymc web series discussion. What do you think of all that?
