### PR TITLE
Small typo corrections in Markdown for overview notebook

### DIFF
--- a/docs/source/learn/core_notebooks/pymc_overview.ipynb
+++ b/docs/source/learn/core_notebooks/pymc_overview.ipynb
@@ -22,17 +22,17 @@
    "source": [
     "## Abstract\n",
     "\n",
-    "Probabilistic Programming allows for automatic Bayesian inference on user-defined probabilistic models. Gradient-based algorithms for Markov chain Monte Carlo (MCMC) sampling, known as Hamiltonian Monte Carlo (HMC), allow inference on increasingly complex models but requires gradient information that is often not trivial to calculate PyMC is an open source Probabilistic Programming framework written in Python that uses Aesara to compute gradients via automatic differentiation as well as compile probabilistic programs on-the-fly to one of a suite of computational backends for increased speed. PyMC allows for model specification in Python code, rather than im a domain specific language, making it easy to learn, customize, and debug. This paper is a tutorial-style introduction to this software package for those already somewhat familiar with Bayesian statistics.\n",
+    "Probabilistic Programming allows for automatic Bayesian inference on user-defined probabilistic models. Gradient-based algorithms for Markov chain Monte Carlo (MCMC) sampling, known as Hamiltonian Monte Carlo (HMC), allow inference on increasingly complex models but requires gradient information that is often not trivial to calculate. PyMC is an open source probabilistic programming framework written in Python that uses Aesara to compute gradients via automatic differentiation, as well as compiling probabilistic programs on-the-fly to one of a suite of computational backends for increased speed. PyMC allows for model specification in Python code, rather than in a domain-specific language, making it easy to learn, customize, and debug. This paper is a tutorial-style introduction to this software package for those already somewhat familiar with Bayesian statistics.\n",
     "\n",
     "## Introduction\n",
     "\n",
-    "Probabilistic programming (PP) allows flexible specification of Bayesian statistical models in code. PyMC is a PP framework with an intuitive and readable, yet powerful, syntax that is close to the natural syntax statisticians use to describe models. It features next-generation Markov chain Monte Carlo (MCMC) sampling algorithms such as the No-U-Turn Sampler (NUTS; Hoffman, 2014), a self-tuning variant of Hamiltonian Monte Carlo (HMC; Duane, 1987). This class of samplers works well on high dimensional and complex posterior distributions and allows many complex models to be fit without specialized knowledge about fitting algorithms. HMC and NUTS take advantage of gradient information from the likelihood to achieve much faster convergence than traditional sampling methods, especially for larger models. NUTS also has several self-tuning strategies for adaptively setting the tunable parameters of Hamiltonian Monte Carlo, which means you usually don't need to have specialized knowledge about how the algorithms work. \n",
+    "Probabilistic programming (PP) allows flexible specification of Bayesian statistical models in code. PyMC is a PP framework with an intuitive and readable, yet powerful, syntax that is close to the natural syntax statisticians use to describe models. It features next-generation Markov chain Monte Carlo (MCMC) sampling algorithms such as the No-U-Turn Sampler (NUTS; Hoffman, 2014), a self-tuning variant of Hamiltonian Monte Carlo (HMC; Duane, 1987). This class of samplers works well on high-dimensional and complex posterior distributions and allows many complex models to be fit without specialized knowledge about fitting algorithms. HMC and NUTS take advantage of gradient information from the likelihood to achieve much faster convergence than traditional sampling methods, especially for larger models. NUTS also has several self-tuning strategies for adaptively setting the tunable parameters of Hamiltonian Monte Carlo, which means you usually don't need to have specialized knowledge about how the algorithms work. \n",
     "\n",
     "Probabilistic programming in Python confers a number of advantages including multi-platform compatibility, an expressive yet clean and readable syntax, easy integration with other scientific libraries, and extensibility via C, C++, Fortran or Cython. These features make it relatively straightforward to write and use custom statistical distributions, samplers and transformation functions, as required by Bayesian analysis.\n",
     "\n",
     "While most of PyMC's user-facing features are written in pure Python, it leverages Aesara (a fork of the Theano project) to transparently transcode models to C and compile them to machine code, thereby boosting performance. Aesara is a library that allows expressions to be defined using generalized vector data structures called *tensors*, which are tightly integrated with the popular NumPy {class}`~numpy.ndarray` data structure, and similarly allow for broadcasting and advanced indexing, just as NumPy arrays do. Aesara also automatically optimizes the likelihood's computational graph for speed and allows for compilation to a suite of computational backends, including Jax and Numba.\n",
     "\n",
-    "Here, we present a primer on the use of PyMC for solving general Bayesian statistical inference and prediction problems. We will first see the basics of how to use PyMC, motivated by a simple example: installation, data creation, model definition, model fitting and posterior analysis. Then we will cover two case studies and use them to show how to define and fit more sophisticated models. Finally we will  discuss a couple of other other useful features: custom distributions and arbitrary deterministic nodes."
+    "Here, we present a primer on the use of PyMC for solving general Bayesian statistical inference and prediction problems. We will first see the basics of how to use PyMC, motivated by a simple example: installation, data creation, model definition, model fitting and posterior analysis. Then we will cover two case studies and use them to show how to define and fit more sophisticated models. Finally we will discuss a couple of other useful features: custom distributions and arbitrary deterministic nodes."
    ]
   },
   {
@@ -41,7 +41,7 @@
    "source": [
     "## Installation\n",
     "\n",
-    "Running PyMC requires a relatively recent Python interpreter, preferrably version 3.8 or greater. A complete Python installation for Mac OSX, Linux and Windows can most easily be obtained by downloading and installing the free [`Anaconda Python Distribution`](https://store.continuum.io/cshop/anaconda/) by ContinuumIO or the open source [Miniforge](https://github.com/conda-forge/miniforge).\n",
+    "Running PyMC requires a relatively recent Python interpreter, preferrably version 3.8 or greater. A complete Python installation for macOS, Linux and Windows can most easily be obtained by downloading and installing the free [`Anaconda Python Distribution`](https://store.continuum.io/cshop/anaconda/) by ContinuumIO or the open source [Miniforge](https://github.com/conda-forge/miniforge).\n",
     "\n",
     "Once Python is installed, follow the {ref}`installation guide <installation>` on the PyMC documentation site.\n",
     "\n",
@@ -54,7 +54,7 @@
    "source": [
     "## A Motivating Example: Linear Regression\n",
     "\n",
-    "To introduce model definition, fitting, and posterior analysis, we first consider a simple Bayesian linear regression model with normal priors for the parameters. We are interested in predicting outcomes $Y$ as normally-distributed observations with an expected value $\\mu$ that is a linear function of two predictor variables, $X_1$ and $X_2$.\n",
+    "To introduce model definition, fitting, and posterior analysis, we first consider a simple Bayesian linear regression model with normally-distributed priors for the parameters. We are interested in predicting outcomes $Y$ as normally-distributed observations with an expected value $\\mu$ that is a linear function of two predictor variables, $X_1$ and $X_2$:\n",
     "\n",
     "$$\\begin{aligned} \n",
     "Y  &\\sim \\mathcal{N}(\\mu, \\sigma^2) \\\\\n",
@@ -163,7 +163,7 @@
    "source": [
     "### Model Specification\n",
     "\n",
-    "Specifying this model in PyMC is straightforward because the syntax is as close to the statistical notation. For the most part, each line of Python code corresponds to a line in the model notation above. \n",
+    "Specifying this model in PyMC is straightforward because the syntax is similar to the statistical notation. For the most part, each line of Python code corresponds to a line in the model notation above. \n",
     "\n",
     "First, we import PyMC. We use the convention of importing it as `pm`."
    ]
@@ -251,11 +251,11 @@
     "beta = pm.Normal('beta', mu=0, sigma=10, shape=2)\n",
     "sigma = pm.HalfNormal('sigma', sigma=1)\n",
     "```\n",
-    "create **stochastic** random variables with Normal prior distributions for the regression coefficients with a mean of 0 and standard deviation of 10, and a half-normal distribution for the standard deviation of the observations, $\\sigma$. These are stochastic because their values are partly determined by its parents in the dependency graph of random variables, which for priors are simple constants, and partly random (or stochastic). \n",
+    "create **stochastic** random variables with normally-distributed prior distributions for the regression coefficients with a mean of 0 and standard deviation of 10, and a half-normal distribution for the standard deviation of the observations, $\\sigma$. These are stochastic because their values are partly determined by their parents in the dependency graph of random variables, which for priors are simple constants, and partly random (or stochastic). \n",
     "\n",
     "We call the `pm.Normal` constructor to create a random variable to use as a normal prior. The first argument is always the *name* of the random variable, which should almost always match the name of the Python variable being assigned to, since it is sometimes used to retrieve the variable from the model for summarizing output. The remaining required arguments for a stochastic object are the parameters, in this case `mu`, the mean, and `sd`, the standard deviation, which we assign hyperparameter values for the model. In general, a distribution's parameters are values that determine the location, shape or scale of the random variable, depending on the parameterization of the distribution. Most commonly-used distributions, such as `Beta`, `Exponential`, `Categorical`, `Gamma`, `Binomial` and many others, are available in PyMC.\n",
     "\n",
-    "The `beta` variable has an additional `shape` argument to denote it as a vector-valued parameter of size 2. The `shape` argument is available for all distributions and specifies the length or shape of the random variable, but is optional for scalar variables, since it defaults to a value of one. It can be an integer, to specify an array, or a tuple, to specify a multidimensional array (*e.g.* `shape=(5,7)` makes random variable that takes on 5 by 7 matrix values). \n",
+    "The `beta` variable has an additional `shape` argument to denote it as a vector-valued parameter of size 2. The `shape` argument is available for all distributions and specifies the length or shape of the random variable, but is optional for scalar variables, since it defaults to a value of one. It can be an integer to specify an array, or a tuple to specify a multidimensional array (*e.g.* `shape=(5,7)` makes a random variable that takes on 5 by 7 matrix values). \n",
     "\n",
     "Detailed notes about distributions, sampling methods and other PyMC functions are available in the {ref}`API documentation <api>`."
    ]
@@ -273,7 +273,7 @@
     "\n",
     "PyMC random variables and data can be arbitrarily added, subtracted, divided, multiplied together and indexed-into to create new random variables. This allows for great model expressivity. Many common mathematical functions like `sum`, `sin`, `exp` and linear algebra functions like `dot` (for inner product) and `inv` (for inverse) are also provided. \n",
     "\n",
-    "The final line of the model, defines `Y_obs`, the sampling distribution of the outcomes in the dataset.\n",
+    "The final line of the model defines `Y_obs`, the sampling distribution of the outcomes in the dataset.\n",
     "\n",
     "```python\n",
     "Y_obs = Normal('Y_obs', mu=mu, sigma=sigma, observed=Y)\n",
@@ -3064,7 +3064,7 @@
    "source": [
     "### The Data\n",
     "\n",
-    "This anonomized dataset is taken from the Listening and Spoken Language Data Repository (LSL-DR), an international data repository that tracks the demographics and longitudinal outcomes for children who have hearing loss and are enrolled programs focused on supporting listening and spoken language development. Researchers are interesting in discovering factors related to improvements in educational outcomes at within these programs.\n",
+    "This anonymized dataset is taken from the Listening and Spoken Language Data Repository (LSL-DR), an international data repository that tracks the demographics and longitudinal outcomes for children who have hearing loss and are enrolled in programs focused on supporting listening and spoken language development. Researchers are interested in discovering factors related to improvements in educational outcomes within these programs.\n",
     "\n",
     "There is a suite of available predictors, including: \n",
     "\n",
@@ -3278,9 +3278,7 @@
     "\n",
     "$$\\beta_i \\sim N\\left(0, \\tau^2 \\cdot \\tilde{\\lambda}_i^2\\right)$$\n",
     "\n",
-    "where $\\sigma$ is the prior on the error standard deviation that will also be used for the model likelihood.\n",
-    "\n",
-    "Where $\\tau$ is the global shrinkage parameter and $\\tilde{\\lambda}_i$ is the local. Let's start global: for the prior on $\\tau$ we will use a Half-StudentT distribution, which is a reasonable choice becuase it is heavy-tailed.\n",
+    "where $\\sigma$ is the prior on the error standard deviation that will also be used for the model likelihood. Here, $\\tau$ is the global shrinkage parameter and $\\tilde{\\lambda}_i$ is the local shrinkage parameter. Let's start global: for the prior on $\\tau$ we will use a Half-StudentT distribution, which is a reasonable choice becuase it is heavy-tailed.\n",
     "\n",
     "$$\n",
     "\\tau \\sim \\textrm{Half-StudentT}_{2} \\left(\\frac{D_0}{D - D_0} \\cdot \\frac{\\sigma}{\\sqrt{N}}\\right).\n",
@@ -3376,7 +3374,7 @@
     "\n",
     "Also note that we have declared the {class}`~pymc.Model` name `test_score_model` in the first occurrence of the context manager, rather than splitting it into two lines, as we did for the first example.\n",
     "\n",
-    "Once the model is complete, we can look at its stucture using GraphViz, which plots the model graph. Its useful to ensure that the relationships in the model you have coded are correct, as its easy to make coding mistakes."
+    "Once the model is complete, we can look at its stucture using GraphViz, which plots the model graph. It's useful to ensure that the relationships in the model you have coded are correct, as it's easy to make coding mistakes."
    ]
   },
   {
@@ -3538,7 +3536,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that we have a few warnings here about divergences. These are samples where NUTS was not able to make a valid move across the posterior distribution, so the resulting points are probably not representative samples from the posterior. There aren't many in this example, so its nothing to worry about, but let's go ahead and follow the advice and increase `target_accept` from its default value of 0.9 to 0.99."
+    "Notice that we have a few warnings here about divergences. These are samples where NUTS was not able to make a valid move across the posterior distribution, so the resulting points are probably not representative samples from the posterior. There aren't many in this example, so it's nothing to worry about, but let's go ahead and follow the advice and increase `target_accept` from its default value of 0.9 to 0.99."
    ]
   },
   {
@@ -3612,7 +3610,7 @@
    "source": [
     "#### Model Checking\n",
     "\n",
-    "A simple first step in model checking is to visually insepct our samples by looking at the traceplot for the univariate latent parameters to check for obvious problems. These names can be passed to `plot_trace` in the `var_names` argument."
+    "A simple first step in model checking is to visually inspect our samples by looking at the traceplot for the univariate latent parameters to check for obvious problems. These names can be passed to `plot_trace` in the `var_names` argument."
    ]
   },
   {
@@ -3644,9 +3642,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Do these look okay? Well, each of the densities on the left side for each parameter looks pretty similar to the others, which means they have converged to the same posterior distribution (be it the correct one or not). The homogeneity of the trace plots on the right are also a good sign; there is no trend or pattern to the time series of sampled values. Note that `c2` and `tau` occasionally sample extreme values, but this is expected from heavy-tailed distributions. \n",
+    "Do these look okay? Well, each of the densities on the left side for each parameter look pretty similar to the others, which means they have converged to the same posterior distribution (be it the correct one or not). The homogeneity of the trace plots on the right are also a good sign; there is no trend or pattern to the time series of sampled values. Note that `c2` and `tau` occasionally sample extreme values, but this is expected from heavy-tailed distributions. \n",
     "\n",
-    "The next easy model checking step is to see if the NUTS sampler performed as expected. An energy plot is a way of checking if the NUTS algorithm was able to adequately explore the posterior distribtion. If it was not, one runs the risk of biased posterior estimates when parts of the posterior are not visited with adequate frequency. The plot shows two density estimates, one is the marginal energy distribution of the sampling run and the other is the distribution of the energy transitions between steps. This is all a little abstract, but all we are looking for is for the distributions to be similar to one another. Ours does not look too bad."
+    "The next easy model-checking step is to see if the NUTS sampler performed as expected. An energy plot is a way of checking if the NUTS algorithm was able to adequately explore the posterior distribtion. If it was not, one runs the risk of biased posterior estimates when parts of the posterior are not visited with adequate frequency. The plot shows two density estimates: one is the marginal energy distribution of the sampling run and the other is the distribution of the energy transitions between steps. This is all a little abstract, but all we are looking for is for the distributions to be similar to one another. Ours does not look too bad."
    ]
   },
   {
@@ -3710,7 +3708,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The posterior distribution of coefficients reveal some factors that appear to be important in predicting test scores. Family involvement (`family_inv`) is large and negative, meaning a largr score (which is related to poorer involvement) results in much worse test scores. On the other end, early identification of hearing impairment is positive, meaning that detecting a problem early results in better educational outcomes down the road, which is also intuitive. Notice that other variables, notably gender (`male`), age at testing (`age_test`), and the mother's educational status (`mother_hs`) have all been shrunk essentially to zero."
+    "The posterior distribution of coefficients reveal some factors that appear to be important in predicting test scores. Family involvement (`family_inv`) is large and negative, meaning a larger score (which is related to poorer involvement) results in much worse test scores. On the other end, early identification of hearing impairment is positive, meaning that detecting a problem early results in better educational outcomes down the road, which is also intuitive. Notice that other variables, notably gender (`male`), age at testing (`age_test`), and the mother's educational status (`mother_hs`) have all been shrunk essentially to zero."
    ]
   },
   {
@@ -3719,7 +3717,7 @@
    "source": [
     "## Case study 2: Coal mining disasters\n",
     "\n",
-    "Consider the following time series of recorded coal mining disasters in the UK from 1851 to 1962 (Jarrett, 1979). The number of disasters is thought to have been affected by changes in safety regulations during this period. Unfortunately, we also have pair of years with missing data, identified as missing by a `nan` in the pandas `Series`. These missing values will be automatically imputed by PyMC. \n",
+    "Consider the following time series of recorded coal mining disasters in the UK from 1851 to 1962 (Jarrett, 1979). The number of disasters is thought to have been affected by changes in safety regulations during this period. Unfortunately, we also have a pair of years with missing data, identified as missing by a `nan` in the pandas `Series`. These missing values will be automatically imputed by PyMC. \n",
     "\n",
     "Next we will build a model for this series and attempt to estimate when the change occurred. At the same time, we will see how to handle missing data, use multiple samplers and sample from discrete random variables. "
    ]
@@ -3768,7 +3766,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Occurrences of disasters in the time series is thought to follow a Poisson process with a large rate parameter in the early part of the time series, and from one with a smaller rate in the later part. We are interested in locating the change point in the series, which perhaps is related to changes in mining safety regulations.\n",
+    "Occurrences of disasters in the time series is thought to follow a Poisson process with a large rate parameter in the early part of the time series, and from one with a smaller rate in the later part. We are interested in locating the change point in the series, which is perhaps related to changes in mining safety regulations.\n",
     "\n",
     "In our model, \n",
     "\n",
@@ -3841,7 +3839,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Unfortunately because they are discrete variables and thus have no meaningful gradient, we cannot use NUTS for sampling `switchpoint` or the missing disaster observations. Instead, we will sample using a {class}`~pymc.Metroplis` step method, which implements adaptive Metropolis-Hastings, because it is designed to handle discrete values. PyMC automatically assigns the correct sampling algorithms."
+    "Unfortunately, because they are discrete variables and thus have no meaningful gradient, we cannot use NUTS for sampling `switchpoint` or the missing disaster observations. Instead, we will sample using a {class}`~pymc.Metropolis` step method, which implements adaptive Metropolis-Hastings, because it is designed to handle discrete values. PyMC automatically assigns the correct sampling algorithms."
    ]
   },
   {
@@ -3908,7 +3906,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the trace plot below we can see that there's about a 10 year span that's plausible for a significant change in safety, but a 5 year span that contains most of the probability mass. The distribution is jagged because of the jumpy relationship between the year switchpoint and the likelihood  and not due to sampling error."
+    "In the trace plot below we can see that there's about a 10 year span that's plausible for a significant change in safety, but a 5 year span that contains most of the probability mass. The distribution is jagged because of the jumpy relationship between the year switchpoint and the likelihood; the jaggedness is not due to sampling error."
    ]
   },
   {
@@ -3947,9 +3945,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the `rate` random variable does not appear in the trace.  That is fine in this case, because it is not of interest in itself.  Remember from the previous example, we would trace the variable by wrapping it in a {class}`~pymc.Deterministic` class, and giving it a name.:\n",
+    "Note that the `rate` random variable does not appear in the trace.  That is fine in this case, because it is not of interest in itself.  Remember from the previous example, we would trace the variable by wrapping it in a {class}`~pymc.Deterministic` class, and giving it a name.\n",
     "\n",
-    "The following plot shows the switch point as an orange vertical line, together with its HPD as a semitransparent band. The dashed black line shows the accident rate."
+    "The following plot shows the switch point as an orange vertical line, together with its highest posterior density (HPD) as a semitransparent band. The dashed black line shows the accident rate."
    ]
   },
   {
@@ -4065,7 +4063,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more complex distributions, one can create a subclass of {class}`~pymc.Continuous` or {class}`~pymc.Discrete` and provide the custom `logp` function, as required. This is how the built-in distributions in PyMC are specified. As an example, fields like psychology and astrophysics have complex likelihood functions for a particular process that may require numerical approximation. \n",
+    "For more complex distributions, one can create a subclass of {class}`~pymc.Continuous` or {class}`~pymc.Discrete` and provide the custom `logp` function, as required. This is how the built-in distributions in PyMC are specified. As an example, fields like psychology and astrophysics have complex likelihood functions for particular processes that may require numerical approximation. \n",
     "\n",
     "Implementing the `beta` variable above as a `Continuous` subclass is shown below, along with an associated {class}`~aesara.RandomVariable` object, an instance of which becomes an attribute of the distribution."
    ]
