### PR TITLE
Simplify measurable transform rewrites

### DIFF
--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -110,7 +110,6 @@ def find_measurable_clips(fgraph: FunctionGraph, node: Node) -> Optional[List[Me
 measurable_ir_rewrites_db.register(
     "find_measurable_clips",
     find_measurable_clips,
-    0,
     "basic",
     "censoring",
 )
@@ -220,7 +219,6 @@ def find_measurable_roundings(fgraph: FunctionGraph, node: Node) -> Optional[Lis
 measurable_ir_rewrites_db.register(
     "find_measurable_roundings",
     find_measurable_roundings,
-    0,
     "basic",
     "censoring",
 )

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -44,7 +44,7 @@ from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.rewriting.basic import node_rewriter
 from pytensor.scalar.basic import Ceil, Clip, Floor, RoundHalfToEven
 from pytensor.scalar.basic import clip as scalar_clip
-from pytensor.tensor.elemwise import Elemwise
+from pytensor.tensor.math import ceil, clip, floor, round_half_to_even
 from pytensor.tensor.var import TensorConstant
 
 from pymc.logprob.abstract import (
@@ -67,7 +67,7 @@ class MeasurableClip(MeasurableElemwise):
 measurable_clip = MeasurableClip(scalar_clip)
 
 
-@node_rewriter(tracks=[Elemwise])
+@node_rewriter(tracks=[clip])
 def find_measurable_clips(fgraph: FunctionGraph, node: Node) -> Optional[List[MeasurableClip]]:
     # TODO: Canonicalize x[x>ub] = ub -> clip(x, x, ub)
 
@@ -77,9 +77,6 @@ def find_measurable_clips(fgraph: FunctionGraph, node: Node) -> Optional[List[Me
 
     if isinstance(node.op, MeasurableClip):
         return None  # pragma: no cover
-
-    if not (isinstance(node.op, Elemwise) and isinstance(node.op.scalar_op, Clip)):
-        return None
 
     clipped_var = node.outputs[0]
     base_var, lower_bound, upper_bound = node.inputs
@@ -179,7 +176,7 @@ class MeasurableRound(MeasurableElemwise):
     valid_scalar_types = (RoundHalfToEven, Floor, Ceil)
 
 
-@node_rewriter(tracks=[Elemwise])
+@node_rewriter(tracks=[ceil, floor, round_half_to_even])
 def find_measurable_roundings(fgraph: FunctionGraph, node: Node) -> Optional[List[MeasurableRound]]:
 
     rv_map_feature = getattr(fgraph, "preserve_rv_mappings", None)
@@ -188,12 +185,6 @@ def find_measurable_roundings(fgraph: FunctionGraph, node: Node) -> Optional[Lis
 
     if isinstance(node.op, MeasurableRound):
         return None  # pragma: no cover
-
-    if not (
-        isinstance(node.op, Elemwise)
-        and isinstance(node.op.scalar_op, MeasurableRound.valid_scalar_types)
-    ):
-        return None
 
     (rounded_var,) = node.outputs
     (base_var,) = node.inputs

--- a/pymc/logprob/cumsum.py
+++ b/pymc/logprob/cumsum.py
@@ -122,7 +122,6 @@ def find_measurable_cumsums(fgraph, node) -> Optional[List[MeasurableCumsum]]:
 measurable_ir_rewrites_db.register(
     "find_measurable_cumsums",
     find_measurable_cumsums,
-    0,
     "basic",
     "cumsum",
 )

--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -461,7 +461,6 @@ logprob_rewrites_db.register(
         [mixture_replace, switch_mixture_replace],
         max_use_ratio=pytensor.config.optdb__max_use_ratio,
     ),
-    0,
     "basic",
     "mixture",
 )

--- a/pymc/logprob/rewriting.py
+++ b/pymc/logprob/rewriting.py
@@ -252,7 +252,7 @@ def incsubtensor_rv_replace(fgraph, node):
 
 logprob_rewrites_db = SequenceDB()
 logprob_rewrites_db.name = "logprob_rewrites_db"
-logprob_rewrites_db.register("pre-canonicalize", optdb.query("+canonicalize"), -10, "basic")
+logprob_rewrites_db.register("pre-canonicalize", optdb.query("+canonicalize"), "basic")
 
 # These rewrites convert un-measurable variables into their measurable forms,
 # but they need to be reapplied, because some of the measurable forms require
@@ -260,15 +260,15 @@ logprob_rewrites_db.register("pre-canonicalize", optdb.query("+canonicalize"), -
 measurable_ir_rewrites_db = NoCallbackEquilibriumDB()
 measurable_ir_rewrites_db.name = "measurable_ir_rewrites_db"
 
-logprob_rewrites_db.register("measurable_ir_rewrites", measurable_ir_rewrites_db, -10, "basic")
+logprob_rewrites_db.register("measurable_ir_rewrites", measurable_ir_rewrites_db, "basic")
 
 # These rewrites push random/measurable variables "down", making them closer to
 # (or eventually) the graph outputs.  Often this is done by lifting other `Op`s
 # "up" through the random/measurable variables and into their inputs.
-measurable_ir_rewrites_db.register("subtensor_lift", local_subtensor_rv_lift, -5, "basic")
-measurable_ir_rewrites_db.register("incsubtensor_lift", incsubtensor_rv_replace, -5, "basic")
+measurable_ir_rewrites_db.register("subtensor_lift", local_subtensor_rv_lift, "basic")
+measurable_ir_rewrites_db.register("incsubtensor_lift", incsubtensor_rv_replace, "basic")
 
-logprob_rewrites_db.register("post-canonicalize", optdb.query("+canonicalize"), 10, "basic")
+logprob_rewrites_db.register("post-canonicalize", optdb.query("+canonicalize"), "basic")
 
 
 def construct_ir_fgraph(

--- a/pymc/logprob/scan.py
+++ b/pymc/logprob/scan.py
@@ -530,7 +530,6 @@ measurable_ir_rewrites_db.register(
     # out2in(
     #     add_opts_to_inner_graphs, name="add_opts_to_inner_graphs", ignore_newtrees=True
     # ),
-    -100,
     "basic",
     "scan",
 )
@@ -538,11 +537,10 @@ measurable_ir_rewrites_db.register(
 measurable_ir_rewrites_db.register(
     "find_measurable_scans",
     find_measurable_scans,
-    0,
     "basic",
     "scan",
 )
 
 # Add scan canonicalizations that aren't in the canonicalization DB
-logprob_rewrites_db.register("scan_eqopt1", scan_eqopt1, -9, "basic", "scan")
-logprob_rewrites_db.register("scan_eqopt2", scan_eqopt2, -9, "basic", "scan")
+logprob_rewrites_db.register("scan_eqopt1", scan_eqopt1, "basic", "scan")
+logprob_rewrites_db.register("scan_eqopt2", scan_eqopt2, "basic", "scan")

--- a/pymc/logprob/tensor.py
+++ b/pymc/logprob/tensor.py
@@ -311,24 +311,21 @@ def find_measurable_dimshuffles(fgraph, node) -> Optional[List[MeasurableDimShuf
     return [measurable_dimshuffle]
 
 
-measurable_ir_rewrites_db.register(
-    "dimshuffle_lift", local_dimshuffle_rv_lift, -5, "basic", "tensor"
-)
+measurable_ir_rewrites_db.register("dimshuffle_lift", local_dimshuffle_rv_lift, "basic", "tensor")
 
 
 # We register this later than `dimshuffle_lift` so that it is only applied as a fallback
 measurable_ir_rewrites_db.register(
-    "find_measurable_dimshuffles", find_measurable_dimshuffles, 0, "basic", "tensor"
+    "find_measurable_dimshuffles", find_measurable_dimshuffles, "basic", "tensor"
 )
 
 
-measurable_ir_rewrites_db.register("broadcast_to_lift", naive_bcast_rv_lift, -5, "basic", "tensor")
+measurable_ir_rewrites_db.register("broadcast_to_lift", naive_bcast_rv_lift, "basic", "tensor")
 
 
 measurable_ir_rewrites_db.register(
     "find_measurable_stacks",
     find_measurable_stacks,
-    0,
     "basic",
     "tensor",
 )

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -373,7 +373,6 @@ def find_measurable_transforms(fgraph: FunctionGraph, node: Node) -> Optional[Li
 measurable_ir_rewrites_db.register(
     "find_measurable_transforms",
     find_measurable_transforms,
-    0,
     "basic",
     "transform",
 )

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -48,7 +48,7 @@ from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.op import Op
 from pytensor.graph.rewriting.basic import GraphRewriter, in2out, node_rewriter
 from pytensor.scalar import Add, Exp, Log, Mul
-from pytensor.tensor.elemwise import Elemwise
+from pytensor.tensor.math import add, exp, log, mul
 from pytensor.tensor.rewriting.basic import (
     register_specialize,
     register_stabilize,
@@ -256,12 +256,9 @@ def measurable_transform_logprob(op: MeasurableTransform, values, *inputs, **kwa
     return input_logprob + jacobian
 
 
-@node_rewriter([Elemwise])
+@node_rewriter([exp, log, add, mul])
 def find_measurable_transforms(fgraph: FunctionGraph, node: Node) -> Optional[List[Node]]:
     """Find measurable transformations from Elemwise operators."""
-    scalar_op = node.op.scalar_op
-    if not isinstance(scalar_op, MeasurableTransform.valid_scalar_types):
-        return None
 
     # Node was already converted
     if isinstance(node.op, MeasurableVariable):
@@ -311,6 +308,7 @@ def find_measurable_transforms(fgraph: FunctionGraph, node: Node) -> Optional[Li
     # This seems to be the only thing preventing nested rewrites from being erased
     measurable_input = assign_custom_measurable_outputs(measurable_input.owner)
 
+    scalar_op = node.op.scalar_op
     measurable_input_idx = 0
     transform_inputs: Tuple[TensorVariable, ...] = (measurable_input,)
     transform: RVTransform

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -47,6 +47,7 @@ pymc/gp/mean.py
 pymc/gp/util.py
 pymc/logprob/__init__.py
 pymc/logprob/abstract.py
+pymc/logprob/cumsum.py
 pymc/math.py
 pymc/ode/__init__.py
 pymc/ode/ode.py


### PR DESCRIPTION
Just some cleanup of the logprob submodule, removing functionality we don't need or are not using in PyMC

Closes #6353