### PR TITLE
Seed flaky test `TestSamplePPC.test_normal_scalar`

### DIFF
--- a/pymc/tests/distributions/test_mixture.py
+++ b/pymc/tests/distributions/test_mixture.py
@@ -333,7 +333,7 @@ class TestMixture(SeededTest):
             weights = [0.5, 0.5]
             components = [Normal.dist(-10, 0.01), Normal.dist(10, 0.01)]
             mix = Mixture.dist(weights, components)
-        draws = draw(mix, draws=10)
+        draws = draw(mix, draws=10, random_seed=self.get_random_state())
         # Probability of coming from same component 10 times is 0.5**10
         assert np.unique(draws > 0).size == 2
 

--- a/pymc/tests/distributions/test_mixture.py
+++ b/pymc/tests/distributions/test_mixture.py
@@ -333,7 +333,7 @@ class TestMixture(SeededTest):
             weights = [0.5, 0.5]
             components = [Normal.dist(-10, 0.01), Normal.dist(10, 0.01)]
             mix = Mixture.dist(weights, components)
-        draws = draw(mix, draws=10, random_seed=self.get_random_state())
+        draws = draw(mix, draws=10)
         # Probability of coming from same component 10 times is 0.5**10
         assert np.unique(draws > 0).size == 2
 

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -630,8 +630,8 @@ class TestSamplePPC(SeededTest):
             ppc0 = pm.sample_posterior_predictive(
                 10 * [model.initial_point()], return_inferencedata=False
             )
-            # # deprecated argument is not introduced to fast version [2019/08/20:rpg]
-            ppc = pm.sample_posterior_predictive(trace, var_names=["a"], return_inferencedata=False)
+            assert "a" in ppc0
+            assert len(ppc0["a"][0]) == 10
             # test empty ppc
             ppc = pm.sample_posterior_predictive(trace, var_names=[], return_inferencedata=False)
             assert len(ppc) == 0
@@ -646,6 +646,8 @@ class TestSamplePPC(SeededTest):
             assert "a" in ppc
             assert ppc["a"].shape == (nchains, ndraws)
             # mu's standard deviation may have changed thanks to a's observed
+            # If you observe this test failing, please report it in
+            # the github issue https://github.com/pymc-devs/pymc/issues/6211
             _, pval = stats.kstest(
                 (ppc["a"] - trace.posterior["mu"]).values.flatten(), stats.norm(loc=0, scale=1).cdf
             )

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -625,27 +625,23 @@ class TestSamplePPC(SeededTest):
                 chains=nchains,
             )
 
-        random_state = self.get_random_state()
         with model:
             # test list input
             ppc0 = pm.sample_posterior_predictive(
-                10 * [model.initial_point()], return_inferencedata=False, random_seed=random_state
+                10 * [model.initial_point()], return_inferencedata=False
             )
             assert "a" in ppc0
             assert len(ppc0["a"][0]) == 10
             # test empty ppc
-            ppc = pm.sample_posterior_predictive(
-                trace, var_names=[], return_inferencedata=False, random_seed=random_state
-            )
+            ppc = pm.sample_posterior_predictive(trace, var_names=[], return_inferencedata=False)
             assert len(ppc) == 0
 
             # test keep_size parameter
-            ppc = pm.sample_posterior_predictive(
-                trace, return_inferencedata=False, random_seed=random_state
-            )
+            ppc = pm.sample_posterior_predictive(trace, return_inferencedata=False)
             assert ppc["a"].shape == (nchains, ndraws)
 
             # test default case
+            random_state = self.get_random_state()
             idata_ppc = pm.sample_posterior_predictive(
                 trace, var_names=["a"], random_seed=random_state
             )

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -625,29 +625,34 @@ class TestSamplePPC(SeededTest):
                 chains=nchains,
             )
 
+        random_state = self.get_random_state()
         with model:
             # test list input
             ppc0 = pm.sample_posterior_predictive(
-                10 * [model.initial_point()], return_inferencedata=False
+                10 * [model.initial_point()], return_inferencedata=False, random_seed=random_state
             )
             assert "a" in ppc0
             assert len(ppc0["a"][0]) == 10
             # test empty ppc
-            ppc = pm.sample_posterior_predictive(trace, var_names=[], return_inferencedata=False)
+            ppc = pm.sample_posterior_predictive(
+                trace, var_names=[], return_inferencedata=False, random_seed=random_state
+            )
             assert len(ppc) == 0
 
             # test keep_size parameter
-            ppc = pm.sample_posterior_predictive(trace, return_inferencedata=False)
+            ppc = pm.sample_posterior_predictive(
+                trace, return_inferencedata=False, random_seed=random_state
+            )
             assert ppc["a"].shape == (nchains, ndraws)
 
             # test default case
-            idata_ppc = pm.sample_posterior_predictive(trace, var_names=["a"])
+            idata_ppc = pm.sample_posterior_predictive(
+                trace, var_names=["a"], random_seed=random_state
+            )
             ppc = idata_ppc.posterior_predictive
             assert "a" in ppc
             assert ppc["a"].shape == (nchains, ndraws)
             # mu's standard deviation may have changed thanks to a's observed
-            # If you observe this test failing, please report it in
-            # the github issue https://github.com/pymc-devs/pymc/issues/6211
             _, pval = stats.kstest(
                 (ppc["a"] - trace.posterior["mu"]).values.flatten(), stats.norm(loc=0, scale=1).cdf
             )


### PR DESCRIPTION
This is related to the issue 
* Remove call to function with unused output
* Add assert to test function with list input
* Add comment to refer to the issue

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
The issue Flaky test: test_normal_scalar #6211 reported a Flaky test in test_normal_scalar https://github.com/pymc-devs/pymc/blob/main/pymc/tests/test_sampling.py#L617. I could not reproduce it yet, but I found other minor issues in the same test: calls to the tested function that were not calling any assert. I added an assert after the line with an input different from the other calls, and removed the other line that looks redundant. Under the suggestion of @michaelosthege, I added a comment asking to report further failing of this test under the same issue

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Seed flaky test `TestSamplePPC.test_normal_scalar`
