### PR TITLE
Improve some type hints to bump mypy pin

### DIFF
--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -38,5 +38,5 @@ dependencies:
 - watermark
 - polyagamma
 - sphinx-remove-toctrees
-- mypy
+- mypy=0.990
 - types-cachetools

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -38,5 +38,5 @@ dependencies:
 - watermark
 - polyagamma
 - sphinx-remove-toctrees
-- mypy=0.982
+- mypy
 - types-cachetools

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -27,5 +27,5 @@ dependencies:
 - pre-commit>=2.8.0
 - pytest-cov>=2.5
 - pytest>=3.0
-- mypy
+- mypy=0.990
 - types-cachetools

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -27,5 +27,5 @@ dependencies:
 - pre-commit>=2.8.0
 - pytest-cov>=2.5
 - pytest>=3.0
-- mypy=0.982
+- mypy
 - types-cachetools

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -35,5 +35,5 @@ dependencies:
 - sphinx>=1.5
 - watermark
 - sphinx-remove-toctrees
-- mypy
+- mypy=0.990
 - types-cachetools

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -35,5 +35,5 @@ dependencies:
 - sphinx>=1.5
 - watermark
 - sphinx-remove-toctrees
-- mypy=0.982
+- mypy
 - types-cachetools

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -28,5 +28,5 @@ dependencies:
 - pre-commit>=2.8.0
 - pytest-cov>=2.5
 - pytest>=3.0
-- mypy
+- mypy=0.990
 - types-cachetools

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -28,5 +28,5 @@ dependencies:
 - pre-commit>=2.8.0
 - pytest-cov>=2.5
 - pytest>=3.0
-- mypy=0.982
+- mypy
 - types-cachetools

--- a/pymc/backends/report.py
+++ b/pymc/backends/report.py
@@ -32,7 +32,7 @@ logger = logging.getLogger("pymc")
 class SamplerReport:
     """Bundle warnings, convergence stats and metadata of a sampling run."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._chain_warnings: Dict[int, List[SamplerWarning]] = {}
         self._global_warnings: List[SamplerWarning] = []
         self._n_tune = None

--- a/pymc/backends/report.py
+++ b/pymc/backends/report.py
@@ -15,7 +15,7 @@
 import dataclasses
 import logging
 
-from typing import Optional
+from typing import Dict, List, Optional
 
 import arviz
 

--- a/pymc/blocking.py
+++ b/pymc/blocking.py
@@ -17,10 +17,9 @@ pymc.blocking
 
 Classes for working with subsets of parameters.
 """
-import collections
 
 from functools import partial
-from typing import Callable, Dict, Generic, Optional, TypeVar
+from typing import Callable, Dict, Generic, NamedTuple, Optional, TypeVar
 
 import numpy as np
 
@@ -32,7 +31,9 @@ PointType = Dict[str, np.ndarray]
 
 # `point_map_info` is a tuple of tuples containing `(name, shape, dtype)` for
 # each of the raveled variables.
-RaveledVars = collections.namedtuple("RaveledVars", "data, point_map_info")
+class RaveledVars(NamedTuple):
+    data: np.ndarray
+    point_map_info: tuple[tuple[str, tuple[int, ...], np.dtype], ...]
 
 
 class Compose(Generic[T]):

--- a/pymc/blocking.py
+++ b/pymc/blocking.py
@@ -17,9 +17,10 @@ pymc.blocking
 
 Classes for working with subsets of parameters.
 """
+from __future__ import annotations
 
 from functools import partial
-from typing import Callable, Dict, Generic, NamedTuple, Optional, TypeVar
+from typing import Callable, Dict, Generic, NamedTuple, TypeVar
 
 import numpy as np
 
@@ -70,7 +71,7 @@ class DictToArrayBijection:
     @staticmethod
     def rmap(
         array: RaveledVars,
-        start_point: Optional[PointType] = None,
+        start_point: PointType | None = None,
     ) -> PointType:
         """Map 1D concatenated array to a dictionary of variables in their original spaces.
 
