### PR TITLE
Wrap sigma parameter with as_tensor_variable() before get_tau_sigma()

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -510,8 +510,8 @@ class Normal(Continuous):
 
     @classmethod
     def dist(cls, mu=0, sigma=None, tau=None, **kwargs):
-        tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
         sigma = pt.as_tensor_variable(sigma)
+        tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
 
         # tau = pt.as_tensor_variable(tau)
         # mean = median = mode = mu = pt.as_tensor_variable(floatX(mu))


### PR DESCRIPTION
For the cases where the sigma parameter is a vector of random variables instead of fixed values,  in get_tau_sigma 
`if np.any(sigma_ <= 0) ` throws the following error: TypeError: Variables do not support boolean operations. 
Sigma parameter normally is wrapped by as_tensor_variable() after get_tau_sigma. Moving the line `sigma= pt.as_tensor_variable(sigma)` before get_tau_sigma() resolves this issue. I ran some tests by supplying sigma argument with different types of values. They are all fine.


## Bugfixes
- For the cases where the sigma parameter is a vector of random variables instead of fixed values,  in get_tau_sigma 
`if np.any(sigma_ <= 0) ` throws the following error: TypeError: Variables do not support boolean operations. 



<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6745.org.readthedocs.build/en/6745/

<!-- readthedocs-preview pymc end -->