### PR TITLE
Optional McBackend support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,7 @@ jobs:
             tests/step_methods/hmc/test_quadpotential.py
 
           - |
+            tests/backends/test_mcbackend.py
             tests/distributions/test_truncated.py
             tests/logprob/test_abstract.py
             tests/logprob/test_censoring.py

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -41,3 +41,4 @@ dependencies:
 - pip:
   - git+https://github.com/pymc-devs/pymc-sphinx-theme
   - numdifftools>=0.9.40
+  - mcbackend>=0.4.0

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -31,3 +31,4 @@ dependencies:
 - types-cachetools
 - pip:
   - numdifftools>=0.9.40
+  - mcbackend>=0.4.0

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -38,3 +38,4 @@ dependencies:
 - pip:
   - git+https://github.com/pymc-devs/pymc-sphinx-theme
   - numdifftools>=0.9.40
+  - mcbackend>=0.4.0

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -31,3 +31,4 @@ dependencies:
 - types-cachetools
 - pip:
   - numdifftools>=0.9.40
+  - mcbackend>=0.4.0

--- a/pymc/backends/__init__.py
+++ b/pymc/backends/__init__.py
@@ -75,7 +75,7 @@ from pymc.step_methods.compound import BlockedStep, CompoundStep
 
 HAS_MCB = False
 try:
-    from mcbackend import Backend, Run
+    from mcbackend import Backend, NumPyBackend, Run
 
     from pymc.backends.mcbackend import init_chain_adapters
 
@@ -123,6 +123,8 @@ def init_traces(
     model: Model,
 ) -> Tuple[Optional[RunType], Sequence[IBaseTrace]]:
     """Initializes a trace recorder for each chain."""
