### PR TITLE
Logprob derivation for switch-encoding graphs

### DIFF
--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -279,6 +279,10 @@ def find_measurable_switch_encoding(
     if rv_map_feature.request_measurable([switch_condn]) != [switch_condn]:
         return None
 
+    [base_var] = rv_map_feature.request_measurable([switch_condn.owner.inputs[0]])
+    if base_var.dtype.startswith("int"):
+        return None
+
     # Maximum one branch allowed to be measurable
     if len(measurable_comp_list) > 1:
         return None

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -269,15 +269,15 @@ def find_measurable_switch_encoding(
     if switch_condn.type.broadcastable != node.outputs[0].type.broadcastable:
         return None
 
-    if rv_map_feature.request_measurable([switch_condn]) != [switch_condn]:
-        return None
-    # this automatically checks the measurability of the switch condition and converts switch to MeasurableSwitch
-
     measurable_comp_list = [
         idx
         for idx, component in enumerate(components)
         if check_potential_measurability([component], valued_rvs)
     ]
+
+    # this automatically checks the measurability of the switch condition and converts switch to MeasurableSwitch
+    if rv_map_feature.request_measurable([switch_condn]) != [switch_condn]:
+        return None
 
     # Maximum one branch allowed to be measurable
     if len(measurable_comp_list) > 1:

--- a/tests/logprob/test_censoring.py
+++ b/tests/logprob/test_censoring.py
@@ -287,7 +287,7 @@ def test_switch_encoding_both_branches():
     ],
 )
 def test_switch_encoding_one_branch_measurable(measurable_idx, test_values, exp_logp):
-    x_rv = pt.random.normal(0.5, 1)  # should not be defined again ideally
+    x_rv = pt.random.normal(0.5, 1)
     branches = (1, x_rv) if measurable_idx == 1 else (x_rv, 1)
 
     y_rv = pt.switch(x_rv < 1, *branches)

--- a/tests/logprob/test_censoring.py
+++ b/tests/logprob/test_censoring.py
@@ -327,6 +327,7 @@ def test_switch_encoding_invalid_bcast():
 
 
 def test_switch_encoding_discrete_fail():
+    """We do not support the encoding graphs of discrete RVs yet"""
     x_rv = pt.random.poisson(2)
     y_rv = pt.switch(x_rv > 3, x_rv, 1)
 

--- a/tests/logprob/test_censoring.py
+++ b/tests/logprob/test_censoring.py
@@ -279,10 +279,9 @@ def test_switch_encoding_both_branches():
     assert np.isclose(logp_fn(2), ref_scipy.logsf(0.3))
 
 
-@pytest.mark.skip(reason="Logprob calculation for measurable branches not added")
 def test_switch_encoding_second_branch_measurable():
     x_rv = pt.random.normal(0.5, 1)
-    y_rv = pt.switch(x_rv < 0.3, 1, x_rv)
+    y_rv = pt.switch(x_rv < 1, 1, x_rv)
 
     y_vv = y_rv.clone()
     ref_scipy = st.norm(0.5, 1)
@@ -290,7 +289,7 @@ def test_switch_encoding_second_branch_measurable():
     logprob = logp(y_rv, y_vv)
     logp_fn = pytensor.function([y_vv], logprob)
 
-    assert logp_fn(3) == -np.inf
+    assert logp_fn(0.5) == -np.inf
 
-    assert np.isclose(logp_fn(1), ref_scipy.logcdf(0.3))
-    assert np.isclose(logp_fn(0.2), -np.inf)
+    assert np.isclose(logp_fn(1), ref_scipy.logcdf(1))
+    assert np.isclose(logp_fn(1.2), ref_scipy.logpdf(1.2))

--- a/tests/logprob/test_censoring.py
+++ b/tests/logprob/test_censoring.py
@@ -268,7 +268,7 @@ def test_rounding(rounding_op):
 
 def test_switch_encoding_both_branches():
     x_rv = pt.random.normal(0.5, 1)
-    y_rv = pt.switch(x_rv < 0.3, 1, 2)
+    y_rv = pt.switch(x_rv < 0.3, 1.0, 2.0)
 
     y_vv = y_rv.clone()
     ref_scipy = st.norm(0.5, 1)
@@ -276,7 +276,7 @@ def test_switch_encoding_both_branches():
     logprob = logp(y_rv, y_vv)
     logp_fn = pytensor.function([y_vv], logprob)
 
-    assert logp_fn(3) == -np.inf
+    assert logp_fn(1.5) == -np.inf
 
     assert np.isclose(logp_fn(1), ref_scipy.logcdf(0.3))
     assert np.isclose(logp_fn(2), ref_scipy.logsf(0.3))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This draft PR consists of the headway made in inferring the log-probability of switch-encoding expressions for the following cases:

1) when both branches have an encoding constant,
```python
x = pt.random.normal(0.3)
y = pt.switch(x > 0.5, 1, 2)
```

2) when one of the two branches is measurable.
```python
x = pt.random.normal(0.3)
y = pt.switch(x > 0.5, 1, x)
```

The pending challenges with the second case above include the following:

1. Add calculation for the logprob when one of the branches is measurable,
2. Get the `pt.invert` to go through the IR rewrite and convert to its Measurable counterpart.

@ricardoV94 @larryshamalama 