### PR TITLE
Allow passing masked arrays with missing values to pm.Data()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     - id: black
     - id: black-jupyter
 - repo: https://github.com/PyCQA/pylint
-  rev: v2.17.0
+  rev: v2.17.1
   hooks:
     - id: pylint
       args: [--rcfile=.pylintrc]

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -84,9 +84,31 @@ __all__ = [
     "make_shared_replacements",
     "generator",
     "convert_observed_data",
+    "unmask_masked_data",
     "compile_pymc",
     "constant_fold",
 ]
+
+
+def unmask_masked_data(data):
+    """Unmask masked numpy arrays for usage within PyTensor"""
+
+    # PyTensor currently does not support masked arrays
+    # If a masked array is passed, we convert it to a standard numpy array with np.nans for float type arrays
+    # In case of integer type arrays, we throw an error as np.nan is a float concept.
+
+    if isinstance(data, np.ma.MaskedArray):
+        if "int" in str(data.dtype):
+            raise TypeError(
+                "Masked integer arrays (integer type datasets with missing values) are not supported by pm.Data() / pm.Model.set_data() at this time. \n"
+                "Consider if using a float type fits your use case. \n"
+                "Alternatively, if you want to benefit from automatic imputation in pyMC, pass a masked array directly to `observed=` parameter when defining a distribution."
+            )
+        else:
+            ret = data.filled(fill_value=np.nan)
+    else:
+        ret = data
+    return ret
 
 
 def convert_observed_data(data):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -454,6 +454,33 @@ def test_get_data():
     assert type(data) == io.BytesIO
 
 
+def test_masked_data_mutable():
+    with pm.Model():
+        data = np.ma.MaskedArray([1.0, 2.0, 3], [0, 0, 1])
+        expected = np.array([1, 2, np.nan])
+        with pytest.warns(UserWarning, match="masked arrays"):
+            result = pm.MutableData("test", data).get_value()
+        np.testing.assert_array_equal(result, expected)
+
+
+def test_masked_data_constant():
+    with pm.Model():
+        data = np.ma.MaskedArray([1.0, 2.0, 3], [0, 0, 1])
+        expected = np.array([1, 2, np.nan])
+        with pytest.warns(UserWarning, match="masked arrays"):
+            result = pm.ConstantData("test", data).data
+        np.testing.assert_array_equal(result, expected)
+
+
+def test_masked_integer_data():
+    with pm.Model():
+        data = np.ma.MaskedArray([1, 2, 3], [0, 0, 1])
+        with pytest.raises(TypeError, match="Masked integer"):
+            pm.ConstantData("test", data)
+        with pytest.raises(TypeError, match="Masked integer"):
+            pm.MutableData("test", data)
+
+
 class _DataSampler:
     """
     Not for users

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -967,6 +967,27 @@ def test_set_data_constant_shape_error():
         pmodel.set_data("y", np.arange(10))
 
 
+def test_set_data_masked_array():
+    data = np.ma.MaskedArray([1.0, 2.0, 3], [0, 0, 1])
+
+    with pm.Model() as pmodel:
+        D = pm.MutableData("test", np.zeros(4))
+
+    with pytest.warns(UserWarning, match="masked arrays"):
+        pmodel.set_data("test", data)
+    result = D.get_value()
+    expected = np.array([1.0, 2.0, np.nan])
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_set_data_masked_integer_array():
+    with pm.Model() as pmodel:
+        D = pm.MutableData("test", np.zeros(4))
+    with pytest.warns(UserWarning, match="masked arrays"):
+        with pytest.raises(TypeError, match="Masked integer"):
+            pmodel.set_data("test", np.ma.MaskedArray([1, 2, 3], [0, 0, 1]))
+
+
 def test_model_deprecation_warning():
     with pm.Model() as m:
         x = pm.Normal("x", 0, 1, size=2)

--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -49,6 +49,7 @@ from pymc.pytensorf import (
     replace_rvs_by_values,
     reseed_rngs,
     rvs_to_value_vars,
+    unmask_masked_data,
     walk_model,
 )
 from pymc.testing import assert_no_rvs
@@ -267,6 +268,25 @@ def test_convert_observed_data(input_dtype):
     assert hasattr(wrapped, "set_default")
     # Make sure the returned object is an PyTensor TensorVariable
     assert isinstance(wrapped, TensorVariable)
+
+
+def test_unmask_masked_data():
+    # test with non-masked data
+    data = np.array([1, 2, 3])
+    result = unmask_masked_data(data)
+    expected = np.array([1, 2, 3])
+    np.testing.assert_array_equal(result, expected)
+
+    # test with masked float data
+    data = np.ma.MaskedArray([1.0, 2.0, 3.0], [0, 0, 1])
+    result = unmask_masked_data(data)
+    expected = np.array([1.0, 2.0, np.nan])
+    np.testing.assert_array_equal(result, expected)
+
+    # test with integer masked data
+    data = np.ma.MaskedArray([1, 2, 3], [0, 0, 1])
+    with pytest.raises(TypeError, match="Masked integer"):
+        unmask_masked_data(data)
 
 
 def test_pandas_to_array_pandas_index():


### PR DESCRIPTION
This PR implements the changes required to support passing masked arrays to pm.Data() as discussed in issue https://github.com/pymc-devs/pymc/issues/6626.

(rest of PR description TBD)
...

**Checklist**
+ [ ] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6645.org.readthedocs.build/en/6645/

<!-- readthedocs-preview pymc end -->