### PR TITLE
Bring back logps

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,7 +6,10 @@ PyMC is distributed under the Apache License, Version 2.0
 
 Copyright (c) 2006 Christopher J. Fonnesbeck (Academic Free License)
 Copyright (c) 2007-2008 Christopher J. Fonnesbeck, Anand Prabhakar Patil, David Huard (Academic Free License)
-Copyright (c) 2009-2017 The PyMC developers (see contributors to pymc-devs on GitHub)
+Copyright (c) 2009-2022 The PyMC developers (see contributors to pymc-devs on GitHub)
+
+Contains code from Aeppl, Copyright (c) 2021-2022, Aesara Developers
+
 All rights reserved.
 
                                  Apache License

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2055,10 +2055,6 @@ class InverseGamma(PositiveContinuous):
 
         return alpha, beta
 
-    @classmethod
-    def _distr_parameters_for_repr(self):
-        return ["alpha", "beta"]
-
     def logcdf(value, alpha, beta):
         res = at.switch(
             at.lt(value, 0),
@@ -2801,9 +2797,6 @@ class Gumbel(Continuous):
         if not rv_size_is_none(size):
             mean = at.full(size, mean)
         return mean
-
-    def _distr_parameters_for_repr(self):
-        return ["mu", "beta"]
 
     def logcdf(value, mu, beta):
         res = -at.exp(-(value - mu) / beta)

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -498,7 +498,7 @@ class Normal(Continuous):
     def logcdf(value, mu, sigma):
         return check_parameters(
             normal_lcdf(mu, sigma, value),
-            0 < sigma,
+            sigma > 0,
             msg="sigma > 0",
         )
 
@@ -790,7 +790,7 @@ class HalfNormal(PositiveContinuous):
 
         return check_parameters(
             logcdf,
-            0 < sigma,
+            sigma > 0,
             msg="sigma > 0",
         )
 
@@ -965,7 +965,11 @@ class Wald(PositiveContinuous):
         )
 
         return check_parameters(
-            logcdf, 0 < mu, 0 < lam, 0 <= alpha, msg="mu > 0, lam > 0, alpha >= 0"
+            logcdf,
+            mu > 0,
+            lam > 0,
+            alpha >= 0,
+            msg="mu > 0, lam > 0, alpha >= 0",
         )
 
 
@@ -1088,8 +1092,8 @@ class Beta(UnitContinuous):
 
         return check_parameters(
             logcdf,
-            0 < alpha,
-            0 < beta,
+            alpha > 0,
+            beta > 0,
             msg="alpha > 0, beta > 0",
         )
 
@@ -1265,7 +1269,11 @@ class Exponential(PositiveContinuous):
             at.log1mexp(-lam * value),
         )
 
-        return check_parameters(res, 0 <= lam, msg="lam >= 0")
+        return check_parameters(
+            res,
+            lam >= 0,
+            msg="lam >= 0",
+        )
 
 
 class Laplace(Continuous):
@@ -1341,7 +1349,7 @@ class Laplace(Continuous):
 
         return check_parameters(
             res,
-            0 < b,
+            b > 0,
             msg="b > 0",
         )
 
@@ -1423,7 +1431,12 @@ class AsymmetricLaplace(Continuous):
             -value * b * at.sgn(value) * (kappa ** at.sgn(value))
         )
 
-        return check_parameters(res, 0 < b, 0 < kappa, msg="b > 0, kappa > 0")
+        return check_parameters(
+            res,
+            b > 0,
+            kappa > 0,
+            msg="b > 0, kappa > 0",
+        )
 
 
 class LogNormal(PositiveContinuous):
@@ -1518,7 +1531,11 @@ class LogNormal(PositiveContinuous):
             normal_lcdf(mu, sigma, at.log(value)),
         )
 
-        return check_parameters(res, 0 < sigma, msg="sigma > 0")
+        return check_parameters(
+            res,
+            sigma > 0,
+            msg="sigma > 0",
+        )
 
 
 Lognormal = LogNormal
@@ -1629,7 +1646,12 @@ class StudentT(Continuous):
             - (nu + 1.0) / 2.0 * at.log1p(lam * (value - mu) ** 2 / nu)
         )
 
