### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,12 @@ repos:
     - id: pyupgrade
       args: [--py37-plus]
 - repo: https://github.com/psf/black
-  rev: 22.12.0
+  rev: 23.1.0
   hooks:
     - id: black
     - id: black-jupyter
 - repo: https://github.com/PyCQA/pylint
-  rev: v2.16.0b1
+  rev: v2.16.1
   hooks:
     - id: pylint
       args: [--rcfile=.pylintrc]

--- a/docs/source/learn/core_notebooks/dimensionality.ipynb
+++ b/docs/source/learn/core_notebooks/dimensionality.ipynb
@@ -1661,7 +1661,6 @@
     "        \"year\": [2020, 2021, 2022],\n",
     "    }\n",
     ") as pmodel:\n",
-    "\n",
     "    pm.Normal(\"profit\", dims=\"year\")\n",
     "\n",
     "pm.model_to_graphviz(pmodel)"

--- a/docs/source/learn/core_notebooks/model_comparison.ipynb
+++ b/docs/source/learn/core_notebooks/model_comparison.ipynb
@@ -135,7 +135,6 @@
    ],
    "source": [
     "with pm.Model() as pooled:\n",
-    "\n",
     "    # Latent pooled effect size\n",
     "    mu = pm.Normal(\"mu\", 0, sigma=1e6)\n",
     "\n",
@@ -242,7 +241,6 @@
    ],
    "source": [
     "with pm.Model() as hierarchical:\n",
-    "\n",
     "    eta = pm.Normal(\"eta\", 0, 1, shape=J)\n",
     "    # Hierarchical mean and SD\n",
     "    mu = pm.Normal(\"mu\", 0, sigma=10)\n",

--- a/docs/source/learn/core_notebooks/pymc_overview.ipynb
+++ b/docs/source/learn/core_notebooks/pymc_overview.ipynb
@@ -205,7 +205,6 @@
     "basic_model = pm.Model()\n",
     "\n",
     "with basic_model:\n",
-    "\n",
     "    # Priors for unknown model parameters\n",
     "    alpha = pm.Normal(\"alpha\", mu=0, sigma=10)\n",
     "    beta = pm.Normal(\"beta\", mu=0, sigma=10, shape=2)\n",
@@ -3417,7 +3416,6 @@
     "import pytensor.tensor as at\n",
     "\n",
     "with pm.Model(coords={\"predictors\": X.columns.values}) as test_score_model:\n",
-    "\n",
     "    # Prior on error SD\n",
     "    sigma = pm.HalfNormal(\"sigma\", 25)\n",
     "\n",
@@ -3752,7 +3750,6 @@
    ],
    "source": [
     "with test_score_model:\n",
-    "\n",
     "    idata = pm.sample(1000, tune=2000, random_seed=42)"
    ]
   },
@@ -3832,7 +3829,6 @@
    ],
    "source": [
     "with test_score_model:\n",
-    "\n",
     "    idata = pm.sample(1000, tune=2000, random_seed=42, target_accept=0.99)"
    ]
   },
