### PR TITLE
Represent `Model._coords` values as 1-dim numpy arrays

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -216,15 +216,19 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
                 " one of trace, prior, posterior_predictive or predictions."
             )
 
-        coords_typed = self.model.coords_typed
-        if coords:
-            coords_typed.update(_as_coord_vals(coords))
-        coords_typed = {
+        given_coords = coords if coords is not None else {}
+        given_coords_typed = {
+            cname: _as_coord_vals(cvals)
+            for cname, cvals in given_coords.items()
+            if cvals is not None
+        }
+        model_coords_typed = {
             cname: cvals_typed
-            for cname, cvals_typed in coords_typed.items()
+            for cname, cvals_typed in self.model.coords_typed.items()
             if cvals_typed is not None
         }
-        self.coords = coords_typed
+        # Coords from argument should have precedence
+        self.coords = {**model_coords_typed, **given_coords_typed}
 
         self.dims = {} if dims is None else dims
         model_dims = {k: list(v) for k, v in self.model.named_vars_to_dims.items()}

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -39,7 +39,7 @@ import pymc
 
 from pymc.model import Model, modelcontext
 from pymc.pytensorf import extract_obs_data
-from pymc.util import get_default_varnames
+from pymc.util import _as_coord_vals, get_default_varnames
 
 if TYPE_CHECKING:
     from pymc.backends.base import MultiTrace  # pylint: disable=invalid-name
@@ -216,15 +216,15 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
                 " one of trace, prior, posterior_predictive or predictions."
             )
 
-        # Make coord types more rigid
-        untyped_coords: Dict[str, Optional[Sequence[Any]]] = {**self.model.coords}
+        coords_typed = self.model.coords_typed
         if coords:
