### PR TITLE
Fix small typing error in `sample` overload

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -348,7 +348,7 @@ def sample(
     discard_tuned_samples: bool = True,
     compute_convergence_checks: bool = True,
     keep_warning_stat: bool = False,
-    return_inferencedata: Literal[True],
+    return_inferencedata: Literal[True] = True,
     idata_kwargs: Optional[Dict[str, Any]] = None,
     nuts_sampler_kwargs: Optional[Dict[str, Any]] = None,
     callback=None,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This fixes a small error in the `pm.sample` overload introduced in #6709, following a discussion over at [pyright's repo](https://github.com/microsoft/pyright/issues/5194).

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Bugfixes
- Fixes small typing error in `pm.sample`


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6743.org.readthedocs.build/en/6743/

<!-- readthedocs-preview pymc end -->