-        return check_parameters(res, lam > 0, nu > 0, msg="lam > 0, nu > 0")
+        return check_parameters(
+            res,
+            lam > 0,
+            nu > 0,
+            msg="lam > 0, nu > 0",
+        )
 
     def logcdf(value, nu, mu, sigma):
         _, sigma = get_tau_sigma(sigma=sigma)
@@ -1640,7 +1662,12 @@ class StudentT(Continuous):
 
         res = at.log(at.betainc(nu / 2.0, nu / 2.0, x))
 
-        return check_parameters(res, 0 < nu, 0 < sigma, msg="nu > 0, sigma > 0")
+        return check_parameters(
+            res,
+            nu > 0,
+            sigma > 0,
+            msg="nu > 0, sigma > 0",
+        )
 
 
 class Pareto(BoundedContinuous):
@@ -1718,7 +1745,12 @@ class Pareto(BoundedContinuous):
             ),
         )
 
-        return check_parameters(res, 0 < alpha, 0 < m, msg="alpha > 0, m > 0")
+        return check_parameters(
+            res,
+            alpha > 0,
+            m > 0,
+            msg="alpha > 0, m > 0",
+        )
 
 
 @_default_transform.register(Pareto)
@@ -1791,7 +1823,7 @@ class Cauchy(Continuous):
         res = at.log(0.5 + at.arctan((value - alpha) / beta) / np.pi)
         return check_parameters(
             res,
-            0 < beta,
+            beta > 0,
             msg="beta > 0",
         )
 
@@ -1854,7 +1886,11 @@ class HalfCauchy(PositiveContinuous):
             at.log(2 * at.arctan((value - loc) / beta) / np.pi),
         )
 
-        return check_parameters(res, 0 < beta, msg="beta > 0")
+        return check_parameters(
+            res,
+            beta > 0,
+            msg="beta > 0",
+        )
 
 
 class Gamma(PositiveContinuous):
@@ -2062,7 +2098,12 @@ class InverseGamma(PositiveContinuous):
             at.log(at.gammaincc(alpha, beta / value)),
         )
 
-        return check_parameters(res, 0 < alpha, 0 < beta, msg="alpha > 0, beta > 0")
+        return check_parameters(
+            res,
+            alpha > 0,
+            beta > 0,
+            msg="alpha > 0, beta > 0",
+        )
 
 
 class ChiSquared(PositiveContinuous):
@@ -2210,7 +2251,12 @@ class Weibull(PositiveContinuous):
             at.log1mexp(-a),
         )
 
-        return check_parameters(res, 0 < alpha, 0 < beta, msg="alpha > 0, beta > 0")
+        return check_parameters(
+            res,
+            alpha > 0,
+            beta > 0,
+            msg="alpha > 0, beta > 0",
+        )
 
     def logp(value, alpha, beta):
         res = (
@@ -2220,7 +2266,12 @@ class Weibull(PositiveContinuous):
             - at.pow(value / beta, alpha)
         )
         res = at.switch(at.ge(value, 0.0), res, -np.inf)
-        return check_parameters(res, 0 < alpha, 0 < beta, msg="alpha > 0, beta > 0")
+        return check_parameters(
+            res,
+            alpha > 0,
+            beta > 0,
+            msg="alpha > 0, beta > 0",
+        )
 
 
 class HalfStudentTRV(RandomVariable):
@@ -2327,7 +2378,12 @@ class HalfStudentT(PositiveContinuous):
             res,
         )
 
-        return check_parameters(res, sigma > 0, nu > 0, msg="sigma > 0, nu > 0")
+        return check_parameters(
+            res,
+            sigma > 0,
+            nu > 0,
+            msg="sigma > 0, nu > 0",
+        )
 
 
 class ExGaussianRV(RandomVariable):
@@ -2442,8 +2498,8 @@ class ExGaussian(Continuous):
         )
         return check_parameters(
             res,
-            0 < sigma,
-            0 < nu,
+            sigma > 0,
+            nu > 0,
             msg="nu > 0, sigma > 0",
         )
 
