### PR TITLE
Block `sample_blackjax_nuts` until sampling finished (#6550)

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -438,7 +438,8 @@ def sample_blackjax_nuts(
         )
 
     states, stats = map_fn(get_posterior_samples)(keys, init_params)
-    raw_mcmc_samples = states.position
+    # block to allow accurate sampling time calculation
+    raw_mcmc_samples = jax.block_until_ready(states.position)
     potential_energy = states.potential_energy
     tic3 = datetime.now()
     print("Sampling time = ", tic3 - tic2, file=sys.stdout)


### PR DESCRIPTION
Due to JAX's asynchronous dispatch model,`sample_blackjax_nuts` sampling time was being underestimated and moved into transformation time. This blocks PR blocks for sampling to complete before calculating the time taken.


## Bugfixes
- `sample_blackjax_nuts` correctly report split between sampling and transformation. (#6550)