@@ -4048,7 +4044,6 @@
    ],
    "source": [
     "with pm.Model() as disaster_model:\n",
-    "\n",
     "    switchpoint = pm.DiscreteUniform(\"switchpoint\", lower=years.min(), upper=years.max())\n",
     "\n",
     "    # Priors for pre- and post-switch rates number of disasters\n",
@@ -4356,7 +4351,6 @@
    "outputs": [],
    "source": [
     "class Beta(pm.Continuous):\n",
-    "\n",
     "    rv_op = beta\n",
     "\n",
     "    @classmethod\n",

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -71,6 +71,7 @@ def find_observations(model: "Model") -> Dict[str, Var]:
 
 def find_constants(model: "Model") -> Dict[str, Var]:
     """If there are constants available, return them as a dictionary."""
+
     # The constant data vars must be either pm.Data or TensorConstant or SharedVariable
     def is_data(name, var, model) -> bool:
         observations = find_observations(model)
@@ -174,7 +175,6 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
         save_warmup: Optional[bool] = None,
         include_transformed: bool = False,
     ):
-
         self.save_warmup = rcParams["data.save_warmup"] if save_warmup is None else save_warmup
         self.include_transformed = include_transformed
         self.trace = trace

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -217,6 +217,7 @@ def point_list_to_multitrace(
     with _model:
         chain = NDArray(model=_model, vars=[_model[vn] for vn in varnames])
         chain.setup(draws=len(point_list), chain=0)
+
         # since we are simply loading a trace by hand, we need only a vacuous function for
         # chain.record() to use. This crushes the default.
         def point_fun(point):

--- a/pymc/blocking.py
+++ b/pymc/blocking.py
@@ -34,6 +34,7 @@ PointType: TypeAlias = Dict[str, np.ndarray]
 StatsDict: TypeAlias = Dict[str, Any]
 StatsType: TypeAlias = List[StatsDict]
 
+
 # `point_map_info` is a tuple of tuples containing `(name, shape, dtype)` for
 # each of the raveled variables.
 class RaveledVars(NamedTuple):

--- a/pymc/distributions/bound.py
+++ b/pymc/distributions/bound.py
@@ -182,7 +182,6 @@ class Bound:
         dims=None,
         **kwargs,
     ):
-
         warnings.warn(
             "Bound has been deprecated in favor of Truncated, and will be removed in a "
             "future release. If Truncated is not an option, Bound can be implemented by"
@@ -234,7 +233,6 @@ class Bound:
         shape=None,
         **kwargs,
     ):
-
         cls._argument_checks(dist, **kwargs)
         lower, upper, initval = cls._set_values(lower, upper, size, shape, initval=None)
         dist = ignore_logprob(dist)

--- a/pymc/distributions/censored.py
+++ b/pymc/distributions/censored.py
@@ -101,7 +101,6 @@ class Censored(Distribution):
 
     @classmethod
     def rv_op(cls, dist, lower=None, upper=None, size=None):
-
         lower = at.constant(-np.inf) if lower is None else at.as_tensor_variable(lower)
         upper = at.constant(np.inf) if upper is None else at.as_tensor_variable(upper)
 

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -171,7 +171,6 @@ def bounded_cont_transform(op, rv, bound_args_indices=None):
         raise ValueError(f"Must specify bound_args_indices for {op} bounded distribution")
 
     def transform_params(*args):
-
         lower, upper = None, None
         if bound_args_indices[0] is not None:
             lower = args[bound_args_indices[0]]
@@ -3474,7 +3473,6 @@ class Interpolated(BoundedContinuous):
 
     @classmethod
     def dist(cls, x_points, pdf_points, *args, **kwargs):
-
         interp = InterpolatedUnivariateSpline(x_points, pdf_points, k=1, ext="zeros")
 
         Z = interp.integral(x_points[0], x_points[-1])

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -97,7 +97,6 @@ class DistributionMeta(ABCMeta):
     """
 
     def __new__(cls, name, bases, clsdict):
-
         # Forcefully deprecate old v3 `Distribution`s
         if "random" in clsdict:
 
@@ -453,7 +452,6 @@ class Discrete(Distribution):
     """Base class for discrete distributions"""
 
     def __new__(cls, name, *args, **kwargs):
-
         if kwargs.get("transform", None):
             raise ValueError("Transformations for discrete distributions")
 
@@ -500,7 +498,6 @@ class _CustomDist(Distribution):
         dtype: str = "floatX",
         **kwargs,
     ):
-
         dist_params = [as_tensor_variable(param) for param in dist_params]
 
         # Assume scalar ndims_params
@@ -608,7 +605,6 @@ class CustomSymbolicDistRV(SymbolicRandomVariable):
 
 
 class _CustomSymbolicDist(Distribution):
-
     rv_type = CustomSymbolicDistRV
 
     @classmethod

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -358,7 +358,6 @@ def marginal_mixture_logprob(op, values, rng, weights, *components, **kwargs):
 
 @_logcdf.register(MarginalMixtureRV)
 def marginal_mixture_logcdf(op, value, rng, weights, *components, **kwargs):
-
     # single component
     if len(components) == 1:
         # Need to broadcast value across mixture axis

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -310,7 +310,6 @@ class MvStudentTRV(RandomVariable):
         return super().make_node(rng, size, dtype, nu, mu, cov)
 
     def __call__(self, nu, mu=None, cov=None, size=None, **kwargs):
-
         dtype = pytensor.config.floatX if self.dtype == "floatX" else self.dtype
 
         if mu is None:
@@ -326,7 +325,6 @@ class MvStudentTRV(RandomVariable):
 
     @classmethod
     def rng_fn(cls, rng, nu, mu, cov, size):
-
         mv_samples = multivariate_normal.rng_fn(rng=rng, mean=np.zeros_like(mu), cov=cov, size=size)
 
         # Take chi2 draws and add an axis of length 1 to the right for correct broadcasting below
@@ -618,7 +616,6 @@ class DirichletMultinomialRV(RandomVariable):
 
     @classmethod
     def rng_fn(cls, rng, n, a, size):
-
         if n.ndim > 0 or a.ndim > 1:
             n, a = broadcast_params([n, a], cls.ndims_params)
             size = tuple(size or ())
@@ -865,7 +862,6 @@ class PosDefMatrix(Op):
 
     # Python implementation:
     def perform(self, node, inputs, outputs):
-
         (x,) = inputs
         (z,) = outputs
         try:
@@ -1494,7 +1490,6 @@ class LKJCorrRV(RandomVariable):
 
     @classmethod
     def rng_fn(cls, rng, n, eta, size):
-
         # We flatten the size to make operations easier, and then rebuild it
         if size is None:
             flat_size = 1
@@ -1651,7 +1646,6 @@ class MatrixNormalRV(RandomVariable):
 
     @classmethod
     def rng_fn(cls, rng, mu, rowchol, colchol, size=None):
-
         size = to_tuple(size)
         dist_shape = to_tuple([rowchol.shape[0], colchol.shape[0]])
         output_shape = size + dist_shape
@@ -1773,7 +1767,6 @@ class MatrixNormal(Continuous):
         *args,
         **kwargs,
     ):
-
         cholesky = Cholesky(lower=True, on_error="raise")
 
         # Among-row matrices
@@ -1971,7 +1964,6 @@ class KroneckerNormal(Continuous):
 
     @classmethod
     def dist(cls, mu, covs=None, chols=None, evds=None, sigma=None, *args, **kwargs):
-
         if len([i for i in [covs, chols, evds] if i is not None]) != 1:
             raise ValueError(
                 "Incompatible parameterization. Specify exactly one of covs, chols, or evds."
@@ -2236,7 +2228,6 @@ class StickBreakingWeightsRV(RandomVariable):
     _print_name = ("StickBreakingWeights", "\\operatorname{StickBreakingWeights}")
 
     def make_node(self, rng, size, dtype, alpha, K):
-
         alpha = at.as_tensor_variable(alpha)
         K = at.as_tensor_variable(intX(K))
 
@@ -2519,7 +2510,6 @@ class ZeroSumNormal(Distribution):
 
     @classmethod
     def rv_op(cls, sigma, zerosum_axes, support_shape, size=None):
-
         shape = to_tuple(size) + tuple(support_shape)
         normal_dist = ignore_logprob(pm.Normal.dist(sigma=sigma, shape=shape))
 
@@ -2546,7 +2536,6 @@ class ZeroSumNormal(Distribution):
 
 @_change_dist_size.register(ZeroSumNormalRV)
 def change_zerosum_size(op, normal_dist, new_size, expand=False):
-
     normal_dist, sigma, support_shape = normal_dist.owner.inputs
 
     if expand:

--- a/pymc/distributions/simulator.py
+++ b/pymc/distributions/simulator.py
@@ -167,7 +167,6 @@ class Simulator(Distribution):
         dtype="floatX",
         **kwargs,
     ):
-
         if not isinstance(distance, Op):
             if distance == "gaussian":
                 distance = gaussian

--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -677,7 +677,6 @@ class AR(Distribution):
 
 @_change_dist_size.register(AutoRegressiveRV)
 def change_ar_size(op, dist, new_size, expand=False):
-
     if expand:
         old_size = dist.shape[:-1]
         new_size = tuple(new_size) + tuple(old_size)
@@ -850,7 +849,6 @@ class GARCH11(Distribution):
 
 @_change_dist_size.register(GARCH11RV)
 def change_garch11_size(op, dist, new_size, expand=False):
-
     if expand:
         old_size = dist.shape[:-1]
         new_size = tuple(new_size) + tuple(old_size)
@@ -1035,7 +1033,6 @@ class EulerMaruyama(Distribution):
 
 @_change_dist_size.register(EulerMaruyamaRV)
 def change_eulermaruyama_size(op, dist, new_size, expand=False):
-
     if expand:
         old_size = dist.shape[:-1]
         new_size = tuple(new_size) + tuple(old_size)

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -164,7 +164,6 @@ class CholeskyCovPacked(RVTransform):
 
 
 class Chain(RVTransform):
-
     __slots__ = ("param_extract_fn", "transform_list", "name")
 
     def __init__(self, transform_list):

--- a/pymc/distributions/truncated.py
+++ b/pymc/distributions/truncated.py
@@ -161,7 +161,6 @@ class Truncated(Distribution):
 
     @classmethod
     def rv_op(cls, dist, lower, upper, max_n_steps, size=None):
-
         # Try to use specialized Op
         try:
             return _truncated(dist.owner.op, lower, upper, size, *dist.owner.inputs)

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -161,7 +161,6 @@ def make_initial_point_fn(
         varnames.append(name)
 
     def make_seeded_function(func):
-
         rngs = find_rng_nodes(func.maker.fgraph.outputs)
 
         @functools.wraps(func)

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -178,7 +178,6 @@ class MeasurableRound(MeasurableElemwise):
 
 @node_rewriter(tracks=[ceil, floor, round_half_to_even])
 def find_measurable_roundings(fgraph: FunctionGraph, node: Node) -> Optional[List[MeasurableRound]]:
-
     rv_map_feature = getattr(fgraph, "preserve_rv_mappings", None)
     if rv_map_feature is None:
         return None  # pragma: no cover

--- a/pymc/logprob/joint_logprob.py
+++ b/pymc/logprob/joint_logprob.py
@@ -196,7 +196,6 @@ def factorized_joint_logprob(
             q_logprob_vars = [q_logprob_vars]
 
         for q_value_var, q_logprob_var in zip(q_value_vars, q_logprob_vars):
-
             q_value_var = original_values[q_value_var]
 
             if q_value_var.name:

--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -138,7 +138,6 @@ def expand_indices(
     shape_copy = list(shape)
     n_preceding_basics = 0
     for d, idx in enumerate(full_indices):
-
         if not is_basic_idx(idx):
             s = shape_copy.pop(0)
 
@@ -326,7 +325,6 @@ def mixture_replace(fgraph, node):
     # that belong to each one (by way of their indices).
     new_mixture_rvs = []
     for i, component_rv in enumerate(mixture_rvs):
-
         # We create custom types for the mixture components and assign them
         # null `get_measurable_outputs` dispatches so that they aren't
         # erroneously encountered in places like `factorized_joint_logprob`.

--- a/pymc/logprob/scan.py
+++ b/pymc/logprob/scan.py
@@ -107,7 +107,6 @@ def convert_outer_out_to_in(
     old_inner_outs_to_outer_outs = {}
 
     for oo_var in outer_out_vars:
-
         var_info = output_scan_args.find_among_fields(
             oo_var, field_filter=lambda x: x.startswith("outer_out")
         )
@@ -123,7 +122,6 @@ def convert_outer_out_to_in(
     # update the outer and inner-inputs to reflect the addition of new
     # inner-inputs.
     for old_inner_out_var, oo_var in old_inner_outs_to_outer_outs.items():
-
         # Couldn't one do the same with `var_info`?
         inner_out_info = output_scan_args.find_among_fields(
             old_inner_out_var, field_filter=lambda x: x.startswith("inner_out")
@@ -280,7 +278,6 @@ def construct_scan(scan_args: ScanArgs, **kwargs) -> Tuple[List[TensorVariable],
 
 @_logprob.register(MeasurableScan)
 def logprob_ScanRV(op, values, *inputs, name=None, **kwargs):
-
     new_node = op.make_node(*inputs)
     scan_args = ScanArgs.from_node(new_node)
     rv_outer_outs = get_random_outer_outputs(scan_args)
@@ -420,7 +417,6 @@ def find_measurable_scans(fgraph, node):
         # We're going to replace the user's random variable/value variable mappings
         # with ones that map directly to outputs of this `Scan`.
         for rv_var, val_var, out_idx in indirect_rv_vars:
-
             # The full/un-`Subtensor`ed `Scan` output that we need to use
             full_out = node.outputs[out_idx]
 

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1388,7 +1388,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         mask = getattr(data, "mask", None)
         if mask is not None:
-
             if mask.all():
                 # If there are no observed values, this variable isn't really
                 # observed.
@@ -1752,7 +1751,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
         value_names_to_dtypes = {value.name: value.dtype for value in self.value_vars}
         value_names_set = set(value_names_to_dtypes.keys())
         for elem in start_points:
-
             for k, v in elem.items():
                 elem[k] = np.asarray(v, dtype=value_names_to_dtypes[k])
 

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -128,7 +128,6 @@ class ModelGraph:
                 # loop created so that the elif block can go through this again
                 # and remove any intermediate ops, notably dtype casting, to observations
                 while True:
-
                     obs_name = obs_node.name
                     if obs_name and obs_name != var_name:
                         input_map[var_name] = input_map[var_name].difference({obs_name})
@@ -319,7 +318,6 @@ class ModelGraph:
                 graphnetwork.graph["name"] = self.model.name
             else:
                 for var_name in all_var_names:
-
                     self._make_node(var_name, graphnetwork, nx=True, formatting=formatting)
 
         for child, parents in self.make_compute_graph(var_names=var_names).items():
@@ -382,7 +380,6 @@ def model_to_networkx(
         model_to_networkx(schools)
     """
     if "plain" not in formatting:
-
         raise ValueError(f"Unsupported formatting for graph nodes: '{formatting}'. See docstring.")
 
     if formatting != "plain":

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -377,7 +377,6 @@ class ParallelSampler:
         progressbar: bool = True,
         mp_ctx=None,
     ):