@@ -2462,7 +2518,12 @@ class ExGaussian(Continuous):
             normal_lcdf(mu, sigma, value),
         )
 
-        return check_parameters(res, 0 < sigma, 0 < nu, msg="sigma > 0, nu > 0")
+        return check_parameters(
+            res,
+            sigma > 0,
+            nu > 0,
+            msg="sigma > 0, nu > 0",
+        )
 
 
 class VonMises(CircularContinuous):
@@ -2630,7 +2691,11 @@ class SkewNormal(Continuous):
             + (-tau * (value - mu) ** 2 + at.log(tau / np.pi / 2.0)) / 2.0
         )
 
-        return check_parameters(res, tau > 0, msg="tau > 0")
+        return check_parameters(
+            res,
+            tau > 0,
+            msg="tau > 0",
+        )
 
 
 class Triangular(BoundedContinuous):
@@ -2801,7 +2866,11 @@ class Gumbel(Continuous):
     def logcdf(value, mu, beta):
         res = -at.exp(-(value - mu) / beta)
 
-        return check_parameters(res, 0 < beta, msg="beta > 0")
+        return check_parameters(
+            res,
+            beta > 0,
+            msg="beta > 0",
+        )
 
 
 class RiceRV(RandomVariable):
@@ -2998,7 +3067,7 @@ class Logistic(Continuous):
 
         return check_parameters(
             res,
-            0 < s,
+            s > 0,
             msg="s > 0",
         )
 
@@ -3327,14 +3396,18 @@ class Moyal(Continuous):
     def logp(value, mu, sigma):
         scaled = (value - mu) / sigma
         res = -(1 / 2) * (scaled + at.exp(-scaled)) - at.log(sigma) - (1 / 2) * at.log(2 * np.pi)
-        return check_parameters(res, 0 < sigma, msg="sigma > 0")
+        return check_parameters(
+            res,
+            sigma > 0,
+            msg="sigma > 0",
+        )
 
     def logcdf(value, mu, sigma):
         scaled = (value - mu) / sigma
         res = at.log(at.erfc(at.exp(-scaled / 2) * (2**-0.5)))
         return check_parameters(
             res,
-            0 < sigma,
+            sigma > 0,
             msg="sigma > 0",
         )
 

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -146,7 +146,13 @@ class Binomial(Discrete):
             binomln(n, value) + logpow(p, value) + logpow(1 - p, n - value),
         )
 
-        return check_parameters(res, 0 <= n, 0 <= p, p <= 1, msg="n >= 0, 0 <= p <= 1")
+        return check_parameters(
+            res,
+            n >= 0,
+            0 <= p,
+            p <= 1,
+            msg="n >= 0, 0 <= p <= 1",
+        )
 
     def logcdf(value, n, p):
         value = at.floor(value)
@@ -163,7 +169,7 @@ class Binomial(Discrete):
 
         return check_parameters(
             res,
-            0 <= n,
+            n >= 0,
             0 <= p,
             p <= 1,
             msg="n >= 0, 0 <= p <= 1",
@@ -248,7 +254,13 @@ class BetaBinomial(Discrete):
             -np.inf,
             binomln(n, value) + betaln(value + alpha, n - value + beta) - betaln(alpha, beta),
         )
-        return check_parameters(res, n >= 0, alpha > 0, beta > 0, msg="n >= 0, alpha > 0, beta > 0")
+        return check_parameters(
+            res,
+            n >= 0,
+            alpha > 0,
+            beta > 0,
+            msg="n >= 0, alpha > 0, beta > 0",
+        )
 
     def logcdf(value, n, alpha, beta):
         # logcdf can only handle scalar values at the moment
@@ -273,7 +285,13 @@ class BetaBinomial(Discrete):
                 0,
             ),
         )
-        return check_parameters(res, 0 <= n, 0 < alpha, 0 < beta, msg="n >= 0, alpha > 0, beta > 0")
+        return check_parameters(
+            res,
+            n >= 0,
+            alpha > 0,
+            beta > 0,
+            msg="n >= 0, alpha > 0, beta > 0",
+        )
 
 
 class Bernoulli(Discrete):
