### PR TITLE
Bugfix for #6143, flakey K-means test in GP submodule

### DIFF
--- a/pymc/tests/gp/test_util.py
+++ b/pymc/tests/gp/test_util.py
@@ -59,11 +59,11 @@ class TestKmeansInducing:
     def test_kmeans(self):
         X = self.x[:, None]
         Xu = pm.gp.util.kmeans_inducing_points(2, X).flatten()
-        npt.assert_allclose(np.asarray(self.centers), np.sort(Xu), atol=0.1)
+        npt.assert_allclose(np.asarray(self.centers), np.sort(Xu), rtol=0.05)
 
         X = at.as_tensor_variable(self.x[:, None])
         Xu = pm.gp.util.kmeans_inducing_points(2, X).flatten()
-        npt.assert_allclose(np.asarray(self.centers), np.sort(Xu), atol=0.1)
+        npt.assert_allclose(np.asarray(self.centers), np.sort(Xu), rtol=0.05)
 
     def test_kmeans_raises(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
closes #6143.

One of the tests of the GP model tests that the kmeans method for locating inducing points works correctly.  It uses an example that should be easy for K-means, a 1d normal mixture model, with mu at -5 and the other at 5, both with sigma=1.   Occasionally the tests give an answer that is close enough, like [-4.98, 5.1], but doesn't pass the tests.  This PR uses a 5% relative tolerance instead. 

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- NA

## Bugfixes / New features
- fix for #6143

## Docs / Maintenance
- NA
