### PR TITLE
codecov coverage uploaded after tests succeed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -493,10 +493,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Install coverage
-        run: conda install coverage -y
       - name: Merge coverage reports
         run: |
+          # Activate conda environment
+          conda activate pymc-test
           # Find all coverage reports and merge them into a single file
           python -m coverage combine --append coverage-*.xml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -173,7 +173,12 @@ jobs:
       - name: Run tests
         run: |
           conda activate pymc-test
-          python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
+          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${steps.matrix-id.outputs.id}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage/coverage-${{ steps.matrix-id.outputs.id }}.xml
 
   windows:
     needs: changes
@@ -242,7 +247,12 @@ jobs:
         # The ">-" in the next line replaces newlines with spaces (see https://stackoverflow.com/a/66809682).
         run: >-
           conda activate pymc-test &&
-          python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
+          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${steps.matrix-id.outputs.id}.xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage/coverage-${{ steps.matrix-id.outputs.id }}.xml
 
   macos:
     needs: changes
@@ -314,7 +324,12 @@ jobs:
           python --version
       - name: Run tests
         run: |
-          python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
+          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${steps.matrix-id.outputs.id}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage/coverage-${{ steps.matrix-id.outputs.id }}.xml
 
   external_samplers:
     needs: changes
@@ -380,7 +395,12 @@ jobs:
           pip install git+https://github.com/blackjax-devs/blackjax.git@0.7.0
       - name: Run tests
         run: |
-          python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
+          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${steps.matrix-id.outputs.id}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage/coverage-${{ steps.matrix-id.outputs.id }}.xml
 
   float32:
     needs: changes
@@ -445,7 +465,12 @@ jobs:
         # The ">-" in the next line replaces newlines with spaces (see https://stackoverflow.com/a/66809682).
         run: >-
           conda activate pymc-test &&
-          python -m pytest -vv --cov=pymc --cov-report=xml:coverage.xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
+          python -m pytest -vv --cov=pymc --cov-report=xml:coverage/coverage-${steps.matrix-id.outputs.id}.xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage/coverage-${{ steps.matrix-id.outputs.id }}.xml
 
   all_tests:
     if: ${{ always() }}
@@ -461,10 +486,29 @@ jobs:
                   needs.float32.result != 'success' ) }}
         run: exit 1
 
+
+  merge-reports:
+    runs-on: ubuntu-latest
+    needs: [all_tests, changes]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Merge coverage reports
+        run: |
+          # Find all coverage reports and merge them into a single file
+          python -m coverage combine
+
+      - name: Save combined coverage report
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: coverage
+
+
   upload-coverage:
     runs-on: ubuntu-latest
     name: "Upload coverage"
-    needs: [all_tests, changes]
+    needs: [merge-reports]
     if: ${{ needs.all_tests.result == 'success' && needs.changes.outputs.changes == 'true'}}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Run tests
         run: |
           conda activate pymc-test
-          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${{ matrix.id }}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
+          python -m pytest -vv --cov=pymc --cov-report=xml:coverage/coverage-${{ matrix.os }}-${{ matrix.python-version }}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
         with:
@@ -247,7 +247,7 @@ jobs:
         # The ">-" in the next line replaces newlines with spaces (see https://stackoverflow.com/a/66809682).
         run: >-
           conda activate pymc-test &&
-          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${{ matrix.id }}.xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
+          python -m pytest -vv --cov=pymc --cov-report=xml:coverage/coverage-${{ matrix.os }}-${{ matrix.python-version }}.xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
         with:
@@ -324,7 +324,7 @@ jobs:
           python --version
       - name: Run tests
         run: |
-          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${{ matrix.id }}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
+          python -m pytest -vv --cov=pymc --cov-report=xml:coverage/coverage-${{ matrix.os }}-${{ matrix.python-version }}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
         with:
@@ -395,7 +395,7 @@ jobs:
           pip install git+https://github.com/blackjax-devs/blackjax.git@0.7.0
       - name: Run tests
         run: |
-          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${{ matrix.id }}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
+          python -m pytest -vv --cov=pymc --cov-report=xml:coverage/coverage-${{ matrix.os }}-${{ matrix.python-version }}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -496,6 +496,7 @@ jobs:
       - name: Merge coverage reports
         run: |
           # Find all coverage reports and merge them into a single file
+          python -m pip install -U coverage>=5.1 coveralls
           python -m coverage combine --append coverage-*.xml
 
       - name: Save combined coverage report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -496,7 +496,7 @@ jobs:
       - name: Merge coverage reports
         run: |
           # Find all coverage reports and merge them into a single file
-          run: python -m coverage combine --append coverage-*.xml
+          python -m coverage combine --append coverage-*.xml
 
       - name: Save combined coverage report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -493,10 +493,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Install coverage
+        run: conda install coverage -y
       - name: Merge coverage reports
         run: |
           # Find all coverage reports and merge them into a single file
-          python -m pip install -U coverage>=5.1 coveralls
           python -m coverage combine --append coverage-*.xml
 
       - name: Save combined coverage report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -487,49 +487,28 @@ jobs:
         run: exit 1
 
 
-  merge-reports:
-    runs-on: ubuntu-latest
-    needs: [all_tests, changes]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Merge coverage reports
-        run: |
-          # Activate conda environment
-          conda activate pymc-test
-          # Find all coverage reports and merge them into a single file
-          python -m coverage combine --append coverage-*.xml
-
-      - name: Save combined coverage report
-        uses: actions/upload-artifact@v2
-        with:
-          name: coverage
-          path: coverage
-
-
   upload-coverage:
     runs-on: ubuntu-latest
