### PR TITLE
Make tests compatible with latest release of PyTensor

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1232,7 +1232,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
                     if isinstance(length_tensor_origin, TensorConstant):
                         raise ShapeError(
                             f"Resizing dimension '{dname}' with values of length {new_length} would lead to incompatibilities, "
-                            f"because the dimension length is tied to a {length_tensor_origin}. "
+                            f"because the dimension length is tied to a TensorConstant. "
                             f"Check if the dimension was defined implicitly before the shared variable '{name}' was created, "
                             f"for example by another model variable.",
                             actual=new_length,

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -316,7 +316,12 @@ class TestMatchesScipy:
             f_logp(cov_val, np.ones(2))
         dlogp = pt.grad(mvn_logp, cov)
         f_dlogp = pytensor.function([cov, x], dlogp)
-        assert not np.all(np.isfinite(f_dlogp(cov_val, np.ones(2))))
+        try:
+            res = f_dlogp(cov_val, np.ones(2))
+        except ValueError:
+            pass  # Op raises internally
+        else:
+            assert not np.all(np.isfinite(res))  # Otherwise, should return nan
 
     def test_mvnormal_init_fail(self):
         with pm.Model():

--- a/tests/logprob/test_basic.py
+++ b/tests/logprob/test_basic.py
@@ -426,7 +426,7 @@ def test_probability_inference(func, scipy_func, test_value):
 def test_probability_inference_fails(func, func_name):
     with pytest.raises(
         NotImplementedError,
-        match=f"{func_name} method not implemented for Elemwise{{cos,no_inplace}}",
+        match=f"{func_name} method not implemented for (Elemwise{{cos,no_inplace}}|Cos)",
     ):
         func(pt.cos(pm.Normal.dist()), 1)
 

--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -575,7 +575,7 @@ class TestCompilePyMC:
 
         with pytest.raises(
             ValueError,
-            match=r"No update found for at least one RNG used in Scan Op for\{cpu,test_scan\}",
+            match="No update found for at least one RNG used in Scan Op",
         ):
             collect_default_updates([xs])
 


### PR DESCRIPTION
Tests started failing in other PRs.

These changes work with both the previous and newer release, so there's no need to bump the dependency

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6782.org.readthedocs.build/en/6782/

<!-- readthedocs-preview pymc end -->