### PR TITLE
Check that sampler vars correspond to value variables in the model

### DIFF
--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -38,5 +38,5 @@ dependencies:
 - watermark
 - polyagamma
 - sphinx-remove-toctrees
-- mypy
+- mypy=0.982
 - types-cachetools

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -27,5 +27,5 @@ dependencies:
 - pre-commit>=2.8.0
 - pytest-cov>=2.5
 - pytest>=3.0
-- mypy
+- mypy=0.982
 - types-cachetools

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -35,5 +35,5 @@ dependencies:
 - sphinx>=1.5
 - watermark
 - sphinx-remove-toctrees
-- mypy
+- mypy=0.982
 - types-cachetools

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -28,5 +28,5 @@ dependencies:
 - pre-commit>=2.8.0
 - pytest-cov>=2.5
 - pytest>=3.0
-- mypy
+- mypy=0.982
 - types-cachetools

--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -261,11 +261,11 @@ def replace_rvs_in_graphs(
 
 
 def rvs_to_value_vars(
-    graphs: Iterable[TensorVariable],
+    graphs: Iterable[Variable],
     apply_transforms: bool = True,
-    initial_replacements: Optional[Dict[TensorVariable, TensorVariable]] = None,
+    initial_replacements: Optional[Dict[Variable, Variable]] = None,
     **kwargs,
-) -> List[TensorVariable]:
+) -> List[Variable]:
     """Clone and replace random variables in graphs with their value variables.
 
     This will *not* recompute test values in the resulting graphs.

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -69,6 +69,7 @@ from pymc.util import (
     UNSET,
     WithMemoization,
     get_transformed_name,
+    get_value_vars_from_user_vars,
     get_var_name,
     treedict,
     treelist,
@@ -617,6 +618,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         if grad_vars is None:
             grad_vars = self.continuous_value_vars
         else:
+            grad_vars = get_value_vars_from_user_vars(grad_vars, self)
             for i, var in enumerate(grad_vars):
                 if var.dtype not in continuous_types:
                     raise ValueError(f"Can only compute the gradient of continuous types: {var}")

--- a/pymc/smc/kernels.py
+++ b/pymc/smc/kernels.py
@@ -28,7 +28,6 @@ from scipy.stats import multivariate_normal
 from pymc.aesaraf import (
     compile_pymc,
     floatX,
-    inputvars,
     join_nonshared_inputs,
     make_shared_replacements,
 )
@@ -160,7 +159,7 @@ class SMC_KERNEL(ABC):
         self.rng = np.random.default_rng(seed=random_seed)
 
         self.model = modelcontext(model)
-        self.variables = inputvars(self.model.value_vars)
+        self.variables = self.model.value_vars
 
         self.var_info = {}
         self.tempered_posterior = None

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -31,6 +31,7 @@ from pymc.step_methods.arraystep import GradientSharedStep
 from pymc.step_methods.hmc import integration
 from pymc.step_methods.hmc.quadpotential import QuadPotentialDiagAdapt, quad_potential
 from pymc.tuning import guess_scaling
+from pymc.util import get_value_vars_from_user_vars
 
 logger = logging.getLogger("pymc")
 
@@ -91,8 +92,7 @@ class BaseHMC(GradientSharedStep):
         if vars is None:
             vars = self._model.continuous_value_vars
         else:
-            vars = [self._model.rvs_to_values.get(var, var) for var in vars]
-
+            vars = get_value_vars_from_user_vars(vars, self._model)
         super().__init__(vars, blocked=blocked, model=self._model, dtype=dtype, **aesara_kwargs)
 
         self.adapt_step_size = adapt_step_size

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -56,6 +56,8 @@ __all__ = [
     "MultivariateNormalProposal",
 ]
 
+from pymc.util import get_value_vars_from_user_vars
+
 # Available proposal distributions for Metropolis
 
 
@@ -176,9 +178,7 @@ class Metropolis(ArrayStepShared):
         if vars is None:
             vars = model.value_vars
         else:
-            vars = [model.rvs_to_values.get(var, var) for var in vars]
-
-        vars = pm.inputvars(vars)
+            vars = get_value_vars_from_user_vars(vars, model)
 
         initial_values_shape = [initial_values[v.name].shape for v in vars]
         if S is None:
@@ -394,7 +394,7 @@ class BinaryMetropolis(ArrayStep):
         self.steps_until_tune = tune_interval
         self.accepted = 0
 
-        vars = [model.rvs_to_values.get(var, var) for var in vars]
+        vars = get_value_vars_from_user_vars(vars, model)
 
         if not all([v.dtype in pm.discrete_types for v in vars]):
             raise ValueError("All variables must be Bernoulli for BinaryMetropolis")
@@ -484,8 +484,9 @@ class BinaryGibbsMetropolis(ArrayStep):
         # transition probabilities
         self.transit_p = transit_p
 
+        vars = get_value_vars_from_user_vars(vars, model)
+
         initial_point = model.initial_point()
-        vars = [model.rvs_to_values.get(var, var) for var in vars]
         self.dim = sum(initial_point[v.name].size for v in vars)
 
         if order == "random":
@@ -566,8 +567,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
 
         model = pm.modelcontext(model)
 
-        vars = [model.rvs_to_values.get(var, var) for var in vars]
-        vars = pm.inputvars(vars)
+        vars = get_value_vars_from_user_vars(vars, model)
 
         initial_point = model.initial_point()
 
@@ -777,8 +777,7 @@ class DEMetropolis(PopulationArrayStepShared):
         if vars is None:
             vars = model.continuous_value_vars
         else:
-            vars = [model.rvs_to_values.get(var, var) for var in vars]
-        vars = pm.inputvars(vars)
+            vars = get_value_vars_from_user_vars(vars, model)
 
         if S is None:
             S = np.ones(initial_values_size)
@@ -928,8 +927,7 @@ class DEMetropolisZ(ArrayStepShared):
         if vars is None:
             vars = model.continuous_value_vars
         else:
-            vars = [model.rvs_to_values.get(var, var) for var in vars]
-        vars = pm.inputvars(vars)
+            vars = get_value_vars_from_user_vars(vars, model)
 
         if S is None:
             S = np.ones(initial_values_size)

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -17,10 +17,10 @@
 import numpy as np
 import numpy.random as nr
 
-from pymc.aesaraf import inputvars
 from pymc.blocking import RaveledVars
 from pymc.model import modelcontext
 from pymc.step_methods.arraystep import ArrayStep, Competence
+from pymc.util import get_value_vars_from_user_vars
 from pymc.vartypes import continuous_types
 
 __all__ = ["Slice"]
@@ -65,8 +65,7 @@ class Slice(ArrayStep):
         if vars is None:
             vars = self.model.continuous_value_vars
         else:
-            vars = [self.model.rvs_to_values.get(var, var) for var in vars]
-        vars = inputvars(vars)
+            vars = get_value_vars_from_user_vars(vars, self.model)
 
         super().__init__(vars, [self.model.compile_logp()], **kwargs)
 

--- a/pymc/tests/tuning/test_starting.py
+++ b/pymc/tests/tuning/test_starting.py
@@ -22,7 +22,7 @@ from pymc.tests import models
 from pymc.tests.checks import close_to
 from pymc.tests.helpers import select_by_precision
 from pymc.tests.models import non_normal, simple_arbitrary_det, simple_model
-from pymc.tuning import find_MAP, starting
+from pymc.tuning import find_MAP
 
 
 @pytest.mark.parametrize("bounded", [False, True])
@@ -147,28 +147,3 @@ def test_find_MAP_issue_4488():
     assert not set.difference({"x_missing", "x_missing_log__", "y"}, set(map_estimate.keys()))
     np.testing.assert_allclose(map_estimate["x_missing"], 0.2, rtol=1e-4, atol=1e-4)
     np.testing.assert_allclose(map_estimate["y"], [2.0, map_estimate["x_missing"][0] + 1])
-
-
-def test_allinmodel():
-    model1 = pm.Model()
-    model2 = pm.Model()
-    with model1:
-        x1 = pm.Normal("x1", mu=0, sigma=1)
-        y1 = pm.Normal("y1", mu=0, sigma=1)
-    with model2:
-        x2 = pm.Normal("x2", mu=0, sigma=1)
-        y2 = pm.Normal("y2", mu=0, sigma=1)
-
-    x1 = model1.rvs_to_values[x1]
-    y1 = model1.rvs_to_values[y1]
-    x2 = model2.rvs_to_values[x2]
-    y2 = model2.rvs_to_values[y2]
-
-    starting.allinmodel([x1, y1], model1)
-    starting.allinmodel([x1], model1)
-    with pytest.raises(ValueError, match=r"Some variables not in the model: \['x2', 'y2'\]"):
-        starting.allinmodel([x2, y2], model1)
-    with pytest.raises(ValueError, match=r"Some variables not in the model: \['x2'\]"):
-        starting.allinmodel([x2, y1], model1)
-    with pytest.raises(ValueError, match=r"Some variables not in the model: \['x2'\]"):
-        starting.allinmodel([x2], model1)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ fastprogress>=0.2.0
 h5py>=2.7
 ipython>=7.16
 jupyter-sphinx
-mypy
+mypy==0.982
 myst-nb
 numpy>=1.15.0
 numpydoc


### PR DESCRIPTION
Closes #6223 

I decided to not allow the old V3 behavior of passing intermediate variables/ Deterministic because I think that does something strange. Those variables are not the ones being sampled/maximized but instead the underlying input value variables are. 

If a user wants to fit the variables that underlie a given graph, but he doesn't know what those are, they should do something like `pm.find_MAP(vars=pm.inputvars(pm.aesaraf.rvs_to_value_vars(graph)))`

**Update**: It is now allowed but a warning is emitted

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Check that only random variables are assigned to samplers and `find_MAP`
