### PR TITLE
Modified logo_link to work with new sphinx schema

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -256,7 +256,9 @@ html_theme_options = {
             "icon": "fab fa-discourse",
         },
     ],
-    "logo_link": "https://www.pymc.io",
+    "logo": {
+        "link": "https://www.pymc.io",
+        },
     "show_prev_next": False,
     "navbar_start": ["navbar-logo", "navbar-version"],
     "navbar_end": ["search-field.html", "navbar-icon-links.html"],

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -258,7 +258,7 @@ html_theme_options = {
     ],
     "logo": {
         "link": "https://www.pymc.io",
-        },
+    },
     "show_prev_next": False,
     "navbar_start": ["navbar-logo", "navbar-version"],
     "navbar_end": ["search-field.html", "navbar-icon-links.html"],


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
I address Issue #6054 -- mainly, I modified a line of code to match Sphinx's new schema around logo linking. With this PR, the logo should again appropriately link to the build-based homepage.

## Major / Breaking Changes
No major changes

## Bugfixes / New features
Modified `conf.py`'s `html_theme_options` to align with Sphinx's latest specifications.