### PR TITLE
Allow CustomDist with inferred logp in Mixture

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,7 @@ jobs:
             tests/logprob/test_abstract.py
             tests/logprob/test_basic.py
             tests/logprob/test_binary.py
+            tests/logprob/test_checks.py
             tests/logprob/test_censoring.py
             tests/logprob/test_composite_logprob.py
             tests/logprob/test_cumsum.py

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -36,7 +36,6 @@ from pytensor.tensor.var import TensorConstant, TensorVariable
 
 import pymc as pm
 
-from pymc.logprob.abstract import _get_measurable_outputs
 from pymc.pytensorf import convert_observed_data
 
 __all__ = [
@@ -133,11 +132,6 @@ class MinibatchIndexRV(IntegersRV):
         if rng is None:
             rng = pytensor.shared(np.random.default_rng())
         return super().make_node(rng, *args, **kwargs)
-
-
-@_get_measurable_outputs.register(MinibatchIndexRV)
-def minibatch_index_rv_measuarable_outputs(op, node):
-    return []
 
 
 minibatch_index = MinibatchIndexRV()

--- a/pymc/distributions/bound.py
+++ b/pymc/distributions/bound.py
@@ -26,7 +26,6 @@ from pymc.distributions.distribution import Continuous, Discrete
 from pymc.distributions.shape_utils import to_tuple
 from pymc.distributions.transforms import _default_transform
 from pymc.logprob.basic import logp
-from pymc.logprob.utils import ignore_logprob
 from pymc.model import modelcontext
 from pymc.pytensorf import floatX, intX
 from pymc.util import check_dist_not_registered
@@ -202,7 +201,6 @@ class Bound:
                 raise ValueError("Given dims do not exist in model coordinates.")
 
         lower, upper, initval = cls._set_values(lower, upper, size, shape, initval)
-        dist = ignore_logprob(dist)
 
         if isinstance(dist.owner.op, Continuous):
             res = _ContinuousBounded(
@@ -236,7 +234,6 @@ class Bound:
     ):
         cls._argument_checks(dist, **kwargs)
         lower, upper, initval = cls._set_values(lower, upper, size, shape, initval=None)
-        dist = ignore_logprob(dist)
         if isinstance(dist.owner.op, Continuous):
             res = _ContinuousBounded.dist(
                 [dist, lower, upper],

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -32,7 +32,6 @@ from pytensor.graph.rewriting.basic import in2out
 from pytensor.graph.utils import MetaType
 from pytensor.tensor.basic import as_tensor_variable
 from pytensor.tensor.random.op import RandomVariable
-from pytensor.tensor.random.type import RandomType
 from pytensor.tensor.random.utils import normalize_size_param
 from pytensor.tensor.var import TensorVariable
 from typing_extensions import TypeAlias
@@ -49,13 +48,7 @@ from pymc.distributions.shape_utils import (
     shape_from_dims,
 )
 from pymc.exceptions import BlockModelAccessError
-from pymc.logprob.abstract import (
-    MeasurableVariable,
-    _get_measurable_outputs,
-    _icdf,
-    _logcdf,
-    _logprob,
-)
+from pymc.logprob.abstract import MeasurableVariable, _icdf, _logcdf, _logprob
 from pymc.logprob.rewriting import logprob_rewrites_db
 from pymc.model import BlockModelAccess
 from pymc.printing import str_for_dist
@@ -399,20 +392,6 @@ class Distribution(metaclass=DistributionMeta):
 
 # Let PyMC know that the SymbolicRandomVariable has a logprob.
 MeasurableVariable.register(SymbolicRandomVariable)
-
-
-@_get_measurable_outputs.register(SymbolicRandomVariable)
-def _get_measurable_outputs_symbolic_random_variable(op, node):
-    # This tells PyMC that any non RandomType outputs are measurable
-
-    # Assume that if there is one default_output, that's the only one that is measurable
-    # In the rare case this is not what one wants, a specialized _get_measuarable_outputs
-    # can dispatch for a subclassed Op
-    if op.default_output is not None:
-        return [node.default_output()]
-
-    # Otherwise assume that any outputs that are not of RandomType are measurable
-    return [out for out in node.outputs if not isinstance(out.type, RandomType)]
 
 
 @node_rewriter([SymbolicRandomVariable])

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -67,7 +67,6 @@ from pymc.distributions.shape_utils import (
 )
 from pymc.distributions.transforms import Interval, ZeroSumTransform, _default_transform
 from pymc.logprob.abstract import _logprob
-from pymc.logprob.utils import ignore_logprob
 from pymc.math import kron_diag, kron_dot
 from pymc.pytensorf import floatX, intX
 from pymc.util import check_dist_not_registered
@@ -1191,9 +1190,6 @@ class _LKJCholeskyCov(Distribution):
             raise TypeError("sd_dist must be a scalar or vector distribution variable")
 
         check_dist_not_registered(sd_dist)
-        # sd_dist is part of the generative graph, but should be completely ignored
-        # by the logp graph, since the LKJ logp explicitly includes these terms.
-        sd_dist = ignore_logprob(sd_dist)
         return super().dist([n, eta, sd_dist], **kwargs)
 
     @classmethod
@@ -2527,7 +2523,7 @@ class ZeroSumNormal(Distribution):
     @classmethod
     def rv_op(cls, sigma, n_zerosum_axes, support_shape, size=None):
         shape = to_tuple(size) + tuple(support_shape)
-        normal_dist = ignore_logprob(pm.Normal.dist(sigma=sigma, shape=shape))
+        normal_dist = pm.Normal.dist(sigma=sigma, shape=shape)
 
         if n_zerosum_axes > normal_dist.ndim:
             raise ValueError("Shape of distribution is too small for the number of zerosum axes")

--- a/pymc/logprob/abstract.py
+++ b/pymc/logprob/abstract.py
@@ -67,10 +67,15 @@ def _logprob_helper(rv, *values, **kwargs):
     """Helper that calls `_logprob` dispatcher."""
     logprob = _logprob(rv.owner.op, values, *rv.owner.inputs, **kwargs)
 
-    for rv in values:
-        if rv.name:
-            logprob.name = f"{rv.name}_logprob"
-            break
+    name = rv.name
+    if (not name) and (len(values) == 1):
+        name = values[0].name
+    if name:
+        if isinstance(logprob, (list, tuple)):
+            for i, term in enumerate(logprob):
+                term.name = f"{name}_logprob.{i}"
+        else:
+            logprob.name = f"{name}_logprob"
 
     return logprob
 

--- a/pymc/logprob/abstract.py
+++ b/pymc/logprob/abstract.py
@@ -36,11 +36,9 @@
 
 import abc
 
-from copy import copy
 from functools import singledispatch
-from typing import Callable, List, Sequence, Tuple
+from typing import Sequence, Tuple
 
-from pytensor.graph.basic import Apply, Variable
 from pytensor.graph.op import Op
 from pytensor.graph.utils import MetaType
 from pytensor.tensor import TensorVariable
@@ -133,107 +131,6 @@ class MeasurableVariable(abc.ABC):
 
 
 MeasurableVariable.register(RandomVariable)
-
-
-class UnmeasurableMeta(MetaType):
-    def __new__(cls, name, bases, dict):
-        if "id_obj" not in dict:
-            dict["id_obj"] = None
-
-        return super().__new__(cls, name, bases, dict)
-
-    def __eq__(self, other):
-        if isinstance(other, UnmeasurableMeta):
-            return hash(self.id_obj) == hash(other.id_obj)
-        return False
-
-    def __hash__(self):
-        return hash(self.id_obj)
-
-
-class UnmeasurableVariable(metaclass=UnmeasurableMeta):
-    """
-    id_obj is an attribute, i.e. tuple of length two, of the unmeasurable class object.
-    e.g. id_obj = (NormalRV, noop_measurable_outputs_fn)
-    """
-
-
-def get_measurable_outputs(op: Op, node: Apply) -> List[Variable]:
-    """Return only the outputs that are measurable."""
-    if isinstance(op, MeasurableVariable):
-        return _get_measurable_outputs(op, node)
-    else:
-        return []
-
-
-@singledispatch
-def _get_measurable_outputs(op, node):
-    return node.outputs
-
-
-@_get_measurable_outputs.register(RandomVariable)
-def _get_measurable_outputs_RandomVariable(op, node):
-    return node.outputs[1:]
-
-
-def noop_measurable_outputs_fn(*args, **kwargs):
-    return []
-
-
-def assign_custom_measurable_outputs(
-    node: Apply,
-    measurable_outputs_fn: Callable = noop_measurable_outputs_fn,
-    type_prefix: str = "Unmeasurable",
-) -> Apply:
-    """Assign a custom ``_get_measurable_outputs`` dispatch function to a measurable variable instance.
-
-    The node is cloned and a custom `Op` that's a copy of the original node's
-    `Op` is created.  That custom `Op` replaces the old `Op` in the cloned
-    node, and then a custom dispatch implementation is created for the clone
-    `Op` in `_get_measurable_outputs`.
-
-    If `measurable_outputs_fn` isn't specified, a no-op is used; the result is
-    a clone of `node` that will effectively be ignored by
-    `factorized_joint_logprob`.
-
-    Parameters
-    ----------
-    node
-        The node to recreate with a new cloned `Op`.
-    measurable_outputs_fn
-        The function that will be assigned to the new cloned `Op` in the
-        `_get_measurable_outputs` dispatcher.
-        The default is a no-op function (i.e. no measurable outputs)
-    type_prefix
-        The prefix used for the new type's name.
-        The default is ``"Unmeasurable"``, which matches the default
-        ``"measurable_outputs_fn"``.
-    """
-
-    new_node = node.clone()
-    op_type = type(new_node.op)
-
-    if op_type in _get_measurable_outputs.registry.keys() and isinstance(op_type, UnmeasurableMeta):
-        if _get_measurable_outputs.registry[op_type] != measurable_outputs_fn:
-            raise ValueError(
-                f"The type {op_type.__name__} with hash value {hash(op_type)} "
-                "has already been dispatched a measurable outputs function."
-            )
-        return node
-
-    new_op_dict = op_type.__dict__.copy()
-    new_op_dict["id_obj"] = (new_node.op, measurable_outputs_fn)
-    new_op_dict.setdefault("original_op_type", op_type)
-
-    new_op_type = type(
-        f"{type_prefix}{op_type.__name__}", (op_type, UnmeasurableVariable), new_op_dict
-    )
-    new_node.op = copy(new_node.op)
-    new_node.op.__class__ = new_op_type
-
-    _get_measurable_outputs.register(new_op_type)(measurable_outputs_fn)
-
-    return new_node
 
 
 class MeasurableElemwise(Elemwise):

--- a/pymc/logprob/binary.py
+++ b/pymc/logprob/binary.py
@@ -60,7 +60,7 @@ def find_measurable_comparisons(
     const = node.inputs[(measurable_var_idx + 1) % 2]
 
     # check for potential measurability of const
-    if not check_potential_measurability([const], rv_map_feature):
+    if check_potential_measurability([const], rv_map_feature.rv_values.keys()):
         return None
 
     node_scalar_op = node.op.scalar_op

--- a/pymc/logprob/checks.py
+++ b/pymc/logprob/checks.py
@@ -44,7 +44,6 @@ from pytensor.tensor.shape import SpecifyShape
 
 from pymc.logprob.abstract import MeasurableVariable, _logprob, _logprob_helper
 from pymc.logprob.rewriting import PreserveRVMappings, measurable_ir_rewrites_db
-from pymc.logprob.utils import ignore_logprob
 
 
 class MeasurableSpecifyShape(SpecifyShape):
@@ -86,10 +85,7 @@ def find_measurable_specify_shapes(fgraph, node) -> Optional[List[MeasurableSpec
         return None  # pragma: no cover
 
     new_op = MeasurableSpecifyShape()
-    # Make base_var unmeasurable
-    unmeasurable_base_rv = ignore_logprob(base_rv)
-    new_rv = new_op.make_node(unmeasurable_base_rv, *shape).default_output()
-    new_rv.name = rv.name
+    new_rv = new_op.make_node(base_rv, *shape).default_output()
 
     return [new_rv]
 
@@ -129,8 +125,6 @@ def find_measurable_asserts(fgraph, node) -> Optional[List[MeasurableCheckAndRai
     if rv_map_feature is None:
         return None  # pragma: no cover
 
-    rv = node.outputs[0]
-
     base_rv, *conds = node.inputs
 
     if not (
@@ -142,10 +136,7 @@ def find_measurable_asserts(fgraph, node) -> Optional[List[MeasurableCheckAndRai
 
     exception_type = ExceptionType()
     new_op = MeasurableCheckAndRaise(exc_type=exception_type)
-    # Make base_var unmeasurable
-    unmeasurable_base_rv = ignore_logprob(base_rv)
-    new_rv = new_op.make_node(unmeasurable_base_rv, *conds).default_output()
-    new_rv.name = rv.name
+    new_rv = new_op.make_node(base_rv, *conds).default_output()
 
     return [new_rv]
 

--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -547,4 +547,7 @@ def logprob_ifelse(op, values, if_var, *base_rvs, **kwargs):
     logps_then = replace_rvs_by_values(logps_then, rvs_to_values=rvs_to_values_then)
     logps_else = replace_rvs_by_values(logps_else, rvs_to_values=rvs_to_values_else)
 
-    return ifelse(if_var, logps_then, logps_else)
+    logps = ifelse(if_var, logps_then, logps_else)
+    if len(logps) == 1:
+        return logps[0]
+    return logps

--- a/pymc/logprob/rewriting.py
+++ b/pymc/logprob/rewriting.py
@@ -33,19 +33,27 @@
 #   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
+import warnings
 
-from typing import Dict, Optional, Sequence, Tuple
+from collections import deque
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import pytensor.tensor as pt
 
+from pytensor import config
 from pytensor.compile.mode import optdb
-from pytensor.graph.basic import Constant, Variable, ancestors
+from pytensor.graph.basic import Constant, Variable, ancestors, io_toposort
 from pytensor.graph.features import Feature
 from pytensor.graph.fg import FunctionGraph
-from pytensor.graph.rewriting.basic import GraphRewriter, node_rewriter
+from pytensor.graph.rewriting.basic import (
+    ChangeTracker,
+    EquilibriumGraphRewriter,
+    GraphRewriter,
+    node_rewriter,
+)
 from pytensor.graph.rewriting.db import (
-    EquilibriumDB,
     LocalGroupDB,
+    RewriteDatabase,
     RewriteDatabaseQuery,
     SequenceDB,
     TopoDB,
@@ -72,18 +80,103 @@ inc_subtensor_ops = (IncSubtensor, AdvancedIncSubtensor, AdvancedIncSubtensor1)
 subtensor_ops = (AdvancedSubtensor, AdvancedSubtensor1, Subtensor)
 
 
-class NoCallbackEquilibriumDB(EquilibriumDB):
-    r"""An `EquilibriumDB` that doesn't hide its exceptions.
+class MeasurableEquilibriumGraphRewriter(EquilibriumGraphRewriter):
+    """EquilibriumGraphRewriter focused on IR measurable rewrites.
 
-    By setting `failure_callback` to ``None`` in the `EquilibriumGraphRewriter`\s
-    that `EquilibriumDB` generates, we're able to directly emit the desired
-    exceptions from within the `NodeRewriter`\s themselves.
+    This is a stripped down version of the EquilibriumGraphRewriter,
+    which specifically targets nodes in `PreserveRVMAppings.needs_measuring`
+    that are not yet measurable.
+
+    """
+
+    def apply(self, fgraph):
+        rv_map_feature: Optional[PreserveRVMappings] = getattr(fgraph, "preserve_rv_mappings", None)
+        if not rv_map_feature:
+            return None
+
+        change_tracker = ChangeTracker()
+        fgraph.attach_feature(change_tracker)
+
+        changed = True
+        max_use_abort = False
+        rewriter_name = None
+        global_process_count = {}
+
+        for rewriter in self.global_rewriters + list(self.get_node_rewriters()):
+            global_process_count.setdefault(rewriter, 0)
+
+        while changed and not max_use_abort:
+            changed = False
+            max_nb_nodes = len(fgraph.apply_nodes)
+            max_use = max_nb_nodes * self.max_use_ratio
+
+            # Apply global rewriters
+            for grewrite in self.global_rewriters:
+                change_tracker.reset()
+                grewrite.apply(fgraph)
+                if change_tracker.changed:
+                    global_process_count[grewrite] += 1
+                    changed = True
+                    if global_process_count[grewrite] > max_use:
+                        max_use_abort = True
+                        rewriter_name = getattr(grewrite, "name", None) or getattr(
+                            grewrite, "__name__", ""
+                        )
+
+            # Apply local node rewriters
+            q = deque(io_toposort(fgraph.inputs, fgraph.outputs))
+            while q:
+                node = q.pop()
+                if node not in fgraph.apply_nodes:
+                    continue
+                # This is where we filter only those nodes we care about:
+                # Nodes that have variables that we want to measure and are not yet measurable
+                if isinstance(node.op, MeasurableVariable):
+                    continue
+                if not any(out in rv_map_feature.needs_measuring for out in node.outputs):
+                    continue
+                for node_rewriter in self.node_tracker.get_trackers(node.op):
+                    node_rewriter_change = self.process_node(fgraph, node, node_rewriter)
+                    if not node_rewriter_change:
+                        continue
+                    global_process_count[node_rewriter] += 1
+                    changed = True
+                    if global_process_count[node_rewriter] > max_use:
+                        max_use_abort = True
+                        rewriter_name = getattr(node_rewriter, "name", None) or getattr(
+                            node_rewriter, "__name__", ""
+                        )
+                    # If we converted to a MeasurableVariable we're done here!
+                    if node not in fgraph.apply_nodes or isinstance(node.op, MeasurableVariable):
+                        # go to next node
+                        break
+
+        if max_use_abort:
+            msg = (
+                f"{type(self).__name__} max'ed out by {rewriter_name}."
+                "You can safely raise the current threshold of "
+                f"{config.optdb__max_use_ratio} with the option `optdb__max_use_ratio`."
+            )
+            if config.on_opt_error == "raise":
+                raise AssertionError(msg)
+            else:
+                warnings.warn(msg)
+        fgraph.remove_feature(change_tracker)
+
+
+class MeasurableEquilibriumDB(RewriteDatabase):
+    """A database of rewrites that should be applied until equilibrium is reached.
+
+    This will return a MeasurableEquilibriumGraphRewriter when queried.
+
     """
 
     def query(self, *tags, **kwtags):
-        res = super().query(*tags, **kwtags)
-        res.failure_callback = None
-        return res
+        rewriters = super().query(*tags, **kwtags)
+        return MeasurableEquilibriumGraphRewriter(
+            rewriters,
+            max_use_ratio=config.optdb__max_use_ratio,
+        )
 
 
 class PreserveRVMappings(Feature):
@@ -116,7 +209,7 @@ class PreserveRVMappings(Feature):
         """
         self.rv_values = rv_values
         self.original_values = {v: v for v in rv_values.values()}
-        self.measurable_conversions: Dict[Variable, Variable] = {}
+        self.needs_measuring = set(rv_values.keys())
 
     def on_attach(self, fgraph):
         if hasattr(fgraph, "preserve_rv_mappings"):
@@ -163,14 +256,21 @@ class PreserveRVMappings(Feature):
         r_value_var = self.rv_values.pop(r, None)
         if r_value_var is not None:
             self.rv_values[new_r] = r_value_var
-        elif (
-            new_r not in self.rv_values
-            and r.owner
-            and new_r.owner
-            and not isinstance(r.owner.op, MeasurableVariable)
-            and isinstance(new_r.owner.op, MeasurableVariable)
-        ):
-            self.measurable_conversions[r] = new_r
+            self.needs_measuring.add(new_r)
+            if new_r.name is None:
+                new_r.name = r.name
+
+    def request_measurable(self, vars: Sequence[Variable]) -> List[Variable]:
+        measurable = []
+        for var in vars:
+            # Input vars or valued vars can't be measured for derived expressions
+            if not var.owner or var in self.rv_values:
+                continue
+            if isinstance(var.owner.op, MeasurableVariable):
+                measurable.append(var)
+            else:
+                self.needs_measuring.add(var)
+        return measurable
 
 
 @register_canonicalize
@@ -222,12 +322,9 @@ def incsubtensor_rv_replace(fgraph, node):
 
     This provides a means of specifying "missing data", for instance.
     """
-    rv_map_feature = getattr(fgraph, "preserve_rv_mappings", None)
+    rv_map_feature: Optional[PreserveRVMappings] = getattr(fgraph, "preserve_rv_mappings", None)
 
     if rv_map_feature is None:
-        return None  # pragma: no cover
-
-    if not isinstance(node.op, inc_subtensor_ops):
         return None  # pragma: no cover
 
     rv_var = node.outputs[0]
@@ -236,12 +333,8 @@ def incsubtensor_rv_replace(fgraph, node):
 
     base_rv_var = node.inputs[0]
 
-    if not (
-        base_rv_var.owner
-        and isinstance(base_rv_var.owner.op, MeasurableVariable)
-        and base_rv_var not in rv_map_feature.rv_values
-    ):
-        return None  # pragma: no cover
+    if not rv_map_feature.request_measurable([base_rv_var]):
+        return None
 
     data = node.inputs[1]
     idx = indices_from_subtensor(getattr(node.op, "idx_list", None), node.inputs[2:])
@@ -262,7 +355,7 @@ logprob_rewrites_db.register("pre-canonicalize", optdb.query("+canonicalize"), "
 # These rewrites convert un-measurable variables into their measurable forms,
 # but they need to be reapplied, because some of the measurable forms require
 # their inputs to be measurable.
-measurable_ir_rewrites_db = NoCallbackEquilibriumDB()
+measurable_ir_rewrites_db = MeasurableEquilibriumDB()
 measurable_ir_rewrites_db.name = "measurable_ir_rewrites_db"
 
 logprob_rewrites_db.register("measurable_ir_rewrites", measurable_ir_rewrites_db, "basic")
@@ -360,11 +453,6 @@ def construct_ir_fgraph(
     if ir_rewriter is None:
         ir_rewriter = logprob_rewrites_db.query(RewriteDatabaseQuery(include=["basic"]))
     ir_rewriter.rewrite(fgraph)
-
-    if rv_remapper.measurable_conversions:
-        # Undo un-valued measurable IR rewrites
-        new_to_old = tuple((v, k) for k, v in reversed(rv_remapper.measurable_conversions.items()))
-        fgraph.replace_all(new_to_old)
 
     return fgraph, rv_values, memo
 

--- a/pymc/logprob/tensor.py
+++ b/pymc/logprob/tensor.py
@@ -52,7 +52,6 @@ from pytensor.tensor.random.rewriting import (
 
 from pymc.logprob.abstract import MeasurableVariable, _logprob, _logprob_helper
 from pymc.logprob.rewriting import PreserveRVMappings, measurable_ir_rewrites_db
-from pymc.logprob.utils import ignore_logprob, ignore_logprob_multiple_vars
 
 
 @node_rewriter([BroadcastTo])
@@ -202,17 +201,10 @@ def find_measurable_stacks(
 ) -> Optional[List[Union[MeasurableMakeVector, MeasurableJoin]]]:
     r"""Finds `Joins`\s and `MakeVector`\s for which a `logprob` can be computed."""
 
-    if isinstance(node.op, (MeasurableMakeVector, MeasurableJoin)):
-        return None  # pragma: no cover
-
     rv_map_feature: Optional[PreserveRVMappings] = getattr(fgraph, "preserve_rv_mappings", None)
 
     if rv_map_feature is None:
         return None  # pragma: no cover
-
-    rvs_to_values = rv_map_feature.rv_values
-
-    stack_out = node.outputs[0]
 
     is_join = isinstance(node.op, Join)
 
@@ -221,22 +213,13 @@ def find_measurable_stacks(
     else:
         base_vars = node.inputs
 
-    if not all(
-        base_var.owner
-        and isinstance(base_var.owner.op, MeasurableVariable)
-        and base_var not in rvs_to_values
-        for base_var in base_vars
-    ):
-        return None  # pragma: no cover
-
-    unmeasurable_base_vars = ignore_logprob_multiple_vars(base_vars, rvs_to_values)
+    if rv_map_feature.request_measurable(base_vars) != base_vars:
+        return None
 
     if is_join:
-        measurable_stack = MeasurableJoin()(axis, *unmeasurable_base_vars)
+        measurable_stack = MeasurableJoin()(axis, *base_vars)
     else:
-        measurable_stack = MeasurableMakeVector(node.op.dtype)(*unmeasurable_base_vars)
-
-    measurable_stack.name = stack_out.name
+        measurable_stack = MeasurableMakeVector(node.op.dtype)(*base_vars)
 
     return [measurable_stack]
 
@@ -287,13 +270,13 @@ def logprob_dimshuffle(op, values, base_var, **kwargs):
 def find_measurable_dimshuffles(fgraph, node) -> Optional[List[MeasurableDimShuffle]]:
     r"""Finds `Dimshuffle`\s for which a `logprob` can be computed."""
 
-    if isinstance(node.op, MeasurableDimShuffle):
-        return None  # pragma: no cover
-
     rv_map_feature: Optional[PreserveRVMappings] = getattr(fgraph, "preserve_rv_mappings", None)
 
     if rv_map_feature is None:
         return None  # pragma: no cover
+
+    if not rv_map_feature.request_measurable(node.inputs):
+        return None
 
     base_var = node.inputs[0]
 
@@ -305,20 +288,12 @@ def find_measurable_dimshuffles(fgraph, node) -> Optional[List[MeasurableDimShuf
     # lifted towards the base RandomVariable.
     # TODO: If we include the support axis as meta information in each
     # intermediate MeasurableVariable, we can lift this restriction.
-    if not (
-        base_var.owner
-        and isinstance(base_var.owner.op, RandomVariable)
-        and base_var not in rv_map_feature.rv_values
-    ):
+    if not isinstance(base_var.owner.op, RandomVariable):
         return None  # pragma: no cover
-
-    # Make base_vars unmeasurable
-    base_var = ignore_logprob(base_var)
 
     measurable_dimshuffle = MeasurableDimShuffle(node.op.input_broadcastable, node.op.new_order)(
         base_var
     )
-    measurable_dimshuffle.name = node.outputs[0].name
 
     return [measurable_dimshuffle]
 

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -529,7 +529,7 @@ def find_measurable_transforms(fgraph: FunctionGraph, node: Node) -> Optional[Li
     # would be invalid
     other_inputs = tuple(inp for inp in node.inputs if inp is not measurable_input)
 
-    if not check_potential_measurability(other_inputs, rv_map_feature):
+    if check_potential_measurability(other_inputs, rv_map_feature.rv_values.keys()):
         return None
 
     scalar_op = node.op.scalar_op

--- a/pymc/logprob/utils.py
+++ b/pymc/logprob/utils.py
@@ -38,6 +38,7 @@ import warnings
 
 from typing import (
     Callable,
+    Container,
     Dict,
     Generator,
     Iterable,
@@ -210,22 +211,24 @@ def indices_from_subtensor(idx_list, indices):
     )
 
 
-def check_potential_measurability(inputs: Tuple[TensorVariable], rv_map_feature):
+def check_potential_measurability(
+    inputs: Tuple[TensorVariable], valued_rvs: Container[TensorVariable]
+) -> bool:
     if any(
-        ancestor_node
-        for ancestor_node in walk_model(
+        ancestor_var
+        for ancestor_var in walk_model(
             inputs,
             walk_past_rvs=False,
-            stop_at_vars=set(rv_map_feature.rv_values),
+            stop_at_vars=set(valued_rvs),
         )
         if (
-            ancestor_node.owner
-            and isinstance(ancestor_node.owner.op, MeasurableVariable)
-            and ancestor_node not in rv_map_feature.rv_values
+            ancestor_var.owner
+            and isinstance(ancestor_var.owner.op, MeasurableVariable)
+            and ancestor_var not in valued_rvs
         )
     ):
-        return None
-    return True
+        return True
+    return False
 
 
 class ParameterValueError(ValueError):

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -65,6 +65,7 @@ from pytensor.tensor.var import TensorConstant, TensorVariable
 from pymc.exceptions import NotConstantValueError
 from pymc.logprob.transforms import RVTransform
 from pymc.logprob.utils import CheckParameterValue
+from pymc.util import makeiter
 from pymc.vartypes import continuous_types, isgenerator, typefilter
 
 PotentialShapeType = Union[int, np.ndarray, Sequence[Union[int, Variable]], TensorVariable]
@@ -548,13 +549,6 @@ def hessian_diag(f, vars=None):
         return -pt.concatenate([hessian_diag1(f, v) for v in vars], axis=0)
     else:
         return empty_gradient
-
-
-def makeiter(a):
-    if isinstance(a, (tuple, list)):
-        return a
-    else:
-        return [a]
 
 
 class IdentityOp(scalar.UnaryScalarOp):

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -14,7 +14,7 @@
 import functools as ft
 import itertools as it
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pytensor
@@ -24,7 +24,7 @@ import pytest
 from numpy import random as nr
 from numpy import testing as npt
 from pytensor.compile.mode import Mode
-from pytensor.graph.basic import walk
+from pytensor.graph.basic import Variable, walk
 from pytensor.graph.op import HasInnerGraph
 from pytensor.graph.rewriting.basic import in2out
 from pytensor.tensor import TensorVariable
@@ -46,6 +46,7 @@ from pymc.pytensorf import (
     inputvars,
     intX,
     local_check_parameter_to_ninf_switch,
+    makeiter,
 )
 
 # This mode can be used for tests where model compilations takes the bulk of the runtime
@@ -963,7 +964,7 @@ def seeded_numpy_distribution_builder(dist_name: str) -> Callable:
     )
 
 
-def assert_no_rvs(var):
+def assert_no_rvs(vars: Union[Variable, Sequence[Variable]]):
     """Assert that there are no `MeasurableVariable` nodes in a graph."""
 
     def expand(r):
@@ -976,6 +977,6 @@ def assert_no_rvs(var):
 
             return inputs
 
-    for v in walk([var], expand, False):
+    for v in walk(makeiter(vars), expand, False):
         if v.owner and isinstance(v.owner.op, (RandomVariable, MeasurableVariable)):
             raise AssertionError(f"RV found in graph: {v}")

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -510,3 +510,10 @@ def _add_future_warning_tag(var) -> None:
         for k, v in old_tag.__dict__.items():
             new_tag.__dict__.setdefault(k, v)
         var.tag = new_tag
+
+
+def makeiter(a):
+    if isinstance(a, (tuple, list)):
+        return a
+    else:
+        return [a]

--- a/pymc/variational/approximations.py
+++ b/pymc/variational/approximations.py
@@ -25,7 +25,7 @@ import pymc as pm
 
 from pymc.blocking import DictToArrayBijection
 from pymc.distributions.dist_math import rho2sigma
-from pymc.pytensorf import makeiter
+from pymc.util import makeiter
 from pymc.variational import opvi
 from pymc.variational.opvi import (
     Approximation,

--- a/pymc/variational/minibatch_rv.py
+++ b/pymc/variational/minibatch_rv.py
@@ -19,13 +19,7 @@ from pytensor import Variable, config
 from pytensor.graph import Apply, Op
 from pytensor.tensor import NoneConst, TensorVariable, as_tensor_variable
 
-from pymc.logprob.abstract import (
-    MeasurableVariable,
-    _get_measurable_outputs,
-    _logprob,
-    _logprob_helper,
-)
-from pymc.logprob.utils import ignore_logprob
+from pymc.logprob.abstract import MeasurableVariable, _logprob, _logprob_helper
 
 
 class MinibatchRandomVariable(Op):
@@ -81,8 +75,6 @@ def create_minibatch_rv(
     else:
         raise TypeError(f"Invalid type for total_size: {total_size}")
 
-    rv = ignore_logprob(rv)
-
     return cast(TensorVariable, minibatch_rv(rv, *total_size))
 
 
@@ -103,11 +95,6 @@ def get_scaling(total_size: Sequence[Variable], shape: TensorVariable) -> Tensor
 
 
 MeasurableVariable.register(MinibatchRandomVariable)
-
-
-@_get_measurable_outputs.register(MinibatchRandomVariable)
-def _get_measurable_outputs_minibatch_random_variable(op, node):
-    return [node.outputs[0]]
 
 
 @_logprob.register(MinibatchRandomVariable)

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -72,7 +72,6 @@ from pymc.pytensorf import (
     compile_pymc,
     find_rng_nodes,
     identity,
-    makeiter,
     reseed_rngs,
 )
 from pymc.util import (
@@ -80,6 +79,7 @@ from pymc.util import (
     WithMemoization,
     _get_seeds_per_chain,
     locally_cachedmethod,
+    makeiter,
 )
 from pymc.variational.minibatch_rv import MinibatchRandomVariable, get_scaling
 from pymc.variational.updates import adagrad_window

--- a/tests/logprob/test_abstract.py
+++ b/tests/logprob/test_abstract.py
@@ -46,15 +46,7 @@ from pytensor.tensor.random.basic import NormalRV
 
 import pymc as pm
 
-from pymc.logprob.abstract import (
-    MeasurableElemwise,
-    MeasurableVariable,
-    UnmeasurableVariable,
-    _get_measurable_outputs,
-    _logcdf_helper,
-    assign_custom_measurable_outputs,
-    noop_measurable_outputs_fn,
-)
+from pymc.logprob.abstract import MeasurableElemwise, MeasurableVariable, _logcdf_helper
 from pymc.logprob.basic import logcdf
 
 
@@ -63,83 +55,6 @@ def assert_equal_hash(classA, classB):
     assert hash(classB) == hash(classB.id_obj)
     assert classA == classB
     assert hash(classA) == hash(classB)
-
-
-@pytest.mark.parametrize(
-    "op, id_obj, class_dict",
-    [
-        (None, None, UnmeasurableVariable.__dict__),
-        (None, (1, 2), UnmeasurableVariable.__dict__),
-        (
-            NormalRV,
-            (NormalRV, noop_measurable_outputs_fn),
-            UnmeasurableVariable.__dict__,
-        ),
-    ],
-)
-def test_unmeasurable_variable_class(op, id_obj, class_dict):
-    A_dict = class_dict.copy()
-    B_dict = class_dict.copy()
-
-    if id_obj is not None:
-        A_dict["id_obj"] = id_obj
-        B_dict["id_obj"] = id_obj
-
-    if op is None:
-        parent_classes = (UnmeasurableVariable,)
-    else:
-        parent_classes = (op, UnmeasurableVariable)
-
-    A = type("A", parent_classes, A_dict)
-    B = type("B", parent_classes, B_dict)
-
-    assert_equal_hash(A, B)
-
-
-def test_unmeasurable_meta_hash_reassignment():
-    A_dict = UnmeasurableVariable.__dict__.copy()
-    B_dict = UnmeasurableVariable.__dict__.copy()
-
-    A_dict["id_obj"] = (1, 2)
-    B_dict["id_obj"] = (1, 3)
-
-    A = type("A", (UnmeasurableVariable,), A_dict)
-    B = type("B", (UnmeasurableVariable,), B_dict)
-
-    assert A != B
-    assert hash(A) != hash(B)
-
-    A.id_obj = (1, 3)
-
-    assert_equal_hash(A, B)
-
-
-def test_assign_custom_measurable_outputs():
-    srng = pt.random.RandomStream(seed=2320)
-
-    X_rv = srng.normal(-10.0, 0.1, name="X")
-    Y_rv = srng.normal(10.0, 0.1, name="Y")
-
-    # manually checking assign_custom_measurable_outputs
-    unmeasurable_X = assign_custom_measurable_outputs(X_rv.owner).op
-    unmeasurable_Y = assign_custom_measurable_outputs(Y_rv.owner).op
-
-    assert_equal_hash(unmeasurable_X.__class__, unmeasurable_Y.__class__)
-    assert unmeasurable_X.__class__.__name__.startswith("Unmeasurable")
-    assert unmeasurable_X.__class__ in _get_measurable_outputs.registry
-
-    # passing unmeasurable_X into assign_custom_measurable_outputs does nothing
-
-    unmeas_X_rv = unmeasurable_X(-5, 0.1, name="unmeas_X")
-
-    unmeasurable_X2_node = assign_custom_measurable_outputs(unmeas_X_rv.owner)
-    unmeasurable_X2 = unmeasurable_X2_node.op
-
-    assert unmeasurable_X2_node == unmeas_X_rv.owner
-    assert_equal_hash(unmeasurable_X.__class__, unmeasurable_X2.__class__)
-
-    with pytest.raises(ValueError):
-        assign_custom_measurable_outputs(unmeas_X_rv.owner, lambda x: x)
 
 
 def test_measurable_elemwise():

--- a/tests/logprob/test_basic.py
+++ b/tests/logprob/test_basic.py
@@ -223,7 +223,7 @@ def test_warn_random_found_factorized_joint_logprob():
 
     y_vv = y_rv.clone()
 
-    with pytest.warns(UserWarning, match="RandomVariables were found in the derived graph"):
+    with pytest.warns(UserWarning, match="Random variables detected in the logp graph: {x}"):
         factorized_joint_logprob({y_rv: y_vv})
 
     with warnings.catch_warnings():
@@ -443,7 +443,9 @@ def test_warn_random_found_probability_inference(func, scipy_func, test_value):
         # In which case the inference should either return that or fail explicitly
         # For now, the lopgrob submodule treats the input as a stochastic value.
         rv = pt.exp(pm.Normal.dist(input_rv))
-        with pytest.warns(UserWarning, match="RandomVariables were found in the derived graph"):
+        with pytest.warns(
+            UserWarning, match="RandomVariables {input} were found in the derived graph"
+        ):
             assert func(rv, 0.0)
 
         res = func(rv, 0.0, warn_missing_rvs=False)

--- a/tests/logprob/test_basic.py
+++ b/tests/logprob/test_basic.py
@@ -223,7 +223,7 @@ def test_warn_random_found_factorized_joint_logprob():
 
     y_vv = y_rv.clone()
 
-    with pytest.warns(UserWarning, match="Found a random variable that was neither among"):
+    with pytest.warns(UserWarning, match="RandomVariables were found in the derived graph"):
         factorized_joint_logprob({y_rv: y_vv})
 
     with warnings.catch_warnings():

--- a/tests/logprob/test_checks.py
+++ b/tests/logprob/test_checks.py
@@ -81,7 +81,7 @@ def test_assert_logprob():
     rv = pt.random.normal()
     assert_op = Assert("Test assert")
     # Example: Add assert that rv must be positive
-    assert_rv = assert_op(rv > 0, rv)
+    assert_rv = assert_op(rv, rv > 0)
     assert_rv.name = "assert_rv"
 
     assert_vv = assert_rv.clone()
@@ -90,8 +90,10 @@ def test_assert_logprob():
     # Check valid value is correct and doesn't raise
     # Since here the value to the rv satisfies the condition, no error is raised.
     valid_value = 3.0
-    with pytest.raises(AssertionError, match="Test assert"):
-        assert_logp.eval({assert_vv: valid_value})
+    np.testing.assert_allclose(
+        assert_logp.eval({assert_vv: valid_value}),
+        stats.norm.logpdf(valid_value),
+    )
 
     # Check invalid value
     # Since here the value to the rv is negative, an exception is raised as the condition is not met

--- a/tests/logprob/test_checks.py
+++ b/tests/logprob/test_checks.py
@@ -33,6 +33,7 @@
 #   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
+import re
 
 import numpy as np
 import pytensor
@@ -43,7 +44,7 @@ from pytensor.raise_op import Assert
 from scipy import stats
 
 from pymc.distributions import Dirichlet
-from pymc.logprob.joint_logprob import factorized_joint_logprob
+from pymc.logprob.basic import factorized_joint_logprob
 from tests.distributions.test_multivariate import dirichlet_logpdf
 
 

--- a/tests/logprob/test_composite_logprob.py
+++ b/tests/logprob/test_composite_logprob.py
@@ -139,7 +139,7 @@ def test_unvalued_ir_reversion(nested):
 
     z_fgraph, _, memo = construct_ir_fgraph(rv_values)
 
-    assert len(z_fgraph.preserve_rv_mappings.measurable_conversions) == 1 + nested
+    # assert len(z_fgraph.preserve_rv_mappings.measurable_conversions) == 1
     assert (
         sum(isinstance(node.op, MeasurableVariable) for node in z_fgraph.apply_nodes) == 2
     )  # Just the 2 rvs

--- a/tests/logprob/test_mixture.py
+++ b/tests/logprob/test_mixture.py
@@ -933,8 +933,6 @@ def test_switch_mixture():
 
     fgraph, _, _ = construct_ir_fgraph({Z1_rv: z_vv, I_rv: i_vv})
 
-    assert fgraph.outputs[0].name == "Z1-mixture"
-
     # building the identical graph but with a stack to check that mixture computations are identical
 
     Z2_rv = pt.stack((X_rv, Y_rv))[I_rv]

--- a/tests/logprob/test_mixture.py
+++ b/tests/logprob/test_mixture.py
@@ -984,7 +984,7 @@ def test_ifelse_mixture_multiple_components():
 
     if_var = pt.scalar("if_var", dtype="bool")
     comp_then1 = pt.random.normal(size=(2,), name="comp_true1")
-    comp_then2 = pt.random.normal(comp_then1, size=(2, 2), name="comp_then2")
+    comp_then2 = comp_then1 + pt.random.normal(size=(2, 2), name="comp_then2")
     comp_else1 = pt.random.halfnormal(size=(4,), name="comp_else1")
     comp_else2 = pt.random.halfnormal(size=(4, 4), name="comp_else2")
 

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -48,7 +48,7 @@ from pytensor.graph.fg import FunctionGraph
 from pytensor.scan import scan
 
 from pymc.distributions.transforms import _default_transform, log, logodds
-from pymc.logprob.abstract import MeasurableVariable, _get_measurable_outputs, _logprob
+from pymc.logprob.abstract import MeasurableVariable, _logprob
 from pymc.logprob.basic import factorized_joint_logprob, logp
 from pymc.logprob.transforms import (
     ChainedTransform,
@@ -488,10 +488,6 @@ def multiout_measurable_op():
     def logp_multiout(op, values, mu1, mu2):
         value1, value2 = values
         return value1 + mu1, value2 + mu2
-
-    @_get_measurable_outputs.register(TestOpFromGraph)
-    def measurable_multiout_op_outputs(op, node):
-        return node.outputs
 
     return multiout_op
 

--- a/tests/logprob/test_utils.py
+++ b/tests/logprob/test_utils.py
@@ -51,6 +51,7 @@ from pymc.logprob.abstract import MeasurableVariable
 from pymc.logprob.basic import joint_logp, logp
 from pymc.logprob.utils import (
     ParameterValueError,
+    check_potential_measurability,
     dirac_delta,
     rvs_to_value_vars,
     walk_model,
@@ -194,3 +195,17 @@ def test_dirac_delta_logprob(dist_params, obs):
         return 0.0 if obs == c else -np.inf
 
     scipy_logprob_tester(x, obs, dist_params, test_fn=scipy_logprob)
+
+
+def test_check_potential_measurability():
+    x1 = pt.random.normal()
+    x2 = pt.random.normal()
+    x3 = pt.scalar("x3")
+    y = pt.exp(x1 + x2 + x3)
+
+    # In the first three cases, y is potentially measurable, because it has at least on unvalued RV input
+    assert check_potential_measurability([y], {})
+    assert check_potential_measurability([y], {x1})
+    assert check_potential_measurability([y], {x2})
+    # y is not potentially measurable because both RV inputs are valued
+    assert not check_potential_measurability([y], {x1, x2})

--- a/tests/logprob/test_utils.py
+++ b/tests/logprob/test_utils.py
@@ -47,13 +47,11 @@ from pytensor.tensor.random.basic import normal, uniform
 
 import pymc as pm
 
-from pymc.logprob.abstract import MeasurableVariable, get_measurable_outputs
+from pymc.logprob.abstract import MeasurableVariable
 from pymc.logprob.basic import joint_logp, logp
 from pymc.logprob.utils import (
     ParameterValueError,
     dirac_delta,
-    ignore_logprob,
-    reconsider_logprob,
     rvs_to_value_vars,
     walk_model,
 )
@@ -196,67 +194,3 @@ def test_dirac_delta_logprob(dist_params, obs):
         return 0.0 if obs == c else -np.inf
 
     scipy_logprob_tester(x, obs, dist_params, test_fn=scipy_logprob)
-
-
-def test_ignore_reconsider_logprob_basic():
-    x = pm.Normal.dist()
-    (measurable_x_out,) = get_measurable_outputs(x.owner.op, x.owner)
-    assert measurable_x_out is x.owner.outputs[1]
-
-    new_x = ignore_logprob(x)
-    assert new_x is not x
-    assert isinstance(new_x.owner.op, pm.Normal)
-    assert type(new_x.owner.op).__name__ == "UnmeasurableNormalRV"
-    # Confirm that it does not have measurable output
-    assert get_measurable_outputs(new_x.owner.op, new_x.owner) == []
-
-    # Test that it will not clone a variable that is already unmeasurable
-    assert ignore_logprob(new_x) is new_x
-
-    orig_x = reconsider_logprob(new_x)
-    assert orig_x is not new_x
-    assert isinstance(orig_x.owner.op, pm.Normal)
-    assert type(orig_x.owner.op).__name__ == "NormalRV"
-    # Confirm that it has measurable outputs again
-    assert get_measurable_outputs(orig_x.owner.op, orig_x.owner) == [orig_x.owner.outputs[1]]
-
-    # Test that will not clone a variable that is already measurable
-    assert reconsider_logprob(x) is x
-    assert reconsider_logprob(orig_x) is orig_x
-
-
-def test_ignore_reconsider_logprob_model():
-    def custom_logp(value, x):
-        # custom_logp is just the logp of x at value
-        x = reconsider_logprob(x)
-        return joint_logp(
-            [x],
-            rvs_to_values={x: value},
-            rvs_to_transforms={},
-        )
-
-    with pm.Model():
-        x = pm.Normal.dist()
-        y = pm.CustomDist("y", x, logp=custom_logp)
-    with pytest.warns(
-        UserWarning,
-        match="Found a random variable that was neither among the observations "
-        "nor the conditioned variables",
-    ):
-        joint_logp(
-            [y],
-            rvs_to_values={y: y.type()},
-            rvs_to_transforms={},
-        )
-
-    # The above warning should go away with ignore_logprob.
-    with pm.Model():
-        x = ignore_logprob(pm.Normal.dist())
-        y = pm.CustomDist("y", x, logp=custom_logp)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        assert joint_logp(
-            [y],
-            rvs_to_values={y: y.type()},
-            rvs_to_transforms={},
-        )

--- a/tests/logprob/utils.py
+++ b/tests/logprob/utils.py
@@ -39,12 +39,9 @@ from typing import Optional
 import numpy as np
 
 from pytensor import tensor as pt
-from pytensor.tensor.var import TensorVariable
 from scipy import stats as stats
 
-from pymc.logprob import factorized_joint_logprob, icdf, logcdf, logp
-from pymc.logprob.abstract import get_measurable_outputs
-from pymc.logprob.utils import ignore_logprob
+from pymc.logprob import icdf, logcdf, logp
 
 
 def scipy_logprob(obs, p):
@@ -116,52 +113,3 @@ def scipy_logprob_tester(
     np.testing.assert_array_equal(pytensor_res_val.shape, numpy_res.shape)
 
     np.testing.assert_array_almost_equal(pytensor_res_val, numpy_res, 4)
-
-
-def test_ignore_logprob_basic():
-    x = Normal.dist()
-    (measurable_x_out,) = get_measurable_outputs(x.owner.op, x.owner)
-    assert measurable_x_out is x.owner.outputs[1]
-
-    new_x = ignore_logprob(x)
-    assert new_x is not x
-    assert isinstance(new_x.owner.op, Normal)
-    assert type(new_x.owner.op).__name__ == "UnmeasurableNormalRV"
-    # Confirm that it does not have measurable output
-    assert get_measurable_outputs(new_x.owner.op, new_x.owner) is None
-
-    # Test that it will not clone a variable that is already unmeasurable
-    new_new_x = ignore_logprob(new_x)
-    assert new_new_x is new_x
-
-
-def test_ignore_logprob_model():
-    # logp that does not depend on input
-    def logp(value, x):
-        return value
-
-    with Model() as m:
-        x = Normal.dist()
-        y = CustomDist("y", x, logp=logp)
-    with pytest.warns(
-        UserWarning,
-        match="Found a random variable that was neither among the observations "
-        "nor the conditioned variables",
-    ):
-        joint_logp(
-            [y],
-            rvs_to_values={y: y.type()},
-            rvs_to_transforms={},
-        )
-
-    # The above warning should go away with ignore_logprob.
-    with Model() as m:
-        x = ignore_logprob(Normal.dist())
-        y = CustomDist("y", x, logp=logp)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        assert joint_logp(
-            [y],
-            rvs_to_values={y: y.type()},
-            rvs_to_transforms={},
-        )

--- a/tests/logprob/utils.py
+++ b/tests/logprob/utils.py
@@ -47,47 +47,6 @@ from pymc.logprob.abstract import get_measurable_outputs
 from pymc.logprob.utils import ignore_logprob
 
 
-def simulate_poiszero_hmm(
-    N, mu=10.0, pi_0_a=np.r_[1, 1], p_0_a=np.r_[5, 1], p_1_a=np.r_[1, 1], seed=None
-):
-    rng = np.random.default_rng(seed)
-
-    p_0 = rng.dirichlet(p_0_a)
-    p_1 = rng.dirichlet(p_1_a)
-
-    Gammas = np.stack([p_0, p_1])
-    Gammas = np.broadcast_to(Gammas, (N,) + Gammas.shape)
-
-    pi_0 = rng.dirichlet(pi_0_a)
-    s_0 = rng.choice(pi_0.shape[0], p=pi_0)
-    s_tm1 = s_0
-
-    y_samples = np.empty((N,), dtype=np.int64)
-    s_samples = np.empty((N,), dtype=np.int64)
-
-    for i in range(N):
-        s_t = rng.choice(Gammas.shape[-1], p=Gammas[i, s_tm1])
-        s_samples[i] = s_t
-        s_tm1 = s_t
-
-        if s_t == 1:
-            y_samples[i] = rng.poisson(mu)
-        else:
-            y_samples[i] = 0
-
-    sample_point = {
-        "Y_t": y_samples,
-        "p_0": p_0,
-        "p_1": p_1,
-        "S_t": s_samples,
-        "P_tt": Gammas,
-        "S_0": s_0,
-        "pi_0": pi_0,
-    }
-
-    return sample_point
-
-
 def scipy_logprob(obs, p):
     if p.ndim > 1:
         if p.ndim > obs.ndim:


### PR DESCRIPTION
This PR changes the logic used for logprob inference. Instead of eager bottom-up conversion to measurable variables in the IR rewrites, we only convert nodes whose outputs were marked as "needs_measuring". This is achieved with the new `PreserveRVMappings.request_measurable` method.

This strategy obviates the need to undo unnecessary conversions. It also obviates a subtle need for graph cloning via the `ignore_logprob` helper, which prevented intermediate measurable rewrites from being reversed when they were needed to derive the logprob of valued variables, but were not directly valued. This indirect role of `ignore_logprob` is now done more explicitly and efficiently via the `request_measurable` method.

All other uses of `ignore_logprob` (and `reconsider_logprob`) were removed from the codebase

The `get_measurable_outputs` dispatching was also abandoned in favor of only considering outputs associated with value variables.

A new MergeOptimizerRewrite was written to further target local rewrites to only those nodes whose variables have been marked as `needs_measuring`. This should be rather more efficient

Closes #6728 
Supersedes #6698 

CC @shreyas3156 @Dhruvanshu-Joshi 

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6746.org.readthedocs.build/en/6746/

<!-- readthedocs-preview pymc end -->