@@ -101,7 +102,7 @@ class DictToArrayBijection:
 
     @classmethod
     def mapf(
-        cls, f: Callable[[PointType], T], start_point: Optional[PointType] = None
+        cls, f: Callable[[PointType], T], start_point: PointType | None = None
     ) -> Callable[[RaveledVars], T]:
         """Create a callable that first maps back to ``dict`` inputs and then applies a function.
 

--- a/pymc/gp/util.py
+++ b/pymc/gp/util.py
@@ -31,7 +31,7 @@ from pymc.aesaraf import compile_pymc, walk_model
 # Avoid circular dependency when importing modelcontext
 from pymc.distributions.distribution import Distribution
 
-assert Distribution  # keep both pylint and black happy
+_ = Distribution  # keep both pylint and black happy
 from pymc.model import modelcontext
 
 JITTER_DEFAULT = 1e-6

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -16,8 +16,7 @@ import logging
 import time
 
 from abc import abstractmethod
-from collections import namedtuple
-from typing import Optional
+from typing import Any, NamedTuple, Optional
 
 import numpy as np
 
@@ -29,20 +28,32 @@ from pymc.stats.convergence import SamplerWarning, WarningType
 from pymc.step_methods import step_sizes
 from pymc.step_methods.arraystep import GradientSharedStep
 from pymc.step_methods.hmc import integration
+from pymc.step_methods.hmc.integration import IntegrationError, State
 from pymc.step_methods.hmc.quadpotential import QuadPotentialDiagAdapt, quad_potential
 from pymc.tuning import guess_scaling
 from pymc.util import get_value_vars_from_user_vars
 
 logger = logging.getLogger("pymc")
 
-HMCStepData = namedtuple("HMCStepData", "end, accept_stat, divergence_info, stats")
 
-DivergenceInfo = namedtuple("DivergenceInfo", "message, exec_info, state, state_div")
+class DivergenceInfo(NamedTuple):
+    message: str
+    exec_info: IntegrationError | None
+    state: State
+    state_div: State | None
+
+
+class HMCStepData(NamedTuple):
+    end: State
+    accept_stat: int
+    divergence_info: DivergenceInfo | None
+    stats: dict[str, Any]
 
 
 class BaseHMC(GradientSharedStep):
     """Superclass to implement Hamiltonian/hybrid monte carlo."""
 
+    integrator: integration.CpuLeapfrogIntegrator
     default_blocked = True
 
     def __init__(
@@ -138,13 +149,13 @@ class BaseHMC(GradientSharedStep):
         self._num_divs_sample = 0
 
     @abstractmethod
-    def _hamiltonian_step(self, start, p0, step_size):
+    def _hamiltonian_step(self, start, p0, step_size) -> HMCStepData:
         """Compute one Hamiltonian trajectory and return the next state.
 
         Subclasses must overwrite this abstract method and return an `HMCStepData` object.
         """
 
-    def astep(self, q0):
+    def astep(self, q0: RaveledVars) -> tuple[RaveledVars, list[dict[str, Any]]]:
         """Perform a single HMC iteration."""
         perf_start = time.perf_counter()
         process_start = time.process_time()
@@ -154,6 +165,7 @@ class BaseHMC(GradientSharedStep):
 
         start = self.integrator.compute_state(q0, p0)
 
+        warning: Optional[SamplerWarning] = None
         if not np.isfinite(start.energy):
             model = self._model
             check_test_point_dict = model.point_logps()
@@ -188,7 +200,6 @@ class BaseHMC(GradientSharedStep):
 
         self.step_adapt.update(hmc_step.accept_stat, adapt_step)
         self.potential.update(hmc_step.end.q, hmc_step.end.q_grad, self.tune)
-        warning: Optional[SamplerWarning] = None
         if hmc_step.divergence_info:
             info = hmc_step.divergence_info
             point = None
@@ -221,7 +232,7 @@ class BaseHMC(GradientSharedStep):
 
         self.iter_count += 1
 
-        stats = {
+        stats: dict[str, Any] = {
             "tune": self.tune,
             "diverging": bool(hmc_step.divergence_info),
             "perf_counter_diff": perf_end - perf_start,

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -12,11 +12,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from __future__ import annotations
+
 import logging
 import time
 
 from abc import abstractmethod
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 
 import numpy as np
 
@@ -165,7 +167,7 @@ class BaseHMC(GradientSharedStep):
 
         start = self.integrator.compute_state(q0, p0)
 
-        warning: Optional[SamplerWarning] = None
+        warning: SamplerWarning | None = None
         if not np.isfinite(start.energy):
             model = self._model
             check_test_point_dict = model.point_logps()

--- a/pymc/step_methods/hmc/hmc.py
+++ b/pymc/step_methods/hmc/hmc.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any
 
 import numpy as np

--- a/pymc/step_methods/hmc/hmc.py
+++ b/pymc/step_methods/hmc/hmc.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from typing import Any
+
 import numpy as np
 
 from pymc.stats.convergence import SamplerWarning
@@ -119,7 +121,7 @@ class HamiltonianMC(BaseHMC):
         self.path_length = path_length
         self.max_steps = max_steps
 
-    def _hamiltonian_step(self, start, p0, step_size):
+    def _hamiltonian_step(self, start, p0, step_size: float) -> HMCStepData:
         n_steps = max(1, int(self.path_length / step_size))
         n_steps = min(self.max_steps, n_steps)
 
@@ -156,7 +158,7 @@ class HamiltonianMC(BaseHMC):
             end = state
             accepted = True
 
-        stats = {
+        stats: dict[str, Any] = {
             "path_length": self.path_length,
             "n_steps": n_steps,
             "accept": accept_stat,

--- a/pymc/step_methods/hmc/integration.py
+++ b/pymc/step_methods/hmc/integration.py
@@ -26,9 +26,9 @@ class State(NamedTuple):
     q: RaveledVars
     p: RaveledVars
     v: np.ndarray
-    q_grad: Any
-    energy: Any
-    model_logp: Any
+    q_grad: np.ndarray
+    energy: float
+    model_logp: float
     index_in_trajectory: int
 
 

--- a/pymc/step_methods/hmc/integration.py
+++ b/pymc/step_methods/hmc/integration.py
@@ -12,15 +12,24 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from collections import namedtuple
+from typing import Any, NamedTuple
 
 import numpy as np
 
 from scipy import linalg
 
 from pymc.blocking import RaveledVars
+from pymc.step_methods.hmc.quadpotential import QuadPotential
 
-State = namedtuple("State", "q, p, v, q_grad, energy, model_logp, index_in_trajectory")
+
+class State(NamedTuple):
+    q: RaveledVars
+    p: RaveledVars
+    v: np.ndarray
+    q_grad: Any
+    energy: Any
+    model_logp: Any
+    index_in_trajectory: int
 
 
 class IntegrationError(RuntimeError):
@@ -28,7 +37,7 @@ class IntegrationError(RuntimeError):
 
 
 class CpuLeapfrogIntegrator:
-    def __init__(self, potential, logp_dlogp_func):
+    def __init__(self, potential: QuadPotential, logp_dlogp_func):
         """Leapfrog integrator using CPU."""
         self._potential = potential
         self._logp_dlogp_func = logp_dlogp_func
@@ -39,14 +48,14 @@ class CpuLeapfrogIntegrator:
                 "don't match." % (self._potential.dtype, self._dtype)
             )
 
-    def compute_state(self, q, p):
+    def compute_state(self, q: RaveledVars, p: RaveledVars):
         """Compute Hamiltonian functions using a position and momentum."""
         if q.data.dtype != self._dtype or p.data.dtype != self._dtype:
             raise ValueError("Invalid dtype. Must be %s" % self._dtype)
 
         logp, dlogp = self._logp_dlogp_func(q)
 
-        v = self._potential.velocity(p.data)
+        v = self._potential.velocity(p.data, out=None)
         kinetic = self._potential.energy(p.data, velocity=v)
         energy = kinetic - logp
         return State(q, p, v, dlogp, energy, logp, 0)

--- a/pymc/step_methods/hmc/integration.py
+++ b/pymc/step_methods/hmc/integration.py
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from typing import Any, NamedTuple
+from typing import NamedTuple
 
 import numpy as np
 

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -232,7 +232,7 @@ Subtree = namedtuple(
 class _Tree:
     def __init__(
         self,
-        ndim,
+        ndim: int,
         integrator: integration.CpuLeapfrogIntegrator,
         start: State,
         step_size: float,

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -257,7 +257,7 @@ class _Tree:
         self.start = start
         self.step_size = step_size
         self.Emax = Emax
-        self.start_energy = np.array(start.energy)
+        self.start_energy = start.energy
 
         self.left = self.right = start
         self.proposal = Proposal(start.q.data, start.q_grad, start.energy, start.model_logp, 0)

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from __future__ import annotations
+
 from collections import namedtuple
 
 import numpy as np

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -262,12 +262,12 @@ class _Tree:
         self.left = self.right = start
         self.proposal = Proposal(start.q.data, start.q_grad, start.energy, start.model_logp, 0)
         self.depth = 0
-        self.log_size = 0
+        self.log_size = 0.0
         self.log_accept_sum = -np.inf
         self.mean_tree_accept = 0.0
         self.n_proposals = 0
         self.p_sum = start.p.data.copy()
-        self.max_energy_change = 0
+        self.max_energy_change = 0.0
 
     def extend(self, direction):
         """Double the treesize by extending the tree in the given direction.

