### PR TITLE
 Add warning if observed in DensityDist is dict

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -577,6 +577,10 @@ class DensityDist(Distribution):
 
     def __new__(cls, name, *args, **kwargs):
         kwargs.setdefault("class_name", name)
+        if "observed" in kwargs.keys() and isinstance(kwargs["observed"], dict):
+            raise TypeError(
+                "The observed parameter should be of type `pd.Series`, " "`np.array`, or `pm.Data`."
+            )
         return super().__new__(cls, name, *args, **kwargs)
 
     @classmethod

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -579,7 +579,11 @@ class DensityDist(Distribution):
         kwargs.setdefault("class_name", name)
         if isinstance(kwargs.get("observed", None), dict):
             raise TypeError(
-                "The observed parameter should be of type `pd.Series`, `np.array`, or `pm.Data`."
+                "Since ``v4.0.0`` the ``observed`` parameter should be of type"
+                " ``pd.Series``, ``np.array``, or ``pm.Data``."
+                " Previous versions allowed passing distribution parameters as"
+                " a dictionary in ``observed``, in the current version these "
+                "parameters are positional arguments."
             )
         return super().__new__(cls, name, *args, **kwargs)
 

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -577,7 +577,7 @@ class DensityDist(Distribution):
 
     def __new__(cls, name, *args, **kwargs):
         kwargs.setdefault("class_name", name)
-        if "observed" in kwargs.keys() and isinstance(kwargs["observed"], dict):
+        if isinstance(kwargs.get("observed", None), dict):
             raise TypeError(
                 "The observed parameter should be of type `pd.Series`, " "`np.array`, or `pm.Data`."
             )

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -579,7 +579,7 @@ class DensityDist(Distribution):
         kwargs.setdefault("class_name", name)
         if isinstance(kwargs.get("observed", None), dict):
             raise TypeError(
-                "The observed parameter should be of type `pd.Series`, " "`np.array`, or `pm.Data`."
+                "The observed parameter should be of type `pd.Series`, `np.array`, or `pm.Data`."
             )
         return super().__new__(cls, name, *args, **kwargs)
 

--- a/pymc/tests/distributions/test_distribution.py
+++ b/pymc/tests/distributions/test_distribution.py
@@ -145,13 +145,18 @@ class TestDensityDist:
                 random=lambda mu, rng=None, size=None: rng.normal(loc=mu, scale=1, size=size),
                 observed=np.random.randn(100, *size),
             )
-
         assert obs.eval().shape == (100,) + size
 
     def test_density_dist_with_random_invalid_observed(self):
         with pytest.raises(
             TypeError,
-            match="The observed parameter should be of type `pd.Series`, `np.array`, or `pm.Data`",
+            match=(
+                "Since ``v4.0.0`` the ``observed`` parameter should be of type"
+                " ``pd.Series``, ``np.array``, or ``pm.Data``."
+                " Previous versions allowed passing distribution parameters as"
+                " a dictionary in ``observed``, in the current version these "
+                "parameters are positional arguments."
+            ),
         ):
             size = (3,)
             with pm.Model() as model:

--- a/pymc/tests/distributions/test_distribution.py
+++ b/pymc/tests/distributions/test_distribution.py
@@ -148,6 +148,21 @@ class TestDensityDist:
 
         assert obs.eval().shape == (100,) + size
 
+    def test_density_dist_with_random_invalid_observed(self):
+        with pytest.raises(
+            TypeError,
+            match="The observed parameter should be of type `pd.Series`, `np.array`, or `pm.Data`",
+        ):
+            size = (3,)
+            with pm.Model() as model:
+                mu = pm.Normal("mu", 0, 1)
+                pm.DensityDist(
+                    "density_dist",
+                    mu,
+                    random=lambda mu, rng=None, size=None: rng.normal(loc=mu, scale=1, size=size),
+                    observed={"values": np.random.randn(100, *size)},
+                )
+
     def test_density_dist_without_random(self):
         with pm.Model() as model:
             mu = pm.Normal("mu", 0, 1)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
It adds a warning if the observed parameter is a dictionary.

**Checklist**
+ [ x] Explain important implementation details 👆
+ [ x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x ] Are the changes covered by tests and docstrings?
+ [ x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...
It solves #6032 
## Docs / Maintenance
- ...
