### PR TITLE
Add icdf functions for Moyal, Gumbel, Triangular and Weibull distributions

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2546,6 +2546,16 @@ class Weibull(PositiveContinuous):
             msg="alpha > 0, beta > 0",
         )
 
+    def icdf(value, alpha, beta):
+        res = beta * (-pt.log(1 - value)) ** (1 / alpha)
+        res = check_icdf_value(res, value)
+        return check_parameters(
+            res,
+            alpha > 0,
+            beta > 0,
+            msg="alpha > 0, beta > 0",
+        )
+
 
 class HalfStudentTRV(RandomVariable):
     name = "halfstudentt"
@@ -3089,6 +3099,20 @@ class Triangular(BoundedContinuous):
             msg="lower <= c <= upper",
         )
 
+    def icdf(value, lower, c, upper):
+        res = pt.switch(
+            pt.lt(value, ((c - lower) / (upper - lower))),
+            lower + np.sqrt((upper - lower) * (c - lower) * value),
+            upper - np.sqrt((upper - lower) * (upper - c) * (1 - value)),
+        )
+        res = check_icdf_value(res, value)
+        return check_parameters(
+            res,
+            lower <= c,
+            c <= upper,
+            msg="lower <= c <= upper",
+        )
+
 
 @_default_transform.register(Triangular)
 def triangular_default_transform(op, rv):
@@ -3171,6 +3195,15 @@ class Gumbel(Continuous):
     def logcdf(value, mu, beta):
         res = -pt.exp(-(value - mu) / beta)
 
+        return check_parameters(
+            res,
+            beta > 0,
+            msg="beta > 0",
+        )
+
+    def icdf(value, mu, beta):
+        res = mu - beta * pt.log(-pt.log(value))
+        res = check_icdf_value(res, value)
         return check_parameters(
             res,
             beta > 0,
@@ -3727,6 +3760,15 @@ class Moyal(Continuous):
     def logcdf(value, mu, sigma):
         scaled = (value - mu) / sigma
         res = pt.log(pt.erfc(pt.exp(-scaled / 2) * (2**-0.5)))
+        return check_parameters(
+            res,
+            sigma > 0,
+            msg="sigma > 0",
+        )
+
+    def icdf(value, mu, sigma):
+        res = sigma * -pt.log(2.0 * pt.erfcinv(value) ** 2) + mu
+        res = check_icdf_value(res, value)
         return check_parameters(
             res,
             sigma > 0,

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -207,6 +207,12 @@ class TestMatchesScipy:
             lambda value, c, lower, upper: st.triang.logcdf(value, c - lower, lower, upper - lower),
             skip_paramdomain_outside_edge_test=True,
         )
+        check_icdf(
+            pm.Triangular,
+            {"lower": -Rplusunif, "c": Runif, "upper": Rplusunif},
+            lambda q, c, lower, upper: st.triang.ppf(q, c - lower, lower, upper - lower),
+            skip_paramdomain_outside_edge_test=True,
+        )
 
         # Custom logp/logcdf check for values outside of domain
         valid_dist = pm.Triangular.dist(lower=0, upper=1, c=0.9, size=2)
@@ -704,6 +710,13 @@ class TestMatchesScipy:
             lambda value, alpha, beta: st.exponweib.logcdf(value, 1, alpha, scale=beta),
         )
 
+    def test_weibull_icdf(self):
+        check_icdf(
+            pm.Weibull,
+            {"alpha": Rplusbig, "beta": Rplusbig},
+            lambda q, alpha, beta: st.exponweib.ppf(q, 1, alpha, scale=beta),
+        )
+
     def test_half_studentt(self):
         # this is only testing for nu=1 (halfcauchy)
         check_logp(
@@ -779,6 +792,11 @@ class TestMatchesScipy:
             R,
             {"mu": R, "beta": Rplusbig},
             lambda value, mu, beta: st.gumbel_r.logcdf(value, loc=mu, scale=beta),
+        )
+        check_icdf(
+            pm.Gumbel,
+            {"mu": R, "beta": Rplusbig},
+            lambda q, mu, beta: st.gumbel_r.ppf(q, loc=mu, scale=beta),
         )
 
     def test_logistic(self):
@@ -862,6 +880,13 @@ class TestMatchesScipy:
         )
         if pytensor.config.floatX == "float32":
             raise Exception("Flaky test: It passed this time, but XPASS is not allowed.")
+
+    def test_moyal_icdf(self):
+        check_icdf(
+            pm.Moyal,
+            {"mu": R, "sigma": Rplusbig},
+            lambda q, mu, sigma: floatX(st.moyal.ppf(q, mu, sigma)),
+        )
 
     def test_interpolated(self):
         for mu in R.vals:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Adds ICDF functions to Moyal, Gumbel, Triangular and Weibull distributions

Issue https://github.com/pymc-devs/pymc/issues/6612

References:
Moyal: https://www.wolframalpha.com/input?i=InverseCDF%5BMoyal+Distribution%5D
Gumbel: https://en.wikipedia.org/wiki/Gumbel_distribution ["Random variate generation" section]
Triangular: http://www.math.wm.edu/~leemis/chart/UDR/PDFs/TriangularV.pdf
Weibull: https://www.mathworks.com/help/stats/wblinv.html

**Checklist**
+ [X] Explain important implementation details 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [X] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [X] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6802.org.readthedocs.build/en/6802/

<!-- readthedocs-preview pymc end -->