### PR TITLE
Fix bug in which TruncatedNormal returns -inf for all values if any value is out of bounds

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -777,11 +777,13 @@ class TruncatedNormal(BoundedContinuous):
             norm = 0.0
 
         logp = _logprob(normal, (value,), None, None, None, mu, sigma) - norm
+        logp = at.switch(
+            at.or_(at.le(value, lower), at.ge(value, upper)),
+            -np.inf,
+            logp,
+        )
+
         bounds = []
-        if not unbounded_lower:
-            bounds.append(value >= lower)
-        if not unbounded_upper:
-            bounds.append(value <= upper)
         if not unbounded_lower and not unbounded_upper:
             bounds.append(lower <= upper)
         return check_parameters(logp, *bounds)

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -760,7 +760,9 @@ class TruncatedNormal(BoundedContinuous):
         -------
         TensorVariable
         """
-        is_lower_bounded = not (isinstance(lower, TensorConstant) and np.all(np.isneginf(lower.value)))
+        is_lower_bounded = not (
+            isinstance(lower, TensorConstant) and np.all(np.isneginf(lower.value))
+        )
         is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value)))
 
         if is_lower_bounded and is_upper_bounded:

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -778,7 +778,7 @@ class TruncatedNormal(BoundedContinuous):
 
         logp = _logprob(normal, (value,), None, None, None, mu, sigma) - norm
         logp = at.switch(
-            at.or_(at.le(value, lower), at.ge(value, upper)),
+            at.or_(at.lt(value, lower), at.gt(value, upper)),
             -np.inf,
             logp,
         )

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -760,33 +760,38 @@ class TruncatedNormal(BoundedContinuous):
         -------
         TensorVariable
         """
-        unbounded_lower = isinstance(lower, TensorConstant) and np.all(lower.value == -np.inf)
-        unbounded_upper = isinstance(upper, TensorConstant) and np.all(upper.value == np.inf)
+        is_lower_bounded = not (isinstance(lower, TensorConstant) and np.all(lower.value == -np.inf))
+        is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(upper.value == np.inf))
 
-        if not unbounded_lower and not unbounded_upper:
+        if is_lower_bounded and is_upper_bounded:
             lcdf_a = normal_lcdf(mu, sigma, lower)
             lcdf_b = normal_lcdf(mu, sigma, upper)
             lsf_a = normal_lccdf(mu, sigma, lower)
             lsf_b = normal_lccdf(mu, sigma, upper)
             norm = at.switch(lower > 0, logdiffexp(lsf_a, lsf_b), logdiffexp(lcdf_b, lcdf_a))
-        elif not unbounded_lower:
+        elif is_lower_bounded:
             norm = normal_lccdf(mu, sigma, lower)
-        elif not unbounded_upper:
+        elif is_upper_bounded:
             norm = normal_lcdf(mu, sigma, upper)
         else:
             norm = 0.0
 
         logp = _logprob(normal, (value,), None, None, None, mu, sigma) - norm
-        logp = at.switch(
-            at.or_(at.lt(value, lower), at.gt(value, upper)),
-            -np.inf,
-            logp,
-        )
 
