### PR TITLE
Gp sigma parameterize 6094

### DIFF
--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -37,6 +37,27 @@ from pymc.math import cartesian, kron_diag, kron_dot, kron_solve_lower, kron_sol
 __all__ = ["Latent", "Marginal", "TP", "MarginalApprox", "LatentKron", "MarginalKron"]
 
 
+_noise_deprecation_warning = (
+    "The 'noise' parameter has been been changed to 'sigma' "
+    "in order to standardize the gp api and will be "
+    "deprecated in future releases."
+)
+def _handle_sigma_noise_parameters(sigma, noise): 
+    """Helper function for transition of 'noise' parameter to be named 'sigma'."""
+
+    if (sigma is None and noise is None) or (sigma is not None and noise is not None): 
+        raise ValueError("'sigma' argument must be specified.")
+
+    if sigma is None: 
+        warnings.warn(
+            _noise_deprecation_warning, 
+            FutureWarning
+        )
+        return noise
+
+    return sigma 
+
+
 class Base:
     R"""
     Base class.
@@ -218,7 +239,7 @@ class Latent(Base):
         Xnew: array-like
             Function input values.
         given: dict
-            Can optionally take as key value pairs: `X`, `y`, `noise`,
+            Can optionally take as key value pairs: `X`, `y`,
             and `gp`.  See the section in the documentation on additive GP
             models in PyMC for more information.
         jitter: scalar
@@ -359,7 +380,7 @@ class TP(Latent):
         return pm.MvStudentT(name, nu=nu2, mu=mu, cov=cov, **kwargs)
 
 
-@conditioned_vars(["X", "y", "noise"])
+@conditioned_vars(["X", "y", "sigma"])
 class Marginal(Base):
     R"""
     Marginal Gaussian process.
@@ -393,7 +414,7 @@ class Marginal(Base):
 
             # Place a GP prior over the function f.
             sigma = pm.HalfCauchy("sigma", beta=3)
-            y_ = gp.marginal_likelihood("y", X=X, y=y, noise=sigma)
+            y_ = gp.marginal_likelihood("y", X=X, y=y, sigma=sigma)
 
         ...
 
@@ -405,15 +426,15 @@ class Marginal(Base):
             fcond = gp.conditional("fcond", Xnew=Xnew)
     """
 
-    def _build_marginal_likelihood(self, X, noise, jitter):
+    def _build_marginal_likelihood(self, X, sigma, jitter):
         mu = self.mean_func(X)
         Kxx = self.cov_func(X)
-        Knx = noise(X)
+        Knx = sigma(X)
         cov = Kxx + Knx
         return mu, stabilize(cov, jitter)
 
     def marginal_likelihood(
-        self, name, X, y, noise, jitter=JITTER_DEFAULT, is_observed=True, **kwargs
+        self, name, X, y, sigma=None, noise=None, jitter=JITTER_DEFAULT, is_observed=True, **kwargs
     ):
         R"""
         Returns the marginal likelihood distribution, given the input
@@ -435,9 +456,11 @@ class Marginal(Base):
         y: array-like
             Data that is the sum of the function with the GP prior and Gaussian
             noise.  Must have shape `(n, )`.
+        sigma: scalar, Variable, or Covariance
+            Standard deviation of the Gaussian noise.  Can also be a Covariance for 
+            non-white noise. 
         noise: scalar, Variable, or Covariance
-            Standard deviation of the Gaussian noise.  Can also be a Covariance for
-            non-white noise.
+            Previous parameterization of `sigma`.
         jitter: scalar
             A small correction added to the diagonal of positive semi-definite
             covariance matrices to ensure numerical stability.
