### PR TITLE
issue #5791, dims & cords inference from xarray

### DIFF
--- a/pymc/data.py
+++ b/pymc/data.py
@@ -209,8 +209,8 @@ def determine_coords(
     model,
     value: Union[pd.DataFrame, pd.Series, xr.DataArray],
     dims: Optional[Sequence[Optional[str]]] = None,
-    coords: Optional[Dict[str, Sequence]] = None,
-) -> Tuple[Dict[str, Sequence], Sequence[Optional[str]]]:
+    coords: Optional[Dict[str, Union[Sequence, np.ndarray]]] = None,
+) -> Tuple[Dict[str, Union[Sequence, np.ndarray]], Sequence[Optional[str]]]:
     """Determines coordinate values from data or the model (via ``dims``)."""
     if coords is None:
         coords = {}
@@ -240,7 +240,7 @@ def determine_coords(
                 dim_name = dim
                 # because coord is expected to be a sequence, we need to convert xarray
                 # using 'tolist()' function
-                coords[dim_name] = value[dim].to_numpy()
+                coords[str(dim_name)] = value[dim].to_numpy()
 
     if isinstance(value, np.ndarray) and dims is not None:
         if len(dims) != value.ndim:
@@ -266,7 +266,7 @@ def ConstantData(
     value,
     *,
     dims: Optional[Sequence[str]] = None,
-    coords: Optional[Dict[str, Sequence]] = None,
+    coords: Optional[Dict[str, Union[Sequence, np.ndarray]]] = None,
     export_index_as_coords=False,
     infer_dims_and_coords=False,
     **kwargs,
@@ -300,7 +300,7 @@ def MutableData(
     value,
     *,
     dims: Optional[Sequence[str]] = None,
-    coords: Optional[Dict[str, Sequence]] = None,
+    coords: Optional[Dict[str, Union[Sequence, np.ndarray]]] = None,
     export_index_as_coords=False,
     infer_dims_and_coords=False,
     **kwargs,
@@ -334,7 +334,7 @@ def Data(
     value,
     *,
     dims: Optional[Sequence[str]] = None,
-    coords: Optional[Dict[str, Sequence]] = None,
+    coords: Optional[Dict[str, Union[Sequence, np.ndarray]]] = None,
     export_index_as_coords=False,
     infer_dims_and_coords=False,
     mutable: Optional[bool] = None,

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -240,7 +240,7 @@ def determine_coords(
                 dim_name = dim
                 # because coord is expected to be a sequence, we need to convert xarray
                 # using 'tolist()' function
-                coords[str(dim_name)] = value[dim].to_numpy()
+                coords[dim_name] = value[dim].to_numpy()
 
     if isinstance(value, np.ndarray) and dims is not None:
         if len(dims) != value.ndim:

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -22,8 +22,10 @@ from copy import copy
 from typing import Dict, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
+import pandas as pd
 import pytensor
 import pytensor.tensor as at
+import xarray as xr
 
 from pytensor.compile.sharedvalue import SharedVariable
 from pytensor.raise_op import Assert
@@ -205,7 +207,7 @@ def Minibatch(variable: TensorVariable, *variables: TensorVariable, batch_size: 
 
 def determine_coords(
     model,
-    value,
+    value: Union[pd.DataFrame, pd.Series, xr.DataArray],
     dims: Optional[Sequence[Optional[str]]] = None,
     coords: Optional[Dict[str, Sequence]] = None,
 ) -> Tuple[Dict[str, Sequence], Sequence[Optional[str]]]:
@@ -213,9 +215,9 @@ def determine_coords(
     if coords is None:
         coords = {}
 
+    dim_name = None
     # If value is a df or a series, we interpret the index as coords:
     if hasattr(value, "index"):
-        dim_name = None
         if dims is not None:
             dim_name = dims[0]
         if dim_name is None and value.index.name is not None:
@@ -225,13 +227,18 @@ def determine_coords(
 
     # If value is a df, we also interpret the columns as coords:
     if hasattr(value, "columns"):
-        dim_name = None
         if dims is not None:
             dim_name = dims[1]
         if dim_name is None and value.columns.name is not None:
             dim_name = value.columns.name
         if dim_name is not None:
             coords[dim_name] = value.columns
+
+    if isinstance(value, xr.DataArray):
+        if dims is not None:
+            for dim in dims:
+                dim_name = dim
+                coords[dim_name] = value["dim"]
 
     if isinstance(value, np.ndarray) and dims is not None:
         if len(dims) != value.ndim:
@@ -259,6 +266,7 @@ def ConstantData(
     dims: Optional[Sequence[str]] = None,
     coords: Optional[Dict[str, Sequence]] = None,
     export_index_as_coords=False,
+    infer_dims_and_coords=False,
     **kwargs,
 ) -> TensorConstant:
     """Alias for ``pm.Data(..., mutable=False)``.
@@ -266,12 +274,19 @@ def ConstantData(
     Registers the ``value`` as a :class:`~pytensor.tensor.TensorConstant` with the model.
     For more information, please reference :class:`pymc.Data`.
     """
+    if export_index_as_coords:
+        infer_dims_and_coords = export_index_as_coords
+        warnings.warn(
+            "Deprecation warning: 'export_index_as_coords; is deprecated adn will be removed in future versions. Please use 'infer_dims_and_coords' instead.",
+            DeprecationWarning,
+        )
+
     var = Data(
         name,
         value,
         dims=dims,
         coords=coords,
-        export_index_as_coords=export_index_as_coords,
+        infer_dims_and_coords=infer_dims_and_coords,
         mutable=False,
         **kwargs,
     )
@@ -285,6 +300,7 @@ def MutableData(
     dims: Optional[Sequence[str]] = None,
     coords: Optional[Dict[str, Sequence]] = None,
     export_index_as_coords=False,
+    infer_dims_and_coords=False,
     **kwargs,
 ) -> SharedVariable:
     """Alias for ``pm.Data(..., mutable=True)``.
@@ -292,12 +308,19 @@ def MutableData(
     Registers the ``value`` as a :class:`~pytensor.compile.sharedvalue.SharedVariable`
     with the model. For more information, please reference :class:`pymc.Data`.
     """
+    if export_index_as_coords:
+        infer_dims_and_coords = export_index_as_coords
+        warnings.warn(
+            "Deprecation warning: 'export_index_as_coords; is deprecated adn will be removed in future versions. Please use 'infer_dims_and_coords' instead.",
+            DeprecationWarning,
+        )
+
     var = Data(
         name,
         value,
         dims=dims,
         coords=coords,
-        export_index_as_coords=export_index_as_coords,
+        infer_dims_and_coords=infer_dims_and_coords,
         mutable=True,
         **kwargs,
     )
@@ -311,6 +334,7 @@ def Data(
     dims: Optional[Sequence[str]] = None,
     coords: Optional[Dict[str, Sequence]] = None,
     export_index_as_coords=False,
+    infer_dims_and_coords=False,
     mutable: Optional[bool] = None,
     **kwargs,
 ) -> Union[SharedVariable, TensorConstant]:
@@ -347,7 +371,8 @@ def Data(
         names.
     coords : dict, optional
         Coordinate values to set for new dimensions introduced by this ``Data`` variable.
-    export_index_as_coords : bool, default=False
+    export_index_as_coords : deprecated, previous version of "infer_dims_and_coords"
+    infer_dims_and_coords : bool, default=False
         If True, the ``Data`` container will try to infer what the coordinates
         and dimension names should be if there is an index in ``value``.
     mutable : bool, optional
@@ -426,7 +451,15 @@ def Data(
         )
 
     # Optionally infer coords and dims from the input value.
+
     if export_index_as_coords:
+        infer_dims_and_coords = export_index_as_coords
+        warnings.warn(
+            "Deprecation warning: 'export_index_as_coords; is deprecated adn will be removed in future versions. Please use 'infer_dims_and_coords' instead.",
+            DeprecationWarning,
+        )
+
+    if infer_dims_and_coords:
         coords, dims = determine_coords(model, value, dims)
 
     if dims:

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -238,7 +238,7 @@ def determine_coords(
         if dims is not None:
             for dim in dims:
                 dim_name = dim
-                coords[dim_name] = value["dim"]
+                coords[dim_name] = value[dim]
 
     if isinstance(value, np.ndarray) and dims is not None:
         if len(dims) != value.ndim:

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -277,7 +277,7 @@ def ConstantData(
     if export_index_as_coords:
         infer_dims_and_coords = export_index_as_coords
         warnings.warn(
-            "Deprecation warning: 'export_index_as_coords; is deprecated adn will be removed in future versions. Please use 'infer_dims_and_coords' instead.",
+            "Deprecation warning: 'export_index_as_coords; is deprecated and will be removed in future versions. Please use 'infer_dims_and_coords' instead.",
             DeprecationWarning,
         )
 
@@ -311,7 +311,7 @@ def MutableData(
     if export_index_as_coords:
         infer_dims_and_coords = export_index_as_coords
         warnings.warn(
-            "Deprecation warning: 'export_index_as_coords; is deprecated adn will be removed in future versions. Please use 'infer_dims_and_coords' instead.",
+            "Deprecation warning: 'export_index_as_coords; is deprecated and will be removed in future versions. Please use 'infer_dims_and_coords' instead.",
             DeprecationWarning,
         )
 
@@ -455,7 +455,7 @@ def Data(
     if export_index_as_coords:
         infer_dims_and_coords = export_index_as_coords
         warnings.warn(
-            "Deprecation warning: 'export_index_as_coords; is deprecated adn will be removed in future versions. Please use 'infer_dims_and_coords' instead.",
+            "Deprecation warning: 'export_index_as_coords; is deprecated and will be removed in future versions. Please use 'infer_dims_and_coords' instead.",
             DeprecationWarning,
         )
 

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -238,8 +238,7 @@ def determine_coords(
         if dims is not None:
             for dim in dims:
                 dim_name = dim
-                # because coord is expected to be a sequence, we need to convert xarray
-                # using 'tolist()' function
+                # str is applied because dim entries may be None
                 coords[str(dim_name)] = value[dim].to_numpy()
 
     if isinstance(value, np.ndarray) and dims is not None:
@@ -373,7 +372,8 @@ def Data(
         names.
     coords : dict, optional
         Coordinate values to set for new dimensions introduced by this ``Data`` variable.
-    export_index_as_coords : deprecated, previous version of "infer_dims_and_coords"
+    export_index_as_coords : bool
+        Deprecated, previous version of "infer_dims_and_coords"
     infer_dims_and_coords : bool, default=False
         If True, the ``Data`` container will try to infer what the coordinates
         and dimension names should be if there is an index in ``value``.
@@ -453,7 +453,6 @@ def Data(
         )
 
     # Optionally infer coords and dims from the input value.
-
     if export_index_as_coords:
         infer_dims_and_coords = export_index_as_coords
         warnings.warn(

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -238,7 +238,9 @@ def determine_coords(
         if dims is not None:
             for dim in dims:
                 dim_name = dim
-                coords[dim_name] = value[dim]
+                # because coord is expected to be a sequence, we need to convert xarray
+                # using 'tolist()' function
+                coords[str(dim_name)] = value[dim].tolist()
 
     if isinstance(value, np.ndarray) and dims is not None:
         if len(dims) != value.ndim:

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -240,7 +240,7 @@ def determine_coords(
                 dim_name = dim
                 # because coord is expected to be a sequence, we need to convert xarray
                 # using 'tolist()' function
-                coords[str(dim_name)] = value[dim].tolist()
+                coords[str(dim_name)] = value[dim].to_numpy()
 
     if isinstance(value, np.ndarray) and dims is not None:
         if len(dims) != value.ndim:

--- a/pymc/tests/test_data.py
+++ b/pymc/tests/test_data.py
@@ -405,6 +405,18 @@ class TestData(SeededTest):
         assert "columns" in pmodel.coords
         assert pmodel.named_vars_to_dims == {"observations": ("rows", "columns")}
 
+    def test_implicit_coords_xarray(self):
+        xr = pytest.importorskip("xarray")
+        data = xr.DataArray([[1, 2, 3], [4, 5, 6]], dims=("y", "x"))
+        with pm.Model() as pmodel:
+            with pytest.warns(DeprecationWarning):
+                pm.ConstantData("observations", data, dims=("x", "y"), export_index_as_coords=True)
+        assert "x" in pmodel.coords
+        assert "y" in pmodel.coords
+        assert pmodel.named_vars_to_dims == {"observations": ("x", "y")}
+        assert pmodel.coords["x"] == [0, 1, 2]
+        assert pmodel.coords["y"] == [0, 1]
+
     def test_data_kwargs(self):
         strict_value = True
         allow_downcast_value = False

--- a/pymc/tests/test_data.py
+++ b/pymc/tests/test_data.py
@@ -414,8 +414,8 @@ class TestData(SeededTest):
         assert "x" in pmodel.coords
         assert "y" in pmodel.coords
         assert pmodel.named_vars_to_dims == {"observations": ("x", "y")}
-        assert tuple(pmodel.coords["x"]) == (data.coords["x"])
-        assert tuple(pmodel.coords["y"]) == (data.coords["y"])
+        assert tuple(pmodel.coords["x"]) == tuple(data.coords["x"].to_numpy())
+        assert tuple(pmodel.coords["y"]) == tuple(data.coords["y"].to_numpy())
 
     def test_data_kwargs(self):
         strict_value = True

--- a/pymc/tests/test_data.py
+++ b/pymc/tests/test_data.py
@@ -414,8 +414,8 @@ class TestData(SeededTest):
         assert "x" in pmodel.coords
         assert "y" in pmodel.coords
         assert pmodel.named_vars_to_dims == {"observations": ("x", "y")}
-        assert pmodel.coords["x"] == [0, 1, 2]
-        assert pmodel.coords["y"] == [0, 1]
+        assert tuple(pmodel.coords["x"]) == (data.coords["x"],)
+        assert tuple(pmodel.coords["y"]) == (data.coords["y"],)
 
     def test_data_kwargs(self):
         strict_value = True

--- a/pymc/tests/test_data.py
+++ b/pymc/tests/test_data.py
@@ -414,8 +414,8 @@ class TestData(SeededTest):
         assert "x" in pmodel.coords
         assert "y" in pmodel.coords
         assert pmodel.named_vars_to_dims == {"observations": ("x", "y")}
-        assert tuple(pmodel.coords["x"]) == (data.coords["x"],)
-        assert tuple(pmodel.coords["y"]) == (data.coords["y"],)
+        assert tuple(pmodel.coords["x"]) == (data.coords["x"])
+        assert tuple(pmodel.coords["y"]) == (data.coords["y"])
 
     def test_data_kwargs(self):
         strict_value = True


### PR DESCRIPTION
added dim inference from xarray, deprecation warning and unittest for the new feature

**What is this PR about?**
Addresses changes requested in Issue #5791 
+ Inferring dims from named pandas indexes
+ Inferring dims from DataArrays
+ Inferring coords from DataArrays
+ A unit test
+ Backwards compatible with deprecation warning rename of the export_index_as_coords to infer_dims_and_coords.

## New features
- It's now possible to infer dims & coords from xarray variables passed to pm.Data

## Documentation
- inline documentation added to data.py