### PR TITLE
Model API cleanup

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -215,12 +215,11 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
         }
 
         self.dims = {} if dims is None else dims
-        if hasattr(self.model, "RV_dims"):
-            model_dims = {
-                var_name: [dim for dim in dims if dim is not None]
-                for var_name, dims in self.model.RV_dims.items()
-            }
-            self.dims = {**model_dims, **self.dims}
+        model_dims = {
+            var_name: [dim for dim in dims if dim is not None]
+            for var_name, dims in self.model.named_vars_to_dims.items()
+        }
+        self.dims = {**model_dims, **self.dims}
         if sample_dims is None:
             sample_dims = ["chain", "draw"]
         self.sample_dims = sample_dims

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -718,6 +718,6 @@ def Data(
                     length=xshape[d],
                 )
 
-    model.add_random_variable(x, dims=dims)
+    model.add_named_variable(x, dims=dims)
 
     return x

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -52,29 +52,11 @@ def convert_str_to_rv_dict(
     return initvals
 
 
-def filter_rvs_to_jitter(step) -> Set[TensorVariable]:
-    """Find the set of RVs for which the responsible step methods ask for
-    the addition of jitter to the initial point.
-
-    Parameters
-    ----------
-    step : BlockedStep or CompoundStep
-        One or many step methods that were assigned model variables.
-
-    Returns
-    -------
-    rvs_to_jitter : set
-        The random variables for which jitter should be added.
-    """
-    # TODO: implement this
-    return set()
-
-
 def make_initial_point_fns_per_chain(
     *,
     model,
     overrides: Optional[Union[StartDict, Sequence[Optional[StartDict]]]],
-    jitter_rvs: Set[TensorVariable],
+    jitter_rvs: Optional[Set[TensorVariable]] = None,
     chains: int,
 ) -> List[Callable]:
     """Create an initial point function for each chain, as defined by initvals
@@ -87,7 +69,7 @@ def make_initial_point_fns_per_chain(
     overrides : optional, list or dict
         Initial value strategy overrides that should take precedence over the defaults from the model.
         A sequence of None or dicts will be treated as chain-wise strategies and must have the same length as `seeds`.
-    jitter_rvs : set
+    jitter_rvs : set, optional
         Random variable tensors for which U(-1, 1) jitter shall be applied.
         (To the transformed space if applicable.)
 

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -133,7 +133,7 @@ def make_initial_point_fn(
 
     sdict_overrides = convert_str_to_rv_dict(model, overrides or {})
     initval_strats = {
-        **model.initial_values,
+        **model.rvs_to_initial_values,
         **sdict_overrides,
     }
 

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -550,8 +550,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
         self.name = self._validate_name(name)
         self.check_bounds = check_bounds
 
-        self._initial_values: Dict[TensorVariable, Optional[Union[np.ndarray, Variable, str]]] = {}
-
         if self.parent is not None:
             self.named_vars = treedict(parent=self.parent.named_vars)
             self.named_vars_to_dims = treedict(parent=self.parent.named_vars_to_dims)
@@ -559,6 +557,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             self.rvs_to_values = treedict(parent=self.parent.rvs_to_values)
             self.rvs_to_transforms = treedict(parent=self.parent.rvs_to_transforms)
             self.rvs_to_total_sizes = treedict(parent=self.parent.rvs_to_total_sizes)
+            self.rvs_to_initial_values = treedict(parent=self.parent.rvs_to_initial_values)
             self.free_RVs = treelist(parent=self.parent.free_RVs)
             self.observed_RVs = treelist(parent=self.parent.observed_RVs)
             self.auto_deterministics = treelist(parent=self.parent.auto_deterministics)
@@ -573,6 +572,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             self.rvs_to_values = treedict()
             self.rvs_to_transforms = treedict()
             self.rvs_to_total_sizes = treedict()
+            self.rvs_to_initial_values = treedict()
             self.free_RVs = treelist()
             self.observed_RVs = treelist()
             self.auto_deterministics = treelist()
@@ -1128,7 +1128,10 @@ class Model(WithMemoization, metaclass=ContextMeta):
         Keys are the random variables (as returned by e.g. ``pm.Uniform()``) and
         values are the numeric/symbolic initial values, strings denoting the strategy to get them, or None.
         """
-        return self._initial_values
+        warnings.warn(
+            "Model.initial_values is deprecated. Use Model.rvs_to_initial_values instead."
+        )
+        return self.rvs_to_initial_values
 
     def set_initval(self, rv_var, initval):
         """Sets an initial value (strategy) for a random variable."""
@@ -1136,7 +1139,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             # Convert scalars or array-like inputs to ndarrays
             initval = rv_var.type.filter(initval)
 
-        self.initial_values[rv_var] = initval
+        self.rvs_to_initial_values[rv_var] = initval
 
     def set_data(
         self,

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -200,10 +200,10 @@ class ModelGraph:
 
         for var_name in self.vars_to_plot(var_names):
             v = self.model[var_name]
-            if var_name in self.model.RV_dims:
+            if var_name in self.model.named_vars_to_dims:
                 plate_label = " x ".join(
                     f"{d} ({self._eval(self.model.dim_lengths[d])})"
-                    for d in self.model.RV_dims[var_name]
+                    for d in self.model.named_vars_to_dims[var_name]
                 )
             else:
                 plate_label = " x ".join(map(str, self._eval(v.shape)))

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -371,11 +371,10 @@ def sample_prior_predictive(
         )
 
     if var_names is None:
-        prior_pred_vars = model.observed_RVs + model.auto_deterministics
-        prior_vars = (
-            get_default_varnames(model.unobserved_RVs, include_transformed=True) + model.potentials
-        )
-        vars_: Set[str] = {var.name for var in prior_vars + prior_pred_vars}
+        vars_: Set[str] = {
+            var.name
+            for var in model.basic_RVs + model.deterministics + model.auto_deterministics
+        }
     else:
         vars_ = set(var_names)
 

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -343,13 +343,10 @@ def sample_blackjax_nuts(
         if cvals is not None
     }
 
-    if hasattr(model, "RV_dims"):
-        dims = {
-            var_name: [dim for dim in dims if dim is not None]
-            for var_name, dims in model.RV_dims.items()
-        }
-    else:
-        dims = {}
+    dims = {
+        var_name: [dim for dim in dims if dim is not None]
+        for var_name, dims in model.named_vars_to_dims.items()
+    }
 
     (random_seed,) = _get_seeds_per_chain(random_seed, 1)
 
@@ -559,13 +556,10 @@ def sample_numpyro_nuts(
         if cvals is not None
     }
 
-    if hasattr(model, "RV_dims"):
-        dims = {
-            var_name: [dim for dim in dims if dim is not None]
-            for var_name, dims in model.RV_dims.items()
-        }
-    else:
-        dims = {}
+    dims = {
+        var_name: [dim for dim in dims if dim is not None]
+        for var_name, dims in model.named_vars_to_dims.items()
+    }
 
     (random_seed,) = _get_seeds_per_chain(random_seed, 1)
 

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -37,12 +37,7 @@ from pymc.backends import _init_trace
 from pymc.backends.base import BaseTrace, MultiTrace, _choose_chains
 from pymc.blocking import DictToArrayBijection
 from pymc.exceptions import SamplingError
-from pymc.initial_point import (
-    PointType,
-    StartDict,
-    filter_rvs_to_jitter,
-    make_initial_point_fns_per_chain,
-)
+from pymc.initial_point import PointType, StartDict, make_initial_point_fns_per_chain
 from pymc.model import Model, modelcontext
 from pymc.sampling.parallel import Draw, _cpu_count
 from pymc.sampling.population import _sample_population
@@ -476,7 +471,7 @@ def sample(
         ipfns = make_initial_point_fns_per_chain(
             model=model,
             overrides=initvals,
-            jitter_rvs=filter_rvs_to_jitter(step),
+            jitter_rvs=set(),
             chains=chains,
         )
         initial_points = [ipfn(seed) for ipfn, seed in zip(ipfns, random_seed_list)]

--- a/pymc/tests/distributions/test_continuous.py
+++ b/pymc/tests/distributions/test_continuous.py
@@ -70,7 +70,6 @@ except ImportError:  # pragma: no cover
 
 class TestBoundedContinuous:
     def get_dist_params_and_interval_bounds(self, model, rv_name):
-        interval_rv = model.named_vars[f"{rv_name}_interval__"]
         rv = model.named_vars[rv_name]
         dist_params = rv.owner.inputs
         lower_interval, upper_interval = model.rvs_to_transforms[rv].args_fn(*rv.owner.inputs)

--- a/pymc/tests/distributions/test_shape_utils.py
+++ b/pymc/tests/distributions/test_shape_utils.py
@@ -288,7 +288,7 @@ class TestSizeShapeDimsObserved:
             # The shape and dims tuples correspond to each other.
             # Note: No checks are performed that implied shape (x), shape and dims actually match.
             y = pm.Normal("y", mu=x, shape=(2, 3), dims=("dshape", "ddata"))
-            assert pmodel.RV_dims["y"] == ("dshape", "ddata")
+            assert pmodel.named_vars_to_dims["y"] == ("dshape", "ddata")
 
             assert "dshape" in pmodel.dim_lengths
             assert y.eval().shape == (2, 3)
@@ -301,7 +301,7 @@ class TestSizeShapeDimsObserved:
             # Size does not include support dims, so this test must use a dist with support dims.
             kwargs = dict(name="y", size=(2, 3), mu=at.ones((3, 4)), cov=at.eye(4))
             y = pm.MvNormal(**kwargs, dims=("dsize", "ddata", "dsupport"))
-            assert pmodel.RV_dims["y"] == ("dsize", "ddata", "dsupport")
+            assert pmodel.named_vars_to_dims["y"] == ("dsize", "ddata", "dsupport")
 
             assert "dsize" in pmodel.dim_lengths
             assert y.eval().shape == (2, 3, 4)
@@ -313,7 +313,7 @@ class TestSizeShapeDimsObserved:
 
             # Note: No checks are performed that observed and dims actually match.
             y = pm.Normal("y", observed=[0, 0, 0], dims="ddata")
-            assert pmodel.RV_dims["y"] == ("ddata",)
+            assert pmodel.named_vars_to_dims["y"] == ("ddata",)
             assert y.eval().shape == (3,)
 
     def test_define_dims_on_the_fly_raises(self):

--- a/pymc/tests/sampling/test_jax.py
+++ b/pymc/tests/sampling/test_jax.py
@@ -235,7 +235,7 @@ def test_idata_kwargs(
 
     posterior = idata.get("posterior")
     assert posterior is not None
-    x_dim_expected = idata_kwargs.get("dims", model_test_idata_kwargs.RV_dims)["x"][0]
+    x_dim_expected = idata_kwargs.get("dims", model_test_idata_kwargs.named_vars_to_dims)["x"][0]
     assert x_dim_expected is not None
     assert posterior["x"].dims[-1] == x_dim_expected
 

--- a/pymc/tests/test_data.py
+++ b/pymc/tests/test_data.py
@@ -331,7 +331,7 @@ class TestData(SeededTest):
         assert pmodel.dim_lengths["rows"].eval() == 5
         assert "columns" in pmodel.coords
         assert pmodel.coords["columns"] == ("C1", "C2", "C3", "C4", "C5", "C6", "C7")
-        assert pmodel.RV_dims == {"observations": ("rows", "columns")}
+        assert pmodel.named_vars_to_dims == {"observations": ("rows", "columns")}
         assert "columns" in pmodel.dim_lengths
         assert pmodel.dim_lengths["columns"].eval() == 7
 
@@ -382,7 +382,7 @@ class TestData(SeededTest):
 
         assert "date" in pmodel.coords
         assert len(pmodel.coords["date"]) == 22
-        assert pmodel.RV_dims == {"sales": ("date",)}
+        assert pmodel.named_vars_to_dims == {"sales": ("date",)}
 
     def test_implicit_coords_dataframe(self):
         pd = pytest.importorskip("pandas")
@@ -402,7 +402,7 @@ class TestData(SeededTest):
 
         assert "rows" in pmodel.coords
         assert "columns" in pmodel.coords
-        assert pmodel.RV_dims == {"observations": ("rows", "columns")}
+        assert pmodel.named_vars_to_dims == {"observations": ("rows", "columns")}
 
     def test_data_kwargs(self):
         strict_value = True

--- a/pymc/tests/test_initial_point.py
+++ b/pymc/tests/test_initial_point.py
@@ -86,7 +86,7 @@ class TestInitvalEvaluation:
             assert ip["B2_interval__"] == 0
 
             # Modify initval of L and re-evaluate
-            pmodel.initial_values[U] = 9.9
+            pmodel.rvs_to_initial_values[U] = 9.9
             ip = pmodel.initial_point(random_seed=0)
             assert ip["B1_interval__"] < 0
             assert ip["B2_interval__"] == 0
@@ -108,7 +108,7 @@ class TestInitvalEvaluation:
         ip_vals = list(make_initial_point_fn(model=pmodel, return_transformed=False)(0).values())
         assert np.allclose(ip_vals, [1, 2, 4, 8, 16, 32], rtol=1e-3)
 
-        pmodel.initial_values[four] = 1
+        pmodel.rvs_to_initial_values[four] = 1
 
         ip_vals = list(make_initial_point_fn(model=pmodel, return_transformed=True)(0).values())
         assert np.allclose(np.exp(ip_vals), [1, 2, 4, 1, 2, 4], rtol=1e-3)

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -1206,9 +1206,8 @@ class TestImputationMissingData:
             with pytest.warns(ImputationWarning):
                 theta2 = pm.Normal("theta2", mu=theta1, observed=obs2, rng=rng)
 
-            assert "theta1_observed" in model.named_vars
-            assert "theta1_missing_interval__" in model.named_vars
-            assert model.rvs_to_transforms[model.named_vars["theta1_observed"]] is None
+            assert isinstance(model.rvs_to_transforms[model["theta1_missing"]], IntervalTransform)
+            assert model.rvs_to_transforms[model["theta1_observed"]] is None
 
             prior_trace = pm.sample_prior_predictive(return_inferencedata=False)
 

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -726,7 +726,7 @@ def test_nested_model_coords():
         e = pm.Normal("e", a[None] + d[:, None], dims=("dim2", "dim1"))
     assert m1.coords is m2.coords
     assert m1.dim_lengths is m2.dim_lengths
-    assert set(m2.RV_dims) < set(m1.RV_dims)
+    assert set(m2.named_vars_to_dims) < set(m1.named_vars_to_dims)
 
 
 def test_shapeerror_from_set_data_dimensionality():
@@ -1378,7 +1378,7 @@ class TestImputationMissingData:
         with pm.Model(coords={"observed": range(10)}) as model:
             with pytest.warns(ImputationWarning):
                 x = pm.Normal("x", observed=data, dims=("observed",))
-        assert model.RV_dims == {"x": ("observed",)}
+        assert model.named_vars_to_dims == {"x": ("observed",)}
 
     def test_error_non_random_variable(self):
         data = np.array([np.nan] * 3 + [0] * 7)

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -586,11 +586,11 @@ def test_initial_point():
     with model:
         y = pm.Normal("y", initval=y_initval)
 
-    assert a in model.initial_values
-    assert x in model.initial_values
-    assert model.initial_values[b] == b_initval
+    assert a in model.rvs_to_initial_values
+    assert x in model.rvs_to_initial_values
+    assert model.rvs_to_initial_values[b] == b_initval
     assert model.initial_point(0)["b_interval__"] == b_initval_trans
-    assert model.initial_values[y] == y_initval
+    assert model.rvs_to_initial_values[y] == y_initval
 
 
 def test_point_logps():

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -1445,7 +1445,7 @@ def test_tag_future_warning_model():
         assert y is not x
         assert y.tag is not x.tag
         assert isinstance(y.tag, _FutureWarningValidatingScratchpad)
-        y = model.register_rv(y, name="y", data=5)
+        y = model.register_rv(y, name="y", observed=5)
         assert isinstance(y.tag, _FutureWarningValidatingScratchpad)
 
         # Test expected warnings

--- a/pymc/tests/test_model_graph.py
+++ b/pymc/tests/test_model_graph.py
@@ -247,7 +247,7 @@ def model_non_random_variable_rvs():
 
         z_raw = pm.Normal.dist(y, shape=(5,))
         z = pm.math.clip(z_raw, -1, 1)
-        model.register_rv(z, name="z", data=[0] * 5)
+        model.register_rv(z, name="z", observed=[0] * 5)
 
     compute_graph = {
         "mu": set(),

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -120,7 +120,7 @@ class treedict(dict):
     update = withparent(dict.update)
 
     def tree_contains(self, item):
-        # needed for `add_random_variable` method
+        # needed for `add_named_variable` method
         if isinstance(self.parent, treedict):
             return dict.__contains__(self, item) or self.parent.tree_contains(item)
         elif isinstance(self.parent, dict):


### PR DESCRIPTION
Trying to standardize mapping names a bit more to facilitate model transformations such as in https://github.com/pymc-devs/pymcx/pull/91

Closes #6305 
Closes #5076


## Major / Breaking Changes
- Sampling of transformed variables from `prior_predictive` is no longer allowed

## Bugfixes / New features
- ...

## Docs / Maintenance
- Rename several internal `Model` variables
