### PR TITLE
Refactoring and addition of helpers to handle flat stats

### DIFF
--- a/pymc/blocking.py
+++ b/pymc/blocking.py
@@ -31,7 +31,8 @@ __all__ = ["DictToArrayBijection"]
 
 T = TypeVar("T")
 PointType: TypeAlias = Dict[str, np.ndarray]
-StatsType: TypeAlias = List[Dict[str, Any]]
+StatsDict: TypeAlias = Dict[str, Any]
+StatsType: TypeAlias = List[StatsDict]
 
 # `point_map_info` is a tuple of tuples containing `(name, shape, dtype)` for
 # each of the raveled variables.

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -19,9 +19,113 @@ Created on Mar 7, 2011
 """
 
 
-from typing import Tuple
+from abc import ABC, abstractmethod
+from enum import IntEnum, unique
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+from pytensor.graph.basic import Variable
 
 from pymc.blocking import PointType, StatsType
+from pymc.model import modelcontext
+
+__all__ = ("Competence", "CompoundStep")
+
+
+@unique
+class Competence(IntEnum):
+    """Enum for characterizing competence classes of step methods.
+    Values include:
+    0: INCOMPATIBLE
+    1: COMPATIBLE
+    2: PREFERRED
+    3: IDEAL
+    """
+
+    INCOMPATIBLE = 0
+    COMPATIBLE = 1
+    PREFERRED = 2
+    IDEAL = 3
+
+
+class BlockedStep(ABC):
+
+    stats_dtypes: List[Dict[str, type]] = []
+    vars: List[Variable] = []
+
+    def __new__(cls, *args, **kwargs):
+        blocked = kwargs.get("blocked")
+        if blocked is None:
+            # Try to look up default value from class
+            blocked = getattr(cls, "default_blocked", True)
+            kwargs["blocked"] = blocked
+
+        model = modelcontext(kwargs.get("model"))
+        kwargs.update({"model": model})
+
+        # vars can either be first arg or a kwarg
+        if "vars" not in kwargs and len(args) >= 1:
+            vars = args[0]
+            args = args[1:]
+        elif "vars" in kwargs:
+            vars = kwargs.pop("vars")
+        else:  # Assume all model variables
+            vars = model.value_vars
+
+        if not isinstance(vars, (tuple, list)):
+            vars = [vars]
+
+        if len(vars) == 0:
+            raise ValueError("No free random variables to sample.")
+
+        if not blocked and len(vars) > 1:
+            # In this case we create a separate sampler for each var
+            # and append them to a CompoundStep
+            steps = []
+            for var in vars:
+                step = super().__new__(cls)
+                # If we don't return the instance we have to manually
+                # call __init__
+                step.__init__([var], *args, **kwargs)
+                # Hack for creating the class correctly when unpickling.
+                step.__newargs = ([var],) + args, kwargs
+                steps.append(step)
+
+            return CompoundStep(steps)
+        else:
+            step = super().__new__(cls)
+            # Hack for creating the class correctly when unpickling.
+            step.__newargs = (vars,) + args, kwargs
+            return step
+
+    # Hack for creating the class correctly when unpickling.
+    def __getnewargs_ex__(self):
+        return self.__newargs
+
+    @abstractmethod
+    def step(self, point: PointType) -> Tuple[PointType, StatsType]:
+        """Perform a single step of the sampler."""
+
+    @staticmethod
+    def competence(var, has_grad):
+        return Competence.INCOMPATIBLE
+
+    @classmethod
+    def _competence(cls, vars, have_grad):
+        vars = np.atleast_1d(vars)
+        have_grad = np.atleast_1d(have_grad)
+        competences = []
+        for var, has_grad in zip(vars, have_grad):
+            try:
+                competences.append(cls.competence(var, has_grad))
+            except TypeError:
+                competences.append(cls.competence(var))
+        return competences
+
+    def stop_tuning(self):
+        if hasattr(self, "tune"):
+            self.tune = False
 
 
 class CompoundStep:

--- a/pymc/step_methods/hmc/hmc.py
+++ b/pymc/step_methods/hmc/hmc.py
@@ -19,7 +19,7 @@ from typing import Any
 import numpy as np
 
 from pymc.stats.convergence import SamplerWarning
-from pymc.step_methods.arraystep import Competence
+from pymc.step_methods.compound import Competence
 from pymc.step_methods.hmc.base_hmc import BaseHMC, DivergenceInfo, HMCStepData
 from pymc.step_methods.hmc.integration import IntegrationError, State
 from pymc.vartypes import discrete_types

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -21,7 +21,7 @@ import numpy as np
 from pymc.math import logbern
 from pymc.pytensorf import floatX
 from pymc.stats.convergence import SamplerWarning
-from pymc.step_methods.arraystep import Competence
+from pymc.step_methods.compound import Competence
 from pymc.step_methods.hmc import integration
 from pymc.step_methods.hmc.base_hmc import BaseHMC, DivergenceInfo, HMCStepData
 from pymc.step_methods.hmc.integration import IntegrationError, State

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -36,11 +36,11 @@ from pymc.pytensorf import (
 from pymc.step_methods.arraystep import (
     ArrayStep,
     ArrayStepShared,
-    Competence,
     PopulationArrayStepShared,
     StatsType,
     metrop_select,
 )
+from pymc.step_methods.compound import Competence
 
 __all__ = [
     "Metropolis",

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -21,7 +21,8 @@ import numpy.random as nr
 
 from pymc.blocking import RaveledVars, StatsType
 from pymc.model import modelcontext
-from pymc.step_methods.arraystep import ArrayStep, Competence
+from pymc.step_methods.arraystep import ArrayStep
+from pymc.step_methods.compound import Competence
 from pymc.util import get_value_vars_from_user_vars
 from pymc.vartypes import continuous_types
 


### PR DESCRIPTION
This is one step towards refactoring of the trace backend.

PyMC supports hierarchies of samplers, which means that sampler stats are not a flat list by default.

First I moved `Competence` and `BlockedStep` to the `compound` module to avoid a circular import.

Second, I added a `StatsBijection` which can be used to flatten a list of sampler stats dicts into one dictionary.

Related: https://github.com/pymc-devs/pymc/issues/4602

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Maintenance
- `Competence` and `BlockedStep` were moved to the `compound` module.
- A non-public `StatsBijection` was added.