+    if HAS_MCB and backend is None:
+        backend = NumPyBackend(preallocate=expected_length)
     if HAS_MCB and isinstance(backend, Backend):
         return init_chain_adapters(
             backend=backend,

--- a/pymc/backends/mcbackend.py
+++ b/pymc/backends/mcbackend.py
@@ -1,0 +1,286 @@
+#   Copyright 2023 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import base64
+import logging
+import pickle
+
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union, cast
+
+import hagelkorn
+import mcbackend as mcb
+import numpy as np
+
+from mcbackend.npproto.utils import ndarray_from_numpy
+from pytensor.compile.sharedvalue import SharedVariable
+from pytensor.graph.basic import Constant
+
+from pymc.backends.base import IBaseTrace
+from pymc.model import Model
+from pymc.pytensorf import PointFunc
+from pymc.step_methods.compound import (
+    BlockedStep,
+    CompoundStep,
+    StatsBijection,
+    flat_statname,
+    flatten_steps,
+)
+
+_log = logging.getLogger("pymc")
+
+
+def find_data(pmodel: Model) -> List[mcb.DataVariable]:
+    """Extracts data variables from a model."""
+    observed_rvs = {pmodel.rvs_to_values[rv] for rv in pmodel.observed_RVs}
+    dvars = []
+    # All data containers are named vars!
+    for name, var in pmodel.named_vars.items():
+        dv = mcb.DataVariable(name)
+        if isinstance(var, Constant):
+            dv.value = ndarray_from_numpy(var.data)
+        elif isinstance(var, SharedVariable):
+            dv.value = ndarray_from_numpy(var.get_value())
+        else:
+            continue
+        dv.dims = list(pmodel.named_vars_to_dims.get(name, []))
+        dv.is_observed = var in observed_rvs
+        dvars.append(dv)
+    return dvars
+
+
+def get_variables_and_point_fn(
+    model: Model, initial_point: Mapping[str, np.ndarray]
+) -> Tuple[List[mcb.Variable], PointFunc]:
+    """Get metadata on free, value and deterministic model variables."""
+    # The samplers act only on the inputs needed for the log-likelihood,
+    # but the user is interested in transformed variables and deterministics.
+    vvars = model.value_vars
+    vars = model.unobserved_value_vars
+    # Below we compilt the "point function" that transforms a draw to the set
+    # of untransformed, transformed and deterministic variables that will be traced.
+    point_fn = model.compile_fn(vars, inputs=vvars, on_unused_input="ignore", point_fn=True)
+    point_fn = cast(PointFunc, point_fn)
+    point = point_fn(initial_point)
+
+    names = [v.name for v in vars]
+    dtypes = [v.dtype for v in vars]
+    shapes = [v.shape for v in point]
+    deterministics = {d.name for d in model.deterministics}
+    variables = [
+        mcb.Variable(
+            name=name,
+            dtype=str(dtype),
+            shape=list(shape),
+            dims=list(model.named_vars_to_dims.get(name, [])),
+            is_deterministic=name in deterministics,
+        )
+        for name, dtype, shape in zip(names, dtypes, shapes)
+    ]
+    return variables, point_fn
+
+
+class ChainRecordAdapter(IBaseTrace):
+    """Wraps an McBackend ``Chain`` as an ``IBaseTrace``."""
+
+    def __init__(
+        self, chain: mcb.Chain, point_fn: PointFunc, stats_bijection: StatsBijection
+    ) -> None:
+        # Assign attributes required by IBaseTrace
+        self.chain = chain.cmeta.chain_number
+        self.varnames = [v.name for v in chain.rmeta.variables]
+        stats_dtypes = {s.name: np.dtype(s.dtype) for s in chain.rmeta.sample_stats}
+        self.sampler_vars = [
+            {sname: stats_dtypes[fname] for fname, sname, is_obj in sstats}
+            for sstats in stats_bijection._stat_groups
+        ]
+
+        self._chain = chain
+        self._point_fn = point_fn
+        self._statsbj = stats_bijection
+        super().__init__()
+
+    def record(self, draw: Mapping[str, np.ndarray], stats: Sequence[Mapping[str, Any]]):
+        values = self._point_fn(draw)
+        value_dict = {n: v for n, v in zip(self.varnames, values)}
+        stats_dict = self._statsbj.map(stats)
+        # Apply pickling to objects stats
+        for fname in self._statsbj.object_stats.keys():
+            val_bytes = pickle.dumps(stats_dict[fname])
+            val = base64.encodebytes(val_bytes).decode("ascii")
+            stats_dict[fname] = np.array(val, dtype=str)
+        return self._chain.append(value_dict, stats_dict)
+
+    def __len__(self):
+        return len(self._chain)
+
+    def get_values(self, varname: str, burn=0, thin=1) -> np.ndarray:
+        return self._chain.get_draws(varname, slice(burn, None, thin))
+
+    def _get_stats(self, fname: str, slc: slice) -> np.ndarray:
+        """Wraps `self._chain.get_stats` but unpickles automatically."""
+        values = self._chain.get_stats(fname, slc)
+        # Unpickle object stats
+        if fname in self._statsbj.object_stats:
+            objs = []
+            for v in values:
+                enc = str(v).encode("ascii")
+                str_ = base64.decodebytes(enc)
+                obj = pickle.loads(str_)
+                objs.append(obj)
+            return np.array(objs, dtype=object)
+        return values
+
+    def get_sampler_stats(
+        self, stat_name: str, sampler_idx: Optional[int] = None, burn=0, thin=1
+    ) -> np.ndarray:
+        slc = slice(burn, None, thin)
+        # When there's just one sampler, default to remove the sampler dimension
+        if sampler_idx is None and self._statsbj.n_samplers == 1:
+            sampler_idx = 0
+        # Fetching for a specific sampler is easy
+        if sampler_idx is not None:
+            return self._get_stats(flat_statname(sampler_idx, stat_name), slc)
+        # To fetch for all samplers, we must collect the arrays one by one.
+        stats_dict = {
+            stat.name: self._get_stats(stat.name, slc)
+            for stat in self._chain.rmeta.sample_stats
+            if stat_name in stat.name
+        }
+        if not stats_dict:
+            raise KeyError(f"No stat '{stat_name}' was recorded.")
+        stats_list = self._statsbj.rmap(stats_dict)
+        stats_arrays = []
+        is_ragged = False
+        for sd in stats_list:
+            if not sd:
+                is_ragged = True
+                continue
+            else:
+                stats_arrays.append(tuple(sd.values())[0])
+
+        if is_ragged:
+            _log.debug("Stat '%s' was not recorded by all samplers.", stat_name)
+        if len(stats_arrays) == 1:
+            return stats_arrays[0]
+        return np.array(stats_arrays).T
+
+    def _slice(self, idx: slice) -> "IBaseTrace":
+        # Get the integer indices
+        start, stop, step = idx.indices(len(self))
+        indices = np.arange(start, stop, step)
+
+        # Create a NumPyChain for the sliced data
+        nchain = mcb.backends.numpy.NumPyChain(
+            self._chain.cmeta, self._chain.rmeta, preallocate=len(indices)
+        )
+
+        # Copy at selected indices and append them to the new chain.
+        # This may be slow, but NumPyChain currently don't have a batch-insert or slice API.
+        vnames = [v.name for v in nchain.variables.values()]
+        snames = [s.name for s in nchain.sample_stats.values()]
+        for i in indices:
+            draw = self._chain.get_draws_at(i, var_names=vnames)
+            stats = self._chain.get_stats_at(i, stat_names=snames)
+            nchain.append(draw, stats)
+        return ChainRecordAdapter(nchain, self._point_fn, self._statsbj)
+
+    def point(self, idx: int) -> Dict[str, np.ndarray]:
+        return self._chain.get_draws_at(idx, [v.name for v in self._chain.variables.values()])
+
+
+def make_runmeta_and_point_fn(
+    *,
+    initial_point: Mapping[str, np.ndarray],
+    step: Union[CompoundStep, BlockedStep],
+    model: Model,
+) -> Tuple[mcb.RunMeta, PointFunc]:
+    variables, point_fn = get_variables_and_point_fn(model, initial_point)
+
+    sample_stats = [
+        mcb.Variable("tune", "bool"),
+    ]
+
+    # In PyMC the sampler stats are grouped by the sampler.
+    steps = flatten_steps(step)
+    for s, sm in enumerate(steps):
+        for statname, (dtype, shape) in sm.stats_dtypes_shapes.items():
+            sname = flat_statname(s, statname)
+            sshape = [
+                # PyMC uses None to indicate dynamic dims, MCB uses -1
+                (-1 if s is None else s)
+                for s in (shape or [])
+            ]
+            svar = mcb.Variable(
+                name=sname,
+                dtype=np.dtype(dtype).name,
+                shape=sshape,
+                undefined_ndim=shape is None,
+            )
+            sample_stats.append(svar)
+
+    coordinates = [
+        mcb.Coordinate(dname, mcb.npproto.utils.ndarray_from_numpy(np.array(cvals)))
+        for dname, cvals in model.coords.items()
+        if cvals is not None
+    ]
+    meta = mcb.RunMeta(
+        rid=hagelkorn.random(),
+        variables=variables,
+        coordinates=coordinates,
+        sample_stats=sample_stats,
+        data=find_data(model),
+    )
+    return meta, point_fn
+
+
+def init_chain_adapters(
+    *,
+    backend: mcb.Backend,
+    chains: int,
+    initial_point: Mapping[str, np.ndarray],
+    step: Union[CompoundStep, BlockedStep],
+    model: Model,
+) -> Tuple[mcb.Run, List[ChainRecordAdapter]]:
+    """Create an McBackend metadata description for the MCMC run.
+
+    Parameters
+    ----------
+    backend
+        An McBackend `Backend` instance.
+    chains
+        Number of chains to initialize.
+    initial_point
+        Dictionary mapping value variable names to initial values.
+    step : CompoundStep or BlockedStep
+        The step method that iterates the MCMC.
+    model : pm.Model
+        The current PyMC model.
+
+    Returns
+    -------
+    adapters
+        Chain recording adapters that wrap McBackend Chains in the PyMC IBaseTrace interface.
+    """
+    meta, point_fn = make_runmeta_and_point_fn(initial_point=initial_point, step=step, model=model)
+    run = backend.init_run(meta)
+    statsbj = StatsBijection(step.stats_dtypes)
+    adapters = [
+        ChainRecordAdapter(
+            chain=run.init_chain(chain_number=chain_number),
+            point_fn=point_fn,
+            stats_bijection=statsbj,
+        )
+        for chain_number in range(chains)
+    ]
+    return run, adapters

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ git+https://github.com/pymc-devs/pymc-sphinx-theme
 h5py>=2.7
 ipython>=7.16
 jupyter-sphinx
+mcbackend>=0.4.0
 mypy==0.990
 myst-nb
 numdifftools>=0.9.40

--- a/tests/backends/test_mcbackend.py
+++ b/tests/backends/test_mcbackend.py
@@ -1,0 +1,305 @@
+#   Copyright 2023 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import logging
+
+import arviz
+import numpy as np
+import pytest
+
+import pymc as pm
+
+from pymc.backends import init_traces
+from pymc.step_methods.arraystep import ArrayStepShared
+
+try:
+    import mcbackend as mcb
+
+    from mcbackend.npproto.utils import ndarray_to_numpy
+except ImportError:
+    pytest.skip("Requires McBackend to be installed.")
+
+from pymc.backends.mcbackend import (
+    ChainRecordAdapter,
+    find_data,
+    get_variables_and_point_fn,
+    make_runmeta_and_point_fn,
+)
+
+
+@pytest.fixture
+def simple_model():
+    seconds = np.linspace(0, 5)
+    observations = np.random.normal(0.5 + np.random.uniform(size=3)[:, None] * seconds[None, :])
+    with pm.Model(
+        coords={
+            "condition": ["A", "B", "C"],
+        }
+    ) as pmodel:
+        x = pm.ConstantData("seconds", seconds, dims="time")
+        a = pm.Normal("scalar")
+        b = pm.Uniform("vector", dims="condition")
+        pm.Deterministic("matrix", a + b[:, None] * x[None, :], dims=("condition", "time"))
+        pm.Bernoulli("integer", p=0.5)
+        obs = pm.MutableData("obs", observations, dims=("condition", "time"))
+        pm.Normal("L", pmodel["matrix"], observed=obs, dims=("condition", "time"))
+    return pmodel
+
+
+def test_find_data(simple_model):
+    dvars = find_data(simple_model)
+    dvardict = {d.name: d for d in dvars}
+    assert set(dvardict) == {"seconds", "obs"}
+
+    secs = dvardict["seconds"]
+    assert isinstance(secs, mcb.DataVariable)
+    assert secs.dims == ["time"]
+    assert not secs.is_observed
+    np.testing.assert_array_equal(ndarray_to_numpy(secs.value), simple_model["seconds"].data)
+
+    obs = dvardict["obs"]
+    assert isinstance(obs, mcb.DataVariable)
+    assert obs.dims == ["condition", "time"]
+    assert obs.is_observed
+    np.testing.assert_array_equal(ndarray_to_numpy(obs.value), simple_model["obs"].get_value())
+
+
+def test_find_data_skips_deterministics():
+    data = np.array([0, 1], dtype="float32")
+    with pm.Model() as pmodel:
+        a = pm.ConstantData("a", data, dims="item")
+        b = pm.Normal("b")
+        pm.Deterministic("c", a + b, dims="item")
+    assert "c" in pmodel.named_vars
+    dvars = find_data(pmodel)
+    assert len(dvars) == 1
+    assert dvars[0].name == "a"
+    assert dvars[0].dims == ["item"]
+    np.testing.assert_array_equal(ndarray_to_numpy(dvars[0].value), data)
+    assert not dvars[0].is_observed
+
+
+def test_get_variables_and_point_fn(simple_model):
+    ip = simple_model.initial_point()
+    variables, point_fn = get_variables_and_point_fn(simple_model, ip)
+    assert isinstance(variables, list)
+    assert callable(point_fn)
+    vdict = {v.name: v for v in variables}
+    assert set(vdict) == {"integer", "scalar", "vector", "vector_interval__", "matrix"}
+    point = point_fn(ip)
+    assert len(point) == len(variables)
+    for v, p in zip(variables, point):
+        assert str(p.dtype) == v.dtype
+
+
+def test_make_runmeta_and_point_fn(simple_model):
+    with simple_model:
+        step = pm.DEMetropolisZ()
+    rmeta, point_fn = make_runmeta_and_point_fn(
+        initial_point=simple_model.initial_point(),
+        step=step,
+        model=simple_model,
+    )
+    assert isinstance(rmeta, mcb.RunMeta)
+    assert callable(point_fn)
+    vars = {v.name: v for v in rmeta.variables}
+    assert set(vars.keys()) == {"scalar", "vector", "vector_interval__", "matrix", "integer"}
+    # NOTE: Technically the "vector" is deterministic, but from the user perspective it is not.
+    #       This is merely a matter of which version of transformed variables should be traced.
+    assert not vars["vector"].is_deterministic
+    assert not vars["vector_interval__"].is_deterministic
+    assert vars["matrix"].is_deterministic
+    assert len(rmeta.sample_stats) == 1 + len(step.stats_dtypes[0])
+    pass
+
+
+def test_init_traces(simple_model):
+    with simple_model:
+        step = pm.DEMetropolisZ()
+    run, traces = init_traces(
+        backend=mcb.NumPyBackend(),
+        chains=2,
+        expected_length=70,
+        step=step,
+        initial_point=simple_model.initial_point(),
+        model=simple_model,
+    )
+    assert isinstance(run, mcb.backends.numpy.NumPyRun)
+    assert isinstance(traces, list)
+    assert len(traces) == 2
+    assert isinstance(traces[0], ChainRecordAdapter)
+    assert isinstance(traces[0]._chain, mcb.backends.numpy.NumPyChain)
+    pass
+
+
+class ToyStepper(ArrayStepShared):
+    stats_dtypes_shapes = {
+        "accepted": (bool, []),
+        "tune": (bool, []),
+        "s1": (np.float64, []),
+    }
+
+    def astep(self, *args, **kwargs):
+        raise NotImplementedError()
+
+
+class ToyStepperWithOtherStats(ToyStepper):
+    stats_dtypes_shapes = {
+        "accepted": (bool, []),
+        "tune": (bool, []),
+        "s2": (np.float64, []),
+    }
+
+
+class TestChainRecordAdapter:
+    def test_get_sampler_stats(self):
+        # Initialize a very simply toy model
+        N = 45
+        with pm.Model() as pmodel:
+            a = pm.Normal("a")
+            b = pm.Uniform("b")
+            c = pm.Deterministic("c", a + b)
+            ip = pmodel.initial_point()
+            shared = pm.make_shared_replacements(ip, [a, b], pmodel)
+            run, traces = init_traces(
+                backend=mcb.NumPyBackend(),
+                chains=1,
+                expected_length=N,
+                step=ToyStepper([a, b], shared),
+                initial_point=pmodel.initial_point(),
+                model=pmodel,
+            )
+        cra = traces[0]
+        assert isinstance(run, mcb.backends.numpy.NumPyRun)
+        assert isinstance(cra, ChainRecordAdapter)
+
+        # Simulate recording of draws and stats
+        rng = np.random.RandomState(2023)
+        for i in range(N):
+            draw = {"a": rng.normal(), "b_interval__": rng.normal()}
+            stats = [dict(tune=(i <= 5), s1=i, accepted=bool(rng.randint(0, 2)))]
+            cra.record(draw, stats)
+
+        # Check final state of the chain
+        assert len(cra) == N
+        # Variables b and c were calculated by the point function
+        draws_a = cra.get_values("a")
+        draws_b = cra.get_values("b")
+        draws_c = cra.get_values("c")
+        np.testing.assert_array_equal(draws_a + draws_b, draws_c)
+        i = np.random.randint(0, N)
+        point = cra.point(idx=i)
+        assert point["a"] == draws_a[i]
+        assert point["b"] == draws_b[i]
+        assert point["c"] == draws_c[i]
+
+        # Stats come in different shapes depending on the query
+        s1 = cra.get_sampler_stats("s1", sampler_idx=None, burn=3, thin=2)
+        assert s1.shape == (21,)
+        assert s1.dtype == np.dtype("float64")
+        np.testing.assert_array_equal(s1, np.arange(N)[3:None:2])
+
+    def test_get_sampler_stats_compound(self, caplog):
+        # Initialize a very simply toy model
+        N = 45
+        with pm.Model() as pmodel:
+            a = pm.Normal("a")
+            b = pm.Uniform("b")
+            c = pm.Deterministic("c", a + b)
+            ip = pmodel.initial_point()
+            shared_a = pm.make_shared_replacements(ip, [a], pmodel)
+            shared_b = pm.make_shared_replacements(ip, [b], pmodel)
+            stepA = ToyStepper([a], shared_a)
+            stepB = ToyStepperWithOtherStats([b], shared_b)
+            run, traces = init_traces(
+                backend=mcb.NumPyBackend(),
+                chains=1,
+                expected_length=N,
+                step=pm.CompoundStep([stepA, stepB]),
+                initial_point=pmodel.initial_point(),
+                model=pmodel,
+            )
+        cra = traces[0]
+        assert isinstance(cra, ChainRecordAdapter)
+
+        # Simulate recording of draws and stats
+        rng = np.random.RandomState(2023)
+        for i in range(N):
+            tune = i <= 5
+            draw = {"a": rng.normal(), "b_interval__": rng.normal()}
+            stats = [
+                dict(tune=tune, s1=i, accepted=bool(rng.randint(0, 2))),
+                dict(tune=tune, s2=i, accepted=bool(rng.randint(0, 2))),
+            ]
+            cra.record(draw, stats)
+
+        # The 'accepted' stat was emitted by both samplers
+        assert cra.get_sampler_stats("accepted", sampler_idx=None).shape == (N, 2)
+        acpt_1 = cra.get_sampler_stats("accepted", sampler_idx=0, burn=3, thin=2)
+        acpt_2 = cra.get_sampler_stats("accepted", sampler_idx=1, burn=3, thin=2)
+        assert acpt_1.shape == (21,)  # (N-3)/2
+        assert not np.array_equal(acpt_1, acpt_2)
+
+        # s1 and s2 were sampler specific
+        # they are squeezed into vectors, but warnings are logged at DEBUG level
+        with caplog.at_level(logging.DEBUG, logger="pymc"):
+            s1 = cra.get_sampler_stats("s1", burn=10)
+            assert s1.shape == (35,)
+            assert s1.dtype == np.dtype("float64")
+            s2 = cra.get_sampler_stats("s2", thin=5)
+            assert s2.shape == (9,)  # N/5
+            assert s2.dtype == np.dtype("float64")
+        assert any("'s1' was not recorded by all samplers" in r.message for r in caplog.records)
+
+        with pytest.raises(KeyError, match="No stat"):
+            cra.get_sampler_stats("notastat")
+
+
+class TestMcBackendSampling:
+    @pytest.mark.parametrize("discard_warmup", [False, True])
+    def test_return_multitrace(self, simple_model, discard_warmup):
+        with simple_model:
+            mtrace = pm.sample(
+                trace=mcb.NumPyBackend(),
+                tune=5,
+                draws=7,
+                cores=1,
+                chains=3,
+                step=pm.Metropolis(),
+                discard_tuned_samples=discard_warmup,
+                return_inferencedata=False,
+            )
+        assert isinstance(mtrace, pm.backends.base.MultiTrace)
+        tune = mtrace._straces[0].get_sampler_stats("tune")
+        assert isinstance(tune, np.ndarray)
+        if discard_warmup:
+            assert tune.shape == (7, 3)
+        else:
+            assert tune.shape == (12, 3)
+        pass
+
+    @pytest.mark.parametrize("cores", [1, 3])
+    def test_return_inferencedata(self, simple_model, cores):
+        with simple_model:
+            idata = pm.sample(
+                trace=mcb.NumPyBackend(),
+                tune=5,
+                draws=7,
+                cores=cores,
+                chains=3,
+                discard_tuned_samples=False,
+            )
+        assert isinstance(idata, arviz.InferenceData)
+        assert idata.warmup_posterior.sizes["draw"] == 5
+        assert idata.posterior.sizes["draw"] == 7
+        pass

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -362,6 +362,7 @@ class TestSampleReturn:
 
         # MultiTrace without warmup
         mtrace_pst = pm.sampling.mcmc._sample_return(
+            run=None,
             traces=traces,
             tune=50,
             t_sampling=123.4,
@@ -380,6 +381,7 @@ class TestSampleReturn:
 
         # InferenceData with warmup
         idata_w = pm.sampling.mcmc._sample_return(
+            run=None,
             traces=traces,
             tune=50,
             t_sampling=123.4,
@@ -398,6 +400,7 @@ class TestSampleReturn:
 
         # InferenceData without warmup
         idata = pm.sampling.mcmc._sample_return(
+            run=None,
             traces=traces,
             tune=50,
             t_sampling=123.4,
@@ -463,6 +466,10 @@ class TestSampleReturn:
             #       This tests flattens so we don't have to be exact in accessing (non-)squeezed items.
             #       Also see https://github.com/pymc-devs/pymc/issues/6207.
             warn_objs = list(idata.sample_stats.warning.sel(chain=0).values.flatten())
+            assert warn_objs
+            if isinstance(warn_objs[0], np.ndarray):
+                # Squeeze warning stats. See https://github.com/pymc-devs/pymc/issues/6207
+                warn_objs = [a.tolist() for a in warn_objs]
             assert any(isinstance(w, SamplerWarning) for w in warn_objs)
             assert any("Asteroid" in w.message for w in warn_objs)
         else:

--- a/tests/step_methods/test_compound.py
+++ b/tests/step_methods/test_compound.py
@@ -164,20 +164,22 @@ class TestStatsBijection:
     def test_stats_bijection(self):
         step_stats_dtypes = [
             {"a": float, "b": int},
-            {"a": float, "c": int},
+            {"a": float, "c": Warning},
         ]
         bij = StatsBijection(step_stats_dtypes)
+        assert bij.object_stats == {"sampler_1__c": (1, "c")}
         assert bij.n_samplers == 2
+        w = Warning("hmm")
         stats_l = [
             dict(a=1.5, b=3),
-            dict(a=2.5, c=4),
+            dict(a=2.5, c=w),
         ]
         stats_d = bij.map(stats_l)
         assert isinstance(stats_d, dict)
         assert stats_d["sampler_0__a"] == 1.5
         assert stats_d["sampler_0__b"] == 3
         assert stats_d["sampler_1__a"] == 2.5
-        assert stats_d["sampler_1__c"] == 4
+        assert stats_d["sampler_1__c"] == w
         rev = bij.rmap(stats_d)
         assert isinstance(rev, list)
         assert len(rev) == len(stats_l)


### PR DESCRIPTION
This PR implements optional support for McBackend based trace backends.

This builds on top of the refactorings from #6475 that decoupled the `pm.sampling` module from `BaseTrace`.

I split the addition of McBackend support into two commits, the first of which makes the necessary code changes without actually adding McBackend as a dependency for the test environments just to confirm that the optional importing works.

The `mcbackend.RunMeta` object that is created by the `make_runmeta` function contains several important metadata about the current model variables. This includes information such as whether a variable is deterministic or not. Related issues:
* https://github.com/arviz-devs/arviz/issues/420
* https://github.com/arviz-devs/arviz/issues/1748
* https://github.com/pymc-devs/pymc/issues/5160

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## New features
- `pm.sample(trace=...)` now accepts `mcbackend.Backend` instances.
