### PR TITLE
Updating Error message when checking the starting values for MCMC

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1779,7 +1779,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
                 raise SamplingError(
                     "Initial evaluation of model at starting point failed!\n"
                     f"Starting values:\n{elem}\n\n"
-                    f"Initial evaluation results:\n{initial_eval}"
+                    f"Logp initial evaluation results:\n{initial_eval}"
                 )
 
     def point_logps(self, point=None, round_vals=2):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This PR aims to solve issue [6629](https://github.com/pymc-devs/pymc/issues/6629). When we check if the starting values for MCMC do not cause the relevant log probability to evaluate to something invalid and it does, the sampling error currently does not explicitly specify that the initial evaluations correspond to the values of the log-probability at starting values of corresponding parameters. This has created some confusion. In this PR, we specify that the initial evaluations correspond to the logp values.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...
