### PR TITLE
Remove duplicate methods

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -989,9 +989,9 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
     @property
     def test_point(self) -> Dict[str, np.ndarray]:
-        """Deprecated alias for `Model.initial_point(seed=None)`."""
+        """Deprecated alias for `Model.initial_point(random_seed=None)`."""
         warnings.warn(
-            "`Model.test_point` has been deprecated. Use `Model.initial_point(seed=None)`.",
+            "`Model.test_point` has been deprecated. Use `Model.initial_point(random_seed=None)`.",
             FutureWarning,
         )
         return self.initial_point()
@@ -1002,7 +1002,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         Parameters
         ----------
         random_seed : SeedSequenceSeed, default None
-            Seed(s) for generating initial point from the model. Used in pymc.aesaraf.reseed_rng
+            Seed(s) for generating initial point from the model. Used in pymc.aesaraf.reseed_rngs
 
         Returns
         -------

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1101,15 +1101,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
         self.dim_lengths[name].set_value(new_length)
         return
 
-    @property
-    def test_point(self) -> Dict[str, np.ndarray]:
-        """Deprecated alias for `Model.initial_point(random_seed=None)`."""
-        warnings.warn(
-            "`Model.test_point` has been deprecated. Use `Model.initial_point(random_seed=None)`.",
-            FutureWarning,
-        )
-        return self.initial_point()
-
     def initial_point(self, random_seed: SeedSequenceSeed = None) -> Dict[str, np.ndarray]:
         """Computes the initial point of the model.
 

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -987,48 +987,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
         """
         return self._dim_lengths
 
-    @property
-    def test_point(self) -> Dict[str, np.ndarray]:
-        """Deprecated alias for `Model.initial_point(random_seed=None)`."""
-        warnings.warn(
-            "`Model.test_point` has been deprecated. Use `Model.initial_point(random_seed=None)`.",
-            FutureWarning,
-        )
-        return self.initial_point()
-
-    def initial_point(self, random_seed: SeedSequenceSeed = None) -> Dict[str, np.ndarray]:
-        """Computes the initial point of the model.
-
-        Parameters
-        ----------
-        random_seed : SeedSequenceSeed, default None
-            Seed(s) for generating initial point from the model. Used in pymc.aesaraf.reseed_rngs
-
-        Returns
-        -------
-        ip : dict of {str : array_like}
-            Maps names of transformed variables to numeric initial values in the transformed space.
-        """
-        fn = make_initial_point_fn(model=self, return_transformed=True)
-        return Point(fn(random_seed), model=self)
-
-    @property
-    def initial_values(self) -> Dict[TensorVariable, Optional[Union[np.ndarray, Variable, str]]]:
-        """Maps transformed variables to initial value placeholders.
-
-        Keys are the random variables (as returned by e.g. ``pm.Uniform()``) and
-        values are the numeric/symbolic initial values, strings denoting the strategy to get them, or None.
-        """
-        return self._initial_values
-
-    def set_initval(self, rv_var, initval):
-        """Sets an initial value (strategy) for a random variable."""
-        if initval is not None and not isinstance(initval, (Variable, str)):
-            # Convert scalars or array-like inputs to ndarrays
-            initval = rv_var.type.filter(initval)
-
-        self.initial_values[rv_var] = initval
-
     def shape_from_dims(self, dims):
         shape = []
         if len(set(dims)) != len(dims):
@@ -1142,6 +1100,48 @@ class Model(WithMemoization, metaclass=ContextMeta):
             self._coords[name] = tuple(coord_values)
         self.dim_lengths[name].set_value(new_length)
         return
