### PR TITLE
Rectify type-hints for `set_data`

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1155,7 +1155,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
     def set_data(
         self,
         name: str,
-        values: Dict[str, Optional[Sequence]],
+        values: Union[Sequence, np.ndarray],
         coords: Optional[Dict[str, Sequence]] = None,
     ):
         """Changes the values of a data variable in the model.


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This PR aims to solve issue [6667](https://github.com/pymc-devs/pymc/issues/6667). 

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- The type-hints for ```values``` in ```model.py``` is given as ```Dict[str, Optional[Sequence]]```.  We update it to be an ```array-like``` object as ```Sequence```.

## Documentation
- ...

## Maintenance
- ...


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6676.org.readthedocs.build/en/6676/

<!-- readthedocs-preview pymc end -->