### PR TITLE
Fix a typo in the docstring for OrderedLogistic

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1572,7 +1572,7 @@ class OrderedLogistic:
         # Ordered logistic regression
         with pm.Model() as model:
             cutpoints = pm.Normal("cutpoints", mu=[-1,1], sigma=10, shape=2,
-                                  transform=pm.distributions.transforms.ordered)
+                                  transform=pm.distributions.transforms.univariate_ordered)
             y_ = pm.OrderedLogistic("y", cutpoints=cutpoints, eta=x, observed=y)
             idata = pm.sample()
 


### PR DESCRIPTION
**Fixing a Docstring Example**

Just a tiny change to fix a docstring for the orderedlogit class, the current docstring fails to run. This resolves it. 
Related to discussion here

**Checklist**
+ [X] Explain important implementation details 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [X] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [X] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇

## Major / Breaking Changes
- NA

## New features
- NA

## Bugfixes
- NA

## Documentation
- Changed docstring

## Maintenance
- NA
