### PR TITLE
Fix no-commit-to-branch pre-commit hook to protect main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: debug-statements
     -   id: end-of-file-fixer
     -   id: no-commit-to-branch
-        args: [--branch, master]
+        args: [--branch, main]
     -   id: requirements-txt-fixer
         exclude: ^requirements-dev\.txt$
     -   id: trailing-whitespace


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**

The `no-commit-to-branch` pre-commit hook prevents people from committing to `main` when pre-commit is properly set up. This is especially helpful for newer contributors who may forget to create a feature branch.

The previous setting of `master` appears to be a holdover from before the time when the default branch was renamed from `master` to `main`.

This PR simply updates `master` to `main` so that the local default branch is protected by pre-commit.
...

**Checklist**
+ [X] Explain important implementation details 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [X] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- Fix no-commit-to-branch pre-commit hook to protect main 
