### PR TITLE
Only add `total_size` mapping to observed RVs

### DIFF
--- a/pymc/util.py
+++ b/pymc/util.py
@@ -490,7 +490,7 @@ class _FutureWarningValidatingScratchpad(ValidatingScratchpad):
         for deprecated_names, alternative in (
             (("value_var", "observations"), "model.rvs_to_values[rv]"),
             (("transform",), "model.rvs_to_transforms[rv]"),
-            (("total_size",), "model.rvs_to_total_sizes[rv]"),
+            (("total_size",), "model.observed_rvs_to_total_sizes[rv]"),
         ):
             if name in deprecated_names:
                 try:

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1046,7 +1046,9 @@ class Group(WithMemoization):
         t = self.to_flat_input(
             at.max(
                 [
-                    _get_scaling(self.model.rvs_to_total_sizes.get(v, None), v.shape, v.ndim)
+                    _get_scaling(
+                        self.model.observed_rvs_to_total_sizes.get(v, None), v.shape, v.ndim
+                    )
                     for v in self.group
                 ]
             )
@@ -1184,7 +1186,7 @@ class Approximation(WithMemoization):
             self.collect("symbolic_normalizing_constant")
             + [
                 _get_scaling(
-                    self.model.rvs_to_total_sizes.get(obs, None),
+                    self.model.observed_rvs_to_total_sizes.get(obs, None),
                     obs.shape,
                     obs.ndim,
                 )


### PR DESCRIPTION
This fixes inconsistent use of the `rvs_to_total_sizes` mapping. It only assigns observed_RVs to it, including the observed component of an imputed variable (even though that is not allowed at the moment).

It also raises if passed to `free_RVs`

## Docs / Maintenance
- Cleanup `total_size` interface
