### PR TITLE
Fix docstring of the ZeroInflatedPoisson distribution

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1465,7 +1465,7 @@ class ZeroInflatedPoisson:
 
         f(x \mid \psi, \mu) = \left\{ \begin{array}{l}
             (1-\psi) + \psi e^{-\mu}, \text{if } x = 0 \\
-            \psi \frac{e^{-\theta}\theta^x}{x!}, \text{if } x=1,2,3,\ldots
+            \psi \frac{e^{-\mu}\mu^x}{x!}, \text{if } x=1,2,3,\ldots
             \end{array} \right.
 
     .. plot::


### PR DESCRIPTION
**What is this PR about?**

The parameterization uses the variable `mu` but the docstring uses $\mu$ in some cases and $\theta$ in other cases. The fix replaces all $\theta$ with $\mu$ to match the argument name for this distribution.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Docs / Maintenance
- Fixed ZeroInflatedPoisson docstring, replacing theta with mu
