### PR TITLE
Fix DiscreteUniformRV dropping degenerate dimension

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from aesara.tensor.random.basic import (
     RandomVariable,
+    ScipyRandomVariable,
     bernoulli,
     betabinom,
     binomial,
@@ -1117,7 +1118,7 @@ class HyperGeometric(Discrete):
         )
 
 
-class DiscreteUniformRV(RandomVariable):
+class DiscreteUniformRV(ScipyRandomVariable):
     name = "discrete_uniform"
     ndim_supp = 0
     ndims_params = [0, 0]
@@ -1125,7 +1126,7 @@ class DiscreteUniformRV(RandomVariable):
     _print_name = ("DiscreteUniform", "\\operatorname{DiscreteUniform}")
 
     @classmethod
-    def rng_fn(cls, rng, lower, upper, size=None):
+    def rng_fn_scipy(cls, rng, lower, upper, size=None):
         return stats.randint.rvs(lower, upper + 1, size=size, random_state=rng)
 
 

--- a/pymc/tests/distributions/test_discrete.py
+++ b/pymc/tests/distributions/test_discrete.py
@@ -1042,6 +1042,10 @@ class TestDiscreteUniform(BaseTestDistributionRandom):
         "check_rv_size",
     ]
 
+    def test_implied_degenerate_shape(self):
+        x = pm.DiscreteUniform.dist(0, [1])
+        assert x.eval().shape == (1,)
+
 
 class TestDiracDelta(BaseTestDistributionRandom):
     def diracdelta_rng_fn(self, size, c):


### PR DESCRIPTION
**What is this PR about?**

Bug found by @drbenvincent 
Scipy does not respect degenerate dimensions (size=1) implied by the parameters

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- Fix bug where `DiscreteUniformRV` would drop degenerate dimensions from draws

## Docs / Maintenance
- ...
