### PR TITLE
Add explicit support for Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         floatx: [float64]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         test-subset:
           - |
             tests/test_util.py
@@ -313,7 +313,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         floatx: [float64]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
         test-subset:
           - tests/sampling/test_jax.py tests/sampling/test_mcmc_external.py
       fail-fast: false
@@ -383,7 +383,7 @@ jobs:
       matrix:
         os: [windows-latest]
         floatx: [float32]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         test-subset:
         - tests/sampling/test_mcmc.py tests/ode/test_ode.py tests/ode/test_utils.py
       fail-fast: false

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -1503,6 +1503,10 @@ class TestMoments:
         with pm.Model() as model:
             pm.Rice("x", nu=nu, sigma=sigma, size=size)
 
+    @pytest.mark.skipif(
+        condition=_polyagamma_not_installed,
+        reason="`polyagamma package is not available/installed.",
+    )
     @pytest.mark.parametrize(
         "h, z, size, expected",
         [


### PR DESCRIPTION
Many people have been installing PyMC on Python 3.11. Checking if all of our tests pass on it, before adding it as an explicit supported version.

Last commit should be dropped before merging

Related to https://github.com/pymc-devs/pytensor/pull/198