### PR TITLE
Removed NoDistribution from docs

### DIFF
--- a/docs/source/api/distributions/utilities.rst
+++ b/docs/source/api/distributions/utilities.rst
@@ -9,6 +9,5 @@ Distribution utilities
     Distribution
     Discrete
     Continuous
-    NoDistribution
     DensityDist
     SymbolicRandomVariable


### PR DESCRIPTION
Removes a doc reference to NoDistribution, which is no longer implemented.
