### PR TITLE
Do not rely on tag information for rv and logp conversions

### DIFF
--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -11,6 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import warnings
+
 from typing import (
     Callable,
     Dict,
@@ -31,6 +33,7 @@ import pandas as pd
 import scipy.sparse as sps
 
 from aeppl.logprob import CheckParameterValue
+from aeppl.transforms import RVTransform
 from aesara import scalar
 from aesara.compile.mode import Mode, get_mode
 from aesara.gradient import grad
@@ -205,7 +208,7 @@ def walk_model(
     yield from walk(graphs, expand, bfs=False)
 
 
-def replace_rvs_in_graphs(
+def _replace_rvs_in_graphs(
     graphs: Iterable[TensorVariable],
     replacement_fn: Callable[[TensorVariable], Dict[TensorVariable, TensorVariable]],
     **kwargs,
@@ -282,6 +285,10 @@ def rvs_to_value_vars(
     apply_transforms
         If ``True``, apply each value variable's transform.
     """
+    warnings.warn(
+        "rvs_to_value_vars is deprecated. Use model.replace_rvs_by_values instead",
+        FutureWarning,
+    )
 
     def populate_replacements(
         random_var: TensorVariable, replacements: Dict[TensorVariable, TensorVariable]
@@ -313,9 +320,72 @@ def rvs_to_value_vars(
     equiv = clone_get_equiv(inputs, graphs, False, False, {})
     graphs = [equiv[n] for n in graphs]
 
-    graphs, _ = replace_rvs_in_graphs(
+    graphs, _ = _replace_rvs_in_graphs(
         graphs,
         replacement_fn=populate_replacements,
+        **kwargs,
+    )
+
+    return graphs
+
+
+def replace_rvs_by_values(
+    graphs: Sequence[TensorVariable],
+    *,
+    rvs_to_values: Dict[TensorVariable, TensorVariable],
+    rvs_to_transforms: Dict[TensorVariable, RVTransform],
+    **kwargs,
+) -> List[TensorVariable]:
+    """Clone and replace random variables in graphs with their value variables.
+
+    This will *not* recompute test values in the resulting graphs.
+
+    Parameters
+    ----------
+    graphs
+        The graphs in which to perform the replacements.
+    rvs_to_values
+        Mapping between the original graph RVs and respective value variables
+    rvs_to_transforms
+        Mapping between the original graph RVs and respective value transforms
+    """
+
+    # Clone original graphs so that we don't modify variables in place
+    inputs = [i for i in graph_inputs(graphs) if not isinstance(i, Constant)]
+    equiv = clone_get_equiv(inputs, graphs, False, False, {})
+    graphs = [equiv[n] for n in graphs]
+
+    # Get needed mappings for equivalent cloned variables
+    equiv_rvs_to_values = {}
+    equiv_rvs_to_transforms = {}
+    for rv, value in rvs_to_values.items():
+        equiv_rv = equiv.get(rv, rv)
+        equiv_rvs_to_values[equiv_rv] = equiv.get(value, value)
+        equiv_rvs_to_transforms[equiv_rv] = rvs_to_transforms[rv]
+
+    def poulate_replacements(rv, replacements):
+        # Populate replacements dict with {rv: value} pairs indicating which graph
+        # RVs should be replaced by what value variables.
+
+        # No value variable to replace RV with
+        value = equiv_rvs_to_values.get(rv, None)
+        if value is None:
+            return []
+
+        transform = equiv_rvs_to_transforms.get(rv, None)
+        if transform is not None:
+            # We want to replace uses of the RV by the back-transformation of its value
+            value = transform.backward(value, *rv.owner.inputs)
+            value.name = rv.name
+
+        replacements[rv] = value
+        # Also walk the graph of the value variable to make any additional
+        # replacements if that is not a simple input variable
+        return [value]
+
+    graphs, _ = _replace_rvs_in_graphs(
+        graphs,
+        replacement_fn=poulate_replacements,
         **kwargs,
     )
 

--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -208,7 +208,6 @@ def walk_model(
 def replace_rvs_in_graphs(
     graphs: Iterable[TensorVariable],
     replacement_fn: Callable[[TensorVariable], Dict[TensorVariable, TensorVariable]],
-    initial_replacements: Optional[Dict[TensorVariable, TensorVariable]] = None,
     **kwargs,
 ) -> Tuple[List[TensorVariable], Dict[TensorVariable, TensorVariable]]:
     """Replace random variables in graphs
@@ -226,8 +225,6 @@ def replace_rvs_in_graphs(
     that were made.
     """
     replacements = {}
-    if initial_replacements:
-        replacements.update(initial_replacements)
 
     def expand_replace(var):
         new_nodes = []
@@ -263,7 +260,6 @@ def replace_rvs_in_graphs(
 def rvs_to_value_vars(
     graphs: Iterable[Variable],
     apply_transforms: bool = True,
-    initial_replacements: Optional[Dict[Variable, Variable]] = None,
     **kwargs,
 ) -> List[Variable]:
     """Clone and replace random variables in graphs with their value variables.
@@ -276,9 +272,6 @@ def rvs_to_value_vars(
         The graphs in which to perform the replacements.
     apply_transforms
         If ``True``, apply each value variable's transform.
-    initial_replacements
-        A ``dict`` containing the initial replacements to be made.
-
     """
 
     def populate_replacements(
@@ -311,15 +304,9 @@ def rvs_to_value_vars(
     equiv = clone_get_equiv(inputs, graphs, False, False, {})
     graphs = [equiv[n] for n in graphs]
 
-    if initial_replacements:
-        initial_replacements = {
-            equiv.get(k, k): equiv.get(v, v) for k, v in initial_replacements.items()
-        }
-
     graphs, _ = replace_rvs_in_graphs(
         graphs,
         replacement_fn=populate_replacements,
-        initial_replacements=initial_replacements,
         **kwargs,
     )
 

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -47,7 +47,7 @@ def find_observations(model: "Model") -> Dict[str, Var]:
     """If there are observations available, return them as a dictionary."""
     observations = {}
     for obs in model.observed_RVs:
-        aux_obs = getattr(obs.tag, "observations", None)
+        aux_obs = model.rvs_to_values.get(obs, None)
         if aux_obs is not None:
             try:
                 obs_data = extract_obs_data(aux_obs)
@@ -261,7 +261,7 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
 
         if isinstance(var.owner.op, (AdvancedIncSubtensor, AdvancedIncSubtensor1)):
             try:
-                obs_data = extract_obs_data(var.tag.observations)
+                obs_data = extract_obs_data(self.model.rvs_to_values[var])
             except TypeError:
                 warnings.warn(f"Could not extract data from symbolic observation {var}")
 

--- a/pymc/distributions/__init__.py
+++ b/pymc/distributions/__init__.py
@@ -16,7 +16,6 @@ from pymc.distributions.logprob import (  # isort:skip
     logcdf,
     logp,
     joint_logp,
-    joint_logpt,
 )
 
 from pymc.distributions.bound import Bound
@@ -199,7 +198,6 @@ __all__ = [
     "Censored",
     "CAR",
     "PolyaGamma",
-    "joint_logpt",
     "joint_logp",
     "logp",
     "logcdf",

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -49,7 +49,7 @@ from pymc.distributions.shape_utils import (
     shape_from_dims,
 )
 from pymc.printing import str_for_dist
-from pymc.util import UNSET
+from pymc.util import UNSET, _add_future_warning_tag
 from pymc.vartypes import string_types
 
 __all__ = [
@@ -371,6 +371,7 @@ class Distribution(metaclass=DistributionMeta):
         rv_out.logp = _make_nice_attr_error("rv.logp(x)", "pm.logp(rv, x)")
         rv_out.logcdf = _make_nice_attr_error("rv.logcdf(x)", "pm.logcdf(rv, x)")
         rv_out.random = _make_nice_attr_error("rv.random()", "pm.draw(rv)")
+        _add_future_warning_tag(rv_out)
         return rv_out
 
 

--- a/pymc/distributions/logprob.py
+++ b/pymc/distributions/logprob.py
@@ -29,14 +29,6 @@ from aeppl.transforms import TransformValuesRewrite
 from aesara import tensor as at
 from aesara.graph.basic import graph_inputs, io_toposort
 from aesara.tensor.random.op import RandomVariable
-from aesara.tensor.subtensor import (
-    AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
-    AdvancedSubtensor,
-    AdvancedSubtensor1,
-    IncSubtensor,
-    Subtensor,
-)
 from aesara.tensor.var import TensorVariable
 
 from pymc.aesaraf import constant_fold, floatX
@@ -110,16 +102,6 @@ def _get_scaling(
             "Unrecognized `total_size` type, expected int or list of ints, got %r" % total_size
         )
     return at.as_tensor(coef, dtype=aesara.config.floatX)
-
-
-subtensor_types = (
-    AdvancedIncSubtensor,
-    AdvancedIncSubtensor1,
-    AdvancedSubtensor,
-    AdvancedSubtensor1,
-    IncSubtensor,
-    Subtensor,
-)
 
 
 def joint_logpt(*args, **kwargs):

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -50,6 +50,7 @@ __all__ = [
 
 from pymc.aesaraf import PotentialShapeType
 from pymc.exceptions import ShapeError
+from pymc.util import _add_future_warning_tag
 
 
 def to_tuple(shape):
@@ -600,6 +601,7 @@ def change_dist_size(
         new_size = tuple(new_size)  # type: ignore
 
     new_dist = _change_dist_size(dist.owner.op, dist, new_size=new_size, expand=expand)
+    _add_future_warning_tag(new_dist)
 
     new_dist.name = dist.name
     for k, v in dist.tag.__dict__.items():

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -56,12 +56,11 @@ from pymc.aesaraf import (
     gradient,
     hessian,
     inputvars,
-    rvs_to_value_vars,
+    replace_rvs_by_values,
 )
 from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.data import GenTensorVariable, Minibatch
-from pymc.distributions import joint_logp
-from pymc.distributions.logprob import _get_scaling
+from pymc.distributions.logprob import _joint_logp
 from pymc.distributions.transforms import _default_transform
 from pymc.exceptions import ImputationWarning, SamplingError, ShapeError, ShapeWarning
 from pymc.initial_point import make_initial_point_fn
@@ -555,6 +554,8 @@ class Model(WithMemoization, metaclass=ContextMeta):
             self.named_vars = treedict(parent=self.parent.named_vars)
             self.values_to_rvs = treedict(parent=self.parent.values_to_rvs)
             self.rvs_to_values = treedict(parent=self.parent.rvs_to_values)
+            self.rvs_to_transforms = treedict(parent=self.parent.rvs_to_transforms)
+            self.rvs_to_total_sizes = treedict(parent=self.parent.rvs_to_total_sizes)
             self.free_RVs = treelist(parent=self.parent.free_RVs)
             self.observed_RVs = treelist(parent=self.parent.observed_RVs)
             self.auto_deterministics = treelist(parent=self.parent.auto_deterministics)
@@ -567,6 +568,8 @@ class Model(WithMemoization, metaclass=ContextMeta):
             self.named_vars = treedict()
             self.values_to_rvs = treedict()
             self.rvs_to_values = treedict()
+            self.rvs_to_transforms = treedict()
+            self.rvs_to_total_sizes = treedict()
             self.free_RVs = treelist()
             self.observed_RVs = treelist()
             self.auto_deterministics = treelist()
@@ -725,13 +728,13 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         # We need to separate random variables from potential terms, and remember their
         # original order so that we can merge them together in the same order at the end
-        rv_values = {}
+        rvs = []
         potentials = []
         rv_order, potential_order = [], []
         for i, var in enumerate(varlist):
-            value_var = self.rvs_to_values.get(var)
-            if value_var is not None:
-                rv_values[var] = value_var
+            rv = self.values_to_rvs.get(var, var)
+            if rv in self.basic_RVs:
+                rvs.append(rv)
                 rv_order.append(i)
             else:
                 if var in self.potentials:
@@ -743,14 +746,20 @@ class Model(WithMemoization, metaclass=ContextMeta):
                     )
 
         rv_logps: List[TensorVariable] = []
-        if rv_values:
-            rv_logps = joint_logp(list(rv_values.keys()), rv_values, sum=False, jacobian=jacobian)
+        if rvs:
+            rv_logps = _joint_logp(
+                rvs=rvs,
+                rvs_to_values=self.rvs_to_values,
+                rvs_to_transforms=self.rvs_to_transforms,
+                rvs_to_total_sizes=self.rvs_to_total_sizes,
+                jacobian=jacobian,
+            )
             assert isinstance(rv_logps, list)
 
         # Replace random variables by their value variables in potential terms
         potential_logps = []
         if potentials:
-            potential_logps = rvs_to_value_vars(potentials)
+            potential_logps = self.replace_rvs_by_values(potentials)
 
         logp_factors = [None] * len(varlist)
         for logp_order, logp in zip((rv_order + potential_order), (rv_logps + potential_logps)):
@@ -870,7 +879,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         """Aesara scalar of log-probability of the Potential terms"""
         # Convert random variables in Potential expression into their log-likelihood
         # inputs and apply their transforms, if any
-        potentials = rvs_to_value_vars(self.potentials)
+        potentials = self.replace_rvs_by_values(self.potentials)
         if potentials:
             return at.sum([at.sum(factor) for factor in potentials])
         else:
@@ -890,23 +899,19 @@ class Model(WithMemoization, metaclass=ContextMeta):
         log-likelihood graph
         """
         vars = []
-        untransformed_vars = []
+        transformed_rvs = []
         for rv in self.free_RVs:
             value_var = self.rvs_to_values[rv]
-            transform = getattr(value_var.tag, "transform", None)
+            transform = self.rvs_to_transforms[rv]
             if transform is not None:
-                # We need to create and add an un-transformed version of
-                # each transformed variable
-                untrans_value_var = transform.backward(value_var, *rv.owner.inputs)
-                untrans_value_var.name = rv.name
-                untransformed_vars.append(untrans_value_var)
+                transformed_rvs.append(rv)
             vars.append(value_var)
 
         # Remove rvs from untransformed values graph
-        untransformed_vars = rvs_to_value_vars(untransformed_vars)
+        untransformed_vars = self.replace_rvs_by_values(transformed_rvs)
 
         # Remove rvs from deterministics graph
-        deterministics = rvs_to_value_vars(self.deterministics)
+        deterministics = self.replace_rvs_by_values(self.deterministics)
 
         return vars + untransformed_vars + deterministics
 
@@ -944,7 +949,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         These are the actual random variable terms that make up the
         "sample-space" graph (i.e. you can sample these graphs by compiling them
         with `aesara.function`).  If you want the corresponding log-likelihood terms,
-        use `var.tag.value_var`.
+        use `model.value_vars` instead.
         """
         return self.free_RVs + self.observed_RVs
 
@@ -955,7 +960,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         These are the actual random variable terms that make up the
         "sample-space" graph (i.e. you can sample these graphs by compiling them
         with `aesara.function`).  If you want the corresponding log-likelihood terms,
-        use `var.tag.value_var`.
+        use `var.unobserved_value_vars` instead.
         """
         return self.free_RVs + self.deterministics
 
@@ -979,17 +984,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
         The values are typically instances of ``TensorVariable`` or ``ScalarSharedVariable``.
         """
         return self._dim_lengths
-
-    @property
-    def unobserved_RVs(self):
-        """List of all random variables, including deterministic ones.
-
-        These are the actual random variable terms that make up the
-        "sample-space" graph (i.e. you can sample these graphs by compiling them
-        with `aesara.function`).  If you want the corresponding log-likelihood terms,
-        use `var.tag.value_var`.
-        """
-        return self.free_RVs + self.deterministics
 
     @property
     def test_point(self) -> Dict[str, np.ndarray]:
@@ -1321,7 +1315,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         name = self.name_for(name)
         rv_var.name = name
         rv_var.tag.total_size = total_size
-        rv_var.tag.scaling = _get_scaling(total_size, shape=rv_var.shape, ndim=rv_var.ndim)
+        self.rvs_to_total_sizes[rv_var] = total_size
 
         # Associate previously unknown dimension names with
         # the length of the corresponding RV dimension.
@@ -1389,7 +1383,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
             if test_value is not None:
                 # We try to reuse the old test value
-                rv_var.tag.test_value = np.broadcast_to(test_value, rv_var.tag.test_value.shape)
+                rv_var.tag.test_value = np.broadcast_to(test_value, rv_var.shape)
             else:
                 rv_var.tag.test_value = data
 
@@ -1516,7 +1510,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
                     value_var, *rv_var.owner.inputs
                 ).tag.test_value
             self.named_vars[value_var.name] = value_var
-
+        self.rvs_to_transforms[rv_var] = transform
         self.rvs_to_values[rv_var] = value_var
         self.values_to_rvs[value_var] = rv_var
 
@@ -1582,9 +1576,29 @@ class Model(WithMemoization, metaclass=ContextMeta):
     def __contains__(self, key):
         return key in self.named_vars or self.name_for(key) in self.named_vars
 
+    def replace_rvs_by_values(
+        self,
+        graphs: Sequence[TensorVariable],
+        **kwargs,
+    ) -> List[TensorVariable]:
+        """Clone and replace random variables in graphs with their value variables.
+
+        This will *not* recompute test values in the resulting graphs.
+
+        Parameters
+        ----------
+        graphs
+            The graphs in which to perform the replacements.
+        """
+        return replace_rvs_by_values(
+            graphs,
+            rvs_to_values=self.rvs_to_values,
+            rvs_to_transforms=self.rvs_to_transforms,
+        )
+
     def compile_fn(
         self,
-        outs: Sequence[Variable],
+        outs: Union[Variable, Sequence[Variable]],
         *,
         inputs: Optional[Sequence[Variable]] = None,
         mode=None,
@@ -1679,8 +1693,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         names = []
         outputs = []
         for rv in self.free_RVs:
-            rv_var = self.rvs_to_values[rv]
-            transform = getattr(rv_var.tag, "transform", None)
+            transform = self.rvs_to_transforms[rv]
             if transform is not None:
                 names.append(get_transformed_name(rv.name, transform))
                 outputs.append(transform.forward(rv, *rv.owner.inputs).shape)
@@ -1689,7 +1702,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         f = aesara.function(
             inputs=[],
             outputs=outputs,
-            givens=[(obs, obs.tag.observations) for obs in self.observed_RVs],
+            givens=[(obs, self.rvs_to_values[obs]) for obs in self.observed_RVs],
             mode=aesara.compile.mode.FAST_COMPILE,
             on_unused_input="ignore",
         )
@@ -1851,15 +1864,22 @@ def set_data(new_data, model=None, *, coords=None):
 
 
 def compile_fn(
-    outs, mode=None, point_fn: bool = True, model: Optional[Model] = None, **kwargs
+    outs: Union[Variable, Sequence[Variable]],
+    *,
+    inputs: Optional[Sequence[Variable]] = None,
+    mode=None,
+    point_fn: bool = True,
+    model: Optional[Model] = None,
+    **kwargs,
 ) -> Union[PointFunc, Callable[[Sequence[np.ndarray]], Sequence[np.ndarray]]]:
-    """Compiles an Aesara function which returns ``outs`` and takes values of model
-    vars as a dict as an argument.
+    """Compiles an Aesara function
 
     Parameters
     ----------
     outs
         Aesara variable or iterable of Aesara variables.
+    inputs
+        Aesara input variables, defaults to aesaraf.inputvars(outs).
     mode
         Aesara compilation mode, default=None.
     point_fn : bool
@@ -1870,10 +1890,17 @@ def compile_fn(
 
     Returns
     -------
-    Compiled Aesara function as point function.
+    Compiled Aesara function
     """
+
     model = modelcontext(model)
-    return model.compile_fn(outs, mode=mode, point_fn=point_fn, **kwargs)
+    return model.compile_fn(
+        outs,
+        inputs=inputs,
+        mode=mode,
+        point_fn=point_fn,
+        **kwargs,
+    )
 
 
 def Point(*args, filter_model_vars=False, **kwargs) -> Dict[str, np.ndarray]:
@@ -1998,7 +2025,6 @@ def Potential(name, var, model=None):
     """
     model = modelcontext(model)
     var.name = model.name_for(name)
-    var.tag.scaling = 1.0
     model.potentials.append(var)
     model.add_random_variable(var)
 

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -67,6 +67,7 @@ from pymc.initial_point import make_initial_point_fn
 from pymc.util import (
     UNSET,
     WithMemoization,
+    _add_future_warning_tag,
     get_transformed_name,
     get_value_vars_from_user_vars,
     get_var_name,
@@ -1314,6 +1315,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         """
         name = self.name_for(name)
         rv_var.name = name
+        _add_future_warning_tag(rv_var)
         rv_var.tag.total_size = total_size
         self.rvs_to_total_sizes[rv_var] = total_size
 
@@ -1495,6 +1497,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         if aesara.config.compute_test_value != "off":
             value_var.tag.test_value = rv_var.tag.test_value
 
+        _add_future_warning_tag(value_var)
         rv_var.tag.value_var = value_var
 
         # Make the value variable a transformed value variable,

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -79,8 +79,8 @@ class ModelGraph:
                 raise ValueError(f"{var_name} is not in this model.")
 
             for model_var in self.var_list:
-                if hasattr(model_var.tag, "observations"):
-                    if model_var.tag.observations == self.model[var_name]:
+                if model_var in self.model.observed_RVs:
+                    if self.model.rvs_to_values[model_var] == self.model[var_name]:
                         selected_names.add(model_var.name)
 
         selected_ancestors = set(
@@ -91,8 +91,8 @@ class ModelGraph:
         )
 
         for var in selected_ancestors.copy():
-            if hasattr(var.tag, "observations"):
-                selected_ancestors.add(var.tag.observations)
+            if var in self.model.observed_RVs:
+                selected_ancestors.add(self.model.rvs_to_values[var])
 
         # ordering of self._all_var_names is important
         return [var.name for var in selected_ancestors]
@@ -108,8 +108,8 @@ class ModelGraph:
             parent_name = self.get_parent_names(var)
             input_map[var_name] = input_map[var_name].union(parent_name)
 
-            if hasattr(var.tag, "observations"):
-                obs_node = var.tag.observations
+            if var in self.model.observed_RVs:
+                obs_node = self.model.rvs_to_values[var]
 
                 # loop created so that the elif block can go through this again
                 # and remove any intermediate ops, notably dtype casting, to observations

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -388,7 +388,7 @@ def sample_prior_predictive(
     for name in sorted(missing_names):
         transformed_value_var = model[name]
         rv_var = model.values_to_rvs[transformed_value_var]
-        transform = transformed_value_var.tag.transform
+        transform = model.rvs_to_transforms[rv_var]
         transformed_rv_var = transform.forward(rv_var, *rv_var.owner.inputs)
 
         names.append(name)

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -210,11 +210,8 @@ def _print_step_hierarchy(s: Step, level: int = 0) -> None:
 
 
 def all_continuous(vars):
-    """Check that vars not include discrete variables, excepting observed RVs."""
-
-    vars_ = [var for var in vars if not hasattr(var.tag, "observations")]
-
-    if any([(var.dtype in discrete_types) for var in vars_]):
+    """Check that vars not include discrete variables"""
+    if any([(var.dtype in discrete_types) for var in vars]):
         return False
     else:
         return True

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -31,7 +31,6 @@ from pymc.aesaraf import (
     floatX,
     join_nonshared_inputs,
     replace_rng_nodes,
-    rvs_to_value_vars,
 )
 from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.step_methods.arraystep import (
@@ -585,7 +584,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
 
             if isinstance(distr, CategoricalRV):
                 k_graph = rv_var.owner.inputs[3].shape[-1]
-                (k_graph,) = rvs_to_value_vars((k_graph,))
+                (k_graph,) = model.replace_rvs_by_values((k_graph,))
                 k = model.compile_fn(k_graph, inputs=model.value_vars, on_unused_input="ignore")(
                     initial_point
                 )

--- a/pymc/tests/backends/fixtures.py
+++ b/pymc/tests/backends/fixtures.py
@@ -143,9 +143,9 @@ class ModelBackendSampledTestCase:
         cls.test_point, cls.model, _ = models.beta_bernoulli(cls.shape)
 
         if hasattr(cls, "write_partial_chain") and cls.write_partial_chain is True:
-            cls.chain_vars = [v.tag.value_var for v in cls.model.unobserved_RVs[1:]]
+            cls.chain_vars = [cls.model.rvs_to_values[v] for v in cls.model.unobserved_RVs[1:]]
         else:
-            cls.chain_vars = [v.tag.value_var for v in cls.model.unobserved_RVs]
+            cls.chain_vars = [cls.model.rvs_to_values[v] for v in cls.model.unobserved_RVs]
 
         with cls.model:
             strace0 = cls.backend(cls.name, vars=cls.chain_vars)

--- a/pymc/tests/distributions/test_continuous.py
+++ b/pymc/tests/distributions/test_continuous.py
@@ -73,7 +73,7 @@ class TestBoundedContinuous:
         interval_rv = model.named_vars[f"{rv_name}_interval__"]
         rv = model.named_vars[rv_name]
         dist_params = rv.owner.inputs
-        lower_interval, upper_interval = interval_rv.tag.transform.args_fn(*rv.owner.inputs)
+        lower_interval, upper_interval = model.rvs_to_transforms[rv].args_fn(*rv.owner.inputs)
         return (
             dist_params,
             lower_interval,

--- a/pymc/tests/distributions/test_discrete.py
+++ b/pymc/tests/distributions/test_discrete.py
@@ -30,7 +30,7 @@ from aesara.tensor import TensorVariable
 import pymc as pm
 
 from pymc.aesaraf import floatX
-from pymc.distributions import joint_logp, logcdf, logp
+from pymc.distributions import logcdf, logp
 from pymc.distributions.discrete import _OrderedLogistic, _OrderedProbit
 from pymc.tests.distributions.util import (
     BaseTestDistributionRandom,
@@ -574,8 +574,8 @@ def test_orderedlogistic_dimensions(shape):
             p=p,
             observed=obs,
         )
-    ologp = joint_logp(ol, np.ones_like(obs), sum=True).eval() * loge
-    clogp = joint_logp(c, np.ones_like(obs), sum=True).eval() * loge
+    ologp = pm.logp(ol, np.ones_like(obs)).sum().eval() * loge
+    clogp = pm.logp(c, np.ones_like(obs)).sum().eval() * loge
     expected = -np.prod((size,) + shape)
 
     assert c.owner.inputs[3].ndim == (len(shape) + 1)

--- a/pymc/tests/distributions/test_distribution.py
+++ b/pymc/tests/distributions/test_distribution.py
@@ -26,7 +26,7 @@ from aesara.tensor import TensorVariable
 
 import pymc as pm
 
-from pymc.distributions import DiracDelta, Flat, MvNormal, MvStudentT, joint_logp, logp
+from pymc.distributions import DiracDelta, Flat, MvNormal, MvStudentT, logp
 from pymc.distributions.distribution import SymbolicRandomVariable, _moment, moment
 from pymc.distributions.shape_utils import to_tuple
 from pymc.tests.distributions.util import assert_moment_is_expected
@@ -215,14 +215,13 @@ class TestDensityDist:
 
             mu = pm.Normal("mu", size=supp_shape)
             a = pm.DensityDist("a", mu, logp=logp, ndims_params=[1], ndim_supp=1, size=size)
-        mu_val = npr.normal(loc=0, scale=1, size=supp_shape).astype(aesara.config.floatX)
-        a_val = npr.normal(loc=mu_val, scale=1, size=to_tuple(size) + (supp_shape,)).astype(
-            aesara.config.floatX
-        )
-        log_densityt = joint_logp(a, a.tag.value_var, sum=False)[0]
-        assert log_densityt.eval(
-            {a.tag.value_var: a_val, mu.tag.value_var: mu_val},
-        ).shape == to_tuple(size)
+
+        mu_test_value = npr.normal(loc=0, scale=1, size=supp_shape).astype(aesara.config.floatX)
+        a_test_value = npr.normal(
+            loc=mu_test_value, scale=1, size=to_tuple(size) + (supp_shape,)
+        ).astype(aesara.config.floatX)
+        log_densityf = model.compile_logp(vars=[a], sum=False)
+        assert log_densityf({"a": a_test_value, "mu": mu_test_value})[0].shape == to_tuple(size)
 
     @pytest.mark.parametrize(
         "moment, size, expected",

--- a/pymc/tests/distributions/test_distribution.py
+++ b/pymc/tests/distributions/test_distribution.py
@@ -28,8 +28,9 @@ import pymc as pm
 
 from pymc.distributions import DiracDelta, Flat, MvNormal, MvStudentT, logp
 from pymc.distributions.distribution import SymbolicRandomVariable, _moment, moment
-from pymc.distributions.shape_utils import to_tuple
+from pymc.distributions.shape_utils import change_dist_size, to_tuple
 from pymc.tests.distributions.util import assert_moment_is_expected
+from pymc.util import _FutureWarningValidatingScratchpad
 
 
 class TestBugfixes:
@@ -358,3 +359,40 @@ class TestSymbolicRandomVarible:
         dirac_delta_2_ = DiracDelta.dist(10)
         node = TestSymbolicRV([], [dirac_delta_1_, dirac_delta_2_], ndim_supp=0)().owner
         assert get_measurable_outputs(node.op, node) == [node.outputs[default_output_idx]]
+
+
+def test_tag_future_warning_dist():
+    # Test no unexpected warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        x = pm.Normal.dist()
+        assert isinstance(x.tag, _FutureWarningValidatingScratchpad)
+
+        x.tag.banana = "banana"
+        assert x.tag.banana == "banana"
+
+        # Check we didn't break test_value filtering
+        x.tag.test_value = np.array(1)
+        assert x.tag.test_value == 1
+        with pytest.raises(TypeError, match="Wrong number of dimensions"):
+            x.tag.test_value = np.array([1, 1])
+        assert x.tag.test_value == 1
+
+        # No warning if deprecated attribute is not present
+        with pytest.raises(AttributeError):
+            x.tag.value_var
+
+        # Warning if present
+        x.tag.value_var = "1"
+        with pytest.warns(FutureWarning, match="Use model.rvs_to_values"):
+            value_var = x.tag.value_var
+        assert value_var == "1"
+
+        # Check that PyMC method that copies tag contents does not erase special tag
+        new_x = change_dist_size(x, new_size=5)
+        assert new_x.tag is not x.tag
+        assert isinstance(new_x.tag, _FutureWarningValidatingScratchpad)
+        with pytest.warns(FutureWarning, match="Use model.rvs_to_values"):
+            value_var = new_x.tag.value_var
+        assert value_var == "1"

--- a/pymc/tests/distributions/test_logprob.py
+++ b/pymc/tests/distributions/test_logprob.py
@@ -52,12 +52,7 @@ from pymc.distributions.logprob import (
     logp,
 )
 from pymc.model import Model, Potential
-from pymc.tests.helpers import select_by_precision
-
-
-def assert_no_rvs(var):
-    assert not any(isinstance(v.owner.op, RandomVariable) for v in ancestors([var]) if v.owner)
-    return var
+from pymc.tests.helpers import assert_no_rvs, select_by_precision
 
 
 def test_get_scaling():

--- a/pymc/tests/distributions/test_logprob.py
+++ b/pymc/tests/distributions/test_logprob.py
@@ -45,9 +45,8 @@ from pymc.distributions.continuous import (
 from pymc.distributions.discrete import Bernoulli
 from pymc.distributions.logprob import (
     _get_scaling,
+    _joint_logp,
     ignore_logprob,
-    joint_logp,
-    joint_logpt,
     logcdf,
     logp,
 )
@@ -112,25 +111,24 @@ def test_joint_logp_basic():
         b = Uniform("b", b_l, b_l + 1.0)
 
     a_value_var = m.rvs_to_values[a]
-    assert a_value_var.tag.transform
+    assert m.rvs_to_transforms[a]
 
     b_value_var = m.rvs_to_values[b]
-    assert b_value_var.tag.transform
+    assert m.rvs_to_transforms[b]
 
     c_value_var = m.rvs_to_values[c]
 
-    b_logp = joint_logp(b, b_value_var, sum=False)
-
-    with pytest.warns(FutureWarning):
-        b_logpt = joint_logpt(b, b_value_var, sum=False)
-
-    res_ancestors = list(walk_model(b_logp))
-    res_rv_ancestors = [
-        v for v in res_ancestors if v.owner and isinstance(v.owner.op, RandomVariable)
-    ]
+    (b_logp,) = _joint_logp(
+        (b,),
+        rvs_to_values=m.rvs_to_values,
+        rvs_to_transforms=m.rvs_to_transforms,
+        rvs_to_total_sizes={},
+    )
 
     # There shouldn't be any `RandomVariable`s in the resulting graph
-    assert len(res_rv_ancestors) == 0
+    assert_no_rvs(b_logp)
+
+    res_ancestors = list(walk_model((b_logp,)))
     assert b_value_var in res_ancestors
     assert c_value_var in res_ancestors
     assert a_value_var in res_ancestors
@@ -166,7 +164,12 @@ def test_joint_logp_incsubtensor(indices, size):
     a_idx_value_var = a_idx.type()
     a_idx_value_var.name = "a_idx_value"
 
-    a_idx_logp = joint_logp(a_idx, {a_idx: a_value_var}, sum=False)
+    a_idx_logp = _joint_logp(
+        (a_idx,),
+        rvs_to_values={a_idx: a_value_var},
+        rvs_to_transforms={},
+        rvs_to_total_sizes={},
+    )
 
     logp_vals = a_idx_logp[0].eval({a_value_var: a_val})
 
@@ -208,7 +211,12 @@ def test_joint_logp_subtensor():
     I_value_var = I_rv.type()
     I_value_var.name = "I_value"
 
-    A_idx_logps = joint_logp(A_idx, {A_idx: A_idx_value_var, I_rv: I_value_var}, sum=False)
+    A_idx_logps = _joint_logp(
+        (A_idx, I_rv),
+        rvs_to_values={A_idx: A_idx_value_var, I_rv: I_value_var},
+        rvs_to_transforms={},
+        rvs_to_total_sizes={},
+    )
     A_idx_logp = at.add(*A_idx_logps)
 
     logp_vals_fn = aesara.function([A_idx_value_var, I_value_var], A_idx_logp)
@@ -337,7 +345,12 @@ def test_ignore_logprob_model():
         match="Found a random variable that was neither among the observations "
         "nor the conditioned variables",
     ):
-        assert joint_logp([y], {y: y.type()})
+        _joint_logp(
+            [y],
+            rvs_to_values={y: y.type()},
+            rvs_to_transforms={},
+            rvs_to_total_sizes={},
+        )
 
     # The above warning should go away with ignore_logprob.
     with Model() as m:
@@ -345,7 +358,12 @@ def test_ignore_logprob_model():
         y = DensityDist("y", x, logp=logp)
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        assert joint_logp([y], {y: y.type()})
+        assert _joint_logp(
+            [y],
+            rvs_to_values={y: y.type()},
+            rvs_to_transforms={},
+            rvs_to_total_sizes={},
+        )
 
 
 def test_hierarchical_logp():
@@ -358,8 +376,8 @@ def test_hierarchical_logp():
     ops = {a.owner.op for a in logp_ancestors if a.owner}
     assert len(ops) > 0
     assert not any(isinstance(o, RandomVariable) for o in ops)
-    assert x.tag.value_var in logp_ancestors
-    assert y.tag.value_var in logp_ancestors
+    assert m.rvs_to_values[x] in logp_ancestors
+    assert m.rvs_to_values[y] in logp_ancestors
 
 
 def test_hierarchical_obs_logp():

--- a/pymc/tests/distributions/test_simulator.py
+++ b/pymc/tests/distributions/test_simulator.py
@@ -196,15 +196,8 @@ class TestSimulator(SeededTest):
         assert self.count_rvs(m.logp()) == 2
 
         # Check that the logps use the correct methods
-        a_val = m.rvs_to_values[a]
-        sim1_val = m.rvs_to_values[sim1]
-        logp_sim1 = pm.joint_logp(sim1, sim1_val)
-        logp_sim1_fn = aesara.function([a_val], logp_sim1)
-
-        b_val = m.rvs_to_values[b]
-        sim2_val = m.rvs_to_values[sim2]
-        logp_sim2 = pm.joint_logp(sim2, sim2_val)
-        logp_sim2_fn = aesara.function([b_val], logp_sim2)
+        logp_sim1_fn = m.compile_fn(m.logp(sim1), point_fn=False)
+        logp_sim2_fn = m.compile_fn(m.logp(sim2), point_fn=False)
 
         assert any(
             node for node in logp_sim1_fn.maker.fgraph.toposort() if isinstance(node.op, SortOp)

--- a/pymc/tests/distributions/util.py
+++ b/pymc/tests/distributions/util.py
@@ -20,7 +20,7 @@ import pymc as pm
 
 from pymc.aesaraf import compile_pymc, floatX, intX
 from pymc.distributions import logcdf, logp
-from pymc.distributions.logprob import joint_logp
+from pymc.distributions.logprob import _joint_logp
 from pymc.distributions.shape_utils import change_dist_size
 from pymc.initial_point import make_initial_point_fn
 from pymc.tests.helpers import SeededTest, select_by_precision
@@ -288,9 +288,9 @@ def check_logp(
         for k, v in pt.items():
             rv_var = model.named_vars.get(k)
             nv = param_vars.get(k, rv_var)
-            nv = getattr(nv.tag, "value_var", nv)
+            nv = model.rvs_to_values.get(nv, nv)
 
-            transform = getattr(nv.tag, "transform", None)
+            transform = model.rvs_to_transforms.get(rv_var, None)
             if transform:
                 # todo: the compiled graph behind this should be cached and
                 # reused (if it isn't already).
@@ -582,7 +582,16 @@ def assert_moment_is_expected(model, expected, check_finite_logp=True):
     assert np.allclose(moment, expected)
 
     if check_finite_logp:
-        logp_moment = joint_logp(model["x"], at.constant(moment), transformed=False).eval()
+        logp_moment = (
+            _joint_logp(
+                (model["x"],),
+                rvs_to_values={model["x"]: at.constant(moment)},
+                rvs_to_transforms={},
+                rvs_to_total_sizes={},
+            )[0]
+            .sum()
+            .eval()
+        )
         assert np.isfinite(logp_moment)
 
 

--- a/pymc/tests/helpers.py
+++ b/pymc/tests/helpers.py
@@ -24,8 +24,10 @@ import numpy as np
 import numpy.random as nr
 
 from aesara.gradient import verify_grad as at_verify_grad
+from aesara.graph import ancestors
 from aesara.graph.rewriting.basic import in2out
 from aesara.sandbox.rng_mrg import MRG_RandomStream as RandomStream
+from aesara.tensor.random.op import RandomVariable
 
 import pymc as pm
 
@@ -218,3 +220,8 @@ class RVsAssignmentStepsTester:
             assert {m.rvs_to_values[c1], m.rvs_to_values[c2]} == set(
                 step([c1, c2], **step_kwargs).vars
             )
+
+
+def assert_no_rvs(var):
+    assert not any(isinstance(v.owner.op, RandomVariable) for v in ancestors([var]) if v.owner)
+    return var

--- a/pymc/tests/test_data.py
+++ b/pymc/tests/test_data.py
@@ -621,12 +621,12 @@ class TestScaling:
             genvar = pm.generator(gen1())
             m = pm.Normal("m")
             pm.Normal("n", observed=genvar, total_size=1000)
-            grad1 = aesara.function([m.tag.value_var], at.grad(model1.logp(), m.tag.value_var))
+            grad1 = model1.compile_fn(model1.dlogp(vars=m), point_fn=False)
         with pm.Model() as model2:
             m = pm.Normal("m")
             shavar = aesara.shared(np.ones((1000, 100)))
             pm.Normal("n", observed=shavar)
-            grad2 = aesara.function([m.tag.value_var], at.grad(model2.logp(), m.tag.value_var))
+            grad2 = model2.compile_fn(model2.dlogp(vars=m), point_fn=False)
 
         for i in range(10):
             shavar.set_value(np.ones((100, 100)) * i)
@@ -709,11 +709,11 @@ class TestScaling:
     def test_free_rv(self):
         with pm.Model() as model4:
             pm.Normal("n", observed=[[1, 1], [1, 1]], total_size=[2, 2])
-            p4 = aesara.function([], model4.logp())
+            p4 = model4.compile_fn(model4.logp(), point_fn=False)
 
         with pm.Model() as model5:
             n = pm.Normal("n", total_size=[2, Ellipsis, 2], size=(2, 2))
-            p5 = aesara.function([n.tag.value_var], model5.logp())
+            p5 = model5.compile_fn(model5.logp(), point_fn=False)
         assert p4() == p5(pm.floatX([[1]]))
         assert p4() == p5(pm.floatX([[1, 1], [1, 1]]))
 

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -28,6 +28,7 @@ import pytest
 import scipy.sparse as sps
 import scipy.stats as st
 
+from aeppl.transforms import IntervalTransform
 from aesara.graph import graph_inputs
 from aesara.tensor import TensorVariable
 from aesara.tensor.random.op import RandomVariable
@@ -39,6 +40,7 @@ import pymc as pm
 from pymc import Deterministic, Potential
 from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.distributions import Normal, transforms
+from pymc.distributions.logprob import _joint_logp
 from pymc.exceptions import ImputationWarning, ShapeError, ShapeWarning
 from pymc.model import Point, ValueGradFunction, modelcontext
 from pymc.tests.helpers import SeededTest
@@ -495,10 +497,22 @@ def test_model_value_vars():
 def test_model_var_maps():
     with pm.Model() as model:
         a = pm.Uniform("a")
-        x = pm.Normal("x", a)
+        x = pm.Normal("x", a, total_size=5)
 
-    assert model.rvs_to_values == {a: a.tag.value_var, x: x.tag.value_var}
-    assert model.values_to_rvs == {a.tag.value_var: a, x.tag.value_var: x}
+    assert set(model.rvs_to_values.keys()) == {a, x}
+    a_value = model.rvs_to_values[a]
+    x_value = model.rvs_to_values[x]
+    assert a_value.owner is None
+    assert x_value.owner is None
+    assert model.values_to_rvs == {a_value: a, x_value: x}
+
+    assert set(model.rvs_to_transforms.keys()) == {a, x}
+    assert isinstance(model.rvs_to_transforms[a], IntervalTransform)
+    assert model.rvs_to_transforms[x] is None
+
+    assert set(model.rvs_to_total_sizes.keys()) == {a, x}
+    assert model.rvs_to_total_sizes[a] is None
+    assert model.rvs_to_total_sizes[x] == 5
 
 
 def test_make_obs_var():
@@ -531,12 +545,12 @@ def test_make_obs_var():
 
     dense_output = fake_model.make_obs_var(fake_distribution, dense_input, None, None)
     assert dense_output == fake_distribution
-    assert isinstance(dense_output.tag.observations, TensorConstant)
+    assert isinstance(fake_model.rvs_to_values[dense_output], TensorConstant)
     del fake_model.named_vars[fake_distribution.name]
 
     sparse_output = fake_model.make_obs_var(fake_distribution, sparse_input, None, None)
     assert sparse_output == fake_distribution
-    assert sparse.basic._is_sparse_variable(sparse_output.tag.observations)
+    assert sparse.basic._is_sparse_variable(fake_model.rvs_to_values[sparse_output])
     del fake_model.named_vars[fake_distribution.name]
 
     # Here the RandomVariable is split into observed/imputed and a Deterministic is returned
@@ -567,8 +581,7 @@ def test_initial_point():
     with pytest.warns(FutureWarning), model:
         b = pm.Uniform("b", testval=b_initval)
 
-    b_value_var = model.rvs_to_values[b]
-    b_initval_trans = b_value_var.tag.transform.forward(b_initval, *b.owner.inputs).eval()
+    b_initval_trans = model.rvs_to_transforms[b].forward(b_initval, *b.owner.inputs).eval()
 
     y_initval = np.array(-2.4, dtype=aesara.config.floatX)
 
@@ -635,12 +648,8 @@ class TestCheckStartVals(SeededTest):
             b = pm.Uniform("b", lower=2.0, upper=3.0)
 
         start = {
-            "a_interval__": model.rvs_to_values[a]
-            .tag.transform.forward(0.3, *a.owner.inputs)
-            .eval(),
-            "b_interval__": model.rvs_to_values[b]
-            .tag.transform.forward(2.1, *b.owner.inputs)
-            .eval(),
+            "a_interval__": model.rvs_to_transforms[a].forward(0.3, *a.owner.inputs).eval(),
+            "b_interval__": model.rvs_to_transforms[b].forward(2.1, *b.owner.inputs).eval(),
         }
         model.check_start_vals(start)
 
@@ -651,9 +660,7 @@ class TestCheckStartVals(SeededTest):
 
         start = {
             "a_interval__": np.nan,
-            "b_interval__": model.rvs_to_values[b]
-            .tag.transform.forward(2.1, *b.owner.inputs)
-            .eval(),
+            "b_interval__": model.rvs_to_transforms[b].forward(2.1, *b.owner.inputs).eval(),
         }
         with pytest.raises(pm.exceptions.SamplingError):
             model.check_start_vals(start)
@@ -664,12 +671,8 @@ class TestCheckStartVals(SeededTest):
             b = pm.Uniform("b", lower=2.0, upper=3.0)
 
         start = {
-            "a_interval__": model.rvs_to_values[a]
-            .tag.transform.forward(0.3, *a.owner.inputs)
-            .eval(),
-            "b_interval__": model.rvs_to_values[b]
-            .tag.transform.forward(2.1, *b.owner.inputs)
-            .eval(),
+            "a_interval__": model.rvs_to_transforms[a].forward(0.3, *a.owner.inputs).eval(),
+            "b_interval__": model.rvs_to_transforms[b].forward(2.1, *b.owner.inputs).eval(),
             "c": 1.0,
         }
         with pytest.raises(KeyError):
@@ -1207,9 +1210,7 @@ class TestImputationMissingData:
 
             assert "theta1_observed" in model.named_vars
             assert "theta1_missing_interval__" in model.named_vars
-            assert not hasattr(
-                model.rvs_to_values[model.named_vars["theta1_observed"]].tag, "transform"
-            )
+            assert model.rvs_to_transforms[model.named_vars["theta1_observed"]] is None
 
             prior_trace = pm.sample_prior_predictive(return_inferencedata=False)
 
@@ -1348,7 +1349,7 @@ class TestImputationMissingData:
 
         This would fail in a previous implementation because the two variables would be
         equivalent and one of them would be discarded during MergeOptimization while
-        buling the logp graph
+        building the logp graph
         """
         with pm.Model() as m:
             with pytest.warns(ImputationWarning):
@@ -1360,8 +1361,13 @@ class TestImputationMissingData:
         x_unobs_rv = m["x_missing"]
         x_unobs_vv = m.rvs_to_values[x_unobs_rv]
 
-        logp = pm.joint_logp([x_obs_rv, x_unobs_rv], {x_obs_rv: x_obs_vv, x_unobs_rv: x_unobs_vv})
-        logp_inputs = list(graph_inputs([logp]))
+        logp = _joint_logp(
+            [x_obs_rv, x_unobs_rv],
+            rvs_to_values={x_obs_rv: x_obs_vv, x_unobs_rv: x_unobs_vv},
+            rvs_to_transforms={},
+            rvs_to_total_sizes={},
+        )
+        logp_inputs = list(graph_inputs(logp))
         assert x_obs_vv in logp_inputs
         assert x_unobs_vv in logp_inputs
 

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -41,10 +41,12 @@ from pymc import Deterministic, Potential
 from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.distributions import Normal, transforms
 from pymc.distributions.logprob import _joint_logp
+from pymc.distributions.transforms import log
 from pymc.exceptions import ImputationWarning, ShapeError, ShapeWarning
 from pymc.model import Point, ValueGradFunction, modelcontext
 from pymc.tests.helpers import SeededTest
 from pymc.tests.models import simple_model
+from pymc.util import _FutureWarningValidatingScratchpad
 
 
 class NewModel(pm.Model):
@@ -1406,3 +1408,59 @@ class TestShared(SeededTest):
             assert np.all(
                 np.isclose(model.compile_logp(sum=False)({}), st.norm().logpdf(data_values))
             )
+
+
+def test_tag_future_warning_model():
+    # Test no unexpected warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        model = pm.Model()
+
+        x = at.random.normal()
+        x.tag.something_else = "5"
+        x.tag.test_value = 0
+        assert not isinstance(x.tag, _FutureWarningValidatingScratchpad)
+
+        # Test that model changes the tag type, but copies exsiting contents
+        x = model.register_rv(x, name="x", transform=log)
+        assert isinstance(x.tag, _FutureWarningValidatingScratchpad)
+        assert x.tag.something_else == "5"
+        assert x.tag.test_value == 0
+
+        # Test expected warnings
+        with pytest.warns(FutureWarning, match="model.rvs_to_values"):
+            x_value = x.tag.value_var
+
+        assert isinstance(x_value.tag, _FutureWarningValidatingScratchpad)
+        with pytest.warns(FutureWarning, match="model.rvs_to_transforms"):
+            transform = x_value.tag.transform
+        assert transform is log
+
+        with pytest.raises(AttributeError):
+            x.tag.observations
+
+        with pytest.warns(FutureWarning, match="model.rvs_to_total_sizes"):
+            total_size = x.tag.total_size
+        assert total_size is None
+
+        # Cloning a node will keep the same tag type and contents
+        y = x.owner.clone().default_output()
+        assert y is not x
+        assert y.tag is not x.tag
+        assert isinstance(y.tag, _FutureWarningValidatingScratchpad)
+        y = model.register_rv(y, name="y", data=5)
+        assert isinstance(y.tag, _FutureWarningValidatingScratchpad)
+
+        # Test expected warnings
+        with pytest.warns(FutureWarning, match="model.rvs_to_values"):
+            y_value = y.tag.value_var
+        with pytest.warns(FutureWarning, match="model.rvs_to_values"):
+            y_obs = y.tag.observations
+        assert y_value is y_obs
+        assert y_value.eval() == 5
+
+        assert isinstance(y_value.tag, _FutureWarningValidatingScratchpad)
+        with pytest.warns(FutureWarning, match="model.rvs_to_total_sizes"):
+            total_size = y.tag.total_size
+        assert total_size is None

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -104,10 +104,8 @@ def find_MAP(
             vars = get_value_vars_from_user_vars(vars, model)
         except ValueError as exc:
             # Accomodate case where user passed non-pure RV nodes
-            vars = pm.inputvars(pm.aesaraf.rvs_to_value_vars(vars))
+            vars = pm.inputvars(model.replace_rvs_by_values(vars))
             if vars:
-                # Make sure they belong to current model again...
-                vars = get_value_vars_from_user_vars(vars, model)
                 warnings.warn(
                     "Intermediate variables (such as Deterministic or Potential) were passed. "
                     "find_MAP will optimize the underlying free_RVs instead.",


### PR DESCRIPTION
This PR will finally clean the interface for accessing meta-information from RVs needed when transforming back and forth between the RV and logp representations of a PyMC model

It does not yet remove that information to not break anything. Some methods relied heavily on this local information and were simply marked for deprecation, with alternatives being provided from scratch.

Accessing these variables (as long as they were introduced by PyMC) via tag will issue a FutureWarning:

```python
with pm.Model() as m:
  x = pm.Normal("x")
x.tag.value_var  # Warning: The tag attribute value_var is deprecated. Use model.rvs_to_values[rv] instead
```

Closes #5033
Closes #6236 


## Major / Breaking Changes
- Deprecated accessing `[value_variable|observations|transform|total_size]` via `var.tag` in favor of `model.rvs_to_[values|transforms|total_sizes]`
- Deprecated `joint_logp` in favor of `model.logp`
- Deprecated `aesaraf.rvs_to_value_vars` in favor of `model.replace_rvs_by_values`

## Bugfixes / New features
- Fix bug when replacing random variables with nested value transforms

## Docs / Maintenance
- ...
