### PR TITLE
Remove support for "dims on the fly"

### DIFF
--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -480,17 +480,13 @@ def convert_size(size: Size) -> Optional[StrongSize]:
     return size
 
 
-def shape_from_dims(
-    dims: StrongDims, shape_implied: Sequence[TensorVariable], model
-) -> StrongShape:
+def shape_from_dims(dims: StrongDims, model) -> StrongShape:
     """Determines shape from a `dims` tuple.
 
     Parameters
     ----------
     dims : array-like
         A vector of dimension names or None.
-    shape_implied : tensor_like of int
-        Shape of RV implied from its inputs alone.
     model : pm.Model
         The current model on stack.
 
@@ -499,20 +495,15 @@ def shape_from_dims(
     dims : tuple of (str or None)
         Names or None for all RV dimensions.
     """
-    ndim_resize = len(dims) - len(shape_implied)
 
-    # Dims must be known already or be inferrable from implied dimensions of the RV
-    unknowndim_resize_dims = set(dims[:ndim_resize]) - set(model.dim_lengths)
-    if unknowndim_resize_dims:
+    # Dims must be known already
+    unknowndim_dims = set(dims) - set(model.dim_lengths)
+    if unknowndim_dims:
         raise KeyError(
-            f"Dimensions {unknowndim_resize_dims} are unknown to the model and cannot be used to specify a `size`."
+            f"Dimensions {unknowndim_dims} are unknown to the model and cannot be used to specify a `shape`."
         )
 
-    # The numeric/symbolic resize tuple can be created using model.RV_dim_lengths
-    return tuple(
-        model.dim_lengths[dname] if dname in model.dim_lengths else shape_implied[i]
-        for i, dname in enumerate(dims)
-    )
+    return tuple(model.dim_lengths[dname] for dname in dims)
 
 
 def find_size(

--- a/pymc/tests/distributions/test_shape_utils.py
+++ b/pymc/tests/distributions/test_shape_utils.py
@@ -312,39 +312,16 @@ class TestShapeDimsSize:
             assert pmodel.RV_dims["y"] == ("ddata",)
             assert y.eval().shape == (3,)
 
-    def test_define_dims_on_the_fly(self):
+    def test_define_dims_on_the_fly_raises(self):
+        # Check that trying to use dims that are not pre-specified fails, even if their
+        # length could be inferred from the shape of the variables
+        msg = "Dimensions {'patient'} are unknown to the model"
         with pm.Model() as pmodel:
-            agedata = aesara.shared(np.array([10, 20, 30]))
+            with pytest.raises(KeyError, match=msg):
+                pm.Normal("x", [0, 1, 2], dims=("patient",))
 
-            # Associate the "patient" dim with an implied dimension
-            age = pm.Normal("age", agedata, dims=("patient",))
-            assert "patient" in pmodel.dim_lengths
-            assert pmodel.dim_lengths["patient"].eval() == 3
-
-            # Use the dim to replicate a new RV
-            effect = pm.Normal("effect", 0, dims=("patient",))
-            assert effect.ndim == 1
-            assert effect.eval().shape == (3,)
-
-            # Now change the length of the implied dimension
-            agedata.set_value([1, 2, 3, 4])
-            # The change should propagate all the way through
-            assert effect.eval().shape == (4,)
-
-    def test_define_dims_on_the_fly_from_observed(self):
-        with pm.Model() as pmodel:
-            data = aesara.shared(np.zeros((4, 5)))
-            x = pm.Normal("x", observed=data, dims=("patient", "trials"))
-            assert pmodel.dim_lengths["patient"].eval() == 4
-            assert pmodel.dim_lengths["trials"].eval() == 5
-
-            # Use dim to create a new RV
-            x_noisy = pm.Normal("x_noisy", 0, dims=("patient", "trials"))
-            assert x_noisy.eval().shape == (4, 5)
-
-            # Change data patient dims
-            data.set_value(np.zeros((10, 6)))
-            assert x_noisy.eval().shape == (10, 6)
+            with pytest.raises(KeyError, match=msg):
+                pm.Normal("x", observed=[0, 1, 2], dims=("patient",))
 
     def test_can_resize_data_defined_size(self):
         with pm.Model() as pmodel:

--- a/pymc/tests/test_data.py
+++ b/pymc/tests/test_data.py
@@ -28,7 +28,6 @@ from aesara.tensor.var import TensorVariable
 import pymc as pm
 
 from pymc.aesaraf import GeneratorOp, floatX
-from pymc.exceptions import ShapeError
 from pymc.tests.helpers import SeededTest, select_by_precision
 
 
@@ -370,20 +369,6 @@ class TestData(SeededTest):
             intensity.set_value(floatX(np.ones((4, 5))))
             assert pmodel.dim_lengths["row"].eval() == 4
             assert pmodel.dim_lengths["column"].eval() == 5
-
-    def test_no_resize_of_implied_dimensions(self):
-        with pm.Model() as pmodel:
-            # Imply a dimension through RV params
-            pm.Normal("n", mu=[1, 2, 3], dims="city")
-            # _Use_ the dimension for a data variable
-            inhabitants = pm.MutableData("inhabitants", [100, 200, 300], dims="city")
-
-            # Attempting to re-size the dimension through the data variable would
-            # cause shape problems in InferenceData conversion, because the RV remains (3,).
-            with pytest.raises(
-                ShapeError, match="was initialized from 'n' which is not a shared variable"
-            ):
-                pmodel.set_data("inhabitants", [1, 2, 3, 4])
 
     def test_implicit_coords_series(self):
         pd = pytest.importorskip("pandas")


### PR DESCRIPTION
Closes #6085

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- Dims can no longer be implied by the size of a variable or observed, they must always be defined in advance

## Bugfixes / New features
- ...

## Docs / Maintenance
- ...
