### PR TITLE
replaces numpy sqrt method with pytensor equivalent

### DIFF
--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -333,8 +333,8 @@ class ZeroSumTransform(RVTransform):
 def extend_axis(array, axis):
     n = array.shape[axis] + 1
     sum_vals = array.sum(axis, keepdims=True)
-    norm = sum_vals / (np.sqrt(n) + n)
-    fill_val = norm - sum_vals / np.sqrt(n)
+    norm = sum_vals / (at.sqrt(n) + n)
+    fill_val = norm - sum_vals / at.sqrt(n)
 
     out = at.concatenate([array, fill_val], axis=axis)
     return out - norm
@@ -346,8 +346,8 @@ def extend_axis_rev(array, axis):
     n = array.shape[normalized_axis]
     last = at.take(array, [-1], axis=normalized_axis)
 
-    sum_vals = -last * np.sqrt(n)
-    norm = sum_vals / (np.sqrt(n) + n)
+    sum_vals = -last * at.sqrt(n)
+    norm = sum_vals / (at.sqrt(n) + n)
     slice_before = (slice(None, None),) * normalized_axis
 
     return array[slice_before + (slice(None, -1),)] + norm


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
When using JAX on a Google hosted VM with TPU support, the float64 dtype is not supported. Unfortunately, numpy uses this as default and aggressively casts arrays to float64. This caused an issue where my model wouldn't compile at all. After debugging, I located the issue to the zerosum-normal transformation, where `np.sqrt` is used. In this PR I'm replacing numpy with the pytensor equivalent, which fixes the issue.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- Replace `zerosumnormal`'s numpy operators with their pytensor counterparts to make them run on JAX

## Documentation
- ...

## Maintenance
- ...
