### PR TITLE
Check shared variable values to determine volatility in posterior predictive sampling

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1149,7 +1149,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             length = len(values)
         if not isinstance(length, Variable):
             if mutable:
-                length = aesara.shared(length)
+                length = aesara.shared(length, name=name)
             else:
                 length = aesara.tensor.constant(length)
         self._dim_lengths[name] = length


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**

Closes #6047.

This PR did two things:

1. It makes the mutable dimension `SharedVariable` length have the name of the corresponding dimension.
2. Adds two arguments to `compile_forward_sampling_function`: `constant_data` and `constant_coords`.

These two arguments allow it to determine if a `SharedVariable` has changed after between a call to `sample` and `sample_posterior_predictive`. We have to note that `constant_data` is only knowable if `sample_posterior_predictive` is called supplying an `InferenceData` object, and `constant_coords` are only knowable if `sample_posterior_predictive` is called supplying an `InferenceData` or an `xarray.Dataset` object.

The way `sample_posterior_predictive` is able to determine if a data container changed is by doing the following. It first checks the `InferenceData.constant_data` group to find the values of data containers at inference time, and passes those into the `constant_data` argument of `compile_forward_sampling_function`. When a `SharedVariable` is found while walking the graph, it looks up the entry in `constant_data`, it it finds an entry, it checks whether the values in the dictionary match the values of the `SharedVariable` at run time. If they match, the `SharedVariable` is deemed not volatile, if they don't match, the `SharedVariable` is considered volatile.
To check if a dimension's coordinates changed, `sample_posterior_predictive` compares the model's coordinates to those found in the supplied trace (must be an `InferenceData` or `xarray.Dataset` to have this information). If the coordinates did not change, then the dimension name is added to the `constant_coords` set. Then, when `compile_forward_sampling_function` finds the dimension length's shared variable, it tries to see if its name is in `constant_coords`. If it is, then the dimension is not deemed volatile, if it isn't it is considered volatile.

**Checklist**
+ [X] Explain important implementation details 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [X] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [X] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- `sample_posterior_predictive`, when supplied with an `InferenceData` object, properly identifies if a `MutableData` or mutable dimension has changed between a call to `pymc.sample` and `pymc.sample_posterior_predictive`. If they have, then the descendant random variables are resampled, if they have not changed, then the descendant random variables are taken from the `InferenceData.posterior`.

## Docs / Maintenance
- ...
