### PR TITLE
fix format library citation

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,7 +1,7 @@
 @article{pymc2023,
   title={PyMC: A Modern and Comprehensive Probabilistic Programming Framework in Python},
   author={Abril-Pla Oriol and Andreani Virgile and Carroll Colin and Dong Larry and Fonnesbeck Christopher J. and Kochurov Maxim and Kumar Ravin and Lao Jupeng and Luhmann Christian C. and Martin Osvaldo A. and Osthege Michael and Vieira Ricardo and Wiecki Thomas and Zinkov Robert},
-  journal = {{PeerJ} Computer Science}
+  journal = {{PeerJ} Computer Science},
   publisher = {{PeerJ}},
   volume={9},
   pages={e1516},

--- a/README.rst
+++ b/README.rst
@@ -68,8 +68,7 @@ Citing PyMC
 ===========
 Please choose from the following:
 
-- |DOIpaper| *PyMC: A Modern and Comprehensive Probabilistic Programming Framework in Python*, Abril-Pla O, Andreani V, Carroll C, Dong L, Fonnesbeck CJ, Kochurov M, Kumar R, Lao J, Luhmann CC, Martin
-OA, Osthege M, Vieira R, Wiecki T, Zinkov R. (2023)
+- |DOIpaper| *PyMC: A Modern and Comprehensive Probabilistic Programming Framework in Python*, Abril-Pla O, Andreani V, Carroll C, Dong L, Fonnesbeck CJ, Kochurov M, Kumar R, Lao J, Luhmann CC, Martin OA, Osthege M, Vieira R, Wiecki T, Zinkov R. (2023)
 - |DOIzenodo| A DOI for all versions.
 - DOIs for specific versions are shown on Zenodo and under `Releases <https://github.com/pymc-devs/pymc/releases>`_
 


### PR DESCRIPTION
There were two formatting issues that I just noticed after merging #6861 :man_facepalming: 

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6863.org.readthedocs.build/en/6863/

<!-- readthedocs-preview pymc end -->