### PR TITLE
Collect sampler warnings only through stats

### DIFF
--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -72,6 +72,7 @@ from pymc.smc import *
 from pymc.stats import *
 from pymc.step_methods import *
 from pymc.tuning import *
+from pymc.util import drop_warning_stat
 from pymc.variational import *
 from pymc.vartypes import *
 

--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -78,10 +78,6 @@ class BaseTrace(ABC):
         self.chain = None
         self._is_base_setup = False
         self.sampler_vars = None
-        self._warnings = []
-
-    def _add_warnings(self, warnings):
-        self._warnings.extend(warnings)
 
     # Sampling methods
 
@@ -288,9 +284,6 @@ class MultiTrace:
             self._straces[strace.chain] = strace
 
         self._report = SamplerReport()
-        for strace in straces:
-            if hasattr(strace, "_warnings"):
-                self._report._add_warnings(strace._warnings, strace.chain)
 
     def __repr__(self):
         template = "<{}: {} chains, {} iterations, {} variables>"

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -59,13 +59,6 @@ class CompoundStep:
                 point = method.step(point)
             return point
 
-    def warnings(self):
-        warns = []
-        for method in self.methods:
-            if hasattr(method, "warnings"):
-                warns.extend(method.warnings())
-        return warns
-
     def stop_tuning(self):
         for method in self.methods:
             method.stop_tuning()

--- a/pymc/step_methods/hmc/hmc.py
+++ b/pymc/step_methods/hmc/hmc.py
@@ -14,6 +14,7 @@
 
 import numpy as np
 
+from pymc.stats.convergence import SamplerWarning
 from pymc.step_methods.arraystep import Competence
 from pymc.step_methods.hmc.base_hmc import BaseHMC, DivergenceInfo, HMCStepData
 from pymc.step_methods.hmc.integration import IntegrationError, State
@@ -53,6 +54,7 @@ class HamiltonianMC(BaseHMC):
             "perf_counter_start": np.float64,
             "largest_eigval": np.float64,
             "smallest_eigval": np.float64,
+            "warning": SamplerWarning,
         }
     ]
 

--- a/pymc/tests/stats/test_convergence.py
+++ b/pymc/tests/stats/test_convergence.py
@@ -1,0 +1,29 @@
+#   Copyright 2022 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import arviz
+import numpy as np
+
+from pymc.stats import convergence
+
+
+def test_warn_divergences():
+    idata = arviz.from_dict(
+        sample_stats={
+            "diverging": np.array([[1, 0, 1, 0], [0, 0, 0, 0]]).astype(bool),
+        }
+    )
+    warns = convergence.warn_divergences(idata)
+    assert len(warns) == 1
+    assert "2 divergences after tuning" in warns[0].message

--- a/pymc/tests/test_parallel_sampling.py
+++ b/pymc/tests/test_parallel_sampling.py
@@ -14,6 +14,7 @@
 import multiprocessing
 import os
 import platform
+import sys
 import warnings
 
 import aesara
@@ -74,7 +75,7 @@ at_vector = TensorType(aesara.config.floatX, [False])
 @as_op([at_vector, at.iscalar], [at_vector])
 def _crash_remote_process(a, master_pid):
     if os.getpid() != master_pid:
-        os.exit(0)
+        sys.exit(0)
     return 2 * np.array(a)
 
 
@@ -86,7 +87,7 @@ def test_remote_pipe_closed():
         pm.Normal("y", mu=_crash_remote_process(x, at_pid), shape=2)
 
         step = pm.Metropolis()
-        with pytest.raises(RuntimeError, match="Chain [0-9] failed"):
+        with pytest.raises(ps.ParallelSamplingError, match="Chain [0-9] failed with") as ex:
             pm.sample(step=step, mp_ctx="spawn", tune=2, draws=2, cores=2, chains=2)
 
 

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -50,6 +50,7 @@ from pymc.sampling import (
     compile_forward_sampling_function,
     get_vars_in_point_list,
 )
