### PR TITLE
Logprob derivation for Min of continuous IID variables

### DIFF
--- a/pymc/logprob/order.py
+++ b/pymc/logprob/order.py
@@ -209,7 +209,7 @@ measurable_ir_rewrites_db.register(
 
 
 @_logprob.register(MeasurableMaxNeg)
-def min_logprob(op, values, base_var, **kwargs):
+def max_neg_logprob(op, values, base_var, **kwargs):
     r"""Compute the log-likelihood graph for the `Max` operation.
     The formula that we use here is :
         \ln(f_{(n)}(x)) = \ln(n) + (n-1) \ln(1 - F(x)) + \ln(f(x))

--- a/tests/logprob/test_order.py
+++ b/tests/logprob/test_order.py
@@ -43,7 +43,6 @@ import pytest
 import pymc as pm
 
 from pymc import logp
-from pymc.logprob import conditional_logp
 from pymc.testing import assert_no_rvs
 
 
@@ -58,55 +57,112 @@ def test_argmax():
         x_max_logprob = logp(x_max, x_max_value)
 
 
-def test_max_non_iid_fails():
-    """Test whether the logprob for ```pt.max``` for non i.i.d is correctly rejected"""
+@pytest.mark.parametrize(
+    "if_max",
+    [
+        True,
+        False,
+    ],
+)
+def test_non_iid_fails(if_max):
+    """Test whether the logprob for ```pt.max``` or ```pt.min``` for non i.i.d is correctly rejected"""
     x = pm.Normal.dist([0, 1, 2, 3, 4], 1, shape=(5,))
     x.name = "x"
-    x_max = pt.max(x, axis=-1)
-    x_max_value = pt.vector("x_max_value")
+    if if_max == True:
+        x_m = pt.max(x, axis=-1)
+        x_m_value = pt.vector("x_max_value")
+    else:
+        x_min = pt.min(x, axis=-1)
+        x_m = x_min.owner.inputs[0]
+        x_m_value = pt.vector("x_min_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
-        x_max_logprob = logp(x_max, x_max_value)
+        x_max_logprob = logp(x_m, x_m_value)
 
 
-def test_max_non_rv_fails():
+@pytest.mark.parametrize(
+    "if_max",
+    [True, False],
+)
+def test_non_rv_fails(if_max):
     """Test whether the logprob for ```pt.max``` for non-RVs is correctly rejected"""
     x = pt.exp(pt.random.beta(0, 1, size=(3,)))
     x.name = "x"
-    x_max = pt.max(x, axis=-1)
-    x_max_value = pt.vector("x_max_value")
+    if if_max == True:
+        x_m = pt.max(x, axis=-1)
+        x_m_value = pt.vector("x_max_value")
+    else:
+        x_min = pt.min(x, axis=-1)
+        x_m = x_min.owner.inputs[0]
+        x_m_value = pt.vector("x_min_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
-        x_max_logprob = logp(x_max, x_max_value)
+        x_max_logprob = logp(x_m, x_m_value)
 
 
-def test_max_multivariate_rv_fails():
+@pytest.mark.parametrize(
+    "if_max",
+    [
+        True,
+        False,
+    ],
+)
+def test_multivariate_rv_fails(if_max):
     _alpha = pt.scalar()
     _k = pt.iscalar()
     x = pm.StickBreakingWeights.dist(_alpha, _k)
     x.name = "x"
-    x_max = pt.max(x, axis=-1)
-    x_max_value = pt.vector("x_max_value")
+    if if_max == True:
+        x_m = pt.max(x, axis=-1)
+        x_m_value = pt.vector("x_max_value")
+    else:
+        x_min = pt.min(x, axis=-1)
+        x_m = x_min.owner.inputs[0]
+        x_m_value = pt.vector("x_min_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
-        x_max_logprob = logp(x_max, x_max_value)
+        x_max_logprob = logp(x_m, x_m_value)
 
 
-def test_max_categorical():
+@pytest.mark.parametrize(
+    "if_max",
+    [
+        True,
+        False,
+    ],
+)
+def test_categorical(if_max):
     """Test whether the logprob for ```pt.max``` for unsupported distributions is correctly rejected"""
     x = pm.Categorical.dist([1, 1, 1, 1], shape=(5,))
     x.name = "x"
-    x_max = pt.max(x, axis=-1)
-    x_max_value = pt.vector("x_max_value")
+    if if_max == True:
+        x_m = pt.max(x, axis=-1)
+        x_m_value = pt.vector("x_max_value")
+    else:
+        x_min = pt.min(x, axis=-1)
+        x_m = x_min.owner.inputs[0]
+        x_m_value = pt.vector("x_min_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
-        x_max_logprob = logp(x_max, x_max_value)
+        x_max_logprob = logp(x_m, x_m_value)
 
 
-def test_non_supp_axis_max():
+@pytest.mark.parametrize(
+    "if_max",
+    [
+        True,
+        False,
+    ],
+)
+def test_non_supp_axis(if_max):
     """Test whether the logprob for ```pt.max``` for unsupported axis is correctly rejected"""
     x = pt.random.normal(0, 1, size=(3, 3))
     x.name = "x"
-    x_max = pt.max(x, axis=-1)
-    x_max_value = pt.vector("x_max_value")
+    if if_max == True:
+        x_m = pt.max(x, axis=-1)
+        x_m_value = pt.vector("x_max_value")
+    else:
+        x_min = pt.min(x, axis=-1)
+        x_m = x_min.owner.inputs[0]
+        x_m_value = pt.vector("x_min_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
-        x_max_logprob = logp(x_max, x_max_value)
+        x_max_logprob = logp(x_m, x_m_value)
 
 
 @pytest.mark.parametrize(
@@ -147,3 +203,54 @@ def test_max_logprob(shape, value, axis):
         (x_max_logprob.eval({x_max_value: test_value})),
         rtol=1e-06,
     )
+
+
+@pytest.mark.parametrize(
+    "shape, value, axis",
+    [
+        (3, 0.85, -1),
+        (3, 0.01, 0),
+        (2, 0.2, None),
+        (4, 0.5, 0),
+        ((3, 4), 0.9, None),
+        ((3, 4), 0.75, (1, 0)),
+    ],
+)
+def test_min_logprob(shape, value, axis):
+    """Test whether the logprob for ```pt.mix``` produces the corrected
+    The fact that order statistics of i.i.d. uniform RVs ~ Beta is used here:
+        U_1, \\dots, U_n \\stackrel{\text{i.i.d.}}{\\sim} \text{Uniform}(0, 1) \\Rightarrow U_{(k)} \\sim \text{Beta}(k, n + 1- k)
+    for all 1<=k<=n
+    """
+    x = pt.random.uniform(0, 1, size=shape)
+    x.name = "x"
+    x_min = pt.min(x, axis=axis)
+    x_min_rv = x_min.owner.inputs[0]
+    x_min_value = pt.scalar("x_min_value")
+    x_min_logprob = logp(x_min_rv, x_min_value)
+
+    assert_no_rvs(x_min_logprob)
+
+    test_value = value
+
+    n = np.prod(shape)
+    beta_rv = pt.random.beta(1, n, name="beta")
+    beta_vv = beta_rv.clone()
+    beta_rv_logprob = logp(beta_rv, beta_vv)
+
+    np.testing.assert_allclose(
+        beta_rv_logprob.eval({beta_vv: test_value}),
+        (x_min_logprob.eval({x_min_value: test_value})),
+        rtol=1e-06,
+    )
+
+
+def test_min_non_mul_elemwise_fails():
+    """Test whether the logprob for ```pt.min``` for non-mul elemwise RVs is rejected correctly"""
+    x = pt.log(pt.random.beta(0, 1, size=(3,)))
+    x.name = "x"
+    x_min = pt.min(x, axis=-1)
+    x_min_rv = x_min.owner.inputs[0]
+    x_min_value = pt.vector("x_min_value")
+    with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
+        x_min_logprob = logp(x_min_rv, x_min_value)

--- a/tests/logprob/test_order.py
+++ b/tests/logprob/test_order.py
@@ -58,104 +58,87 @@ def test_argmax():
 
 
 @pytest.mark.parametrize(
-    "if_max",
+    "pt_op",
     [
-        True,
-        False,
+        pt.max,
+        pt.min,
     ],
 )
-def test_non_iid_fails(if_max):
+def test_non_iid_fails(pt_op):
     """Test whether the logprob for ```pt.max``` or ```pt.min``` for non i.i.d is correctly rejected"""
     x = pm.Normal.dist([0, 1, 2, 3, 4], 1, shape=(5,))
     x.name = "x"
-    if if_max == True:
-        x_m = pt.max(x, axis=-1)
-        x_m_value = pt.vector("x_max_value")
-    else:
-        x_m = pt.min(x, axis=-1)
-        x_m_value = pt.vector("x_min_value")
+    x_m = pt_op(x, axis=-1)
+    x_m_value = pt.vector("x_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
         x_max_logprob = logp(x_m, x_m_value)
 
 
 @pytest.mark.parametrize(
-    "if_max",
-    [True, False],
+    "pt_op",
+    [
+        pt.max,
+        pt.min,
+    ],
 )
-def test_non_rv_fails(if_max):
+def test_non_rv_fails(pt_op):
     """Test whether the logprob for ```pt.max``` for non-RVs is correctly rejected"""
     x = pt.exp(pt.random.beta(0, 1, size=(3,)))
     x.name = "x"
-    if if_max == True:
-        x_m = pt.max(x, axis=-1)
-        x_m_value = pt.vector("x_max_value")
-    else:
-        x_m = pt.min(x, axis=-1)
-        x_m_value = pt.vector("x_min_value")
+    x_m = pt_op(x, axis=-1)
+    x_m_value = pt.vector("x_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
         x_max_logprob = logp(x_m, x_m_value)
 
 
 @pytest.mark.parametrize(
-    "if_max",
+    "pt_op",
     [
-        True,
-        False,
+        pt.max,
+        pt.min,
     ],
 )
-def test_multivariate_rv_fails(if_max):
+def test_multivariate_rv_fails(pt_op):
     _alpha = pt.scalar()
     _k = pt.iscalar()
     x = pm.StickBreakingWeights.dist(_alpha, _k)
     x.name = "x"
-    if if_max == True:
-        x_m = pt.max(x, axis=-1)
-        x_m_value = pt.vector("x_max_value")
-    else:
-        x_m = pt.min(x, axis=-1)
-        x_m_value = pt.vector("x_min_value")
+    x_m = pt_op(x, axis=-1)
+    x_m_value = pt.vector("x_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
         x_max_logprob = logp(x_m, x_m_value)
 
 
 @pytest.mark.parametrize(
-    "if_max",
+    "pt_op",
     [
-        True,
-        False,
+        pt.max,
+        pt.min,
     ],
 )
-def test_categorical(if_max):
+def test_categorical(pt_op):
     """Test whether the logprob for ```pt.max``` for unsupported distributions is correctly rejected"""
     x = pm.Categorical.dist([1, 1, 1, 1], shape=(5,))
     x.name = "x"
-    if if_max == True:
-        x_m = pt.max(x, axis=-1)
-        x_m_value = pt.vector("x_max_value")
-    else:
-        x_m = pt.min(x, axis=-1)
-        x_m_value = pt.vector("x_min_value")
+    x_m = pt_op(x, axis=-1)
+    x_m_value = pt.vector("x_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
         x_max_logprob = logp(x_m, x_m_value)
 
 
 @pytest.mark.parametrize(
-    "if_max",
+    "pt_op",
     [
-        True,
-        False,
+        pt.max,
+        pt.min,
     ],
 )
-def test_non_supp_axis(if_max):
+def test_non_supp_axis(pt_op):
     """Test whether the logprob for ```pt.max``` for unsupported axis is correctly rejected"""
     x = pt.random.normal(0, 1, size=(3, 3))
     x.name = "x"
-    if if_max == True:
-        x_m = pt.max(x, axis=-1)
-        x_m_value = pt.vector("x_max_value")
-    else:
-        x_m = pt.min(x, axis=-1)
-        x_m_value = pt.vector("x_min_value")
+    x_m = pt_op(x, axis=-1)
+    x_m_value = pt.vector("x_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
         x_max_logprob = logp(x_m, x_m_value)
 

--- a/tests/logprob/test_order.py
+++ b/tests/logprob/test_order.py
@@ -72,8 +72,7 @@ def test_non_iid_fails(if_max):
         x_m = pt.max(x, axis=-1)
         x_m_value = pt.vector("x_max_value")
     else:
-        x_min = pt.min(x, axis=-1)
-        x_m = x_min.owner.inputs[0]
+        x_m = pt.min(x, axis=-1)
         x_m_value = pt.vector("x_min_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
         x_max_logprob = logp(x_m, x_m_value)
@@ -91,8 +90,7 @@ def test_non_rv_fails(if_max):
         x_m = pt.max(x, axis=-1)
         x_m_value = pt.vector("x_max_value")
     else:
-        x_min = pt.min(x, axis=-1)
-        x_m = x_min.owner.inputs[0]
+        x_m = pt.min(x, axis=-1)
         x_m_value = pt.vector("x_min_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
         x_max_logprob = logp(x_m, x_m_value)
@@ -114,8 +112,7 @@ def test_multivariate_rv_fails(if_max):
         x_m = pt.max(x, axis=-1)
         x_m_value = pt.vector("x_max_value")
     else:
-        x_min = pt.min(x, axis=-1)
-        x_m = x_min.owner.inputs[0]
+        x_m = pt.min(x, axis=-1)
         x_m_value = pt.vector("x_min_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
         x_max_logprob = logp(x_m, x_m_value)
@@ -136,8 +133,7 @@ def test_categorical(if_max):
         x_m = pt.max(x, axis=-1)
         x_m_value = pt.vector("x_max_value")
     else:
-        x_min = pt.min(x, axis=-1)
-        x_m = x_min.owner.inputs[0]
+        x_m = pt.min(x, axis=-1)
         x_m_value = pt.vector("x_min_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
         x_max_logprob = logp(x_m, x_m_value)
@@ -158,8 +154,7 @@ def test_non_supp_axis(if_max):
         x_m = pt.max(x, axis=-1)
         x_m_value = pt.vector("x_max_value")
     else:
-        x_min = pt.min(x, axis=-1)
-        x_m = x_min.owner.inputs[0]
+        x_m = pt.min(x, axis=-1)
         x_m_value = pt.vector("x_min_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
         x_max_logprob = logp(x_m, x_m_value)
@@ -225,9 +220,8 @@ def test_min_logprob(shape, value, axis):
     x = pt.random.uniform(0, 1, size=shape)
     x.name = "x"
     x_min = pt.min(x, axis=axis)
-    x_min_rv = x_min.owner.inputs[0]
     x_min_value = pt.scalar("x_min_value")
-    x_min_logprob = logp(x_min_rv, x_min_value)
+    x_min_logprob = logp(x_min, x_min_value)
 
     assert_no_rvs(x_min_logprob)
 
@@ -250,7 +244,6 @@ def test_min_non_mul_elemwise_fails():
     x = pt.log(pt.random.beta(0, 1, size=(3,)))
     x.name = "x"
     x_min = pt.min(x, axis=-1)
-    x_min_rv = x_min.owner.inputs[0]
     x_min_value = pt.vector("x_min_value")
     with pytest.raises(RuntimeError, match=re.escape("Logprob method not implemented")):
-        x_min_logprob = logp(x_min_rv, x_min_value)
+        x_min_logprob = logp(x_min, x_min_value)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This PR aims to provide a solution for implementing the Max operation from order statistics to solve the issue [#6350](https://github.com/pymc-devs/pymc/issues/6350) and issue [6773](https://github.com/pymc-devs/pymc/issues/6773). This is an extension of [#6769](https://github.com/pymc-devs/pymc/pull/6769). More tests related to MIN operation are to be added.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- Logprob derivation for ```pt.min```

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6846.org.readthedocs.build/en/6846/

<!-- readthedocs-preview pymc end -->