-
         if any(len(arg) != chains for arg in [seeds, start_points]):
             raise ValueError("Number of seeds and start_points must be %s." % chains)
 

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -347,7 +347,6 @@ def _sample_smc_int(
     stage = 0
     sample_stats = defaultdict(list)
     while smc.beta < 1:
-
         smc.update_beta_and_weights()
 
         if progressbar:

--- a/pymc/step_methods/arraystep.py
+++ b/pymc/step_methods/arraystep.py
@@ -47,7 +47,6 @@ class ArrayStep(BlockedStep):
         self.blocked = blocked
 
     def step(self, point: PointType) -> Tuple[PointType, StatsType]:
-
         partial_funcs_and_point: List[Union[Callable, PointType]] = [
             DictToArrayBijection.mapf(x, start_point=point) for x in self.fs
         ]
@@ -92,7 +91,6 @@ class ArrayStepShared(BlockedStep):
         self.blocked = blocked
 
     def step(self, point: PointType) -> Tuple[PointType, StatsType]:
-
         for name, shared_var in self.shared.items():
             shared_var.set_value(point[name])
 

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -49,7 +49,6 @@ class Competence(IntEnum):
 
 
 class BlockedStep(ABC):
-
     stats_dtypes: List[Dict[str, type]] = []
     vars: List[Variable] = []
 

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -235,7 +235,6 @@ class Metropolis(ArrayStepShared):
         return
 
     def astep(self, q0: RaveledVars) -> Tuple[RaveledVars, StatsType]:
-
         point_map_info = q0.point_map_info
         q0d = q0.data
 
@@ -373,7 +372,6 @@ class BinaryMetropolis(ArrayStep):
     ]
 
     def __init__(self, vars, scaling=1.0, tune=True, tune_interval=100, model=None):
