### PR TITLE
Run mypy outside of pre-commit in its own job

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,3 +14,53 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0
+  mypy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache conda
+        uses: actions/cache@v3
+        env:
+          # Increase this value to reset cache if environment-test.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-py39-conda-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('conda-envs/environment-test.yml') }}
+      - name: Cache multiple paths
+        uses: actions/cache@v3
+        env:
+          # Increase this value to reset cache if requirements.txt has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: |
+            ~/.cache/pip
+            $RUNNER_TOOL_CACHE/Python/*
+            ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-build-${{ matrix.python-version }}-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('requirements.txt') }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          mamba-version: "*"
+          activate-environment: pymc-test
+          channel-priority: strict
+          environment-file: conda-envs/environment-test.yml
+          python-version: 3.9
+          use-mamba: true
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+      - name: Install-pymc and mypy dependencies
+        run: |
+          conda activate pymc-test
+          pip install -e .
+          pip install --pre -U polyagamma
+          pip install mypy types-cachetools
+          python --version
+      - name: Run mypy
+        run: |
+          conda activate pymc-test
+          python ./scripts/run_mypy.py --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,24 +13,6 @@ repos:
     -   id: requirements-txt-fixer
         exclude: ^requirements-dev\.txt$
     -   id: trailing-whitespace
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.981
-  hooks:
-    - id: mypy
-      name: Run static type checks
-      language: python
-      entry: python ./scripts/run_mypy.py --verbose
-      additional_dependencies:
-      - pandas
-      - types-cachetools
-      - types-filelock
-      - types-setuptools
-      - arviz
-      - aeppl==0.0.38
-      - aesara==2.8.7
-      always_run: true
-      require_serial: true
-      pass_filenames: false
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:


### PR DESCRIPTION
Closes #5907

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Speeding up pre-commit by running `mypy` in a dedicated job in GitHub Actions.

The job definition is a stripped-down version of the one in the `tests.yml` action.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- None

## Bugfixes / New features
- None

## Docs / Maintenance
- `mypy` now runs as its own job on GitHub Actions and is no longer part of the pre-commit steps.
