### PR TITLE
Fix typos in PolyaGamma's docstring

### DIFF
--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -22,6 +22,7 @@ dependencies:
 - jupyter-sphinx
 - myst-nb
 - numpydoc
+- polyagamma
 - pre-commit>=2.8.0
 - pymc-sphinx-theme==0.13
 - sphinx-copybutton

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3771,7 +3771,8 @@ class PolyaGamma(PositiveContinuous):
         import matplotlib.pyplot as plt
         import numpy as np
         from polyagamma import polyagamma_pdf
-        plt.style.use('seaborn-darkgrid')
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
         x = np.linspace(0.01, 5, 500);x.sort()
         hs = [1., 5., 10., 15.]
         zs = [0.] * 4
@@ -3785,7 +3786,7 @@ class PolyaGamma(PositiveContinuous):
 
     ========  =============================
     Support   :math:`x \in (0, \infty)`
-    Mean      :math:`dfrac{h}{4} if :math:`z=0`, :math:`\dfrac{tanh(z/2)h}{2z}` otherwise.
+    Mean      :math:`\dfrac{h}{4}` if :math:`z=0`, :math:`\dfrac{tanh(z/2)h}{2z}` otherwise.
     Variance  :math:`0.041666688h` if :math:`z=0`, :math:`\dfrac{h(sinh(z) - z)(1 - tanh^2(z/2))}{4z^3}` otherwise.
     ========  =============================
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

Fix typos and change a detail in PolyaGamma's docstring.

* A backslash and a backtick were missing in the math code block for the mean and the deployment looked like this:
![Captura desde 2023-04-13 20-03-09](https://user-images.githubusercontent.com/11216696/231901437-34423c12-e255-4f69-9c91-27dcfe16af13.png)

* The example plot wasn't deployed and it was the only distribution with `plt.style.use('seaborn-darkgrid')`. This commit imports arviz and uses `plt.style.use('arviz-darkgrid')` instead.

...

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6672.org.readthedocs.build/en/6672/

<!-- readthedocs-preview pymc end -->