### PR TITLE
Public test utilities can now be found in `testing` module

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
             tests/test_func_utils.py
             tests/distributions/test_shape_utils.py
             tests/distributions/test_mixture.py
+            tests/test_testing.py
 
           - |
             tests/distributions/test_continuous.py

--- a/docs/source/contributing/implementing_distribution.md
+++ b/docs/source/contributing/implementing_distribution.md
@@ -240,10 +240,11 @@ Most tests can be accommodated by the default `BaseTestDistributionRandom` class
 1. Shape variable inference is correct, via `check_rv_size`
 
 ```python
-from tests.distributions.util import BaseTestDistributionRandom, seeded_scipy_distribution_builder
+
+from pymc.testing import BaseTestDistributionRandom, seeded_scipy_distribution_builder
+
 
 class TestBlah(BaseTestDistributionRandom):
-
     pymc_dist = pm.Blah
     # Parameters with which to test the blah pymc Distribution
     pymc_dist_params = {"param1": 0.25, "param2": 2.0}
@@ -311,38 +312,36 @@ Tests for the `logp` and `logcdf` mostly make use of the helpers `check_logp`, `
 `check_selfconsistency_discrete_logcdf` implemented in `~tests.distributions.util`
 
 ```python
-from tests.helpers import select_by_precision
-from tests.distributions.util import check_logp, check_logcdf, Domain
+
+from pymc.testing import Domain, check_logp, check_logcdf, select_by_precision
 
 R = Domain([-np.inf, -2.1, -1, -0.01, 0.0, 0.01, 1, 2.1, np.inf])
 Rplus = Domain([0, 0.01, 0.1, 0.9, 0.99, 1, 1.5, 2, 100, np.inf])
 
 
-
 def test_blah():
+    check_logp(
+        pymc_dist=pm.Blah,
+        # Domain of the distribution values
+        domain=R,
+        # Domains of the distribution parameters
+        paramdomains={"mu": R, "sigma": Rplus},
+        # Reference scipy (or other) logp function
+        scipy_logp=lambda value, mu, sigma: sp.norm.logpdf(value, mu, sigma),
+        # Number of decimal points expected to match between the pymc and reference functions
+        decimal=select_by_precision(float64=6, float32=3),
+        # Maximum number of combinations of domain * paramdomains to test
+        n_samples=100,
+    )
 
-  check_logp(
-      pymc_dist=pm.Blah,
-      # Domain of the distribution values
-      domain=R,
-      # Domains of the distribution parameters
-      paramdomains={"mu": R, "sigma": Rplus},
-      # Reference scipy (or other) logp function
-      scipy_logp = lambda value, mu, sigma: sp.norm.logpdf(value, mu, sigma),
-      # Number of decimal points expected to match between the pymc and reference functions
-      decimal=select_by_precision(float64=6, float32=3),
-      # Maximum number of combinations of domain * paramdomains to test
-      n_samples=100,
-  )
-
-  check_logcdf(
-      pymc_dist=pm.Blah,
-      domain=R,
-      paramdomains={"mu": R, "sigma": Rplus},
-      scipy_logcdf=lambda value, mu, sigma: sp.norm.logcdf(value, mu, sigma),
-      decimal=select_by_precision(float64=6, float32=1),
-      n_samples=-1,
-  )
+    check_logcdf(
+        pymc_dist=pm.Blah,
+        domain=R,
+        paramdomains={"mu": R, "sigma": Rplus},
+        scipy_logcdf=lambda value, mu, sigma: sp.norm.logcdf(value, mu, sigma),
+        decimal=select_by_precision(float64=6, float32=1),
+        n_samples=-1,
+    )
 
 ```
 
@@ -382,7 +381,8 @@ which checks if:
 
 import pytest
 from pymc.distributions import Blah