@@ -348,7 +366,12 @@ class Bernoulli(Discrete):
             at.switch(value, at.log(p), at.log1p(-p)),
         )
 
-        return check_parameters(res, p >= 0, p <= 1, msg="0 <= p <= 1")
+        return check_parameters(
+            res,
+            0 <= p,
+            p <= 1,
+            msg="0 <= p <= 1",
+        )
 
     def logcdf(value, p):
         res = at.switch(
@@ -360,7 +383,12 @@ class Bernoulli(Discrete):
                 0,
             ),
         )
-        return check_parameters(res, 0 <= p, p <= 1, msg="0 <= p <= 1")
+        return check_parameters(
+            res,
+            0 <= p,
+            p <= 1,
+            msg="0 <= p <= 1",
+        )
 
 
 class DiscreteWeibullRV(RandomVariable):
@@ -448,7 +476,13 @@ class DiscreteWeibull(Discrete):
             at.log(at.power(q, at.power(value, beta)) - at.power(q, at.power(value + 1, beta))),
         )
 
-        return check_parameters(res, 0 < q, q < 1, 0 < beta, msg="0 < q < 1, beta > 0")
+        return check_parameters(
+            res,
+            0 < q,
+            q < 1,
+            beta > 0,
+            msg="0 < q < 1, beta > 0",
+        )
 
     def logcdf(value, q, beta):
         res = at.switch(
@@ -456,7 +490,13 @@ class DiscreteWeibull(Discrete):
             -np.inf,
             at.log1p(-at.power(q, at.power(value + 1, beta))),
         )
-        return check_parameters(res, 0 < q, q < 1, 0 < beta, msg="0 < q < 1, beta > 0")
+        return check_parameters(
+            res,
+            0 < q,
+            q < 1,
+            beta > 0,
+            msg="0 < q < 1, beta > 0",
+        )
 
 
 class Poisson(Discrete):
@@ -518,18 +558,22 @@ class Poisson(Discrete):
         return mu
 
     def logp(value, mu):
-        logprob = at.switch(
+        res = at.switch(
             at.lt(value, 0),
             -np.inf,
             logpow(mu, value) - factln(value) - mu,
         )
         # Return zero when mu and value are both zero
-        logprob = at.switch(
+        res = at.switch(
             at.eq(mu, 0) * at.eq(value, 0),
             0,
-            logprob,
+            res,
         )
-        return check_parameters(logprob, mu >= 0, msg="mu >= 0")
+        return check_parameters(
+            res,
+            mu >= 0,
+            msg="mu >= 0",
+        )
 
     def logcdf(value, mu):
         value = at.floor(value)
@@ -543,7 +587,11 @@ class Poisson(Discrete):
             at.log(at.gammaincc(safe_value + 1, safe_mu)),
         )
 
-        return check_parameters(res, 0 <= mu, msg="mu >= 0")
+        return check_parameters(
+            res,
+            mu >= 0,
+            msg="mu >= 0",
+        )
 
 
 class NegativeBinomial(Discrete):
@@ -685,10 +733,10 @@ class NegativeBinomial(Discrete):
         )
         return check_parameters(
             res,
-            0 < n,
+            n > 0,
             0 <= p,
             p <= 1,
-            msg="0 < n, 0 <= p <= 1",
+            msg="n > 0, 0 <= p <= 1",
         )
 
 
@@ -860,7 +908,11 @@ class HyperGeometric(Discrete):
             ),
         )
 
-        return check_parameters(res, lower <= upper, msg="lower <= upper")
+        return check_parameters(
+            res,
+            lower <= upper,
+            msg="lower <= upper",
+        )
 
     def logcdf(value, good, bad, n):
         # logcdf can only handle scalar values at the moment
@@ -888,10 +940,10 @@ class HyperGeometric(Discrete):
 
         return check_parameters(
             res,
-            0 < N,
+            N > 0,
             0 <= good,
-            0 <= n,
             good <= N,
+            0 <= n,
             n <= N,
             msg="N > 0, 0 <= good <= N, 0 <= n <= N",
         )
@@ -973,7 +1025,11 @@ class DiscreteUniform(Discrete):
             -np.inf,
             at.fill(value, -at.log(upper - lower + 1)),
         )
