### PR TITLE
Prevent unbound trace due to type hints

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -50,6 +50,7 @@ from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.type import RandomType
 from pytensor.tensor.sharedvar import ScalarSharedVariable
 from pytensor.tensor.var import TensorConstant, TensorVariable
+from typing_extensions import Self
 
 from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.data import GenTensorVariable, is_minibatch
@@ -478,10 +479,10 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
     if TYPE_CHECKING:
 
-        def __enter__(self: "Model") -> "Model":
+        def __enter__(self: Self) -> Self:
             ...
 
-        def __exit__(self: "Model", *exc: Any) -> bool:
+        def __exit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None:
             ...
 
     def __new__(cls, *args, **kwargs):

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -107,6 +107,14 @@ class ContextMeta(type):
     the `with` statement.
     """
 
+    if TYPE_CHECKING:
+
+        def __enter__(self: Self) -> Self:
+            ...
+
+        def __exit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None:
+            ...
+
     def __new__(cls, name, bases, dct, **kwargs):  # pylint: disable=unused-argument
         """Add __enter__ and __exit__ methods to the class."""
 
@@ -476,14 +484,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         # variables inside both scopes will be named like `first::*`, `second::*`
     """
-
-    if TYPE_CHECKING:
-
-        def __enter__(self: Self) -> Self:
-            ...
-
-        def __exit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None:
-            ...
 
     def __new__(cls, *args, **kwargs):
         # resolves the parent instance

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -107,14 +107,6 @@ class ContextMeta(type):
     the `with` statement.
     """
 
-    if TYPE_CHECKING:
-
-        def __enter__(self: Self) -> Self:
-            ...
-
-        def __exit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None:
-            ...
-
     def __new__(cls, name, bases, dct, **kwargs):  # pylint: disable=unused-argument
         """Add __enter__ and __exit__ methods to the class."""
 
@@ -222,7 +214,7 @@ class ContextMeta(type):
     # Initialize object in its own context...
     # Merged from InitContextMeta in the original.
     def __call__(cls, *args, **kwargs):
-        instance = cls.__new__(cls, *args, **kwargs)
+        instance: "Model" = cls.__new__(cls, *args, **kwargs)
         with instance:  # appends context
             instance.__init__(*args, **kwargs)
         return instance
@@ -484,6 +476,14 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         # variables inside both scopes will be named like `first::*`, `second::*`
     """
+
+    if TYPE_CHECKING:
+
+        def __enter__(self: Self) -> Self:
+            ...
+
+        def __exit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None:
+            ...
 
     def __new__(cls, *args, **kwargs):
         # resolves the parent instance

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -214,6 +214,8 @@ class ContextMeta(type):
     # Initialize object in its own context...
     # Merged from InitContextMeta in the original.
     def __call__(cls, *args, **kwargs):
+        # We type hint Model here so type checkers understand that Model is a context manager.
+        # This metaclass is only used for Model, so this is safe to do. See #6809 for more info.
         instance: "Model" = cls.__new__(cls, *args, **kwargs)
         with instance:  # appends context
             instance.__init__(*args, **kwargs)


### PR DESCRIPTION
There are currently two type errors in the Model class, preventing smooth usage with type checkers (like in VSCode):
This one became present in recent versions of pyright:
```python
# script.py
import pymc as pm
import arviz as az

with pm.Model() as m: # <-- (...) does not implement __enter__ 
    pm.Normal("a", mu=0, sigma=1)
    trace = pm.sample()

az.plot_posterior(trace)
```
and before that one, this one has been there for a long time:
```python
# script.py
import pymc as pm
import arviz as az

with pm.Model() as m:
    pm.Normal("a", mu=0, sigma=1)
    trace = pm.sample()

az.plot_posterior(trace) # <-- 9:19 - error: "trace" is possibly unbound (reportUnboundVariable)
```

This PR implements two small changes:
1. Sets the type of the `instance` variable in the ContextMeta `__call__` method to "Model". This fixes the first error.
2. Sets the return type of the context manager used by `with pm.Model()` to return `None`, which means that it won't be catching errors.

In the first fix, `instance` should be a resultant type that the `ContextMeta` is a metaclass for. I'm not sure how if a type hint that says "returns the child of a metaclass" exists. But I think this is safe, since `ContextMeta` isn't used as a metaclass anywhere else, and I'm not going for perfect type coverage, just to make it easy for people to code with autocompletion.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Bugfixes
- Fixed pm.Model not being interpreted as a context manager by pyright
- Fixed unbound type errors due to objects being created inside the pm.Model context



<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6809.org.readthedocs.build/en/6809/

<!-- readthedocs-preview pymc end -->