### PR TITLE
Support automatic imputation for multivariate and symbolic distributions

### DIFF
--- a/pymc/data.py
+++ b/pymc/data.py
@@ -423,6 +423,11 @@ def Data(
     # `convert_observed_data` takes care of parameter `value` and
     # transforms it to something digestible for PyTensor.
     arr = convert_observed_data(value)
+    if isinstance(arr, np.ma.MaskedArray):
+        raise NotImplementedError(
+            "Masked arrays or arrays with `nan` entries are not supported. "
+            "Pass them directly to `observed` if you want to trigger auto-imputation"
+        )
 
     if mutable is None:
         warnings.warn(

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -1423,7 +1423,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             self.observed_RVs.append(observed_rv)
 
             # Register FreeRV corresponding to unobserved components
-            self.register_rv(unobserved_rv, f"{name}_missing", transform=transform)
+            self.register_rv(unobserved_rv, f"{name}_unobserved", transform=transform)
 
             # Register Deterministic that combines observed and missing
             # Note: This can widely increase memory consumption during sampling for large datasets

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -338,10 +338,10 @@ class TestDataPyMC:
             )
 
         # make sure that data is really missing
-        assert "y_missing" in model.named_vars
+        assert "y_unobserved" in model.named_vars
 
         test_dict = {
-            "posterior": ["x", "y_missing"],
+            "posterior": ["x", "y_unobserved"],
             "observed_data": ["y_observed"],
             "log_likelihood": ["y_observed"],
         }

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -437,6 +437,14 @@ class TestData(SeededTest):
             assert isinstance(data, pt.TensorConstant)
         pass
 
+    def test_masked_array_error(self):
+        with pm.Model():
+            with pytest.raises(
+                NotImplementedError,
+                match="Masked arrays or arrays with `nan` entries are not supported.",
+            ):
+                pm.ConstantData("x", [0, 1, np.nan, 2])
+
 
 def test_data_naming():
     """

--- a/tests/test_model_graph.py
+++ b/tests/test_model_graph.py
@@ -145,13 +145,13 @@ def model_with_imputations():
 
     compute_graph = {
         "a": set(),
-        "L_missing": {"a"},
+        "L_unobserved": {"a"},
         "L_observed": {"a"},
-        "L": {"L_missing", "L_observed"},
+        "L": {"L_unobserved", "L_observed"},
     }
     plates = {
         "": {"a"},
-        "2": {"L_missing"},
+        "2": {"L_unobserved"},
         "10": {"L_observed"},
         "12": {"L"},
     }

--- a/tests/tuning/test_starting.py
+++ b/tests/tuning/test_starting.py
@@ -146,9 +146,9 @@ def test_find_MAP_issue_4488():
         y = pm.Deterministic("y", x + 1)
         map_estimate = find_MAP()
 
-    assert not set.difference({"x_missing", "x_missing_log__", "y"}, set(map_estimate.keys()))
-    np.testing.assert_allclose(map_estimate["x_missing"], 0.2, rtol=1e-4, atol=1e-4)
-    np.testing.assert_allclose(map_estimate["y"], [2.0, map_estimate["x_missing"][0] + 1])
+    assert not set.difference({"x_unobserved", "x_unobserved_log__", "y"}, set(map_estimate.keys()))
+    np.testing.assert_allclose(map_estimate["x_unobserved"], 0.2, rtol=1e-4, atol=1e-4)
+    np.testing.assert_allclose(map_estimate["y"], [2.0, map_estimate["x_unobserved"][0] + 1])
 
 
 def test_find_MAP_warning_non_free_RVs():


### PR DESCRIPTION
Closes #5260 
Related to #6626
Related to #5255
Related to #6645

This PR creates a new Op: `PartialObservedRV` that splits the sample space according to a boolean mask and allows separate variables/values for these. This enables automatic imputation for cases not supported before. For multivariate cases it is not always possible to "attribute" the logp to one variable or the other, so they are all associated with the observed variable. This means the values will show up exclusively in the model `log_likelihood`, even if some (or all) entries were imputed. Directly related to: https://github.com/pymc-devs/pymc/issues/5255

There is some logic to avoid the use of the `PartialObservedRV` for pure Multivariate variables when it's safe to do so (i.e., there is no mixed indexing across the support dims). This has the benefit that automatic transforms will still apply. It also avoids the logp issue mentioned above. This behavior is the same that existed until now for univariate pure RandomVariables, which keep behaving as before.

The new `PartialObservedRV` allows for symbolic (constant or mutable) mask, but this is not accessible to users using the current API based on `MaskedArray` or `nan` entries. Similarly, one can't use `ConstantData`/`MutableData` because those try to convert such arrays to `MaskedArray` which aren't supported in PyTensor: https://github.com/pymc-devs/pytensor/issues/259. I added an early error for that.

An alternative would be to provide a separate API for users, something like `pm.Imputed(name, dist, obs_mask, obs_data)` where both data and the mask could be tensors wrapped in `Data`.

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6797.org.readthedocs.build/en/6797/

<!-- readthedocs-preview pymc end -->