### PR TITLE
Allow creating `SymbolicRandomVariable`s inside `CustomDist`

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -601,7 +601,7 @@ class _CustomSymbolicDist(Distribution):
         moment: Optional[Callable] = None,
         ndim_supp: int = 0,
         dtype: str = "floatX",
-        class_name: str = "CustomSymbolicDist",
+        class_name: str = "CustomDist",
         **kwargs,
     ):
         dist_params = [as_tensor_variable(param) for param in dist_params]
@@ -952,7 +952,7 @@ class CustomDist:
         dist_params = cls.parse_dist_params(dist_params)
         cls.check_valid_dist_random(dist, random, dist_params)
         if dist is not None:
-            kwargs.setdefault("class_name", f"CustomSymbolicDist_{name}")
+            kwargs.setdefault("class_name", f"CustomDist_{name}")
             return _CustomSymbolicDist(
                 name,
                 *dist_params,

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -27,6 +27,8 @@ from pytensor import Variable
 from pytensor.compile import SharedVariable
 from pytensor.graph.utils import ValidatingScratchpad
 
+from pymc.exceptions import BlockModelAccessError
+
 
 class _UnsetType:
     """Type for the `UNSET` object to make it look nice in `help(...)` outputs."""
@@ -367,7 +369,7 @@ def check_dist_not_registered(dist, model=None):
 
     try:
         model = modelcontext(None)
-    except TypeError:
+    except (TypeError, BlockModelAccessError):
         pass
     else:
         if dist in model.basic_RVs:

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -590,6 +590,13 @@ class TestCustomSymbolicDist:
             pm.logp(pm.NormalMixture.dist(w=w, mu=mus, sigma=sds), test_value).eval(),
         )
 
+    def test_symbolic_dist(self):
+        # Test we can create a SymbolicDist inside a CustomDist
+        def dist(size):
+            return pm.Truncated.dist(pm.Beta.dist(1, 1, size=size), lower=0.1, upper=0.9)
+
+        assert pm.CustomDist.dist(dist=dist)
+
 
 class TestSymbolicRandomVariable:
     def test_inline(self):


### PR DESCRIPTION
Some small maintenance for `CustomDist`

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6805.org.readthedocs.build/en/6805/

<!-- readthedocs-preview pymc end -->