### PR TITLE
Derive logprob of `<` and `>` operations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,6 +104,7 @@ jobs:
             tests/distributions/test_truncated.py
             tests/logprob/test_abstract.py
             tests/logprob/test_basic.py
+            tests/logprob/test_binary.py
             tests/logprob/test_censoring.py
             tests/logprob/test_composite_logprob.py
             tests/logprob/test_cumsum.py

--- a/pymc/logprob/__init__.py
+++ b/pymc/logprob/__init__.py
@@ -38,6 +38,7 @@ from pymc.logprob.basic import factorized_joint_logprob, icdf, joint_logp, logcd
 
 # isort: off
 # Add rewrites to the DBs
+import pymc.logprob.binary
 import pymc.logprob.censoring
 import pymc.logprob.cumsum
 import pymc.logprob.checks

--- a/pymc/logprob/binary.py
+++ b/pymc/logprob/binary.py
@@ -1,0 +1,109 @@
+#   Copyright 2023 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from typing import List, Optional
+
+import numpy as np
+import pytensor.tensor as pt
+
+from pytensor.graph.basic import Node
+from pytensor.graph.fg import FunctionGraph
+from pytensor.graph.rewriting.basic import node_rewriter
+from pytensor.scalar.basic import GT, LT
+from pytensor.tensor.math import gt, lt
+
+from pymc.logprob.abstract import (
+    MeasurableElemwise,
+    MeasurableVariable,
+    _logcdf,
+    _logprob,
+)
+from pymc.logprob.rewriting import measurable_ir_rewrites_db
+from pymc.logprob.utils import ignore_logprob
+
+
+class MeasurableComparison(MeasurableElemwise):
+    """A placeholder used to specify a log-likelihood for a binary comparison RV sub-graph."""
+
+    valid_scalar_types = (GT, LT)
+
+
+@node_rewriter(tracks=[gt, lt])
+def find_measurable_comparisons(
+    fgraph: FunctionGraph, node: Node
+) -> Optional[List[MeasurableComparison]]:
+    rv_map_feature = getattr(fgraph, "preserve_rv_mappings", None)
+    if rv_map_feature is None:
+        return None  # pragma: no cover
+
+    if isinstance(node.op, MeasurableComparison):
+        return None  # pragma: no cover
+
+    (compared_var,) = node.outputs
+    base_var, const = node.inputs
+
+    if not (
+        base_var.owner
+        and isinstance(base_var.owner.op, MeasurableVariable)
+        and base_var not in rv_map_feature.rv_values
+    ):
+        return None
+
+    # Make base_var unmeasurable
+    unmeasurable_base_var = ignore_logprob(base_var)
+
+    compared_op = MeasurableComparison(node.op.scalar_op)
+    compared_rv = compared_op.make_node(unmeasurable_base_var, const).default_output()
+    compared_rv.name = compared_var.name
+    return [compared_rv]
+
+
+measurable_ir_rewrites_db.register(
+    "find_measurable_comparisons",
+    find_measurable_comparisons,
+    "basic",
+    "comparison",
+)
+
+
+@_logprob.register(MeasurableComparison)
+def comparison_logprob(op, values, base_rv, operand, **kwargs):
+    (value,) = values
+
+    base_rv_op = base_rv.owner.op
+    base_rv_inputs = base_rv.owner.inputs
+
+    logcdf = _logcdf(base_rv_op, operand, *base_rv_inputs, **kwargs)
+    logccdf = pt.log1mexp(logcdf)
+
+    condn_exp = pt.eq(value, np.array(True))
+
+    if isinstance(op.scalar_op, GT):
+        logprob = pt.switch(condn_exp, logccdf, logcdf)
+    elif isinstance(op.scalar_op, LT):
+        logprob = pt.switch(condn_exp, logcdf, logccdf)
+    else:
+        raise TypeError(f"Unsupported scalar_op {op.scalar_op}")
+
+    if base_rv.dtype.startswith("int"):
+        logp_point = _logprob(base_rv_op, (operand,), *base_rv_inputs, **kwargs)
+        if isinstance(op.scalar_op, GT):
+            logprob = pt.switch(condn_exp, pt.logaddexp(logprob, logp_point), logprob)
+        elif isinstance(op.scalar_op, LT):
+            logprob = pt.switch(condn_exp, logprob, pt.logaddexp(logprob, logp_point))
+
+    if base_rv_op.name:
+        logprob.name = f"{base_rv_op}_logprob"
+        logcdf.name = f"{base_rv_op}_logcdf"
+
+    return logprob

--- a/pymc/logprob/binary.py
+++ b/pymc/logprob/binary.py
@@ -30,7 +30,7 @@ from pymc.logprob.abstract import (
     _logprob_helper,
 )
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
-from pymc.logprob.utils import ignore_logprob
+from pymc.logprob.utils import check_potential_measurability, ignore_logprob
 
 
 class MeasurableComparison(MeasurableElemwise):
