### PR TITLE
Add nuts_sampler_kwargs to pm.sample

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -317,6 +317,7 @@ def sample_blackjax_nuts(
     postprocessing_backend: Optional[str] = None,
     postprocessing_chunks: Optional[int] = None,
     idata_kwargs: Optional[Dict[str, Any]] = None,
+    **kwargs,
 ) -> az.InferenceData:
     """
     Draw samples from the posterior using the NUTS method from the ``blackjax`` library.
@@ -529,6 +530,7 @@ def sample_numpyro_nuts(
     postprocessing_chunks: Optional[int] = None,
     idata_kwargs: Optional[Dict] = None,
     nuts_kwargs: Optional[Dict] = None,
+    **kwargs,
 ) -> az.InferenceData:
     """
     Draw samples from the posterior using the NUTS method from the ``numpyro`` library.

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -276,7 +276,7 @@ def _sample_external_nuts(
             target_accept=target_accept,
             seed=_get_seeds_per_chain(random_seed, 1)[0],
             progress_bar=progressbar,
-            **kwargs,
+            **nuts_sampler_kwargs,
         )
         return idata
 
@@ -294,7 +294,6 @@ def _sample_external_nuts(
             progressbar=progressbar,
             idata_kwargs=idata_kwargs,
             nuts_kwargs=nuts_kwargs,
-            **kwargs,
             **nuts_sampler_kwargs,
         )
         return idata

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -577,7 +577,6 @@ def sample(
             draws=draws,
             tune=tune,
             chains=chains,
-            target_accept=nuts_kwargs.get("target_accept", 0.8),
             random_seed=random_seed,
             initvals=initvals,
             model=model,
@@ -586,13 +585,14 @@ def sample(
             nuts_kwargs=nuts_kwargs,
             nuts_sampler_kwargs=nuts_sampler_kwargs,
             **kwargs,
+            **nuts_kwargs,
         )
 
     if isinstance(step, list):
         step = CompoundStep(step)
     elif isinstance(step, NUTS) and auto_nuts_init:
-        for k, v in nuts_kwargs.items():
-            kwargs.setdefault(k, v)
+        # for k, v in nuts_kwargs.items():
+        #     kwargs.setdefault(k, v)
         _log.info("Auto-assigning NUTS sampler...")
         initial_points, step = init_nuts(
             init=init,
@@ -604,7 +604,8 @@ def sample(
             jitter_max_retries=jitter_max_retries,
             tune=tune,
             initvals=initvals,
-            **kwargs,
+            # **kwargs,
+            **nuts_kwargs,
         )
 
     if initial_points is None:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -238,10 +238,13 @@ def _sample_external_nuts(
     progressbar: bool,
     idata_kwargs: Optional[Dict],
     nuts_kwargs: Optional[Dict],
-    sampler_kwargs: Optional[Dict],
+    nuts_sampler_kwargs: Optional[Dict],
     **kwargs,
 ):
     warnings.warn("Use of external NUTS sampler is still experimental", UserWarning)
+
+    if nuts_sampler_kwargs is None:
+        nuts_sampler_kwargs = {}
 
     if sampler == "nutpie":
         try:
@@ -289,10 +292,10 @@ def _sample_external_nuts(
             initvals=initvals,
             model=model,
             progressbar=progressbar,
-            keep_untransformed=sampler_kwargs.get("keep_untransformed", False),
-            chain_method=sampler_kwargs.get("chain_method", "parallel"),
-            postprocessing_backend=sampler_kwargs.get("postprocessing_backend"),
-            postprocessing_chunks=sampler_kwargs.get("postprocessing_chunks"),
+            keep_untransformed=nuts_sampler_kwargs.get("keep_untransformed", False),
+            chain_method=nuts_sampler_kwargs.get("chain_method", "parallel"),
+            postprocessing_backend=nuts_sampler_kwargs.get("postprocessing_backend"),
+            postprocessing_chunks=nuts_sampler_kwargs.get("postprocessing_chunks"),
             idata_kwargs=idata_kwargs,
             nuts_kwargs=nuts_kwargs,
             **kwargs,
@@ -310,10 +313,10 @@ def _sample_external_nuts(
             random_seed=random_seed,
             initvals=initvals,
             model=model,
-            keep_untransformed=sampler_kwargs.get("keep_untransformed", False),
-            chain_method=sampler_kwargs.get("chain_method", "parallel"),
-            postprocessing_backend=sampler_kwargs.get("postprocessing_backend"),
-            postprocessing_chunks=sampler_kwargs.get("postprocessing_chunks"),
+            keep_untransformed=nuts_sampler_kwargs.get("keep_untransformed", False),
+            chain_method=nuts_sampler_kwargs.get("chain_method", "parallel"),
+            postprocessing_backend=nuts_sampler_kwargs.get("postprocessing_backend"),
+            postprocessing_chunks=nuts_sampler_kwargs.get("postprocessing_chunks"),
             idata_kwargs=idata_kwargs,
         )
         return idata
@@ -345,7 +348,7 @@ def sample(
     return_inferencedata: bool = True,
     idata_kwargs: Optional[Dict[str, Any]] = None,
     nuts_kwargs: Optional[Dict[str, Any]] = None,
-    sampler_kwargs: Optional[Dict[str, Any]] = None,
+    nuts_sampler_kwargs: Optional[Dict[str, Any]] = None,
     callback=None,
     mp_ctx=None,
     model: Optional[Model] = None,
@@ -424,7 +427,7 @@ def sample(
         Keyword arguments for :func:`pymc.to_inference_data`
     nuts_kwargs : dict, optional
         Keyword arguments for the NUTS sampler.
-    sampler_kwargs : dict, optional
+    nuts_sampler_kwargs : dict, optional
         Keyword arguments for the sampler.
     callback : function, default=None
         A function which gets called for every sample from the trace of a chain. The function is
@@ -509,6 +512,8 @@ def sample(
             stacklevel=2,
         )
         initvals = kwargs.pop("start")
+    if nuts_sampler_kwargs is None:
+        nuts_sampler_kwargs = {}
     if nuts_kwargs is None:
         nuts_kwargs = {}
     if "target_accept" in kwargs:
@@ -585,7 +590,7 @@ def sample(
             progressbar=progressbar,
             idata_kwargs=idata_kwargs,
             nuts_kwargs=nuts_kwargs,
-            sampler_kwargs=sampler_kwargs,
+            nuts_sampler_kwargs=nuts_sampler_kwargs,
             **kwargs,
         )
 

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -597,8 +597,8 @@ def sample(
     if isinstance(step, list):
         step = CompoundStep(step)
     elif isinstance(step, NUTS) and auto_nuts_init:
-        if nuts_kwargs is not None:
-            [kwargs.setdefault(k, v) for k, v in nuts_kwargs.items()]
+        for k, v in nuts_kwargs.items():
+            kwargs.setdefault(k, v)
         _log.info("Auto-assigning NUTS sampler...")
         initial_points, step = init_nuts(
             init=init,

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -238,6 +238,7 @@ def _sample_external_nuts(
     progressbar: bool,
     idata_kwargs: Optional[Dict],
     nuts_kwargs: Optional[Dict],
+    sampler_kwargs: Optional[Dict],
     **kwargs,
 ):
     warnings.warn("Use of external NUTS sampler is still experimental", UserWarning)
@@ -288,10 +289,10 @@ def _sample_external_nuts(
             initvals=initvals,
             model=model,
             progressbar=progressbar,
-            keep_untransformed=nuts_kwargs.get("keep_untransformed", False),
-            chain_method=nuts_kwargs.get("chain_method", "parallel"),
-            postprocessing_backend=nuts_kwargs.get("postprocessing_backend"),
-            postprocessing_chunks=nuts_kwargs.get("postprocessing_chunks"),
+            keep_untransformed=sampler_kwargs.get("keep_untransformed", False),
+            chain_method=sampler_kwargs.get("chain_method", "parallel"),
+            postprocessing_backend=sampler_kwargs.get("postprocessing_backend"),
+            postprocessing_chunks=sampler_kwargs.get("postprocessing_chunks"),
             idata_kwargs=idata_kwargs,
             nuts_kwargs=nuts_kwargs,
             **kwargs,
@@ -309,6 +310,10 @@ def _sample_external_nuts(
             random_seed=random_seed,
             initvals=initvals,
             model=model,
+            keep_untransformed=sampler_kwargs.get("keep_untransformed", False),
+            chain_method=sampler_kwargs.get("chain_method", "parallel"),
+            postprocessing_backend=sampler_kwargs.get("postprocessing_backend"),
+            postprocessing_chunks=sampler_kwargs.get("postprocessing_chunks"),
             idata_kwargs=idata_kwargs,
         )
         return idata
@@ -340,6 +345,7 @@ def sample(
     return_inferencedata: bool = True,
     idata_kwargs: Optional[Dict[str, Any]] = None,
     nuts_kwargs: Optional[Dict[str, Any]] = None,
+    sampler_kwargs: Optional[Dict[str, Any]] = None,
     callback=None,
     mp_ctx=None,
     model: Optional[Model] = None,
@@ -418,6 +424,8 @@ def sample(
         Keyword arguments for :func:`pymc.to_inference_data`
     nuts_kwargs : dict, optional
         Keyword arguments for the NUTS sampler.
+    sampler_kwargs : dict, optional
+        Keyword arguments for the sampler.
     callback : function, default=None
         A function which gets called for every sample from the trace of a chain. The function is
         called with the trace and the current draw and will contain all samples for a single trace.
@@ -442,7 +450,7 @@ def sample(
 
     For example:
 
-       1. ``target_accept`` to NUTS: nuts={'target_accept':0.9}
+       1. ``target_accept`` to NUTS: nuts_kwargs={'target_accept':0.9}
        2. ``transit_p`` to BinaryGibbsMetropolis: binary_gibbs_metropolis={'transit_p':.7}
 
     Note that available step names are:
@@ -577,6 +585,7 @@ def sample(
             progressbar=progressbar,
             idata_kwargs=idata_kwargs,
             nuts_kwargs=nuts_kwargs,
+            sampler_kwargs=sampler_kwargs,
             **kwargs,
         )
 

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -567,11 +567,16 @@ def sample(
             raise ValueError(
                 "Model can not be sampled with NUTS alone. Your model is probably not continuous."
             )
+        if "nuts" in kwargs:
+            target_accept = kwargs["nuts"].get("target_accept", 0.8)
+        else:
+            target_accept = 0.8
         return _sample_external_nuts(
             sampler=nuts_sampler,
             draws=draws,
             tune=tune,
             chains=chains,
+            target_accept=target_accept,
             random_seed=random_seed,
             initvals=initvals,
             model=model,

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -417,6 +417,7 @@ def sample(
         Keyword arguments for :func:`pymc.to_inference_data`
     nuts_sampler_kwargs : dict, optional
         Keyword arguments for the sampling library that implements nuts.
+        Only used when an external sampler is specified via the `nuts_sampler` kwarg. 
     callback : function, default=None
         A function which gets called for every sample from the trace of a chain. The function is
         called with the trace and the current draw and will contain all samples for a single trace.

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -504,7 +504,7 @@ def sample(
     if nuts_kwargs is None:
         nuts_kwargs = {}
     if "target_accept" in kwargs:
-        if nuts_kwargs is not None and "target_accept" in nuts_kwargs:
+        if "target_accept" in nuts_kwargs:
             raise ValueError(
                 "`target_accept` was defined twice. Please specify it either as a direct keyword argument or in the `nuts_kwargs` dict."
             )

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -567,16 +567,12 @@ def sample(
             raise ValueError(
                 "Model can not be sampled with NUTS alone. Your model is probably not continuous."
             )
-        if "nuts" in kwargs:
-            target_accept = kwargs["nuts"].get("target_accept", 0.8)
-        else:
-            target_accept = 0.8
         return _sample_external_nuts(
             sampler=nuts_sampler,
             draws=draws,
             tune=tune,
             chains=chains,
-            target_accept=target_accept,
+            target_accept=kwargs.pop("nuts", {}).get("target_accept", 0.8),
             random_seed=random_seed,
             initvals=initvals,
             model=model,

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -292,13 +292,10 @@ def _sample_external_nuts(
             initvals=initvals,
             model=model,
             progressbar=progressbar,
-            keep_untransformed=nuts_sampler_kwargs.get("keep_untransformed", False),
-            chain_method=nuts_sampler_kwargs.get("chain_method", "parallel"),
-            postprocessing_backend=nuts_sampler_kwargs.get("postprocessing_backend"),
-            postprocessing_chunks=nuts_sampler_kwargs.get("postprocessing_chunks"),
             idata_kwargs=idata_kwargs,
             nuts_kwargs=nuts_kwargs,
             **kwargs,
+            **nuts_sampler_kwargs,
         )
         return idata
 
@@ -313,11 +310,8 @@ def _sample_external_nuts(
             random_seed=random_seed,
             initvals=initvals,
             model=model,
-            keep_untransformed=nuts_sampler_kwargs.get("keep_untransformed", False),
-            chain_method=nuts_sampler_kwargs.get("chain_method", "parallel"),
-            postprocessing_backend=nuts_sampler_kwargs.get("postprocessing_backend"),
-            postprocessing_chunks=nuts_sampler_kwargs.get("postprocessing_chunks"),
             idata_kwargs=idata_kwargs,
+            **nuts_sampler_kwargs,
         )
         return idata
 

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -420,9 +420,9 @@ def sample(
     idata_kwargs : dict, optional
         Keyword arguments for :func:`pymc.to_inference_data`
     nuts_kwargs : dict, optional
-        Keyword arguments for the NUTS sampler.
+        Keyword arguments for the NUTS step method.
     nuts_sampler_kwargs : dict, optional
-        Keyword arguments for the sampler.
+        Keyword arguments for the sampling library that implements nuts.
     callback : function, default=None
         A function which gets called for every sample from the trace of a chain. The function is
         called with the trace and the current draw and will contain all samples for a single trace.
@@ -591,8 +591,8 @@ def sample(
     if isinstance(step, list):
         step = CompoundStep(step)
     elif isinstance(step, NUTS) and auto_nuts_init:
-        # for k, v in nuts_kwargs.items():
-        #     kwargs.setdefault(k, v)
+        for k, v in nuts_kwargs.items():
+            kwargs.setdefault(k, v)
         _log.info("Auto-assigning NUTS sampler...")
         initial_points, step = init_nuts(
             init=init,
@@ -604,8 +604,7 @@ def sample(
             jitter_max_retries=jitter_max_retries,
             tune=tune,
             initvals=initvals,
-            # **kwargs,
-            **nuts_kwargs,
+            **kwargs,
         )
 
     if initial_points is None:

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -646,12 +646,6 @@ def test_step_args():
         idata0 = pm.sample(target_accept=0.5, random_seed=1410)
         idata1 = pm.sample(nuts_kwargs={"target_accept": 0.5}, random_seed=1410 * 2)
         idata2 = pm.sample(target_accept=0.5, nuts_kwargs={"max_treedepth": 10}, random_seed=1410)
-        idata3 = pm.sample(
-            nuts_sampler="numpyro",
-            target_accept=0.5,
-            nuts_kwargs={"max_treedepth": 10},
-            random_seed=1410,
-        )
 
         with pytest.raises(ValueError, match="`target_accept` was defined twice."):
             pm.sample(target_accept=0.5, nuts_kwargs={"target_accept": 0.95}, random_seed=1410)
@@ -659,7 +653,6 @@ def test_step_args():
     npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
     npt.assert_almost_equal(idata1.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
     npt.assert_almost_equal(idata2.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
-    npt.assert_almost_equal(idata3.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
 
     with pm.Model() as model:
         a = pm.Normal("a")

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -644,11 +644,11 @@ def test_step_args():
     with pm.Model() as model:
         a = pm.Normal("a")
         idata0 = pm.sample(target_accept=0.5, random_seed=1410)
-        idata1 = pm.sample(nuts_kwargs={"target_accept": 0.5}, random_seed=1410 * 2)
-        idata2 = pm.sample(target_accept=0.5, nuts_kwargs={"max_treedepth": 10}, random_seed=1410)
+        idata1 = pm.sample(nuts={"target_accept": 0.5}, random_seed=1410 * 2)
+        idata2 = pm.sample(target_accept=0.5, nuts={"max_treedepth": 10}, random_seed=1410)
 
         with pytest.raises(ValueError, match="`target_accept` was defined twice."):
-            pm.sample(target_accept=0.5, nuts_kwargs={"target_accept": 0.95}, random_seed=1410)
+            pm.sample(target_accept=0.5, nuts={"target_accept": 0.95}, random_seed=1410)
 
     npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
     npt.assert_almost_equal(idata1.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
@@ -663,7 +663,7 @@ def test_step_args():
                 "ignore", "invalid value encountered in double_scalars", RuntimeWarning
             )
             idata1 = pm.sample(
-                nuts_kwargs={"target_accept": 0.5}, metropolis={"scaling": 0}, random_seed=1418 * 2
+                nuts={"target_accept": 0.5}, metropolis={"scaling": 0}, random_seed=1418 * 2
             )
 
     npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -665,6 +665,12 @@ def test_step_args():
             idata1 = pm.sample(
                 nuts_kwargs={"target_accept": 0.5}, metropolis={"scaling": 0}, random_seed=1418 * 2
             )
+            idata2 = pm.sample(
+                nuts_sampler="numpyro",
+                nuts_kwargs={"target_accept": 0.5},
+                metropolis={"scaling": 0},
+                random_seed=1418 * 2,
+            )
 
     npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
     npt.assert_almost_equal(idata1.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -644,11 +644,11 @@ def test_step_args():
     with pm.Model() as model:
         a = pm.Normal("a")
         idata0 = pm.sample(target_accept=0.5, random_seed=1410)
-        idata1 = pm.sample(nuts={"target_accept": 0.5}, random_seed=1410 * 2)
-        idata2 = pm.sample(target_accept=0.5, nuts={"max_treedepth": 10}, random_seed=1410)
+        idata1 = pm.sample(nuts_kwargs={"target_accept": 0.5}, random_seed=1410 * 2)
+        idata2 = pm.sample(target_accept=0.5, nuts_kwargs={"max_treedepth": 10}, random_seed=1410)
 
         with pytest.raises(ValueError, match="`target_accept` was defined twice."):
-            pm.sample(target_accept=0.5, nuts={"target_accept": 0.95}, random_seed=1410)
+            pm.sample(target_accept=0.5, nuts_kwargs={"target_accept": 0.95}, random_seed=1410)
 
     npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
     npt.assert_almost_equal(idata1.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
@@ -663,7 +663,7 @@ def test_step_args():
                 "ignore", "invalid value encountered in double_scalars", RuntimeWarning
             )
             idata1 = pm.sample(
-                nuts={"target_accept": 0.5}, metropolis={"scaling": 0}, random_seed=1418 * 2
+                nuts_kwargs={"target_accept": 0.5}, metropolis={"scaling": 0}, random_seed=1418 * 2
             )
 
     npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -646,6 +646,12 @@ def test_step_args():
         idata0 = pm.sample(target_accept=0.5, random_seed=1410)
         idata1 = pm.sample(nuts_kwargs={"target_accept": 0.5}, random_seed=1410 * 2)
         idata2 = pm.sample(target_accept=0.5, nuts_kwargs={"max_treedepth": 10}, random_seed=1410)
+        idata3 = pm.sample(
+            nuts_sampler="numpyro",
+            target_accept=0.5,
+            nuts_kwargs={"max_treedepth": 10},
+            random_seed=1410,
+        )
 
         with pytest.raises(ValueError, match="`target_accept` was defined twice."):
             pm.sample(target_accept=0.5, nuts_kwargs={"target_accept": 0.95}, random_seed=1410)
@@ -653,6 +659,7 @@ def test_step_args():
     npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
     npt.assert_almost_equal(idata1.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
     npt.assert_almost_equal(idata2.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
+    npt.assert_almost_equal(idata3.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
 
     with pm.Model() as model:
         a = pm.Normal("a")
@@ -664,12 +671,6 @@ def test_step_args():
             )
             idata1 = pm.sample(
                 nuts_kwargs={"target_accept": 0.5}, metropolis={"scaling": 0}, random_seed=1418 * 2
-            )
-            idata2 = pm.sample(
-                nuts_sampler="numpyro",
-                nuts_kwargs={"target_accept": 0.5},
-                metropolis={"scaling": 0},
-                random_seed=1418 * 2,
             )
 
     npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 import numpy as np
+import numpy.testing as npt
 import pytest
 
 from pymc import Model, Normal, sample
@@ -63,3 +64,16 @@ def test_external_nuts_sampler(recwarn, nuts_sampler):
     assert idata1.posterior.chain.size == 2
     assert idata1.posterior.draw.size == 500
     np.testing.assert_array_equal(idata1.posterior.x, idata2.posterior.x)
+
+
+def test_step_args():
+    with Model() as model:
+        a = Normal("a")
+        idata = sample(
+            nuts_sampler="numpyro",
+            target_accept=0.5,
+            nuts_kwargs={"max_treedepth": 10},
+            random_seed=1410,
+        )
+
+    npt.assert_almost_equal(idata.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -18,9 +18,6 @@ import pytest
 
 from pymc import Model, Normal, sample
 
-# turns all warnings into errors for this module
-pytestmark = pytest.mark.filterwarnings("error")
-
 
 @pytest.mark.parametrize("nuts_sampler", ["pymc", "nutpie", "blackjax", "numpyro"])
 def test_external_nuts_sampler(recwarn, nuts_sampler):
@@ -72,7 +69,7 @@ def test_step_args():
         idata = sample(
             nuts_sampler="numpyro",
             target_accept=0.5,
-            nuts_kwargs={"max_treedepth": 10},
+            nuts={"max_treedepth": 10},
             random_seed=1410,
         )
 


### PR DESCRIPTION
**What is this PR about?**

In the current release, optional parameters for `sample_numpyro_nuts` were not making it through when passed from `pm.sample`:

    ValueError: Unused step method arguments: {'postprocessing_backend', 'chain_method', 'nuts_kwargs'}

This PR reinstates the `nuts_kwargs` argument as a means for getting NUTS arguments to the sampler, and adds a `sampler_kwargs` argument for passing sampler-specific arguments, such as "chain_method" or "postprocessing_backend".

```
with model:
    trace = pm.sample(draws=500, tune=1000, chains=2, nuts_sampler='numpyro', target_accept=0.7, nuts_kwargs={"max_tree_depth": 12}, sampler_kwargs="chain_method":'vectorized'}, idata_kwargs={"log_likelihood": False})
```

**Checklist**
+ [ ] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes


## New features

- Add `nuts_sampler_kwargs` optional argument to `pm.sample()` to forward kwargs to an external nuts implementation.

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...
