### PR TITLE
Remove versioneer from requirements.txt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
       - "*.py"
       - "conda-envs/**"
       - "codecov.yml"
+      - "requirements*.txt"
       - "scripts/*.sh"
   push:
     branches: [main]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ numpy>=1.15.0
 pandas>=0.24.0
 scipy>=1.4.1
 typing-extensions>=3.7.4
-versioneer>=0.23


### PR DESCRIPTION
Context: Versioneer was added in #6078, installed in "vendored mode" so that the necessary code is installed into `versioneer.py`.

It seems strange to me that versioneer is an install requirement. It looks like nothing breaks when I remove it.

In order to enable CI, I had to add `requirements.txt` to the list of test-triggering files in `.github/workflows/tests.yml`.

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
...

**Checklist**
+ [X] Explain important implementation details 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Remove (apparently) unnecessary `versioneer` requirement
- Trigger CI on a PR which modifies `requirements.txt`