+
+    @property
+    def test_point(self) -> Dict[str, np.ndarray]:
+        """Deprecated alias for `Model.initial_point(random_seed=None)`."""
+        warnings.warn(
+            "`Model.test_point` has been deprecated. Use `Model.initial_point(random_seed=None)`.",
+            FutureWarning,
+        )
+        return self.initial_point()
+
+    def initial_point(self, random_seed: SeedSequenceSeed = None) -> Dict[str, np.ndarray]:
+        """Computes the initial point of the model.
+
+        Parameters
+        ----------
+        random_seed : SeedSequenceSeed, default None
+            Seed(s) for generating initial point from the model. Passed into :func:`pymc.aesaraf.reseed_rngs`
+
+        Returns
+        -------
+        ip : dict of {str : array_like}
+            Maps names of transformed variables to numeric initial values in the transformed space.
+        """
+        fn = make_initial_point_fn(model=self, return_transformed=True)
+        return Point(fn(random_seed), model=self)
+
+    @property
+    def initial_values(self) -> Dict[TensorVariable, Optional[Union[np.ndarray, Variable, str]]]:
+        """Maps transformed variables to initial value placeholders.
+
+        Keys are the random variables (as returned by e.g. ``pm.Uniform()``) and
+        values are the numeric/symbolic initial values, strings denoting the strategy to get them, or None.
+        """
+        return self._initial_values
+
+    def set_initval(self, rv_var, initval):
+        """Sets an initial value (strategy) for a random variable."""
+        if initval is not None and not isinstance(initval, (Variable, str)):
+            # Convert scalars or array-like inputs to ndarrays
+            initval = rv_var.type.filter(initval)
+
+        self.initial_values[rv_var] = initval
 
     def set_data(
         self,

--- a/pymc/smc/kernels.py
+++ b/pymc/smc/kernels.py
@@ -198,7 +198,7 @@ class SMC_KERNEL(ABC):
 
         """
         # Create dictionary that stores original variables shape and size
-        initial_point = self.model.initial_point(seed=self.rng.integers(2**30))
+        initial_point = self.model.initial_point(random_seed=self.rng.integers(2**30))
         for v in self.variables:
             self.var_info[v.name] = (initial_point[v.name].shape, initial_point[v.name].size)
         # Create particles bijection map

--- a/pymc/tests/test_initial_point.py
+++ b/pymc/tests/test_initial_point.py
@@ -47,7 +47,7 @@ class TestInitvalAssignment:
         with pm.Model() as pmodel:
             with pytest.warns(FutureWarning, match="`testval` argument is deprecated"):
                 rv = pm.Uniform("u", 0, 1, testval=0.75)
-                initial_point = pmodel.initial_point(seed=0)
+                initial_point = pmodel.initial_point(random_seed=0)
                 assert initial_point["u_interval__"] == transform_fwd(rv, 0.75, model=pmodel)
                 assert not hasattr(rv.tag, "test_value")
         pass
@@ -56,7 +56,7 @@ class TestInitvalAssignment:
         with pm.Model() as pmodel:
             pm.Uniform("x", 0, 1, size=2, initval="unknown")
             with pytest.raises(ValueError, match="Invalid string strategy: unknown"):
-                pmodel.initial_point(seed=0)
+                pmodel.initial_point(random_seed=0)
 
 
 class TestInitvalEvaluation:
@@ -79,7 +79,7 @@ class TestInitvalEvaluation:
             U = pm.Uniform("U", lower=9, upper=10, initval=9.5)
             B1 = pm.Uniform("B1", lower=L, upper=U, initval=5)
             B2 = pm.Uniform("B2", lower=L, upper=U, initval=(L + U) / 2)
-            ip = pmodel.initial_point(seed=0)
+            ip = pmodel.initial_point(random_seed=0)
             assert ip["L_interval__"] == 0
             assert ip["U_interval__"] == 0
             assert ip["B1_interval__"] == 0
@@ -87,7 +87,7 @@ class TestInitvalEvaluation:
 
             # Modify initval of L and re-evaluate
             pmodel.initial_values[U] = 9.9
-            ip = pmodel.initial_point(seed=0)
+            ip = pmodel.initial_point(random_seed=0)
             assert ip["B1_interval__"] < 0
             assert ip["B2_interval__"] == 0
         pass
@@ -121,11 +121,11 @@ class TestInitvalEvaluation:
             data = aesara.shared(np.arange(4))
             rv = pm.Uniform("u", lower=data, upper=10, initval="prior")
 
-            ip = pmodel.initial_point(seed=0)
+            ip = pmodel.initial_point(random_seed=0)
             assert np.shape(ip["u_interval__"]) == (4,)
 
             data.set_value(np.arange(5))
-            ip = pmodel.initial_point(seed=0)
+            ip = pmodel.initial_point(random_seed=0)
             assert np.shape(ip["u_interval__"]) == (5,)
         pass
 
@@ -134,9 +134,9 @@ class TestInitvalEvaluation:
             pm.Normal("A", initval="prior")
             pm.Uniform("B", initval="prior")
             pm.Normal("C", initval="moment")
-            ip1 = pmodel.initial_point(seed=42)
-            ip2 = pmodel.initial_point(seed=42)
-            ip3 = pmodel.initial_point(seed=15)
+            ip1 = pmodel.initial_point(random_seed=42)
+            ip2 = pmodel.initial_point(random_seed=42)
+            ip3 = pmodel.initial_point(random_seed=15)
             assert ip1 == ip2
             assert ip3 != ip2
         pass
@@ -285,7 +285,7 @@ class TestMoment:
 def test_pickling_issue_5090():
     with pm.Model() as model:
         pm.Normal("x", initval="prior")
-    ip_before = model.initial_point(seed=5090)
+    ip_before = model.initial_point(random_seed=5090)
     model = cloudpickle.loads(cloudpickle.dumps(model))
-    ip_after = model.initial_point(seed=5090)
+    ip_after = model.initial_point(random_seed=5090)
     assert ip_before["x"] == ip_after["x"]

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -573,8 +573,6 @@ def test_initial_point():
         a = pm.Uniform("a")
         x = pm.Normal("x", a)
 
-    assert all(var.name in initial_point for var in model.value_vars)
-
     b_initval = np.array(0.3, dtype=aesara.config.floatX)
 
     with pytest.warns(FutureWarning), model:

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -573,9 +573,6 @@ def test_initial_point():
         a = pm.Uniform("a")
         x = pm.Normal("x", a)
 
-    with pytest.warns(FutureWarning):
-        initial_point = model.test_point
-
     assert all(var.name in initial_point for var in model.value_vars)
 
     b_initval = np.array(0.3, dtype=aesara.config.floatX)

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -355,7 +355,7 @@ class TestValueGradFunction(unittest.TestCase):
 
         assert m["x2_missing"].type == gf._extra_vars_shared["x2_missing"].type
 
-        pnt = m.initial_point(seed=None).copy()
+        pnt = m.initial_point(random_seed=None).copy()
         del pnt["x2_missing"]
 
         res = [gf(DictToArrayBijection.map(Point(pnt, model=m))) for i in range(5)]


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Noticed some duplicated methods in the `pymc/model.py` file mentioned in [issue here](https://github.com/pymc-devs/pymc/issues/6290).
Removed the duplication and tried to improve the docstrings

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- Using keyword `seed` for initial point no longer supported

## Bugfixes / New features
- NA

## Docs / Maintenance
- More consistent seeding argument with `random_seed`
- Removed duplication function and method names throughout the package
