### PR TITLE
Improved docstring for predictions argument in sample_posterior_predictive

### DIFF
--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -481,7 +481,7 @@ def sample_posterior_predictive(
         Whether to automatically use :meth:`arviz.InferenceData.extend` to add the posterior predictive samples to
         ``trace`` or not. If True, ``trace`` is modified inplace but still returned.
     predictions : bool, default False
-        Flag used to set the location of posteior predictive samples within the returned ``InferenceData`` object. If False, assumes samples are generated based on the fitting data to be used for posterior predictive checks, and samples are stored in the ``posterior_predictive``. If True, assumes samples are generated based on out-of-sample data as predictions, and samples are stored in the ``predictions`` group.
+        Flag used to set the location of posterior predictive samples within the returned ``arviz.InferenceData`` object. If False, assumes samples are generated based on the fitting data to be used for posterior predictive checks, and samples are stored in the ``posterior_predictive``. If True, assumes samples are generated based on out-of-sample data as predictions, and samples are stored in the ``predictions`` group.
     idata_kwargs : dict, optional
         Keyword arguments for :func:`pymc.to_inference_data` if ``predictions=False`` or to
         :func:`pymc.predictions_to_inference_data` otherwise.

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -481,8 +481,7 @@ def sample_posterior_predictive(
         Whether to automatically use :meth:`arviz.InferenceData.extend` to add the posterior predictive samples to
         ``trace`` or not. If True, ``trace`` is modified inplace but still returned.
     predictions : bool, default False
-        Choose the function used to convert the samples to inferencedata. See ``idata_kwargs``
-        for more details.
+        Flag used to set the location of posteior predictive samples within the returned ``InferenceData`` object. If False, assumes samples are generated based on the fitting data to be used for posterior predictive checks, and samples are stored in the ``posterior_predictive``. If True, assumes samples are generated based on out-of-sample data as predictions, and samples are stored in the ``predictions`` group.
     idata_kwargs : dict, optional
         Keyword arguments for :func:`pymc.to_inference_data` if ``predictions=False`` or to
         :func:`pymc.predictions_to_inference_data` otherwise.


### PR DESCRIPTION
**What is this PR about?**

The current docstring for `predictions=` in `sample_posterior_prediction` has been the source of some confusion, as it does not adequately describe what is going on. This PR aims to address this and provide a clearer picture of what it is for.

![image](https://user-images.githubusercontent.com/81476/227009090-f001babc-c080-4644-bdfd-3171c370a9a9.png)

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...
