### PR TITLE
Replace rvs_to_total_sizes mapping by MinibatchRandomVariables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,6 +240,7 @@ jobs:
           - |
             tests/sampling/test_parallel.py
             tests/test_data.py
+            tests/variational/test_minibatch_rv.py
             tests/test_model.py
 
           - |

--- a/pymc/logprob/joint_logprob.py
+++ b/pymc/logprob/joint_logprob.py
@@ -39,7 +39,6 @@ import warnings
 from collections import deque
 from typing import Dict, List, Optional, Sequence, Union
 
-import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
@@ -55,7 +54,6 @@ from pymc.logprob.abstract import logprob as logp_logprob
 from pymc.logprob.rewriting import construct_ir_fgraph
 from pymc.logprob.transforms import RVTransform, TransformValuesRewrite
 from pymc.logprob.utils import rvs_to_value_vars
-from pymc.pytensorf import floatX
 
 
 def logp(rv: TensorVariable, value) -> TensorVariable:
@@ -248,77 +246,6 @@ def factorized_joint_logprob(
     return logprob_vars
 
 
-TOTAL_SIZE = Union[int, Sequence[int], None]
-
-
-def _get_scaling(total_size: TOTAL_SIZE, shape, ndim: int) -> TensorVariable:
-    """
-    Gets scaling constant for logp.
-
-    Parameters
-    ----------
-    total_size: Optional[int|List[int]]
-        size of a fully observed data without minibatching,
-        `None` means data is fully observed
-    shape: shape
-        shape of an observed data
-    ndim: int
-        ndim hint
-
-    Returns
-    -------
-    scalar
-    """
-    if total_size is None:
-        coef = 1.0
-    elif isinstance(total_size, int):
-        if ndim >= 1:
-            denom = shape[0]
-        else:
-            denom = 1
-        coef = floatX(total_size) / floatX(denom)
-    elif isinstance(total_size, (list, tuple)):
-        if not all(isinstance(i, int) for i in total_size if (i is not Ellipsis and i is not None)):
-            raise TypeError(
-                "Unrecognized `total_size` type, expected "
-                "int or list of ints, got %r" % total_size
-            )
-        if Ellipsis in total_size:
-            sep = total_size.index(Ellipsis)
-            begin = total_size[:sep]
-            end = total_size[sep + 1 :]
-            if Ellipsis in end:
-                raise ValueError(
-                    "Double Ellipsis in `total_size` is restricted, got %r" % total_size
-                )
-        else:
-            begin = total_size
-            end = []
-        if (len(begin) + len(end)) > ndim:
-            raise ValueError(
-                "Length of `total_size` is too big, "
-                "number of scalings is bigger that ndim, got %r" % total_size
-            )
-        elif (len(begin) + len(end)) == 0:
-            coef = 1.0
-        if len(end) > 0:
-            shp_end = shape[-len(end) :]
-        else:
-            shp_end = np.asarray([])
-        shp_begin = shape[: len(begin)]
-        begin_coef = [
-            floatX(t) / floatX(shp_begin[i]) for i, t in enumerate(begin) if t is not None
-        ]
-        end_coef = [floatX(t) / floatX(shp_end[i]) for i, t in enumerate(end) if t is not None]
-        coefs = begin_coef + end_coef
-        coef = pt.prod(coefs)
-    else:
-        raise TypeError(
-            "Unrecognized `total_size` type, expected int or list of ints, got %r" % total_size
-        )
-    return pt.as_tensor(coef, dtype=pytensor.config.floatX)
-
-
 def _check_no_rvs(logp_terms: Sequence[TensorVariable]):
     # Raise if there are unexpected RandomVariables in the logp graph
     # Only SimulatorRVs MinibatchIndexRVs are allowed
@@ -348,7 +275,6 @@ def joint_logp(
     rvs_to_values: Dict[TensorVariable, TensorVariable],
     rvs_to_transforms: Dict[TensorVariable, RVTransform],
     jacobian: bool = True,
-    rvs_to_total_sizes: Dict[TensorVariable, TOTAL_SIZE],
     **kwargs,
 ) -> List[TensorVariable]:
     """Thin wrapper around pymc.logprob.factorized_joint_logprob, extended with Model
@@ -371,18 +297,13 @@ def joint_logp(
         **kwargs,
     )
 
-    # The function returns the logp for every single value term we provided to it. This
-    # includes the extra values we plugged in above, so we filter those we actually
-    # wanted in the same order they were given in.
+    # The function returns the logp for every single value term we provided to it.
+    # This includes the extra values we plugged in above, so we filter those we
+    # actually wanted in the same order they were given in.
     logp_terms = {}
     for rv in rvs:
         value_var = rvs_to_values[rv]
-        logp_term = temp_logp_terms[value_var]
-        total_size = rvs_to_total_sizes.get(rv, None)
-        if total_size is not None:
-            scaling = _get_scaling(total_size, value_var.shape, value_var.ndim)
-            logp_term *= scaling
-        logp_terms[value_var] = logp_term
+        logp_terms[value_var] = temp_logp_terms[value_var]
 
     _check_no_rvs(list(logp_terms.values()))
     return list(logp_terms.values())

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -489,7 +489,6 @@ class _FutureWarningValidatingScratchpad(ValidatingScratchpad):
         for deprecated_names, alternative in (
             (("value_var", "observations"), "model.rvs_to_values[rv]"),
             (("transform",), "model.rvs_to_transforms[rv]"),
-            (("total_size",), "model.rvs_to_total_sizes[rv]"),
         ):
             if name in deprecated_names:
                 try:

--- a/pymc/variational/minibatch_rv.py
+++ b/pymc/variational/minibatch_rv.py
@@ -1,0 +1,113 @@
+#   Copyright 2023 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from typing import Any, Sequence, Union, cast
+
+import pytensor.tensor as pt
+
+from pytensor import Variable, config
+from pytensor.graph import Apply, Op
+from pytensor.tensor import NoneConst, TensorVariable, as_tensor_variable
+
+from pymc.logprob.abstract import MeasurableVariable, _get_measurable_outputs, _logprob
+from pymc.logprob.abstract import logprob as logprob_logprob
+from pymc.logprob.utils import ignore_logprob
+
+
+class MinibatchRandomVariable(Op):
+    """RV whose logprob should be rescaled to match total_size"""
+
+    __props__ = ()
+    view_map = {0: [0]}
+
+    def make_node(self, rv, *total_size):
+        rv = as_tensor_variable(rv)
+        total_size = [
+            as_tensor_variable(t, dtype="int64", ndim=0) if t is not None else NoneConst
+            for t in total_size
+        ]
+        assert len(total_size) == rv.ndim
+        out = rv.type()
+        return Apply(self, [rv, *total_size], [out])
+
+    def perform(self, node, inputs, output_storage):
+        output_storage[0][0] = inputs[0]
+
+
+minibatch_rv = MinibatchRandomVariable()
+
+
+EllipsisType = Any  # EllipsisType is not present in Python 3.8 yet
+
+
+def create_minibatch_rv(
+    rv: TensorVariable,
+    total_size: Union[int, None, Sequence[Union[int, EllipsisType, None]]],
+) -> TensorVariable:
+    """Create variable whose logp is rescaled by total_size."""
+    if isinstance(total_size, int):
+        if rv.ndim <= 1:
+            total_size = [total_size]
+        else:
+            missing_ndims = rv.ndim - 1
+            total_size = [total_size] + [None] * missing_ndims
+    elif isinstance(total_size, (list, tuple)):
+        total_size = list(total_size)
+        if Ellipsis in total_size:
+            # Replace Ellipsis by None
+            if total_size.count(Ellipsis) > 1:
+                raise ValueError("Only one Ellipsis can be present in total_size")
+            sep = total_size.index(Ellipsis)
+            begin = total_size[:sep]
+            end = total_size[sep + 1 :]
+            missing_ndims = max((rv.ndim - len(begin) - len(end), 0))
+            total_size = begin + [None] * missing_ndims + end
+        if len(total_size) > rv.ndim:
+            raise ValueError(f"Length of total_size {total_size} is langer than RV ndim {rv.ndim}")
+    else:
+        raise TypeError(f"Invalid type for total_size: {total_size}")
+
+    rv = ignore_logprob(rv)
+
+    return cast(TensorVariable, minibatch_rv(rv, *total_size))
+
+
+def get_scaling(total_size: Sequence[Variable], shape: TensorVariable) -> TensorVariable:
+    """Gets scaling constant for logp."""
+
+    # mypy doesn't understand we can convert a shape TensorVariable into a tuple
+    shape = tuple(shape)  # type: ignore
+
+    # Scalar RV
+    if len(shape) == 0:  # type: ignore
+        coef = total_size[0] if not NoneConst.equals(total_size[0]) else 1.0
+    else:
+        coefs = [t / shape[i] for i, t in enumerate(total_size) if not NoneConst.equals(t)]
+        coef = pt.prod(coefs)
+
+    return pt.cast(coef, dtype=config.floatX)
+
+
+MeasurableVariable.register(MinibatchRandomVariable)
+
+
+@_get_measurable_outputs.register(MinibatchRandomVariable)
+def _get_measurable_outputs_minibatch_random_variable(op, node):
+    return [node.outputs[0]]
+
+
+@_logprob.register(MinibatchRandomVariable)
+def minibatch_rv_logprob(op, values, *inputs, **kwargs):
+    [value] = values
+    rv, *total_size = inputs
+    return logprob_logprob(rv, value, **kwargs) * get_scaling(total_size, value.shape)

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -66,7 +66,6 @@ from pymc.backends.base import MultiTrace
 from pymc.backends.ndarray import NDArray
 from pymc.blocking import DictToArrayBijection
 from pymc.initial_point import make_initial_point_fn
-from pymc.logprob.joint_logprob import _get_scaling
 from pymc.model import modelcontext
 from pymc.pytensorf import (
     SeedSequenceSeed,
@@ -82,6 +81,7 @@ from pymc.util import (
     _get_seeds_per_chain,
     locally_cachedmethod,
 )
+from pymc.variational.minibatch_rv import MinibatchRandomVariable, get_scaling
 from pymc.variational.updates import adagrad_window
 from pymc.vartypes import discrete_types
 
@@ -1069,9 +1069,11 @@ class Group(WithMemoization):
         t = self.to_flat_input(
             at.max(
                 [
-                    _get_scaling(self.model.rvs_to_total_sizes.get(v, None), v.shape, v.ndim)
+                    get_scaling(v.owner.inputs[1:], v.shape)
                     for v in self.group
+                    if isinstance(v.owner.op, MinibatchRandomVariable)
                 ]
+                + [1.0]  # To avoid empty max
             )
         )
         t = self.symbolic_single_sample(t)
@@ -1237,12 +1239,9 @@ class Approximation(WithMemoization):
         t = at.max(
             self.collect("symbolic_normalizing_constant")
             + [
-                _get_scaling(
-                    self.model.rvs_to_total_sizes.get(obs, None),
-                    obs.shape,
-                    obs.ndim,
-                )
+                get_scaling(obs.owner.inputs[1:], obs.shape)
                 for obs in self.model.observed_RVs
+                if isinstance(obs.owner.op, MinibatchRandomVariable)
             ]
         )
         t = at.switch(self._scale_cost_to_minibatch, t, at.constant(1, dtype=t.dtype))

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -312,7 +312,6 @@ class TestElementWiseLogp(SeededTest):
                 (x,),
                 rvs_to_values={x: x_val_transf},
                 rvs_to_transforms={x: transform},
-                rvs_to_total_sizes={},
                 jacobian=False,
             )[0]
             .sum()
@@ -323,7 +322,6 @@ class TestElementWiseLogp(SeededTest):
                 (x,),
                 rvs_to_values={x: x_val_untransf},
                 rvs_to_transforms={},
-                rvs_to_total_sizes={},
             )[0]
             .sum()
             .eval({x_val_untransf: test_array_untransf})
@@ -362,7 +360,6 @@ class TestElementWiseLogp(SeededTest):
                 (x,),
                 rvs_to_values={x: x_val_transf},
                 rvs_to_transforms={x: transform},
-                rvs_to_total_sizes={},
                 jacobian=False,
             )[0]
             .sum()
@@ -373,7 +370,6 @@ class TestElementWiseLogp(SeededTest):
                 (x,),
                 rvs_to_values={x: x_val_untransf},
                 rvs_to_transforms={},
-                rvs_to_total_sizes={},
             )[0]
             .sum()
             .eval({x_val_untransf: test_array_untransf})

--- a/tests/distributions/util.py
+++ b/tests/distributions/util.py
@@ -600,7 +600,6 @@ def assert_moment_is_expected(model, expected, check_finite_logp=True):
                 (model["x"],),
                 rvs_to_values={model["x"]: at.constant(moment)},
                 rvs_to_transforms={},
-                rvs_to_total_sizes={},
             )[0]
             .sum()
             .eval()

--- a/tests/logprob/test_utils.py
+++ b/tests/logprob/test_utils.py
@@ -233,7 +233,6 @@ def test_ignore_reconsider_logprob_model():
             [x],
             rvs_to_values={x: value},
             rvs_to_transforms={},
-            rvs_to_total_sizes={},
         )
 
     with pm.Model():
@@ -248,7 +247,6 @@ def test_ignore_reconsider_logprob_model():
             [y],
             rvs_to_values={y: y.type()},
             rvs_to_transforms={},
-            rvs_to_total_sizes={},
         )
 
     # The above warning should go away with ignore_logprob.
@@ -261,5 +259,4 @@ def test_ignore_reconsider_logprob_model():
             [y],
             rvs_to_values={y: y.type()},
             rvs_to_transforms={},
-            rvs_to_total_sizes={},
         )

--- a/tests/logprob/utils.py
+++ b/tests/logprob/utils.py
@@ -246,7 +246,6 @@ def test_ignore_logprob_model():
             [y],
             rvs_to_values={y: y.type()},
             rvs_to_transforms={},
-            rvs_to_total_sizes={},
         )
 
     # The above warning should go away with ignore_logprob.
@@ -259,5 +258,4 @@ def test_ignore_logprob_model():
             [y],
             rvs_to_values={y: y.type()},
             rvs_to_transforms={},
-            rvs_to_total_sizes={},
         )

--- a/tests/variational/test_minibatch_rv.py
+++ b/tests/variational/test_minibatch_rv.py
@@ -1,0 +1,157 @@
+#   Copyright 2023 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import numpy as np
+import pytensor
+import pytest
+
+from scipy import stats as st
+
+import pymc as pm
+
+from pymc import Normal, draw
+from pymc.variational.minibatch_rv import create_minibatch_rv
+from tests.helpers import select_by_precision
+from tests.test_data import gen1, gen2
+
+
+class TestMinibatchRandomVariable:
+    """
+    Related to minibatch training
+    """
+
+    def test_density_scaling(self):
+        with pm.Model() as model1:
+            pm.Normal("n", observed=[[1]], total_size=1)
+            p1 = pytensor.function([], model1.logp())
+
+        with pm.Model() as model2:
+            pm.Normal("n", observed=[[1]], total_size=2)
+            p2 = pytensor.function([], model2.logp())
+        assert p1() * 2 == p2()
+
+    def test_density_scaling_with_generator(self):
+        # We have different size generators
+
+        def true_dens():
+            g = gen1()
+            for i, point in enumerate(g):
+                yield st.norm.logpdf(point).sum() * 10
+
+        t = true_dens()
+        # We have same size models
+        with pm.Model() as model1:
+            pm.Normal("n", observed=gen1(), total_size=100)
+            p1 = pytensor.function([], model1.logp())
+
+        with pm.Model() as model2:
+            gen_var = pm.generator(gen2())
+            pm.Normal("n", observed=gen_var, total_size=100)
+            p2 = pytensor.function([], model2.logp())
+
+        for i in range(10):
+            _1, _2, _t = p1(), p2(), next(t)
+            decimals = select_by_precision(float64=7, float32=1)
+            np.testing.assert_almost_equal(_1, _t, decimal=decimals)  # Value O(-50,000)
+            np.testing.assert_almost_equal(_1, _2)
+        # Done
+
+    def test_gradient_with_scaling(self):
+        with pm.Model() as model1:
+            genvar = pm.generator(gen1())
+            m = pm.Normal("m")
+            pm.Normal("n", observed=genvar, total_size=1000)
+            grad1 = model1.compile_fn(model1.dlogp(vars=m), point_fn=False)
+        with pm.Model() as model2:
+            m = pm.Normal("m")
+            shavar = pytensor.shared(np.ones((1000, 100)))
+            pm.Normal("n", observed=shavar)
+            grad2 = model2.compile_fn(model2.dlogp(vars=m), point_fn=False)
+
+        for i in range(10):
+            shavar.set_value(np.ones((100, 100)) * i)
+            g1 = grad1(1)
+            g2 = grad2(1)
+            np.testing.assert_almost_equal(g1, g2)
+
+    def test_multidim_scaling(self):
+        with pm.Model() as model0:
+            pm.Normal("n", observed=[[1, 1], [1, 1]], total_size=[])
+            p0 = pytensor.function([], model0.logp())
+
+        with pm.Model() as model1:
+            pm.Normal("n", observed=[[1, 1], [1, 1]], total_size=[2, 2])
+            p1 = pytensor.function([], model1.logp())
+
+        with pm.Model() as model2:
+            pm.Normal("n", observed=[[1], [1]], total_size=[2, 2])
+            p2 = pytensor.function([], model2.logp())
+
+        with pm.Model() as model3:
+            pm.Normal("n", observed=[[1, 1]], total_size=[2, 2])
+            p3 = pytensor.function([], model3.logp())
+
+        with pm.Model() as model4:
+            pm.Normal("n", observed=[[1]], total_size=[2, 2])
+            p4 = pytensor.function([], model4.logp())
+
+        with pm.Model() as model5:
+            pm.Normal("n", observed=[[1]], total_size=[2, Ellipsis, 2])
+            p5 = pytensor.function([], model5.logp())
+        _p0 = p0()
+        assert (
+            np.allclose(_p0, p1())
+            and np.allclose(_p0, p2())
+            and np.allclose(_p0, p3())
+            and np.allclose(_p0, p4())
+            and np.allclose(_p0, p5())
+        )
+
+    def test_common_errors(self):
+        with pytest.raises(ValueError, match="Length of"):
+            with pm.Model() as m:
+                pm.Normal("n", observed=[[1]], total_size=[2, Ellipsis, 2, 2])
+                m.logp()
+        with pytest.raises(ValueError, match="Length of"):
+            with pm.Model() as m:
+                pm.Normal("n", observed=[[1]], total_size=[2, 2, 2])
+                m.logp()
+        with pytest.raises(TypeError, match="Invalid type for total_size"):
+            with pm.Model() as m:
+                pm.Normal("n", observed=[[1]], total_size="foo")
+                m.logp()
+        with pytest.raises(NotImplementedError, match="Cannot convert"):
+            with pm.Model() as m:
+                pm.Normal("n", observed=[[1]], total_size=["foo"])
+                m.logp()
+        with pytest.raises(ValueError, match="Only one Ellipsis"):
+            with pm.Model() as m:
+                pm.Normal("n", observed=[[1]], total_size=[Ellipsis, Ellipsis])
+                m.logp()
+
+        with pm.Model() as model4:
+            with pytest.raises(ValueError, match="only be passed to observed RVs"):
+                pm.Normal("n", shape=(1, 1), total_size=[2, 2])
+
+    def test_mixed1(self):
+        with pm.Model():
+            data = np.random.rand(10, 20)
+            mb = pm.Minibatch(data, batch_size=5)
+            v = pm.Normal("n", observed=mb, total_size=10)
+            assert pm.logp(v, 1) is not None, "Check index is allowed in graph"
+
+    def test_random(self):
+        x = Normal.dist(size=(5,))
+        mx = create_minibatch_rv(x, total_size=(10,))
+        assert mx is not x
+        np.testing.assert_array_equal(draw(mx, random_seed=1), draw(x, random_seed=1))

--- a/tests/variational/test_opvi.py
+++ b/tests/variational/test_opvi.py
@@ -48,7 +48,7 @@ def test_discrete_not_allowed():
 @pytest.fixture(scope="module")
 def three_var_model():
     with pm.Model() as model:
-        pm.HalfNormal("one", size=(10, 2), total_size=100)
+        pm.HalfNormal("one", size=(10, 2))
         pm.Normal("two", size=(10,))
         pm.Normal("three", size=(10, 1, 2))
     return model


### PR DESCRIPTION
This PR refactors the way rescaling of minibatched variables is achieved, so as to not require keeping any meta-information at the model level.

Ideally, the API would follow that of other RV factories with something like `pm.MinibatchRV(dist=dist, total_size=...)` so that we don't have to add any extra complexity at the Model level, but for the sake of backwards compatibility we let `Model` do this for now.

I removed support for scaling of non-observed RVs even though it would be equally easy to support them. **This is a breaking change**

Closes #6061 
Closes #6332