### PR TITLE
Make logprob inference for binary ops independent of order of inputs

### DIFF
--- a/pymc/logprob/binary.py
+++ b/pymc/logprob/binary.py
@@ -62,6 +62,7 @@ def find_measurable_comparisons(
     if len(measurable_inputs) != 1:
         return None
 
+    # Make the measurable base_var always be the first input to the MeasurableComparison node
     base_var: TensorVariable = measurable_inputs[0][0]
 
     # Check that the other input is not potentially measurable, in which case this rewrite
@@ -79,6 +80,7 @@ def find_measurable_comparisons(
 
     node_scalar_op = node.op.scalar_op
 
+    # Change the Op if the base_var is the second input in node.inputs. e.g. pt.lt(const, dist) -> pt.gt(dist, const)
     if measurable_inputs[0][1] == 1:
         if isinstance(node_scalar_op, LT):
             node_scalar_op = GT()

--- a/tests/logprob/test_binary.py
+++ b/tests/logprob/test_binary.py
@@ -25,16 +25,17 @@ from pymc.testing import assert_no_rvs
 
 
 @pytest.mark.parametrize(
-    "comparison_op, exp_logp_true, exp_logp_false",
+    "comparison_op, exp_logp_true, exp_logp_false, inputs",
     [
-        ((pt.lt, pt.le), "logcdf", "logsf"),
-        ((pt.gt, pt.ge), "logsf", "logcdf"),
+        ((pt.lt, pt.le), "logcdf", "logsf", (pt.random.normal(0, 1), 0.5)),
+        ((pt.gt, pt.ge), "logsf", "logcdf", (pt.random.normal(0, 1), 0.5)),
+        ((pt.lt, pt.le), "logsf", "logcdf", (0.5, pt.random.normal(0, 1))),
+        ((pt.gt, pt.ge), "logcdf", "logsf", (0.5, pt.random.normal(0, 1))),
     ],
 )
-def test_continuous_rv_comparison(comparison_op, exp_logp_true, exp_logp_false):
-    x_rv = pt.random.normal(0, 1)
+def test_continuous_rv_comparison(comparison_op, exp_logp_true, exp_logp_false, inputs):
     for op in comparison_op:
-        comp_x_rv = op(x_rv, 0.5)
+        comp_x_rv = op(*inputs)
 
         comp_x_vv = comp_x_rv.clone()
 
@@ -49,33 +50,45 @@ def test_continuous_rv_comparison(comparison_op, exp_logp_true, exp_logp_false):
 
 
 @pytest.mark.parametrize(
-    "comparison_op, exp_logp_true, exp_logp_false",
+    "comparison_op, exp_logp_true, exp_logp_false, inputs",
     [
         (
             pt.lt,
             lambda x: st.poisson(2).logcdf(x - 1),
             lambda x: np.logaddexp(st.poisson(2).logsf(x), st.poisson(2).logpmf(x)),
+            (pt.random.poisson(2), 3),
         ),
         (
             pt.ge,
             lambda x: np.logaddexp(st.poisson(2).logsf(x), st.poisson(2).logpmf(x)),
             lambda x: st.poisson(2).logcdf(x - 1),
+            (pt.random.poisson(2), 3),
         ),
+        (pt.gt, st.poisson(2).logsf, st.poisson(2).logcdf, (pt.random.poisson(2), 3)),
+        (pt.le, st.poisson(2).logcdf, st.poisson(2).logsf, (pt.random.poisson(2), 3)),
         (
-            pt.gt,
+            pt.lt,
             st.poisson(2).logsf,
             st.poisson(2).logcdf,
+            (3, pt.random.poisson(2)),
+        ),
+        (pt.ge, st.poisson(2).logcdf, st.poisson(2).logsf, (3, pt.random.poisson(2))),
+        (
+            pt.gt,
+            lambda x: st.poisson(2).logcdf(x - 1),
+            lambda x: np.logaddexp(st.poisson(2).logsf(x), st.poisson(2).logpmf(x)),
+            (3, pt.random.poisson(2)),
         ),
         (
             pt.le,
-            st.poisson(2).logcdf,
-            st.poisson(2).logsf,
+            lambda x: np.logaddexp(st.poisson(2).logsf(x), st.poisson(2).logpmf(x)),
+            lambda x: st.poisson(2).logcdf(x - 1),
+            (3, pt.random.poisson(2)),
         ),
     ],
 )
-def test_discrete_rv_comparison(comparison_op, exp_logp_true, exp_logp_false):
-    x_rv = pt.random.poisson(2)
-    cens_x_rv = comparison_op(x_rv, 3)
+def test_discrete_rv_comparison(inputs, comparison_op, exp_logp_true, exp_logp_false):
+    cens_x_rv = comparison_op(*inputs)
 
     cens_x_vv = cens_x_rv.clone()
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This PR makes the logprob derivation of binary comparison ops (`<=, >=, <, >`) independent of the order of the inputs. e.g. `pt.le(x, 0.4)` and `pt.le(0.4, x)` would have the same logp. 

Addresses #6633.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6682.org.readthedocs.build/en/6682/

<!-- readthedocs-preview pymc end -->