### PR TITLE
Numpyro keep warmup

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -676,6 +676,7 @@ def sample_numpyro_nuts(
     if tune > 0:
         pmap_numpyro.warmup(
             map_seed,
+            collect_warmup=True,
             init_params=init_params,
             extra_fields=extra_fields,
         )

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -664,18 +664,37 @@ def sample_numpyro_nuts(
     if chains > 1:
         map_seed = jax.random.split(map_seed, chains)
 
-    pmap_numpyro.run(
-        map_seed,
-        init_params=init_params,
-        extra_fields=(
-            "num_steps",
-            "potential_energy",
-            "energy",
-            "adapt_state.step_size",
-            "accept_prob",
-            "diverging",
-        ),
+    extra_fields=(
+        "num_steps",
+        "potential_energy",
+        "energy",
+        "adapt_state.step_size",
+        "accept_prob",
+        "diverging",
     )
+
+    if tune > 0:
+        pmap_numpyro.warmup(
+            map_seed,
+            init_params=init_params,
+            extra_fields=extra_fields,
+        )
+
+        raw_mcmc_warmup_samples = pmap_numpyro.get_samples(group_by_chain=True)
+        warmup_sample_stats = _sample_stats_to_xarray(pmap_numpyro)
+
+        pmap_numpyro.post_warmup_state = pmap_numpyro.last_state
+        pmap_numpyro.run(
+            pmap_numpyro.post_warmup_state.rng_key,
+            extra_fields=extra_fields,
+        )
+
+    else:
+        pmap_numpyro.run(
+            map_seed,
+            init_params=init_params,
+            extra_fields=extra_fields,
+        )
 
     raw_mcmc_samples = pmap_numpyro.get_samples(group_by_chain=True)
 
@@ -730,5 +749,13 @@ def sample_numpyro_nuts(
         dims=dims,
         attrs=make_attrs(attrs, library=numpyro),
     )
-    az_trace = to_trace(posterior=posterior, **idata_kwargs)
+
+    if tune > 0:
+        az_trace = to_trace(
+            posterior=posterior,
+            warmup_sample_stats=warmup_sample_stats,
+            **idata_kwargs,
+        )
+    else:
+        az_trace = to_trace(posterior=posterior, **idata_kwargs)
     return az_trace

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -658,8 +658,6 @@ def sample_numpyro_nuts(
     tic2 = datetime.now()
     print("Compilation time = ", tic2 - tic1, file=sys.stdout)
 
-    print("Sampling...", file=sys.stdout)
-
     map_seed = jax.random.PRNGKey(random_seed)
     if chains > 1:
         map_seed = jax.random.split(map_seed, chains)
@@ -674,6 +672,7 @@ def sample_numpyro_nuts(
     )
 
     if tune > 0:
+        print("Warmup...", file=sys.stdout)
         pmap_numpyro.warmup(
             map_seed,
             collect_warmup=True,
@@ -684,6 +683,7 @@ def sample_numpyro_nuts(
         raw_mcmc_warmup_samples = pmap_numpyro.get_samples(group_by_chain=True)
         warmup_sample_stats = _sample_stats_to_xarray(pmap_numpyro)
 
+        print("Sampling...", file=sys.stdout)
         pmap_numpyro.post_warmup_state = pmap_numpyro.last_state
         pmap_numpyro.run(
             pmap_numpyro.post_warmup_state.rng_key,
@@ -691,6 +691,7 @@ def sample_numpyro_nuts(
         )
 
     else:
+        print("Sampling...", file=sys.stdout)
         pmap_numpyro.run(
             map_seed,
             init_params=init_params,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This PR aims to improve on the experimental feature of the numpyro NUTS sampler within PyMC. 
It enables access to the warmup_sample_stats xarray data struct by passing along save_warmup in `idata_kwargs`. It is a first step to fulfill  #6723 
It would be nice to eliminate the need of a jax recompilation for `numpyro.infer.MCMC.run` after `.warmup` has completed.

**Checklist**
+ [ ] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- ...

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- `idata = pm.sample(..., nuts_sampler="numpyro", idata_kwargs=dict( save_warmup=True, ))` now provides warmup_sample_stats


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6875.org.readthedocs.build/en/6875/

<!-- readthedocs-preview pymc end -->