@@ -445,13 +468,14 @@ class Marginal(Base):
             Extra keyword arguments that are passed to `MvNormal` distribution
             constructor.
         """
+        sigma = _handle_sigma_noise_parameters(sigma=sigma, noise=noise)
 
-        if not isinstance(noise, Covariance):
-            noise = pm.gp.cov.WhiteNoise(noise)
-        mu, cov = self._build_marginal_likelihood(X, noise, jitter)
+        if not isinstance(sigma, Covariance):
+            sigma = pm.gp.cov.WhiteNoise(sigma)
+        mu, cov = self._build_marginal_likelihood(X=X, sigma=sigma, jitter=jitter)
         self.X = X
         self.y = y
-        self.noise = noise
+        self.sigma = sigma
         if is_observed:
             return pm.MvNormal(name, mu=mu, cov=cov, observed=y, **kwargs)
         else:
@@ -472,20 +496,27 @@ class Marginal(Base):
         else:
             cov_total = self.cov_func
             mean_total = self.mean_func
-        if all(val in given for val in ["X", "y", "noise"]):
-            X, y, noise = given["X"], given["y"], given["noise"]
-            if not isinstance(noise, Covariance):
-                noise = pm.gp.cov.WhiteNoise(noise)
+
+        if "noise" in given: 
+            warnings.warn(
+                _noise_deprecation_warning, FutureWarning
+            )
+            given["sigma"] = given["noise"]
+
+        if all(val in given for val in ["X", "y", "sigma"]):
+            X, y, sigma = given["X"], given["y"], given["sigma"]
+            if not isinstance(sigma, Covariance):
+                sigma = pm.gp.cov.WhiteNoise(sigma)
         else:
-            X, y, noise = self.X, self.y, self.noise
-        return X, y, noise, cov_total, mean_total
+            X, y, sigma = self.X, self.y, self.sigma
+        return X, y, sigma, cov_total, mean_total
 
     def _build_conditional(
-        self, Xnew, pred_noise, diag, X, y, noise, cov_total, mean_total, jitter
+        self, Xnew, pred_noise, diag, X, y, sigma, cov_total, mean_total, jitter
     ):
         Kxx = cov_total(X)
         Kxs = self.cov_func(X, Xnew)
-        Knx = noise(X)
+        Knx = sigma(X)
         rxx = y - mean_total(X)
         L = cholesky(stabilize(Kxx, jitter) + Knx)
         A = solve_lower(L, Kxs)
@@ -495,13 +526,13 @@ class Marginal(Base):
             Kss = self.cov_func(Xnew, diag=True)
             var = Kss - at.sum(at.square(A), 0)
             if pred_noise:
-                var += noise(Xnew, diag=True)
+                var += sigma(Xnew, diag=True)
             return mu, var
         else:
             Kss = self.cov_func(Xnew)
             cov = Kss - at.dot(at.transpose(A), A)
             if pred_noise:
-                cov += noise(Xnew)
+                cov += sigma(Xnew)
             return mu, cov if pred_noise else stabilize(cov, jitter)
 
     def conditional(
@@ -531,7 +562,7 @@ class Marginal(Base):
             Whether or not observation noise is included in the conditional.
             Default is `False`.
         given: dict
-            Can optionally take as key value pairs: `X`, `y`, `noise`,
+            Can optionally take as key value pairs: `X`, `y`, `sigma`,
             and `gp`.  See the section in the documentation on additive GP
             models in PyMC for more information.
         jitter: scalar
@@ -720,7 +751,7 @@ class MarginalApprox(Marginal):
         quadratic = 0.5 * (at.dot(r, r_l) - at.dot(c, c))
         return -1.0 * (constant + logdet + quadratic + trace)
 
-    def marginal_likelihood(self, name, X, Xu, y, noise=None, jitter=JITTER_DEFAULT, **kwargs):
+    def marginal_likelihood(self, name, X, Xu, y, sigma=None, noise=None, jitter=JITTER_DEFAULT, **kwargs):
         R"""
         Returns the approximate marginal likelihood distribution, given the input
         locations `X`, inducing point locations `Xu`, data `y`, and white noise
@@ -738,8 +769,10 @@ class MarginalApprox(Marginal):
         y: array-like
             Data that is the sum of the function with the GP prior and Gaussian
             noise.  Must have shape `(n, )`.
+        sigma: scalar, Variable
+            Standard deviation of the Gaussian noise. 
         noise: scalar, Variable
-            Standard deviation of the Gaussian noise.
+            Previous parameterization of `sigma`
         jitter: scalar
             A small correction added to the diagonal of positive semi-definite
             covariance matrices to ensure numerical stability.
@@ -752,12 +785,9 @@ class MarginalApprox(Marginal):
         self.Xu = Xu
         self.y = y
 
-        if noise is None:
-            raise ValueError("noise argument must be specified")
-        else:
-            self.sigma = noise
+        self.sigma = _handle_sigma_noise_parameters(sigma=sigma, noise=noise)
 
