### PR TITLE
Fix flaky `TestTruncation.truncation_discrete_random`

### DIFF
--- a/pymc/tests/distributions/test_truncated.py
+++ b/pymc/tests/distributions/test_truncated.py
@@ -184,8 +184,7 @@ def test_truncation_discrete_random(op_type, lower, upper):
             # Rejections sampling with probability = (1 - p ** max_n_steps) ** sample_size =
             # = (1 - 0.2 ** 3) ** 500 = 0.018
             # Still, this probability can be too high to make this test pass with any seed.
-            random_seed = 2297228
-            draw(xt, random_seed=np.random.RandomState(random_seed))
+            draw(xt, random_seed=2297228)
 
 
 @pytest.mark.parametrize("lower, upper", [(2, np.inf), (2, 5), (-np.inf, 5)])

--- a/pymc/tests/distributions/test_truncated.py
+++ b/pymc/tests/distributions/test_truncated.py
@@ -181,7 +181,11 @@ def test_truncation_discrete_random(op_type, lower, upper):
             assert np.any(xt_draws == upper)
     else:
         with pytest.raises(TruncationError, match="^Truncation did not converge"):
-            draw(xt)
+            # Rejections sampling with probability = (1 - p ** max_n_steps) ** sample_size =
+            # = (1 - 0.2 ** 3) ** 500 = 0.018
+            # Still, this probability can be too high to make this test pass with any seed.
+            random_seed = 2297228
+            draw(xt, random_seed=np.random.RandomState(random_seed))
 
 
 @pytest.mark.parametrize("lower, upper", [(2, np.inf), (2, 5), (-np.inf, 5)])


### PR DESCRIPTION
Closes #6206
* Add seed to rejection test
* Add a comment about the test probability

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Fix Potential flaky test: truncation_discrete_random
I add a seed to the test part that can fail stochastically.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Fix flaky `TestTruncation.truncation_discrete_random`
