### PR TITLE
Add support for automatic naming of random variables

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -44,7 +44,7 @@ from pymc.distributions.dist_math import (
     normal_lccdf,
     normal_lcdf,
 )
-from pymc.distributions.distribution import Discrete
+from pymc.distributions.distribution import Distribution, Discrete
 from pymc.distributions.logprob import logp
 from pymc.distributions.mixture import Mixture
 from pymc.distributions.shape_utils import rv_size_is_none
@@ -1254,7 +1254,7 @@ def _zero_inflated_mixture(*, name, nonzero_p, nonzero_dist, **kwargs):
         return Mixture.dist(weights, comp_dists, **kwargs)
 
 
-class ZeroInflatedPoisson:
+class ZeroInflatedPoisson(Distribution):
     R"""
     Zero-inflated Poisson log-likelihood.
 
@@ -1305,11 +1305,6 @@ class ZeroInflatedPoisson:
         Expected number of occurrences during the given interval
         (mu >= 0).
     """
-
-    def __new__(cls, name, psi, mu, **kwargs):
-        return _zero_inflated_mixture(
-            name=name, nonzero_p=psi, nonzero_dist=Poisson.dist(mu=mu), **kwargs
-        )
 
     @classmethod
     def dist(cls, psi, mu, **kwargs):

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -322,7 +322,11 @@ class Distribution(metaclass=DistributionMeta):
         else:
             name = _extract_target_of_assignment(2)
             if name is None:
-                raise TypeError("Name could not be inferred for variable")
+                raise TypeError(
+                    "Name could not be inferred for variable from surrounding "
+                    "context. Pass a name explicitly as the first argument to "
+                    "the Distribution."
+                )
 
         if not isinstance(name, string_types):
             raise TypeError(f"Name needs to be a string but got: {name}")

--- a/pymc/tests/distributions/test_distribution.py
+++ b/pymc/tests/distributions/test_distribution.py
@@ -433,6 +433,13 @@ def test_autonaming():
 
 def test_autonaming_noname():
     """Test that autonaming fails if no assignment can be found"""
-    with pytest.raises(TypeError, match="Name could not be inferred for variable"):
+    with pytest.raises(
+        TypeError,
+        match=(
+            "Name could not be inferred for variable from surrounding "
+            "context. Pass a name explicitly as the first argument to "
+            "the Distribution."
+        ),
+    ):
         with pm.Model():
             pm.Normal()

--- a/pymc/tests/distributions/test_distribution.py
+++ b/pymc/tests/distributions/test_distribution.py
@@ -416,3 +416,23 @@ def test_tag_future_warning_dist():
         with pytest.warns(FutureWarning, match="Use model.rvs_to_values"):
             value_var = new_x.tag.value_var
         assert value_var == "1"
+
+
+def test_autonaming():
+    """Test that random variable ends up with same name as assignment variable"""
+    d = {}
+    with pm.Model() as m:
+        x = pm.Normal(0.0, 1.0)
+        d[2] = pm.Normal(0.0, 1.0)
+
+    assert x.name == "x"
+    assert m["x"] == x
+    assert d[2].name == "d[2]"
+    assert m["d[2]"] == d[2]
+
+
+def test_autonaming_noname():
+    """Test that autonaming fails if no assignment can be found"""
+    with pytest.raises(TypeError, match="Name could not be inferred for variable"):
+        with pm.Model():
+            pm.Normal()


### PR DESCRIPTION
This PR introduces a way to use distributions without needing to provide a name.

This means:

````python
import pymc as pm
with pm.Model():
    x = pm.Normal(0., 1.)
````

is equivalent to

````python
import pymc as pm
with pm.Model():
    x = pm.Normal("x", 0., 1.)
````

I use some code originally written by @Tobias-Kohn for pyprob. The implementation is done by inspecting stack frames to figure out what the assignment will be. It picks earliest point an assignment can take place.

This PR is intended to be fully backwards-compatible.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇
