### PR TITLE
Refactoring towards `IBaseTrace` interfaces

### DIFF
--- a/pymc/backends/__init__.py
+++ b/pymc/backends/__init__.py
@@ -65,7 +65,8 @@ from typing import Dict, List, Optional
 
 from pymc.backends.arviz import predictions_to_inference_data, to_inference_data
 from pymc.backends.base import BaseTrace
-from pymc.backends.ndarray import NDArray, point_list_to_multitrace
+from pymc.backends.ndarray import NDArray
+from pymc.model import Model
 
 __all__ = ["to_inference_data", "predictions_to_inference_data"]
 
@@ -76,7 +77,7 @@ def _init_trace(
     chain_number: int,
     stats_dtypes: List[Dict[str, type]],
     trace: Optional[BaseTrace],
-    model,
+    model: Model,
 ) -> BaseTrace:
     """Initializes a trace backend for a chain."""
     strace: BaseTrace

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -156,7 +156,7 @@ class NDArray(base.BaseTrace):
         """
         return self.samples[varname][burn::thin]
 
-    def _slice(self, idx):
+    def _slice(self, idx: slice):
         # Slicing directly instead of using _slice_as_ndarray to
         # support stop value in slice (which is needed by
         # iter_sample).
@@ -174,7 +174,7 @@ class NDArray(base.BaseTrace):
             return sliced
         sliced._stats = []
         for vars in self._stats:
-            var_sliced = {}
+            var_sliced: Dict[str, np.ndarray] = {}
             sliced._stats.append(var_sliced)
             for key, vals in vars.items():
                 var_sliced[key] = vals[idx]

--- a/pymc/tests/distributions/test_continuous.py
+++ b/pymc/tests/distributions/test_continuous.py
@@ -618,10 +618,13 @@ class TestMatchesScipy:
         reason="Fails on float32 due to numerical issues",
     )
     def test_weibull_logp(self):
+        # SciPy has new (?) precision issues at {alpha=20, beta=2, x=100}
+        # We circumvent it by skipping alpha=20:
+        rplusbig = Domain([0, 0.5, 0.9, 0.99, 1, 1.5, 2, np.inf])
         check_logp(
             pm.Weibull,
             Rplus,
-            {"alpha": Rplusbig, "beta": Rplusbig},
+            {"alpha": rplusbig, "beta": Rplusbig},
             lambda value, alpha, beta: st.exponweib.logpdf(value, 1, alpha, scale=beta),
         )
 


### PR DESCRIPTION
The goal of this PR is to identify & specify the `BaseTrace` attributes & methods that are necessary from the perspectives of internal sampling functions (`pm.sampling.mcmc.*`) and `MultiTrace`.

By extracting these signatures/interfaces into an abstract class `IBaseTrace` it becomes much easier to write a small adapter class that can wrap other kinds of backends to be used instead of `BaseTrace`. (hint hint 🍔)


**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- `MultiTrace.straces` type changes from `Sequence[BaseTrace]` to `Sequence[IBaseTrace]`

## Maintenance
- Internal backend types and sampling functions are refactored for more substitutability
- Fixes flakyness of the `weibull_logp` test
