### PR TITLE
Don't mask inputs to `pm.Data` containers

### DIFF
--- a/pymc/data.py
+++ b/pymc/data.py
@@ -33,8 +33,6 @@ from aesara.tensor.var import TensorConstant, TensorVariable
 
 import pymc as pm
 
-from pymc.aesaraf import convert_observed_data
-
 __all__ = [
     "get_data",
     "GeneratorAdapter",
@@ -668,9 +666,10 @@ def Data(
         )
     name = model.name_for(name)
 
-    # `convert_observed_data` takes care of parameter `value` and
-    # transforms it to something digestible for Aesara.
-    arr = convert_observed_data(value)
+    # Conversion to floatX is important to avoid having another conversion when the variable
+    # is used for observed somewhere.  This breaks identification of the pm.Data variables
+    # as observed data, which is a Problem for model_to_graphviz and posterior predictive sampling.
+    arr = pm.floatX(value)
 
     if mutable is None:
         warnings.warn(


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
I ran into a problem where NaN values in my data got masked away when creating `pm.Data` containers.
This was quite unexpected.

We need the masking for `observed`, but that's being taken care of in other places already.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- NaN values passed to `pm.Data` are no longer masked automatically.

## Bugfixes / New features
- None

## Docs / Maintenance
- None
