### PR TITLE
Do not use `seeded_test` fixture in exported `BaseTestDistributionRandom`

### DIFF
--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -848,7 +848,7 @@ class BaseTestDistributionRandom:
     repeated_params_shape = 5
     random_state = None
 
-    def test_distribution(self, seeded_test):
+    def test_distribution(self):
         self.validate_tests_list()
         if self.pymc_dist == pm.Wishart:
             with pytest.warns(UserWarning, match="can currently not be used for MCMC sampling"):

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -1825,7 +1825,7 @@ class TestStudentT(BaseTestDistributionRandom):
 
 class TestHalfStudentT(BaseTestDistributionRandom):
     def halfstudentt_rng_fn(self, df, loc, scale, size, rng):
-        return np.abs(st.t.rvs(df=df, loc=loc, scale=scale, size=size))
+        return np.abs(st.t.rvs(df=df, loc=loc, scale=scale, size=size, random_state=rng))
 
     pymc_dist = pm.HalfStudentT
     pymc_dist_params = {"nu": 5.0, "sigma": 2.0}

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -1972,7 +1972,7 @@ class TestKroneckerNormal(BaseTestDistributionRandom):
     def kronecker_rng_fn(self, size, mu, covs=None, sigma=None, rng=None):
         cov = pm.math.kronecker(covs[0], covs[1]).eval()
         cov += sigma**2 * np.identity(cov.shape[0])
-        return st.multivariate_normal.rvs(mean=mu, cov=cov, size=size)
+        return st.multivariate_normal.rvs(mean=mu, cov=cov, size=size, random_state=rng)
 
     pymc_dist = pm.KroneckerNormal
 


### PR DESCRIPTION
This caused pymc-experimental to fail as the test is used there but there is no access to the fixture. 
The fixture was added after the changes in #6799 
I don't think we need it?

CC @aerubanov 

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6848.org.readthedocs.build/en/6848/

<!-- readthedocs-preview pymc end -->