-    name: "Upload coverage"
-    needs: [merge-reports]
+    needs: [all_tests, changes]
     if: ${{ needs.all_tests.result == 'success' && needs.changes.outputs.changes == 'true'}}
     steps:
       - uses: actions/checkout@v3
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-
       - name: Install dependencies
         run: |
           python -m pip install -U coverage>=5.1 coveralls
-
-      - name: Download coverage file
+      - name: Download coverage files
         uses: actions/download-artifact@v3
         with:
           name: coverage
           path: coverage
-
+      - name: Merge coverage reports
+        run: |
+          # Find all coverage reports and merge them into a single file
+          python -m coverage combine --append coverage/*.xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -496,7 +496,7 @@ jobs:
       - name: Merge coverage reports
         run: |
           # Find all coverage reports and merge them into a single file
-          python -m coverage combine
+          run: python -m coverage combine --append coverage-*.xml
 
       - name: Save combined coverage report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,13 @@ on:
 # A pre-commit hook (scripts/check_all_tests_are_covered.py)
 # enforces that test run just once per OS / floatX setting.
 
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
 
   changes:
@@ -438,7 +445,7 @@ jobs:
         # The ">-" in the next line replaces newlines with spaces (see https://stackoverflow.com/a/66809682).
         run: >-
           conda activate pymc-test &&
-          python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
+          python -m pytest -vv --cov=pymc --cov-report=xml:coverage.xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
 
   all_tests:
     if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,13 +167,6 @@ jobs:
         run: |
           conda activate pymc-test
           python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
-          env_vars: TEST_SUBSET
-          name: ${{ matrix.os }} ${{ matrix.floatx }}
-          fail_ci_if_error: false
 
   windows:
     needs: changes
@@ -243,13 +236,6 @@ jobs:
         run: >-
           conda activate pymc-test &&
           python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
-          env_vars: TEST_SUBSET
-          name: ${{ matrix.os }} ${{ matrix.floatx }}
-          fail_ci_if_error: false
 
   macos:
     needs: changes
@@ -322,13 +308,6 @@ jobs:
       - name: Run tests
         run: |
           python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
-          env_vars: TEST_SUBSET
-          name: ${{ matrix.os }} ${{ matrix.floatx }}
-          fail_ci_if_error: false
 
   external_samplers:
     needs: changes
@@ -395,13 +374,6 @@ jobs:
       - name: Run tests
         run: |
           python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
-          env_vars: TEST_SUBSET
-          name: JAX tests - ${{ matrix.os }} ${{ matrix.floatx }}
-          fail_ci_if_error: false
 
   float32:
     needs: changes
@@ -467,13 +439,6 @@ jobs:
         run: >-
           conda activate pymc-test &&
           python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
-          env_vars: TEST_SUBSET
-          name: ${{ matrix.os }} ${{ matrix.floatx }}
-          fail_ci_if_error: false
 
   all_tests:
     if: ${{ always() }}
@@ -488,3 +453,33 @@ jobs:
                   needs.external_samplers.result != 'success' ||
                   needs.float32.result != 'success' ) }}
         run: exit 1
+
+  upload-coverage:
+    runs-on: ubuntu-latest
+    name: "Upload coverage"
+    needs: [all_tests, changes]
+    if: ${{ needs.all_tests.result == 'success' && needs.changes.outputs.changes == 'true'}}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U coverage>=5.1 coveralls
+
+      - name: Download coverage file
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+          path: coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
+          directory: ./coverage/
+          fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -173,12 +173,12 @@ jobs:
       - name: Run tests
         run: |
           conda activate pymc-test
-          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${steps.matrix-id.outputs.id}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
+          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${{ matrix.id }}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: coverage/coverage-${{ steps.matrix-id.outputs.id }}.xml
+          path: coverage/coverage-${{ matrix.id }}.xml
 
   windows:
     needs: changes
@@ -247,12 +247,12 @@ jobs:
         # The ">-" in the next line replaces newlines with spaces (see https://stackoverflow.com/a/66809682).
         run: >-
           conda activate pymc-test &&
-          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${steps.matrix-id.outputs.id}.xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
+          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${{ matrix.id }}.xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: coverage/coverage-${{ steps.matrix-id.outputs.id }}.xml
+          path: coverage/coverage-${{ matrix.id }}.xml
 
   macos:
     needs: changes
@@ -324,12 +324,12 @@ jobs:
           python --version
       - name: Run tests
         run: |
-          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${steps.matrix-id.outputs.id}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
+          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${{ matrix.id }}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: coverage/coverage-${{ steps.matrix-id.outputs.id }}.xml
+          path: coverage/coverage-${{ matrix.id }}.xml
 
   external_samplers:
     needs: changes
@@ -395,12 +395,12 @@ jobs:
           pip install git+https://github.com/blackjax-devs/blackjax.git@0.7.0
       - name: Run tests
         run: |
-          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${steps.matrix-id.outputs.id}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
+          python -m pytest -vv --cov=pymc --cov-report=coverage/coverage-${{ matrix.id }}.xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: coverage/coverage-${{ steps.matrix-id.outputs.id }}.xml
+          path: coverage/coverage-${{ matrix.id }}.xml
 
   float32:
     needs: changes
@@ -470,7 +470,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: coverage/coverage-${{ steps.matrix-id.outputs.id }}.xml
+          path: coverage/coverage-${{ matrix.id }}.xml
 
   all_tests:
     if: ${{ always() }}


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Adaptations of tests.yaml requested in #6660 

**Implementation details:
Removed partial codecov upload that was triggered after each subtest, instead added one that is made only In case of all tests passing





<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6705.org.readthedocs.build/en/6705/

<!-- readthedocs-preview pymc end -->