### PR TITLE
Derive logprob for hyperbolic and error transformations

### DIFF
--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -42,6 +42,7 @@ from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 import numpy as np
 import pytensor.tensor as pt
 
+from pytensor import scan
 from pytensor.gradient import DisconnectedType, jacobian
 from pytensor.graph.basic import Apply, Node, Variable
 from pytensor.graph.features import AlreadyThere, Feature
@@ -791,9 +792,9 @@ class ErfcxTransform(RVTransform):
                 2 * prior_result * pt.erfcx(prior_result) - 2 / pt.sqrt(np.pi)
             )
 
-        result, updates = pytensor.scan(
+        result, updates = scan(
             fn=calc_delta_x,
-            outputs_info=at.ones_like(x),
+            outputs_info=pt.ones_like(x),
             sequences=value,
             non_sequences=x,
             n_steps=k,

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -419,7 +419,7 @@ def measurable_transform_logprob(op: MeasurableTransform, values, *inputs, **kwa
         jacobian = jacobian.sum(axis=tuple(range(-ndim_supp, 0)))
 
     # The jacobian is used to ensure a value in the supported domain was provided
-    return pt.switch(pt.isnan(input_logprob + jacobian), -np.inf, input_logprob + jacobian)
+    return pt.switch(pt.isnan(jacobian), -np.inf, input_logprob + jacobian)
 
 
 @_logcdf.register(MeasurableTransform)
@@ -737,7 +737,6 @@ class CoshTransform(RVTransform):
 
     def backward(self, value, *inputs):
         return pt.arccosh(value)
-
 
 
 class TanhTransform(RVTransform):

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -719,6 +719,7 @@ measurable_ir_rewrites_db.register(
 
 class SinhTransform(RVTransform):
     name = "sinh"
+    ndim_supp = 0
 
     def forward(self, value, *inputs):
         return pt.sinh(value)
@@ -726,12 +727,10 @@ class SinhTransform(RVTransform):
     def backward(self, value, *inputs):
         return pt.arcsinh(value)
 
-    def log_jac_det(self, value, *inputs):
-        return pt.log(pt.cosh(value))
-
 
 class CoshTransform(RVTransform):
     name = "cosh"
+    ndim_supp = 0
 
     def forward(self, value, *inputs):
         return pt.cosh(value)
@@ -739,21 +738,19 @@ class CoshTransform(RVTransform):
     def backward(self, value, *inputs):
         return pt.arccosh(value)
 
-    def log_jac_det(self, value, *inputs):
-        return pt.log(pt.sinh(value))
+    # def log_jac_det(self, value, *inputs):
+    #     return pt.log(pt.sinh(value))
 
 
 class TanhTransform(RVTransform):
     name = "tanh"
+    ndim_supp = 0
 
     def forward(self, value, *inputs):
         return pt.tanh(value)
 
     def backward(self, value, *inputs):
         return pt.arctanh(value)
-
-    def log_jac_det(self, value, *inputs):
-        return pt.log(1 / pt.cosh(value))
 
 
 class ErfTransform(RVTransform):
@@ -769,6 +766,7 @@ class ErfTransform(RVTransform):
 
 class ErfcTransform(RVTransform):
     name = "erfc"
+    ndim_supp = 0
 
     def forward(self, value, *inputs):
         return pt.erfc(value)
@@ -776,17 +774,15 @@ class ErfcTransform(RVTransform):
     def backward(self, value, *inputs):
         return pt.erfcinv(value)
 
-    def log_jac_det(self, value, *inputs):
-        return pt.log(-2 * pt.exp(-(value**2)) / (pt.sqrt(np.pi)))
-
 
 class ErfcxTransform(RVTransform):
     name = "erfcx"
+    ndim_supp = 0
 
     def forward(self, value, *inputs):
         return pt.erfcx(value)
 
-    def backward(self, value, k=10):
+    def backward(self, value, *inputs):
         # computes the inverse of erfcx, this was adapted from
         # https://tinyurl.com/4mxfd3cz
         x = pt.switch(value <= 1, 1.0 / (value * pt.sqrt(np.pi)), -pt.sqrt(pt.log(value)))
@@ -800,12 +796,9 @@ class ErfcxTransform(RVTransform):
             fn=calc_delta_x,
             outputs_info=pt.ones_like(x),
             non_sequences=value,
-            n_steps=k,
+            n_steps=10,
         )
         return result[-1]
-
-    def log_jac_det(self, value, *inputs):
-        return pt.log((2 * value * pt.exp(value**2) * pt.erfc(value) - 2.0) / pt.sqrt(np.pi))
 
 
 class LocTransform(RVTransform):

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -728,6 +728,56 @@ class TanhTransform(RVTransform):
         return pt.log(1 / pt.cosh(value))
 
 
+class ErfTransform(RVTransform):
+    name = "erf"
+
+    def forward(self, value, *inputs):
+        return pt.erf(value)
+
+    def backward(self, value, *inputs):
+        return pt.erfinv(value)
+
+    def log_jac_det(self, value, *inputs):
+        return at.log(2 * at.exp(-(value**2)) / (at.sqrt(np.pi)))
+
+
+class ErfcTransform(RVTransform):
+    name = "erfc"
+
+    def forward(self, value, *inputs):
+        return at.erfc(value)
+
+    def backward(self, value, *inputs):
+        return at.erfcinv(value)
+
+    def log_jac_det(self, value, *inputs):
+        return at.log(-2 * at.exp(-(value**2)) / (at.sqrt(np.pi)))
+
+
+class ErfcxTransform(RVTransform):
+    name = "erfcx"
+
+    def forward(self, value, *inputs):
+        return at.erfcx(value)
+
+    def backward(y, tol=1e-10, max_iter=100):
+        # Compute x using the appropriate formula for each value of y
+        x = at.switch(y <= 1, 1.0 / (y * at.sqrt(np.pi)), -at.sqrt(at.log(y)))
+        iter_count = 0
+        while iter_count < max_iter:
+            iter_count += 1
+            fx = at.erfcx(x) - y
+            fpx = 2 * x * at.erfcx(x) - 2 / at.sqrt(np.pi)
+            delta_x = fx / fpx
+            x = x - delta_x
+            if (at.abs(delta_x) < tol).all():
+                break
+        return x
+
+    def log_jac_det(self, value, *inputs):
+        return at.log(2 * x * at.exp(x**2) * at.erfc(x) - 2.0 / at.sqrt(np.pi))
+
+
 class LocTransform(RVTransform):
     name = "loc"
 

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -599,19 +599,17 @@ def find_measurable_transforms(fgraph: FunctionGraph, node: Node) -> Optional[Li
     measurable_input_idx = 0
     transform_inputs: Tuple[TensorVariable, ...] = (measurable_input,)
     transform: RVTransform
-    if isinstance(scalar_op, Exp):
-        transform = ExpTransform()
-    elif isinstance(scalar_op, Log):
-        transform = LogTransform()
-    elif isinstance(scalar_op, Abs):
-        transform = AbsTransform()
-    elif isinstance(scalar_op, Sinh):
-        transform = SinhTransform()
-    elif isinstance(scalar_op, Cosh):
-        transform = CoshTransform()
-    elif isinstance(scalar_op, Tanh):
-        transform = TanhTransform()
-    elif isinstance(scalar_op, Pow):
+
+    transform_dict = {
+        Exp: ExpTransform(),
+        Log: LogTransform(),
+        Abs: AbsTransform(),
+        Sinh: SinhTransform(),
+        Cosh: CoshTransform(),
+        Tanh: TanhTransform(),
+    }
+    transform = transform_dict.get(type(scalar_op), None)
+    if isinstance(scalar_op, Pow):
         # We only allow for the base to be measurable
         if measurable_input_idx != 0:
             return None
@@ -628,7 +626,7 @@ def find_measurable_transforms(fgraph: FunctionGraph, node: Node) -> Optional[Li
         transform = LocTransform(
             transform_args_fn=lambda *inputs: inputs[-1],
         )
-    else:
+    elif transform is None:
         transform_inputs = (measurable_input, pt.mul(*other_inputs))
         transform = ScaleTransform(
             transform_args_fn=lambda *inputs: inputs[-1],

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -413,7 +413,7 @@ def measurable_transform_logprob(op: MeasurableTransform, values, *inputs, **kwa
         jacobian = jacobian.sum(axis=tuple(range(-ndim_supp, 0)))
 
     # The jacobian is used to ensure a value in the supported domain was provided
-    return pt.switch(pt.isnan(jacobian), -np.inf, input_logprob + jacobian)
+    return pt.switch(pt.isnan(input_logprob + jacobian), -np.inf, input_logprob + jacobian)
 
 
 @_logcdf.register(MeasurableTransform)
@@ -795,8 +795,7 @@ class ErfcxTransform(RVTransform):
         result, updates = scan(
             fn=calc_delta_x,
             outputs_info=pt.ones_like(x),
-            sequences=value,
-            non_sequences=x,
+            non_sequences=value,
             n_steps=k,
         )
         return result[-1]

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -738,8 +738,6 @@ class CoshTransform(RVTransform):
     def backward(self, value, *inputs):
         return pt.arccosh(value)
 
-    # def log_jac_det(self, value, *inputs):
-    #     return pt.log(pt.sinh(value))
 
 
 class TanhTransform(RVTransform):

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -782,14 +782,13 @@ class ErfcxTransform(RVTransform):
         return pt.erfcx(value)
 
     def backward(self, value, tol=1e-10, max_iter=100):
-        # Compute x using the appropriate formula for each value of y
+        # computes the inverse of erfcx, this was adapted from
+        # https://tinyurl.com/4mxfd3cz
         x = pt.switch(value <= 1, 1.0 / (value * pt.sqrt(np.pi)), -pt.sqrt(pt.log(value)))
         iter_count = 0
         while iter_count < max_iter:
             iter_count += 1
-            fx = pt.erfcx(x) - value
-            fpx = 2 * x * pt.erfcx(x) - 2 / pt.sqrt(np.pi)
-            delta_x = fx / fpx
+            delta_x = (pt.erfcx(x) - value) / (2 * x * pt.erfcx(x) - 2 / pt.sqrt(np.pi))
             x = x - delta_x
             if (pt.abs(delta_x) < tol).all():
                 break

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -758,15 +758,13 @@ class TanhTransform(RVTransform):
 
 class ErfTransform(RVTransform):
     name = "erf"
+    ndim_supp = 0
 
     def forward(self, value, *inputs):
         return pt.erf(value)
 
     def backward(self, value, *inputs):
         return pt.erfinv(value)
-
-    def log_jac_det(self, value, *inputs):
-        return pt.log(2 * pt.exp(-(value**2)) / (pt.sqrt(np.pi)))
 
 
 class ErfcTransform(RVTransform):

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -112,7 +112,7 @@ def check_jacobian_det(
     )
 
     for yval in domain.vals:
-        close_to(actual_ljd(yval), computed_ljd(yval), tol)
+        np.testing.assert_allclose(actual_ljd(yval), computed_ljd(yval), rtol=tol)
 
 
 def test_simplex():

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -997,18 +997,15 @@ def test_multivariate_transform(shift, scale):
     )
 
 
-from pytensor.tensor import cosh, erf, erfc, erfcx, sinh, tanh
-
-
 @pytest.mark.parametrize(
     "pt_transform, transform",
     [
-        (erf, ErfTransform()),
-        (erfc, ErfcTransform()),
-        (erfcx, ErfcxTransform()),
-        (sinh, SinhTransform()),
-        (cosh, CoshTransform()),
-        (tanh, TanhTransform()),
+        (pt.erf, ErfTransform()),
+        (pt.erfc, ErfcTransform()),
+        (pt.erfcx, ErfcxTransform()),
+        (pt.sinh, SinhTransform()),
+        (pt.cosh, CoshTransform()),
+        (pt.tanh, TanhTransform()),
     ],
 )
 def test_erf_logp(pt_transform, transform):
@@ -1024,10 +1021,7 @@ def test_erf_logp(pt_transform, transform):
 
     vv_test = np.array(0.25)  # Arbitrary test value
     np.testing.assert_almost_equal(
-        rv_logp.eval({vv: vv_test}),
-        np.where(
-            np.isnan(expected_logp.eval({vv: vv_test})), -np.inf, expected_logp.eval({vv: vv_test})
-        ),
+        rv_logp.eval({vv: vv_test}), np.nan_to_num(expected_logp.eval({vv: vv_test}), nan=-np.inf)
     )
 
 

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -1048,9 +1048,20 @@ from pymc.testing import Rplusbig, Vector
 from tests.distributions.test_transform import check_jacobian_det
 
 
-def test_check_jac_det():
-    check_jacobian_det(
+@pytest.mark.parametrize(
+    "transform",
+    [
         ErfTransform(),
+        ErfcTransform(),
+        ErfcxTransform(),
+        SinhTransform(),
+        CoshTransform(),
+        TanhTransform(),
+    ],
+)
+def test_check_jac_det(transform):
+    check_jacobian_det(
+        transform,
         Vector(Rplusbig, 2),
         pt.dvector,
         [0.1, 0.1],

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -1025,7 +1025,9 @@ def test_erf_logp(pt_transform, transform):
     vv_test = np.array(0.25)  # Arbitrary test value
     np.testing.assert_almost_equal(
         rv_logp.eval({vv: vv_test}),
-        expected_logp.eval({vv: vv_test}),
+        np.where(
+            np.isnan(expected_logp.eval({vv: vv_test})), -np.inf, expected_logp.eval({vv: vv_test})
+        ),
     )
 
 
@@ -1034,4 +1036,11 @@ from tests.distributions.test_transform import check_jacobian_det
 
 
 def test_check_jac_det():
-    check_jacobian_det(ErfTransform(), Vector(Rplusbig, 2), pt.dvector, [0, 0], elemwise=False)
+    check_jacobian_det(
+        ErfTransform(),
+        Vector(Rplusbig, 2),
+        pt.dvector,
+        [0.1, 0.1],
+        elemwise=True,
+        rv_var=pt.random.normal(0.5, 1, name="base_rv"),
+    )


### PR DESCRIPTION
**What is this PR about?**
I have implemented additional Elemwise transformations as suggested in issue #6631. Specifically, this pull request adds cosh, sinh, tanh, erf, erfc, and erfcx functions. I plan to address the other suggested transformations in a separate pull request, as they require a more significant rewrite of existing functions. However, if it is preferred to include them all in one pull request, I'm happy to do so.

Please note that this is still a work in progress, and I have not yet written any tests for the new Transforms. I would appreciate some guidance on how to design these tests as its not clear to me what I should be testing them against.

Also for the erfcx transform it would be great double check my math is correct, for the backward I have rewrote a matlab function and for the log jacobian determinant I used wolfram alpha to get the derivative of erfcx. 
...

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- New elemwise transforms 
- Cleaned up the if block in `find_measureable_transforms()` as it was getting quite large

## New features
Transforms for:
- cosh
- sinh
- tanh
- erf
- erfc
- erfcx 

## Bugfixes
- NA

## Documentation
- Haven't added any in this PR 

## Maintenance
- NA 


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6664.org.readthedocs.build/en/6664/

<!-- readthedocs-preview pymc end -->