### PR TITLE
Bump PyTensor dependency

### DIFF
--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.12.0,<2.13
+- pytensor>=2.14.1,<2.15
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.12.0,<2.13
+- pytensor>=2.14.1,<2.15
 - python-graphviz
 - scipy>=1.4.1
 - typing-extensions>=3.7.4

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -17,7 +17,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.12.0,<2.13
+- pytensor>=2.14.1,<2.15
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.12.0,<2.13
+- pytensor>=2.14.1,<2.15
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -17,7 +17,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.12.0,<2.13
+- pytensor>=2.14.1,<2.15
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -488,6 +488,11 @@ class _CustomDist(Distribution):
         class_name: str = "CustomDist",
         **kwargs,
     ):
+        if ndim_supp > 0:
+            raise NotImplementedError(
+                "CustomDist with ndim_supp > 0 and without a `dist` function are not supported."
+            )
+
         dist_params = [as_tensor_variable(param) for param in dist_params]
 
         # Assume scalar ndims_params

--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -183,7 +183,10 @@ class Covariance(BaseCovariance):
     def _slice(self, X, Xs=None):
         xdims = X.shape[-1]
         if isinstance(xdims, Variable):
-            xdims = xdims.eval()
+            # Circular dependency
+            from pymc.pytensorf import constant_fold
+
+            [xdims] = constant_fold([xdims])
         if self.input_dim != xdims:
             warnings.warn(
                 f"Only {self.input_dim} column(s) out of {xdims} are"

--- a/pymc/logprob/order.py
+++ b/pymc/logprob/order.py
@@ -52,6 +52,7 @@ from pymc.logprob.abstract import (
     _logprob_helper,
 )
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
+from pymc.pytensorf import constant_fold
 
 
 class MeasurableMax(Max):
@@ -120,7 +121,7 @@ def max_logprob(op, values, base_rv, **kwargs):
     logprob = _logprob_helper(base_rv, value)
     logcdf = _logcdf_helper(base_rv, value)
 
-    n = base_rv.size
+    [n] = constant_fold([base_rv.size])
 
     logprob = (n - 1) * logcdf + logprob + pt.math.log(n)
 

--- a/pymc/math.py
+++ b/pymc/math.py
@@ -75,13 +75,14 @@ from pytensor.tensor import (
     where,
     zeros_like,
 )
+from pytensor.tensor.special import log_softmax, softmax
 
 try:
     from pytensor.tensor.basic import extract_diag
 except ImportError:
     from pytensor.tensor.nlinalg import extract_diag
 
-from pytensor.tensor.nlinalg import det, matrix_dot, matrix_inverse, trace
+from pytensor.tensor.nlinalg import matrix_inverse
 from scipy.linalg import block_diag as scipy_block_diag
 
 from pymc.pytensorf import floatX, ix_, largest_common_dtype
@@ -267,31 +268,7 @@ def logdiffexp_numpy(a, b):
     return a + log1mexp_numpy(b - a, negative_input=True)
 
 
-def invlogit(x, eps=None):
-    """The inverse of the logit function, 1 / (1 + exp(-x))."""
-    if eps is not None:
-        warnings.warn(
-            "pymc.math.invlogit no longer supports the ``eps`` argument and it will be ignored.",
-            FutureWarning,
-            stacklevel=2,
-        )
-    return pt.sigmoid(x)
-
-
-def softmax(x, axis=None):
-    # Ignore vector case UserWarning issued by PyTensor. This can be removed once PyTensor
-    # drops that warning
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        return pt.special.softmax(x, axis=axis)
-
-
-def log_softmax(x, axis=None):
-    # Ignore vector case UserWarning issued by PyTensor. This can be removed once PyTensor
-    # drops that warning
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        return pt.special.log_softmax(x, axis=axis)
+invlogit = sigmoid
 
 
 def logbern(log_p):

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -23,6 +23,7 @@ from pytensor.graph.basic import ancestors, walk
 from pytensor.scalar.basic import Cast
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.random.op import RandomVariable
+from pytensor.tensor.shape import Shape
 from pytensor.tensor.var import TensorConstant, TensorVariable
 
 import pymc as pm
@@ -55,6 +56,9 @@ class ModelGraph:
 
         def _filter_non_parameter_inputs(var):
             node = var.owner
+            if isinstance(node.op, Shape):
+                # Don't show shape-related dependencies
+                return []
             if isinstance(node.op, RandomVariable):
                 # Filter out rng, dtype and size parameters or RandomVariable nodes
                 return node.inputs[3:]

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -87,7 +87,6 @@ __all__ = [
     "generator",
     "convert_observed_data",
     "compile_pymc",
-    "constant_fold",
 ]
 
 

--- a/pymc/variational/approximations.py
+++ b/pymc/variational/approximations.py
@@ -19,6 +19,7 @@ import pytensor
 from arviz import InferenceData
 from pytensor import tensor as pt
 from pytensor.graph.basic import Variable
+from pytensor.graph.replace import graph_replace
 from pytensor.tensor.var import TensorVariable
 
 import pymc as pm
@@ -390,7 +391,7 @@ class Empirical(SingleGroupApproximation):
         node = self.to_flat_input(node)
 
         def sample(post, *_):
-            return pytensor.clone_replace(node, {self.input: post})
+            return graph_replace(node, {self.input: post}, strict=False)
 
         nodes, _ = pytensor.scan(
             sample, self.histogram, non_sequences=_known_scan_ignored_inputs(makeiter(node))

--- a/pymc/variational/stein.py
+++ b/pymc/variational/stein.py
@@ -12,8 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import pytensor
 import pytensor.tensor as pt
+
+from pytensor.graph.replace import graph_replace
 
 from pymc.pytensorf import floatX
 from pymc.util import WithMemoization, locally_cachedmethod
@@ -85,9 +86,10 @@ class Stein(WithMemoization):
     def logp_norm(self):
         sized_symbolic_logp = self.approx.sized_symbolic_logp
         if self.use_histogram:
-            sized_symbolic_logp = pytensor.clone_replace(
+            sized_symbolic_logp = graph_replace(
                 sized_symbolic_logp,
                 dict(zip(self.approx.symbolic_randoms, self.approx.collect("histogram"))),
+                strict=False,
             )
         return sized_symbolic_logp / self.approx.symbolic_normalizing_constant
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ numpydoc
 pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
-pytensor>=2.12.0,<2.13
+pytensor>=2.14.1,<2.15
 pytest-cov>=2.5
 pytest>=3.0
 scipy>=1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ cloudpickle
 fastprogress>=0.2.0
 numpy>=1.15.0
 pandas>=0.24.0
-pytensor>=2.12.0,<2.13
+pytensor>=2.14.1,<2.15
 scipy>=1.4.1
 typing-extensions>=3.7.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import warnings
 
 import numpy as np
 import pytensor
@@ -45,3 +46,10 @@ def strict_float32():
 def seeded_test():
     # TODO: use this instead of SeededTest
     np.random.seed(42)
+
+
+@pytest.fixture
+def fail_on_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        yield

--- a/tests/distributions/test_dist_math.py
+++ b/tests/distributions/test_dist_math.py
@@ -224,7 +224,7 @@ def check_vals(fn1, fn2, *args):
 
 
 def test_multigamma():
-    x = pt.vector("x")
+    x = pt.vector("x", shape=(1,))
     p = pt.scalar("p")
 
     xvals = [np.array([v], dtype=config.floatX) for v in [0.1, 2, 5, 10, 50, 100]]

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -217,6 +217,10 @@ class TestCustomDist:
         with pytest.raises(NotImplementedError):
             pm.sample_posterior_predictive(idata, model=model)
 
+    @pytest.mark.xfail(
+        NotImplementedError,
+        reason="Support shape of multivariate CustomDist cannot be inferred. See https://github.com/pymc-devs/pytensor/pull/388",
+    )
     @pytest.mark.parametrize("size", [(), (3,), (3, 2)], ids=str)
     def test_custom_dist_with_random_multivariate(self, size):
         supp_shape = 5
@@ -264,6 +268,10 @@ class TestCustomDist:
             ):
                 CustomDist("a", lambda x: x)
 
+    @pytest.mark.xfail(
+        NotImplementedError,
+        reason="Support shape of multivariate CustomDist cannot be inferred. See https://github.com/pymc-devs/pytensor/pull/388",
+    )
     @pytest.mark.parametrize("size", [None, (), (2,)], ids=str)
     def test_custom_dist_multivariate_logp(self, size):
         supp_shape = 5
@@ -314,6 +322,10 @@ class TestCustomDist:
         assert evaled_moment.shape == to_tuple(size)
         assert np.all(evaled_moment == mu_val)
 
+    @pytest.mark.xfail(
+        NotImplementedError,
+        reason="Support shape of multivariate CustomDist cannot be inferred. See https://github.com/pymc-devs/pytensor/pull/388",
+    )
     @pytest.mark.parametrize("size", [(), (2,), (3, 2)], ids=str)
     def test_custom_dist_custom_moment_multivariate(self, size):
         def density_moment(rv, size, mu):
@@ -328,6 +340,10 @@ class TestCustomDist:
         assert evaled_moment.shape == to_tuple(size) + (5,)
         assert np.all(evaled_moment == mu_val)
 
+    @pytest.mark.xfail(
+        NotImplementedError,
+        reason="Support shape of multivariate CustomDist cannot be inferred. See https://github.com/pymc-devs/pytensor/pull/388",
+    )
     @pytest.mark.parametrize(
         "with_random, size",
         [

--- a/tests/logprob/test_mixture.py
+++ b/tests/logprob/test_mixture.py
@@ -1119,6 +1119,7 @@ def test_ifelse_mixture_shared_component():
     )
 
 
+@pytest.mark.xfail(reason="Relied on rewrite-case that is no longer supported by PyTensor")
 def test_joint_logprob_subtensor():
     """Make sure we can compute a joint log-probability for ``Y[I]`` where ``Y`` and ``I`` are random variables."""
 
@@ -1137,6 +1138,10 @@ def test_joint_logprob_subtensor():
     I_rv = pt.random.bernoulli(p, size=size, rng=rng)
     I_rv.name = "I"
 
+    # The rewrite for lifting subtensored RVs refuses to work with advanced
+    # indexing as it could lead to repeated draws.
+    # TODO: Re-enable rewrite for cases where this is not a concern
+    #  (e.g., at least one of the advanced indexes has non-repeating values)
     A_idx = A_rv[I_rv, pt.ogrid[A_rv.shape[-1] :]]
 
     assert isinstance(A_idx.owner.op, (Subtensor, AdvancedSubtensor, AdvancedSubtensor1))

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -262,37 +262,3 @@ def test_expand_packed_triangular():
     assert np.all(expand_upper.eval({packed: upper_packed}) == upper)
     assert np.all(expand_diag_lower.eval({packed: lower_packed}) == floatX(np.diag(vals)))
     assert np.all(expand_diag_upper.eval({packed: upper_packed}) == floatX(np.diag(vals)))
-
-
-def test_invlogit_deprecation_warning():
-    with pytest.warns(
-        FutureWarning,
-        match="pymc.math.invlogit no longer supports the",
-    ):
-        res = invlogit(np.array(-750.0), 1e-5).eval()
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        res_zero_eps = invlogit(np.array(-750.0)).eval()
-
-    assert np.isclose(res, res_zero_eps)
-
-
-@pytest.mark.parametrize(
-    "pytensor_function, pymc_wrapper",
-    [
-        (pt.special.softmax, softmax),
-        (pt.special.log_softmax, log_softmax),
-    ],
-)
-def test_softmax_logsoftmax_no_warnings(pytensor_function, pymc_wrapper):
-    """Test that wrappers for pytensor functions do not issue Warnings"""
-
-    vector = pt.vector("vector")
-    with pytest.warns(Warning) as record:
-        pytensor_function(vector)
-    assert {w.category for w in record.list} == {UserWarning, FutureWarning}
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        pymc_wrapper(vector)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -963,7 +963,7 @@ def test_set_data_constant_shape_error():
         pmodel.add_coord("weekday", length=x.shape[0])
         pm.MutableData("y", np.arange(7), dims="weekday")
 
-    msg = "because the dimension length is tied to a TensorConstant"
+    msg = "because the dimension was initialized from 'x'"
     with pytest.raises(ShapeError, match=msg):
         pmodel.set_data("y", np.arange(10))
 


### PR DESCRIPTION
Bumps PyTensor dependency to 2.14.1

This PyTensor release reverts dynamic broadcasting in Elemwise. Code that started to rely on it will fail, hence why it is marked as a major PyMC release as well.

We also keep shape dependencies in the original graph, so some logic that expected eager Constants had to be tweaked.

Finally, no more automatic support shape inference for Multivariate RVs. The thing we had going on wasn't robust and made errors cryptic in the cases where it didn't apply. This includes dropping support for Multivariate CustomDist not implemented with via `dist`

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6830.org.readthedocs.build/en/6830/

<!-- readthedocs-preview pymc end -->