### PR TITLE
Implement transforms for discrete variables

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -48,6 +48,7 @@ from pymc.distributions.shape_utils import (
     rv_size_is_none,
     shape_from_dims,
 )
+from pymc.distributions.transforms import DiscreteRVTransform
 from pymc.exceptions import BlockModelAccessError
 from pymc.logprob.abstract import MeasurableVariable, _icdf, _logcdf, _logprob
 from pymc.logprob.basic import logp
@@ -436,8 +437,12 @@ class Discrete(Distribution):
     """Base class for discrete distributions"""
 
     def __new__(cls, name, *args, **kwargs):
-        if kwargs.get("transform", None):
-            raise ValueError("Transformations for discrete distributions")
+        if kwargs.get("transform", None) is not None and not isinstance(
+            kwargs["transform"], DiscreteRVTransform
+        ):
+            tr = kwargs["transform"]
+            tr_name = getattr(tr, "name", tr)
+            raise ValueError(f"{tr_name} transformation cannot be used with discrete distribution.")
 
         return super().__new__(cls, name, *args, **kwargs)
 

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -87,7 +87,7 @@ class TestBugfixes:
         npt.assert_almost_equal(m.compile_logp()({"x": np.ones(10)}), -np.log(2) * 10)
 
         with pm.Model(check_bounds=False) as m:
-            x = pm.DiscreteUniform("x", 0, 1, size=10)
+            x = pm.DiscreteUniform("x", 0, 1, size=10, transform=None)
         npt.assert_almost_equal(m.compile_logp()({"x": np.ones(10)}), -np.log(2) * 10)
 
         with pm.Model(check_bounds=False) as m:

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -645,9 +645,9 @@ def test_interval_transform_raises():
 
 def test_discrete_trafo():
     with pm.Model():
-        with pytest.raises(ValueError) as err:
-            pm.Binomial("a", n=5, p=0.5, transform="log")
-        err.match("Transformations for discrete distributions")
+        msg = "log transformation cannot be used with discrete distribution"
+        with pytest.raises(ValueError, match=msg):
+            pm.Binomial("a", n=5, p=0.5, transform=tr.log)
 
 
 def test_2d_univariate_ordered():

--- a/tests/smc/test_smc.py
+++ b/tests/smc/test_smc.py
@@ -154,7 +154,7 @@ class TestSMC(SeededTest):
 
     def test_start(self):
         with pm.Model() as model:
-            a = pm.Poisson("a", 5)
+            a = pm.Poisson("a", 5, transform=None)
             b = pm.HalfNormal("b", 10)
             y = pm.Normal("y", a, b, observed=[1, 2, 3, 4])
             start = {


### PR DESCRIPTION
I am marking this as a draft, as I might very well be shooting myself in the foot... but it seems like it should work?

```python
import arviz as az
import numpy as np
import matplotlib.pyplot as plt
import pymc as pm

with pm.Model() as m:
    pm.DiscreteUniform("w", 0, 10, transform=None)
    pm.DiscreteUniform("wt", 0, 10)
    
    pm.Poisson("x", 5, transform=None)    
    pm.Poisson("xt", 5)
      
    pm.Geometric("y", 0.2, transform=None)
    pm.Geometric("yt", 0.2)
    
    pm.HyperGeometric("z", N=30, k=12, n=20, transform=None)
    pm.HyperGeometric("zt", N=30, k=12, n=20)
            
    trace = pm.sample(draws=5_000, chains=4)
    
az.summary(trace, var_names=sorted(map(str, m.free_RVs)))
```
One trace
```
     mean     sd  hdi_3%  hdi_97%  ...  mcse_sd  ess_bulk  ess_tail  r_hat
w   5.015  3.177     0.0     10.0  ...    0.033    4555.0    4930.0    1.0
wt  4.984  3.174     0.0     10.0  ...    0.016   20072.0   20000.0    1.0
x   5.021  2.226     1.0      9.0  ...    0.024    4303.0    5023.0    1.0
xt  4.936  2.197     1.0      9.0  ...    0.021    6805.0    5489.0    1.0
y   4.912  4.323     1.0     13.0  ...    0.094    1553.0    1585.0    1.0
yt  4.947  4.447     1.0     13.0  ...    0.069    1943.0    1816.0    1.0
z   8.030  1.286     6.0     10.0  ...    0.014    4265.0    4769.0    1.0
zt  7.987  1.299     6.0     10.0  ...    0.012    6036.0    5622.0    1.0
```
Another trace
```
     mean     sd  hdi_3%  hdi_97%  ...  mcse_sd  ess_bulk  ess_tail  r_hat
w   5.006  3.168     0.0     10.0  ...    0.033    4689.0    4554.0    1.0
wt  4.995  3.162     0.0     10.0  ...    0.016   19678.0   19990.0    1.0
x   5.008  2.235     1.0      9.0  ...    0.025    4397.0    4587.0    1.0
xt  4.970  2.222     1.0      9.0  ...    0.021    6671.0    5428.0    1.0
y   4.906  4.368     1.0     13.0  ...    0.104    1445.0    1307.0    1.0
yt  5.018  4.515     1.0     13.0  ...    0.084    1940.0    2067.0    1.0
z   8.002  1.265     6.0     10.0  ...    0.013    4551.0    4953.0    1.0
zt  8.020  1.286     6.0     10.0  ...    0.012    5338.0    5512.0    1.0
```

I purposely chose parameters I thought would benefit from transforms. In general it seems to improve slightly. The outlier clearly being the DiscreteUniform which now has a 100% acceptance rate (which will probably drive Metropolis tuning crazy :P)

**Checklist**
+ [ ] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- Add interval transform for discrete variables.
  - As with transformed continuous variables, the respective value variables are now named `f"{var}_dinterval"` when manually evaluating the model `logp/dlogp`.

## Bugfixes / New features
- ...

## Docs / Maintenance
- ...
