### PR TITLE
Fix flaky `test_truncation_specialized_op`

### DIFF
--- a/pymc/tests/distributions/test_truncated.py
+++ b/pymc/tests/distributions/test_truncated.py
@@ -84,9 +84,7 @@ def test_truncation_specialized_op(shape_info):
                 dist=x,
                 lower=5,
                 upper=15,
-                observed=np.empty(
-                    100,
-                ),
+                observed=np.zeros(100),
             )
         else:
             raise ValueError(f"Not a valid shape_info parametrization: {shape_info}")


### PR DESCRIPTION
Using empty for the observed would sometimes lead PyMC into triggering automatic imputation, whenever the trash values in empty were nan.

Closes #6384 