### PR TITLE
Update HSGP prior_linearized example to point to _m_star instead of m_star

### DIFF
--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -264,8 +264,8 @@ class HSGP(Base):
 
                 # Specify standard normal prior in the coefficients.  The number of which
                 # is given by the number of basis vectors, which is also saved in the GP object
-                # as m_star.
-                beta = pm.Normal("beta", size=gp.m_star)
+                # as _m_star.
+                beta = pm.Normal("beta", size=gp._m_star)
 
                 # The (non-centered) GP approximation is given by
                 f = pm.Deterministic("f", phi @ (beta * sqrt_psd))


### PR DESCRIPTION
**What is this PR about?**
The [docs](https://www.pymc.io/projects/docs/en/v5.4.0/api/gp/generated/classmethods/pymc.gp.HSGP.prior_linearized.html) for `pymc.gp.HSGP.prior_linearized` refer to `m_star` to find the number of basis functions used in the approximation, but that value is actually stored as `_m_star`. 

## Major / Breaking Changes
- N/A

## New features
- N/A

## Bugfixes
- N/A

## Documentation
- Two small fixes to the `prior_linearized` docstring in [pymc/gp/hsgp_approx.py](https://github.com/pymc-devs/pymc/blob/main/pymc/gp/hsgp_approx.py)

## Maintenance
- N/A


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6731.org.readthedocs.build/en/6731/

<!-- readthedocs-preview pymc end -->