### PR TITLE
Exclude tests from package discovery

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,3 @@
-recursive-include tests/data *
-recursive-include source *
-# because of an upload-size limit by PyPI, we're temporarily removing docs from the tarball:
-recursive-exclude docs *
 include requirements.txt
 include *.md *.rst
 include scripts/*.sh

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -13,8 +13,6 @@
 #   limitations under the License.
 
 import io
-import os
-import pkgutil
 import urllib.request
 import warnings
 
@@ -63,12 +61,8 @@ def get_data(filename):
     -------
     BytesIO of the data
     """
-    data_pkg = "tests"
-    try:
-        content = pkgutil.get_data(data_pkg, os.path.join("data", filename))
-    except FileNotFoundError:
-        with urllib.request.urlopen(BASE_URL.format(filename=filename)) as handle:
-            content = handle.read()
+    with urllib.request.urlopen(BASE_URL.format(filename=filename)) as handle:
+        content = handle.read()
     return io.BytesIO(content)
 
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
         url=URL,
         long_description=LONG_DESCRIPTION,
         long_description_content_type="text/x-rst",
-        packages=find_packages(),
+        packages=find_packages(exclude=["tests*"]),
         # because of an upload-size limit by PyPI, we're temporarily removing docs from the tarball.
         # Also see MANIFEST.in
         # package_data={'docs': ['*']},

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ if __name__ == "__main__":
         # because of an upload-size limit by PyPI, we're temporarily removing docs from the tarball.
         # Also see MANIFEST.in
         # package_data={'docs': ['*']},
-        include_package_data=True,
         classifiers=classifiers,
         python_requires=">=3.8",
         install_requires=install_reqs,


### PR DESCRIPTION
`setuptools` was now picking up the `tests` directory as an installable package and was installing it alongside `pymc`, which could conflict with any other package named `tests`.

This PR configures `setuptools` to exclude `tests` from the automated package discovery.

I took this opportunity to clean up some warning-generating lines in `MANIFEST.in`, and an unused option in `setup.py`.


**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- Exclude tests from the package discovery
