### PR TITLE
Bugfixes to increase robustness against unnamed `dims`

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1498,6 +1498,8 @@ class Model(WithMemoization, metaclass=ContextMeta):
         This can include several types of variables such basic_RVs, Data, Deterministics,
         and Potentials.
         """
+        if var.name is None:
+            raise ValueError("Variable is unnamed.")
         if self.named_vars.tree_contains(var.name):
             raise ValueError(f"Variable name {var.name} already exists.")
 
@@ -1507,7 +1509,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             for dim in dims:
                 if dim not in self.coords and dim is not None:
                     raise ValueError(f"Dimension {dim} is not specified in `coords`.")
-            if any(var.name == dim for dim in dims):
+            if any(var.name == dim for dim in dims if dim is not None):
                 raise ValueError(f"Variable `{var.name}` has the same name as its dimension label.")
             self.named_vars_to_dims[var.name] = dims
 

--- a/pymc/tests/test_model_graph.py
+++ b/pymc/tests/test_model_graph.py
@@ -14,6 +14,7 @@
 import warnings
 
 import aesara
+import aesara.tensor as at
 import numpy as np
 import pytest
 
@@ -339,6 +340,18 @@ class TestImputationModel(BaseModelGraphTest):
 
 class TestModelWithDims(BaseModelGraphTest):
     model_func = model_with_dims
+
+    def test_issue_6335_dims_containing_none(self):
+        with pm.Model(coords=dict(time=np.arange(5))) as pmodel:
+            data = at.as_tensor(np.ones((3, 5)))
+            pm.Deterministic("n", data, dims=(None, "time"))
+
+        mg = ModelGraph(pmodel)
+        plates_actual = mg.get_plates()
+        plates_expected = {
+            "n_dim0 (3) x time (5)": {"n"},
+        }
+        assert plates_actual == plates_expected
 
 
 class TestUnnamedObservedNodes(BaseModelGraphTest):


### PR DESCRIPTION
This fixes the two bugs I described in #6335.

Essentially two `Model.get_plates` and `Model.add_named_variable` methods did not anticipate that elements of a `dims` tuple can be `None`.

I added some comments to the refactored code and tests.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- None

## Bugfixes / New features
- Fixes bugs in `pm.model_to_graphviz` and `Model.add_named_variable` that were triggered by `None` elements in `dims` tuples.

## Docs / Maintenance
- None