-
         model = pm.modelcontext(model)
 
         self.scaling = scaling
@@ -464,7 +462,6 @@ class BinaryGibbsMetropolis(ArrayStep):
     name = "binary_gibbs_metropolis"
 
     def __init__(self, vars, order="random", transit_p=0.8, model=None):
-
         model = pm.modelcontext(model)
 
         # transition probabilities
@@ -550,7 +547,6 @@ class CategoricalGibbsMetropolis(ArrayStep):
     name = "categorical_gibbs_metropolis"
 
     def __init__(self, vars, proposal="uniform", order="random", model=None):
-
         model = pm.modelcontext(model)
 
         vars = get_value_vars_from_user_vars(vars, model)
@@ -563,7 +559,6 @@ class CategoricalGibbsMetropolis(ArrayStep):
         # variable with M categories and y being a 3-D variable with N
         # categories, we will have dimcats = [(0, M), (1, M), (2, N), (3, N), (4, N)].
         for v in vars:
-
             v_init_val = initial_point[v.name]
 
             rv_var = model.values_to_rvs[v]
@@ -754,7 +749,6 @@ class DEMetropolis(PopulationArrayStepShared):
         mode=None,
         **kwargs
     ):
-
         model = pm.modelcontext(model)
         initial_values = model.initial_point()
         initial_values_size = sum(initial_values[n.name].size for n in model.value_vars)
