### PR TITLE
Add logprob inference for `not` operations

### DIFF
--- a/pymc/logprob/binary.py
+++ b/pymc/logprob/binary.py
@@ -161,6 +161,9 @@ def find_measurable_bitwise(fgraph: FunctionGraph, node: Node) -> Optional[List[
     ):
         return None
 
+    if not base_var.dtype.startswith("bool"):
+        raise None
+
     # Make base_var unmeasurable
     unmeasurable_base_var = ignore_logprob(base_var)
 
@@ -184,6 +187,6 @@ measurable_ir_rewrites_db.register(
 def bitwise_not_logprob(op, values, base_rv, **kwargs):
     (value,) = values
 
-    logprob = _logprob_helper(base_rv, np.bitwise_not(value), **kwargs)
+    logprob = _logprob_helper(base_rv, invert(value), **kwargs)
 
     return logprob


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Implementation of logprob derivation for bitwise 'not' operations as discussed in #6680, using the following logic:
`not(gt(x, const), True) -> (gt(x, const), not(True))`.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## New features
- Logprob inference for bitwise 'not' Ops.


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6689.org.readthedocs.build/en/6689/

<!-- readthedocs-preview pymc end -->