### PR TITLE
Use more readable ignore logprob

### DIFF
--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -52,10 +52,9 @@ from pymc.logprob.abstract import (
     MeasurableVariable,
     _logcdf,
     _logprob,
-    assign_custom_measurable_outputs,
 )
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
-from pymc.logprob.utils import CheckParameterValue
+from pymc.logprob.utils import CheckParameterValue, ignore_logprob
 
 
 class MeasurableClip(MeasurableElemwise):
@@ -95,7 +94,7 @@ def find_measurable_clips(fgraph: FunctionGraph, node: Node) -> Optional[List[Me
     upper_bound = upper_bound if (upper_bound is not base_var) else at.constant(np.inf)
 
     # Make base_var unmeasurable
-    unmeasurable_base_var = assign_custom_measurable_outputs(base_var.owner)
+    unmeasurable_base_var = ignore_logprob(base_var)
     clipped_rv_node = measurable_clip.make_node(unmeasurable_base_var, lower_bound, upper_bound)
     clipped_rv = clipped_rv_node.outputs[0]
 
@@ -198,7 +197,7 @@ def find_measurable_roundings(fgraph: FunctionGraph, node: Node) -> Optional[Lis
         return None
 
     # Make base_var unmeasurable
-    unmeasurable_base_var = assign_custom_measurable_outputs(base_var.owner)
+    unmeasurable_base_var = ignore_logprob(base_var)
 
     rounded_op = MeasurableRound(node.op.scalar_op)
     rounded_rv = rounded_op.make_node(unmeasurable_base_var).default_output()

--- a/pymc/logprob/cumsum.py
+++ b/pymc/logprob/cumsum.py
@@ -41,13 +41,9 @@ import pytensor.tensor as at
 from pytensor.graph.rewriting.basic import node_rewriter
 from pytensor.tensor.extra_ops import CumOp
 
-from pymc.logprob.abstract import (
-    MeasurableVariable,
-    _logprob,
-    assign_custom_measurable_outputs,
-    logprob,
-)
+from pymc.logprob.abstract import MeasurableVariable, _logprob, logprob
 from pymc.logprob.rewriting import PreserveRVMappings, measurable_ir_rewrites_db
+from pymc.logprob.utils import ignore_logprob
 
 
 class MeasurableCumsum(CumOp):
@@ -112,7 +108,7 @@ def find_measurable_cumsums(fgraph, node) -> Optional[List[MeasurableCumsum]]:
 
     new_op = MeasurableCumsum(axis=node.op.axis or 0, mode="add")
     # Make base_var unmeasurable
-    unmeasurable_base_rv = assign_custom_measurable_outputs(base_rv.owner)
+    unmeasurable_base_rv = ignore_logprob(base_rv)
     new_rv = new_op.make_node(unmeasurable_base_rv).default_output()
     new_rv.name = rv.name
 

--- a/pymc/logprob/tensor.py
+++ b/pymc/logprob/tensor.py
@@ -50,13 +50,9 @@ from pytensor.tensor.random.rewriting import (
     local_rv_size_lift,
 )
 
-from pymc.logprob.abstract import (
-    MeasurableVariable,
-    _logprob,
-    assign_custom_measurable_outputs,
-    logprob,
-)
+from pymc.logprob.abstract import MeasurableVariable, _logprob, logprob
 from pymc.logprob.rewriting import PreserveRVMappings, measurable_ir_rewrites_db
+from pymc.logprob.utils import ignore_logprob
 
 
 @node_rewriter([BroadcastTo])
@@ -233,12 +229,7 @@ def find_measurable_stacks(
         return None  # pragma: no cover
 
     # Make base_vars unmeasurable
-    base_to_unmeasurable_vars = {
-        base_var: assign_custom_measurable_outputs(base_var.owner).outputs[
-            base_var.owner.outputs.index(base_var)
-        ]
-        for base_var in base_vars
-    }
+    base_to_unmeasurable_vars = {base_var: ignore_logprob(base_var) for base_var in base_vars}
 
     def replacement_fn(var, replacements):
         if var in base_to_unmeasurable_vars:
@@ -339,7 +330,7 @@ def find_measurable_dimshuffles(fgraph, node) -> Optional[List[MeasurableDimShuf
         return None  # pragma: no cover
 
     # Make base_vars unmeasurable
-    base_var = assign_custom_measurable_outputs(base_var.owner)
+    base_var = ignore_logprob(base_var)
 
     measurable_dimshuffle = MeasurableDimShuffle(node.op.input_broadcastable, node.op.new_order)(
         base_var

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -78,11 +78,10 @@ from pymc.logprob.abstract import (
     MeasurableVariable,
     _get_measurable_outputs,
     _logprob,
-    assign_custom_measurable_outputs,
     logprob,
 )
 from pymc.logprob.rewriting import PreserveRVMappings, measurable_ir_rewrites_db
-from pymc.logprob.utils import walk_model
+from pymc.logprob.utils import ignore_logprob, walk_model
 
 
 class TransformedVariable(Op):
@@ -549,7 +548,7 @@ def find_measurable_transforms(fgraph: FunctionGraph, node: Node) -> Optional[Li
 
     # Make base_measure outputs unmeasurable
     # This seems to be the only thing preventing nested rewrites from being erased
-    measurable_input = assign_custom_measurable_outputs(measurable_input.owner)
+    measurable_input = ignore_logprob(measurable_input)
 
     scalar_op = node.op.scalar_op
     measurable_input_idx = 0

--- a/pymc/logprob/utils.py
+++ b/pymc/logprob/utils.py
@@ -272,6 +272,7 @@ def ignore_logprob(rv: TensorVariable) -> TensorVariable:
     op_type = type(node.op)
     if op_type.__name__.startswith(prefix):
         return rv
+    # By default `assign_custom_measurable_outputs` makes all outputs unmeasurable
     new_node = assign_custom_measurable_outputs(node, type_prefix=prefix)
     return new_node.outputs[node.outputs.index(rv)]
 


### PR DESCRIPTION
This PR replaces uses of `assign_custom_measurable_outputs` by the more readable `ignore_logprob`. 

It also refactors a utility to ignore the logprob of multiple (potentially nested) variables consistently.

This PR is a spinoff of #6529 