### PR TITLE
Fix plot in HyperGeometric docstring

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -847,9 +847,7 @@ class HyperGeometric(Discrete):
         k = 10
         for n in [20, 25]:
             pmf = st.hypergeom.pmf(x, N, k, n)
-            plt.plot(x, pmf, '-o', label='n = {}'.format(n))
-        plt.plot(x, pmf, '-o', label='N = {}'.format(N))
-        plt.plot(x, pmf, '-o', label='k = {}'.format(k))
+            plt.plot(x, pmf, '-o', label='N = {}, k = {}, n = {}'.format(N, k, n))
         plt.xlabel('x', fontsize=12)
         plt.ylabel('f(x)', fontsize=12)
         plt.legend(loc=1)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Fix correspondence between parameters legend and color label in the docstring example plot for the HyperGeometric distribution.

This is how it currently looks like:
![current_plot](https://user-images.githubusercontent.com/11216696/217967323-01271db4-00fb-46b5-b7a7-a4264cdf7eb0.png)

And this is how it will look like with this commit:
![fixed_plot](https://user-images.githubusercontent.com/11216696/217967060-73ed8530-6373-4601-abdf-615cd788dfd5.png)


**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- Fix HyperGeometric legend in example dist plot.

## Maintenance
- ...