-        return check_parameters(res, lower <= upper, msg="lower <= upper")
+        return check_parameters(
+            res,
+            lower <= upper,
+            msg="lower <= upper",
+        )
 
     def logcdf(value, lower, upper):
         res = at.switch(
@@ -986,7 +1042,11 @@ class DiscreteUniform(Discrete):
             ),
         )
 
-        return check_parameters(res, lower <= upper, msg="lower <= upper")
+        return check_parameters(
+            res,
+            lower <= upper,
+            msg="lower <= upper",
+        )
 
 
 class Categorical(Discrete):
@@ -1089,7 +1149,7 @@ class Categorical(Discrete):
 
         return check_parameters(
             res,
-            p_ >= 0,
+            0 <= p_,
             p_ <= 1,
             at.isclose(at.sum(p, axis=-1), 1),
             msg="0 <= p <=1, sum(p) = 1",

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -288,7 +288,11 @@ class MvNormal(Continuous):
         quaddist, logdet, ok = quaddist_parse(value, mu, cov)
         k = floatX(value.shape[-1])
         norm = -0.5 * k * pm.floatX(np.log(2 * np.pi))
-        return check_parameters(norm - 0.5 * quaddist - logdet, ok)
+        return check_parameters(
+            norm - 0.5 * quaddist - logdet,
+            ok,
+            msg="posdef",
+        )
 
 
 class MvStudentTRV(RandomVariable):
@@ -429,11 +433,7 @@ class MvStudentT(Continuous):
         inner = -(nu + k) / 2.0 * at.log1p(quaddist / nu)
         res = norm + inner - logdet
 
-        return check_parameters(
-            res,
-            ok,
-            nu > 0,
-        )
+        return check_parameters(res, ok, nu > 0, msg="posdef, nu > 0")
 
 
 class Dirichlet(SimplexContinuous):
@@ -596,7 +596,7 @@ class Multinomial(Discrete):
         )
         return check_parameters(
             res,
-            p >= 0,
+            0 <= p,
             p <= 1,
             at.isclose(at.sum(p, axis=-1), 1),
             at.ge(n, 0),
@@ -2222,8 +2222,8 @@ class CAR(Continuous):
         logquad = (tau * delta * tau_dot_delta).sum(axis=-1)
         return check_parameters(
             0.5 * (logtau + logdet - logquad),
+            -1 <= alpha,
             alpha <= 1,
-            alpha >= -1,
             tau > 0,
             msg="-1 <= alpha <= 1, tau > 0",
         )
@@ -2591,4 +2591,4 @@ def zerosumnormal_logp(op, values, normal_dist, sigma, support_shape, **kwargs):
         axis=tuple(np.arange(-zerosum_axes, 0)),
     )
 
-    return check_parameters(out, *zerosums, msg="at.mean(value, axis=zerosum_axes) == 0")
+    return check_parameters(out, *zerosums, msg="mean(value, axis=zerosum_axes) = 0")

--- a/pymc/tests/distributions/test_continuous.py
+++ b/pymc/tests/distributions/test_continuous.py
@@ -185,8 +185,10 @@ class TestMatchesScipy:
         # Custom logp / logcdf check for invalid parameters
         invalid_dist = pm.Uniform.dist(lower=1, upper=0)
         with aesara.config.change_flags(mode=Mode("py")):
-            assert logp(invalid_dist, np.array(0.5)).eval() == -np.inf
-            assert logcdf(invalid_dist, np.array(2.0)).eval() == -np.inf
+            with pytest.raises(ParameterValueError):
+                logp(invalid_dist, np.array(0.5)).eval()
+            with pytest.raises(ParameterValueError):
+                logcdf(invalid_dist, np.array(0.5)).eval()
 
     def test_triangular(self):
         check_logp(


### PR DESCRIPTION
This PR brings back univariate continuous logp methods that had been moved to Aeppl

~~I also removed all old logp/logcdf docstrings. They were both wrong and too cumbersome to update.~~ Will do in a separate PR

Closes #5329


## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Remove old `logp` and `logcdf` docstrings
