### PR TITLE
Automatically label PRs based on modified files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+# Add 'maintenance` label to any change to *.yml files
+maintenance:
+- any: ['**.yml', '']
+
+# Add "no releasenotes" label if only the pre-commit config changed
+no releasenotes:
+- any: []
+  all: ['.pre-commit-config.yml']

--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -29,5 +29,7 @@ jobs:
             pre-commit autoupdate || (exit 0);
             pre-commit run -a || (exit 0);
           COMMIT_MESSAGE: "⬆️ UPGRADE: Autoupdate pre-commit config"
+          COMMIT_NAME: "pymc-bot"
+          COMMIT_EMAIL: "pymc-devs@users.noreply.github.com"
           PR_BRANCH_NAME: "pre-commit-config-update-${PR_ID}"
           PR_TITLE: "⬆️ UPGRADE: Autoupdate pre-commit config"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Closes #6139

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
- Automatically labeling PRs based on modified files
- Anonymizing the pre-commit config updating bot

I'm not sure if the pattern matching is correct, but we'll see the next time a pre-commit dependency upgrades.


## Major / Breaking Changes
- None

## Bugfixes / New features
- None

## Docs / Maintenance
- Pre-commit config updates are now committed by a bot user
- Created a GH Action to automatically label PRs based on modified files
