### PR TITLE
`CustomDist` and `Simulator` no longer require `class_name` when creating a `dist`

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -684,9 +684,11 @@ class _CustomSymbolicDist(Distribution):
             def custom_dist_logp(op, values, size, *params, **kwargs):
                 return logp(values[0], *params[: len(dist_params)])
 
-        @_logcdf.register(rv_type)
-        def custom_dist_logcdf(op, value, size, *params, **kwargs):
-            return logcdf(value, *params[: len(dist_params)])
+        if logcdf is not None:
+
+            @_logcdf.register(rv_type)
+            def custom_dist_logcdf(op, value, size, *params, **kwargs):
+                return logcdf(value, *params[: len(dist_params)])
 
         @_moment.register(rv_type)
         def custom_dist_get_moment(op, rv, size, *params):

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -404,6 +404,22 @@ class TestCustomSymbolicDist:
         ip = m.initial_point()
         np.testing.assert_allclose(m.compile_logp()(ip), ref_m.compile_logp()(ip))
 
+    def test_logcdf_inference(self):
+        def custom_dist(mu, sigma, size):
+            return pt.exp(pm.Normal.dist(mu, sigma, size=size))
+
+        mu = 1
+        sigma = 1.25
+        test_value = 0.9
+
+        custom_lognormal = CustomDist.dist(mu, sigma, dist=custom_dist)
+        ref_lognormal = LogNormal.dist(mu, sigma)
+
+        np.testing.assert_allclose(
+            pm.logcdf(custom_lognormal, test_value).eval(),
+            pm.logcdf(ref_lognormal, test_value).eval(),
+        )
+
     def test_random_multiple_rngs(self):
         def custom_dist(p, sigma, size):
             idx = pm.Bernoulli.dist(p=p)

--- a/tests/distributions/test_simulator.py
+++ b/tests/distributions/test_simulator.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 import warnings
 
+import cloudpickle
 import numpy as np
 import pytensor
 import pytest
@@ -357,9 +358,10 @@ class TestSimulator(SeededTest):
         assert np.all(np.abs((result - expected_sample_mean) / expected_sample_mean_std) < cutoff)
 
     def test_dist(self):
-        x = pm.Simulator.dist(self.normal_sim, 0, 1, sum_stat="sort", shape=(3,), class_name="test")
-        x_logp = pm.logp(x, [0, 1, 2])
+        x = pm.Simulator.dist(self.normal_sim, 0, 1, sum_stat="sort", shape=(3,))
+        x = cloudpickle.loads(cloudpickle.dumps(x))
 
+        x_logp = pm.logp(x, [0, 1, 2])
         x_logp_fn = compile_pymc([], x_logp, random_seed=1)
         res1, res2 = x_logp_fn(), x_logp_fn()
         assert res1.shape == (3,)


### PR DESCRIPTION
Apparently cloudpickle is happy with classes with the same name, so we don't need to request them from users...

```python
import cloudpickle

class A:
    def __init__(self, a):
        self.a = a
        
a = A(5)

class A:
    def __init__(self, b):
        self.b = b
        
b = A(3)

a_, b_ = cloudpickle.loads(cloudpickle.dumps((a, b)))

print(a_.a, b_.b)  # 5, 3
print(type(a_) is type(b_))  # False
print(type(a))  # <class '__main__.A'>
print(type(b))  # <class '__main__.A'>
print(type(a_) is A)  # False
print(type(b_) is A)  # True
```

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6668.org.readthedocs.build/en/6668/

<!-- readthedocs-preview pymc end -->