-        approx_loglik = self._build_marginal_likelihood_loglik(y, X, Xu, noise, jitter)
+        approx_loglik = self._build_marginal_likelihood_loglik(y=self.y, X=self.X, Xu=self.Xu, sigma=self.sigma, jitter=jitter)
         pm.Potential(f"marginalapprox_loglik_{name}", approx_loglik, **kwargs)
 
     def _build_conditional(
@@ -828,7 +858,7 @@ class MarginalApprox(Marginal):
             Whether or not observation noise is included in the conditional.
             Default is `False`.
         given: dict
-            Can optionally take as key value pairs: `X`, `Xu`, `y`, `noise`,
+            Can optionally take as key value pairs: `X`, `Xu`, `y`, `sigma`,
             and `gp`.  See the section in the documentation on additive GP
             models in PyMC for more information.
         jitter: scalar

--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -42,20 +42,19 @@ _noise_deprecation_warning = (
     "in order to standardize the gp api and will be "
     "deprecated in future releases."
 )
-def _handle_sigma_noise_parameters(sigma, noise): 
+
+
+def _handle_sigma_noise_parameters(sigma, noise):
     """Helper function for transition of 'noise' parameter to be named 'sigma'."""
 
-    if (sigma is None and noise is None) or (sigma is not None and noise is not None): 
+    if (sigma is None and noise is None) or (sigma is not None and noise is not None):
         raise ValueError("'sigma' argument must be specified.")
 
-    if sigma is None: 
-        warnings.warn(
-            _noise_deprecation_warning, 
-            FutureWarning
-        )
+    if sigma is None:
+        warnings.warn(_noise_deprecation_warning, FutureWarning)
         return noise
 
-    return sigma 
+    return sigma
 
 
 class Base:
@@ -457,8 +456,8 @@ class Marginal(Base):
             Data that is the sum of the function with the GP prior and Gaussian
             noise.  Must have shape `(n, )`.
         sigma: scalar, Variable, or Covariance
-            Standard deviation of the Gaussian noise.  Can also be a Covariance for 
-            non-white noise. 
+            Standard deviation of the Gaussian noise.  Can also be a Covariance for
+            non-white noise.
         noise: scalar, Variable, or Covariance
             Previous parameterization of `sigma`.
         jitter: scalar
@@ -497,10 +496,8 @@ class Marginal(Base):
             cov_total = self.cov_func
             mean_total = self.mean_func
 
-        if "noise" in given: 
-            warnings.warn(
-                _noise_deprecation_warning, FutureWarning
-            )
+        if "noise" in given:
+            warnings.warn(_noise_deprecation_warning, FutureWarning)
             given["sigma"] = given["noise"]
 
         if all(val in given for val in ["X", "y", "sigma"]):
@@ -751,7 +748,9 @@ class MarginalApprox(Marginal):
         quadratic = 0.5 * (at.dot(r, r_l) - at.dot(c, c))
         return -1.0 * (constant + logdet + quadratic + trace)
 
-    def marginal_likelihood(self, name, X, Xu, y, sigma=None, noise=None, jitter=JITTER_DEFAULT, **kwargs):
+    def marginal_likelihood(
+        self, name, X, Xu, y, sigma=None, noise=None, jitter=JITTER_DEFAULT, **kwargs
+    ):
         R"""
         Returns the approximate marginal likelihood distribution, given the input
         locations `X`, inducing point locations `Xu`, data `y`, and white noise
@@ -770,7 +769,7 @@ class MarginalApprox(Marginal):
             Data that is the sum of the function with the GP prior and Gaussian
             noise.  Must have shape `(n, )`.
         sigma: scalar, Variable
-            Standard deviation of the Gaussian noise. 
+            Standard deviation of the Gaussian noise.
         noise: scalar, Variable
             Previous parameterization of `sigma`
         jitter: scalar
@@ -787,7 +786,9 @@ class MarginalApprox(Marginal):
 
         self.sigma = _handle_sigma_noise_parameters(sigma=sigma, noise=noise)
 
-        approx_loglik = self._build_marginal_likelihood_loglik(y=self.y, X=self.X, Xu=self.Xu, sigma=self.sigma, jitter=jitter)
+        approx_loglik = self._build_marginal_likelihood_loglik(
+            y=self.y, X=self.X, Xu=self.Xu, sigma=self.sigma, jitter=jitter
+        )
         pm.Potential(f"marginalapprox_loglik_{name}", approx_loglik, **kwargs)
 
     def _build_conditional(

--- a/pymc/tests/gp/test_gp.py
+++ b/pymc/tests/gp/test_gp.py
@@ -113,20 +113,20 @@ class TestGPAdditive:
             gp3 = pm.gp.Marginal(mean_func=self.means[2], cov_func=self.covs[2])
 
             gpsum = gp1 + gp2 + gp3
-            fsum = gpsum.marginal_likelihood("f", self.X, self.y, noise=self.noise)
+            fsum = gpsum.marginal_likelihood("f", self.X, self.y, sigma=self.noise)
             model1_logp = model1.compile_logp()({})
 
         with pm.Model() as model2:
             gptot = pm.gp.Marginal(
                 mean_func=reduce(add, self.means), cov_func=reduce(add, self.covs)
             )
-            fsum = gptot.marginal_likelihood("f", self.X, self.y, noise=self.noise)
+            fsum = gptot.marginal_likelihood("f", self.X, self.y, sigma=self.noise)
             model2_logp = model2.compile_logp()({})
         npt.assert_allclose(model1_logp, model2_logp, atol=0, rtol=1e-2)
 
         with model1:
             fp1 = gpsum.conditional(
-                "fp1", self.Xnew, given={"X": self.X, "y": self.y, "noise": self.noise, "gp": gpsum}
+                "fp1", self.Xnew, given={"X": self.X, "y": self.y, "sigma": self.noise, "gp": gpsum}
             )
         with model2:
             fp2 = gptot.conditional("fp2", self.Xnew)
@@ -152,14 +152,14 @@ class TestGPAdditive:
             )
 
             gpsum = gp1 + gp2 + gp3
-            fsum = gpsum.marginal_likelihood("f", self.X, Xu, self.y, noise=sigma)
+            fsum = gpsum.marginal_likelihood("f", self.X, Xu, self.y, sigma=sigma)
             model1_logp = model1.compile_logp()({})
 
         with pm.Model() as model2:
             gptot = pm.gp.MarginalApprox(
                 mean_func=reduce(add, self.means), cov_func=reduce(add, self.covs), approx=approx
             )
-            fsum = gptot.marginal_likelihood("f", self.X, Xu, self.y, noise=sigma)
+            fsum = gptot.marginal_likelihood("f", self.X, Xu, self.y, sigma=sigma)
             model2_logp = model2.compile_logp()({})
         npt.assert_allclose(model1_logp, model2_logp, atol=0, rtol=1e-2)
 
@@ -233,7 +233,7 @@ class TestGPAdditive:
 
 class TestMarginalVsLatent:
     R"""
-    Compare the logp of models Marginal, noise=0 and Latent.
+    Compare the logp of models Marginal, sigma=0 and Latent.
     """
 
     def setup_method(self):
@@ -245,7 +245,7 @@ class TestMarginalVsLatent:
             cov_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
             mean_func = pm.gp.mean.Constant(0.5)
             gp = pm.gp.Marginal(mean_func=mean_func, cov_func=cov_func)
-            f = gp.marginal_likelihood("f", X, y, noise=0.0)
+            f = gp.marginal_likelihood("f", X, y, sigma=0.0)
             p = gp.conditional("p", Xnew)
         self.logp = model.compile_logp()({"p": pnew})
         self.X = X
@@ -422,7 +422,7 @@ class TestMarginalKron:
             cov_func = pm.gp.cov.Kron(self.cov_funcs)
             self.mean = pm.gp.mean.Constant(0.5)
             gp = pm.gp.Marginal(mean_func=self.mean, cov_func=cov_func)
-            f = gp.marginal_likelihood("f", self.X, self.y, noise=self.sigma)
+            f = gp.marginal_likelihood("f", self.X, self.y, sigma=self.sigma)
             p = gp.conditional("p", self.Xnew)
             self.mu, self.cov = gp.predict(self.Xnew)
         self.logp = model.compile_logp()({"p": self.pnew})


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Addressing the issue raised: https://github.com/pymc-devs/pymc/issues/6094

Helps migrates toward standardized API for noise in GPs. Changes the `noise` parameter to `sigma` where applicable.  A `FutureWarning` is used if `noise` parameter is still used in the previous locations.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- NA

## Bugfixes / New features
- Standardize the gp API

## Docs / Maintenance
- GP docstring examples all work and use `sigma` parameter instead of `noise`
- Small changes to the Latent GP docs that mistakenly reference the `noise`