+from pymc.stats.convergence import SamplerWarning, WarningType
 from pymc.step_methods import (
     NUTS,
     BinaryGibbsMetropolis,
@@ -1735,6 +1736,109 @@ def test_step_args():
     npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
     npt.assert_almost_equal(idata1.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
     npt.assert_allclose(idata1.sample_stats.scaling, 0)
+
+
+def test_log_warning_stats(caplog):
+    s1 = dict(warning="Temperature too low!")
+    s2 = dict(warning="Temperature too high!")
+    stats = [s1, s2]
+
+    with caplog.at_level(logging.WARNING):
+        pm.sampling.log_warning_stats(stats)
+
+    # We have a list of stats dicts, because there might be several samplers involved.
+    assert "too low" in caplog.records[0].message
+    assert "too high" in caplog.records[1].message
+
+
+def test_log_warning_stats_knows_SamplerWarning(caplog):
+    """Checks that SamplerWarning "warning" stats get special treatment."""
+    stats = [dict(warning=SamplerWarning(WarningType.BAD_ENERGY, "Not that interesting", "debug"))]
+
+    with caplog.at_level(logging.DEBUG, logger="pymc"):
+        pm.sampling.log_warning_stats(stats)
+
+    assert "Not that interesting" in caplog.records[0].message
+
+
+class ApolypticMetropolis(pm.Metropolis):
+    """A stepper that warns in every iteration."""
+
+    stats_dtypes = [
+        {
+            **pm.Metropolis.stats_dtypes[0],
+            "warning": SamplerWarning,
+        }
+    ]
+
+    def astep(self, q0):
+        draw, stats = super().astep(q0)
+        stats[0]["warning"] = SamplerWarning(
+            WarningType.BAD_ENERGY,
+            "Asteroid incoming!",
+            "warn",
+        )
+        return draw, stats
+
+
+@pytest.mark.parametrize("cores", [1, 2])
+def test_logs_sampler_warnings(caplog, cores):
+    """Asserts that "warning" sampler stats are logged during sampling."""
+    with pm.Model():
+        pm.Normal("n")
+        with caplog.at_level(logging.WARNING):
+            idata = pm.sample(
+                tune=2,
+                draws=3,
+                cores=cores,
+                chains=cores,
+                step=ApolypticMetropolis(),
+                compute_convergence_checks=False,
+                discard_tuned_samples=False,
+                keep_warning_stat=True,
+            )
+
+    # Sampler warnings should be logged
+    nwarns = sum("Asteroid" in rec.message for rec in caplog.records)
+    assert nwarns == (2 + 3) * cores
+
+
+@pytest.mark.parametrize("keep_warning_stat", [None, True])
+def test_keep_warning_stat_setting(keep_warning_stat):
+    """The ``keep_warning_stat`` stat (aka "Adrian's kwarg) enables users
+    to keep the ``SamplerWarning`` objects from the ``sample_stats.warning`` group.
+    This breaks ``idata.to_netcdf()`` which is why it defaults to ``False``.
+    """
+    sample_kwargs = dict(
+        tune=2,
+        draws=3,
+        chains=1,
+        compute_convergence_checks=False,
+        discard_tuned_samples=False,
+        keep_warning_stat=keep_warning_stat,
+    )
+    if keep_warning_stat:
+        sample_kwargs["keep_warning_stat"] = True
+    with pm.Model():
+        pm.Normal("n")
+        idata = pm.sample(step=ApolypticMetropolis(), **sample_kwargs)
+
+    if keep_warning_stat:
+        assert "warning" in idata.warmup_sample_stats
+        assert "warning" in idata.sample_stats
+        # And end up in the InferenceData
+        assert "warning" in idata.sample_stats
+        # NOTE: The stats are squeezed by default but this does not always work.
+        #       This tests flattens so we don't have to be exact in accessing (non-)squeezed items.
+        #       Also see https://github.com/pymc-devs/pymc/issues/6207.
+        warn_objs = list(idata.sample_stats.warning.sel(chain=0).values.flatten())
+        assert any(isinstance(w, SamplerWarning) for w in warn_objs)
+        assert any("Asteroid" in w.message for w in warn_objs)
+    else:
+        assert "warning" not in idata.warmup_sample_stats
+        assert "warning" not in idata.sample_stats
+        assert "warning_dim_0" not in idata.warmup_sample_stats
+        assert "warning_dim_0" not in idata.sample_stats
 
 
 def test_init_nuts(caplog):

--- a/pymc/tests/test_util.py
+++ b/pymc/tests/test_util.py
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import arviz
 import numpy as np
 import pytest
 import xarray
@@ -24,6 +25,7 @@ from pymc.distributions.transforms import RVTransform
 from pymc.util import (
     UNSET,
     dataset_to_point_list,
+    drop_warning_stat,
     hash_key,
     hashable,
     locally_cachedmethod,
@@ -164,3 +166,35 @@ def test_dataset_to_point_list():
     ds[3] = xarray.DataArray([1, 2, 3])
     with pytest.raises(ValueError, match="must be str"):
         dataset_to_point_list(ds, sample_dims=["chain", "draw"])
+
+
+def test_drop_warning_stat():
+    idata = arviz.from_dict(
+        sample_stats={
+            "a": np.ones((2, 5, 4)),
+            "warning": np.ones((2, 5, 3), dtype=object),
+        },
+        warmup_sample_stats={
+            "a": np.ones((2, 5, 4)),
+            "warning": np.ones((2, 5, 3), dtype=object),
+        },
+        attrs=dict(version="0.1.2"),
+        coords={
+            "adim": [0, 1, None, 3],
+            "warning_dim_0": list("ABC"),
+        },
+        dims={"a": ["adim"], "warning": ["warning_dim_0"]},
+        save_warmup=True,
+    )
+
+    new = drop_warning_stat(idata)
+
+    assert new is not idata
+    assert new.attrs.get("version") == "0.1.2"
+
+    for gname in ["sample_stats", "warmup_sample_stats"]:
+        ss = new.get(gname)
+        assert isinstance(ss, xarray.Dataset), gname
+        assert "a" in ss
+        assert "warning" not in ss
+        assert "warning_dim_0" not in ss

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -16,6 +16,7 @@ import functools
 
 from typing import Any, Dict, List, Tuple, cast
 
+import arviz
 import cloudpickle
 import numpy as np
 import xarray

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -14,7 +14,7 @@
 
 import functools
 
-from typing import Any, Dict, List, Tuple, cast
+from typing import Any, Dict, List, Tuple, Union, cast
 
 import arviz
 import cloudpickle

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -56,6 +56,7 @@ pymc/smc/__init__.py
 pymc/smc/sample_smc.py
 pymc/smc/smc.py
 pymc/stats/__init__.py
+pymc/stats/convergence.py
 pymc/step_methods/__init__.py
 pymc/step_methods/compound.py
 pymc/step_methods/hmc/__init__.py


### PR DESCRIPTION
**What is this PR about?**
Deleting code that gave special treatments to sampler warnings.

This PR mostly changes three things:
+ [x] The `SamplerWarning` class and related code, including the code for `run_convergence_checks` is moved from `report.py` to `convergence.py`. Here it is more functionally structure, and no longer coupled to the state of a `SamplerReport`.
+ [x] A new stat called `"warning"` is introduced. This is an `object` stat to which samplers can emit warnings instead of piggy-backing them onto the draws.
+ [x] Handling warnings is removed from the `BaseTrace`, in favor of managing them via the "warning" stat.
+ <s>updating the minimum ArviZ requirement to the latest version that can handle `object`-typed variables (by skipping and warning about them) when saving (related #6194).</s>
+ [x] A `pm.sample(keep_warning_stat={False, True})` setting was added to enable access to sampler warnings without breaking `.to_netcdf()` by default.

The logic in `sampling.py` was modified to stop handling warnings separately.
Instead, the `record_and_warn` function now takes over the task of logging warnings that are coming through via the "warning" stat.

I also modified the corresponding tests to be more targeted.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- Detailed information about divergent samples is no longer captured.
- Support for handling sampler warnings via `._warnings` attributes on samplers and `BaseTrace` was removed in favor of a "warning" stat.

## Bugfixes / New features
- HMC/NUTS samplers now emit a "warning" stat that ends up in the `InferenceData`.
- With `pm.sample(keep_warning_stat=True)` one can now access detailed info about divergence warnings directly via `idata.sample_stats.warning`, at the cost of not being able to save these `InferenceData` objects.

## Docs / Maintenance
- New `pm.stats.convergence` submodule for functional implementation of convergence diagnostics and warnings.
