### PR TITLE
chore: fix scipy version temp lock problem and chore to master

### DIFF
--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -17,7 +17,7 @@ dependencies:
 - python-graphviz
 - python=3.7
 - recommonmark>=0.4
-- scipy>=1.4.1,<1.8.0
+- scipy>=1.4.1
 - sphinx-autobuild>=0.7
 - sphinx>=1.5
 - watermark

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -17,7 +17,7 @@ dependencies:
 - python-graphviz
 - python=3.8
 - recommonmark>=0.4
-- scipy>=1.4.1,<1.8.0
+- scipy>=1.4.1
 - sphinx-autobuild>=0.7
 - sphinx>=1.5
 - watermark

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -17,7 +17,7 @@ dependencies:
 - python-graphviz
 - python=3.9
 - recommonmark>=0.4
-- scipy>=1.4.1,<1.8.0
+- scipy>=1.4.1
 - sphinx-autobuild>=0.7
 - sphinx>=1.5
 - watermark

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -22,7 +22,7 @@ dependencies:
 - pytest-cov>=2.5
 - pytest>=3.0
 - recommonmark>=0.4
-- scipy>=1.4.1,<1.8.0
+- scipy>=1.4.1
 - sphinx-autobuild>=0.7
 - sphinx>=1.5
 - watermark

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ fastprogress>=0.2.0
 numpy>=1.15.0,<1.22.2
 pandas>=0.24.0
 patsy>=0.5.1
-scipy>=1.7.3,<1.8.0
+scipy>=1.4.1
 semver>=2.13.0
 theano-pymc==1.1.2
 typing-extensions>=3.7.4


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**

We use pymc3 and need to upgrade the scipy version because the current locked version is < 1.81, preventing successful               
 installation.   

this PR chore with the master that for scipy locked < 1.81

https://github.com/pymc-devs/pymc/issues/5448


