### PR TITLE
Repair the plot of pm.Interpolated and add an example for pm.Deterministic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,10 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf $(SOURCEDIR)/api/generated
 	rm -rf $(SOURCEDIR)/api/**/generated
 	rm -rf $(SOURCEDIR)/api/**/classmethods
+	rm -rf $(SOURCEDIR)/contributing/private_api/generated
 	rm -rf $(SOURCEDIR)/contributing/private_api/**/generated
 	rm -rf $(SOURCEDIR)/contributing/private_api/**/classmethods
 	rm -rf docs/jupyter_execute

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ clean:
 html:
 	$(SPHINXBUILD) $(SOURCEDIR) $(BUILDDIR) -b html
 	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)."
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
@@ -199,4 +199,4 @@ pseudoxml:
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
 serve: html
-	cd $(BUILDDIR)/html && python -m http.server
+	python -m http.server --directory $(BUILDDIR)

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3711,16 +3711,16 @@ class Interpolated(BoundedContinuous):
         from scipy.stats import gamma
         plt.style.use('arviz-darkgrid')
         rv = gamma(1.99)
-        x = np.linspace(rv.ppf(0.01),rv.ppf(0.99), 1000)
+        x = np.linspace(rv.ppf(0.01), rv.ppf(0.99), 1000)
         points = np.linspace(x[0], x[-1], 50)
         pdf = rv.pdf(points)
         interpolated = pm.Interpolated.dist(points, pdf)
         fig, ax = plt.subplots(1, 1)
-        ax.plot(x, rv.pdf(x), 'C0', linestyle = '--',  label='Original Gamma pdf',alpha=0.8,lw=2)
-        ax.plot(points, pdf, color='black', marker='o', label='Lattice Points',alpha=0.5,linestyle='')
-        ax.plot(x, np.exp(interpolated.logp(x).eval()),'C1',label='Interpolated pdf',alpha=0.8,lw=3)
-        r = interpolated.random(size=1000)
-        ax.hist(r, density=True, alpha=0.4,align ='mid',color='grey')
+        ax.plot(x, rv.pdf(x), 'C0', linestyle = '--',  label='Original Gamma pdf', alpha=0.8, lw=2)
+        ax.plot(points, pdf, color='black', marker='o', label='Lattice Points', alpha=0.5, linestyle='')
+        ax.plot(x, np.exp(pm.logp(interpolated, x).eval()), 'C1', label='Interpolated pdf', alpha=0.8, lw=3)
+        r = pm.draw(interpolated, draws=1000)
+        ax.hist(r, density=True, alpha=0.4, align ='mid', color='grey')
         ax.legend(loc='best', frameon=False)
         plt.show()
 
@@ -4008,6 +4008,7 @@ class PolyaGamma(PositiveContinuous):
     .. math::
 
        f(x \mid h, z) = cosh^h(\frac{z}{2})e^{-\frac{1}{2}xz^2}f(x \mid h, 0),
+
     where :math:`f(x \mid h, 0)` is the pdf of a :math:`PG(h, 0)` variable.
     Notice that the pdf of this distribution is expressed as an alternating-sign
     sum of inverse-Gaussian densities.

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -194,7 +194,7 @@ class Interval(IntervalTransform):
     lower : int or float, optional
         Lower bound of the interval transform. Must be a constant finite value.
         By default (``lower=None``), the interval is not bounded below.
-    upper : int or float, optinoal
+    upper : int or float, optional
         Upper bound of the interval transform. Must be a constant finite value.
         By default (``upper=None``), the interval is not bounded above.
     bounds_fn : callable, optional


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

This PR closes #6124 by adding an example and explanation of `pm.Deterministic`.

It also repairs the plot of `pm.Interpolated` which was not working, and fixes some of the doc makefile commands.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Fix `make serve`
- Fix `make html`
- Fix `make clean`
- Repair the plot of `pm.Interpolated`
- Add an explanation and example to `pm.Deterministic`