-            untyped_coords.update(coords)
-        self.coords = {
-            cname: np.array(cvals) if isinstance(cvals, tuple) else cvals
-            for cname, cvals in untyped_coords.items()
-            if cvals is not None
+            coords_typed.update(_as_coord_vals(coords))
+        coords_typed = {
+            cname: cvals_typed
+            for cname, cvals_typed in coords_typed.items()
+            if cvals_typed is not None
         }
+        self.coords = coords_typed
 
         self.dims = {} if dims is None else dims
         model_dims = {k: list(v) for k, v in self.model.named_vars_to_dims.items()}

--- a/pymc/backends/mcbackend.py
+++ b/pymc/backends/mcbackend.py
@@ -230,9 +230,9 @@ def make_runmeta_and_point_fn(
             sample_stats.append(svar)
 
     coordinates = [
-        mcb.Coordinate(dname, mcb.npproto.utils.ndarray_from_numpy(np.array(cvals)))
-        for dname, cvals in model.coords.items()
-        if cvals is not None
+        mcb.Coordinate(dname, mcb.npproto.utils.ndarray_from_numpy(cvals_typed))
+        for dname, cvals_typed in model.coords_typed.items()
+        if cvals_typed is not None
     ]
     meta = mcb.RunMeta(
         rid=hagelkorn.random(),

--- a/pymc/distributions/bound.py
+++ b/pymc/distributions/bound.py
@@ -195,8 +195,8 @@ class Bound:
 
         if dims is not None:
             model = modelcontext(None)
-            if dims in model.coords:
-                dim_obj = np.asarray(model.coords[dims])
+            if dims in model.coords_typed:
+                dim_obj = model.coords_typed[dims]
                 size = dim_obj.shape
             else:
                 raise ValueError("Given dims do not exist in model coordinates.")

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1061,9 +1061,8 @@ class Model(WithMemoization, metaclass=ContextMeta):
         if values is not None:
             # Conversion to numpy array to ensure coord vals are 1-dim
             values = _as_coord_vals(values)
-        if name in self.coords_typed:
-            if not np.array_equal(_as_coord_vals(values), self.coords_typed[name]):
-                raise ValueError(f"Duplicate and incompatible coordinate: {name}.")
+        if name in self.coords_typed and not np.array_equal(values, self.coords_typed[name]):
+            raise ValueError(f"Duplicate and incompatible coordinate: {name}.")
         if length is not None and not isinstance(length, (int, Variable)):
             raise ValueError(
                 f"The `length` passed for the '{name}' coord must be an int, PyTensor Variable or None."

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -575,7 +575,7 @@ def sample_posterior_predictive(
 
     constant_coords = set()
     for dim, coord in trace_coords.items():
-        current_coord = model.coords.get(dim, None)
+        current_coord = model.coords_typed.get(dim, None)
         if (
             current_coord is not None
             and len(coord) == len(current_coord)

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -384,9 +384,9 @@ def sample_blackjax_nuts(
     vars_to_sample = list(get_default_varnames(var_names, include_transformed=keep_untransformed))
 
     coords = {
-        cname: np.array(cvals) if isinstance(cvals, tuple) else cvals
-        for cname, cvals in model.coords.items()
-        if cvals is not None
+        cname: cvals_typed
+        for cname, cvals_typed in model.coords_typed.items()
+        if cvals_typed is not None
     }
 
     dims = {
@@ -605,9 +605,9 @@ def sample_numpyro_nuts(
     vars_to_sample = list(get_default_varnames(var_names, include_transformed=keep_untransformed))
 
     coords = {
-        cname: np.array(cvals) if isinstance(cvals, tuple) else cvals
-        for cname, cvals in model.coords.items()
-        if cvals is not None
+        cname: cvals_typed
+        for cname, cvals_typed in model.coords_typed.items()
+        if cvals_typed is not None
     }
 
     dims = {

--- a/pymc/stats/log_likelihood.py
+++ b/pymc/stats/log_likelihood.py
@@ -13,8 +13,6 @@
 #   limitations under the License.
 from typing import Optional, Sequence, cast
 
-import numpy as np
-
 from arviz import InferenceData, dict_to_dataset
 from fastprogress import progress_bar
 
@@ -117,10 +115,7 @@ def compute_log_likelihood(
         loglike_trace,
         library=pymc,
         dims={dname: list(dvals) for dname, dvals in model.named_vars_to_dims.items()},
-        coords={
-            cname: np.array(cvals) if isinstance(cvals, tuple) else cvals
-            for cname, cvals in model.coords.items()
-        },
+        coords={cname: cvals_typed for cname, cvals_typed in model.coords_typed.items()},
         default_dims=list(sample_dims),
         skip_event_dims=True,
     )

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -27,6 +27,8 @@ from pytensor import Variable
 from pytensor.compile import SharedVariable
 from pytensor.graph.utils import ValidatingScratchpad
 
+from pymc.exceptions import ShapeError
+
 
 class _UnsetType:
     """Type for the `UNSET` object to make it look nice in `help(...)` outputs."""
@@ -511,8 +513,17 @@ def _add_future_warning_tag(var) -> None:
             new_tag.__dict__.setdefault(k, v)
         var.tag = new_tag
 
-def _as_coord_vals(values: Sequence) -> np.ndarray:
-    """Coerce a sequence coordinate values into a 1-dim array of values"""
+
+def _as_coord_vals(values: Union[Sequence, np.ndarray]) -> np.ndarray:
+    """Coerce a sequence of coordinate values into a 1-dim array"""
+    if isinstance(values, np.ndarray):
+        if values.ndim != 1:
+            raise ShapeError(
+                "Coordinate values passed as a numpy array must be 1-dimensional",
+                actual=values.ndim,
+                expected=1,
+            )
+        return values
     arr = np.array(values)
     if arr.ndim > 1:
         arr = np.empty(len(values), dtype="O")

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -510,3 +510,11 @@ def _add_future_warning_tag(var) -> None:
         for k, v in old_tag.__dict__.items():
             new_tag.__dict__.setdefault(k, v)
         var.tag = new_tag
+
+def _as_coord_vals(values: Sequence) -> np.ndarray:
+    """Coerce a sequence coordinate values into a 1-dim array of values"""
+    arr = np.array(values)
+    if arr.ndim > 1:
+        arr = np.empty(len(values), dtype="O")
+        arr[:] = values
+    return arr

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1135,7 +1135,7 @@ class Group(WithMemoization):
         for name, s, shape, dtype in self.ordering.values():
             dims = self.model.named_vars_to_dims.get(name, None)
             if dims is not None:
-                coords = {d: np.array(self.model.coords[d]) for d in dims}
+                coords = {d: self.model.coords_typed[d] for d in dims}
             else:
                 coords = None
             values = shared_nda[s].reshape(shape).astype(dtype)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -733,7 +733,7 @@ def test_nested_model_coords():
             c = pm.HalfNormal("c", dims="dim3")
             d = pm.Normal("d", b, c, dims="dim2")
         e = pm.Normal("e", a[None] + d[:, None], dims=("dim2", "dim1"))
-    assert m1.coords is m2.coords
+    assert m1.coords == m2.coords
     assert m1.dim_lengths is m2.dim_lengths
     assert set(m2.named_vars_to_dims) < set(m1.named_vars_to_dims)
 


### PR DESCRIPTION
**What is this PR about?**
Seeks to address #6496: buggy behavior could occur in InferenceData creation (and perhaps elsewhere, see diff) when a user provides a coordinate value sequence that numpy interprets as `ndim>1`.

We prevent this by changing the internal representation of `Model._coords` to be `Dict[str, Optional[np.ndarray]]` rather than `Dict[str, Optional[Tuple]]`, and we ensure that the internal ndarray is 1dim.

Currently this PR does not change the publicly-named `Model.coords` property. For backwards-compatibility, that property still returns a dict of tuples. Instead we expose a new model property `Model.coords_typed` that gives the model coord values in the ndarray format.

As it turns out, nearly all of the times that pymc library would access `Model.coords`, it would seek to convert the (tupled) coordinate values to numpy array. This PR instead updates the whole library *(not currently tests)* to use the new `coords_typed` property. Ultimately this is how #6496 is resolved.

This PR is currently a draft to request discussion on if this is the best approach. One alternative would be to update the `Model.coords` property itself—this would prevent cluttering Model with another property but would be less backwards-compatible. Another question is if `np.ndarray` is in fact the best way to represent coordinate values. E.g. one existing test case in the library gives an example of passing `pd.MultiIndex` to coords when converting a trace to InferenceData, and allowing pandas indexes has been discussed in #6081.

Once an approach is given the :+1: I'll add some tests (especially regression test).

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- n/a

## New features
- The new `Model.coords_typed` property ensures that coordinate values are 1dim (if not none)

## Bugfixes
- #6496
- Also as discussed, both `coords` properties return coordinates/coordinate values as *copies*

## Documentation
- n/a

## Maintenance
- n/a
