### PR TITLE
Do not try to infer the logprob of broadcasted or advanced indexed variables

### DIFF
--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -445,6 +445,10 @@ def logprob_MixtureRV(
             logp_val = at.set_subtensor(logp_val[idx_m_on_axis], logp_m)
 
     else:
+        # FIXME: This logprob implementation does not support mixing across distinct components,
+        # but we sometimes use it, because MixtureRV does not keep information about at which
+        # dimension scalar indexing actually starts
+
         # If the stacking operation expands the component RVs, we have
         # to expand the value and later squeeze the logprob for everything
         # to work correctly

--- a/pymc/logprob/tensor.py
+++ b/pymc/logprob/tensor.py
@@ -357,10 +357,6 @@ measurable_ir_rewrites_db.register(
     "find_measurable_dimshuffles", find_measurable_dimshuffles, "basic", "tensor"
 )
 
-
-measurable_ir_rewrites_db.register("broadcast_to_lift", naive_bcast_rv_lift, "basic", "tensor")
-
-
 measurable_ir_rewrites_db.register(
     "find_measurable_stacks",
     find_measurable_stacks,

--- a/pymc/tests/logprob/test_mixture.py
+++ b/pymc/tests/logprob/test_mixture.py
@@ -226,7 +226,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (),
             0,
         ),
-        # Degenerate vector mixture components, scalar index
+        # Degenerate vector mixture components, scalar index along join axis
         (
             (
                 np.array([0], dtype=pytensor.config.floatX),
@@ -246,7 +246,87 @@ def test_hetero_mixture_binomial(p_val, size):
             (),
             0,
         ),
-        # Scalar mixture components, vector index
+        # Degenerate vector mixture components, scalar index along join axis (axis=1)
+        (
+            (
+                np.array([0], dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array([0.5], dtype=pytensor.config.floatX),
+                np.array(0.5, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array([100], dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            np.array([0.1, 0.5, 0.4], dtype=pytensor.config.floatX),
+            None,
+            (),
+            (slice(None),),
+            1,
+        ),
+        # Vector mixture components, scalar index along the join axis
+        (
+            (
+                np.array(0, dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array(0.5, dtype=pytensor.config.floatX),
+                np.array(0.5, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array(100, dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            np.array([0.1, 0.5, 0.4], dtype=pytensor.config.floatX),
+            (4,),
+            (),
+            (),
+            0,
+        ),
+        # Vector mixture components, scalar index along the join axis (axis=1)
+        (
+            (
+                np.array(0, dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array(0.5, dtype=pytensor.config.floatX),
+                np.array(0.5, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array(100, dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            np.array([0.1, 0.5, 0.4], dtype=pytensor.config.floatX),
+            (4,),
+            (),
+            (slice(None),),
+            1,
+        ),
+        # Matrix components, scalar index along first axis
+        (
+            (
+                np.array(0, dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array(0.5, dtype=pytensor.config.floatX),
+                np.array(0.5, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array(100, dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            np.array([0.1, 0.5, 0.4], dtype=pytensor.config.floatX),
+            (2, 3),
+            (),
+            (),
+            0,
+        ),
+        # Scalar mixture components, vector index along first axis
         (
             (
                 np.array(0, dtype=pytensor.config.floatX),
@@ -266,44 +346,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (),
             0,
         ),
-        (
-            (
-                np.array([0, -100], dtype=pytensor.config.floatX),
-                np.array(1, dtype=pytensor.config.floatX),
-            ),
-            (
-                np.array([0.5, 1], dtype=pytensor.config.floatX),
-                np.array([0.5, 1], dtype=pytensor.config.floatX),
-            ),
-            (
-                np.array([100, 1000], dtype=pytensor.config.floatX),
-                np.array(1, dtype=pytensor.config.floatX),
-            ),
-            np.array([[0.1, 0.5, 0.4], [0.4, 0.1, 0.5]], dtype=pytensor.config.floatX),
-            (2,),
-            (2,),
-            (),
-            0,
-        ),
-        (
-            (
-                np.array([0, -100], dtype=pytensor.config.floatX),
-                np.array(1, dtype=pytensor.config.floatX),
-            ),
-            (
-                np.array([0.5, 1], dtype=pytensor.config.floatX),
-                np.array([0.5, 1], dtype=pytensor.config.floatX),
-            ),
-            (
-                np.array([100, 1000], dtype=pytensor.config.floatX),
-                np.array(1, dtype=pytensor.config.floatX),
-            ),
-            np.array([[0.1, 0.5, 0.4], [0.4, 0.1, 0.5]], dtype=pytensor.config.floatX),
-            None,
-            None,
-            (),
-            0,
-        ),
+        # Vector mixture components, vector index along first axis
         (
             (
                 np.array(0, dtype=pytensor.config.floatX),
@@ -320,10 +363,31 @@ def test_hetero_mixture_binomial(p_val, size):
             np.array([0.1, 0.5, 0.4], dtype=pytensor.config.floatX),
             (2,),
             (2,),
-            (),
+            (slice(None),),
             0,
         ),
-        # Same as before but with degenerate vector parameters
+        # Vector mixture components, vector index along last axis
+        pytest.param(
+            (
+                np.array(0, dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array(0.5, dtype=pytensor.config.floatX),
+                np.array(0.5, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array(100, dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            np.array([0.1, 0.5, 0.4], dtype=pytensor.config.floatX),
+            (2,),
+            (4,),
+            (slice(None),),
+            1,
+            marks=pytest.mark.xfail(IndexError, reason="Bug in AdvancedIndex Mixture logprob"),
+        ),
+        # Vector mixture components (with degenerate vector parameters), vector index along first axis
         (
             (
                 np.array([0], dtype=pytensor.config.floatX),
@@ -343,6 +407,47 @@ def test_hetero_mixture_binomial(p_val, size):
             (),
             0,
         ),
+        # Vector mixture components (with vector parameters), vector index along first axis
+        (
+            (
+                np.array([0, -100], dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array([0.5, 1], dtype=pytensor.config.floatX),
+                np.array([0.5, 1], dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array([100, 1000], dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            np.array([[0.1, 0.5, 0.4], [0.4, 0.1, 0.5]], dtype=pytensor.config.floatX),
+            (2,),
+            (2,),
+            (),
+            0,
+        ),
+        # Vector mixture components (with vector parameters), vector index along first axis, implicit sizes
+        (
+            (
+                np.array([0, -100], dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array([0.5, 1], dtype=pytensor.config.floatX),
+                np.array([0.5, 1], dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array([100, 1000], dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            np.array([[0.1, 0.5, 0.4], [0.4, 0.1, 0.5]], dtype=pytensor.config.floatX),
+            None,
+            None,
+            (),
+            0,
+        ),
+        # Matrix mixture components, matrix index
         (
             (
                 np.array(0, dtype=pytensor.config.floatX),
@@ -362,45 +467,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (),
             0,
         ),
-        (
-            (
-                np.array(0, dtype=pytensor.config.floatX),
-                np.array(1, dtype=pytensor.config.floatX),
-            ),
-            (
-                np.array(0.5, dtype=pytensor.config.floatX),
-                np.array(0.5, dtype=pytensor.config.floatX),
-            ),
-            (
-                np.array(100, dtype=pytensor.config.floatX),
-                np.array(1, dtype=pytensor.config.floatX),
-            ),
-            np.array([0.1, 0.5, 0.4], dtype=pytensor.config.floatX),
-            (2, 3),
-            (),
-            (),
-            0,
-        ),
-        pytest.param(
-            (
-                np.array(0, dtype=pytensor.config.floatX),
-                np.array(1, dtype=pytensor.config.floatX),
-            ),
-            (
-                np.array(0.5, dtype=pytensor.config.floatX),
-                np.array(0.5, dtype=pytensor.config.floatX),
-            ),
-            (
-                np.array(100, dtype=pytensor.config.floatX),
-                np.array(1, dtype=pytensor.config.floatX),
-            ),
-            np.array([0.1, 0.5, 0.4], dtype=pytensor.config.floatX),
-            (3,),
-            (3,),
-            (slice(None),),
-            1,
-            marks=pytest.mark.xfail(IndexError, reason="Bug in AdvancedIndex Mixture logprob"),
-        ),
+        # Vector components, matrix indexing (constant along first dimension, then random)
         (
             (
                 np.array(0, dtype=pytensor.config.floatX),
@@ -420,6 +487,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (np.arange(5),),
             0,
         ),
+        # Vector mixture components, tensor3 indexing (constant along first dimension, then degenerate, then random)
         (
             (
                 np.array(0, dtype=pytensor.config.floatX),

--- a/pymc/tests/logprob/test_mixture.py
+++ b/pymc/tests/logprob/test_mixture.py
@@ -91,7 +91,7 @@ def test_mixture_basics():
     with pytest.raises(RuntimeError, match="could not be derived: {m}"):
         factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv, X_rv: x_vv})
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(RuntimeError, match="could not be derived: {m}"):
         axis_at = at.lscalar("axis")
         axis_at.tag.test_value = 0
         env = create_mix_model((2,), axis_at)
@@ -139,17 +139,19 @@ def test_compute_test_value(op_constructor):
 
 
 @pytest.mark.parametrize(
-    "p_val, size",
+    "p_val, size, supported",
     [
-        (np.array(0.0, dtype=pytensor.config.floatX), ()),
-        (np.array(1.0, dtype=pytensor.config.floatX), ()),
-        (np.array(0.0, dtype=pytensor.config.floatX), (2,)),
-        (np.array(1.0, dtype=pytensor.config.floatX), (2, 1)),
-        (np.array(1.0, dtype=pytensor.config.floatX), (2, 3)),
-        (np.array([0.1, 0.9], dtype=pytensor.config.floatX), (2, 3)),
+        (np.array(0.0, dtype=pytensor.config.floatX), (), True),
+        (np.array(1.0, dtype=pytensor.config.floatX), (), True),
+        (np.array([0.1, 0.9], dtype=pytensor.config.floatX), (), True),
+        # The cases belowe are not supported because they may pick repeated values via AdvancedIndexing
+        (np.array(0.0, dtype=pytensor.config.floatX), (2,), False),
+        (np.array(1.0, dtype=pytensor.config.floatX), (2, 1), False),
+        (np.array(1.0, dtype=pytensor.config.floatX), (2, 3), False),
+        (np.array([0.1, 0.9], dtype=pytensor.config.floatX), (2, 3), False),
     ],
 )
-def test_hetero_mixture_binomial(p_val, size):
+def test_hetero_mixture_binomial(p_val, size, supported):
     srng = at.random.RandomStream(29833)
 
     X_rv = srng.normal(0, 1, size=size, name="X")
@@ -175,7 +177,12 @@ def test_hetero_mixture_binomial(p_val, size):
     m_vv = M_rv.clone()
     m_vv.name = "m"
 
-    M_logp = joint_logprob({M_rv: m_vv, I_rv: i_vv}, sum=False)
+    if supported:
+        M_logp = joint_logprob({M_rv: m_vv, I_rv: i_vv}, sum=False)
+    else:
+        with pytest.raises(RuntimeError, match="could not be derived: {m}"):
+            joint_logprob({M_rv: m_vv, I_rv: i_vv}, sum=False)
+        return
 
     M_logp_fn = pytensor.function([p_at, m_vv, i_vv], M_logp)
 
@@ -204,9 +211,9 @@ def test_hetero_mixture_binomial(p_val, size):
 
 
 @pytest.mark.parametrize(
-    "X_args, Y_args, Z_args, p_val, comp_size, idx_size, extra_indices, join_axis",
+    "X_args, Y_args, Z_args, p_val, comp_size, idx_size, extra_indices, join_axis, supported",
     [
-        # Scalar mixture components, scalar index
+        # Scalar components, scalar index
         (
             (
                 np.array(0, dtype=pytensor.config.floatX),
@@ -225,6 +232,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (),
             (),
             0,
+            True,
         ),
         # Degenerate vector mixture components, scalar index along join axis
         (
@@ -245,6 +253,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (),
             (),
             0,
+            True,
         ),
         # Degenerate vector mixture components, scalar index along join axis (axis=1)
         (
@@ -265,6 +274,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (),
             (slice(None),),
             1,
+            True,
         ),
         # Vector mixture components, scalar index along the join axis
         (
@@ -285,6 +295,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (),
             (),
             0,
+            True,
         ),
         # Vector mixture components, scalar index along the join axis (axis=1)
         (
@@ -305,6 +316,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (),
             (slice(None),),
             1,
+            True,
         ),
         # Vector mixture components, scalar index that mixes across components
         pytest.param(
@@ -325,6 +337,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (),
             (),
             1,
+            True,
             marks=pytest.mark.xfail(
                 AssertionError,
                 match="Arrays are not almost equal to 6 decimals",  # This is ignored, but that's where it should fail!
@@ -350,7 +363,10 @@ def test_hetero_mixture_binomial(p_val, size):
             (),
             (),
             0,
+            True,
         ),
+        # All the tests below rely on AdvancedIndexing, which is not supported at the moment
+        # See https://github.com/pymc-devs/pymc/issues/6398
         # Scalar mixture components, vector index along first axis
         (
             (
@@ -370,6 +386,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (6,),
             (),
             0,
+            False,
         ),
         # Vector mixture components, vector index along first axis
         (
@@ -390,9 +407,10 @@ def test_hetero_mixture_binomial(p_val, size):
             (2,),
             (slice(None),),
             0,
+            False,
         ),
         # Vector mixture components, vector index along last axis
-        pytest.param(
+        (
             (
                 np.array(0, dtype=pytensor.config.floatX),
                 np.array(1, dtype=pytensor.config.floatX),
@@ -410,7 +428,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (4,),
             (slice(None),),
             1,
-            marks=pytest.mark.xfail(IndexError, reason="Bug in AdvancedIndex Mixture logprob"),
+            False,
         ),
         # Vector mixture components (with degenerate vector parameters), vector index along first axis
         (
@@ -431,6 +449,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (2,),
             (),
             0,
+            False,
         ),
         # Vector mixture components (with vector parameters), vector index along first axis
         (
@@ -451,6 +470,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (2,),
             (),
             0,
+            False,
         ),
         # Vector mixture components (with vector parameters), vector index along first axis, implicit sizes
         (
@@ -471,6 +491,7 @@ def test_hetero_mixture_binomial(p_val, size):
             None,
             (),
             0,
+            False,
         ),
         # Matrix mixture components, matrix index
         (
@@ -491,6 +512,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (2, 3),
             (),
             0,
+            False,
         ),
         # Vector components, matrix indexing (constant along first dimension, then random)
         (
@@ -511,6 +533,7 @@ def test_hetero_mixture_binomial(p_val, size):
             (5,),
             (np.arange(5),),
             0,
+            False,
         ),
         # Vector mixture components, tensor3 indexing (constant along first dimension, then degenerate, then random)
         (
@@ -531,11 +554,12 @@ def test_hetero_mixture_binomial(p_val, size):
             (5,),
             (np.arange(5), None),
             0,
+            False,
         ),
     ],
 )
 def test_hetero_mixture_categorical(
-    X_args, Y_args, Z_args, p_val, comp_size, idx_size, extra_indices, join_axis
+    X_args, Y_args, Z_args, p_val, comp_size, idx_size, extra_indices, join_axis, supported
 ):
     srng = at.random.RandomStream(29833)
 
@@ -561,7 +585,12 @@ def test_hetero_mixture_categorical(
     m_vv = M_rv.clone()
     m_vv.name = "m"
 
-    logp_parts = factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv}, sum=False)
+    if supported:
+        logp_parts = factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv}, sum=False)
+    else:
+        with pytest.raises(RuntimeError, match="could not be derived: {m}"):
+            factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv}, sum=False)
+        return
 
     I_logp_fn = pytensor.function([p_at, i_vv], logp_parts[i_vv])
     M_logp_fn = pytensor.function([m_vv, i_vv], logp_parts[m_vv])
@@ -854,7 +883,7 @@ def test_mixture_with_DiracDelta():
     Y_rv = dirac_delta(0.0)
     Y_rv.name = "Y"
 
-    I_rv = srng.categorical([0.5, 0.5], size=4)
+    I_rv = srng.categorical([0.5, 0.5], size=1)
 
     i_vv = I_rv.clone()
     i_vv.name = "i"

--- a/pymc/tests/logprob/test_mixture.py
+++ b/pymc/tests/logprob/test_mixture.py
@@ -306,6 +306,31 @@ def test_hetero_mixture_binomial(p_val, size):
             (slice(None),),
             1,
         ),
+        # Vector mixture components, scalar index that mixes across components
+        pytest.param(
+            (
+                np.array(0, dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array(0.5, dtype=pytensor.config.floatX),
+                np.array(0.5, dtype=pytensor.config.floatX),
+            ),
+            (
+                np.array(100, dtype=pytensor.config.floatX),
+                np.array(1, dtype=pytensor.config.floatX),
+            ),
+            np.array([0.1, 0.5, 0.1, 0.3], dtype=pytensor.config.floatX),
+            (4,),
+            (),
+            (),
+            1,
+            marks=pytest.mark.xfail(
+                AssertionError,
+                match="Arrays are not almost equal to 6 decimals",  # This is ignored, but that's where it should fail!
+                reason="IfElse Mixture logprob fails when indexing mixes across components",
+            ),
+        ),
         # Matrix components, scalar index along first axis
         (
             (

--- a/pymc/tests/logprob/test_transforms.py
+++ b/pymc/tests/logprob/test_transforms.py
@@ -778,16 +778,16 @@ def test_discrete_rv_multinary_transform_fails():
         joint_logprob({y_rv: y_rv.clone()})
 
 
-@pytest.mark.xfail(reason="Check not implemented yet, see #51")
+@pytest.mark.xfail(reason="Check not implemented yet")
 def test_invalid_broadcasted_transform_rv_fails():
     loc = at.vector("loc")
-    y_rv = loc + at.random.normal(0, 1, size=2, name="base_rv")
+    y_rv = loc + at.random.normal(0, 1, size=1, name="base_rv")
     y_rv.name = "y"
     y_vv = y_rv.clone()
 
-    logp = joint_logprob({y_rv: y_vv})
-    logp.eval({y_vv: [0, 0, 0, 0], loc: [0, 0, 0, 0]})
-    assert False, "Should have failed before"
+    # This logp derivation should fail or count only once the values that are broadcasted
+    logp = joint_logprob({y_rv: y_vv}, sum=False)
+    assert logp.eval({y_vv: [0, 0, 0, 0], loc: [0, 0, 0, 0]}).shape == ()
 
 
 @pytest.mark.parametrize("numerator", (1.0, 2.0))


### PR DESCRIPTION
This PR removes an invalid rewrite from the logprob submodule

It also suppresses a NotImplementedError in the Mixture rewrite. Individual rewrites should not judge whether logprob for a graph is implemented or not, because other rewrites might be able to handle it.