@@ -4133,7 +4131,7 @@
     "\n",
     "Probabilistic programming is an emerging paradigm in statistical learning, of which Bayesian modeling is an important sub-discipline. The signature characteristics of probabilistic programming--specifying variables as probability distributions and conditioning variables on other variables and on observations--makes it a powerful tool for building models in a variety of settings, and over a range of model complexity. Accompanying the rise of probabilistic programming has been a burst of innovation in fitting methods for Bayesian models that represent notable improvement over existing MCMC methods. Yet, despite this expansion, there are few software packages available that have kept pace with the methodological innovation, and still fewer that allow non-expert users to implement models.\n",
     "\n",
-    "PyMC provides a probabilistic programming platform for quantitative researchers to implement statistical models flexibly and succinctly. A large library of statistical distributions and several pre-defined fitting algorithms allows users to focus on the scientific problem at hand, rather than the implementation details of Bayesian modeling. The choice of Python as a development language, rather than a domain-specific language, means that PyMC users are able to work interactively to build models, introspect model objects, and debug or profile their work, using a dynamic, high-level programming language that is easy to learn. The modular, object-oriented design of PyMC means that adding new fitting algorithms or other features is straightforward. In addition, PyMC comes with several features not found in most other packages, most notably Hamiltonian-based samplers as well as automatical transforms of constrained random variables which is only offered by Stan. Unlike Stan, however, PyMC supports discrete variables as well as non-gradient based sampling algorithms like Metropolis-Hastings and Slice sampling.\n",
+    "PyMC provides a probabilistic programming platform for quantitative researchers to implement statistical models flexibly and succinctly. A large library of statistical distributions and several pre-defined fitting algorithms allows users to focus on the scientific problem at hand, rather than the implementation details of Bayesian modeling. The choice of Python as a development language, rather than a domain-specific language, means that PyMC users are able to work interactively to build models, introspect model objects, and debug or profile their work, using a dynamic, high-level programming language that is easy to learn. The modular, object-oriented design of PyMC means that adding new fitting algorithms or other features is straightforward. In addition, PyMC comes with several features not found in most other packages, most notably Hamiltonian-based samplers as well as automatic transforms of constrained random variables which is only offered by Stan. Unlike Stan, however, PyMC supports discrete variables as well as non-gradient based sampling algorithms like Metropolis-Hastings and Slice sampling.\n",
     "\n",
     "Development of PyMC is an ongoing effort and several features are planned for future versions. Most notably, variational inference techniques are often more efficient than MCMC sampling, at the cost of generalizability. More recently, however, black-box variational inference algorithms have been developed, such as automatic differentiation variational inference (ADVI; Kucukelbir et al., 2017). This algorithm is slated for addition to PyMC. As an open-source scientific computing toolkit, we encourage researchers developing new fitting algorithms for Bayesian models to provide reference implementations in PyMC. Since samplers can be written in pure Python code, they can be implemented generally to make them work on arbitrary PyMC models, giving authors a larger audience to put their methods into use."
    ]


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

I corrected about a dozen small spelling and grammar typos in the overview notebook to improve readibility. There is no change to any of the code cells or executions. 

...

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings? **No**
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- None

## Bugfixes / New features
- Changed typos for readibility.

## Docs / Maintenance
- N/A
