### PR TITLE
fix(sec): upgrade numpy to 1.22.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ arviz>=0.13.0
 cachetools>=4.2.1
 cloudpickle
 fastprogress>=0.2.0
-numpy>=1.15.0
+numpy>=1.22.2
 pandas>=0.24.0
 pytensor==2.8.11
 scipy>=1.4.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in numpy 1.15.0
- [CVE-2021-33430](https://www.oscs1024.com/hd/CVE-2021-33430)


### What did I do？
Upgrade numpy from 1.15.0 to 1.22.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS