### PR TITLE
Rename basic "joint_logprob" functions to "conditional_logp"

### DIFF
--- a/pymc/logprob/__init__.py
+++ b/pymc/logprob/__init__.py
@@ -34,7 +34,13 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
-from pymc.logprob.basic import factorized_joint_logprob, icdf, joint_logp, logcdf, logp
+from pymc.logprob.basic import (
+    conditional_logp,
+    icdf,
+    logcdf,
+    logp,
+    transformed_conditional_logp,
+)
 
 # isort: off
 # Add rewrites to the DBs

--- a/pymc/logprob/scan.py
+++ b/pymc/logprob/scan.py
@@ -54,7 +54,7 @@ from pytensor.tensor.var import TensorVariable
 from pytensor.updates import OrderedUpdates
 
 from pymc.logprob.abstract import MeasurableVariable, _logprob
-from pymc.logprob.basic import factorized_joint_logprob
+from pymc.logprob.basic import conditional_logp
 from pymc.logprob.rewriting import (
     PreserveRVMappings,
     construct_ir_fgraph,
@@ -310,7 +310,7 @@ def logprob_ScanRV(op, values, *inputs, name=None, **kwargs):
 
     def create_inner_out_logp(value_map: Dict[TensorVariable, TensorVariable]) -> TensorVariable:
         """Create a log-likelihood inner-output for a `Scan`."""
-        logp_parts = factorized_joint_logprob(value_map, warn_rvs=False)
+        logp_parts = conditional_logp(value_map, warn_rvs=False)
         return logp_parts.values()
 
     logp_scan_args = convert_outer_out_to_in(

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -64,7 +64,7 @@ from pymc.exceptions import (
     ShapeWarning,
 )
 from pymc.initial_point import make_initial_point_fn
-from pymc.logprob.basic import joint_logp
+from pymc.logprob.basic import transformed_conditional_logp
 from pymc.logprob.utils import ParameterValueError
 from pymc.pytensorf import (
     PointFunc,
@@ -761,7 +761,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         rv_logps: List[TensorVariable] = []
         if rvs:
-            rv_logps = joint_logp(
+            rv_logps = transformed_conditional_logp(
                 rvs=rvs,
                 rvs_to_values=self.rvs_to_values,
                 rvs_to_transforms=self.rvs_to_transforms,

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -35,7 +35,7 @@ import pymc as pm
 from pymc.distributions.distribution import Distribution
 from pymc.distributions.shape_utils import change_dist_size
 from pymc.initial_point import make_initial_point_fn
-from pymc.logprob.basic import icdf, joint_logp, logcdf, logp
+from pymc.logprob.basic import icdf, logcdf, logp, transformed_conditional_logp
 from pymc.logprob.utils import ParameterValueError, find_rvs_in_graph
 from pymc.pytensorf import (
     compile_pymc,
@@ -673,7 +673,7 @@ def assert_moment_is_expected(model, expected, check_finite_logp=True):
 
     if check_finite_logp:
         logp_moment = (
-            joint_logp(
+            transformed_conditional_logp(
                 (model["x"],),
                 rvs_to_values={model["x"]: pt.constant(moment)},
                 rvs_to_transforms={},

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -25,7 +25,7 @@ from pytensor.tensor.var import TensorConstant
 import pymc as pm
 import pymc.distributions.transforms as tr
 
-from pymc.logprob.basic import joint_logp
+from pymc.logprob.basic import transformed_conditional_logp
 from pymc.pytensorf import floatX, jacobian
 from pymc.testing import (
     Circ,
@@ -308,7 +308,7 @@ class TestElementWiseLogp(SeededTest):
         assert model.logp(x, sum=False)[0].ndim == x.ndim == jacob_det.ndim
 
         v1 = (
-            joint_logp(
+            transformed_conditional_logp(
                 (x,),
                 rvs_to_values={x: x_val_transf},
                 rvs_to_transforms={x: transform},
@@ -318,7 +318,7 @@ class TestElementWiseLogp(SeededTest):
             .eval({x_val_transf: test_array_transf})
         )
         v2 = (
-            joint_logp(
+            transformed_conditional_logp(
                 (x,),
                 rvs_to_values={x: x_val_untransf},
                 rvs_to_transforms={},
@@ -356,7 +356,7 @@ class TestElementWiseLogp(SeededTest):
             assert model.logp(x, sum=False)[0].ndim == (x.ndim - 1) == jacob_det.ndim
 
         a = (
-            joint_logp(
+            transformed_conditional_logp(
                 (x,),
                 rvs_to_values={x: x_val_transf},
                 rvs_to_transforms={x: transform},
@@ -366,7 +366,7 @@ class TestElementWiseLogp(SeededTest):
             .eval({x_val_transf: test_array_transf})
         )
         b = (
-            joint_logp(
+            transformed_conditional_logp(
                 (x,),
                 rvs_to_values={x: x_val_untransf},
                 rvs_to_transforms={},

--- a/tests/logprob/test_binary.py
+++ b/tests/logprob/test_binary.py
@@ -20,7 +20,7 @@ import scipy.stats as st
 from pytensor import function
 
 from pymc import logp
-from pymc.logprob import factorized_joint_logprob
+from pymc.logprob import conditional_logp
 from pymc.testing import assert_no_rvs
 
 
@@ -131,7 +131,7 @@ def test_potentially_measurable_operand():
     y_vv = y_rv.clone()
     z_vv = z_rv.clone()
 
-    logprob = factorized_joint_logprob({z_rv: z_vv, y_rv: y_vv})[y_vv]
+    logprob = conditional_logp({z_rv: z_vv, y_rv: y_vv})[y_vv]
     assert_no_rvs(logprob)
 
     fn = function([z_vv, y_vv], logprob)

--- a/tests/logprob/test_censoring.py
+++ b/tests/logprob/test_censoring.py
@@ -42,7 +42,7 @@ import scipy as sp
 import scipy.stats as st
 
 from pymc import logp
-from pymc.logprob import factorized_joint_logprob
+from pymc.logprob import conditional_logp
 from pymc.logprob.transforms import LogTransform, TransformValuesRewrite
 from pymc.testing import assert_no_rvs
 
@@ -133,7 +133,7 @@ def test_random_clip():
 
     lb_vv = lb_rv.clone()
     cens_x_vv = cens_x_rv.clone()
-    logp = factorized_joint_logprob({cens_x_rv: cens_x_vv, lb_rv: lb_vv})
+    logp = conditional_logp({cens_x_rv: cens_x_vv, lb_rv: lb_vv})
     logp_combined = pt.add(*logp.values())
 
     assert_no_rvs(logp_combined)
@@ -152,7 +152,7 @@ def test_broadcasted_clip_constant():
     lb_vv = lb_rv.clone()
     cens_x_vv = cens_x_rv.clone()
 
-    logp = factorized_joint_logprob({cens_x_rv: cens_x_vv, lb_rv: lb_vv})
+    logp = conditional_logp({cens_x_rv: cens_x_vv, lb_rv: lb_vv})
     logp_combined = pt.sum([pt.sum(factor) for factor in logp.values()])
 
     assert_no_rvs(logp_combined)
@@ -166,7 +166,7 @@ def test_broadcasted_clip_random():
     lb_vv = lb_rv.clone()
     cens_x_vv = cens_x_rv.clone()
 
-    logp = factorized_joint_logprob({cens_x_rv: cens_x_vv, lb_rv: lb_vv})
+    logp = conditional_logp({cens_x_rv: cens_x_vv, lb_rv: lb_vv})
     logp_combined = pt.sum([pt.sum(factor) for factor in logp.values()])
 
     assert_no_rvs(logp_combined)
@@ -181,7 +181,7 @@ def test_fail_base_and_clip_have_values():
     x_vv = x_rv.clone()
     cens_x_vv = cens_x_rv.clone()
     with pytest.raises(RuntimeError, match="could not be derived: {cens_x}"):
-        factorized_joint_logprob({cens_x_rv: cens_x_vv, x_rv: x_vv})
+        conditional_logp({cens_x_rv: cens_x_vv, x_rv: x_vv})
 
 
 def test_fail_multiple_clip_single_base():
@@ -195,7 +195,7 @@ def test_fail_multiple_clip_single_base():
     cens_vv1 = cens_rv1.clone()
     cens_vv2 = cens_rv2.clone()
     with pytest.raises(RuntimeError, match="could not be derived: {cens2}"):
-        factorized_joint_logprob({cens_rv1: cens_vv1, cens_rv2: cens_vv2})
+        conditional_logp({cens_rv1: cens_vv1, cens_rv2: cens_vv2})
 
 
 def test_deterministic_clipping():
@@ -205,7 +205,7 @@ def test_deterministic_clipping():
 
     x_vv = x_rv.clone()
     y_vv = y_rv.clone()
-    logp = factorized_joint_logprob({x_rv: x_vv, y_rv: y_vv})
+    logp = conditional_logp({x_rv: x_vv, y_rv: y_vv})
     logp_combined = pt.sum([pt.sum(factor) for factor in logp.values()])
     assert_no_rvs(logp_combined)
 
@@ -223,7 +223,7 @@ def test_clip_transform():
     cens_x_vv = cens_x_rv.clone()
 
     transform = TransformValuesRewrite({cens_x_vv: LogTransform()})
-    logp = factorized_joint_logprob({cens_x_rv: cens_x_vv}, extra_rewrites=transform)
+    logp = conditional_logp({cens_x_rv: cens_x_vv}, extra_rewrites=transform)
     logp_combined = pt.sum([pt.sum(factor) for factor in logp.values()])
 
     cens_x_vv_testval = -1

--- a/tests/logprob/test_checks.py
+++ b/tests/logprob/test_checks.py
@@ -44,7 +44,7 @@ from pytensor.raise_op import Assert
 from scipy import stats
 
 from pymc.distributions import Dirichlet
-from pymc.logprob.basic import factorized_joint_logprob
+from pymc.logprob.basic import conditional_logp
 from tests.distributions.test_multivariate import dirichlet_logpdf
 
 
@@ -59,7 +59,7 @@ def test_specify_shape_logprob():
 
     # 2. Request logp
     x_vv = x_rv.clone()
-    [x_logp] = factorized_joint_logprob({x_rv: x_vv}).values()
+    [x_logp] = conditional_logp({x_rv: x_vv}).values()
 
     # 3. Test logp
     x_logp_fn = pytensor.function([last_dim, x_vv], x_logp)
@@ -85,7 +85,7 @@ def test_assert_logprob():
     assert_rv.name = "assert_rv"
 
     assert_vv = assert_rv.clone()
-    assert_logp = factorized_joint_logprob({assert_rv: assert_vv})[assert_vv]
+    assert_logp = conditional_logp({assert_rv: assert_vv})[assert_vv]
 
     # Check valid value is correct and doesn't raise
     # Since here the value to the rv satisfies the condition, no error is raised.

--- a/tests/logprob/test_composite_logprob.py
+++ b/tests/logprob/test_composite_logprob.py
@@ -42,7 +42,7 @@ import scipy.stats as st
 
 from pymc import draw, logp
 from pymc.logprob.abstract import MeasurableVariable
-from pymc.logprob.basic import factorized_joint_logprob
+from pymc.logprob.basic import conditional_logp
 from pymc.logprob.censoring import MeasurableClip
 from pymc.logprob.rewriting import construct_ir_fgraph
 from pymc.testing import assert_no_rvs
@@ -64,7 +64,7 @@ def test_scalar_clipped_mixture():
     idxs_vv = idxs.clone()
     idxs_vv.name = "idxs_val"
 
-    logp = factorized_joint_logprob({idxs: idxs_vv, mix: mix_vv})
+    logp = conditional_logp({idxs: idxs_vv, mix: mix_vv})
     logp_combined = pt.sum([pt.sum(factor) for factor in logp.values()])
 
     logp_fn = pytensor.function([idxs_vv, mix_vv], logp_combined)
@@ -102,9 +102,7 @@ def test_nested_scalar_mixtures():
     idxs12_vv = idxs12.clone()
     mix12_vv = mix12.clone()
 
-    logp = factorized_joint_logprob(
-        {idxs1: idxs1_vv, idxs2: idxs2_vv, idxs12: idxs12_vv, mix12: mix12_vv}
-    )
+    logp = conditional_logp({idxs1: idxs1_vv, idxs2: idxs2_vv, idxs12: idxs12_vv, mix12: mix12_vv})
     logp_combined = pt.sum([pt.sum(factor) for factor in logp.values()])
 
     logp_fn = pytensor.function([idxs1_vv, idxs2_vv, idxs12_vv, mix12_vv], logp_combined)
@@ -239,7 +237,7 @@ def test_affine_join_interdependent(reverse):
     x_vv = x.clone()
     ys_vv = ys.clone()
 
-    logp = factorized_joint_logprob({x: x_vv, ys: ys_vv})
+    logp = conditional_logp({x: x_vv, ys: ys_vv})
     logp_combined = pt.sum([pt.sum(factor) for factor in logp.values()])
     assert_no_rvs(logp_combined)
 
@@ -247,9 +245,7 @@ def test_affine_join_interdependent(reverse):
     y1_vv = y_rvs[1].clone()
     y2_vv = y_rvs[2].clone()
 
-    ref_logp = factorized_joint_logprob(
-        {x: x_vv, y_rvs[0]: y0_vv, y_rvs[1]: y1_vv, y_rvs[2]: y2_vv}
-    )
+    ref_logp = conditional_logp({x: x_vv, y_rvs[0]: y0_vv, y_rvs[1]: y1_vv, y_rvs[2]: y2_vv})
     ref_logp_combined = pt.sum([pt.sum(factor) for factor in ref_logp.values()])
 
     rng = np.random.default_rng()

--- a/tests/logprob/test_cumsum.py
+++ b/tests/logprob/test_cumsum.py
@@ -41,7 +41,7 @@ import pytest
 import scipy.stats as st
 
 from pymc import logp
-from pymc.logprob.basic import factorized_joint_logprob
+from pymc.logprob.basic import conditional_logp
 from pymc.testing import assert_no_rvs
 
 
@@ -98,7 +98,7 @@ def test_destructive_cumsum_fails():
     x_rv = pt.random.normal(size=(2, 2, 2)).cumsum()
     x_vv = x_rv.clone()
     with pytest.raises(RuntimeError, match="could not be derived"):
-        factorized_joint_logprob({x_rv: x_vv})
+        conditional_logp({x_rv: x_vv})
 
 
 def test_deterministic_cumsum():
@@ -110,7 +110,7 @@ def test_deterministic_cumsum():
     x_vv = x_rv.clone()
     y_vv = y_rv.clone()
 
-    logp = factorized_joint_logprob({x_rv: x_vv, y_rv: y_vv})
+    logp = conditional_logp({x_rv: x_vv, y_rv: y_vv})
     logp_combined = pt.sum([pt.sum(factor) for factor in logp.values()])
     assert_no_rvs(logp_combined)
 

--- a/tests/logprob/test_mixture.py
+++ b/tests/logprob/test_mixture.py
@@ -52,7 +52,7 @@ from pytensor.tensor.subtensor import (
     as_index_constant,
 )
 
-from pymc.logprob.basic import factorized_joint_logprob, logp
+from pymc.logprob.basic import conditional_logp, logp
 from pymc.logprob.mixture import MixtureRV, expand_indices
 from pymc.logprob.rewriting import construct_ir_fgraph
 from pymc.logprob.utils import dirac_delta
@@ -96,7 +96,7 @@ def test_mixture_basics():
     x_vv.name = "x"
 
     with pytest.raises(RuntimeError, match="could not be derived: {m}"):
-        factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv, X_rv: x_vv})
+        conditional_logp({M_rv: m_vv, I_rv: i_vv, X_rv: x_vv})
 
     with pytest.raises(RuntimeError, match="could not be derived: {m}"):
         axis_at = pt.lscalar("axis")
@@ -106,7 +106,7 @@ def test_mixture_basics():
         i_vv = env["i_vv"]
         M_rv = env["M_rv"]
         m_vv = env["m_vv"]
-        factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv})
+        conditional_logp({M_rv: m_vv, I_rv: i_vv})
 
 
 @pytensor.config.change_flags(compute_test_value="warn")
@@ -139,7 +139,7 @@ def test_compute_test_value(op_constructor):
 
     del M_rv.tag.test_value
 
-    M_logp = factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv})
+    M_logp = conditional_logp({M_rv: m_vv, I_rv: i_vv})
     M_logp_combined = pt.add(*M_logp.values())
 
     assert isinstance(M_logp_combined.tag.test_value, np.ndarray)
@@ -185,11 +185,11 @@ def test_hetero_mixture_binomial(p_val, size, supported):
     m_vv.name = "m"
 
     if supported:
-        M_logp = factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv})
+        M_logp = conditional_logp({M_rv: m_vv, I_rv: i_vv})
         M_logp_combined = pt.add(*M_logp.values())
     else:
         with pytest.raises(RuntimeError, match="could not be derived: {m}"):
-            factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv})
+            conditional_logp({M_rv: m_vv, I_rv: i_vv})
         return
 
     M_logp_fn = pytensor.function([p_at, m_vv, i_vv], M_logp_combined)
@@ -594,10 +594,10 @@ def test_hetero_mixture_categorical(
     m_vv.name = "m"
 
     if supported:
-        logp_parts = factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv}, sum=False)
+        logp_parts = conditional_logp({M_rv: m_vv, I_rv: i_vv}, sum=False)
     else:
         with pytest.raises(RuntimeError, match="could not be derived: {m}"):
-            factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv}, sum=False)
+            conditional_logp({M_rv: m_vv, I_rv: i_vv}, sum=False)
         return
 
     I_logp_fn = pytensor.function([p_at, i_vv], logp_parts[i_vv])
@@ -902,7 +902,7 @@ def test_mixture_with_DiracDelta():
     m_vv = M_rv.clone()
     m_vv.name = "m"
 
-    logp_res = factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv})
+    logp_res = conditional_logp({M_rv: m_vv, I_rv: i_vv})
 
     assert m_vv in logp_res
 
@@ -941,8 +941,8 @@ def test_switch_mixture():
 
     assert equal_computations(fgraph.outputs, fgraph2.outputs)
 
-    z1_logp = factorized_joint_logprob({Z1_rv: z_vv, I_rv: i_vv})
-    z2_logp = factorized_joint_logprob({Z2_rv: z_vv, I_rv: i_vv})
+    z1_logp = conditional_logp({Z1_rv: z_vv, I_rv: i_vv})
+    z2_logp = conditional_logp({Z2_rv: z_vv, I_rv: i_vv})
     z1_logp_combined = pt.sum([pt.sum(factor) for factor in z1_logp.values()])
     z2_logp_combined = pt.sum([pt.sum(factor) for factor in z2_logp.values()])
 
@@ -963,7 +963,7 @@ def test_ifelse_mixture_one_component():
     if_vv = if_rv.clone()
     scale_vv = scale_rv.clone()
     mix_vv = mix_rv.clone()
-    mix_logp = factorized_joint_logprob({if_rv: if_vv, scale_rv: scale_vv, mix_rv: mix_vv})[mix_vv]
+    mix_logp = conditional_logp({if_rv: if_vv, scale_rv: scale_vv, mix_rv: mix_vv})[mix_vv]
     assert_no_rvs(mix_logp)
 
     fn = function([if_vv, scale_vv, mix_vv], mix_logp)
@@ -993,7 +993,7 @@ def test_ifelse_mixture_multiple_components():
     )
     mix_vv1 = mix_rv1.clone()
     mix_vv2 = mix_rv2.clone()
-    mix_logp1, mix_logp2 = factorized_joint_logprob({mix_rv1: mix_vv1, mix_rv2: mix_vv2}).values()
+    mix_logp1, mix_logp2 = conditional_logp({mix_rv1: mix_vv1, mix_rv2: mix_vv2}).values()
     assert_no_rvs(mix_logp1)
     assert_no_rvs(mix_logp2)
 
@@ -1030,7 +1030,7 @@ def test_ifelse_mixture_shared_component():
     outer_vv = outer_rv.clone()
     shared_vv = shared_rv.clone()
     mix_vv = mix_rv.clone()
-    outer_logp, mix_logp1, mix_logp2 = factorized_joint_logprob(
+    outer_logp, mix_logp1, mix_logp2 = conditional_logp(
         {outer_rv: outer_vv, shared_rv: shared_vv, mix_rv: mix_vv}
     ).values()
     assert_no_rvs(outer_logp)
@@ -1087,7 +1087,7 @@ def test_joint_logprob_subtensor():
     I_value_var = I_rv.type()
     I_value_var.name = "I_value"
 
-    A_idx_logp = factorized_joint_logprob({A_idx: A_idx_value_var, I_rv: I_value_var})
+    A_idx_logp = conditional_logp({A_idx: A_idx_value_var, I_rv: I_value_var})
     A_idx_logp_comb = pt.add(*A_idx_logp.values())
 
     logp_vals_fn = pytensor.function([A_idx_value_var, I_value_var], A_idx_logp_comb)

--- a/tests/logprob/test_rewriting.py
+++ b/tests/logprob/test_rewriting.py
@@ -52,7 +52,7 @@ from pytensor.tensor.subtensor import (
 )
 
 from pymc.distributions.transforms import logodds
-from pymc.logprob.basic import factorized_joint_logprob
+from pymc.logprob.basic import conditional_logp
 from pymc.logprob.rewriting import cleanup_ir, local_lift_DiracDelta
 from pymc.logprob.transforms import TransformedVariable, TransformValuesRewrite
 from pymc.logprob.utils import DiracDelta, dirac_delta
@@ -103,7 +103,7 @@ def test_local_remove_TransformedVariable():
     p_vv = p_rv.clone()
 
     tr = TransformValuesRewrite({p_vv: logodds})
-    [p_logp] = factorized_joint_logprob({p_rv: p_vv}, extra_rewrites=tr).values()
+    [p_logp] = conditional_logp({p_rv: p_vv}, extra_rewrites=tr).values()
 
     assert not any(
         isinstance(v.owner.op, TransformedVariable) for v in ancestors([p_logp]) if v.owner
@@ -136,7 +136,7 @@ def test_joint_logprob_incsubtensor(indices, size):
 
     assert isinstance(Y_rv.owner.op, (IncSubtensor, AdvancedIncSubtensor, AdvancedIncSubtensor1))
 
-    Y_rv_logp = factorized_joint_logprob({Y_rv: y_value_var})
+    Y_rv_logp = conditional_logp({Y_rv: y_value_var})
     Y_rv_logp_combined = pt.add(*Y_rv_logp.values())
 
     obs_logps = Y_rv_logp_combined.eval({y_value_var: y_val})

--- a/tests/logprob/test_scan.py
+++ b/tests/logprob/test_scan.py
@@ -45,7 +45,7 @@ from pytensor.scan.utils import ScanArgs
 from scipy import stats
 
 from pymc.logprob.abstract import _logprob_helper
-from pymc.logprob.basic import factorized_joint_logprob, logp
+from pymc.logprob.basic import conditional_logp, logp
 from pymc.logprob.scan import (
     construct_scan,
     convert_outer_out_to_in,
@@ -335,7 +335,7 @@ def test_scan_joint_logprob(require_inner_rewrites):
     s_vv = S_rv.clone()
     s_vv.name = "s"
 
-    y_logp = factorized_joint_logprob({Y_rv: y_vv, S_rv: s_vv, Gamma_rv: Gamma_vv})
+    y_logp = conditional_logp({Y_rv: y_vv, S_rv: s_vv, Gamma_rv: Gamma_vv})
     y_logp_combined = pt.sum([pt.sum(factor) for factor in y_logp.values()])
 
     y_val = np.arange(10)
@@ -421,7 +421,7 @@ def test_initial_values():
     s_1T_vv = S_1T_rv.clone()
     s_1T_vv.name = "s_1T"
 
-    logp_parts = factorized_joint_logprob({S_1T_rv: s_1T_vv, S_0_rv: s_0_vv})
+    logp_parts = conditional_logp({S_1T_rv: s_1T_vv, S_0_rv: s_0_vv})
 
     s_0_val = 0
     s_1T_val = np.array([1, 0, 1, 0, 1, 1, 0, 1, 0, 1])
@@ -492,7 +492,7 @@ def test_scan_over_seqs():
 
     xs_vv = ys.clone()
     ys_vv = ys.clone()
-    ys_logp = factorized_joint_logprob({xs: xs_vv, ys: ys_vv})[ys_vv]
+    ys_logp = conditional_logp({xs: xs_vv, ys: ys_vv})[ys_vv]
 
     assert_no_rvs(ys_logp)
 

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -49,7 +49,7 @@ from pytensor.scan import scan
 
 from pymc.distributions.transforms import _default_transform, log, logodds
 from pymc.logprob.abstract import MeasurableVariable, _logprob
-from pymc.logprob.basic import factorized_joint_logprob, logp
+from pymc.logprob.basic import conditional_logp, logp
 from pymc.logprob.transforms import (
     ChainedTransform,
     CoshTransform,
@@ -240,9 +240,7 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
 
     transform = _default_transform(a.owner.op, a)
     transform_rewrite = TransformValuesRewrite({a_value_var: transform})
-    res = factorized_joint_logprob(
-        {a: a_value_var, b: b_value_var}, extra_rewrites=transform_rewrite
-    )
+    res = conditional_logp({a: a_value_var, b: b_value_var}, extra_rewrites=transform_rewrite)
     res_combined = pt.sum([pt.sum(factor) for factor in res.values()])
 
     test_val_rng = np.random.RandomState(3238)
@@ -316,7 +314,7 @@ def test_simple_transformed_logprob_nojac(use_jacobian):
     x_vv.name = "x"
 
     transform_rewrite = TransformValuesRewrite({x_vv: log})
-    tr_logp = factorized_joint_logprob(
+    tr_logp = conditional_logp(
         {X_rv: x_vv}, extra_rewrites=transform_rewrite, use_jacobian=use_jacobian
     )
     tr_logp_combined = pt.sum([pt.sum(factor) for factor in tr_logp.values()])
@@ -394,7 +392,7 @@ def test_hierarchical_uniform_transform():
             x: _default_transform(x_rv.owner.op, x_rv),
         }
     )
-    logp = factorized_joint_logprob(
+    logp = conditional_logp(
         {lower_rv: lower, upper_rv: upper, x_rv: x},
         extra_rewrites=transform_rewrite,
     )
@@ -421,7 +419,7 @@ def test_nondefault_transforms():
         }
     )
 
-    logp = factorized_joint_logprob(
+    logp = conditional_logp(
         {loc_rv: loc, scale_rv: scale, x_rv: x},
         extra_rewrites=transform_rewrite,
     )
@@ -459,7 +457,7 @@ def test_default_transform_multiout():
 
     transform_rewrite = TransformValuesRewrite({x: None})
 
-    logp = factorized_joint_logprob(
+    logp = conditional_logp(
         {x_rv: x},
         extra_rewrites=transform_rewrite,
     )
@@ -508,7 +506,7 @@ def test_nondefault_transform_multiout(transform_x, transform_y, multiout_measur
         }
     )
 
-    logp = factorized_joint_logprob({x: x_vv, y: y_vv}, extra_rewrites=transform_rewrite)
+    logp = conditional_logp({x: x_vv, y: y_vv}, extra_rewrites=transform_rewrite)
     logp_combined = pt.sum([pt.sum(factor) for factor in logp.values()])
 
     x_vv_test = np.random.normal()
@@ -552,7 +550,7 @@ def test_original_values_output_dict():
     p_vv = p_rv.clone()
 
     tr = TransformValuesRewrite({p_vv: logodds})
-    logp_dict = factorized_joint_logprob({p_rv: p_vv}, extra_rewrites=tr)
+    logp_dict = conditional_logp({p_rv: p_vv}, extra_rewrites=tr)
 
     assert p_vv in logp_dict
 
@@ -578,14 +576,14 @@ def test_mixture_transform():
     y_vv = Y_rv.clone()
     y_vv.name = "y"
 
-    logp_no_trans = factorized_joint_logprob(
+    logp_no_trans = conditional_logp(
         {Y_rv: y_vv, I_rv: i_vv},
     )
     logp_no_trans_comb = pt.sum([pt.sum(factor) for factor in logp_no_trans.values()])
 
     transform_rewrite = TransformValuesRewrite({y_vv: LogTransform()})
 
-    logp_trans = factorized_joint_logprob(
+    logp_trans = conditional_logp(
         {Y_rv: y_vv, I_rv: i_vv},
         extra_rewrites=transform_rewrite,
         use_jacobian=False,
@@ -759,7 +757,7 @@ def test_transformed_rv_and_value():
 
     transform_rewrite = TransformValuesRewrite({y_vv: LogTransform()})
 
-    logp = factorized_joint_logprob({y_rv: y_vv}, extra_rewrites=transform_rewrite)
+    logp = conditional_logp({y_rv: y_vv}, extra_rewrites=transform_rewrite)
     logp_combined = pt.sum([pt.sum(factor) for factor in logp.values()])
     assert_no_rvs(logp_combined)
     logp_fn = pytensor.function([y_vv], logp_combined)
@@ -780,7 +778,7 @@ def test_loc_transform_multiple_rvs_fails1():
     y = y_rv.clone()
 
     with pytest.raises(RuntimeError, match="could not be derived"):
-        factorized_joint_logprob({y_rv: y})
+        conditional_logp({y_rv: y})
 
 
 def test_nested_loc_transform_multiple_rvs_fails2():
@@ -791,19 +789,19 @@ def test_nested_loc_transform_multiple_rvs_fails2():
     y = y_rv.clone()
 
     with pytest.raises(RuntimeError, match="could not be derived"):
-        factorized_joint_logprob({y_rv: y})
+        conditional_logp({y_rv: y})
 
 
 def test_discrete_rv_unary_transform_fails():
     y_rv = pt.exp(pt.random.poisson(1))
     with pytest.raises(RuntimeError, match="could not be derived"):
-        factorized_joint_logprob({y_rv: y_rv.clone()})
+        conditional_logp({y_rv: y_rv.clone()})
 
 
 def test_discrete_rv_multinary_transform_fails():
     y_rv = 5 + pt.random.poisson(1)
     with pytest.raises(RuntimeError, match="could not be derived"):
-        factorized_joint_logprob({y_rv: y_rv.clone()})
+        conditional_logp({y_rv: y_rv.clone()})
 
 
 @pytest.mark.xfail(reason="Check not implemented yet")
@@ -963,9 +961,9 @@ def test_scan_transform():
             innov_vv: LogOddsTransform(),
         }
     )
-    logp = factorized_joint_logprob(
-        {init: init_vv, innov: innov_vv}, extra_rewrites=tr, use_jacobian=True
-    )[innov_vv]
+    logp = conditional_logp({init: init_vv, innov: innov_vv}, extra_rewrites=tr, use_jacobian=True)[
+        innov_vv
+    ]
     logp_fn = pytensor.function([init_vv, innov_vv], logp, on_unused_input="ignore")
 
     # Create an unrolled scan graph as reference
@@ -984,7 +982,7 @@ def test_scan_transform():
             innov_vv: LogOddsTransform(),
         }
     )
-    ref_logp = factorized_joint_logprob(
+    ref_logp = conditional_logp(
         {init: init_vv, innov: innov_vv}, extra_rewrites=tr, use_jacobian=True
     )[innov_vv]
     ref_logp_fn = pytensor.function([init_vv, innov_vv], ref_logp, on_unused_input="ignore")
@@ -1006,7 +1004,7 @@ def test_multivariate_transform(shift, scale):
     x_rv.name = "x"
 
     x_vv = x_rv.clone()
-    logp = factorized_joint_logprob({x_rv: x_vv})[x_vv]
+    logp = conditional_logp({x_rv: x_vv})[x_vv]
     assert_no_rvs(logp)
 
     x_vv_test = np.array([5.0, 4.9, -6.3])

--- a/tests/logprob/test_utils.py
+++ b/tests/logprob/test_utils.py
@@ -48,7 +48,7 @@ from pytensor.tensor.random.basic import normal, uniform
 import pymc as pm
 
 from pymc.logprob.abstract import MeasurableVariable
-from pymc.logprob.basic import joint_logp, logp
+from pymc.logprob.basic import logp, transformed_conditional_logp
 from pymc.logprob.utils import (
     ParameterValueError,
     check_potential_measurability,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -43,7 +43,7 @@ from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.distributions import Normal, transforms
 from pymc.distributions.transforms import log
 from pymc.exceptions import ImputationWarning, ShapeError, ShapeWarning
-from pymc.logprob.basic import joint_logp
+from pymc.logprob.basic import transformed_conditional_logp
 from pymc.logprob.transforms import IntervalTransform
 from pymc.model import Point, ValueGradFunction, modelcontext
 from pymc.testing import SeededTest
@@ -1461,7 +1461,7 @@ class TestImputationMissingData:
         x_unobs_rv = m["x_missing"]
         x_unobs_vv = m.rvs_to_values[x_unobs_rv]
 
-        logp = joint_logp(
+        logp = transformed_conditional_logp(
             [x_obs_rv, x_unobs_rv],
             rvs_to_values={x_obs_rv: x_obs_vv, x_unobs_rv: x_unobs_vv},
             rvs_to_transforms={},


### PR DESCRIPTION
It only becomes a "joint_logp" after the terms are summed

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6760.org.readthedocs.build/en/6760/

<!-- readthedocs-preview pymc end -->