### PR TITLE
Require all step methods to return stats

### DIFF
--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -35,7 +35,7 @@ import scipy.sparse as sps
 from aeppl.logprob import CheckParameterValue
 from aeppl.transforms import RVTransform
 from aesara import scalar
-from aesara.compile.mode import Mode, get_mode
+from aesara.compile import Function, Mode, get_mode
 from aesara.gradient import grad
 from aesara.graph import node_rewriter, rewrite_graph
 from aesara.graph.basic import (
@@ -1044,7 +1044,7 @@ def compile_pymc(
     random_seed: SeedSequenceSeed = None,
     mode=None,
     **kwargs,
-) -> Callable[..., Union[np.ndarray, List[np.ndarray]]]:
+) -> Function:
     """Use ``aesara.function`` with specialized pymc rewrites always enabled.
 
     This function also ensures shared RandomState/Generator used by RandomVariables

--- a/pymc/blocking.py
+++ b/pymc/blocking.py
@@ -20,15 +20,18 @@ Classes for working with subsets of parameters.
 from __future__ import annotations
 
 from functools import partial
-from typing import Callable, Dict, Generic, NamedTuple, TypeVar
+from typing import Any, Callable, Dict, Generic, List, NamedTuple, TypeVar
 
 import numpy as np
+
+from typing_extensions import TypeAlias
 
 __all__ = ["DictToArrayBijection"]
 
 
 T = TypeVar("T")
-PointType = Dict[str, np.ndarray]
+PointType: TypeAlias = Dict[str, np.ndarray]
+StatsType: TypeAlias = List[Dict[str, Any]]
 
 # `point_map_info` is a tuple of tuples containing `(name, shape, dtype)` for
 # each of the raveled variables.

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -912,14 +912,10 @@ def _iter_sample(
                 step.iter_count = 0
             if i == tune:
                 step.stop_tuning()
-            if step.generates_stats:
-                point, stats = step.step(point)
-                strace.record(point, stats)
-                log_warning_stats(stats)
-                diverging = i > tune and stats and stats[0].get("diverging")
-            else:
-                point = step.step(point)
-                strace.record(point, [])
+            point, stats = step.step(point)
+            strace.record(point, stats)
+            log_warning_stats(stats)
+            diverging = i > tune and stats and stats[0].get("diverging")
             if callback is not None:
                 callback(
                     trace=strace,

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -173,7 +173,7 @@ class _Process:
 
             if draw < self._draws + self._tune:
                 try:
-                    point, stats = self._compute_point()
+                    point, stats = self._step_method.step(self._point)
                 except SamplingError as e:
                     e = ExceptionWithTraceback(e, e.__traceback__)
                     self._msg_pipe.send(("error", e))
@@ -190,14 +190,6 @@ class _Process:
                 draw += 1
             else:
                 raise ValueError("Unknown message " + msg[0])
-
-    def _compute_point(self):
-        if self._step_method.generates_stats:
-            point, stats = self._step_method.step(self._point)
-        else:
-            point = self._step_method.step(self._point)
-            stats = None
-        return point, stats
 
 
 def _run_process(*args):

--- a/pymc/step_methods/arraystep.py
+++ b/pymc/step_methods/arraystep.py
@@ -14,21 +14,19 @@
 
 from abc import ABC, abstractmethod
 from enum import IntEnum, unique
-from typing import Dict, List, Tuple, TypeVar, Union
+from typing import Callable, Dict, List, Tuple, Union, cast
 
 import numpy as np
 
 from aesara.graph.basic import Variable
 from numpy.random import uniform
 
-from pymc.blocking import DictToArrayBijection, PointType, RaveledVars
+from pymc.blocking import DictToArrayBijection, PointType, RaveledVars, StatsType
 from pymc.model import modelcontext
 from pymc.step_methods.compound import CompoundStep
 from pymc.util import get_var_name
 
 __all__ = ["ArrayStep", "ArrayStepShared", "metrop_select", "Competence"]
-
-StatsType = TypeVar("StatsType")
 
 
 @unique
@@ -49,7 +47,6 @@ class Competence(IntEnum):
 
 class BlockedStep(ABC):
 
-    generates_stats = False
     stats_dtypes: List[Dict[str, type]] = []
     vars: List[Variable] = []
 
@@ -103,7 +100,7 @@ class BlockedStep(ABC):
         return self.__newargs
 
     @abstractmethod
-    def step(point: PointType, *args, **kwargs) -> Union[PointType, Tuple[PointType, StatsType]]:
+    def step(self, point: PointType) -> Tuple[PointType, StatsType]:
         """Perform a single step of the sampler."""
 
     @staticmethod
@@ -146,19 +143,17 @@ class ArrayStep(BlockedStep):
         self.allvars = allvars
         self.blocked = blocked
 
-    def step(self, point: PointType):
+    def step(self, point: PointType) -> Tuple[PointType, StatsType]:
 
-        partial_funcs_and_point = [DictToArrayBijection.mapf(x, start_point=point) for x in self.fs]
+        partial_funcs_and_point: List[Union[Callable, PointType]] = [
+            DictToArrayBijection.mapf(x, start_point=point) for x in self.fs
+        ]
         if self.allvars:
             partial_funcs_and_point.append(point)
 
-        apoint = DictToArrayBijection.map({v.name: point[v.name] for v in self.vars})
-        step_res = self.astep(apoint, *partial_funcs_and_point)
-
-        if self.generates_stats:
-            apoint_new, stats = step_res
-        else:
-            apoint_new = step_res
+        var_dict = {cast(str, v.name): point[cast(str, v.name)] for v in self.vars}
+        apoint = DictToArrayBijection.map(var_dict)
+        apoint_new, stats = self.astep(apoint, *partial_funcs_and_point)
 
         if not isinstance(apoint_new, RaveledVars):
             # We assume that the mapping has stayed the same
@@ -166,15 +161,10 @@ class ArrayStep(BlockedStep):
 
         point_new = DictToArrayBijection.rmap(apoint_new, start_point=point)
 
-        if self.generates_stats:
-            return point_new, stats
-
-        return point_new
+        return point_new, stats
 
     @abstractmethod
-    def astep(
-        self, apoint: RaveledVars, point: PointType, *args
-    ) -> Union[RaveledVars, Tuple[RaveledVars, StatsType]]:
+    def astep(self, apoint: RaveledVars, *args) -> Tuple[RaveledVars, StatsType]:
         """Perform a single sample step in a raveled and concatenated parameter space."""
 
 
@@ -198,19 +188,15 @@ class ArrayStepShared(BlockedStep):
         self.shared = {get_var_name(var): shared for var, shared in shared.items()}
         self.blocked = blocked
 
-    def step(self, point):
+    def step(self, point: PointType) -> Tuple[PointType, StatsType]:
 
         for name, shared_var in self.shared.items():
             shared_var.set_value(point[name])
 
-        q = DictToArrayBijection.map({v.name: point[v.name] for v in self.vars})
+        var_dict = {cast(str, v.name): point[cast(str, v.name)] for v in self.vars}
+        q = DictToArrayBijection.map(var_dict)
 
-        step_res = self.astep(q)
-
-        if self.generates_stats:
-            apoint, stats = step_res
-        else:
-            apoint = step_res
+        apoint, stats = self.astep(q)
 
         if not isinstance(apoint, RaveledVars):
             # We assume that the mapping has stayed the same
@@ -218,10 +204,11 @@ class ArrayStepShared(BlockedStep):
 
         new_point = DictToArrayBijection.rmap(apoint, start_point=point)
 
-        if self.generates_stats:
-            return new_point, stats
+        return new_point, stats
 
-        return new_point
+    @abstractmethod
+    def astep(self, q0: RaveledVars) -> Tuple[RaveledVars, StatsType]:
+        """Perform a single sample step in a raveled and concatenated parameter space."""
 
 
 class PopulationArrayStepShared(ArrayStepShared):
@@ -281,7 +268,7 @@ class GradientSharedStep(ArrayStepShared):
 
         super().__init__(vars, func._extra_vars_shared, blocked)
 
-    def step(self, point):
+    def step(self, point) -> Tuple[PointType, StatsType]:
         self._logp_dlogp_func._extra_are_set = True
         return super().step(point)
 

--- a/pymc/step_methods/arraystep.py
+++ b/pymc/step_methods/arraystep.py
@@ -273,7 +273,7 @@ class GradientSharedStep(ArrayStepShared):
         return super().step(point)
 
 
-def metrop_select(mr, q, q0):
+def metrop_select(mr: np.ndarray, q: np.ndarray, q0: np.ndarray) -> Tuple[np.ndarray, bool]:
     """Perform rejection/acceptance step for Metropolis class samplers.
 
     Returns the new sample q if a uniform random number is less than the

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -23,7 +23,7 @@ from typing import Any, NamedTuple
 import numpy as np
 
 from pymc.aesaraf import floatX
