### PR TITLE
The Gumbel Distribution is incorrectly described

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2985,7 +2985,9 @@ def triangular_default_transform(op, rv):
 
 class Gumbel(Continuous):
     r"""
-    Univariate Gumbel log-likelihood.
+    Univariate Gumbel right Skew log-likelihood. This parameterization will provide the extrem maximum value. 
+    Those looking to find the extrem minimum provided by the left skew Gumbel should 
+    invert the sign to all X and Y values (positive to negative and negative to positive).
 
     The pdf of this distribution is
 


### PR DESCRIPTION
The version currently in PYTensor is the Gumbel Right Skew which gives the extreme maximum. Anyone using this to find the extreme minimum--in survival analysis for example, is using the wrong distribution. A sign change on the x and y inputs is an effective solution if the user is notified before hand.

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
...

**Checklist**
+ [x] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- Muy only chnage is to the documentation for the distribution so that it reads as floows:
    Univariate Gumbel right Skew log-likelihood. This parameterization will provide the extrem maximum value. 
    Those looking to find the extrem minimum provided by the left skew Gumbel should 
    invert the sign to all X and Y values (positive to negative and negative to positive).

## Maintenance
- ...