--- a/pymc/step_methods/hmc/quadpotential.py
+++ b/pymc/step_methods/hmc/quadpotential.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from __future__ import annotations
+
 import warnings
 
 from typing import overload

--- a/pymc/step_methods/hmc/quadpotential.py
+++ b/pymc/step_methods/hmc/quadpotential.py
@@ -14,6 +14,8 @@
 
 import warnings
 
+from typing import overload
+
 import aesara
 import numpy as np
 import scipy.linalg
@@ -94,7 +96,17 @@ class PositiveDefiniteError(ValueError):
 
 
 class QuadPotential:
-    def velocity(self, x, out=None):
+    dtype: np.dtype
+
+    @overload
+    def velocity(self, x: np.ndarray, out: None) -> np.ndarray:
+        ...
+
+    @overload
+    def velocity(self, x: np.ndarray, out: np.ndarray) -> None:
+        ...
+
+    def velocity(self, x: np.ndarray, out: np.ndarray | None = None) -> np.ndarray | None:
         """Compute the current velocity at a position in parameter space."""
         raise NotImplementedError("Abstract method")
 

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -74,7 +74,7 @@ class CheckParametersConvergence(Callback):
         self.prev = None
         self.tolerance = tolerance
 
-    def __call__(self, approx, _, i):
+    def __call__(self, approx, _, i) -> None:
         if self.prev is None:
             self.prev = self.flatten_shared(approx.params)
             return

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -14,6 +14,8 @@
 
 import collections
 