@@ -791,7 +785,6 @@ class DEMetropolis(PopulationArrayStepShared):
         super().__init__(vars, shared)
 
     def astep(self, q0: RaveledVars) -> Tuple[RaveledVars, StatsType]:
-
         point_map_info = q0.point_map_info
         q0d = q0.data
 
@@ -958,7 +951,6 @@ class DEMetropolisZ(ArrayStepShared):
         return
 
     def astep(self, q0: RaveledVars) -> Tuple[RaveledVars, StatsType]:
-
         point_map_info = q0.point_map_info
         q0d = q0.data
 

--- a/pymc/tests/distributions/test_continuous.py
+++ b/pymc/tests/distributions/test_continuous.py
@@ -56,7 +56,6 @@ try:
 
     _polyagamma_not_installed = False
 except ImportError:  # pragma: no cover
-
     _polyagamma_not_installed = True
 
     def polyagamma_pdf(*args, **kwargs):
@@ -2277,7 +2276,6 @@ class TestICDF:
         ],
     )
     def test_normal_icdf(self, dist_params, obs, size):
-
         dist_params_at, obs_at, size_at = create_pytensor_params(dist_params, obs, size)
         dist_params = dict(zip(dist_params_at, dist_params))
 

--- a/pymc/tests/distributions/test_discrete.py
+++ b/pymc/tests/distributions/test_discrete.py
@@ -1164,7 +1164,6 @@ class TestICDF:
         ],
     )
     def test_geometric_icdf(self, dist_params, obs, size):
-
         dist_params_at, obs_at, size_at = create_pytensor_params(dist_params, obs, size)
         dist_params = dict(zip(dist_params_at, dist_params))
 

--- a/pymc/tests/distributions/test_dist_math.py
+++ b/pymc/tests/distributions/test_dist_math.py
@@ -107,7 +107,6 @@ class MultinomialB(Discrete):
 
 
 def test_multinomial_check_parameters():
-
     x = np.array([1, 5])
     n = x.sum()
 

--- a/pymc/tests/distributions/test_logprob.py
+++ b/pymc/tests/distributions/test_logprob.py
@@ -56,7 +56,6 @@ from pymc.tests.helpers import assert_no_rvs, select_by_precision
 
 
 def test_get_scaling():
-
     assert _get_scaling(None, (2, 3), 2).eval() == 1
     # ndim >=1 & ndim<1
     assert _get_scaling(45, (2, 3), 1).eval() == 22.5

--- a/pymc/tests/distributions/test_multivariate.py
+++ b/pymc/tests/distributions/test_multivariate.py
@@ -1542,7 +1542,6 @@ class TestZeroSumNormal:
         ],
     )
     def test_zsn_variance(self, sigma, n):
-
         dist = pm.ZeroSumNormal.dist(sigma=sigma, shape=(100_000, n))
         random_samples = pm.draw(dist)
 
@@ -1854,7 +1853,6 @@ class TestWishart(BaseTestDistributionRandom):
 
 
 class TestMatrixNormal(BaseTestDistributionRandom):
-
     pymc_dist = pm.MatrixNormal
 
     mu = np.random.random((3, 3))

--- a/pymc/tests/distributions/util.py
+++ b/pymc/tests/distributions/util.py
@@ -812,7 +812,6 @@ class BaseTestDistributionRandom(SeededTest):
         for (expected_name, expected_value), actual_variable in zip(
             self.expected_rv_op_params.items(), pytensor_dist_inputs
         ):
-
             # Add additional line to evaluate symbolic inputs to distributions
             if isinstance(expected_value, pytensor.tensor.Variable):
                 expected_value = expected_value.eval()

--- a/pymc/tests/helpers.py
+++ b/pymc/tests/helpers.py
@@ -80,7 +80,6 @@ class LoggingHandler(BufferingHandler):
 
 
 class Matcher:
