### PR TITLE
Fixes for the McBackend adapter

### DIFF
--- a/pymc/backends/mcbackend.py
+++ b/pymc/backends/mcbackend.py
@@ -221,9 +221,13 @@ def make_runmeta_and_point_fn(
                 (-1 if s is None else s)
                 for s in (shape or [])
             ]
+            dt = np.dtype(dtype).name
+            # Object types will be pickled by the ChainRecordAdapter!
+            if dt == "object":
+                dt = "str"
             svar = mcb.Variable(
                 name=sname,
-                dtype=np.dtype(dtype).name,
+                dtype=dt,
                 shape=sshape,
                 undefined_ndim=shape is None,
             )

--- a/pymc/backends/mcbackend.py
+++ b/pymc/backends/mcbackend.py
@@ -33,6 +33,7 @@ from pymc.step_methods.compound import (
     BlockedStep,
     CompoundStep,
     StatsBijection,
+    check_step_emits_tune,
     flat_statname,
     flatten_steps,
 )
@@ -207,11 +208,10 @@ def make_runmeta_and_point_fn(
 ) -> Tuple[mcb.RunMeta, PointFunc]:
     variables, point_fn = get_variables_and_point_fn(model, initial_point)
 
-    sample_stats = [
-        mcb.Variable("tune", "bool"),
-    ]
+    check_step_emits_tune(step)
 
     # In PyMC the sampler stats are grouped by the sampler.
+    sample_stats = []
     steps = flatten_steps(step)
     for s, sm in enumerate(steps):
         for statname, (dtype, shape) in sm.stats_dtypes_shapes.items():

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -262,6 +262,16 @@ def flatten_steps(step: Union[BlockedStep, CompoundStep]) -> List[BlockedStep]:
     return steps
 
 
+def check_step_emits_tune(step: Union[CompoundStep, BlockedStep]):
+    if isinstance(step, BlockedStep) and "tune" not in step.stats_dtypes_shapes:
+        raise TypeError(f"{type(step)} does not emit the required 'tune' stat.")
+    elif isinstance(step, CompoundStep):
+        for sstep in step.methods:
+            if "tune" not in sstep.stats_dtypes_shapes:
+                raise TypeError(f"{type(sstep)} does not emit the required 'tune' stat.")
+    return
+
+
 class StatsBijection:
     """Map between a `list` of stats to `dict` of stats."""
 

--- a/tests/backends/test_mcbackend.py
+++ b/tests/backends/test_mcbackend.py
@@ -120,6 +120,19 @@ def test_make_runmeta_and_point_fn(simple_model):
     assert not vars["vector_interval__"].is_deterministic
     assert vars["matrix"].is_deterministic
     assert len(rmeta.sample_stats) == len(step.stats_dtypes[0])
+
+    with simple_model:
+        step = pm.NUTS()
+    rmeta, point_fn = make_runmeta_and_point_fn(
+        initial_point=simple_model.initial_point(),
+        step=step,
+        model=simple_model,
+    )
+    assert isinstance(rmeta, mcb.RunMeta)
+    svars = {s.name: s for s in rmeta.sample_stats}
+    # Unbeknownst to McBackend, object stats are pickled to str
+    assert "sampler_0__warning" in svars
+    assert svars["sampler_0__warning"].dtype == "str"
     pass
 
 

--- a/tests/backends/test_mcbackend.py
+++ b/tests/backends/test_mcbackend.py
@@ -119,7 +119,7 @@ def test_make_runmeta_and_point_fn(simple_model):
     assert not vars["vector"].is_deterministic
     assert not vars["vector_interval__"].is_deterministic
     assert vars["matrix"].is_deterministic
-    assert len(rmeta.sample_stats) == 1 + len(step.stats_dtypes[0])
+    assert len(rmeta.sample_stats) == len(step.stats_dtypes[0])
     pass
 
 

--- a/tests/step_methods/test_compound.py
+++ b/tests/step_methods/test_compound.py
@@ -26,6 +26,7 @@ from pymc.step_methods import (
     Slice,
 )
 from pymc.step_methods.compound import (
+    BlockedStep,
     StatsBijection,
     flatten_steps,
     get_stats_dtypes_shapes_from_steps,
@@ -34,6 +35,16 @@ from pymc.step_methods.compound import (
 from pymc.testing import fast_unstable_sampling_mode
 from tests.helpers import StepMethodTester
 from tests.models import simple_2model_continuous
+
+
+def test_all_stepmethods_emit_tune_stat():
+    attrs = [getattr(pm.step_methods, n) for n in dir(pm.step_methods)]
+    step_types = [
+        attr for attr in attrs if isinstance(attr, type) and issubclass(attr, BlockedStep)
+    ]
+    assert len(step_types) > 5
+    for cls in step_types:
+        assert "tune" in cls.stats_dtypes_shapes
 
 
 class TestCompoundStep:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This fixes two bugs that were reported by @thelogicalgrammar in https://github.com/michaelosthege/mcbackend/issues/93.

The first was a leftover of a previous refactoring of sampler stats, and the way how the `"tune"` stat is handled in PyMC.

**For the record:** Our current approach of passing information about tuning/not-tuning via sample stats is brittle. It's a per-sampler thing, but in practice it's actually a per-iteration thing from the PyMC, ArviZ and McBackend perspective. IMO we should consider taking it out of the step method attributes and stats, and instead pass `tune` as a parameter to the `astep` method.

However, this is out of scope for this PR, so I aligned with the current design and added `"tune"` to two step methods that didn't have it, much like Ricardo did for `Slice` in fee9a02c55763dea9dfe497ed509a3c05ad04972.


The second bug was just a small dtype thing for pickled stat objects.
I tested it locally with a ClickHouse server:

```python
def test_issue_93_b():
    seconds = np.linspace(0, 5)
    observations = np.random.normal(0.5 + np.random.uniform(size=3)[:, None] * seconds[None, :])
    with pm.Model(
        coords={
            "condition": ["A", "B", "C"],
        }
    ) as pmodel:
        x = pm.ConstantData("seconds", seconds, dims="time")
        a = pm.Normal("scalar")
        b = pm.Uniform("vector", dims="condition")
        pm.Deterministic("matrix", a + b[:, None] * x[None, :], dims=("condition", "time"))
        obs = pm.MutableData("obs", observations, dims=("condition", "time"))
        pm.Normal("L", pmodel["matrix"], observed=obs, dims=("condition", "time"))

    ch_client = clickhouse_driver.Client("localhost")
    backend = ClickHouseBackend(ch_client)
    with pmodel:
        pm.sample(trace=backend, tune=5, draws=7, discard_tuned_samples=False)
    assert idata.warmup_posterior.sizes["draw"] == 5
    assert idata.posterior.sizes["draw"] == 7
    pass
```


**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- None

## New features
- None

## Bugfixes
- Two bugs in McBackend adapter were fixed

## Documentation
- None

## Maintenance
- All of PyMC's step methods now emit a `"tune"` stat


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6835.org.readthedocs.build/en/6835/

<!-- readthedocs-preview pymc end -->