### PR TITLE
Extend logprob inference for scans with carried auxiliary states

### DIFF
--- a/tests/logprob/utils.py
+++ b/tests/logprob/utils.py
@@ -39,19 +39,11 @@ from typing import Optional
 import numpy as np
 
 from pytensor import tensor as pt
-from pytensor.graph.basic import walk
-from pytensor.graph.op import HasInnerGraph
 from pytensor.tensor.var import TensorVariable
 from scipy import stats as stats
 
 from pymc.logprob import factorized_joint_logprob
-from pymc.logprob.abstract import (
-    MeasurableVariable,
-    get_measurable_outputs,
-    icdf,
-    logcdf,
-    logprob,
-)
+from pymc.logprob.abstract import get_measurable_outputs, icdf, logcdf, logprob
 from pymc.logprob.utils import ignore_logprob
 
 
@@ -80,24 +72,6 @@ def joint_logprob(*args, sum: bool = True, **kwargs) -> Optional[TensorVariable]
     if sum:
         return pt.sum([pt.sum(factor) for factor in logprob.values()])
     return pt.add(*logprob.values())
-
-
-def assert_no_rvs(var):
-    """Assert that there are no `MeasurableVariable` nodes in a graph."""
-
-    def expand(r):
-        owner = r.owner
-        if owner:
-            inputs = list(reversed(owner.inputs))
-
-            if isinstance(owner.op, HasInnerGraph):
-                inputs += owner.op.inner_outputs
-
-            return inputs
-
-    for v in walk([var], expand, False):
-        if v.owner and isinstance(v.owner.op, MeasurableVariable):
-            raise AssertionError(f"Variable {v} is a MeasurableVariable")
 
 
 def simulate_poiszero_hmm(


### PR DESCRIPTION
PyMC can now infer graphs like MA(2)

```python
import numpy as np
import pytensor

import pymc as pm

init_eps = pm.DiracDelta.dist(np.zeros(2, dtype="float64"))
rho = [0.3, 0.9]
sigma = 1
n_steps = 100

def ma2_step(eps_tm2, eps_tm1, rho, sigma):
    mu = eps_tm1 * rho[0] + eps_tm2 * rho[1]
    y = pm.Normal.dist(mu, sigma)
    eps = y - mu
    return eps, y

[_, ma2], _ = pytensor.scan(
    fn=ma2_step,
    outputs_info=[{"initial": init_eps, "taps": range(-2, 0)}, None],
    non_sequences=[rho, sigma],
    n_steps=n_steps,
    name="ma2",
)

ma2_test = ma2.eval()
pm.logp(ma2, ma2_test).sum().eval()
```

CC @jessegrabowski 