### PR TITLE
Ignore named variables that are not traceable in `get_vars_in_point_list`

### DIFF
--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -89,7 +89,8 @@ def get_vars_in_point_list(trace, model):
         names_in_trace = list(trace[0])
     else:
         names_in_trace = trace.varnames
-    vars_in_trace = [model[v] for v in names_in_trace if v in model]
+    traceable_varnames = {var.name for var in (model.free_RVs + model.deterministics)}
+    vars_in_trace = [model[v] for v in names_in_trace if v in traceable_varnames]
     return vars_in_trace
 
 

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -1634,11 +1634,13 @@ def test_get_vars_in_point_list():
     with pm.Model() as modelA:
         pm.Normal("a", 0, 1)
         pm.Normal("b", 0, 1)
+        pm.Normal("d", 0, 1)
     with pm.Model() as modelB:
         a = pm.Normal("a", 0, 1)
         pm.Normal("c", 0, 1)
+        pm.ConstantData("d", 0)
 
-    point_list = [{"a": 0, "b": 0}]
+    point_list = [{"a": 0, "b": 0, "d": 0}]
     vars_in_trace = get_vars_in_point_list(point_list, modelB)
     assert set(vars_in_trace) == {a}
 


### PR DESCRIPTION
This showed up when trying to do posterior predictive on https://github.com/pymc-devs/pymc-experimental/pull/168

It would consider a named_var that is now just a `ConstantData` or `MutableData` as having a trace equivalent. The `compile_forward_function` would then fail because we can't pass constants or shared variables as explicit inputs to a PyTensor function

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6741.org.readthedocs.build/en/6741/

<!-- readthedocs-preview pymc end -->