### PR TITLE
Adding function for mutable coords

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -588,7 +588,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             self._dim_lengths = {}
         self.add_coords(coords)
         for name, values in coords_mutable.items():
-            self.add_coord(name, values, mutable=True, length=lengths.get(name, None))
+            self.add_coord(name, values, mutable=True)
 
         from pymc.printing import str_for_model
 

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -51,6 +51,7 @@ from pytensor.tensor.var import TensorConstant, TensorVariable
 
 from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.data import GenTensorVariable, is_minibatch
+from pymc.distributions.logprob import _joint_logp
 from pymc.distributions.transforms import _default_transform
 from pymc.exceptions import (
     BlockModelAccessError,
@@ -60,7 +61,6 @@ from pymc.exceptions import (
     ShapeWarning,
 )
 from pymc.initial_point import make_initial_point_fn
-from pymc.logprob.joint_logprob import joint_logp
 from pymc.pytensorf import (
     PointFunc,
     SeedSequenceSeed,
@@ -586,6 +586,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             self._coords = {}
             self._dim_lengths = {}
         self.add_coords(coords)
+        self.add_mutable_coords(coords)
 
         from pymc.printing import str_for_model
 
@@ -754,7 +755,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         rv_logps: List[TensorVariable] = []
         if rvs:
-            rv_logps = joint_logp(
+            rv_logps = _joint_logp(
                 rvs=rvs,
                 rvs_to_values=self.rvs_to_values,
                 rvs_to_transforms=self.rvs_to_transforms,
@@ -1079,6 +1080,20 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         for name, values in coords.items():
             self.add_coord(name, values, length=lengths.get(name, None))
+
+    def add_mutable_coords(
+        self,
+        coords: Dict[str, Optional[Sequence]],
+        *,
+        lengths: Optional[Dict[str, Optional[Union[int, Variable]]]] = None,
+    ):
+        """Registers a mutable dimension coordinate with the model"""
+        if coords is None:
+            return
+        lengths = lengths or {}
+
+        for name, values in coords.items():
+            self.add_coord(name, values, mutable=True, length=lengths.get(name, None))
 
     def set_dim(self, name: str, new_length: int, coord_values: Optional[Sequence] = None):
         """Update a mutable dimension.

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -548,6 +548,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         self,
         name="",
         coords=None,
+        coords_mutable=None,
         check_bounds=True,
         *,
         pytensor_config=None,
@@ -586,6 +587,8 @@ class Model(WithMemoization, metaclass=ContextMeta):
             self._coords = {}
             self._dim_lengths = {}
         self.add_coords(coords)
+        for name, values in coords_mutable.items():
+            self.add_coord(name, values, mutable=True, length=lengths.get(name, None))
 
         from pymc.printing import str_for_model
 

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -587,8 +587,9 @@ class Model(WithMemoization, metaclass=ContextMeta):
             self._coords = {}
             self._dim_lengths = {}
         self.add_coords(coords)
-        for name, values in coords_mutable.items():
-            self.add_coord(name, values, mutable=True)
+        if coords_mutable is not None:
+            for name, values in coords_mutable.items():
+                self.add_coord(name, values, mutable=True)
 
         from pymc.printing import str_for_model
 

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -548,9 +548,9 @@ class Model(WithMemoization, metaclass=ContextMeta):
         self,
         name="",
         coords=None,
-        coords_mutable=None,
         check_bounds=True,
         *,
+        coords_mutable=None,
         pytensor_config=None,
         model=None,
     ):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
In this PR , I have made attempts to incorporate suggestions made from [6497](https://github.com/pymc-devs/pymc/issues/6497).
Coordinate dimensions by default are assumed to be immutable unless they are explicitly mentioned to be mutable in the ```add_coord``` function. 
In this PR, we aim to register mutable dimension coordinates with the model without having to explicitly set ```mutable = True``` in the ```add_coord``` method for each item in ```coords```.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- no

## New features
- Added another function called ```add_mutable_coords``` which registers new coordinates that are mutable by iterating in a ```for``` loop and calling ```self.add_coord(..., mutable=True)``` for every iteration.

## Bugfixes
- no

## Documentation
- Documentation has been updated consistent with modifications

## Maintenance
- no
