### PR TITLE
Include `observed_RVs` in `eval_rv_shapes`

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1659,7 +1659,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         )
 
     def eval_rv_shapes(self) -> Dict[str, Tuple[int, ...]]:
-        """Evaluates shapes of untransformed AND transformed free variables.
+        """Evaluates shapes of untransformed AND transformed random variables.
 
         Returns
         -------
@@ -1668,7 +1668,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         """
         names = []
         outputs = []
-        for rv in self.free_RVs:
+        for rv in self.basic_RVs:
             rv_var = self.rvs_to_values[rv]
             transform = getattr(rv_var.tag, "transform", None)
             if transform is not None:
@@ -1679,7 +1679,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
         f = aesara.function(
             inputs=[],
             outputs=outputs,
-            givens=[(obs, obs.tag.observations) for obs in self.observed_RVs],
             mode=aesara.compile.mode.FAST_COMPILE,
             on_unused_input="ignore",
         )

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -620,6 +620,7 @@ class TestShapeEvaluation:
         assert shapes["untransformed"] == (1, 2)
         assert shapes["transformed"] == (7,)
         assert shapes["transformed_interval__"] == (7,)
+        assert shapes["observed"] == (3,)
         assert shapes["lognorm"] == (3,)
         assert shapes["lognorm_log__"] == (3,)
         assert shapes["from_dims"] == (3, 4)


### PR DESCRIPTION
It seems helpful for debugging.

The givens also seems unnecessary now that we take into consideration the shape of `observations` by default. I assume that when we didn't, it was necessary?

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Include `observed_RVs` in `eval_rv_shapes`
