### PR TITLE
Add `start_sigma` to ADVI 2

### DIFF
--- a/pymc/tests/test_variational_inference.py
+++ b/pymc/tests/test_variational_inference.py
@@ -571,6 +571,28 @@ def test_fit_oo(inference, fit_kwargs, simple_model_data):
     np.testing.assert_allclose(np.std(trace.posterior["mu"]), np.sqrt(1.0 / d), rtol=0.2)
 
 
+def test_fit_start(inference_spec, simple_model):
+    mu_init = 17
+    mu_sigma_init = 13
+
+    with simple_model:
+        if type(inference_spec()) == ADVI:
+            has_start_sigma = True
+        else:
+            has_start_sigma = False
+
+    kw = {"start": {"mu": mu_init}}
+    if has_start_sigma:
+        kw.update({"start_sigma": {"mu": mu_sigma_init}})
+
+    with simple_model:
+        inference = inference_spec(**kw)
+    trace = inference.fit(n=0).sample(10000)
+    np.testing.assert_allclose(np.mean(trace.posterior["mu"]), mu_init, rtol=0.05)
+    if has_start_sigma:
+        np.testing.assert_allclose(np.std(trace.posterior["mu"]), mu_sigma_init, rtol=0.05)
+
+
 def test_profile(inference):
     inference.run_profiling(n=100).summary()
 

--- a/pymc/tests/test_variational_inference.py
+++ b/pymc/tests/test_variational_inference.py
@@ -576,7 +576,10 @@ def test_fit_start(inference_spec, simple_model):
     mu_sigma_init = 13
 
     with simple_model:
-        if type(inference_spec()) == ADVI:
+        if type(inference_spec()) == ASVGD:
+            # ASVGD doesn't support the start argument
+            return
+        elif type(inference_spec()) == ADVI:
             has_start_sigma = True
         else:
             has_start_sigma = False

--- a/pymc/variational/approximations.py
+++ b/pymc/variational/approximations.py
@@ -88,7 +88,7 @@ class MeanFieldGroup(Group):
     def _prepare_start_sigma(self, start_sigma):
         rho = np.zeros((self.ddim,))
         if start_sigma is not None:
-            for name, slice_, *_ in self.ordering.items():
+            for name, slice_, *_ in self.ordering.values():
                 sigma = start_sigma.get(name)
                 if sigma is not None:
                     rho[slice_] = np.log(np.exp(np.abs(sigma)) - 1.0)

--- a/pymc/variational/inference.py
+++ b/pymc/variational/inference.py
@@ -257,7 +257,9 @@ class Inference:
                     )
                 )
         else:
-            if n < 10:
+            if n == 0:
+                logger.info(f"Initialization only")
+            elif n < 10:
                 logger.info(f"Finished [100%]: Loss = {scores[-1]:,.5g}")
             else:
                 avg_loss = _infmean(scores[max(0, i - 1000) : i + 1])
@@ -466,7 +468,7 @@ class FullRankADVI(KLqp):
     random_seed: None or int
         leave None to use package global RandomStream or other
         valid value to create instance specific one
-    start: `Point`
+    start: `dict[str, np.ndarray]` or `StartDict`
         starting point for inference
 
     References
@@ -534,13 +536,11 @@ class SVGD(ImplicitGradient):
         kernel function for KSD :math:`f(histogram) -> (k(x,.), \nabla_x k(x,.))`
     temperature: float
         parameter responsible for exploration, higher temperature gives more broad posterior estimate
-    start: `dict`
+    start: `dict[str, np.ndarray]` or `StartDict`
         initial point for inference
     random_seed: None or int
         leave None to use package global RandomStream or other
         valid value to create instance specific one
-    start: `Point`
-        starting point for inference
     kwargs: other keyword arguments passed to estimator
 
     References
@@ -631,7 +631,11 @@ class ASVGD(ImplicitGradient):
             "is often **underestimated** when using temperature = 1."
         )
         if approx is None:
-            approx = FullRank(model=kwargs.pop("model", None))
+            approx = FullRank(
+                model=kwargs.pop("model", None),
+                random_seed=kwargs.pop("random_seed", None),
+                start=kwargs.pop("start", None),
+            )
         super().__init__(estimator=estimator, approx=approx, kernel=kernel, **kwargs)
 
     def fit(

--- a/pymc/variational/inference.py
+++ b/pymc/variational/inference.py
@@ -433,8 +433,10 @@ class ADVI(KLqp):
     random_seed: None or int
         leave None to use package global RandomStream or other
         valid value to create instance specific one
-    start: `Point`
+    start: `dict[str, np.ndarray]` or `StartDict`
         starting point for inference
+    start_sigma: `dict[str, np.ndarray]`
+        starting standard deviation for inference, only available for method 'advi'
 
     References
     ----------
@@ -660,6 +662,7 @@ def fit(
     model=None,
     random_seed=None,
     start=None,
+    start_sigma=None,
     inf_kwargs=None,
     **kwargs,
 ):
@@ -684,8 +687,10 @@ def fit(
         valid value to create instance specific one
     inf_kwargs: dict
         additional kwargs passed to :class:`Inference`
-    start: `Point`
+    start: `dict[str, np.ndarray]` or `StartDict`
         starting point for inference
+    start_sigma: `dict[str, np.ndarray]`
+        starting standard deviation for inference, only available for method 'advi'
 
     Other Parameters
     ----------------
@@ -728,6 +733,10 @@ def fit(
         inf_kwargs["random_seed"] = random_seed
     if start is not None:
         inf_kwargs["start"] = start
+    if start_sigma is not None:
+        if method != "advi":
+            raise NotImplementedError("start_sigma is only available for method advi")
+        inf_kwargs["start_sigma"] = start_sigma
     if model is None:
         model = pm.modelcontext(model)
     _select = dict(advi=ADVI, fullrank_advi=FullRankADVI, svgd=SVGD, asvgd=ASVGD)

--- a/pymc/variational/inference.py
+++ b/pymc/variational/inference.py
@@ -631,11 +631,7 @@ class ASVGD(ImplicitGradient):
             "is often **underestimated** when using temperature = 1."
         )
         if approx is None:
-            approx = FullRank(
-                model=kwargs.pop("model", None),
-                random_seed=kwargs.pop("random_seed", None),
-                start=kwargs.pop("start", None),
-            )
+            approx = FullRank(model=kwargs.pop("model", None))
         super().__init__(estimator=estimator, approx=approx, kernel=kernel, **kwargs)
 
     def fit(


### PR DESCRIPTION
Recreation of https://github.com/pymc-devs/pymc/pull/6096 after failing test (fixed in latest commit).

Introduces the `start_sigma` argument which allows to set a starting value for the sigmas of mean field approximation in `ADVI`. I am using the `ordering` property to create the mapping between the variables and the flat 1d array required by `ADVI`. 

See also:
https://discourse.pymc.io/t/quality-of-life-improvements-to-advi/10254

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- None

## Bugfixes / New features
- Allow `start_sigma` being given to `fit`.
- ~~For `ASVGD` forward the key word arguments `start` and `random_seed` to the constructor of the default approximation `FullRank` instead of sending them to `super().__init__` which can't process them~~
- Enable `_iterate_with_loss` to run with `n=0` by giving an appropriate logger message. This allows to check initialization values, which is useful for testing, but could also be useful for debugging a user model

## Docs / Maintenance
- The documentation for the `start` argument was outdated, it claimed type `Point`, but it gets passed through to a function that requires `StartDict`. Since users are probably unfamiliar with this custom type (`Dict[Union[Variable, str], Union[np.ndarray, Variable, str]]`), I decided to also mention the most relevant and most commonly used subtype `dict[str, np.ndarray]`.
