### PR TITLE
Refactor internal sampling functions

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -21,7 +21,6 @@ import time
 import warnings
 
 from collections import defaultdict
-from copy import copy
 from typing import Iterator, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -654,6 +653,7 @@ def _check_start_shape(model, start: PointType):
 
 
 def _sample_many(
+    *,
     draws: int,
     chains: int,
     start: Sequence[PointType],
@@ -754,10 +754,16 @@ def _sample(
     """
     skip_first = kwargs.get("skip_first", 0)
 
-    trace = copy(trace)
-
     sampling_gen = _iter_sample(
-        draws, step, start, trace, chain, tune, model, random_seed, callback
+        draws=draws,
+        step=step,
+        start=start,
+        trace=trace,
+        chain=chain,
+        tune=tune,
+        model=model,
+        random_seed=random_seed,
+        callback=callback,
     )
     _pbar_data = {"chain": chain, "divergences": 0}
     _desc = "Sampling chain {chain:d}, {divergences:,d} divergences"
@@ -832,12 +838,23 @@ def iter_sample(
         for trace in iter_sample(500, step):
             ...
     """
-    sampling = _iter_sample(draws, step, start, trace, chain, tune, model, random_seed, callback)
+    sampling = _iter_sample(
+        draws=draws,
+        step=step,
+        start=start,
+        trace=trace,
+        chain=chain,
+        tune=tune,
+        model=model,
+        random_seed=random_seed,
+        callback=callback,
+    )
     for i, (strace, _) in enumerate(sampling):
         yield MultiTrace([strace[: i + 1]])
 
 
 def _iter_sample(
+    *,
     draws: int,
     step,
     start: PointType,
@@ -934,6 +951,7 @@ def _iter_sample(
 
 
 def _mp_sample(
+    *,
     draws: int,
     tune: int,
     step,

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -58,7 +58,6 @@ sys.setrecursionlimit(10000)
 
 __all__ = [
     "sample",
-    "iter_sample",
     "init_nuts",
 ]
 
@@ -768,73 +767,6 @@ def _sample(
     if strace is None:
         raise Exception("KeyboardInterrupt happened before the base trace was created.")
     return strace
-
-
-def iter_sample(
-    draws: int,
-    step,
-    start: PointType,
-    trace=None,
-    chain: int = 0,
-    tune: int = 0,
-    model: Optional[Model] = None,
-    random_seed: RandomSeed = None,
-    callback=None,
-) -> Iterator[MultiTrace]:
-    """Generate a trace on each iteration using the given step method.
-
-    Multiple step methods ared supported via compound step methods.  Returns the
-    amount of time taken.
-
-    Parameters
-    ----------
-    draws : int
-        The number of samples to draw
-    step : function
-        Step function
-    start : dict
-        Starting point in parameter space (or partial point).
-    trace : backend or list
-        This should be a backend instance, or a list of variables to track.
-        If None or a list of variables, the NDArray backend is used.
-    chain : int, optional
-        Chain number used to store sample in backend.
-    tune : int, optional
-        Number of iterations to tune (defaults to 0).
-    model : Model (optional if in ``with`` context)
-    random_seed : single random seed, optional
-    callback :
-        A function which gets called for every sample from the trace of a chain. The function is
-        called with the trace and the current draw and will contain all samples for a single trace.
-        the ``draw.chain`` argument can be used to determine which of the active chains the sample
-        is drawn from.
-        Sampling can be interrupted by throwing a ``KeyboardInterrupt`` in the callback.
-
-    Yields
-    ------
-    trace : MultiTrace
-        Contains all samples up to the current iteration
-
-    Examples
-    --------
-    ::
-
-        for trace in iter_sample(500, step):
-            ...
-    """
-    sampling = _iter_sample(
-        draws=draws,
-        step=step,
-        start=start,
-        trace=trace,
-        chain=chain,
-        tune=tune,
-        model=model,
-        random_seed=random_seed,
-        callback=callback,
-    )
-    for i, (strace, _) in enumerate(sampling):
-        yield MultiTrace([strace[: i + 1]])
 
 
 def _iter_sample(

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -28,7 +28,7 @@ from typing_extensions import TypeAlias
 
 from pymc.backends.base import BaseTrace
 from pymc.initial_point import PointType
-from pymc.model import modelcontext
+from pymc.model import Model, modelcontext
 from pymc.stats.convergence import log_warning_stats
 from pymc.step_methods import CompoundStep
 from pymc.step_methods.arraystep import (
@@ -50,13 +50,13 @@ _log = logging.getLogger("pymc")
 
 def _sample_population(
     *,
-    initial_points,
+    initial_points: Sequence[PointType],
     draws: int,
     start: Sequence[PointType],
     random_seed: RandomSeed,
-    step,
+    step: Union[BlockedStep, CompoundStep],
     tune: int,
-    model,
+    model: Model,
     progressbar: bool = True,
     parallelize: bool = False,
     traces: Sequence[BaseTrace],
@@ -108,7 +108,14 @@ def _sample_population(
     return
 
 
-def warn_population_size(*, step: CompoundStep, initial_points, model, chains: int):
+def warn_population_size(
+    *,
+    step: Union[BlockedStep, CompoundStep],
+    initial_points: Sequence[PointType],
+    model: Model,
+    chains: int,
+):
+    """Emit informative errors/warnings for dangerously small population size."""
     has_demcmc = np.any(
         [
             isinstance(m, DEMetropolis)

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -48,6 +48,7 @@ _log = logging.getLogger("pymc")
 
 
 def _sample_population(
+    *,
     draws: int,
     chains: int,
     start: Sequence[PointType],
@@ -86,10 +87,10 @@ def _sample_population(
         Contains samples of all chains
     """
     sampling = _prepare_iter_population(
-        draws,
-        step,
-        start,
-        parallelize,
+        draws=draws,
+        step=step,
+        start=start,
+        parallelize=parallelize,
         tune=tune,
         model=model,
         random_seed=random_seed,
@@ -259,6 +260,7 @@ class PopulationStepper:
 
 
 def _prepare_iter_population(
+    *,
     draws: int,
     step,
     start: Sequence[PointType],
@@ -344,11 +346,19 @@ def _prepare_iter_population(
 
     # Because the preparations above are expensive, the actual iterator is
     # in another method. This way the progbar will not be disturbed.
-    return _iter_population(draws, tune, popstep, steppers, traces, population)
+    return _iter_population(
+        draws=draws, tune=tune, popstep=popstep, steppers=steppers, traces=traces, points=population
+    )
 
 
 def _iter_population(
-    draws: int, tune: int, popstep: PopulationStepper, steppers, traces: Sequence[BaseTrace], points
+    *,
+    draws: int,
+    tune: int,
+    popstep: PopulationStepper,
+    steppers,
+    traces: Sequence[BaseTrace],
+    points,
 ) -> Iterator[Sequence[BaseTrace]]:
     """Iterate a ``PopulationStepper``.
 

--- a/pymc/stats/log_likelihood.py
+++ b/pymc/stats/log_likelihood.py
@@ -11,7 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from typing import Optional, Sequence
+from typing import Optional, Sequence, cast
 
 import numpy as np
 
@@ -22,6 +22,7 @@ import pymc
 
 from pymc.backends.arviz import _DefaultTrace
 from pymc.model import Model, modelcontext
+from pymc.pytensorf import PointFunc
 from pymc.util import dataset_to_point_list
 
 __all__ = ("compute_log_likelihood",)
@@ -86,6 +87,7 @@ def compute_log_likelihood(
             outs=model.logp(vars=observed_vars, sum=False),
             on_unused_input="ignore",
         )
+        elemwise_loglike_fn = cast(PointFunc, elemwise_loglike_fn)
     finally:
         model.rvs_to_values = original_rvs_to_values
         model.rvs_to_transforms = original_rvs_to_transforms

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -36,6 +36,7 @@ class CompoundStep:
         self.name = (
             f"Compound[{', '.join(getattr(m, 'name', 'UNNAMED_STEP') for m in self.methods)}]"
         )
+        self.tune = True
 
     def step(self, point) -> Tuple[PointType, StatsType]:
         stats = []

--- a/pymc/tests/sampling/test_mcmc.py
+++ b/pymc/tests/sampling/test_mcmc.py
@@ -205,18 +205,6 @@ class TestSample(SeededTest):
                 pm.sample(50, tune=0, foo={})
             assert "foo" in str(excinfo.value)
 
-    def test_iter_sample(self):
-        with self.model:
-            samps = pm.sampling.mcmc.iter_sample(
-                draws=5,
-                step=self.step,
-                start=self.start,
-                tune=0,
-                random_seed=self.random_seed,
-            )
-            for i, trace in enumerate(samps):
-                assert i == len(trace) - 1, "Trace does not have correct length."
-
     def test_parallel_start(self):
         with self.model:
             with warnings.catch_warnings():

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -235,7 +235,7 @@ def biwrap(wrapper):
 
 
 def dataset_to_point_list(
-    ds: xarray.Dataset, sample_dims: List
+    ds: xarray.Dataset, sample_dims: Sequence[str]
 ) -> Tuple[List[Dict[str, np.ndarray]], Dict[str, Any]]:
     # All keys of the dataset must be a str
     var_names = list(ds.keys())

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -42,7 +42,6 @@ pymc/model_graph.py
 pymc/printing.py
 pymc/pytensorf.py
 pymc/sampling/jax.py
-pymc/stats/log_likelihood.py
 pymc/variational/approximations.py
 pymc/variational/opvi.py
 """


### PR DESCRIPTION
This is a refactor to simplify signatures of internal sampling functions.

The goal is to avoid returning/yielding `BaseTrace` or `MultiTrace` objects, making it easier to refactor the trace backend.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- The `pm.iter_sample` function was removed.

## Maintenance
- Signatures of internal sampling functions were changed.
- Refactoring of internal sampling code to make it more maintainable.
