### PR TITLE
Bump PyTensor to 2.9.1

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -52,7 +52,7 @@ jobs:
           environment-file: conda-envs/environment-test.yml
           python-version: 3.9
           use-mamba: true
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          use-only-tar-bz2: false # IMPORTANT: This may break caching of conda packages! See https://github.com/conda-incubator/setup-miniconda/issues/267
       - name: Install-pymc and mypy dependencies
         run: |
           conda activate pymc-test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,7 @@ jobs:
           environment-file: conda-envs/environment-test.yml
           python-version: ${{matrix.python-version}}
           use-mamba: true
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          use-only-tar-bz2: false # IMPORTANT: This may break caching of conda packages! See https://github.com/conda-incubator/setup-miniconda/issues/267
       - name: Install-pymc
         run: |
           conda activate pymc-test
@@ -211,7 +211,7 @@ jobs:
           environment-file: conda-envs/windows-environment-test.yml
           python-version: ${{matrix.python-version}}
           use-mamba: true
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          use-only-tar-bz2: false # IMPORTANT: This may break caching of conda packages! See https://github.com/conda-incubator/setup-miniconda/issues/267
       - name: Install-pymc
         run: |
           conda activate pymc-test
@@ -290,7 +290,7 @@ jobs:
           environment-file: conda-envs/environment-test.yml
           python-version: ${{matrix.python-version}}
           use-mamba: true
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          use-only-tar-bz2: false # IMPORTANT: This may break caching of conda packages! See https://github.com/conda-incubator/setup-miniconda/issues/267
       - name: Install pymc
         run: |
           conda activate pymc-test
@@ -355,7 +355,7 @@ jobs:
           environment-file: conda-envs/environment-test.yml
           python-version: ${{matrix.python-version}}
           use-mamba: true
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          use-only-tar-bz2: false # IMPORTANT: This may break caching of conda packages! See https://github.com/conda-incubator/setup-miniconda/issues/267
       - name: Install pymc
         run: |
           conda activate pymc-test
@@ -425,7 +425,7 @@ jobs:
           environment-file: conda-envs/windows-environment-test.yml
           python-version: ${{matrix.python-version}}
           use-mamba: true
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          use-only-tar-bz2: false # IMPORTANT: This may break caching of conda packages! See https://github.com/conda-incubator/setup-miniconda/issues/267
       - name: Install-pymc
         run: |
           conda activate pymc-test

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor=2.8.11
+- pytensor=2.9.1
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -17,7 +17,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor=2.8.11
+- pytensor=2.9.1
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor=2.8.11
+- pytensor=2.9.1
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -17,7 +17,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor=2.8.11
+- pytensor=2.9.1
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -740,14 +740,15 @@ def get_support_shape(
             observed.shape[i] - support_shape_offset[i] for i in np.arange(-ndim_supp, 0)
         ]
 
-    # We did not learn anything
-    if inferred_support_shape is None and support_shape is None:
-        return None
-    # Only source of information was the originally provided support_shape
-    elif inferred_support_shape is None:
-        inferred_support_shape = support_shape
-    # There were two sources of support_shape, make sure they are consistent
+    if inferred_support_shape is None:
+        if support_shape is not None:
+            # Only source of information was the originally provided support_shape
+            inferred_support_shape = support_shape
+        else:
+            # We did not learn anything
+            return None
     elif support_shape is not None:
+        # There were two sources of support_shape, make sure they are consistent
         inferred_support_shape = [
             cast(
                 Variable,
@@ -758,6 +759,8 @@ def get_support_shape(
             for inferred, explicit in zip(inferred_support_shape, support_shape)
         ]
 
+    # Workaround https://github.com/pymc-devs/pytensor/issues/193 typing bug in stack signature
+    inferred_support_shape = cast(Sequence[TensorVariable], inferred_support_shape)
     return at.stack(inferred_support_shape)
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ numpydoc
 pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
-pytensor==2.8.11
+pytensor==2.9.1
 pytest-cov>=2.5
 pytest>=3.0
 scipy>=1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ cloudpickle
 fastprogress>=0.2.0
 numpy>=1.15.0
 pandas>=0.24.0
-pytensor==2.8.11
+pytensor==2.9.1
 scipy>=1.4.1
 typing-extensions>=3.7.4


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Updating to the latest PyTensor version, because I'm looking forward to a bugfix in the release after, and I want things to go smooth =)

After major complications due to (unnoticed) broken release pipelines on the PyTensor side, it appears that the upgrade actually was comparably smooth with only a minor typing issue.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- Updated PyTensor 2.8.11→[2.9.1](https://github.com/pymc-devs/pytensor/releases/tag/rel-2.9.1)

## Maintenance
- Turned off `*.tar.bz2`-only installations because PyTensor 2.9.1 is no longer available from `.tar-bz2` artifacts. This _may_ break caching in GitHub Actions.