### PR TITLE
Restrict domain on alpha in the CAR distribution

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2063,8 +2063,6 @@ class CARRV(RandomVariable):
         tau = pt.as_tensor_variable(floatX(tau))
 
         alpha = pt.as_tensor_variable(floatX(alpha))
-        msg = "the domain of alpha is: -1 < alpha < 1."
-        alpha = Assert(msg)(alpha, pt.lt(alpha, 1) and pt.gt(alpha, -1))
 
         return super().make_node(rng, size, dtype, mu, W, alpha, tau)
 
@@ -2080,6 +2078,9 @@ class CARRV(RandomVariable):
         Journal of the Royal Statistical Society Series B, Royal Statistical Society,
         vol. 63(2), pages 325-338. DOI: 10.1111/1467-9868.00288
         """
+        if np.all(alpha >= 1) or np.all(alpha <= -1):
+            raise ValueError("the domain of alpha is: -1 < alpha < 1")
+
         if not scipy.sparse.issparse(W):
             W = scipy.sparse.csr_matrix(W)
         s = np.asarray(W.sum(axis=0))[0]

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2078,7 +2078,7 @@ class CARRV(RandomVariable):
         Journal of the Royal Statistical Society Series B, Royal Statistical Society,
         vol. 63(2), pages 325-338. DOI: 10.1111/1467-9868.00288
         """
-        if np.all(alpha >= 1) or np.all(alpha <= -1):
+        if np.any(alpha >= 1) or np.any(alpha <= -1):
             raise ValueError("the domain of alpha is: -1 < alpha < 1")
 
         if not scipy.sparse.issparse(W):

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2061,7 +2061,10 @@ class CARRV(RandomVariable):
             W = Assert(msg)(W, pt.allclose(W, W.T))
 
         tau = pt.as_tensor_variable(floatX(tau))
+
         alpha = pt.as_tensor_variable(floatX(alpha))
+        msg = "the domain of alpha is: -1 < alpha < 1."
+        alpha = Assert(msg)(alpha, pt.lt(alpha, 1) and pt.gt(alpha, -1))
 
         return super().make_node(rng, size, dtype, mu, W, alpha, tau)
 
@@ -2143,8 +2146,9 @@ class CAR(Continuous):
         :func:`~pytensor.sparse.basic.as_sparse_or_tensor_variable` is
         used for this sparse or tensorvariable conversion.
     alpha : tensor_like of float
-        Autoregression parameter taking values between -1 and 1. Values closer to 0 indicate weaker
-        correlation and values closer to 1 indicate higher autocorrelation. For most use cases, the
+        Autoregression parameter taking values greater than -1 and less than 1.
+        Values closer to 0 indicate weaker correlation and values closer to
+        1 indicate higher autocorrelation. For most use cases, the
         support of alpha should be restricted to (0, 1).
     tau : tensor_like of float
         Positive precision variable controlling the scale of the underlying normal variates.
@@ -2211,10 +2215,10 @@ class CAR(Continuous):
         logquad = (tau * delta * tau_dot_delta).sum(axis=-1)
         return check_parameters(
             0.5 * (logtau + logdet - logquad),
-            -1 <= alpha,
-            alpha <= 1,
+            -1 < alpha,
+            alpha < 1,
             tau > 0,
-            msg="-1 <= alpha <= 1, tau > 0",
+            msg="-1 < alpha < 1, tau > 0",
         )
 
 

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -835,6 +835,23 @@ def test_car_matrix_check(sparse):
             car_dist = pm.CAR.dist(mu, W, alpha, tau)
 
 
+@pytest.mark.parametrize("alpha", [1, -1])
+def test_car_alpha(alpha):
+    """
+    Tests the check that -1 < alpha < 1
+    """
+
+    W = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
+
+    tau = 1
+    mu = np.array([0, 0, 0])
+
+    car_dist = pm.CAR.dist(W=W, alpha=alpha, mu=mu, tau=tau)
+
+    with pytest.raises(ValueError, match="the domain of alpha is: -1 < alpha < 1"):
+        pm.draw(car_dist)
+
+
 class TestLKJCholeskCov:
     def test_dist(self):
         sd_dist = pm.Exponential.dist(1, size=(10, 3))

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -836,7 +836,7 @@ def test_car_matrix_check(sparse):
 
 
 @pytest.mark.parametrize("alpha", [1, -1])
-def test_car_alpha(alpha):
+def test_car_alpha_bounds(alpha):
     """
     Tests the check that -1 < alpha < 1
     """
@@ -845,11 +845,15 @@ def test_car_alpha(alpha):
 
     tau = 1
     mu = np.array([0, 0, 0])
+    values = np.array([-0.5, 0, 0.5])
 
     car_dist = pm.CAR.dist(W=W, alpha=alpha, mu=mu, tau=tau)
 
     with pytest.raises(ValueError, match="the domain of alpha is: -1 < alpha < 1"):
         pm.draw(car_dist)
+
+    with pytest.raises(ValueError, match="-1 < alpha < 1, tau > 0"):
+        pm.logp(car_dist, values).eval()
 
 
 class TestLKJCholeskCov:


### PR DESCRIPTION
#6792

Hi, I think I need some help writing the checks correctly. The intended change is supposed to be fairly trivial. the alpha parameter should be restricted to be (-1,1). I tried making the changes that I thought would enforce them but they are not working. The `make_node()` check is not triggering when I create the random variable with `.dist` or when I use `pm.draw()`. The `lopg()` check is triggering all the time, even when alpha is in the acceptable range.

Maybe something we can discuss @fonnesbeck @bwengals today?


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6801.org.readthedocs.build/en/6801/

<!-- readthedocs-preview pymc end -->