### PR TITLE
Make rvs_to_values work with non-RandomVariables

### DIFF
--- a/pymc/gp/util.py
+++ b/pymc/gp/util.py
@@ -57,7 +57,7 @@ def replace_with_values(vars_needed, replacements=None, model=None):
     model = modelcontext(model)
 
     inputs, input_names = [], []
-    for rv in walk_model(vars_needed, walk_past_rvs=True):
+    for rv in walk_model(vars_needed):
         if rv in model.named_vars.values() and not isinstance(rv, SharedVariable):
             inputs.append(rv)
             input_names.append(rv.name)

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -761,7 +761,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         # Replace random variables by their value variables in potential terms
         potential_logps = []
         if potentials:
-            potential_logps, _ = rvs_to_value_vars(potentials, apply_transforms=True)
+            potential_logps = rvs_to_value_vars(potentials)
 
         logp_factors = [None] * len(varlist)
         for logp_order, logp in zip((rv_order + potential_order), (rv_logps + potential_logps)):
@@ -935,7 +935,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         """Aesara scalar of log-probability of the Potential terms"""
         # Convert random variables in Potential expression into their log-likelihood
         # inputs and apply their transforms, if any
-        potentials, _ = rvs_to_value_vars(self.potentials, apply_transforms=True)
+        potentials = rvs_to_value_vars(self.potentials)
         if potentials:
             return at.sum([at.sum(factor) for factor in potentials])
         else:
@@ -976,10 +976,10 @@ class Model(WithMemoization, metaclass=ContextMeta):
             vars.append(value_var)
 
         # Remove rvs from untransformed values graph
-        untransformed_vars, _ = rvs_to_value_vars(untransformed_vars, apply_transforms=True)
+        untransformed_vars = rvs_to_value_vars(untransformed_vars)
 
         # Remove rvs from deterministics graph
-        deterministics, _ = rvs_to_value_vars(self.deterministics, apply_transforms=True)
+        deterministics = rvs_to_value_vars(self.deterministics)
 
         return vars + untransformed_vars + deterministics
 

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -583,7 +583,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
 
             if isinstance(distr, CategoricalRV):
                 k_graph = rv_var.owner.inputs[3].shape[-1]
-                (k_graph,), _ = rvs_to_value_vars((k_graph,), apply_transforms=True)
+                (k_graph,) = rvs_to_value_vars((k_graph,))
                 k = model.compile_fn(k_graph, inputs=model.value_vars, on_unused_input="ignore")(
                     initial_point
                 )

--- a/pymc/tests/distributions/test_logprob.py
+++ b/pymc/tests/distributions/test_logprob.py
@@ -129,7 +129,7 @@ def test_joint_logp_basic():
     with pytest.warns(FutureWarning):
         b_logpt = joint_logpt(b, b_value_var, sum=False)
 
-    res_ancestors = list(walk_model(b_logp, walk_past_rvs=True))
+    res_ancestors = list(walk_model(b_logp))
     res_rv_ancestors = [
         v for v in res_ancestors if v.owner and isinstance(v.owner.op, RandomVariable)
     ]

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1386,7 +1386,7 @@ class Approximation(WithMemoization):
             node = aesara.clone_replace(node, more_replacements)
         if not isinstance(node, (list, tuple)):
             node = [node]
-        node, _ = rvs_to_value_vars(node, apply_transforms=True)
+        node = rvs_to_value_vars(node)
         if not isinstance(node_in, (list, tuple)):
             node = node[0]
         if size is None:


### PR DESCRIPTION
**What is this PR about?**
Cleanup some logic that assumed only RandomVariables can be valued

Related to #6072 
Related to https://github.com/aesara-devs/aeppl/issues/174

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- rvs_to_values now works with non-RandomVariables and unvalued RandomVariables

## Docs / Maintenance
- ...
