### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Ideally I'd like to have dependabot bump our PyTensor version pin, but [as of 2023-01 it does not yet support conda environments](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem), and the fact that we have versions pinned in `environment.yml` and `requirements.txt` at the same time will further complicate things.

However, we can already use it to keep our GitHub Actions updated.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] ~Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))~
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Maintenance
- Added dependabot to keep GitHub Actions updated.
