### PR TITLE
Deprecate ordered transform

### DIFF
--- a/docs/source/api/distributions/transforms.rst
+++ b/docs/source/api/distributions/transforms.rst
@@ -16,7 +16,8 @@ Transform instances are the entities that should be used in the
     simplex
     logodds
     log_exp_m1
-    ordered
+    ordered_univariate
+    ordered_multivariate
     log
     sum_to_1
     circular

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -37,7 +37,6 @@ __all__ = [
     "logodds",
     "Interval",
     "log_exp_m1",
-    "ordered",
     "univariate_ordered",
     "multivariate_ordered",
     "log",
@@ -369,14 +368,6 @@ multivariate_ordered = Ordered(ndim_supp=1)
 multivariate_ordered.__doc__ = """
 Instantiation of :class:`pymc.distributions.transforms.Ordered`
 for use in the ``transform`` argument of a multivariate random variable."""
-
-# backwards compatibility
-ordered = Ordered(ndim_supp=1)
-ordered.__doc__ = """
-Instantiation of :class:`pymc.distributions.transforms.Ordered`
-for use in the ``transform`` argument of a random variable.
-This instantiation is for backwards compatibility only.
-Please use `univariate_ordererd` or `multivariate_ordered` instead."""
 
 log = LogTransform()
 log.__doc__ = """


### PR DESCRIPTION
Closes #6330

## Major / Breaking Changes
- `ordered` transform was removed in favor of `ordered_univariate` and `ordered_multivariate`
