### PR TITLE
Fix Categorical and Multinomial bugs

### DIFF
--- a/pymc/tests/distributions/test_discrete.py
+++ b/pymc/tests/distributions/test_discrete.py
@@ -469,6 +469,15 @@ class TestMatchesScipy:
             {"n": NatSmall, "p": Unit, "psi": Unit},
         )
 
+    @pytest.mark.parametrize("n", [2, 3, 4])
+    def test_categorical(self, n):
+        check_logp(
+            pm.Categorical,
+            Domain(range(n), dtype="int64", edges=(0, n)),
+            {"p": Simplex(n)},
+            lambda value, p: categorical_logpdf(value, p),
+        )
+
     @aesara.config.change_flags(compute_test_value="raise")
     def test_categorical_bounds(self):
         with pm.Model():
@@ -495,6 +504,14 @@ class TestMatchesScipy:
             with pm.Model():
                 x = pm.Categorical("x", p=p)
 
+    def test_categorical_p_not_normalized(self):
+        # test UserWarning is raised for p vals that sum to more than 1
+        # and normaliation is triggered
+        with pytest.warns(UserWarning, match="[5]"):
+            with pm.Model() as m:
+                x = pm.Categorical("x", p=[1, 1, 1, 1, 1])
+        assert np.isclose(m.x.owner.inputs[3].sum().eval(), 1.0)
+
     def test_categorical_negative_p_symbolic(self):
         with pytest.raises(ParameterValueError):
             value = np.array([[1, 1, 1]])
@@ -506,23 +523,6 @@ class TestMatchesScipy:
             value = np.array([[1, 1, 1]])
             invalid_dist = pm.Categorical.dist(p=at.as_tensor_variable([2, 2, 2]))
             pm.logp(invalid_dist, value).eval()
-
-    @pytest.mark.parametrize("n", [2, 3, 4])
-    def test_categorical(self, n):
-        check_logp(
-            pm.Categorical,
-            Domain(range(n), dtype="int64", edges=(0, n)),
-            {"p": Simplex(n)},
-            lambda value, p: categorical_logpdf(value, p),
-        )
-
-    def test_categorical_p_not_normalized(self):
-        # test UserWarning is raised for p vals that sum to more than 1
-        # and normaliation is triggered
-        with pytest.warns(UserWarning, match="[5]"):
-            with pm.Model() as m:
-                x = pm.Categorical("x", p=[1, 1, 1, 1, 1])
-        assert np.isclose(m.x.owner.inputs[3].sum().eval(), 1.0)
 
     @pytest.mark.parametrize("n", [2, 3, 4])
     def test_orderedlogistic(self, n):

--- a/pymc/tests/distributions/test_discrete.py
+++ b/pymc/tests/distributions/test_discrete.py
@@ -497,32 +497,39 @@ class TestMatchesScipy:
             # entries if there is a single or pair number of negative values
             # and the rest are zero
             np.array([-1, -1, 0, 0]),
+            at.as_tensor_variable([-1, -1, 0, 0]),
         ],
     )
     def test_categorical_negative_p(self, p):
-        with pytest.raises(ValueError, match=f"{p}"):
+        with pytest.raises(ValueError, match="Negative `p` parameters are not valid"):
             with pm.Model():
                 x = pm.Categorical("x", p=p)
 
     def test_categorical_p_not_normalized(self):
         # test UserWarning is raised for p vals that sum to more than 1
         # and normaliation is triggered
-        with pytest.warns(UserWarning, match="[5]"):
+        with pytest.warns(UserWarning, match="They will be automatically rescaled"):
             with pm.Model() as m:
                 x = pm.Categorical("x", p=[1, 1, 1, 1, 1])
         assert np.isclose(m.x.owner.inputs[3].sum().eval(), 1.0)
 
     def test_categorical_negative_p_symbolic(self):
+        value = np.array([[1, 1, 1]])
+
+        x = at.scalar("x")
+        invalid_dist = pm.Categorical.dist(p=[x, x, x])
+
         with pytest.raises(ParameterValueError):
-            value = np.array([[1, 1, 1]])
-            invalid_dist = pm.Categorical.dist(p=at.as_tensor_variable([-1, 0.5, 0.5]))
-            pm.logp(invalid_dist, value).eval()
+            pm.logp(invalid_dist, value).eval({x: -1 / 3})
 
     def test_categorical_p_not_normalized_symbolic(self):
+        value = np.array([[1, 1, 1]])
+
+        x = at.scalar("x")
+        invalid_dist = pm.Categorical.dist(p=(x, x, x))
+
         with pytest.raises(ParameterValueError):
-            value = np.array([[1, 1, 1]])
-            invalid_dist = pm.Categorical.dist(p=at.as_tensor_variable([2, 2, 2]))
-            pm.logp(invalid_dist, value).eval()
+            pm.logp(invalid_dist, value).eval({x: 0.5})
 
     @pytest.mark.parametrize("n", [2, 3, 4])
     def test_orderedlogistic(self, n):

--- a/pymc/tests/distributions/test_mixture.py
+++ b/pymc/tests/distributions/test_mixture.py
@@ -1009,12 +1009,12 @@ class TestMixtureSameFamily(SeededTest):
     @pytest.mark.parametrize("batch_shape", [(3, 4), (20,)], ids=str)
     def test_with_multinomial(self, batch_shape):
         p = np.random.uniform(size=(*batch_shape, self.mixture_comps, 3))
+        p /= p.sum(axis=-1, keepdims=True)
         n = 100 * np.ones((*batch_shape, 1))
         w = np.ones(self.mixture_comps) / self.mixture_comps
         mixture_axis = len(batch_shape)
         with Model() as model:
-            with pytest.warns(UserWarning, match="parameters sum up to"):
-                comp_dists = Multinomial.dist(p=p, n=n, shape=(*batch_shape, self.mixture_comps, 3))
+            comp_dists = Multinomial.dist(p=p, n=n, shape=(*batch_shape, self.mixture_comps, 3))
             mixture = Mixture(
                 "mixture",
                 w=w,


### PR DESCRIPTION
Closes #5514 


## Major / Breaking Changes
- ...

## Bugfixes / New features
- Fix bug when passing a list or tuple of variables as the `p` parameter of Categorical and Multinomial distributions

## Docs / Maintenance
- ...
