### PR TITLE
Fix mathematical notation in conditional_logprob docstrings

### DIFF
--- a/pymc/logprob/basic.py
+++ b/pymc/logprob/basic.py
@@ -430,12 +430,12 @@ def conditional_logp(
 
     .. math::
 
-        \Sigma^2 \sim& \operatorname{InvGamma}(0.5, 0.5) \\
-        Y \sim& \operatorname{N}(0, \Sigma)
+        s^2 \sim& \operatorname{InvGamma}(0.5, 0.5) \\
+        Y \sim& \operatorname{N}(0, s)
 
     If we create a value variable for ``Y_rv``, i.e. ``y_vv = pt.scalar("y")``,
     the graph of ``conditional_logp({Y_rv: y_vv})`` is equivalent to the
-    conditional log-probability :math:`\log p(Y = y \mid \Sigma^2)`, with a stochastic
+    conditional log-probability :math:`\log p_{Y \mid s^2}(y \mid s^2)`, with a stochastic
     ``sigma2_rv``.
 
     If we specify a value variable for ``sigma2_rv``, i.e.
@@ -445,8 +445,8 @@ def conditional_logp(
 
     .. math::
 
-        \log p(Y = y, \Sigma^2 = \sigma^2) =
-            \log p(Y = y \mid \Sigma^2 = \sigma^2) + \log p(\Sigma^2 = \sigma^2)
+        \log p_{Y,s^2}(y, \sigma^2) =
+            \log p_{Y \mid s^2}(y \mid \sigma^2) + \log p_{s^2}(\sigma^2)
 
 
     Parameters

--- a/pymc/logprob/basic.py
+++ b/pymc/logprob/basic.py
@@ -430,7 +430,7 @@ def conditional_logp(
 
     .. math::
 
-        s^2 \sim& \operatorname{InvGamma}(0.5, 0.5) \\
+        \sigma^2 \sim& \operatorname{InvGamma}(0.5, 0.5) \\
         Y \sim& \operatorname{N}(0, s)
 
     If we create a value variable for ``Y_rv``, i.e. ``y_vv = pt.scalar("y")``,

--- a/pymc/logprob/basic.py
+++ b/pymc/logprob/basic.py
@@ -431,7 +431,7 @@ def conditional_logp(
     .. math::
 
         \sigma^2 \sim& \operatorname{InvGamma}(0.5, 0.5) \\
-        Y \sim& \operatorname{N}(0, s)
+        Y \sim& \operatorname{N}(0, \sigma^2)
 
     If we create a value variable for ``Y_rv``, i.e. ``y_vv = pt.scalar("y")``,
     the graph of ``conditional_logp({Y_rv: y_vv})`` is equivalent to the

--- a/pymc/logprob/basic.py
+++ b/pymc/logprob/basic.py
@@ -435,7 +435,7 @@ def conditional_logp(
 
     If we create a value variable for ``Y_rv``, i.e. ``y_vv = pt.scalar("y")``,
     the graph of ``conditional_logp({Y_rv: y_vv})`` is equivalent to the
-    conditional log-probability :math:`\log p_{Y \mid s^2}(y \mid s^2)`, with a stochastic
+    conditional log-probability :math:`\log p_{Y \mid \sigma^2}(y \mid s^2)`, with a stochastic
     ``sigma2_rv``.
 
     If we specify a value variable for ``sigma2_rv``, i.e.
@@ -445,8 +445,8 @@ def conditional_logp(
 
     .. math::
 
-        \log p_{Y,s^2}(y, \sigma^2) =
-            \log p_{Y \mid s^2}(y \mid \sigma^2) + \log p_{s^2}(\sigma^2)
+        \log p_{Y, \sigma^2}(y, s^2) =
+            \log p_{Y \mid \sigma^2}(y \mid s^2) + \log p_{\sigma^2}(s^2)
 
 
     Parameters

--- a/pymc/logprob/basic.py
+++ b/pymc/logprob/basic.py
@@ -439,7 +439,7 @@ def conditional_logp(
     ``sigma2_rv``.
 
     If we specify a value variable for ``sigma2_rv``, i.e.
-    ``s_vv = pt.scalar("s2")``, then ``conditional_logp({Y_rv: y_vv, sigma2_rv: s_vv})``
+    ``s2_vv = pt.scalar("s2")``, then ``conditional_logp({Y_rv: y_vv, sigma2_rv: s2_vv})``
     yields the conditional log-probabilities of the two variables.
     The sum of the two terms gives their joint log-probability.
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Closes #6798

This PR Fix mathematical notation in `conditional_logprob` docstrings

The changes are pointed out by @larryshamalama in #6798. The notation changes are:
- Given that $\Sigma$ is commonly used for covariance matrices, it is replaced by $\sigma$ which is a more common notation.
- $P(Y = y)$ is replaced by $P_{Y}(y)$ to avoid incorrect notation in the case of continuous-valued random variables.

<img width="615" alt="image" src="https://github.com/pymc-devs/pymc/assets/22087841/5df33b30-3a64-44a7-8dbe-f03b259ef7aa">


**Checklist**
+ [ ] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6821.org.readthedocs.build/en/6821/

<!-- readthedocs-preview pymc end -->