### PR TITLE
Add ICAR to the list of distributions in the docs

### DIFF
--- a/docs/source/api/distributions/multivariate.rst
+++ b/docs/source/api/distributions/multivariate.rst
@@ -10,6 +10,7 @@ Multivariate
    CAR
    Dirichlet
    DirichletMultinomial
+   ICAR
    KroneckerNormal
    LKJCholeskyCov
    LKJCorr


### PR DESCRIPTION
I added a new distribution in #6831 but it's not appearing on the API reference on the website. I'm pretty sure I just need to change the `.rst` file in the docs folder. 


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6867.org.readthedocs.build/en/6867/

<!-- readthedocs-preview pymc end -->