### PR TITLE
fixing links to images in the pymc_pytensor.ipynb notebook

### DIFF
--- a/docs/source/learn/core_notebooks/pymc_pytensor.ipynb
+++ b/docs/source/learn/core_notebooks/pymc_pytensor.ipynb
@@ -55,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![pytensor logo](https://raw.githubusercontent.com/pytensor-devs/pytensor/main/doc/images/pytensor_logo_2400.png)"
+    "![pytensor logo](https://raw.githubusercontent.com/pymc-devs/pytensor/main/doc/images/PyTensor_RGB.svg)"
    ]
   },
   {
@@ -402,7 +402,7 @@
     "\n",
     "The following diagram shows the basic structure of an `pytensor` graph.\n",
     "\n",
-    "![pytensor graph](https://raw.githubusercontent.com/pytensor-devs/pytensor/main/doc/tutorial/apply.png)"
+    "![pytensor graph](https://raw.githubusercontent.com/pymc-devs/pytensor/main/doc/tutorial/apply.png)"
    ]
   },
   {
@@ -1925,7 +1925,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.10"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

Fixing links to images in the pymc_pytensor.ipynb notebook, issue #6733 

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6739.org.readthedocs.build/en/6739/

<!-- readthedocs-preview pymc end -->