### PR TITLE
Fix changed files filters in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,10 +33,10 @@ jobs:
           filters: |
             src:
               - ".github/workflows/tests.yml"
-              - "pymc/**.py"
-              - "tests/**.py"
+              - "pymc/**/*.py"
+              - "tests/**/*.py"
               - "*.py"
-              - "conda-envs/**"
+              - "conda-envs/*"
               - "requirements*.txt"
               - "codecov.yml"
               - "scripts/*.sh"


### PR DESCRIPTION
The paths filter action syntax is different than the githubs action one, so that `pymc/**.py` only matches python files in the first subdirectory, whereas the github one matched files in any subdirectories.

We need to use `pymc/**/*.py` instead.

The tests in #6658 were not triggered because of this

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6659.org.readthedocs.build/en/6659/

<!-- readthedocs-preview pymc end -->