### PR TITLE
Seed pm.sample in BaseSampler(SeededTest) to make deriving test classes deterministic

### DIFF
--- a/pymc/tests/sampler_fixtures.py
+++ b/pymc/tests/sampler_fixtures.py
@@ -149,6 +149,7 @@ class BaseSampler(SeededTest):
                 cores=cls.chains,
                 return_inferencedata=False,
                 compute_convergence_checks=False,
+                random_seed=cls.random_seed,
             )
         cls.samples = {}
         for var in cls.model.unobserved_RVs:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Add a seed to `pm.sample()` in `BaseSampler`, which is a `SeededTest` but its draws are not yet seeded.
This solves flaky tests like the one reported in #6246. Closes #6246 
Given the complex structure of the tests in this file, made of many mixins of fixtures, each with its own class hierarchies, I found `BaseSampler` to be the only point where the seed can be added meaningfully.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Docs / Maintenance
- Seed BaseSampler class tests
