### PR TITLE
Default VonMises  kappa to 1.0 and fix math notation in doc

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2727,16 +2727,16 @@ class VonMises(CircularContinuous):
 
     Parameters
     ----------
-    mu : tensor_like of float, default 0
+    mu : tensor_like of float, default 0.0
         Mean.
-    kappa : tensor_like of float
-        Concentration (\frac{1}{kappa} is analogous to \sigma^2).
+    kappa : tensor_like of float, default 1.0
+        Concentration (:math:`\frac{1}{\kappa}` is analogous to :math:`\sigma^2`).
     """
 
     rv_op = vonmises
 
     @classmethod
-    def dist(cls, mu=0.0, kappa=None, *args, **kwargs):
+    def dist(cls, mu=0.0, kappa=1.0, *args, **kwargs):
         mu = at.as_tensor_variable(floatX(mu))
         kappa = at.as_tensor_variable(floatX(kappa))
         return super().dist([mu, kappa], *args, **kwargs)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This PR fixes the default value concern raised in the issue [here](https://github.com/pymc-devs/pymc/issues/6418). The docs are also adjusted. 

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- None

## New features
- VonMises without args will allow sampling

## Bugfixes
- pm.draw, pm.sample... will now produce sample with defaults / no args in VonMises distribution

## Documentation
- The math will render now. Defaults now updated

## Maintenance
- ...
