### PR TITLE
Refactor sample return

### DIFF
--- a/tests/backends/test_ndarray.py
+++ b/tests/backends/test_ndarray.py
@@ -123,6 +123,12 @@ class TestMultiTrace(bf.ModelBackendSetupTestCase):
         with pytest.raises(ValueError):
             base.MultiTrace([self.strace0, self.strace1])
 
+    def test_multitrace_iter_notimplemented(self):
+        mtrace = base.MultiTrace([self.strace0])
+        with pytest.raises(NotImplementedError):
+            for _ in mtrace:
+                pass
+
 
 class TestSqueezeCat:
     def setup_method(self):


### PR DESCRIPTION
This refactors the post-MCMC part of `pm.sample` into a function which simplifies testing and future refactoring.

In `test_mcmc.py` I consolidated the test cases, mostly by using `pm.Metropolis` and avoiding to re-run MCMCs just to test different flavors of `discard_tuned_samples`, `return_inferencedata` and so on.

Locally this reduced the `test_mcmc.py` runtime by ~200 seconds.

## Maintenance
- Post-MCMC parts of `pm.sample` were extracted into a function.
