### PR TITLE
Fix regression #6840

### DIFF
--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -492,7 +492,6 @@ class BinaryGibbsMetropolis(ArrayStep):
 
     def reset_tuning(self):
         # There are no tuning parameters in this step method.
-        self.tune = False
         return
 
     def astep(self, apoint: RaveledVars, *args) -> Tuple[RaveledVars, StatsType]:
@@ -620,7 +619,6 @@ class CategoricalGibbsMetropolis(ArrayStep):
 
     def reset_tuning(self):
         # There are no tuning parameters in this step method.
-        self.tune = False
         return
 
     def astep_unif(self, apoint: RaveledVars, *args) -> Tuple[RaveledVars, StatsType]:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -133,7 +133,7 @@ class StepMethodTester:
                     continue
                 assert idata.sample_stats[stat].dtype == np.dtype(dtype)
 
-    def step_continuous(self, step_fn, draws):
+    def step_continuous(self, step_fn, draws, chains=1, tune=1000):
         start, model, (mu, C) = mv_simple()
         unc = np.diag(C) ** 0.5
         check = (("x", np.mean, mu, unc / 10), ("x", np.std, unc, unc / 10))
@@ -143,14 +143,19 @@ class StepMethodTester:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", "More chains .* than draws .*", UserWarning)
                 idata = pm.sample(
-                    tune=1000,
+                    tune=tune,
                     draws=draws,
-                    chains=1,
+                    chains=chains,
                     step=step,
                     initvals=start,
                     model=model,
                     random_seed=1,
+                    discard_tuned_samples=False,
                 )
+            assert idata.warmup_posterior.sizes["chain"] == chains
+            assert idata.warmup_posterior.sizes["draw"] == tune
+            assert idata.posterior.sizes["chain"] == chains
+            assert idata.posterior.sizes["draw"] == draws
             self.check_stat(check, idata, step.__class__.__name__)
             self.check_stat_dtype(idata, step)
 


### PR DESCRIPTION
The `tune` attribute is reset by the sampling iterator.

Closes #6840

Tested locally with

```python
import pymc

def test_issue_6840():
    with pymc.Model():
        pymc.Bernoulli('X', p=0.2)
        idata = pymc.sample(draws=3, chains=2, discard_tuned_samples=False)
    assert idata.warmup_posterior.sizes["draw"] == 1000
    assert idata.posterior.sizes["draw"] == 3
    assert idata.warmup_posterior.sizes["chain"] == 2
    assert idata.posterior.sizes["chain"] == 2
```

## Bugfixes
- Fixes a regression in `BinaryGibbsMetropolis` and `CategoricalGibbsMetropolis`


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6843.org.readthedocs.build/en/6843/

<!-- readthedocs-preview pymc end -->