### PR TITLE
speed up posterior predictive sampling

### DIFF
--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
 # Base dependencies
 - aeppl=0.0.38
 - aesara=2.8.7
-- arviz>=0.12.0
+- arviz>=0.13.0
 - blas
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -7,7 +7,7 @@ dependencies:
 # Base dependencies
 - aeppl=0.0.38
 - aesara=2.8.7
-- arviz>=0.12.0
+- arviz>=0.13.0
 - blas
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
 # Base dependencies (see install guide for Windows)
 - aeppl=0.0.38
 - aesara=2.8.7
-- arviz>=0.12.0
+- arviz>=0.13.0
 - blas
 - cachetools>=4.2.1
 - cloudpickle

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -7,7 +7,7 @@ dependencies:
 # Base dependencies (see install guide for Windows)
 - aeppl=0.0.38
 - aesara=2.8.7
-- arviz>=0.12.0
+- arviz>=0.13.0
 - blas
 - cachetools>=4.2.1
 - cloudpickle

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -431,9 +431,7 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
     def posterior_predictive_to_xarray(self):
         """Convert posterior_predictive samples to xarray."""
         data = self.posterior_predictive
-        dims = {
-            var_name: self.sample_dims + self.dims.get(var_name, []) for var_name in data.keys()
-        }
+        dims = {var_name: self.sample_dims + self.dims.get(var_name, []) for var_name in data}
         return dict_to_dataset(
             data, library=pymc, coords=self.coords, dims=dims, default_dims=self.sample_dims
         )
@@ -442,9 +440,7 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
     def predictions_to_xarray(self):
         """Convert predictions (out of sample predictions) to xarray."""
         data = self.predictions