@@ -58,6 +58,10 @@ def find_measurable_comparisons(
         and isinstance(base_var.owner.op, MeasurableVariable)
         and base_var not in rv_map_feature.rv_values
     ):
+        return None
+
+    # check for potential measurability of const
+    if not check_potential_measurability((const,), rv_map_feature):
         return None
 
     # Make base_var unmeasurable

--- a/pymc/logprob/utils.py
+++ b/pymc/logprob/utils.py
@@ -210,6 +210,24 @@ def indices_from_subtensor(idx_list, indices):
     )
 
 
+def check_potential_measurability(inputs: Tuple[TensorVariable], rv_map_feature):
+    if any(
+        ancestor_node
+        for ancestor_node in walk_model(
+            inputs,
+            walk_past_rvs=False,
+            stop_at_vars=set(rv_map_feature.rv_values),
+        )
+        if (
+            ancestor_node.owner
+            and isinstance(ancestor_node.owner.op, MeasurableVariable)
+            and ancestor_node not in rv_map_feature.rv_values
+        )
+    ):
+        return None
+    return True
+
+
 class ParameterValueError(ValueError):
     """Exception for invalid parameters values in logprob graphs"""
 

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -29,6 +29,7 @@ pymc/distributions/multivariate.py
 pymc/distributions/timeseries.py
 pymc/distributions/truncated.py
 pymc/initial_point.py
+pymc/logprob/binary.py
 pymc/logprob/censoring.py
 pymc/logprob/basic.py
 pymc/logprob/mixture.py

--- a/tests/logprob/test_binary.py
+++ b/tests/logprob/test_binary.py
@@ -51,12 +51,12 @@ def test_continuous_rv_comparison(comparison_op, exp_logp_true, exp_logp_false):
     [
         (
             pt.lt,
-            st.poisson(2).logcdf,
+            lambda x: st.poisson(2).logcdf(x - 1),
             lambda x: np.logaddexp(st.poisson(2).logsf(x), st.poisson(2).logpmf(x)),
         ),
         (
             pt.gt,
-            lambda x: np.logaddexp(st.poisson(2).logsf(x), st.poisson(2).logpmf(x)),
+            st.poisson(2).logsf,
             st.poisson(2).logcdf,
         ),
     ],

--- a/tests/logprob/test_binary.py
+++ b/tests/logprob/test_binary.py
@@ -1,0 +1,70 @@
+#   Copyright 2023 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import scipy.stats as st
+
+from pymc import logp
+from pymc.testing import assert_no_rvs
+
+
+def test_continuous_rv_comparison_lt():
+    x_rv = pt.random.normal(0.5, 1)
+    comp_x_rv = pt.lt(x_rv, 0.5)
+
+    comp_x_vv = comp_x_rv.clone()
+    comp_x_vv.tag.test_value = 0
+
+    logprob = logp(comp_x_rv, comp_x_vv)
+    assert_no_rvs(logprob)
+
+    logp_fn = pytensor.function([comp_x_vv], logprob)
+    ref_scipy = st.norm(0.5, 1)
+
+    assert np.isclose(logp_fn(0), ref_scipy.logcdf(0.5))
+    assert np.isclose(logp_fn(1), ref_scipy.logsf(0.5))
+
+
+def test_continuous_rv_comparison_gt():
+    x_rv = pt.random.normal(0.5, 1)
+    comp_x_rv = pt.gt(x_rv, 0.5)
+
+    comp_x_vv = comp_x_rv.clone()
+    comp_x_vv.tag.test_value = 0
+
+    logprob = logp(comp_x_rv, comp_x_vv)
+    assert_no_rvs(logprob)
+
+    logp_fn = pytensor.function([comp_x_vv], logprob)
+    ref_scipy = st.norm(0.5, 1)
+
+    assert np.isclose(logp_fn(0), ref_scipy.logsf(0.5))
+    assert np.isclose(logp_fn(1), ref_scipy.logcdf(0.5))
+
+
+def test_discrete_rv_comparison():
+    x_rv = pt.random.poisson(2)
+    cens_x_rv = pt.lt(x_rv, 3)
+
+    cens_x_vv = cens_x_rv.clone()
+
+    logprob = logp(cens_x_rv, cens_x_vv)
+    assert_no_rvs(logprob)
+
+    logp_fn = pytensor.function([cens_x_vv], logprob)
+    ref_scipy = st.poisson(2)
+
+    assert np.isclose(logp_fn(1), ref_scipy.logcdf(3))
+    assert np.isclose(logp_fn(0), np.logaddexp(ref_scipy.logsf(3), ref_scipy.logpmf(3)))

