### PR TITLE
Add check for variables in step samplers

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -168,6 +168,11 @@ def assign_step_methods(model, step=None, methods=None, step_kwargs=None):
         except TypeError:
             steps.append(step)
         for step in steps:
+            for var in step.vars:
+                if var not in model.value_vars:
+                    raise ValueError(
+                        "Step samplers should only contain value variables that belong to the model."
+                    )
             assigned_vars = assigned_vars.union(set(step.vars))
 
     # Use competence classmethods to select step methods for remaining

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -171,7 +171,7 @@ def assign_step_methods(model, step=None, methods=None, step_kwargs=None):
             for var in step.vars:
                 if var not in model.value_vars:
                     raise ValueError(
-                        "Step samplers should only contain value variables that belong to the model."
+                        f"{var} assigned to {step} sampler is not a value variable in the model. You can use `util.get_value_vars_from_user_vars` to parse user provided variables."
                     )
             assigned_vars = assigned_vars.union(set(step.vars))
 

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -40,11 +40,11 @@ from pymc.step_methods import (
     NUTS,
     BinaryGibbsMetropolis,
     CategoricalGibbsMetropolis,
+    CompoundStep,
     HamiltonianMC,
     Metropolis,
     Slice,
 )
-from step_methods.compound import CompoundStep
 from tests.helpers import SeededTest, fast_unstable_sampling_mode
 from tests.models import simple_init
 

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -827,11 +827,12 @@ class TestAssignStepMethods:
             with pytensor.config.change_flags(mode=fast_unstable_sampling_mode):
                 step1 = NUTS([c1])
                 step2 = NUTS([c2])
-                step2.vars = [
-                    at.dscalar("x"),
-                ]
+                step2.vars = [c2]
                 step = CompoundStep([step1, step2])
-                with pytest.raises(ValueError):
+                with pytest.raises(
+                    ValueError,
+                    match=r".* assigned to .* sampler is not a value variable in the model. You can use `util.get_value_vars_from_user_vars` to parse user provided variables.",
+                ):
                     assign_step_methods(model, step)
 
 


### PR DESCRIPTION
**What is this PR about?**
Added safety check to prevent incorrect step assignment with custom step functions.
Nów assign_step_method from mcmc.py before assigning variables from step to
assigned_var, checks if they can be found in model.value_vars.

## Major / Breaking Changes
-

## New features
- step value check for assign_step_methods

## Bugfixes
- 

## Documentation
- 

## Maintenance
- 
