### PR TITLE
More informative error message for unused step sampler arguments

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -139,10 +139,11 @@ def instantiate_steppers(
         s = "s" if len(unused_args) > 1 else ""
         example_arg = sorted(unused_args)[0]
         example_step = (list(selected_steps.keys()) or pm.STEP_METHODS)[0]
+        example_step_name = getattr(example_step, "name")
         raise ValueError(
             f"Invalid key{s} found in step_kwargs: {unused_args}. "
             "Keys must be step names and values valid kwargs for that stepper. "
-            f'Did you mean {{"{example_step.name}": {{"{example_arg}": ...}}}}?'
+            f'Did you mean {{"{example_step_name}": {{"{example_arg}": ...}}}}?'
         )
 
     if len(steps) == 1:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -90,7 +90,10 @@ _log = logging.getLogger(__name__)
 
 
 def instantiate_steppers(
-    model, steps: List[Step], selected_steps, step_kwargs=None
+    model,
+    steps: List[Step],
+    selected_steps: Dict[str, List[Any]],
+    step_kwargs: Optional[Dict[str, Dict]] = None,
 ) -> Union[Step, List[Step]]:
     """Instantiate steppers assigned to the model variables.
 
@@ -129,7 +132,14 @@ def instantiate_steppers(
 
     unused_args = set(step_kwargs).difference(used_keys)
     if unused_args:
-        raise ValueError("Unused step method arguments: %s" % unused_args)
+        s = "s" if len(unused_args) > 1 else ""
+        example_arg = sorted(unused_args)[0]
+        example_step = list(selected_steps.keys())[0]
+        raise ValueError(
+            f"Invalid key{s} found in step_kwargs: {unused_args}. "
+            "Keys must be step names and values valid kwargs for that stepper. "
+            f'Did you mean {{"{example_step}": {{"{example_arg}": ...}}}}?'
+        )
 
     if len(steps) == 1:
         return steps[0]

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -30,6 +30,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Type,
     Union,
     overload,
 )
@@ -92,7 +93,7 @@ _log = logging.getLogger(__name__)
 def instantiate_steppers(
     model,
     steps: List[Step],
-    selected_steps: Dict[str, List[Any]],
+    selected_steps: Dict[Type[BlockedStep], List[Any]],
     step_kwargs: Optional[Dict[str, Dict]] = None,
 ) -> Union[Step, List[Step]]:
     """Instantiate steppers assigned to the model variables.
@@ -125,8 +126,9 @@ def instantiate_steppers(
     used_keys = set()
     for step_class, vars in selected_steps.items():
         if vars:
-            args = step_kwargs.get(step_class.name, {})
-            used_keys.add(step_class.name)
+            name = getattr(step_class, "name")
+            args = step_kwargs.get(name, {})
+            used_keys.add(name)
             step = step_class(vars=vars, model=model, **args)
             steps.append(step)
 

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -138,11 +138,11 @@ def instantiate_steppers(
     if unused_args:
         s = "s" if len(unused_args) > 1 else ""
         example_arg = sorted(unused_args)[0]
-        example_step = list(selected_steps.keys())[0]
+        example_step = (list(selected_steps.keys()) or pm.STEP_METHODS)[0]
         raise ValueError(
             f"Invalid key{s} found in step_kwargs: {unused_args}. "
             "Keys must be step names and values valid kwargs for that stepper. "
-            f'Did you mean {{"{example_step}": {{"{example_arg}": ...}}}}?'
+            f'Did you mean {{"{example_step.name}": {{"{example_arg}": ...}}}}?'
         )
 
     if len(steps) == 1:

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -246,7 +246,7 @@ class CompoundStep:
                 method.reset_tuning()
 
     @property
-    def vars(self):
+    def vars(self) -> List[Variable]:
         return [var for method in self.methods for var in method.vars]
 
 

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -180,13 +180,11 @@ class TestSample(SeededTest):
 
     def test_sample_args(self):
         with self.model:
-            with pytest.raises(ValueError) as excinfo:
+            with pytest.raises(ValueError, match=r"'foo'"):
                 pm.sample(50, tune=0, chains=1, step=pm.Metropolis(), foo=1)
-            assert "'foo'" in str(excinfo.value)
 
-            with pytest.raises(ValueError) as excinfo:
+            with pytest.raises(ValueError, match=r"'foo'") as excinfo:
                 pm.sample(50, tune=0, chains=1, step=pm.Metropolis(), foo={})
-            assert "foo" in str(excinfo.value)
 
     def test_parallel_start(self):
         with self.model:


### PR DESCRIPTION
More informative error message when passing invalid kwargs to `sample`

## Bugfixes
Closes #6737


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6738.org.readthedocs.build/en/6738/

<!-- readthedocs-preview pymc end -->