-from pymc.blocking import DictToArrayBijection, RaveledVars
+from pymc.blocking import DictToArrayBijection, RaveledVars, StatsType
 from pymc.exceptions import SamplingError
 from pymc.model import Point, modelcontext
 from pymc.stats.convergence import SamplerWarning, WarningType
@@ -157,7 +157,7 @@ class BaseHMC(GradientSharedStep):
         Subclasses must overwrite this abstract method and return an `HMCStepData` object.
         """
 
-    def astep(self, q0: RaveledVars) -> tuple[RaveledVars, list[dict[str, Any]]]:
+    def astep(self, q0: RaveledVars) -> tuple[RaveledVars, StatsType]:
         """Perform a single HMC iteration."""
         perf_start = time.perf_counter()
         process_start = time.process_time()

--- a/pymc/step_methods/hmc/hmc.py
+++ b/pymc/step_methods/hmc/hmc.py
@@ -39,7 +39,6 @@ class HamiltonianMC(BaseHMC):
 
     name = "hmc"
     default_blocked = True
-    generates_stats = True
     stats_dtypes = [
         {
             "step_size": np.float64,

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -97,7 +97,6 @@ class NUTS(BaseHMC):
     name = "nuts"
 
     default_blocked = True
-    generates_stats = True
     stats_dtypes = [
         {
             "depth": np.int64,

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -14,10 +14,12 @@
 
 # Modified from original implementation by Dominik Wabersich (2013)
 
+from typing import Tuple
+
 import numpy as np
 import numpy.random as nr
 
-from pymc.blocking import RaveledVars
+from pymc.blocking import RaveledVars, StatsType
 from pymc.model import modelcontext
 from pymc.step_methods.arraystep import ArrayStep, Competence
 from pymc.util import get_value_vars_from_user_vars
@@ -47,7 +49,6 @@ class Slice(ArrayStep):
 
     name = "slice"
     default_blocked = False
-    generates_stats = True
     stats_dtypes = [
         {
             "nstep_out": int,
@@ -69,8 +70,10 @@ class Slice(ArrayStep):
 
         super().__init__(vars, [self.model.compile_logp()], **kwargs)
 
-    def astep(self, q0, logp):
-        q0_val = q0.data
+    def astep(self, apoint: RaveledVars, *args) -> Tuple[RaveledVars, StatsType]:
+        # The arguments are determined by the list passed via `super().__init__(..., fs, ...)`
+        logp = args[0]
+        q0_val = apoint.data
         self.w = np.resize(self.w, len(q0_val))  # this is a repmat
 
         nstep_out = nstep_in = 0
@@ -81,9 +84,9 @@ class Slice(ArrayStep):
 
         # The points are not copied, so it's fine to update them inplace in the
         # loop below
-        q_ra = RaveledVars(q, q0.point_map_info)
-        ql_ra = RaveledVars(ql, q0.point_map_info)
-        qr_ra = RaveledVars(qr, q0.point_map_info)
+        q_ra = RaveledVars(q, apoint.point_map_info)
+        ql_ra = RaveledVars(ql, apoint.point_map_info)
+        qr_ra = RaveledVars(qr, apoint.point_map_info)
 
         for i, wi in enumerate(self.w):
             # uniformly sample from 0 to p(q), but in log space
@@ -142,7 +145,7 @@ class Slice(ArrayStep):
             "nstep_in": nstep_in,
         }
 
-        return q, (stats,)
+        return RaveledVars(q, apoint.point_map_info), [stats]
 
     @staticmethod
     def competence(var, has_grad):

--- a/pymc/tests/sampling/test_mcmc.py
+++ b/pymc/tests/sampling/test_mcmc.py
@@ -642,7 +642,7 @@ def test_step_args():
     npt.assert_allclose(idata1.sample_stats.scaling, 0)
 
 
-class ApolypticMetropolis(pm.Metropolis):
+class ApocalypticMetropolis(pm.Metropolis):
     """A stepper that warns in every iteration."""
 
     stats_dtypes = [
@@ -673,7 +673,7 @@ def test_logs_sampler_warnings(caplog, cores):
                 draws=3,
                 cores=cores,
                 chains=cores,
-                step=ApolypticMetropolis(),
+                step=ApocalypticMetropolis(),
                 compute_convergence_checks=False,
                 discard_tuned_samples=False,
                 keep_warning_stat=True,
@@ -702,7 +702,7 @@ def test_keep_warning_stat_setting(keep_warning_stat):
         sample_kwargs["keep_warning_stat"] = True
     with pm.Model():
         pm.Normal("n")
-        idata = pm.sample(step=ApolypticMetropolis(), **sample_kwargs)
+        idata = pm.sample(step=ApocalypticMetropolis(), **sample_kwargs)
 
     if keep_warning_stat:
         assert "warning" in idata.warmup_sample_stats

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -62,6 +62,7 @@ pymc/smc/kernels.py
 pymc/stats/__init__.py
 pymc/stats/convergence.py
 pymc/step_methods/__init__.py
+pymc/step_methods/arraystep.py
 pymc/step_methods/compound.py
 pymc/step_methods/hmc/__init__.py
 pymc/step_methods/hmc/base_hmc.py

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -64,6 +64,7 @@ pymc/stats/convergence.py
 pymc/step_methods/__init__.py
 pymc/step_methods/arraystep.py
 pymc/step_methods/compound.py
+pymc/step_methods/metropolis.py
 pymc/step_methods/hmc/__init__.py
 pymc/step_methods/hmc/base_hmc.py
 pymc/step_methods/hmc/hmc.py


### PR DESCRIPTION
The reason for these changes are the resulting simplification of code, including simpler branching and less type ambiguity.

This change may break custom step methods, but whoever had enough skill to implement a custom step method should have no trouble to append a `, []` to the `return` of their `(a)step` method.

Closes #6270

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- Reuires all step methods to return stats from their `step`/`asteo` method.
- The `BlockedStep.generates_stats` attribute was removed.

## Bugfixes / New features
- Removed a branch in `Compound.step` that supported `namedtuple` `stats` which are in violation of the `BlockedStep.step` signature.

## Docs / Maintenance
- Added & fixed some type hints on `step` and `astep` methods. (`arraystep.py` now passing mypy!)

