### PR TITLE
Fix versioneer config to match version tags

### DIFF
--- a/pymc/_version.py
+++ b/pymc/_version.py
@@ -43,7 +43,7 @@ def get_config():
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = "rel-"
+    cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "None"
     cfg.versionfile_source = "pymc/_version.py"
     cfg.verbose = False


### PR DESCRIPTION
The config was slightly wrong: We're prefixing release tags with `v` not with `rel-`.

Closes #6303

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] ~Are the changes covered by tests and docstrings?~ A test would require the git history to get the previous tag, but we're just doing shallow checkouts in the CI pipeline. Deep checkout just for this isn't worth it..
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- None

## Bugfixes / New features
- Fixes a bug that excluded the latest release version from `pm.__version__` in git installs.

## Docs / Maintenance
- None
