### PR TITLE
Fixed overriding user provided `mp_ctx` strings to `pm.sample()` on M1 MacOS

### DIFF
--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -386,9 +386,13 @@ class ParallelSampler:
         if mp_ctx is None or isinstance(mp_ctx, str):
             # Closes issue https://github.com/pymc-devs/pymc/issues/3849
             # Related issue https://github.com/pymc-devs/pymc/issues/5339
-            if platform.system() == "Darwin":
+            if mp_ctx is None and platform.system() == "Darwin":
                 if platform.processor() == "arm":
                     mp_ctx = "fork"
+                    logger.debug(
+                        "mp_ctx is set to 'fork' for MacOS with ARM architecture. "
+                        + "This might cause unexpected behavior with JAX, which is inherently multithreaded."
+                    )
                 else:
                     mp_ctx = "forkserver"
 


### PR DESCRIPTION
**What is this PR about?**
Per #6362, when the user provides a `str` to `mp_ctx` on ARM-based Macs, this string will be overridden without warnings to `"fork"`, which might be incompatible with some JAX operations in parallel settings. This change was introduced in #6218.

Closes #6362 

## Bugfixes / New features
- Changed one if-statement so user provided `str`s are not overridden.
- Added a debugging message about the incompatibility of `"fork"` and JAX.