### PR TITLE
Add install instructions for nutpie

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -32,3 +32,14 @@ conda install blackjax
 ```
 
 Note that JAX is not directly supported on Windows systems at the moment.
+
+## Nutpie sampling
+
+You can also enable sampling with [nutpie](https://github.com/pymc-devs/nutpie).
+Nutpie uses numba as the compiler and a sampler written in Rust for faster performance.
+
+```console
+conda install -c conda-forge nutpie
+```
+
+Unlike JAX, nutpie is directly supported on Windows.


### PR DESCRIPTION
I verified that the conda + conda-forge instructions work after getting a fresh install of pymc. I suspect this will be the simplest install instructions that work for most users. If they want further ideas, they can follow the link to the nutpie page for mamba, source or pip install commands. Mostly I think this change serves as a good advertisement for nutpie and will encourage more folks to try it out.

Issue #6851

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6862.org.readthedocs.build/en/6862/

<!-- readthedocs-preview pymc end -->