### PR TITLE
Change logger names from all `pymc` to module name

### DIFF
--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -16,7 +16,7 @@
 
 import logging
 
-_log = logging.getLogger("pymc")
+_log = logging.getLogger(__name__)
 
 if not logging.root.handlers:
     _log.setLevel(logging.INFO)

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
 ___all__ = [""]
 
-_log = logging.getLogger("pymc")
+_log = logging.getLogger(__name__)
 
 # random variable object ...
 Var = Any  # pylint: disable=invalid-name

--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -42,7 +42,7 @@ from pymc.backends.report import SamplerReport
 from pymc.model import modelcontext
 from pymc.util import get_var_name
 
-logger = logging.getLogger("pymc")
+logger = logging.getLogger(__name__)
 
 
 class BackendError(Exception):

--- a/pymc/backends/mcbackend.py
+++ b/pymc/backends/mcbackend.py
@@ -37,7 +37,7 @@ from pymc.step_methods.compound import (
     flatten_steps,
 )
 
-_log = logging.getLogger("pymc")
+_log = logging.getLogger(__name__)
 
 
 def find_data(pmodel: Model) -> List[mcb.DataVariable]:

--- a/pymc/backends/report.py
+++ b/pymc/backends/report.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional
 
 from pymc.stats.convergence import _LEVELS, SamplerWarning
 
-logger = logging.getLogger("pymc")
+logger = logging.getLogger(__name__)
 
 
 class SamplerReport:

--- a/pymc/distributions/simulator.py
+++ b/pymc/distributions/simulator.py
@@ -29,7 +29,7 @@ from pymc.pytensorf import floatX
 
 __all__ = ["Simulator"]
 
-_log = logging.getLogger("pymc")
+_log = logging.getLogger(__name__)
 
 
 class SimulatorRV(RandomVariable):

--- a/pymc/ode/ode.py
+++ b/pymc/ode/ode.py
@@ -26,7 +26,7 @@ from pytensor.tensor.type import TensorType
 from pymc.exceptions import DtypeError, ShapeError
 from pymc.ode import utils
 
-_log = logging.getLogger("pymc")
+_log = logging.getLogger(__name__)
 floatX = pytensor.config.floatX
 
 

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -80,7 +80,7 @@ __all__ = (
 ArrayLike: TypeAlias = Union[np.ndarray, List[float]]
 PointList: TypeAlias = List[PointType]
 
-_log = logging.getLogger("pymc")
+_log = logging.getLogger(__name__)
 
 
 def get_vars_in_point_list(trace, model):

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -75,7 +75,7 @@ class SamplingIteratorCallback(Protocol):
         pass
 
 
-_log = logging.getLogger("pymc")
+_log = logging.getLogger(__name__)
 
 
 def instantiate_steppers(

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -32,7 +32,7 @@ from pymc.blocking import DictToArrayBijection
 from pymc.exceptions import SamplingError
 from pymc.util import RandomSeed
 
-logger = logging.getLogger("pymc")
+logger = logging.getLogger(__name__)
 
 
 class ParallelSamplingError(Exception):

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -45,7 +45,7 @@ __all__ = ()
 Step: TypeAlias = Union[BlockedStep, CompoundStep]
 
 
-_log = logging.getLogger("pymc")
+_log = logging.getLogger(__name__)
 
 
 def _sample_population(

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -193,7 +193,7 @@ def sample_smc(
 
     model = modelcontext(model)
 
-    _log = logging.getLogger("pymc")
+    _log = logging.getLogger(__name__)
     _log.info("Initializing SMC sampler...")
     _log.info(
         f"Sampling {chains} chain{'s' if chains > 1 else ''} "

--- a/pymc/stats/convergence.py
+++ b/pymc/stats/convergence.py
@@ -29,7 +29,7 @@ _LEVELS = {
     "critical": logging.CRITICAL,
 }
 
-logger = logging.getLogger("pymc")
+logger = logging.getLogger(__name__)
 
 
 @enum.unique

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -35,7 +35,7 @@ from pymc.step_methods.hmc.quadpotential import QuadPotentialDiagAdapt, quad_pot
 from pymc.tuning import guess_scaling
 from pymc.util import get_value_vars_from_user_vars
 
-logger = logging.getLogger("pymc")
+logger = logging.getLogger(__name__)
 
 
 class DivergenceInfo(NamedTuple):


### PR DESCRIPTION
Resolves #6694

Logger names are set to `__name__` rather than `"pymc"`. This allows more fine-grained control of logging.

I updated the tests that this broke so that they pass again.

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6712.org.readthedocs.build/en/6712/

<!-- readthedocs-preview pymc end -->