--- a/tests/logprob/test_binary.py
+++ b/tests/logprob/test_binary.py
@@ -14,49 +14,53 @@
 import numpy as np
 import pytensor
 import pytensor.tensor as pt
+import pytest
 import scipy.stats as st
 
 from pymc import logp
 from pymc.testing import assert_no_rvs
 
 
-def test_continuous_rv_comparison_lt():
-    x_rv = pt.random.normal(0.5, 1)
-    comp_x_rv = pt.lt(x_rv, 0.5)
+@pytest.mark.parametrize(
+    "comparison_op, exp_logp_true, exp_logp_false",
+    [
+        (pt.lt, st.norm(0, 1).logcdf, st.norm(0, 1).logsf),
+        (pt.gt, st.norm(0, 1).logsf, st.norm(0, 1).logcdf),
+    ],
+)
+def test_continuous_rv_comparison(comparison_op, exp_logp_true, exp_logp_false):
+    x_rv = pt.random.normal(0, 1)
+    comp_x_rv = comparison_op(x_rv, 0.5)
 
     comp_x_vv = comp_x_rv.clone()
-    comp_x_vv.tag.test_value = 0
 
     logprob = logp(comp_x_rv, comp_x_vv)
     assert_no_rvs(logprob)
 
     logp_fn = pytensor.function([comp_x_vv], logprob)
-    ref_scipy = st.norm(0.5, 1)
 
-    assert np.isclose(logp_fn(0), ref_scipy.logcdf(0.5))
-    assert np.isclose(logp_fn(1), ref_scipy.logsf(0.5))
-
-
-def test_continuous_rv_comparison_gt():
-    x_rv = pt.random.normal(0.5, 1)
-    comp_x_rv = pt.gt(x_rv, 0.5)
-
-    comp_x_vv = comp_x_rv.clone()
-    comp_x_vv.tag.test_value = 0
-
-    logprob = logp(comp_x_rv, comp_x_vv)
-    assert_no_rvs(logprob)
-
-    logp_fn = pytensor.function([comp_x_vv], logprob)
-    ref_scipy = st.norm(0.5, 1)
-
-    assert np.isclose(logp_fn(0), ref_scipy.logsf(0.5))
-    assert np.isclose(logp_fn(1), ref_scipy.logcdf(0.5))
+    assert np.isclose(logp_fn(0), exp_logp_false(0.5))
+    assert np.isclose(logp_fn(1), exp_logp_true(0.5))
 
 
-def test_discrete_rv_comparison():
+@pytest.mark.parametrize(
+    "comparison_op, exp_logp_true, exp_logp_false",
+    [
+        (
+            pt.lt,
+            st.poisson(2).logcdf,
+            lambda x: np.logaddexp(st.poisson(2).logsf(x), st.poisson(2).logpmf(x)),
+        ),
+        (
+            pt.gt,
+            lambda x: np.logaddexp(st.poisson(2).logsf(x), st.poisson(2).logpmf(x)),
+            st.poisson(2).logcdf,
+        ),
+    ],
+)
+def test_discrete_rv_comparison(comparison_op, exp_logp_true, exp_logp_false):
     x_rv = pt.random.poisson(2)
-    cens_x_rv = pt.lt(x_rv, 3)
+    cens_x_rv = comparison_op(x_rv, 3)
 
     cens_x_vv = cens_x_rv.clone()
 
@@ -64,7 +68,6 @@ def test_discrete_rv_comparison():
     assert_no_rvs(logprob)
 
     logp_fn = pytensor.function([cens_x_vv], logprob)
-    ref_scipy = st.poisson(2)
 
-    assert np.isclose(logp_fn(1), ref_scipy.logcdf(3))
-    assert np.isclose(logp_fn(0), np.logaddexp(ref_scipy.logsf(3), ref_scipy.logpmf(3)))
+    assert np.isclose(logp_fn(1), exp_logp_true(3))
+    assert np.isclose(logp_fn(0), exp_logp_false(3))

--- a/tests/logprob/test_binary.py
+++ b/tests/logprob/test_binary.py
@@ -94,3 +94,9 @@ def test_potentially_measurable_operand():
         fn(z_vv_test, y_vv_test),
         st.norm(2, 1).logcdf(z_vv_test),
     )
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Logprob method not implemented",
+    ):
+        logp(y_rv, y_vv).eval({y_vv: y_vv_test})


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

This PR implements the logprob inference for binary comparison Ops `>` and `<`. 

It creates a MeasurableComparison variable and evaluates the logprob based on the truth value of the condition.

Addresses #6633.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## New features
- Logprob inference for GT and LT Ops.


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6662.org.readthedocs.build/en/6662/

<!-- readthedocs-preview pymc end -->