### PR TITLE
Revert "Merge AePPL with history"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,6 @@ jobs:
             pymc/tests/logprob/test_censoring.py
             pymc/tests/logprob/test_composite_logprob.py
             pymc/tests/logprob/test_cumsum.py
-            pymc/tests/logprob/test_joint_logprob.py
             pymc/tests/logprob/test_mixture.py
             pymc/tests/logprob/test_rewriting.py
             pymc/tests/logprob/test_scan.py


### PR DESCRIPTION
Reverts pymc-devs/pymc#6357

I can see the commit history: 
![Screenshot 2022-11-30 at 08 43 17](https://user-images.githubusercontent.com/12952641/204736850-7339a709-e177-40fe-b2d4-74cedfa62fd2.png)

But the history in https://github.com/pymc-devs/pymc/tree/main/pymc/logprob is empty.

Reverting and try again.