### PR TITLE
Fix `check_all_tests_are_covered` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
     - id: check-no-tests-are-ignored
       additional_dependencies: [pandas,pyyaml]
       entry: python scripts/check_all_tests_are_covered.py
-      files: ^\.github/workflows/pytest\.yml$
+      files: ^.github/workflows/tests.yml$
       language: python
       name: Check no tests are ignored
       pass_filenames: false

--- a/scripts/check_all_tests_are_covered.py
+++ b/scripts/check_all_tests_are_covered.py
@@ -105,9 +105,11 @@ def from_yaml():
     _log.info("Number of test runs (❌=0, ✅=once)\n%s", df.replace(0, "❌").replace(1, "✅"))
 
     if ignored_by_all:
-        _log.warning("%i tests are completely ignored:\n%s", len(ignored_by_all), ignored_by_all)
+        raise AssertionError(
+            f"{len(ignored_by_all)} tests are completely ignored:\n{ignored_by_all}"
+        )
     if run_multiple_times:
-        raise Exception(
+        raise AssertionError(
             f"{len(run_multiple_times)} tests are run multiple times with the same OS and floatX setting:\n{run_multiple_times}"
         )
     return


### PR DESCRIPTION
Accidentally deleted this branch. Previous in #6756

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6759.org.readthedocs.build/en/6759/

<!-- readthedocs-preview pymc end -->