### PR TITLE
Add graphviz support for SymbolicRVs

### DIFF
--- a/pymc/tests/test_model_graph.py
+++ b/pymc/tests/test_model_graph.py
@@ -28,6 +28,7 @@ from pymc.distributions import (
     GaussianRandomWalk,
     Mixture,
     Normal,
+    RandomWalk,
     StudentT,
     Truncated,
     ZeroInflatedPoisson,
@@ -399,8 +400,21 @@ class TestVariableSelection:
             },
             "MarginalMixture",
         ),
-        (GaussianRandomWalk, {"init_dist": Normal.dist(0.0, 5.0), "steps": 10}, "RandomWalk"),
+        (
+            GaussianRandomWalk,
+            {"init_dist": Normal.dist(0.0, 5.0), "steps": 10},
+            "GaussianRandomWalk",
+        ),
         (Truncated, {"dist": StudentT.dist(7), "upper": 3.0}, "TruncatedStudentT"),
+        (
+            RandomWalk,
+            {
+                "innovation_dist": pm.StudentT.dist(7),
+                "init_dist": pm.Normal.dist(0, 1),
+                "steps": 10,
+            },
+            "StudentTRandomWalk",
+        ),
     ],
 )
 def test_symbolic_distribution_display(symbolic_dist, dist_kwargs, display_name):


### PR DESCRIPTION
Closes #5766.

Prior to this PR, symbolic distributions were labelled as "Deterministic" in the graph produced by Graphviz. The recent addition of symbolic RVs in #6072 allows `pymc/model_graph.py` to be adapted more easily. Here is an example of what is obtained using symbolic distributions such as `pm.Mixture`, `pm.Censored`, `pm.ZeroInflatedPoisson`.

```python
with pm.Model() as model:
    psi = pm.Beta("psi", 1., 1.)
    mu_zip = pm.Gamma("mu_zip", 1., 1.)
    zip_var = pm.ZeroInflatedPoisson("zip", psi=psi, mu=mu_zip)
    
    mu_cens = pm.Normal("mu_cens", 0., 5.)
    sigma_cens = pm.HalfCauchy("sigma_cens", 2.5)
    normal_dist = pm.Normal.dist(mu=mu_cens, sigma=sigma_cens)
    censored_normal = pm.Censored("censored_normal", normal_dist, lower=-2., upper=2., observed=[0, 0.5, 1])
    
    mu_grw = pm.Normal("mu_grw", 0., 5.)
    sigma_grw = pm.HalfCauchy("sigma_grw", 2.5)
    pm.GaussianRandomWalk("grw", init_dist=pm.Normal.dist(mu_grw, sigma_grw), steps=10)
    
pm.model_to_graphviz(zip_model)
```

<img width="984" alt="image" src="https://user-images.githubusercontent.com/24764859/192386042-98f6b97f-d971-4621-8c74-110822a54c00.png">

Tests in [`pymc/tests/test_model_graph.py`](https://github.com/pymc-devs/pymc/blob/main/pymc/tests/test_model_graph.py) checks that the arrows are pointing to and from the right variables and that the overall shape of the Graphviz Digraph is correct. Perhaps an additional check that the distribution names are correct can be added, because this is what this PR is about.