### PR TITLE
Fix bug when compiling logp with `mode="FAST_COMPILE"`

### DIFF
--- a/pymc/logprob/basic.py
+++ b/pymc/logprob/basic.py
@@ -64,7 +64,7 @@ from pymc.logprob.abstract import (
     _logprob_helper,
     get_measurable_outputs,
 )
-from pymc.logprob.rewriting import construct_ir_fgraph
+from pymc.logprob.rewriting import cleanup_ir, construct_ir_fgraph
 from pymc.logprob.transforms import RVTransform, TransformValuesRewrite
 from pymc.logprob.utils import rvs_to_value_vars
 
@@ -107,6 +107,7 @@ def logp(
         fgraph, _, _ = construct_ir_fgraph({rv: value})
         [(ir_rv, ir_value)] = fgraph.preserve_rv_mappings.rv_values.items()
         expr = _logprob_helper(ir_rv, ir_value, **kwargs)
+        cleanup_ir([expr])
         if warn_missing_rvs:
             _warn_rvs_in_inferred_graph(expr)
         return expr
@@ -124,6 +125,7 @@ def logcdf(
         fgraph, rv_values, _ = construct_ir_fgraph({rv: value})
         [ir_rv] = fgraph.outputs
         expr = _logcdf_helper(ir_rv, value, **kwargs)
+        cleanup_ir([expr])
         if warn_missing_rvs:
             _warn_rvs_in_inferred_graph(expr)
         return expr
@@ -141,6 +143,7 @@ def icdf(
         fgraph, rv_values, _ = construct_ir_fgraph({rv: value})
         [ir_rv] = fgraph.outputs
         expr = _icdf_helper(ir_rv, value, **kwargs)
+        cleanup_ir([expr])
         if warn_missing_rvs:
             _warn_rvs_in_inferred_graph(expr)
         return expr
@@ -320,6 +323,8 @@ def factorized_joint_logprob(
         raise RuntimeError(
             f"The logprob terms of the following value variables could not be derived: {missing_value_terms}"
         )
+
+    cleanup_ir(logprob_vars.values())
 
     return logprob_vars
 

--- a/pymc/logprob/rewriting.py
+++ b/pymc/logprob/rewriting.py
@@ -347,7 +347,7 @@ def construct_ir_fgraph(
 
     if rv_remapper.measurable_conversions:
         # Undo un-valued measurable IR rewrites
-        new_to_old = tuple((v, k) for k, v in rv_remapper.measurable_conversions.items())
+        new_to_old = tuple((v, k) for k, v in reversed(rv_remapper.measurable_conversions.items()))
         fgraph.replace_all(new_to_old)
 
     return fgraph, rv_values, memo

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -88,11 +88,6 @@ from pytensor.tensor.math import (
     tanh,
     true_div,
 )
-from pytensor.tensor.rewriting.basic import (
-    register_specialize,
-    register_stabilize,
-    register_useless,
-)
 from pytensor.tensor.var import TensorVariable
 
 from pymc.logprob.abstract import (
@@ -106,7 +101,11 @@ from pymc.logprob.abstract import (
     _logprob,
     _logprob_helper,
 )
-from pymc.logprob.rewriting import PreserveRVMappings, measurable_ir_rewrites_db
+from pymc.logprob.rewriting import (
+    PreserveRVMappings,
+    cleanup_ir_rewrites_db,
+    measurable_ir_rewrites_db,
+)
 from pymc.logprob.utils import check_potential_measurability, ignore_logprob
 
 
@@ -134,13 +133,18 @@ class TransformedVariable(Op):
 transformed_variable = TransformedVariable()
 
 
-@register_specialize
-@register_stabilize
-@register_useless
 @node_rewriter([TransformedVariable])
 def remove_TransformedVariables(fgraph, node):
     if isinstance(node.op, TransformedVariable):
         return [node.inputs[0]]
+
+
+cleanup_ir_rewrites_db.register(
+    "remove_TransformedVariables",
+    remove_TransformedVariables,
+    "cleanup",
+    "transform",
+)
 
 
 class RVTransform(abc.ABC):

--- a/tests/logprob/test_rewriting.py
+++ b/tests/logprob/test_rewriting.py
@@ -40,6 +40,7 @@ import pytensor.tensor as pt
 import pytest
 import scipy.stats.distributions as sp
 
+from pytensor.graph import ancestors
 from pytensor.graph.rewriting.basic import in2out
 from pytensor.graph.rewriting.utils import rewrite_graph
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
@@ -50,8 +51,10 @@ from pytensor.tensor.subtensor import (
     Subtensor,
 )
 
+from pymc.distributions.transforms import logodds
 from pymc.logprob.basic import factorized_joint_logprob
-from pymc.logprob.rewriting import local_lift_DiracDelta
+from pymc.logprob.rewriting import cleanup_ir, local_lift_DiracDelta
+from pymc.logprob.transforms import TransformedVariable, TransformValuesRewrite
 from pymc.logprob.utils import DiracDelta, dirac_delta
 
 
@@ -88,10 +91,23 @@ def test_local_lift_DiracDelta():
 
 def test_local_remove_DiracDelta():
     c_at = pt.vector()
-    dd_at = dirac_delta(c_at)
+    dd_at = dirac_delta(c_at) + dirac_delta(5)
+    assert sum(isinstance(v.owner.op, DiracDelta) for v in ancestors([dd_at]) if v.owner) == 2
 
-    fn = pytensor.function([c_at], dd_at)
-    assert not any(isinstance(node.op, DiracDelta) for node in fn.maker.fgraph.toposort())
+    cleanup_ir([dd_at])
+    assert not any(isinstance(v.owner.op, DiracDelta) for v in ancestors([dd_at]) if v.owner)
+
+
+def test_local_remove_TransformedVariable():
+    p_rv = pt.random.beta(1, 1, name="p")
+    p_vv = p_rv.clone()
+
+    tr = TransformValuesRewrite({p_vv: logodds})
+    [p_logp] = factorized_joint_logprob({p_rv: p_vv}, extra_rewrites=tr).values()
+
+    assert not any(
+        isinstance(v.owner.op, TransformedVariable) for v in ancestors([p_logp]) if v.owner
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -561,6 +561,7 @@ def test_original_values_output_dict():
     assert p_vv in logp_dict
 
 
+@pytest.mark.filterwarnings("error")
 def test_mixture_transform():
     """Make sure that non-`RandomVariable` `MeasurableVariable`s can be transformed.
 
@@ -588,21 +589,17 @@ def test_mixture_transform():
 
     transform_rewrite = TransformValuesRewrite({y_vv: LogTransform()})
 
-    with pytest.warns(None) as record:
-        # This shouldn't raise any warnings
-        logp_trans = factorized_joint_logprob(
-            {Y_rv: y_vv, I_rv: i_vv},
-            extra_rewrites=transform_rewrite,
-            use_jacobian=False,
-        )
-        logp_trans_combined = pt.sum([pt.sum(factor) for factor in logp_trans.values()])
-
-    assert not record.list
+    logp_trans = factorized_joint_logprob(
+        {Y_rv: y_vv, I_rv: i_vv},
+        extra_rewrites=transform_rewrite,
+        use_jacobian=False,
+    )
+    logp_trans_combined = pt.sum([pt.sum(factor) for factor in logp_trans.values()])
 
     # The untransformed graph should be the same as the transformed graph after
     # replacing the `Y_rv` value variable with a transformed version of itself
     logp_nt_fg = FunctionGraph(outputs=[logp_no_trans_comb], clone=False)
-    y_trans = transformed_variable(pt.exp(y_vv), y_vv)
+    y_trans = pt.exp(y_vv)
     y_trans.name = "y_log"
     logp_nt_fg.replace(y_vv, y_trans)
     logp_nt = logp_nt_fg.outputs[0]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1625,3 +1625,12 @@ class TestModelDebug:
             "Some of the observed values of variable y are associated with a non-finite logp" in out
         )
         assert "value = 0.53 -> logp = -inf" in out
+
+
+def test_model_logp_fast_compile():
+    # Issue #5618
+    with pm.Model() as m:
+        pm.Dirichlet("a", np.ones(3))
+
+    with pytensor.config.change_flags(mode="FAST_COMPILE"):
+        assert m.point_logps() == {"a": -1.5}


### PR DESCRIPTION
Closes #5618 

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6735.org.readthedocs.build/en/6735/

<!-- readthedocs-preview pymc end -->