-        bounds = []
-        if not unbounded_lower and not unbounded_upper:
-            bounds.append(lower <= upper)
-        return check_parameters(logp, *bounds)
+        if is_lower_bounded:
+            logp = at.switch(value < lower, -np.inf, logp)
+
+        if is_upper_bounded:
+            logp = at.switch(value > upper, -np.inf, logp)
+
+        if is_lower_bounded and is_upper_bounded:
+            logp = check_parameters(
+                logp,
+                at.le(lower, upper),
+                msg="lower_bound <= upper_bound",
+            )
+
+        return logp
 
 
 @_default_transform.register(TruncatedNormal)

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -760,8 +760,8 @@ class TruncatedNormal(BoundedContinuous):
         -------
         TensorVariable
         """
-        is_lower_bounded = not (isinstance(lower, TensorConstant) and np.all(lower.value == -np.inf))
-        is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(upper.value == np.inf))
+        is_lower_bounded = not (isinstance(lower, TensorConstant) and np.all(np.isneginf(lower.value)))
+        is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value)))
 
         if is_lower_bounded and is_upper_bounded:
             lcdf_a = normal_lcdf(mu, sigma, lower)

--- a/pymc/tests/distributions/test_continuous.py
+++ b/pymc/tests/distributions/test_continuous.py
@@ -108,13 +108,6 @@ class TestBoundedContinuous:
         assert lower_interval.value == -2
         assert upper_interval is None
 
-    def test_bounded_value(self):
-        dist = pm.TruncatedNormal.dist(mu=1, sigma=2, lower=0, upper=3)
-        logp = pm.logp(dist, [-2., 1., 4.]).eval()
-        assert np.isinf(logp[0])
-        assert np.isfinite(logp[1])
-        assert np.isinf(logp[2])
-
     def test_lower_bounded_vector(self):
         bounded_rv_name = "upper_bounded"
         with pm.Model() as model:
@@ -864,6 +857,14 @@ class TestMatchesScipy:
             decimal=select_by_precision(float64=6, float32=1),
             skip_paramdomain_outside_edge_test=True,
         )
+
+        # This is a regression test for #6128: Check that having one out-of-bound value
+        # in an input array does not set all logp values to -inf
+        dist = pm.TruncatedNormal.dist(mu=1, sigma=2, lower=0, upper=3)
+        logp = pm.logp(dist, [-2., 1., 4.]).eval()
+        assert np.isinf(logp[0])
+        assert np.isfinite(logp[1])
+        assert np.isinf(logp[2])
 
     def test_get_tau_sigma(self):
         sigma = np.array(2)

--- a/pymc/tests/distributions/test_continuous.py
+++ b/pymc/tests/distributions/test_continuous.py
@@ -861,7 +861,7 @@ class TestMatchesScipy:
         # This is a regression test for #6128: Check that having one out-of-bound value
         # in an input array does not set all logp values to -inf
         dist = pm.TruncatedNormal.dist(mu=1, sigma=2, lower=0, upper=3)
-        logp = pm.logp(dist, [-2., 1., 4.]).eval()
+        logp = pm.logp(dist, [-2.0, 1.0, 4.0]).eval()
         assert np.isinf(logp[0])
         assert np.isfinite(logp[1])
         assert np.isinf(logp[2])

--- a/pymc/tests/distributions/test_continuous.py
+++ b/pymc/tests/distributions/test_continuous.py
@@ -109,16 +109,11 @@ class TestBoundedContinuous:
         assert upper_interval is None
 
     def test_bounded_value(self):
-        with pm.Model() as model:
-            dist = pm.TruncatedNormal(
-                'bounded_both', mu=1, sigma=2, lower=0, upper=3
-            )
-            value = pm.Deterministic('value', pm.logp(dist, [-2., 1., 4.]))
-
-        values = model.compile_fn(value)({})
-        assert np.isinf(values[0])
-        assert np.isfinite(values[1])
-        assert np.isinf(values[2])
+        dist = pm.TruncatedNormal.dist(mu=1, sigma=2, lower=0, upper=3)
+        logp = pm.logp(dist, [-2., 1., 4.]).eval()
+        assert np.isinf(logp[0])
+        assert np.isfinite(logp[1])
+        assert np.isinf(logp[2])
 
     def test_lower_bounded_vector(self):
         bounded_rv_name = "upper_bounded"

--- a/pymc/tests/distributions/test_continuous.py
+++ b/pymc/tests/distributions/test_continuous.py
@@ -108,6 +108,18 @@ class TestBoundedContinuous:
         assert lower_interval.value == -2
         assert upper_interval is None
 
+    def test_bounded_value(self):
+        with pm.Model() as model:
+            dist = pm.TruncatedNormal(
+                'bounded_both', mu=1, sigma=2, lower=0, upper=3
+            )
+            value = pm.Deterministic('value', pm.logp(dist, [-2., 1., 4.]))
+
+        values = model.compile_fn(value)({})
+        assert np.isinf(values[0])
+        assert np.isfinite(values[1])
+        assert np.isinf(values[2])
+
     def test_lower_bounded_vector(self):
         bounded_rv_name = "upper_bounded"
         with pm.Model() as model:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**

With pymc v4.1.7, I found that evaluating `TruncatedNormal`'s `logp` with an array of values was returning all `-inf` values -- for example:
```python
import numpy as np
import pymc as pm

p = {'mu': 1, 'sigma': 0.1}
with pm.Model() as model:    
    dist1 = pm.TruncatedNormal.dist(**p, lower=0.)
    dist2 = pm.Normal.dist(**p)
    
    x_grid = np.linspace(-5, 10, 1024)
    dist1_logp = pm.Deterministic('dist1', pm.logp(dist1, x_grid))
    dist2_logp = pm.Deterministic('dist2', pm.logp(dist2, x_grid))

func1 = model.compile_fn(dist1_logp, inputs=[])
func2 = model.compile_fn(dist2_logp, inputs=[])

print(func1({}))
print(func2({}))
```
Output:
```
[-inf -inf -inf ... -inf -inf -inf]
[-1798.61635344 -1789.8294493  -1781.06404481 ... -4022.26639085
 -4035.43062232 -4048.61635344]
```
In the output above, the first line should not be `-inf` everywhere, as the grid we evaluate on includes values in the allowed range of values.

With @ricardoV94's help, we tracked this down to the way that `TruncatedNormal.logp` was enforcing the value bounds:
https://github.com/pymc-devs/pymc/blob/main/pymc/distributions/continuous.py#L779

I noticed [this comment](https://github.com/pymc-devs/pymc/blob/7af102d40f7b64184cd0fa013ced8570772fc8eb/pymc/distributions/dist_math.py#L59) in the `check_parameters()` docstring: "Note that check_parameter should not be used to enforce the logic of the logp expression under the normal parameter support as it can be disabled by the user via check_bounds = False in pm.Model()" and indeed the above example works as expected with `check_bounds=False`.

This PR instead follows the implementation in other truncated distributions, for example, [HalfStudentT](https://github.com/pymc-devs/pymc/blob/main/pymc/distributions/continuous.py#L2739) to use a `switch` statement instead. I also added a regression test for the example case above.

See https://discourse.pymc.io/t/truncatednormal-logp-returning-all-inf/10398 for more context.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- n/a

## Bugfixes / New features
- Fixed a bug in which `TruncatedNormal` would return -inf for all logp values if any input value was outside of the bounds.

## Docs / Maintenance
- n/a
