### PR TITLE
Probabilty inference for arc transformations

### DIFF
--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -51,6 +51,9 @@ from pymc.distributions.transforms import _default_transform, log, logodds
 from pymc.logprob.abstract import MeasurableVariable, _logprob
 from pymc.logprob.basic import conditional_logp, logp
 from pymc.logprob.transforms import (
+    ArccoshTransform,
+    ArcsinhTransform,
+    ArctanhTransform,
     ChainedTransform,
     CoshTransform,
     ErfcTransform,
@@ -1028,6 +1031,9 @@ def test_multivariate_transform(shift, scale):
         (pt.sinh, SinhTransform()),
         (pt.cosh, CoshTransform()),
         (pt.tanh, TanhTransform()),
+        (pt.arcsinh, ArcsinhTransform()),
+        (pt.arccosh, ArccoshTransform()),
+        (pt.arctanh, ArctanhTransform()),
     ],
 )
 def test_erf_logp(pt_transform, transform):
@@ -1060,6 +1066,9 @@ from tests.distributions.test_transform import check_jacobian_det
         SinhTransform(),
         CoshTransform(),
         TanhTransform(),
+        ArcsinhTransform(),
+        ArccoshTransform(),
+        ArctanhTransform(),
     ],
 )
 def test_check_jac_det(transform):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

Users have asked for the ability to use aditional transformations #6631, also see https://discourse.pymc.io/t/the-sinh-arcsinh-normal-distribution/12136. This ended up being quite fast as the logic is very similar to many of the previous transforms I've implemented.

I've added these transforms to the existing tests, which pass. However, it seems there are a few tests that aren't passing in tests/logprob/test_transform.py. I think they may have been failing prior to me, as they fail on main as well....

...

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## New features
- Arcsinh transform
- Arccosh transform
- Arctanh transform


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6775.org.readthedocs.build/en/6775/

<!-- readthedocs-preview pymc end -->