### PR TITLE
`TruncatedNormal` only accepts `mu` and `sigma` as non keyword arguments

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -650,10 +650,10 @@ class TruncatedNormal(BoundedContinuous):
         cls,
         mu: Optional[DIST_PARAMETER_TYPES] = None,
         sigma: Optional[DIST_PARAMETER_TYPES] = None,
+        *,
         tau: Optional[DIST_PARAMETER_TYPES] = None,
         lower: Optional[DIST_PARAMETER_TYPES] = None,
         upper: Optional[DIST_PARAMETER_TYPES] = None,
-        *args,
         **kwargs,
     ) -> RandomVariable:
         tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)


### PR DESCRIPTION
**What is this PR about?**
Making params of TruncatedNormal distribution to avoid issues with icdf testing.

**Checklist**

## Major / Breaking Changes

## New features

## Bugfixes

## Documentation
Changes are self descriptive

## Maintenance
