### PR TITLE
Remove `auto` argument from `pm.Deterministic` docstring

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -2012,9 +2012,6 @@ def Deterministic(name, var, model=None, dims=None):
     ----------
     name: str
     var: PyTensor variables
-    auto: bool
-        Add automatically created deterministics (e.g., when imputing missing values)
-        to a separate model.auto_deterministics list for filtering during sampling.
 
 
     Returns

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1969,19 +1969,19 @@ def Deterministic(name, var, model=None, dims=None):
 
     Parameters
     ----------
-    name: str
+    name : str
         Name of the deterministic variable to be registered in the model.
-    var: tensor_like
+    var : tensor_like
         Expression for the calculation of the variable.
     model : Model, optional
-        The model object to which the Deterministic function is added.
+        The model object to which the Deterministic variable is added.
         If ``None`` is provided, the current model in the context stack is used.
     dims : str or tuple of str, optional
         Dimension names for the variable.
 
     Returns
     -------
-    var: tensor_like
+    var : tensor_like
         The registered, named variable wrapped in Deterministic.
 
     Examples

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -2065,7 +2065,9 @@ def Potential(name, var, model=None, dims=None):
         Expression to be added to the model joint logp.
     model : Model, optional
         The model object to which the potential function is added.
-        If ``None`` is provided, the current model is used.
+        If ``None`` is provided, the current model in the context stack is used.
+    dims : str or tuple of str, optional
+        Dimension names for the variable.
 
     Returns
     -------

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1967,6 +1967,25 @@ def Deterministic(name, var, model=None, dims=None):
     they don't add randomness to the model.  They are generally used to record
     an intermediary result.
 
+    Parameters
+    ----------
+    name: str
+        Name of the deterministic variable to be registered in the model.
+    var: tensor_like
+        Expression for the calculation of the variable.
+    model : Model, optional
+        The model object to which the Deterministic function is added.
+        If ``None`` is provided, the current model in the context stack is used.
+    dims : str or tuple of str, optional
+        Dimension names for the variable.
+
+    Returns
+    -------
+    var: tensor_like
+        The registered, named variable wrapped in Deterministic.
+
+    Examples
+    --------
     Indeed, PyMC allows for arbitrary combinations of random variables, for
     example in the case of a logistic regression
 
@@ -2007,16 +2026,6 @@ def Deterministic(name, var, model=None, dims=None):
     of times during a NUTS step, the Deterministic quantities are just
     computeed once at the end of the step, with the final values of the other
     random variables.
-
-    Parameters
-    ----------
-    name: str
-    var: PyTensor variables
-
-
-    Returns
-    -------
-    var: var, with name attribute
     """
     model = modelcontext(model)
     var = var.copy(model.name_for(name))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Closes #6588 
Removed the `auto` argument from the docstring of `pm.Deterministic` as it was removed in the cleanup in #6309 

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