-
     _partial_matches = ("msg", "message")
 
     def matches(self, d, **kwargs):
@@ -162,7 +161,7 @@ class StepMethodTester:
 
     def check_stat(self, check, idata, name):
         group = idata.posterior
-        for (var, stat, value, bound) in check:
+        for var, stat, value, bound in check:
             s = stat(group[var].sel(chain=0), axis=0)
             close_to(s, value, bound, name)
 

--- a/pymc/tests/logprob/test_joint_logprob.py
+++ b/pymc/tests/logprob/test_joint_logprob.py
@@ -112,7 +112,6 @@ def test_joint_logprob_basic():
 
 
 def test_joint_logprob_multi_obs():
-
     a = at.random.uniform(0.0, 1.0)
     b = at.random.normal(0.0, 1.0)
 

--- a/pymc/tests/logprob/test_mixture.py
+++ b/pymc/tests/logprob/test_mixture.py
@@ -111,7 +111,6 @@ def test_mixture_basics():
     ],
 )
 def test_compute_test_value(op_constructor):
-
     srng = at.random.RandomStream(29833)
 
     X_rv = srng.normal(0, 1, name="X")

--- a/pymc/tests/logprob/test_transforms.py
+++ b/pymc/tests/logprob/test_transforms.py
@@ -261,7 +261,6 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
         if a_val.ndim > 0:
 
             def jacobian_estimate_novec(value):
-
                 dim_diff = a_val.ndim - value.ndim  # pylint: disable=cell-var-from-loop
                 if dim_diff > 0:
                     # Make sure the dimensions match the expected input
@@ -672,7 +671,6 @@ def test_log_transform_rv():
     ],
 )
 def test_loc_transform_rv(rv_size, loc_type, addition):
-
     loc = loc_type("loc")
     if addition:
         y_rv = loc + at.random.normal(0, 1, size=rv_size, name="base_rv")
@@ -703,7 +701,6 @@ def test_loc_transform_rv(rv_size, loc_type, addition):
     ],
 )
 def test_scale_transform_rv(rv_size, scale_type, product):
-
     scale = scale_type("scale")
     if product:
         y_rv = at.random.normal(0, 1, size=rv_size, name="base_rv") * scale

--- a/pymc/tests/logprob/test_utils.py
+++ b/pymc/tests/logprob/test_utils.py
@@ -78,7 +78,6 @@ def test_walk_model():
 
 
 def test_rvs_to_value_vars():
-
     a = at.random.uniform(0.0, 1.0)
     a.name = "a"
     a.tag.value_var = a_value_var = a.clone()
@@ -180,7 +179,6 @@ def test_dirac_delta():
     ],
 )
 def test_dirac_delta_logprob(dist_params, obs):
-
     dist_params_at, obs_at, _ = create_pytensor_params(dist_params, obs, ())
     dist_params = dict(zip(dist_params_at, dist_params))
 

--- a/pymc/tests/models.py
+++ b/pymc/tests/models.py
@@ -161,7 +161,7 @@ def mv_simple_discrete():
         mu = n * p
         # covariance matrix
         C = np.zeros((d, d))
-        for (i, j) in product(range(d), range(d)):
+        for i, j in product(range(d), range(d)):
             if i == j:
                 C[i, i] = n * p[i] * (1 - p[i])
             else:

--- a/pymc/tests/ode/test_ode.py
+++ b/pymc/tests/ode/test_ode.py
@@ -50,11 +50,11 @@ def test_simulate():
 
 
 class TestSensitivityInitialCondition:
-
     t = np.arange(0, 12, 0.25).reshape(-1, 1)
 
     def test_sens_ic_scalar_1_param(self):
         """Tests the creation of the initial condition for the sensitivities"""
+
         # Scalar ODE 1 Param
         # Create an ODe to integrate
         def ode_func_1(y, t, p):

--- a/pymc/tests/sampling/test_population.py
+++ b/pymc/tests/sampling/test_population.py
@@ -20,7 +20,6 @@ from pymc.step_methods.metropolis import DEMetropolis
 
 
 class TestPopulationSamplers:
-
     steppers = [DEMetropolis]
 
     def test_checks_population_size(self):

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -572,7 +572,6 @@ def test_make_obs_var():
 
 
 def test_initial_point():
-
     with pm.Model() as model:
         a = pm.Uniform("a")
         x = pm.Normal("x", a)
@@ -597,7 +596,6 @@ def test_initial_point():
 
 
 def test_point_logps():
-
     with pm.Model() as model:
         a = pm.Uniform("a")
         pm.Normal("x", a)

--- a/pymc/tests/test_pytensorf.py
+++ b/pymc/tests/test_pytensorf.py
@@ -75,7 +75,6 @@ def test_pd_series_as_tensor_variable(np_array: np.ndarray) -> None:
 
 
 def test_pd_as_tensor_variable_multiindex() -> None:
-
     tuples = [("L", "Q"), ("L", "I"), ("O", "L"), ("O", "I")]
 
     index = pd.MultiIndex.from_tuples(tuples, names=["Id1", "Id2"])
