### PR TITLE
Update metropolis.py

### DIFF
--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -758,8 +758,13 @@ class DEMetropolis(PopulationArrayStepShared):
 
         if proposal_dist is not None:
             self.proposal_dist = proposal_dist(S)
-        else:
+        elif S.ndim == 1:
             self.proposal_dist = NormalProposal(S)
+        elif S.ndim == 2:
+            self.proposal_dist = MultivariateNormalProposal(S)
+        else:
+            raise ValueError("Invalid rank for variance: %s" % S.ndim)
+
 
         self.scaling = np.atleast_1d(scaling).astype("d")
         if lamb is None:
@@ -902,8 +907,12 @@ class DEMetropolisZ(ArrayStepShared):
 
         if proposal_dist is not None:
             self.proposal_dist = proposal_dist(S)
-        else:
+        elif S.ndim == 1:
             self.proposal_dist = NormalProposal(S)
+        elif S.ndim == 2:
+            self.proposal_dist = MultivariateNormalProposal(S)
+        else:
+            raise ValueError("Invalid rank for variance: %s" % S.ndim)
 
         self.scaling = np.atleast_1d(scaling).astype("d")
         if lamb is None:


### PR DESCRIPTION
allow for covariance matrix not only variance

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
...

**Checklist**
+ [ ] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
 - when using the differential evolution metropolis methods the parameters say that they accept a 2D covariance matrix but fail when this is given. This is because the initialization step does not check for a 2D covariance function as other classes do and go straight to normal. Then the step gives a "scale < 0" error. I fix this.

## Documentation
- ...

## Maintenance
- ...


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6825.org.readthedocs.build/en/6825/

<!-- readthedocs-preview pymc end -->