### PR TITLE
Add informative error if user mixes Aesara functions with PyTensor variables

### DIFF
--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -92,6 +92,23 @@ __all__ = [
 ]
 
 
+# Temporarily add an Aesara dispatch for PyTensor TensorVariable to inform users
+# of incorrect mixing of libraries
+try:
+    from aesara.tensor import _as_tensor_variable as _as_tensor_variable_aesara
+
+    @_as_tensor_variable_aesara.register(TensorVariable)
+    def raise_informative_error(*args, **kwargs):
+        raise TypeError(
+            "You are calling an Aesara function with PyTensor variables.\n"
+            "Starting with PyMC 5.0, Aesara was replaced by PyTensor (see https://www.pymc.io/blog/pytensor_announcement.html).\n"
+            "Replace your import of aesara.tensor with pytensor.tensor.",
+        )
+
+except ImportError:
+    pass
+
+
 def convert_observed_data(data):
     """Convert user provided dataset to accepted formats."""
 


### PR DESCRIPTION
To help with the V5 transition. This will happen now:

```python
import aesara.tensor as at
import pymc as pm

at.exp(pm.Normal.dist())
```

```
TypeError: You are calling an Aesara function with PyTensor variables. Did you import aesara.tensor instead of pytensor.tensor?
```

I didn't add a test, to not require Aesara as a dependency.