### PR TITLE
Added scale parameterization to Exponential

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -1347,13 +1347,22 @@ class Exponential(PositiveContinuous):
     ----------
     lam : tensor_like of float
         Rate or inverse scale (``lam`` > 0).
+    scale: tensor_like of float
+        Alternative parameter (scale = 1/lam).
     """
     rv_op = exponential
 
     @classmethod
-    def dist(cls, lam: DIST_PARAMETER_TYPES, *args, **kwargs):
-        lam = pt.as_tensor_variable(floatX(lam))
+    def dist(cls, lam=None, scale=None, *args, **kwargs):
+        if lam is not None and scale is not None:
+            raise ValueError("Incompatible parametrization. Can't specify both lam and scale.")
+        elif lam is None and scale is None:
+            raise ValueError("Incompatible parametrization. Must specify either lam or scale.")
 
+        if scale is not None:
+            lam = pt.reciprocal(scale)
+
+        lam = pt.as_tensor_variable(floatX(lam))
         # PyTensor exponential op is parametrized in terms of mu (1/lam)
         return super().dist([pt.reciprocal(lam)], **kwargs)
 

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -1359,12 +1359,12 @@ class Exponential(PositiveContinuous):
         elif lam is None and scale is None:
             raise ValueError("Incompatible parametrization. Must specify either lam or scale.")
 
-        if scale is not None:
-            lam = pt.reciprocal(scale)
+        if scale is None:
+            scale = pt.reciprocal(lam)
 
-        lam = pt.as_tensor_variable(floatX(lam))
+        scale = pt.as_tensor_variable(floatX(scale))
         # PyTensor exponential op is parametrized in terms of mu (1/lam)
-        return super().dist([pt.reciprocal(lam)], **kwargs)
+        return super().dist([scale], **kwargs)
 
     def moment(rv, size, mu):
         if not rv_size_is_none(size):

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -445,17 +445,13 @@ class TestMatchesScipy:
         )
 
     def test_exponential_wrong_arguments(self):
-        m = pm.Model()
-
         msg = "Incompatible parametrization. Can't specify both lam and scale"
-        with m:
-            with pytest.raises(ValueError, match=msg):
-                pm.Exponential("x", lam=0.5, scale=5)
+        with pytest.raises(ValueError, match=msg):
+            pm.Exponential.dist(lam=0.5, scale=5)
 
         msg = "Incompatible parametrization. Must specify either lam or scale"
-        with m:
-            with pytest.raises(ValueError, match=msg):
-                pm.Exponential("x")
+        with pytest.raises(ValueError, match=msg):
+            pm.Exponential.dist()
 
     def test_laplace(self):
         check_logp(

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -432,17 +432,42 @@ class TestMatchesScipy:
             {"lam": Rplus},
             lambda value, lam: st.expon.logpdf(value, 0, 1 / lam),
         )
+        check_logp(
+            pm.Exponential,
+            Rplus,
+            {"scale": Rplus},
+            lambda value, scale: st.expon.logpdf(value, 0, scale),
+        )
         check_logcdf(
             pm.Exponential,
             Rplus,
             {"lam": Rplus},
             lambda value, lam: st.expon.logcdf(value, 0, 1 / lam),
         )
+        check_logcdf(
+            pm.Exponential,
+            Rplus,
+            {"scale": Rplus},
+            lambda value, scale: st.expon.logcdf(value, 0, scale),
+        )
         check_icdf(
             pm.Exponential,
             {"lam": Rplus},
             lambda q, lam: st.expon.ppf(q, loc=0, scale=1 / lam),
         )
+
+    def test_exponential_wrong_arguments(self):
+        m = pm.Model()
+
+        msg = "Incompatible parametrization. Can't specify both lam and scale"
+        with m:
+            with pytest.raises(ValueError, match=msg):
+                pm.Exponential("x", lam=0.5, scale=5)
+
+        msg = "Incompatible parametrization. Must specify either lam or scale"
+        with m:
+            with pytest.raises(ValueError, match=msg):
+                pm.Exponential("x")
 
     def test_laplace(self):
         check_logp(
@@ -2089,6 +2114,13 @@ class TestExponential(BaseTestDistributionRandom):
         "check_pymc_params_match_rv_op",
         "check_pymc_draws_match_reference",
     ]
+
+
+class TestExponentialScale(BaseTestDistributionRandom):
+    pymc_dist = pm.Exponential
+    pymc_dist_params = {"scale": 5.0}
+    expected_rv_op_params = {"mu": pymc_dist_params["scale"]}
+    checks_to_run = ["check_pymc_params_match_rv_op"]
 
 
 class TestCauchy(BaseTestDistributionRandom):

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -432,23 +432,11 @@ class TestMatchesScipy:
             {"lam": Rplus},
             lambda value, lam: st.expon.logpdf(value, 0, 1 / lam),
         )
-        check_logp(
-            pm.Exponential,
-            Rplus,
-            {"scale": Rplus},
-            lambda value, scale: st.expon.logpdf(value, 0, scale),
-        )
         check_logcdf(
             pm.Exponential,
             Rplus,
             {"lam": Rplus},
             lambda value, lam: st.expon.logcdf(value, 0, 1 / lam),
-        )
-        check_logcdf(
-            pm.Exponential,
-            Rplus,
-            {"scale": Rplus},
-            lambda value, scale: st.expon.logcdf(value, 0, scale),
         )
         check_icdf(
             pm.Exponential,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Fixes #6637 
Adds alternative **scale** parametrization to exponential function. scale = 1 / lam

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...
## New features
- Extended functionality of specifing alternative scale parameter in exponential.

 
## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- Relavant test cases added in test_continuous.py.


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6677.org.readthedocs.build/en/6677/

<!-- readthedocs-preview pymc end -->