-        dims = {
-            var_name: self.sample_dims + self.dims.get(var_name, []) for var_name in data.keys()
-        }
+        dims = {var_name: self.sample_dims + self.dims.get(var_name, []) for var_name in data}
         return dict_to_dataset(
             data, library=pymc, coords=self.coords, dims=dims, default_dims=self.sample_dims
         )

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -1841,7 +1841,7 @@ def sample_posterior_predictive(
     trace_coords: Dict[str, np.ndarray] = {}
     if "coords" not in idata_kwargs:
         idata_kwargs["coords"] = {}
-    idata = None
+    idata: Optional[InferenceData] = None
     stacked_dims = None
     if isinstance(trace, InferenceData):
         _constant_data = getattr(trace, "constant_data", None)
@@ -1986,7 +1986,7 @@ def sample_posterior_predictive(
         return pm.predictions_to_inference_data(ppc_trace, **ikwargs)
     idata_pp = pm.to_inference_data(posterior_predictive=ppc_trace, **ikwargs)
 
-    if extend_inferencedata:
+    if extend_inferencedata and idata is not None:
         idata.extend(idata_pp)
         return idata
     return idata_pp

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -1791,6 +1791,10 @@ def sample_posterior_predictive(
         generally be the model used to generate the ``trace``, but it doesn't need to be.
     var_names : Iterable[str]
         Names of variables for which to compute the posterior predictive samples.
+    sample_dims : list of str, optional
+        Dimensions over which to loop and generate posterior predictive samples.
+        When `sample_dims` is ``None`` (default) both "chain" and "draw" are considered sample
+        dimensions. Only taken into account when `trace` is InferenceData or Dataset.
     random_seed : int, RandomState or Generator, optional
         Seed for the random number generator.
     progressbar : bool
@@ -1827,6 +1831,14 @@ def sample_posterior_predictive(
         thinned_idata = idata.sel(draw=slice(None, None, 5))
         with model:
             idata.extend(pymc.sample_posterior_predictive(thinned_idata))
+
+    Generate 5 posterior predictive samples per posterior sample.
+
+    .. code:: python
+
+        expanded_data = idata.posterior.expand_dims(pred_id=5)
+        with model:
+            idata.extend(pymc.sample_posterior_predictive(expanded_data))
     """
 
     _trace: Union[MultiTrace, PointList]

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -1618,6 +1618,22 @@ class TestSamplePosteriorPredictive:
 
         assert np.all(pp["y"] == np.arange(5) * 2)
 
+    def test_sample_dims(self, point_list_arg_bug_fixture):
+        pmodel, trace = point_list_arg_bug_fixture
+        with pmodel:
+            post = pm.to_inference_data(trace).posterior.stack(sample=["chain", "draw"])
+            pp = pm.sample_posterior_predictive(post, var_names=["d"], sample_dims=["sample"])
+            assert "sample" in pp.posterior_predictive
+            assert len(pp.posterior_predictive["sample"]) == len(post["sample"])
+            post = post.expand_dims(pp_dim=5)
+            pp = pm.sample_posterior_predictive(
+                post, var_names=["d"], sample_dims=["sample", "pp_dim"]
+            )
+            assert "sample" in pp.posterior_predictive
+            assert "pp_dim" in pp.posterior_predictive
+            assert len(pp.posterior_predictive["sample"]) == len(post["sample"])
+            assert len(pp.posterior_predictive["pp_dim"]) == 5
+
 
 class TestDraw(SeededTest):
     def test_univariate(self):

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -1625,14 +1625,14 @@ class TestSamplePosteriorPredictive:
             pp = pm.sample_posterior_predictive(post, var_names=["d"], sample_dims=["sample"])
             assert "sample" in pp.posterior_predictive
             assert len(pp.posterior_predictive["sample"]) == len(post["sample"])
-            post = post.expand_dims(pp_dim=5)
+            post = post.expand_dims(pred_id=5)
             pp = pm.sample_posterior_predictive(
-                post, var_names=["d"], sample_dims=["sample", "pp_dim"]
+                post, var_names=["d"], sample_dims=["sample", "pred_id"]
             )
             assert "sample" in pp.posterior_predictive
-            assert "pp_dim" in pp.posterior_predictive
+            assert "pred_id" in pp.posterior_predictive
             assert len(pp.posterior_predictive["sample"]) == len(post["sample"])
-            assert len(pp.posterior_predictive["pp_dim"]) == 5
+            assert len(pp.posterior_predictive["pred_id"]) == 5
 
 
 class TestDraw(SeededTest):

--- a/pymc/tests/test_util.py
+++ b/pymc/tests/test_util.py
@@ -154,7 +154,7 @@ def test_unset_repr(capsys):
 def test_dataset_to_point_list():
     ds = xarray.Dataset()
     ds["A"] = xarray.DataArray([[1, 2, 3]] * 2, dims=("chain", "draw"))
-    pl = dataset_to_point_list(ds)
+    pl, _ = dataset_to_point_list(ds, sample_dims=["chain", "draw"])
     assert isinstance(pl, list)
     assert len(pl) == 6
     assert isinstance(pl[0], dict)
@@ -163,4 +163,4 @@ def test_dataset_to_point_list():
     # Check that non-str keys are caught
     ds[3] = xarray.DataArray([1, 2, 3])
     with pytest.raises(ValueError, match="must be str"):
-        dataset_to_point_list(ds)
+        dataset_to_point_list(ds, sample_dims=["chain", "draw"])

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -14,9 +14,8 @@
 
 import functools
 
-from typing import Dict, List, Tuple, Union, cast
+from typing import Dict, List, cast
 
-import arviz
 import cloudpickle
 import numpy as np
 import xarray
@@ -244,26 +243,7 @@ def dataset_to_point_list(ds: xarray.Dataset, sample_dims: List) -> List[Dict[st
         for i in range(stacked_ds.dims["__pp_aux_dim__"])
     ]
     # use the list of points
-    return cast(List[Dict[str, np.ndarray]], points)
-
-
-def chains_and_samples(data: Union[xarray.Dataset, arviz.InferenceData]) -> Tuple[int, int]:
-    """Extract and return number of chains and samples in xarray or arviz traces."""
-    dataset: xarray.Dataset
-    if isinstance(data, xarray.Dataset):
-        dataset = data
-    elif isinstance(data, arviz.InferenceData):
-        dataset = data["posterior"]
-    else:
-        raise ValueError(
-            "Argument must be xarray Dataset or arviz InferenceData. Got %s",
-            data.__class__,
-        )
-
-    coords = dataset.coords
-    nchains = coords["chain"].sizes["chain"]
-    nsamples = coords["draw"].sizes["draw"]
-    return nchains, nsamples
+    return cast(List[Dict[str, np.ndarray]], points), stacked_ds["__pp_aux_dim__"]
 
 
 def hashable(a=None) -> int:

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -14,7 +14,7 @@
 
 import functools
 
-from typing import Dict, List, cast
+from typing import Any, Dict, List, Tuple, cast
 
 import cloudpickle
 import numpy as np
@@ -230,7 +230,9 @@ def biwrap(wrapper):
     return enhanced
 
 
-def dataset_to_point_list(ds: xarray.Dataset, sample_dims: List) -> List[Dict[str, np.ndarray]]:
+def dataset_to_point_list(
+    ds: xarray.Dataset, sample_dims: List
+) -> Tuple[List[Dict[str, np.ndarray]], Dict[str, Any]]:
     # All keys of the dataset must be a str
     var_names = list(ds.keys())
     for vn in var_names:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 
 aeppl==0.0.38
 aesara==2.8.7
-arviz>=0.12.0
+arviz>=0.13.0
 cachetools>=4.2.1
 cloudpickle
 fastprogress>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aeppl==0.0.38
 aesara==2.8.7
-arviz>=0.12.0
+arviz>=0.13.0
 cachetools>=4.2.1
 cloudpickle
 fastprogress>=0.2.0


### PR DESCRIPTION
The goal of this PR is to accelerate the `dataset_to_point_list` function which right now is
often the bottleneck of posterior predictive sampling. Moreover, I would also like to add some
extra flexibility on the dimensions that are considered sample dimensions.

related to #5160 

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Bugfixes / New features
- Added `sample_dims` argument to `sample_posterior_predictive`.

## Docs / Maintenance
- Improved the performance of `sample_posterior_predictive` when using InferenceData or Dataset as input.
