### PR TITLE
Fix two deprecation warnings

### DIFF
--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -528,7 +528,7 @@ def make_shared_replacements(point, vars, model):
     """
     othervars = set(model.value_vars) - set(vars)
     return {
-        var: aesara.shared(point[var.name], var.name + "_shared", broadcastable=var.broadcastable)
+        var: aesara.shared(point[var.name], var.name + "_shared", shape=var.type.shape)
         for var in othervars
     }
 

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3994,9 +3994,9 @@ class _PolyaGammaLogDistFunc(Op):
         x = at.as_tensor_variable(floatX(x))
         h = at.as_tensor_variable(floatX(h))
         z = at.as_tensor_variable(floatX(z))
-        shape = broadcast_shape(x, h, z)
-        broadcastable = [] if not shape else [False] * len(shape)
-        return Apply(self, [x, h, z], [at.TensorType(aesara.config.floatX, broadcastable)()])
+        bshape = broadcast_shape(x, h, z)
+        shape = [None] * len(bshape)
+        return Apply(self, [x, h, z], [at.TensorType(aesara.config.floatX, shape)()])
 
     def perform(self, node, ins, outs):
         x, h, z = ins[0], ins[1], ins[2]

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -380,7 +380,7 @@ class MvStudentT(Continuous):
     def dist(cls, nu, Sigma=None, mu=None, scale=None, tau=None, chol=None, lower=True, **kwargs):
         if kwargs.get("cov") is not None:
             warnings.warn(
-                "Use the scale argument to specify the scale matrix."
+                "Use the scale argument to specify the scale matrix. "
                 "cov will be removed in future versions.",
                 FutureWarning,
             )

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -851,7 +851,7 @@ class PosDefMatrix(Op):
     def make_node(self, x):
         x = at.as_tensor_variable(x)
         assert x.ndim == 2
-        o = TensorType(dtype="int8", broadcastable=[])()
+        o = TensorType(dtype="int8", shape=[])()
         return Apply(self, [x], [o])
 
     # Python implementation:

--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -307,7 +307,7 @@ class TP(Latent):
             v = pm.StudentT(name + "_rotated_", mu=0.0, sigma=1.0, nu=self.nu, size=size, **kwargs)
             f = pm.Deterministic(name, mu + cholesky(cov).dot(v), dims=kwargs.get("dims", None))
         else:
-            f = pm.MvStudentT(name, nu=self.nu, mu=mu, cov=cov, **kwargs)
+            f = pm.MvStudentT(name, nu=self.nu, mu=mu, scale=cov, **kwargs)
         return f
 
     def prior(self, name, X, reparameterize=True, jitter=JITTER_DEFAULT, **kwargs):
@@ -376,7 +376,7 @@ class TP(Latent):
         X = self.X
         f = self.f
         nu2, mu, cov = self._build_conditional(Xnew, X, f, jitter)
-        return pm.MvStudentT(name, nu=nu2, mu=mu, cov=cov, **kwargs)
+        return pm.MvStudentT(name, nu=nu2, mu=mu, scale=cov, **kwargs)
 
 
 @conditioned_vars(["X", "y", "sigma"])

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -364,7 +364,7 @@ class ValueGradFunction:
         self._extra_vars_shared = {}
         for var, value in extra_vars_and_values.items():
             shared = aesara.shared(
-                value, var.name + "_shared__", broadcastable=[s == 1 for s in value.shape]
+                value, var.name + "_shared__", shape=[1 if s == 1 else None for s in value.shape]
             )
             self._extra_vars_shared[var.name] = shared
             givens.append((var, shared))

--- a/pymc/smc/smc.py
+++ b/pymc/smc/smc.py
@@ -593,7 +593,7 @@ def _logp_forw(point, out_vars, in_vars, shared):
         new_in_vars = []
         for in_var in in_vars:
             if in_var.dtype in discrete_types:
-                float_var = at.TensorType("floatX", in_var.broadcastable)(in_var.name)
+                float_var = at.TensorType("floatX", in_var.type.shape)(in_var.name)
                 new_in_vars.append(float_var)
                 replace_int_input[in_var] = at.round(float_var).astype(in_var.dtype)
             else:

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -550,7 +550,7 @@ def test_choose_chains(n_points, tune, expected_length, expected_n_traces):
 @pytest.mark.xfail(condition=(aesara.config.floatX == "float32"), reason="Fails on float32")
 class TestNamedSampling(SeededTest):
     def test_shared_named(self):
-        G_var = shared(value=np.atleast_2d(1.0), broadcastable=(True, False), name="G")
+        G_var = shared(value=np.atleast_2d(1.0), shape=(1, None), name="G")
 
         with pm.Model():
             theta0 = pm.Normal(
@@ -567,7 +567,7 @@ class TestNamedSampling(SeededTest):
             assert np.isclose(res, 0.0)
 
     def test_shared_unnamed(self):
-        G_var = shared(value=np.atleast_2d(1.0), broadcastable=(True, False))
+        G_var = shared(value=np.atleast_2d(1.0), shape=(1, None))
         with pm.Model():
             theta0 = pm.Normal(
                 "theta0",

--- a/pymc/variational/updates.py
+++ b/pymc/variational/updates.py
@@ -275,9 +275,7 @@ def apply_momentum(updates, params=None, momentum=0.9):
 
     for param in params:
         value = param.get_value(borrow=True)
-        velocity = aesara.shared(
-            np.zeros(value.shape, dtype=value.dtype), broadcastable=param.broadcastable
-        )
+        velocity = aesara.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
         x = momentum * velocity + updates[param]
         updates[velocity] = x - param
         updates[param] = x
@@ -390,9 +388,7 @@ def apply_nesterov_momentum(updates, params=None, momentum=0.9):
 
     for param in params:
         value = param.get_value(borrow=True)
-        velocity = aesara.shared(
-            np.zeros(value.shape, dtype=value.dtype), broadcastable=param.broadcastable
-        )
+        velocity = aesara.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
         x = momentum * velocity + updates[param] - param
         updates[velocity] = x
         updates[param] = momentum * x + updates[param]
@@ -534,9 +530,7 @@ def adagrad(loss_or_grads=None, params=None, learning_rate=1.0, epsilon=1e-6):
 
     for param, grad in zip(params, grads):
         value = param.get_value(borrow=True)
-        accu = aesara.shared(
-            np.zeros(value.shape, dtype=value.dtype), broadcastable=param.broadcastable
-        )
+        accu = aesara.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
         accu_new = accu + grad**2
         updates[accu] = accu_new
         updates[param] = param - (learning_rate * grad / at.sqrt(accu_new + epsilon))
@@ -662,9 +656,7 @@ def rmsprop(loss_or_grads=None, params=None, learning_rate=1.0, rho=0.9, epsilon
 
     for param, grad in zip(params, grads):
         value = param.get_value(borrow=True)
-        accu = aesara.shared(
-            np.zeros(value.shape, dtype=value.dtype), broadcastable=param.broadcastable
-        )
+        accu = aesara.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
         accu_new = rho * accu + (one - rho) * grad**2
         updates[accu] = accu_new
         updates[param] = param - (learning_rate * grad / at.sqrt(accu_new + epsilon))
@@ -755,13 +747,9 @@ def adadelta(loss_or_grads=None, params=None, learning_rate=1.0, rho=0.95, epsil
     for param, grad in zip(params, grads):
         value = param.get_value(borrow=True)
         # accu: accumulate gradient magnitudes
-        accu = aesara.shared(
-            np.zeros(value.shape, dtype=value.dtype), broadcastable=param.broadcastable
-        )
+        accu = aesara.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
         # delta_accu: accumulate update magnitudes (recursively!)
-        delta_accu = aesara.shared(
-            np.zeros(value.shape, dtype=value.dtype), broadcastable=param.broadcastable
-        )
+        delta_accu = aesara.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
 
         # update accu (as in rmsprop)
         accu_new = rho * accu + (one - rho) * grad**2
@@ -850,12 +838,8 @@ def adam(
 
     for param, g_t in zip(params, all_grads):
         value = param.get_value(borrow=True)
-        m_prev = aesara.shared(
-            np.zeros(value.shape, dtype=value.dtype), broadcastable=param.broadcastable
-        )
-        v_prev = aesara.shared(
-            np.zeros(value.shape, dtype=value.dtype), broadcastable=param.broadcastable
-        )
+        m_prev = aesara.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
+        v_prev = aesara.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
 
         m_t = beta1 * m_prev + (one - beta1) * g_t
         v_t = beta2 * v_prev + (one - beta2) * g_t**2
@@ -938,12 +922,8 @@ def adamax(
 
     for param, g_t in zip(params, all_grads):
         value = param.get_value(borrow=True)
-        m_prev = aesara.shared(
-            np.zeros(value.shape, dtype=value.dtype), broadcastable=param.broadcastable
-        )
-        u_prev = aesara.shared(
-            np.zeros(value.shape, dtype=value.dtype), broadcastable=param.broadcastable
-        )
+        m_prev = aesara.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
+        u_prev = aesara.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
 
         m_t = beta1 * m_prev + (one - beta1) * g_t
         u_t = at.maximum(beta2 * u_prev, abs(g_t))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This PR fixes two deprecation warnings:
* `broadcastable` -> `shape` in aesara variables (second version of the commit reverted in #6140)
* `cov` -> `scale` in `MvStudentT`.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Fix `broadcastable` -> `shape` deprecation in aesara variables
- Fix `cov` -> `scale` deprecation in `MvStudentT`
