### PR TITLE
add alternative parametrization for AssymetricLaplace

### DIFF
--- a/pymc/tests/distributions/test_continuous.py
+++ b/pymc/tests/distributions/test_continuous.py
@@ -1647,6 +1647,19 @@ class TestAsymmetricLaplace(BaseTestDistributionRandom):
     ]
 
 
+class TestAsymmetricLaplaceQ(BaseTestDistributionRandom):
+    pymc_dist = pm.AsymmetricLaplace
+
+    pymc_dist_params = {"mu": 0.0, "b": 2.0, "q": 0.9}
+    expected_kappa = pymc_dist.get_kappa(None, pymc_dist_params["q"])
+    expected_rv_op_params = {
+        "b": pymc_dist_params["b"],
+        "kappa": expected_kappa,
+        "mu": pymc_dist_params["mu"],
+    }
+    checks_to_run = ["check_pymc_params_match_rv_op"]
+
+
 class TestExGaussian(BaseTestDistributionRandom):
     def exgaussian_rng_fn(self, mu, sigma, nu, size, normal_rng_fct, exponential_rng_fct):
         return normal_rng_fct(mu, sigma, size=size) + exponential_rng_fct(scale=nu, size=size)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**

This adds an alternative parametrization to AsymmetricLaplace distribution. This is parametrization is useful for quantile regression with the new parameter `q` being fixed at the quantile of interest. 

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## Bugfixes / New features
- Add alternative parametrization to AsymmetricLaplace distribution. This parametrization is useful for quantile regression with the new parameter `q` being fixed at the quantile of interest. 

## Docs / Maintenance
- ...
