### PR TITLE
Use `ordered_univariate` in documentation example of NormalMixture

### DIFF
--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -539,7 +539,7 @@ class NormalMixture:
                 mu=data.mean(),
                 sigma=10,
                 shape=n_components,
-                transform=pm.transforms.ordered,
+                transform=pm.distributions.transforms.Ordered(),
                 initval=[1, 2, 3],
             )
             σ = pm.HalfNormal("σ", sigma=10, shape=n_components)

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -539,7 +539,7 @@ class NormalMixture:
                 mu=data.mean(),
                 sigma=10,
                 shape=n_components,
-                transform=pm.distributions.transforms.Ordered(),
+                transform=pm.distributions.transforms.univariate_ordered,
                 initval=[1, 2, 3],
             )
             σ = pm.HalfNormal("σ", sigma=10, shape=n_components)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
The documentation example of a [normal mixture](https://www.pymc.io/projects/docs/en/v5.7.0/api/distributions/generated/pymc.NormalMixture.html#pymc.NormalMixture) used an outdated path in the `transform` argument of `pm.Normal`.

**Checklist**
+ [X] Explain important implementation details 👆
+ [X] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [X] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [X] Are the changes covered by tests and docstrings?
+ [X] Fill out the short summary sections 👇

## Major / Breaking Changes
- None

## New features
- None

## Bugfixes
- None

## Documentation
- Instead of `pm.transforms.ordered`, an [`Ordered`](https://www.pymc.io/projects/docs/en/latest/api/distributions/generated/pymc.distributions.transforms.Ordered.html) is instantiated and used in its place.

## Maintenance
- None


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6842.org.readthedocs.build/en/6842/

<!-- readthedocs-preview pymc end -->