### PR TITLE
Fix bug that does not correctly set the dtype of determinsitic variab…

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1456,7 +1456,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
             # Create deterministic that combines observed and missing
             # Note: This can widely increase memory consumption during sampling for large datasets
-            rv_var = at.zeros(data.shape)
+            rv_var = at.zeros(data.shape, dtype=observed_rv_var.type.dtype)
             rv_var = at.set_subtensor(rv_var[mask.nonzero()], missing_rv_var)
             rv_var = at.set_subtensor(rv_var[antimask_idx], observed_rv_var)
             rv_var = Deterministic(name, rv_var, self, dims)

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1456,7 +1456,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
             # Create deterministic that combines observed and missing
             # Note: This can widely increase memory consumption during sampling for large datasets
-            rv_var = at.zeros(data.shape, dtype=observed_rv_var.type.dtype)
+            rv_var = at.empty(data.shape, dtype=observed_rv_var.type.dtype)
             rv_var = at.set_subtensor(rv_var[mask.nonzero()], missing_rv_var)
             rv_var = at.set_subtensor(rv_var[antimask_idx], observed_rv_var)
             rv_var = Deterministic(name, rv_var, self, dims)

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -356,6 +356,9 @@ class TestValueGradFunction(unittest.TestCase):
 
         assert m["x2_missing"].type == gf._extra_vars_shared["x2_missing"].type
 
+        # The dtype of the merged observed/missing deterministic should match the RV dtype
+        assert m.deterministics[0].type.dtype == x2.type.dtype
+
         pnt = m.initial_point(random_seed=None).copy()
         del pnt["x2_missing"]
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**

Closes #6424 by setting the dtype of combined observed/interpolated deterministic generated by `model.make_obs_var` to be the same as the underling RV being interpolated. 

**Checklist**
+ [x] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- None

## New features
- None

## Bugfixes
- Allow indexing by discrete RVs with missing data
- 

## Documentation
- ...

## Maintenance
- ...
