### PR TITLE
Sample stats for blackjax nuts

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -440,11 +440,12 @@ def sample_blackjax_nuts(
         log_likelihood=log_likelihood,
         observed_data=find_observations(model),
         constant_data=find_constants(model),
+        sample_stats=mcmc_stats,
         coords=coords,
         dims=dims,
         attrs=make_attrs(attrs, library=blackjax),
     )
-    az_trace = to_trace(posterior=posterior, sample_stats=mcmc_stats, **idata_kwargs)
+    az_trace = to_trace(posterior=posterior, **idata_kwargs)
 
     return az_trace
 

--- a/pymc/tests/sampling/test_jax.py
+++ b/pymc/tests/sampling/test_jax.py
@@ -365,3 +365,50 @@ def test_numpyro_nuts_kwargs_are_used(mocked: mock.MagicMock):
     assert nuts_sampler._adapt_step_size == adapt_step_size
     assert nuts_sampler._adapt_mass_matrix
     assert nuts_sampler._target_accept_prob == target_accept
+
+
+@pytest.mark.parametrize(
+    "sampler_name",
+    [
+        "sample_blackjax_nuts",
+        "sample_numpyro_nuts",
+    ],
+)
+def test_idata_contains_stats(sampler_name: str):
+    """Tests whether sampler statistics were written to sample_stats
+    group of InferenceData"""
+    if sampler_name == "sample_blackjax_nuts":
+        sampler = sample_blackjax_nuts
+    elif sampler_name == "sample_numpyro_nuts":
+        sampler = sample_numpyro_nuts
+
+    with pm.Model():
+        pm.Normal("a")
+        idata = sampler(draws=10, tune=10)
+
+    stats = idata.get("sample_stats")
+    assert stats is not None
+    n_chains = stats.dims["chain"]
+    n_draws = stats.dims["draw"]
+
+    # Stats vars expected for both samplers
+    expected_stat_vars = {
+        "acceptance_rate": (n_chains, n_draws),
+        "diverging": (n_chains, n_draws),
+        "energy": (n_chains, n_draws),
+        "n_steps": (n_chains, n_draws),
+        "tree_depth": (n_chains, n_draws),
+        "lp": (n_chains, n_draws),
+    }
+    # Stats only expected for blackjax nuts
+    if sampler_name == "sample_blackjax_nuts":
+        blackjax_special_vars = {}
+        stat_vars = expected_stat_vars | blackjax_special_vars
+    # Stats only expected for numpyro nuts
+    elif sampler_name == "sample_numpyro_nuts":
+        numpyro_special_vars = {"step_size": (n_chains, n_draws)}
+        stat_vars = expected_stat_vars | numpyro_special_vars
+    # test existence and dimensionality
+    for stat_var, stat_var_dims in stat_vars.items():
+        assert stat_var in stats
+        assert stats.get(stat_var).values.shape == stat_var_dims

--- a/pymc/tests/sampling/test_jax.py
+++ b/pymc/tests/sampling/test_jax.py
@@ -384,7 +384,7 @@ def test_idata_contains_stats(sampler_name: str):
 
     with pm.Model():
         pm.Normal("a")
-        idata = sampler(draws=10, tune=10)
+        idata = sampler(tune=50, draws=50)
 
     stats = idata.get("sample_stats")
     assert stats is not None

--- a/pymc/tests/sampling/test_jax.py
+++ b/pymc/tests/sampling/test_jax.py
@@ -396,7 +396,6 @@ def test_idata_contains_stats(sampler_name: str):
         "acceptance_rate": (n_chains, n_draws),
         "diverging": (n_chains, n_draws),
         "energy": (n_chains, n_draws),
-        "n_steps": (n_chains, n_draws),
         "tree_depth": (n_chains, n_draws),
         "lp": (n_chains, n_draws),
     }
@@ -406,9 +405,12 @@ def test_idata_contains_stats(sampler_name: str):
         stat_vars = expected_stat_vars | blackjax_special_vars
     # Stats only expected for numpyro nuts
     elif sampler_name == "sample_numpyro_nuts":
-        numpyro_special_vars = {"step_size": (n_chains, n_draws)}
+        numpyro_special_vars = {
+            "step_size": (n_chains, n_draws),
+            "n_steps": (n_chains, n_draws),
+        }
         stat_vars = expected_stat_vars | numpyro_special_vars
     # test existence and dimensionality
     for stat_var, stat_var_dims in stat_vars.items():
-        assert stat_var in stats
+        assert stat_var in stats.variables
         assert stats.get(stat_var).values.shape == stat_var_dims


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
With this PR I want to address #5718. As of now no stats are saved in InferenceData if one uses `sample_blackjax_nuts`. 
However I am unsure about the meaning of the attributes `energy` and `num_trajectory_expansions`.  
[Here](https://github.com/blackjax-devs/blackjax/blob/c58a97b6b4a98add4c51227f86a3679188bbb35f/blackjax/mcmc/nuts.py#L22-L59) is what is documented in the blackjax code.  I first understood `energy` to be the absolute energy of a state and `num_trajectory_expansions` to be the `tree_depth` (That's the current state of the code). But second reading made me skeptical.  Any help here is very welcome :smiley: 

How it works: 
+ blackjax returns sample statistics as instance of `blackjax.mcmc.nuts.NUTSInfo`. The attributes of this instance
   are converted to a dictionary `Dict[str,ArrayLike]` mapping the stats with pymc naming conventions
+ potential energy is stored alongside states in a `blackjax.mcmc.hmc.HMCState` object. The potential energy is extracted and
   stored in the above mentioned dictionary.
+ the dictionary is passed as `sample_stats` argument to `arviz.from_dict` at the end of `pymc.sampling.jax.sample_blackjax_nuts`
 
**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Bugfixes / New features
- `pm.sample.jax.sample_blackjax_nuts` returns `InferenceData` with `sample_stats` group
