### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -183,7 +183,7 @@ jobs:
       matrix:
         os: [windows-latest]
         floatx: [float64]
-        python-version: ["3.8"]
+        python-version: ["3.9"]
         test-subset:
           - tests/variational/test_approximations.py tests/variational/test_callbacks.py tests/variational/test_inference.py tests/variational/test_opvi.py tests/test_initial_point.py
           - tests/test_model.py tests/sampling/test_mcmc.py
@@ -259,7 +259,7 @@ jobs:
       matrix:
         os: [macos-latest]
         floatx: [float64]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
         test-subset:
           - |
             tests/sampling/test_parallel.py
@@ -338,7 +338,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         floatx: [float64]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         test-subset:
           - tests/sampling/test_jax.py tests/sampling/test_mcmc_external.py
       fail-fast: false

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -71,7 +70,7 @@ if __name__ == "__main__":
         # Also see MANIFEST.in
         # package_data={'docs': ['*']},
         classifiers=classifiers,
-        python_requires=">=3.8",
+        python_requires=">=3.9",
         install_requires=install_reqs,
         tests_require=test_reqs,
     )


### PR DESCRIPTION
Separating from #6830 so that other PRs can be merged in the meantime

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6832.org.readthedocs.build/en/6832/

<!-- readthedocs-preview pymc end -->