-from tests.distributions.util import assert_moment_is_expected
+from pymc.testing import assert_moment_is_expected
+
 
 @pytest.mark.parametrize(
     "param1, param2, size, expected",

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -32,7 +32,7 @@ from pymc.logprob.abstract import logcdf
 from pymc.logprob.joint_logprob import logp
 from pymc.logprob.utils import ParameterValueError
 from pymc.pytensorf import floatX
-from tests.distributions.util import (
+from pymc.testing import (
     BaseTestDistributionRandom,
     Circ,
     Domain,
@@ -45,11 +45,11 @@ from tests.distributions.util import (
     assert_moment_is_expected,
     check_logcdf,
     check_logp,
-    pymc_random,
+    continuous_random_tester,
     seeded_numpy_distribution_builder,
     seeded_scipy_distribution_builder,
+    select_by_precision,
 )
-from tests.helpers import select_by_precision
 from tests.logprob.utils import create_pytensor_params, scipy_logprob_tester
 
 try:
@@ -2259,7 +2259,7 @@ class TestInterpolated(BaseTestDistributionRandom):
                         pdf_points = st.norm.pdf(x_points, loc=mu, scale=sigma)
                         return super().dist(x_points=x_points, pdf_points=pdf_points, **kwargs)
 
-                pymc_random(
+                continuous_random_tester(
                     TestedInterpolated,
                     {},
                     extra_args={"rng": pytensor.shared(rng)},

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -33,8 +33,7 @@ from pymc.logprob.abstract import logcdf
 from pymc.logprob.joint_logprob import logp
 from pymc.logprob.utils import ParameterValueError
 from pymc.pytensorf import floatX
-from pymc.vartypes import discrete_types
-from tests.distributions.util import (
+from pymc.testing import (
     BaseTestDistributionRandom,
     Bool,
     Domain,
@@ -58,6 +57,7 @@ from tests.distributions.util import (
     seeded_numpy_distribution_builder,
     seeded_scipy_distribution_builder,
 )
+from pymc.vartypes import discrete_types
 from tests.logprob.utils import create_pytensor_params, scipy_logprob_tester
 
 

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -50,8 +50,8 @@ from pymc.logprob.abstract import get_measurable_outputs, logcdf
 from pymc.logprob.joint_logprob import logp
 from pymc.model import Model
 from pymc.sampling import draw, sample
+from pymc.testing import assert_moment_is_expected
 from pymc.util import _FutureWarningValidatingScratchpad
-from tests.distributions.util import assert_moment_is_expected
 
 
 class TestBugfixes:

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -62,13 +62,13 @@ from pymc.sampling.forward import (
 )
 from pymc.sampling.mcmc import sample
 from pymc.step_methods import Metropolis
-from tests.distributions.util import (
+from pymc.testing import (
     Domain,
+    SeededTest,
     Simplex,
     assert_moment_is_expected,
-    pymc_random,
+    continuous_random_tester,
 )
-from tests.helpers import SeededTest
 
 
 def generate_normal_mixture_data(w, mu, sigma, size=1000):
@@ -850,7 +850,7 @@ class TestNormalMixture(SeededTest):
             component = np.random.choice(w.size, size=size, p=w)
             return np.random.normal(mu[component], sigma[component], size=size)
 
-        pymc_random(
+        continuous_random_tester(
             NormalMixture,
             {
                 "w": Simplex(2),
@@ -861,7 +861,7 @@ class TestNormalMixture(SeededTest):
             size=1000,
             ref_rand=ref_rand,
         )
-        pymc_random(
+        continuous_random_tester(
             NormalMixture,
             {
                 "w": Simplex(3),

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -42,7 +42,7 @@ from pymc.logprob.utils import ParameterValueError
 from pymc.math import kronecker
 from pymc.pytensorf import compile_pymc, floatX, intX
 from pymc.sampling.forward import draw
-from tests.distributions.util import (
+from pymc.testing import (
     BaseTestDistributionRandom,
     Domain,
     Nat,
@@ -54,10 +54,10 @@ from tests.distributions.util import (
     Vector,
     assert_moment_is_expected,
     check_logp,
-    pymc_random,
+    continuous_random_tester,
     seeded_numpy_distribution_builder,
+    select_by_precision,
 )
-from tests.helpers import select_by_precision
 
 
 def betafn(a):
@@ -2010,7 +2010,7 @@ class TestLKJCorr(BaseTestDistributionRandom):
             beta = eta - 1 + n / 2
             return (st.beta.rvs(size=(size, shape), a=beta, b=beta) - 0.5) * 2
 
-        pymc_random(
+        continuous_random_tester(
             pm.LKJCorr,
             {
                 "n": Domain([2, 10, 50], edges=(None, None)),

--- a/tests/distributions/test_simulator.py
+++ b/tests/distributions/test_simulator.py
@@ -32,7 +32,7 @@ from pymc import floatX
 from pymc.initial_point import make_initial_point_fn
 from pymc.pytensorf import compile_pymc
 from pymc.smc.kernels import IMH
-from tests.helpers import SeededTest
+from pymc.testing import SeededTest
 
 
 class TestSimulator(SeededTest):

--- a/tests/distributions/test_timeseries.py
+++ b/tests/distributions/test_timeseries.py
@@ -44,8 +44,7 @@ from pymc.model import Model
 from pymc.pytensorf import floatX
 from pymc.sampling.forward import draw, sample_posterior_predictive
 from pymc.sampling.mcmc import sample
-from tests.distributions.util import assert_moment_is_expected
-from tests.helpers import select_by_precision
+from pymc.testing import assert_moment_is_expected, select_by_precision
 
 # Turn all warnings into errors for this module
 # Ignoring NumPy deprecation warning tracked in https://github.com/pymc-devs/pytensor/issues/146

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -27,20 +27,20 @@ import pymc.distributions.transforms as tr
 
 from pymc.logprob.joint_logprob import joint_logp
 from pymc.pytensorf import floatX, jacobian
-from tests.checks import close_to, close_to_logical
-from tests.distributions.util import (
+from pymc.testing import (
     Circ,
     MultiSimplex,
     R,
     Rminusbig,
     Rplusbig,
+    SeededTest,
     Simplex,
     SortedVector,
     Unit,
     UnitSortedVector,
     Vector,
 )
-from tests.helpers import SeededTest
+from tests.checks import close_to, close_to_logical
 
 # some transforms (stick breaking) require addition of small slack in order to be numerically
 # stable. The minimal addable slack for float32 is higher thus we need to be less strict

--- a/tests/distributions/test_truncated.py
+++ b/tests/distributions/test_truncated.py
@@ -29,7 +29,7 @@ from pymc.logprob.abstract import _icdf
 from pymc.logprob.joint_logprob import logp
 from pymc.logprob.transforms import IntervalTransform
 from pymc.logprob.utils import ParameterValueError
-from tests.distributions.util import assert_moment_is_expected
+from pymc.testing import assert_moment_is_expected
 
 
 class IcdfNormalRV(NormalRV):

--- a/tests/logprob/test_censoring.py
+++ b/tests/logprob/test_censoring.py
@@ -43,7 +43,7 @@ import scipy.stats as st
 
 from pymc.logprob import factorized_joint_logprob
 from pymc.logprob.transforms import LogTransform, TransformValuesRewrite
-from tests.helpers import assert_no_rvs
+from pymc.testing import assert_no_rvs
 from tests.logprob.utils import joint_logprob
 
 

--- a/tests/logprob/test_composite_logprob.py
+++ b/tests/logprob/test_composite_logprob.py
@@ -41,7 +41,7 @@ import scipy.stats as st
 
 from pymc.logprob.censoring import MeasurableClip
 from pymc.logprob.rewriting import construct_ir_fgraph
-from tests.helpers import assert_no_rvs
+from pymc.testing import assert_no_rvs
 from tests.logprob.utils import joint_logprob
 
 

--- a/tests/logprob/test_cumsum.py
+++ b/tests/logprob/test_cumsum.py
@@ -40,7 +40,7 @@ import pytensor.tensor as at
 import pytest
 import scipy.stats as st
 
-from tests.helpers import assert_no_rvs
+from pymc.testing import assert_no_rvs
 from tests.logprob.utils import joint_logprob
 
 

--- a/tests/logprob/test_joint_logprob.py
+++ b/tests/logprob/test_joint_logprob.py
@@ -58,7 +58,7 @@ import pymc as pm
 from pymc.logprob.abstract import logprob
 from pymc.logprob.joint_logprob import factorized_joint_logprob, joint_logp
 from pymc.logprob.utils import rvs_to_value_vars, walk_model
-from tests.helpers import assert_no_rvs
+from pymc.testing import assert_no_rvs
 from tests.logprob.utils import joint_logprob
 
 

--- a/tests/logprob/test_mixture.py
+++ b/tests/logprob/test_mixture.py
@@ -49,7 +49,7 @@ from pymc.logprob.joint_logprob import factorized_joint_logprob
 from pymc.logprob.mixture import MixtureRV, expand_indices
 from pymc.logprob.rewriting import construct_ir_fgraph
 from pymc.logprob.utils import dirac_delta
-from tests.helpers import assert_no_rvs
+from pymc.testing import assert_no_rvs
 from tests.logprob.utils import joint_logprob, scipy_logprob
 
 

--- a/tests/logprob/test_scan.py
+++ b/tests/logprob/test_scan.py
@@ -50,7 +50,7 @@ from pymc.logprob.scan import (
     convert_outer_out_to_in,
     get_random_outer_outputs,
 )
-from tests.helpers import assert_no_rvs
+from pymc.testing import assert_no_rvs
 from tests.logprob.utils import joint_logprob
 
 

--- a/tests/logprob/test_tensor.py
+++ b/tests/logprob/test_tensor.py
@@ -48,7 +48,7 @@ from scipy import stats as st
 from pymc.logprob import factorized_joint_logprob
 from pymc.logprob.rewriting import logprob_rewrites_db
 from pymc.logprob.tensor import naive_bcast_rv_lift
-from tests.helpers import assert_no_rvs
+from pymc.testing import assert_no_rvs
 from tests.logprob.utils import joint_logprob
 
 

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -63,7 +63,7 @@ from pymc.logprob.transforms import (
     TransformValuesRewrite,
     transformed_variable,
 )
-from tests.helpers import assert_no_rvs
+from pymc.testing import assert_no_rvs
 from tests.logprob.utils import joint_logprob
 
 

--- a/tests/logprob/test_utils.py
+++ b/tests/logprob/test_utils.py
@@ -57,7 +57,7 @@ from pymc.logprob.utils import (
     rvs_to_value_vars,
     walk_model,
 )
-from tests.helpers import assert_no_rvs
+from pymc.testing import assert_no_rvs
 from tests.logprob.utils import create_pytensor_params, scipy_logprob_tester
 
 

--- a/tests/ode/test_ode.py
+++ b/tests/ode/test_ode.py
@@ -23,7 +23,7 @@ from scipy.stats import norm
 import pymc as pm
 
 from pymc.ode import DifferentialEquation
-from tests.helpers import fast_unstable_sampling_mode
+from pymc.testing import fast_unstable_sampling_mode
 
 
 def test_simulate():

--- a/tests/sampler_fixtures.py
+++ b/tests/sampler_fixtures.py
@@ -21,8 +21,8 @@ from scipy import stats
 import pymc as pm
 
 from pymc.backends.arviz import to_inference_data
+from pymc.testing import SeededTest
 from pymc.util import get_var_name
-from tests.helpers import SeededTest
 
 
 class KnownMean:

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -40,7 +40,7 @@ from pymc.sampling.forward import (
     get_vars_in_point_list,
     observed_dependent_deterministics,
 )
-from tests.helpers import SeededTest, fast_unstable_sampling_mode
+from pymc.testing import SeededTest, fast_unstable_sampling_mode
 
 
 class TestDraw(SeededTest):

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -45,7 +45,7 @@ from pymc.step_methods import (
     Metropolis,
     Slice,
 )
-from tests.helpers import SeededTest, fast_unstable_sampling_mode
+from pymc.testing import SeededTest, fast_unstable_sampling_mode
 from tests.models import simple_init
 
 

--- a/tests/smc/test_smc.py
+++ b/tests/smc/test_smc.py
@@ -26,7 +26,8 @@ import pymc as pm
 from pymc.backends.base import MultiTrace
 from pymc.pytensorf import floatX
 from pymc.smc.kernels import IMH, systematic_resampling
-from tests.helpers import SeededTest, assert_random_state_equal
+from pymc.testing import SeededTest
+from tests.helpers import assert_random_state_equal
 
 
 class TestSMC(SeededTest):

--- a/tests/step_methods/test_compound.py
+++ b/tests/step_methods/test_compound.py
@@ -31,7 +31,8 @@ from pymc.step_methods.compound import (
     get_stats_dtypes_shapes_from_steps,
     infer_warn_stats_info,
 )
-from tests.helpers import StepMethodTester, fast_unstable_sampling_mode
+from pymc.testing import fast_unstable_sampling_mode
+from tests.helpers import StepMethodTester
 from tests.models import simple_2model_continuous
 
 

--- a/tests/step_methods/test_metropolis.py
+++ b/tests/step_methods/test_metropolis.py
@@ -31,12 +31,9 @@ from pymc.step_methods.metropolis import (
     MultivariateNormalProposal,
     NormalProposal,
 )
+from pymc.testing import fast_unstable_sampling_mode
 from tests import sampler_fixtures as sf
-from tests.helpers import (
-    RVsAssignmentStepsTester,
-    StepMethodTester,
-    fast_unstable_sampling_mode,
-)
+from tests.helpers import RVsAssignmentStepsTester, StepMethodTester
 from tests.models import mv_simple, mv_simple_discrete, simple_categorical
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -28,7 +28,7 @@ import pymc as pm
 
 from pymc.data import is_minibatch
 from pymc.pytensorf import GeneratorOp, floatX
-from tests.helpers import SeededTest
+from pymc.testing import SeededTest
 
 
 class TestData(SeededTest):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -39,7 +39,8 @@ from pymc.math import (
     softmax,
 )
 from pymc.pytensorf import floatX
-from tests.helpers import SeededTest, verify_grad
+from pymc.testing import SeededTest
+from tests.helpers import verify_grad
 
 
 def test_kronecker():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -45,9 +45,9 @@ from pymc.exceptions import ImputationWarning, ShapeError, ShapeWarning
 from pymc.logprob.joint_logprob import joint_logp
 from pymc.logprob.transforms import IntervalTransform
 from pymc.model import Point, ValueGradFunction, modelcontext
+from pymc.testing import SeededTest
 from pymc.util import _FutureWarningValidatingScratchpad
 from pymc.variational.minibatch_rv import MinibatchRandomVariable
-from tests.helpers import SeededTest
 from tests.models import simple_model
 
 

--- a/tests/test_model_graph.py
+++ b/tests/test_model_graph.py
@@ -25,7 +25,7 @@ import pymc as pm
 
 from pymc.exceptions import ImputationWarning
 from pymc.model_graph import ModelGraph, model_to_graphviz, model_to_networkx
-from tests.helpers import SeededTest
+from pymc.testing import SeededTest
 
 
 def school_model():

--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -48,8 +48,8 @@ from pymc.pytensorf import (
     rvs_to_value_vars,
     walk_model,
 )
+from pymc.testing import assert_no_rvs
 from pymc.vartypes import int_types
-from tests.helpers import assert_no_rvs
 
 
 @pytest.mark.parametrize(

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,34 @@
+#   Copyright 2023 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from contextlib import ExitStack as does_not_raise
+
+import pytest
+
+from pymc.testing import Domain
+
+
+@pytest.mark.parametrize(
+    "values, edges, expectation",
+    [
+        ([], None, pytest.raises(IndexError)),
+        ([], (0, 0), pytest.raises(ValueError)),
+        ([0], None, pytest.raises(ValueError)),
+        ([0], (0, 0), does_not_raise()),
+        ([-1, 1], None, pytest.raises(ValueError)),
+        ([-1, 0, 1], None, does_not_raise()),
+    ],
+)
+def test_domain(values, edges, expectation):
+    with expectation:
+        Domain(values, edges=edges)

--- a/tests/tuning/test_starting.py
+++ b/tests/tuning/test_starting.py
@@ -20,10 +20,10 @@ import pymc as pm
 
 from pymc.exceptions import ImputationWarning
 from pymc.step_methods.metropolis import tune
+from pymc.testing import select_by_precision
 from pymc.tuning import find_MAP
 from tests import models
 from tests.checks import close_to
-from tests.helpers import select_by_precision
 from tests.models import non_normal, simple_arbitrary_det, simple_model
 
 

--- a/tests/variational/test_minibatch_rv.py
+++ b/tests/variational/test_minibatch_rv.py
@@ -20,8 +20,8 @@ from scipy import stats as st
 import pymc as pm
 
 from pymc import Normal, draw
+from pymc.testing import select_by_precision
 from pymc.variational.minibatch_rv import create_minibatch_rv
-from tests.helpers import select_by_precision
 from tests.test_data import gen1, gen2
 
 


### PR DESCRIPTION
Tests in [pymc-experimental](https://github.com/pymc-devs/pymc-experimental) and [pymc-marketing](https://github.com/pymc-labs/pymc-marketing) relied on these test utilities.

Follow up to
* 534a9ae28a6bfea3bc31921cd92e4e4d2875b6c9
* e1d36cacb2cfb946f56872ee03e8678dc6ccf7f4