### PR TITLE
ModelGraph only stops ancestry check at model defined named_vars

### DIFF
--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -62,8 +62,11 @@ class ModelGraph:
                 # Otherwise return all inputs
                 return node.inputs
 
+        blockers = set(self.model.named_vars)
+
         def _expand(x):
-            if x.name:
+            nonlocal blockers
+            if x.name in blockers:
                 return [x]
             if isinstance(x.owner, Apply):
                 return reversed(_filter_non_parameter_inputs(x))


### PR DESCRIPTION
Closes #6421 

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- `ModelGraph.get_parent_names` now will only stop at `Variable` instances whose names are in `model.named_vars`. Before this, the above mentioned method would return `Variable` instances with a name that was not `None`, which could break edges in the returned compute graph.

## Documentation
- ...

## Maintenance
- ...
