### PR TITLE
Remove `add_values`/`remove_values` to fix backend type issues

### DIFF
--- a/pymc/tests/backends/test_ndarray.py
+++ b/pymc/tests/backends/test_ndarray.py
@@ -124,25 +124,6 @@ class TestMultiTrace(bf.ModelBackendSetupTestCase):
             base.MultiTrace([self.strace0, self.strace1])
 
 
-class TestMultiTrace_add_remove_values(bf.ModelBackendSampledTestCase):
-    name = None
-    backend = ndarray.NDArray
-    shape = ()
-
-    def test_add_values(self):
-        mtrace = self.mtrace
-        orig_varnames = list(mtrace.varnames)
-        name = "new_var"
-        vals = mtrace[orig_varnames[0]]
-        mtrace.add_values({name: vals})
-        assert len(orig_varnames) == len(mtrace.varnames) - 1
-        assert name in mtrace.varnames
-        assert np.all(mtrace[orig_varnames[0]] == mtrace[name])
-        mtrace.remove_values(name)
-        assert len(orig_varnames) == len(mtrace.varnames)
-        assert name not in mtrace.varnames
-
-
 class TestSqueezeCat:
     def setup_method(self):
         self.x = np.arange(10)


### PR DESCRIPTION
The `add_values`/`remove_values` methods accessed attributes that are not present on `BaseTrace` but only on `NDarray`, therefore violating the signature.


**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- `MultiTrace.add_values`/`MultiTrace.remove_values` were removed.

## Maintenance
- More type hints in `BaseTrace` and `MultiTrace` signatures
