### PR TITLE
Access to external nuts samplers via  `sample`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -305,14 +305,14 @@ jobs:
           env_vars: TEST_SUBSET
           name: ${{ matrix.os }} ${{ matrix.floatx }}
           fail_ci_if_error: false
-  jax:
+  external_samplers:
     strategy:
       matrix:
         os: [ubuntu-20.04]
         floatx: [float64]
         python-version: ["3.9"]
         test-subset:
-          - pymc/tests/sampling/test_jax.py
+          - pymc/tests/sampling/test_jax.py pymc/tests/sampling/test_mcmc_external.py
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
@@ -360,9 +360,10 @@ jobs:
           conda activate pymc-test
           pip install -e .
           python --version
-      - name: Install jax specific dependencies
+      - name: Install external samplers
         run: |
           conda activate pymc-test
+          conda install -c conda-forge nutpie
           pip install "numpyro>=0.8.0"
           pip install git+https://github.com/blackjax-devs/blackjax.git@0.7.0
       - name: Run tests

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -48,7 +48,12 @@ from pytensor.tensor.shape import SpecifyShape
 from pymc import Model, modelcontext
 from pymc.backends.arviz import find_constants, find_observations
 from pymc.logprob.utils import CheckParameterValue
-from pymc.util import RandomSeed, _get_seeds_per_chain, get_default_varnames
+from pymc.util import (
+    RandomSeed,
+    RandomState,
+    _get_seeds_per_chain,
+    get_default_varnames,
+)
 
 __all__ = (
     "get_jaxified_graph",
@@ -308,7 +313,7 @@ def sample_blackjax_nuts(
     tune: int = 1000,
     chains: int = 4,
     target_accept: float = 0.8,
-    random_seed: Optional[RandomSeed] = None,
+    random_seed: Optional[RandomState] = None,
     initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]] = None,
     model: Optional[Model] = None,
     var_names: Optional[Sequence[str]] = None,
@@ -518,7 +523,7 @@ def sample_numpyro_nuts(
     tune: int = 1000,
     chains: int = 4,
     target_accept: float = 0.8,
-    random_seed: Optional[RandomSeed] = None,
+    random_seed: Optional[RandomState] = None,
     initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]] = None,
     model: Optional[Model] = None,
     var_names: Optional[Sequence[str]] = None,

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -14,7 +14,6 @@
 import os
 import re
 import sys
-import warnings
 
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
@@ -48,9 +47,6 @@ from pymc import Model, modelcontext
 from pymc.backends.arviz import find_constants, find_observations
 from pymc.logprob.utils import CheckParameterValue
 from pymc.util import RandomSeed, _get_seeds_per_chain, get_default_varnames
-
-warnings.warn("This module is experimental.")
-
 
 __all__ = (
     "get_jaxified_graph",

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -18,6 +18,8 @@ import sys
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
+from pytensor.tensor.random.type import RandomType
+
 from pymc.initial_point import StartDict
 from pymc.sampling.mcmc import _init_jitter
 
@@ -80,6 +82,11 @@ def _replace_shared_variables(graph: List[TensorVariable]) -> List[TensorVariabl
     """
 
     shared_variables = [var for var in graph_inputs(graph) if isinstance(var, SharedVariable)]
+
+    if any(isinstance(var.type, RandomType) for var in shared_variables):
+        raise ValueError(
+            "Graph contains shared RandomType variables which cannot be safely replaced"
+        )
 
     if any(var.default_update is not None for var in shared_variables):
         raise ValueError(

--- a/pymc/tests/distributions/test_mixture.py
+++ b/pymc/tests/distributions/test_mixture.py
@@ -456,7 +456,7 @@ class TestMixture(SeededTest):
                 warnings.filterwarnings("ignore", "overflow encountered in exp", RuntimeWarning)
                 trace = sample(
                     5000,
-                    step,
+                    step=step,
                     random_seed=self.random_seed,
                     progressbar=False,
                     chains=1,
@@ -783,7 +783,7 @@ class TestNormalMixture(SeededTest):
                 warnings.filterwarnings("ignore", "overflow encountered in exp", RuntimeWarning)
                 trace = sample(
                     5000,
-                    step,
+                    step=step,
                     random_seed=self.random_seed,
                     progressbar=False,
                     chains=1,

--- a/pymc/tests/sampling/test_mcmc_external.py
+++ b/pymc/tests/sampling/test_mcmc_external.py
@@ -1,0 +1,66 @@
+#   Copyright 2023 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import numpy as np
+import pytest
+
+from pymc import Model, Normal, sample
+
+pytest.importorskip("nutpie")
+pytest.importorskip("blackjax")
+pytest.importorskip("numpyro")
+
+# turns all warnings into errors for this module
+pytestmark = pytest.mark.filterwarnings("error")
+
+
+@pytest.mark.parametrize("nuts_sampler", ["pymc", "nutpie", "blackjax", "numpyro"])
+def test_external_nuts_sampler(recwarn, nuts_sampler):
+    with Model():
+        Normal("x")
+
+        kwargs = dict(
+            nuts_sampler=nuts_sampler,
+            random_seed=123,
+            chains=2,
+            tune=500,
+            draws=500,
+            progressbar=False,
+            initvals={"x": 0.0},
+        )
+
+        idata1 = sample(**kwargs)
+        idata2 = sample(**kwargs)
+
+    warns = {
+        (warn.category, warn.message.args[0])
+        for warn in recwarn
+        if warn.category is not FutureWarning
+    }
+    expected = set()
+    if nuts_sampler != "pymc":
+        expected.add((UserWarning, "Use of external NUTS sampler is still experimental"))
+    if nuts_sampler == "nutpie":
+        expected.add(
+            (
+                UserWarning,
+                "`initvals` are currently not passed to nutpie sampler. "
+                "Use `init_mean` kwarg following nutpie specification instead.",
+            )
+        )
+    assert warns == expected
+
+    assert idata1.posterior.chain.size == 2
+    assert idata1.posterior.draw.size == 500
+    np.testing.assert_array_equal(idata1.posterior.x, idata2.posterior.x)


### PR DESCRIPTION
TODO:

- [x] Tests
- [x] Figure out circular dependency on nutpie test...

### Major
- All arguments except `draws` in `sample` are now keyword-only.

### Enhancements
- Access to external nuts samplers via `sample`
