### PR TITLE
Doc infra updates

### DIFF
--- a/.github/workflows/rtd-link-preview.yml
+++ b/.github/workflows/rtd-link-preview.yml
@@ -1,0 +1,16 @@
+name: Read the Docs Pull Request Preview
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "pymc"

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -26,10 +26,10 @@ dependencies:
 - sphinx-copybutton
 - sphinx-design
 - sphinx-notfound-page
-- sphinx>=1.5
+- sphinx>=5
 - sphinxext-rediraffe
 - watermark
 - sphinx-remove-toctrees
 - pip:
-  - git+https://github.com/pymc-devs/pymc-sphinx-theme
+  - pymc-sphinx-theme==0.13
   - numdifftools>=0.9.40


### PR DESCRIPTION
Once merged, the preview action will add a link at the bottom of the PRs with the link to the docs preview so it is easier to access. Also updates the version of the theme to use pypi (just created a package for the theme) and pins the version.