@@ -135,7 +134,6 @@ def _make_along_axis_idx(arr_shape, indices, axis):
 
 
 def test_extract_obs_data():
-
     with pytest.raises(TypeError):
         extract_obs_data(at.matrix())
 
@@ -538,7 +536,6 @@ class TestReplaceRVsByValues:
     @pytest.mark.parametrize("apply_transforms", (True, False))
     @pytest.mark.parametrize("test_deprecated_fn", (True, False))
     def test_basic(self, symbolic_rv, apply_transforms, test_deprecated_fn):
-
         # Interval transform between last two arguments
         interval = (
             Interval(bounds_fn=lambda *args: (args[-2], args[-1])) if apply_transforms else None

--- a/pymc/tests/variational/test_approximations.py
+++ b/pymc/tests/variational/test_approximations.py
@@ -89,7 +89,6 @@ def test_scale_cost_to_minibatch_works(aux_total_size):
     # did not not work as expected
     # there were some numeric problems, so float64 is forced
     with pytensor.config.change_flags(floatX="float64", warn_float64="ignore"):
-
         assert pytensor.config.floatX == "float64"
         assert pytensor.config.warn_float64 == "ignore"
 
@@ -138,7 +137,6 @@ def test_elbo_beta_kl(aux_total_size):
     beta = len(y_obs) / float(aux_total_size)
 
     with pytensor.config.change_flags(floatX="float64", warn_float64="ignore"):
-
         post_mu = np.array([1.88], dtype=pytensor.config.floatX)
         post_sigma = np.array([1], dtype=pytensor.config.floatX)
 

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -350,7 +350,6 @@ class WithMemoization:
 
 
 def locally_cachedmethod(f):
-
     from collections import defaultdict
 
     def self_cache_fn(f_name):


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/pymc-devs/pymc/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Defaulting to user installation because normal site-packages is not writeable
Collecting pre-commit
  Downloading pre_commit-3.0.4-py2.py3-none-any.whl (202 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 202.2/202.2 KB 3.9 MB/s eta 0:00:00
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.7.0-py2.py3-none-any.whl (21 kB)
Collecting identify>=1.0.0
  Downloading identify-2.5.17-py2.py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.7/98.7 KB 24.8 MB/s eta 0:00:00
Requirement already satisfied: pyyaml>=5.1 in /usr/lib/python3/dist-packages (from pre-commit) (5.4.1)
Collecting virtualenv>=20.10.0
  Downloading virtualenv-20.17.1-py3-none-any.whl (8.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.8/8.8 MB 76.5 MB/s eta 0:00:00
Collecting cfgv>=2.0.0
  Downloading cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
Requirement already satisfied: setuptools in /usr/lib/python3/dist-packages (from nodeenv>=0.11.1->pre-commit) (59.6.0)
Collecting filelock<4,>=3.4.1
  Downloading filelock-3.9.0-py3-none-any.whl (9.7 kB)
Collecting distlib<1,>=0.3.6
  Downloading distlib-0.3.6-py2.py3-none-any.whl (468 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 468.5/468.5 KB 68.1 MB/s eta 0:00:00
Collecting platformdirs<3,>=2.4
  Downloading platformdirs-2.6.2-py3-none-any.whl (14 kB)
Installing collected packages: distlib, platformdirs, nodeenv, identify, filelock, cfgv, virtualenv, pre-commit
Successfully installed cfgv-3.3.1 distlib-0.3.6 filelock-3.9.0 identify-2.5.17 nodeenv-1.7.0 platformdirs-2.6.2 pre-commit-3.0.4 virtualenv-20.17.1
```



</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
already up to date.
Updating https://github.com/lucianopaz/head_of_apache ... [INFO] Initializing environment for https://github.com/lucianopaz/head_of_apache.
already up to date.
Updating https://github.com/PyCQA/isort ... [INFO] Initializing environment for https://github.com/PyCQA/isort.
already up to date.
Updating https://github.com/asottile/pyupgrade ... [INFO] Initializing environment for https://github.com/asottile/pyupgrade.
already up to date.
Updating https://github.com/psf/black ... [INFO] Initializing environment for https://github.com/psf/black.
updating 22.12.0 -> 23.1.0.
Updating https://github.com/PyCQA/pylint ... [INFO] Initializing environment for https://github.com/PyCQA/pylint.
updating v2.16.0b1 -> v2.16.1.
Updating https://github.com/PyCQA/pydocstyle ... [INFO] Initializing environment for https://github.com/PyCQA/pydocstyle.
already up to date.
Updating https://github.com/MarcoGorelli/madforhooks ... [INFO] Initializing environment for https://github.com/MarcoGorelli/madforhooks.
already up to date.
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/psf/black:.[jupyter].
[INFO] Initializing environment for local:pandas,pyyaml.
[INFO] Initializing environment for local:pyyaml.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/lucianopaz/head_of_apache.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/pylint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/pydocstyle.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/MarcoGorelli/madforhooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for local.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for local.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check for merge conflicts............................................................Passed
check toml...........................................................................Passed
check yaml...........................................................................Passed
debug statements (python)............................................................Passed
fix end of files.....................................................................Passed
don't commit to branch...............................................................Passed
fix requirements.txt.................................................................Passed
trim trailing whitespace.............................................................Passed
Apply Apache 2.0 License.............................................................Passed
isort................................................................................Passed
pyupgrade............................................................................Passed
black................................................................................Failed
- hook id: black
- files were modified by this hook

reformatted pymc/backends/ndarray.py
reformatted pymc/backends/arviz.py
reformatted pymc/blocking.py
reformatted pymc/distributions/censored.py
reformatted pymc/distributions/bound.py
reformatted pymc/distributions/distribution.py
reformatted pymc/distributions/mixture.py
reformatted pymc/distributions/continuous.py
reformatted pymc/distributions/simulator.py
reformatted pymc/distributions/multivariate.py
reformatted pymc/distributions/timeseries.py
reformatted pymc/distributions/transforms.py
reformatted pymc/distributions/truncated.py
reformatted pymc/initial_point.py
reformatted pymc/logprob/joint_logprob.py
reformatted pymc/logprob/censoring.py
reformatted pymc/logprob/mixture.py
reformatted pymc/logprob/scan.py
reformatted pymc/model_graph.py
reformatted pymc/model.py
reformatted pymc/sampling/parallel.py
reformatted pymc/smc/sampling.py
reformatted pymc/step_methods/arraystep.py
reformatted pymc/step_methods/compound.py
reformatted pymc/step_methods/metropolis.py
reformatted pymc/tests/distributions/test_discrete.py
reformatted pymc/tests/distributions/test_dist_math.py
reformatted pymc/tests/distributions/test_logprob.py
reformatted pymc/tests/distributions/test_continuous.py
reformatted pymc/tests/distributions/util.py
reformatted pymc/tests/distributions/test_multivariate.py
reformatted pymc/tests/helpers.py
reformatted pymc/tests/logprob/test_joint_logprob.py
reformatted pymc/tests/logprob/test_mixture.py
reformatted pymc/tests/logprob/test_transforms.py
reformatted pymc/tests/logprob/test_utils.py
reformatted pymc/tests/models.py
reformatted pymc/tests/ode/test_ode.py
reformatted pymc/tests/sampling/test_population.py
reformatted pymc/tests/test_pytensorf.py
reformatted pymc/tests/variational/test_approximations.py
reformatted pymc/tests/test_model.py
reformatted pymc/util.py

All done! ✨ 🍰 ✨
43 files reformatted, 142 files left unchanged.

black-jupyter........................................................................Failed
- hook id: black-jupyter
- files were modified by this hook

reformatted docs/source/learn/core_notebooks/model_comparison.ipynb
reformatted docs/source/learn/core_notebooks/dimensionality.ipynb
reformatted docs/source/learn/core_notebooks/pymc_overview.ipynb

All done! ✨ 🍰 ✨
3 files reformatted, 188 files left unchanged.

pylint...............................................................................Passed
pydocstyle...........................................................................Passed
Disallow print statements............................................................Passed
Check no tests are ignored.......................................(no files to check)Skipped
Generate pip dependency from conda...................................................Passed
No relative imports..................................................................Passed
Check no links that should be cross-references are in the docs.......................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed 47 files: </summary>

- .pre-commit-config.yaml
- docs/source/learn/core_notebooks/dimensionality.ipynb
- docs/source/learn/core_notebooks/model_comparison.ipynb
- docs/source/learn/core_notebooks/pymc_overview.ipynb
- pymc/backends/arviz.py
- pymc/backends/ndarray.py
- pymc/blocking.py
- pymc/distributions/bound.py
- pymc/distributions/censored.py
- pymc/distributions/continuous.py
- pymc/distributions/distribution.py
- pymc/distributions/mixture.py
- pymc/distributions/multivariate.py
- pymc/distributions/simulator.py
- pymc/distributions/timeseries.py
- pymc/distributions/transforms.py
- pymc/distributions/truncated.py
- pymc/initial_point.py
- pymc/logprob/censoring.py
- pymc/logprob/joint_logprob.py
- pymc/logprob/mixture.py
- pymc/logprob/scan.py
- pymc/model.py
- pymc/model_graph.py
- pymc/sampling/parallel.py
- pymc/smc/sampling.py
- pymc/step_methods/arraystep.py
- pymc/step_methods/compound.py
- pymc/step_methods/metropolis.py
- pymc/tests/distributions/test_continuous.py
- pymc/tests/distributions/test_discrete.py
- pymc/tests/distributions/test_dist_math.py
- pymc/tests/distributions/test_logprob.py
- pymc/tests/distributions/test_multivariate.py
- pymc/tests/distributions/util.py
- pymc/tests/helpers.py
- pymc/tests/logprob/test_joint_logprob.py
- pymc/tests/logprob/test_mixture.py
- pymc/tests/logprob/test_transforms.py
- pymc/tests/logprob/test_utils.py
- pymc/tests/models.py
- pymc/tests/ode/test_ode.py
- pymc/tests/sampling/test_population.py
- pymc/tests/test_model.py
- pymc/tests/test_pytensorf.py
- pymc/tests/variational/test_approximations.py
- pymc/util.py

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)