### PR TITLE
Improve collect_default_updates

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -593,7 +593,9 @@ class CustomSymbolicDistRV(SymbolicRandomVariable):
 
     def update(self, node: Node):
         op = node.op
-        inner_updates = collect_default_updates(op.inner_inputs, op.inner_outputs)
+        inner_updates = collect_default_updates(
+            op.inner_inputs, op.inner_outputs, must_be_shared=False
+        )
 
         # Map inner updates to outer inputs/outputs
         updates = {}


### PR DESCRIPTION
This is part of some work to make CustomDist more powerful, specially for timeseries distributions. 

Immediate changes:

* It works with nested RNGs
* It raises error if RNG used in SymbolicRandomVariable is not given an update
* It raises warning if same RNG is used in multiple nodes
