### PR TITLE
Fix bug in `get_vars_in_point_list` when model does not have variables that exist in the trace

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1601,6 +1601,9 @@ class Model(WithMemoization, metaclass=ContextMeta):
             except KeyError:
                 raise e
 
+    def __contains__(self, key):
+        return key in self.named_vars or self.name_for(key) in self.named_vars
+
     def compile_fn(
         self,
         outs: Sequence[Variable],

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -1592,7 +1592,7 @@ def get_vars_in_point_list(trace, model):
         names_in_trace = list(trace[0])
     else:
         names_in_trace = trace.varnames
-    vars_in_trace = [model[v] for v in names_in_trace]
+    vars_in_trace = [model[v] for v in names_in_trace if v in model]
     return vars_in_trace
 
 

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -48,6 +48,7 @@ from pymc.sampling import (
     _get_seeds_per_chain,
     assign_step_methods,
     compile_forward_sampling_function,
+    get_vars_in_point_list,
 )
 from pymc.step_methods import (
     NUTS,
@@ -2628,3 +2629,24 @@ class TestShared(SeededTest):
         np.testing.assert_allclose(
             x_pred, pp_trace1.posterior_predictive["obs"].mean(("chain", "draw")), atol=1e-1
         )
+
+
+def test_get_vars_in_point_list():
+    with pm.Model() as modelA:
+        pm.Normal("a", 0, 1)
+        pm.Normal("b", 0, 1)
+    with pm.Model() as modelB:
+        a = pm.Normal("a", 0, 1)
+        pm.Normal("c", 0, 1)
+
+    point_list = [{"a": 0, "b": 0}]
+    vars_in_trace = get_vars_in_point_list(point_list, modelB)
+    assert set(vars_in_trace) == {a}
+
+    strace = pm.backends.NDArray(model=modelB, vars=modelA.free_RVs)
+    strace.setup(1, 1)
+    strace.values = point_list[0]
+    strace.draw_idx = 1
+    trace = MultiTrace([strace])
+    vars_in_trace = get_vars_in_point_list(trace, modelB)
+    assert set(vars_in_trace) == {a}


### PR DESCRIPTION
Closes #6199 

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
...

**Checklist**
+ [X] Explain important implementation details 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [X] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [X] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- `get_vars_in_point_list` was implemented in a way that expected all of the variables that were contained in the trace, to also be defined in the model. This fixes that problem and makes the function return a list of the variables that are defined both in the trace and in the model.

## Docs / Maintenance
- ...
