### PR TITLE
Rewrite logp graph before taking the gradient

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -132,6 +132,9 @@ def quaddist_matrix(cov=None, chol=None, tau=None, lower=True, *args, **kwargs):
         chol = pt.as_tensor_variable(chol)
         if chol.ndim != 2:
             raise ValueError("chol must be two dimensional.")
+
+        # tag as lower triangular to enable pytensor rewrites of chol(l.l') -> l
+        chol.tag.lower_triangular = True
         cov = chol.dot(chol.T)
 
     return cov

--- a/pymc/math.py
+++ b/pymc/math.py
@@ -443,11 +443,17 @@ def expand_packed_triangular(n, packed, lower=True, diagonal_only=False):
     elif lower:
         out = pt.zeros((n, n), dtype=pytensor.config.floatX)
         idxs = np.tril_indices(n)
-        return pt.set_subtensor(out[idxs], packed)
+        # tag as lower triangular to enable pytensor rewrites
+        out = pt.set_subtensor(out[idxs], packed)
+        out.tag.lower_triangular = True
+        return out
     elif not lower:
         out = pt.zeros((n, n), dtype=pytensor.config.floatX)
         idxs = np.triu_indices(n)
-        return pt.set_subtensor(out[idxs], packed)
+        # tag as upper triangular to enable pytensor rewrites
+        out = pt.set_subtensor(out[idxs], packed)
+        out.tag.upper_triangular = True
+        return out
 
 
 class BatchedDiag(Op):

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -75,6 +75,7 @@ from pymc.pytensorf import (
     hessian,
     inputvars,
     replace_rvs_by_values,
+    rewrite_pregrad,
 )
 from pymc.util import (
     UNSET,
@@ -380,6 +381,8 @@ class ValueGradFunction:
             )
             self._extra_vars_shared[var.name] = shared
             givens.append((var, shared))
+
+        cost = rewrite_pregrad(cost)
 
         if compute_grads:
             grads = pytensor.grad(cost, grad_vars, disconnected_inputs="ignore")
@@ -824,6 +827,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
                     )
 
         cost = self.logp(jacobian=jacobian)
+        cost = rewrite_pregrad(cost)
         return gradient(cost, value_vars)
 
     def d2logp(
@@ -862,6 +866,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
                     )
 
         cost = self.logp(jacobian=jacobian)
+        cost = rewrite_pregrad(cost)
         return hessian(cost, value_vars)
 
     @property

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -1228,3 +1228,10 @@ def constant_fold(
     return tuple(
         folded_x.data if isinstance(folded_x, Constant) else folded_x for folded_x in folded_xs
     )
+
+
+def rewrite_pregrad(graph):
+    """Apply simplifying or stabilizing rewrites to graph that are safe to use
+    pre-grad.
+    """
+    return rewrite_graph(graph, include=("canonicalize", "stabilize"))

--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -30,6 +30,7 @@ from pytensor.graph.basic import Variable, equal_computations
 from pytensor.tensor.random.basic import normal, uniform
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.var import RandomStateSharedVariable
+from pytensor.tensor.slinalg import Cholesky
 from pytensor.tensor.subtensor import AdvancedIncSubtensor, AdvancedIncSubtensor1
 from pytensor.tensor.var import TensorVariable
 
@@ -878,3 +879,34 @@ class TestReplaceRVsByValues:
         [new_x], _ = _replace_vars_in_graphs([x], replacement_fn=replacement_fn)
 
         assert new_x.eval() > 50
+
+
+def test_mvnormal_no_cholesky_op():
+    """
+    Test MvNormal likelihood when using Cholesky factor parameterization does not unnecessarily
+    recompute the cholesky factorization
+    Reversion test of #6717
+    """
+    with pm.Model() as m:
+        n = 3
+        sd_dist = pm.HalfNormal.dist(shape=n)
+        chol, corr, sigmas = pm.LKJCholeskyCov("cov", n=n, eta=1, sd_dist=sd_dist)
+        mu = np.zeros(n)
+        data = np.ones((10, n))
+        pm.MvNormal("y", mu=mu, chol=chol, observed=data)
+
+    contains_cholesky_op = lambda fgraph: any(
+        isinstance(node.op, Cholesky) for node in fgraph.apply_nodes
+    )
+
+    logp = m.compile_logp()
+    assert not contains_cholesky_op(logp.f.maker.fgraph)
+
+    dlogp = m.compile_dlogp()
+    assert not contains_cholesky_op(dlogp.f.maker.fgraph)
+
+    d2logp = m.compile_d2logp()
+    assert not contains_cholesky_op(d2logp.f.maker.fgraph)
+
+    logp_dlogp = m.logp_dlogp_function()
+    assert not contains_cholesky_op(logp_dlogp._pytensor_function.maker.fgraph)


### PR DESCRIPTION
With pymc-devs/pytensor#303 merged, `cholesky(L.dot(L.T))` will be rewritten to `L` if `L.tag.lower_triangular` is set. This change adds these where appropriate. This is important for #6717, however more work is likely required to improve the gradient in such cases.

Some rough benchmarks of computing logp and its grad on the initial point of following model.

<details>

```
n=1000
with pm.Model() as m:
    chol, corr, sigmas = pm.LKJCholeskyCov('cov', n=n, eta=1, sd_dist=pm.HalfNormal.dist())
    pm.MvNormal('y', mu=np.zeros(n), chol=chol, observed=np.ones((1000, n)))

```

</details>


|  | C backend |  JAX backend |
|-|---|-----|
|before | 292 ms ± 28.6 ms | 285 ms ± 28.9 ms  | 
|after | 260 ms ± 19.9 ms | 107 ms ± 969 µs |

The major difference in the "after" between C and JAX backends is that JAX is computing the grad after the rewrite is applied. As mentioned in #6717, this is probably a good motivator for performing some kind of rewrite before computing the gradient.

## Maintenance
- improve performance of MvNormal logp with Cholesky factor.



<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6736.org.readthedocs.build/en/6736/

<!-- readthedocs-preview pymc end -->