+from typing import Callable, Dict
+
 import numpy as np
 
 __all__ = ["Callback", "CheckParametersConvergence", "Tracker"]
@@ -24,15 +26,19 @@ class Callback:
         raise NotImplementedError
 
 
-def relative(current, prev, eps=1e-6):
-    return (np.abs(current - prev) + eps) / (np.abs(prev) + eps)
+def relative(current: np.ndarray, prev: np.ndarray, eps=1e-6) -> np.ndarray:
+    diff = current - prev  # type: ignore
+    return (np.abs(diff) + eps) / (np.abs(prev) + eps)
 
 
-def absolute(current, prev):
-    return np.abs(current - prev)
+def absolute(current: np.ndarray, prev: np.ndarray) -> np.ndarray:
+    diff = current - prev  # type: ignore
+    return np.abs(diff)
 
 
-_diff = dict(relative=relative, absolute=absolute)
+_diff: Dict[str, Callable[[np.ndarray, np.ndarray], np.ndarray]] = dict(
+    relative=relative, absolute=absolute
+)
 
 
 class CheckParametersConvergence(Callback):
@@ -76,7 +82,7 @@ class CheckParametersConvergence(Callback):
             return
         current = self.flatten_shared(approx.params)
         prev = self.prev
-        delta = self._diff(current, prev)  # type: np.ndarray
+        delta: np.ndarray = self._diff(current, prev)
         self.prev = current
         norm = np.linalg.norm(delta, self.ord)
         if norm < self.tolerance:

--- a/pymc/variational/operators.py
+++ b/pymc/variational/operators.py
@@ -77,7 +77,7 @@ class KSDObjective(ObjectiveFunction):
 
     @aesara.config.change_flags(compute_test_value="off")
     def __call__(self, nmc, **kwargs):
-        op = self.op  # type: KSD
+        op: KSD = self.op
         grad = op.apply(self.tf)
         if self.approx.all_histograms:
             z = self.approx.joint_histogram

--- a/pymc/variational/operators.py
+++ b/pymc/variational/operators.py
@@ -11,9 +11,11 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import annotations
+
 import aesara
 
-from aesara import tensor as at
+from aesara.graph.basic import Variable
 
 import pymc as pm
 
@@ -70,13 +72,15 @@ class KSDObjective(ObjectiveFunction):
         OPVI TestFunction
     """
 
-    def __init__(self, op, tf):
+    op: KSD
+
+    def __init__(self, op: KSD, tf: opvi.TestFunction):
         if not isinstance(op, KSD):
             raise opvi.ParametrizationError("Op should be KSD")
         super().__init__(op, tf)
 
     @aesara.config.change_flags(compute_test_value="off")
-    def __call__(self, nmc, **kwargs):
+    def __call__(self, nmc, **kwargs) -> list[Variable]:
         op: KSD = self.op
         grad = op.apply(self.tf)
         if self.approx.all_histograms:
@@ -88,7 +92,7 @@ class KSDObjective(ObjectiveFunction):
         else:
             params = self.test_params + kwargs["more_tf_params"]
             grad *= pm.floatX(-1)
-        grads = at.grad(None, params, known_grads={z: grad})
+        grads = aesara.grad(None, params, known_grads={z: grad})
         return self.approx.set_size_and_deterministic(
             grads, nmc, 0, kwargs.get("more_replacements")
         )

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -45,6 +45,8 @@ References
     https://arxiv.org/abs/1610.09033 (2016)
 """
 
+from __future__ import annotations
+
 import collections
 import itertools
 import warnings
@@ -181,7 +183,7 @@ class ObjectiveFunction:
         OPVI TestFunction
     """
 
-    def __init__(self, op, tf):
+    def __init__(self, op: Operator, tf: TestFunction):
         self.op = op
         self.tf = tf
 
@@ -962,7 +964,9 @@ class Group(WithMemoization):
         raise NotImplementedError
 
     @aesara.config.change_flags(compute_test_value="off")
-    def set_size_and_deterministic(self, node, s, d, more_replacements=None):
+    def set_size_and_deterministic(
+        self, node: Variable, s, d: bool, more_replacements: dict | None = None
+    ) -> list[Variable]:
         """*Dev* - after node is sampled via :func:`symbolic_sample_over_posterior` or
         :func:`symbolic_single_sample` new random generator can be allocated and applied to node
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ fastprogress>=0.2.0
 h5py>=2.7
 ipython>=7.16
 jupyter-sphinx
-mypy
+mypy==0.990
 myst-nb
 numpy>=1.15.0
 numpydoc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ fastprogress>=0.2.0
 h5py>=2.7
 ipython>=7.16
 jupyter-sphinx
