### PR TITLE
Removed **kwargs from sample_numpyro_nuts and sample_blackjax_nuts

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -317,7 +317,6 @@ def sample_blackjax_nuts(
     postprocessing_backend: Optional[str] = None,
     postprocessing_chunks: Optional[int] = None,
     idata_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs,
 ) -> az.InferenceData:
     """
     Draw samples from the posterior using the NUTS method from the ``blackjax`` library.
@@ -530,7 +529,6 @@ def sample_numpyro_nuts(
     postprocessing_chunks: Optional[int] = None,
     idata_kwargs: Optional[Dict] = None,
     nuts_kwargs: Optional[Dict] = None,
-    **kwargs,
 ) -> az.InferenceData:
     """
     Draw samples from the posterior using the NUTS method from the ``numpyro`` library.


### PR DESCRIPTION
**What is this PR about?**

The `**kwargs` for `sample_numpyro_nuts` and `sample_blackjax_nuts` are not used by the functions and can cause hard-to-detect bugs when keyword arguments are passed but not used. With this change, unused arguments will generate an exception.

**Checklist**
+ [ ] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇



<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6768.org.readthedocs.build/en/6768/

<!-- readthedocs-preview pymc end -->