-mypy==0.982
+mypy
 myst-nb
 numpy>=1.15.0
 numpydoc


### PR DESCRIPTION
Closes #6282

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**

As explained in #6282, we were failing with the latest version of mypy for the pre-commit check, so we pinned to an older version of mypy where we were passing. This is my attempt to fix enough type issues so that we can unpin mypy and close #6282.

* Please feel free to commit directly to my branch. (I don't have much more time to put into this right now.)
* I'd be happy to unpin `mypy=0.982` in a separate PR, have all my commits squashed, or for me to squash all the typing commits (leaving two commits: "improve type hints" and "unpin mypy")

I put in some medium effort to infer the correct types (but without a debugger), and probably I have a few incorrect types which should ideally be corrected. In the process of trying to infer types, I recursed in various places while adding type hints along the way. Thus this PR isn't minimal for closing #6282, and there are also files where I have updated some annotations without updating other similar annotations.

I'd like to think that things are better than they were before, and this is just about type hints which should be irrelevant at runtime, so probably this doesn't require an extremely thorough review. Nevertheless, here are several technical details to explain what I'm thinking:

* The most mysterious new errors ("notes") are:
    ```
    pymc/backends/report.py:36: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
    ```
    They generally seem to point to some seemingly random line inside of a function body. Adding a return type hint to the function declaration seems to resolve the error. ([Example](https://github.com/pymc-devs/pymc/blob/363b4c8e90710047979e2455cc7c6879c1710297/pymc/backends/report.py#L35): add ` -> None`.)
* Type hints are much nicer after `from __future__ import annotations`, but I have noticed that there are currently no such imports in `main`. Is there any particular reason for this? (Just in case, I installed Python 3.8.0 and was successfully able to import all the relevant modules, so it seems to me like it should be fine.)
* Using `collections.namedtuple` is out-of-favor. It's preferable to define named tuples as classes inheriting from `typing.NamedTuple`, and then type annotations are provided with a nice syntax.
* Importing `__future__.annotations` allows for replacing `Optional[SomeType]` with `SomeType | None` and `List[SomeType]` with `list[SomeType]`, and indeed pyupgrade enforces this as soon as `__future__.annotations` is imported.
* I don't understand why pylint was still complaining about an unused import after I added `# pylint: disable=unused-import`. But then mypy began complaining about the assertion `assert Distribution` which was meant to "use" the import. Thus I replaced the assert with a null assignment `_ = Distribution` to achieve the same effect without the warning.
* I gave up on [these lines](https://github.com/pymc-devs/pymc/blob/363b4c8e90710047979e2455cc7c6879c1710297/pymc/step_methods/hmc/integration.py#L29-L31) while trying to infer types for the named tuple `State`, so I sloppily set these types to `Any` so that I didn't have to deal with them. I'm also not very confident about `q`, `p`, and `v`, as I'm not so sure when what should be a `RaveledVars`, a numpy array, an Aesara tensor, or potentially unions of these. Any insights @aseyboldt?
* The `integrator` attribute for `_Tree` has type `integration.CpuLeapfrogIntegrator`, since it seems to be the only available implementation of an integrator, and there doesn't yet seem to exist an abstract `Integrator` class.
* For velocity I added two `@overload`s. Note that `@overload`s are type annotations and not real definitions. They are telling type checkers that when the parameter `out` is `None`, then `velocity` returns a numpy array, and when `out` is a numpy array, then `velocity` returns `None`. What doesn't seem to work is type inference from PyRight in VS Code based on the default parameter value `out=None`, presumably because this default may be overridden in implementing subclasses. Thus when calling `velocity()` I set `out=None` [explicitly](https://github.com/pymc-devs/pymc/blob/363b4c8e90710047979e2455cc7c6879c1710297/pymc/step_methods/hmc/integration.py#L58), so that VS Code infers the right types.


**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- ...

## Docs / Maintenance
- Improve type hints
- Unpin mypy
