### PR TITLE
Implement periodic kernel for HSGP

### DIFF
--- a/pymc/gp/__init__.py
+++ b/pymc/gp/__init__.py
@@ -22,4 +22,4 @@ from pymc.gp.gp import (
     MarginalKron,
     MarginalSparse,
 )
-from pymc.gp.hsgp_approx import HSGP
+from pymc.gp.hsgp_approx import HSGP, HSGPPeriodic

--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -791,10 +791,11 @@ class Periodic(Stationary):
         r2 = dist if squared else dist**2
         return pt.exp(-0.5 * r2)
 
-    def power_spectral_density(self, m: TensorLike) -> TensorVariable:
+    def power_spectral_density(self, J: TensorLike) -> TensorVariable:
         """
         Technically, this is not a spectral density but these are the first `m` coefficients of
         the low rank approximation for the periodic kernel, which are used in the same way.
+        `J` is a vector of `np.arange(m)`.
 
         The coefficients of the HSGP approximation for the Periodic kernel are given by:
 
@@ -806,7 +807,6 @@ class Periodic(Stationary):
         where $\text{I}_j$ is the modified Bessel function of the first kind.
         """
         a = 1 / pt.square(self.ls)
-        J = pt.arange(0, m)
         c = pt.where(J > 0, 2, 1)
 
         q2 = c * pt.iv(J, a) / pt.exp(a)

--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -791,6 +791,28 @@ class Periodic(Stationary):
         r2 = dist if squared else dist**2
         return pt.exp(-0.5 * r2)
 
+    def power_spectral_density(self, m: TensorLike) -> TensorVariable:
+        """
+        Technically, this is not a spectral density but these are the first `m` coefficients of
+        the low rank approximation for the periodic kernel, which are used in the same way.
+
+        The coefficients of the HSGP approximation for the Periodic kernel are given by:
+
+        .. math::
+
+            \tilde{q}_j^2 = \frac{2 \text{I}_j (\\ell^{-2})}{\\exp(\\ell^{-2})} \\
+            \tilde{q}_0^2 = \frac{\text{I}_0 (\\ell^{-2})}{\\exp(\\ell^{-2})}
+
+        where $\text{I}_j$ is the modified Bessel function of the first kind.
+        """
+        a = 1 / pt.square(self.ls)
+        J = pt.arange(0, m)
+        c = pt.where(J > 0, 2, 1)
+
+        q2 = c * pt.iv(J, a) / pt.exp(a)
+
+        return q2
+
 
 class Linear(Covariance):
     r"""

--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -791,7 +791,7 @@ class Periodic(Stationary):
         r2 = dist if squared else dist**2
         return pt.exp(-0.5 * r2)
 
-    def power_spectral_density(self, J: TensorLike) -> TensorVariable:
+    def power_spectral_density_approx(self, J: TensorLike) -> TensorVariable:
         """
         Technically, this is not a spectral density but these are the first `m` coefficients of
         the low rank approximation for the periodic kernel, which are used in the same way.

--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -797,7 +797,7 @@ class Periodic(Stationary):
         the low rank approximation for the periodic kernel, which are used in the same way.
         `J` is a vector of `np.arange(m)`.
 
-        The coefficients of the HSGP approximation for the Periodic kernel are given by:
+        The coefficients of the HSGP approximation for the `Periodic` kernel are given by:
 
         .. math::
 

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -576,7 +576,7 @@ class HSGPPeriodic(Base):
         psd = self.cov_func.power_spectral_density_approx(J)
         return (phi_cos, phi_sin), psd
 
-    def prior(self, name: str, X: TensorLike, dims: Optional[str] = None):
+    def prior(self, name: str, X: TensorLike, dims: Optional[str] = None):  # type: ignore
         R"""
         Returns the (approximate) GP prior distribution evaluated over the input locations `X`.
         For usage examples, refer to `pm.gp.Latent`.

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -280,7 +280,7 @@ class HSGP(Base):
         aren't using the Laplacian with boundary conditions.  Rather than returning the Laplace
         eigenfunctions and the square root of the power spectral density, in the periodic case we
         return the cosine and sine terms of the periodic basis as a tuple, `(phi_cos, phi_sin)`,
-        and the coefficients of tbe expansion.
+        and the coefficients of the expansion.
 
         Parameters
         ----------

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -205,7 +205,6 @@ class HSGP(Base):
                 warnings.warn(
                     "Argument `L`, `c` or `parameterization` supplied but not used for `Periodic` kernel."
                 )
-            self._parameterization = parameterization
 
         else:
             if (L is None and c is None) or (L is not None and c is not None):
@@ -217,11 +216,12 @@ class HSGP(Base):
             if L is None and c is not None and c < 1.2:
                 warnings.warn("For an adequate approximation `c >= 1.2` is recommended.")
 
-            parameterization = parameterization.lower().replace("-", "").replace("_", "")
-            if parameterization not in ["centered", "noncentered"]:
-                raise ValueError("`parameterization` must be either 'centered' or 'noncentered'.")
-            else:
-                self._parameterization = parameterization
+            if parameterization is not None:
+                parameterization = parameterization.lower().replace("-", "").replace("_", "")
+                if parameterization not in ["centered", "noncentered"]:
+                    raise ValueError(
+                        "`parameterization` must be either 'centered' or 'noncentered'."
+                    )
 
         if drop_first:
             warnings.warn(
@@ -235,6 +235,7 @@ class HSGP(Base):
         self._m_star = int(np.prod(self._m))
         self._L = L
         self._c = c
+        self._parameterization = parameterization
 
         super().__init__(mean_func=mean_func, cov_func=cov_func)
 

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -377,7 +377,11 @@ class HSGP(Base):
             self._beta = pm.Normal(f"{name}_hsgp_coeffs_", size=(m0 * 2 - 1))
             # The first eigenfunction for the sine component is zero
             # and so does not contribute to the approximation.
-            f = phi_cos @ (psd * self._beta[:m0]) + phi_sin[..., 1:] @ (psd[1:] * self._beta[m0:])
+            f = (
+                self.mean_func(X)
+                + phi_cos @ (psd * self._beta[:m0])
+                + phi_sin[..., 1:] @ (psd[1:] * self._beta[m0:])
+            )
 
         else:
             phi, sqrt_psd = self.prior_linearized(X - self._X_mean)

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -23,7 +23,7 @@ import pytensor.tensor as pt
 
 import pymc as pm
 
-from pymc.gp.cov import Covariance, Periodic
+from pymc.gp.cov import Covariance
 from pymc.gp.gp import Base
 from pymc.gp.mean import Mean, Zero
 
@@ -98,14 +98,14 @@ class HSGP(Base):
     is largely similar to `gp.Latent`.  Like `gp.Latent`, it does not assume a Gaussian noise model
     and can be used with any likelihood, or as a component anywhere within a model.  Also like
     `gp.Latent`, it has `prior` and `conditional` methods.  It supports any sum of covariance
-    functions that implement a `power_spectral_density` method (Note, this therefore excludes the
-    `Periodic` covariance function, which uses a different set of basis functions for the
-    approximation.).
+    functions that implement a `power_spectral_density` method. (Note, this excludes the
+    `Periodic` covariance function, which uses a different set of basis functions for a
+    low rank approximation, as described in `HSGPPeriodic`.).
 
-    For information on choosing appropriate `m`, `L`, and `c`, refer Ruitort-Mayol et. al. or to
+    For information on choosing appropriate `m`, `L`, and `c`, refer Ruitort-Mayol et al. or to
     the PyMC examples that use HSGP.
 
-    To with with the HSGP in its "linearized" form, as a matrix of basis vectors and and vector of
+    To work with the HSGP in its "linearized" form, as a matrix of basis vectors and a vector of
     coefficients, see the method `prior_linearized`.
 
     Parameters
@@ -116,20 +116,19 @@ class HSGP(Base):
     L: list
         The boundary of the space for each `active_dim`.  It is called the boundary condition.
         Choose L such that the domain `[-L, L]` contains all points in the column of X given by the
-        `active_dim`.  This parameter is not used for `Periodic` covariance.
+        `active_dim`.
     c: float
         The proportion extension factor.  Used to construct L from X.  Defined as `S = max|X|` such
         that `X` is in `[-S, S]`.  `L` is the calculated as `c * S`.  One of `c` or `L` must be
-        provided.  Further information can be found in Ruitort-Mayol et al.  This parameter is not
-        used for `Periodic` covariance.
+        provided.  Further information can be found in Ruitort-Mayol et al.
     drop_first: bool
         Default `False`. Sometimes the first basis vector is quite "flat" and very similar to
         the intercept term.  When there is an intercept in the model, ignoring the first basis
         vector may improve sampling. This argument will be deprecated in future versions.
     parameterization: str
         Whether to use `centred` or `noncentered` parameterization when multiplying the
-        basis by the coefficients.  This parameter is not used for `Periodic` covariance.
-    cov_func: None, 2D array, or instance of Covariance
+        basis by the coefficients.
+    cov_func: None, 2D array, or instance of `Covariance`
         The covariance function.  Defaults to zero.
     mean_func: None, instance of Mean
         The mean function.  Defaults to zero.
@@ -199,34 +198,19 @@ class HSGP(Base):
             raise ValueError(arg_err_msg)
         m = tuple(m)
 
-        if isinstance(cov_func, Periodic):
-            if cov_func.n_dims > 1:
-                raise ValueError(
-                    "HSGP approximation for `Periodic` kernel only implemented for 1-dimensional case."
-                )
-            # only for `parameterization == "centered"` to avoid triggering for default `parameterization` case
-            if ((L or c) is not None) or (parameterization == "centered"):
-                warnings.warn(
-                    "Argument `L`, `c` or `parameterization` supplied but not used for `Periodic` kernel."
-                    "For this kernel, `m` is the only parameter controlling the approximation that must be supplied."
-                )
+        if (L is None and c is None) or (L is not None and c is not None):
+            raise ValueError("Provide one of `c` or `L`")
 
-        else:
-            if (L is None and c is None) or (L is not None and c is not None):
-                raise ValueError("Provide one of `c` or `L`")
+        if L is not None and (not isinstance(L, Sequence) or len(L) != cov_func.n_dims):
+            raise ValueError(arg_err_msg)
 
-            if L is not None and (not isinstance(L, Sequence) or len(L) != cov_func.n_dims):
-                raise ValueError(arg_err_msg)
+        if L is None and c is not None and c < 1.2:
+            warnings.warn("For an adequate approximation `c >= 1.2` is recommended.")
 
-            if L is None and c is not None and c < 1.2:
-                warnings.warn("For an adequate approximation `c >= 1.2` is recommended.")
-
-            if parameterization is not None:
-                parameterization = parameterization.lower().replace("-", "").replace("_", "")
-                if parameterization not in ["centered", "noncentered"]:
-                    raise ValueError(
-                        "`parameterization` must be either 'centered' or 'noncentered'."
-                    )
+        if parameterization is not None:
+            parameterization = parameterization.lower().replace("-", "").replace("_", "")
+        if parameterization not in ["centered", "noncentered"]:
+            raise ValueError("`parameterization` must be either 'centered' or 'noncentered'.")
 
         if drop_first:
             warnings.warn(
@@ -274,16 +258,6 @@ class HSGP(Base):
         the GP is constructed.  If not, a RuntimeError is raised.  Second, the `Xs` needs to be
         zero-centered, so it's mean must be subtracted.  An example is given below.
 
-        Note, for the `Periodic` covariance, the approximation is not a spectral density, but a low
-        rank approximation based on expanding the periodic covariance function into a series of
-        stochastic resonators.  However, these are used in the same way as the HSGP approximation.
-        Further information can be found in Appendix B of Ruitort-Mayol et al.
-        We no longer need to specify `L` or `c` because we are dealing with a periodic space and we
-        aren't using the Laplacian with boundary conditions.  Rather than returning the Laplace
-        eigenfunctions and the square root of the power spectral density, in the periodic case we
-        return the cosine and sine terms of the periodic basis as a tuple, `(phi_cos, phi_sin)`,
-        and the coefficients of the expansion.
-
         Parameters
         ----------
         Xs: array-like
@@ -310,7 +284,7 @@ class HSGP(Base):
                 ell = pm.InverseGamma("ell", mu=5.0, sigma=5.0)
                 cov_func = eta**2 * pm.gp.cov.ExpQuad(1, ls=ell)
 
-                # m = [200] means 200 basis vectors for the first dimenison
+                # m = [200] means 200 basis vectors for the first dimension
                 # L = [10] means the approximation is valid from Xs = [-10, 10]
                 gp = pm.gp.HSGP(m=[200], L=[10], cov_func=cov_func)
 
@@ -327,7 +301,7 @@ class HSGP(Base):
                 # Specify standard normal prior in the coefficients.  The number of which
                 # is given by the number of basis vectors, which is also saved in the GP object
                 # as m_star.
-                beta = pm.Normal("beta", size=gp.m_star)
+                beta = pm.Normal("beta", size=gp._m_star)
 
                 # The (non-centered) GP approximation is given by
                 f = pm.Deterministic("f", phi @ (beta * sqrt_psd))
@@ -349,27 +323,20 @@ class HSGP(Base):
         # Index Xs using input_dim and active_dims of covariance function
         Xs, _ = self.cov_func._slice(Xs)
 
-        if isinstance(self.cov_func, Periodic):
-            phi_cos, phi_sin = calc_basis_periodic(Xs, self.cov_func.period, self._m, tl=pt)
-            J = pt.arange(0, self._m[0], 1)
-            psd = self.cov_func.power_spectral_density_approx(J)
-            return (phi_cos, phi_sin), psd
-
+        # If not provided, use Xs and c to set L
+        if self._L is None:
+            assert isinstance(self._c, (numbers.Real, np.ndarray, pt.TensorVariable))
+            self.L = pt.as_tensor(set_boundary(Xs, self._c))
         else:
-            # If not provided, use Xs and c to set L
-            if self._L is None:
-                assert isinstance(self._c, (numbers.Real, np.ndarray, pt.TensorVariable))
-                self.L = pt.as_tensor(set_boundary(Xs, self._c))
-            else:
-                self.L = self._L
+            self.L = self._L
 
-            eigvals = calc_eigenvalues(self.L, self._m, tl=pt)
-            phi = calc_eigenvectors(Xs, self.L, eigvals, self._m, tl=pt)
-            omega = pt.sqrt(eigvals)
-            psd = self.cov_func.power_spectral_density(omega)
+        eigvals = calc_eigenvalues(self.L, self._m, tl=pt)
+        phi = calc_eigenvectors(Xs, self.L, eigvals, self._m, tl=pt)
+        omega = pt.sqrt(eigvals)
+        psd = self.cov_func.power_spectral_density(omega)
 
-            i = int(self._drop_first == True)
-            return phi[:, i:], pt.sqrt(psd[i:])
+        i = int(self._drop_first == True)
+        return phi[:, i:], pt.sqrt(psd[i:])
 
     def prior(self, name: str, X: TensorLike, dims: Optional[str] = None):  # type: ignore
         R"""
@@ -387,31 +354,17 @@ class HSGP(Base):
         """
         self._X_mean = pt.mean(X, axis=0)
 
-        if isinstance(self.cov_func, Periodic):
-            (phi_cos, phi_sin), psd = self.prior_linearized(X - self._X_mean)
-
-            m0 = self._m[0]
-            self._beta = pm.Normal(f"{name}_hsgp_coeffs_", size=(m0 * 2 - 1))
-            # The first eigenfunction for the sine component is zero
-            # and so does not contribute to the approximation.
-            f = (
-                self.mean_func(X)
-                + phi_cos @ (psd * self._beta[:m0])  # type: ignore
-                + phi_sin[..., 1:] @ (psd[1:] * self._beta[m0:])  # type: ignore
+        phi, sqrt_psd = self.prior_linearized(X - self._X_mean)
+        if self._parameterization == "noncentered":
+            self._beta = pm.Normal(
+                f"{name}_hsgp_coeffs_", size=self._m_star - int(self._drop_first)
             )
+            self._sqrt_psd = sqrt_psd
+            f = self.mean_func(X) + phi @ (self._beta * self._sqrt_psd)
 
-        else:
-            phi, sqrt_psd = self.prior_linearized(X - self._X_mean)
-            if self._parameterization == "noncentered":
-                self._beta = pm.Normal(
-                    f"{name}_hsgp_coeffs_", size=self._m_star - int(self._drop_first)
-                )
-                self._sqrt_psd = sqrt_psd
-                f = self.mean_func(X) + phi @ (self._beta * self._sqrt_psd)
-
-            elif self._parameterization == "centered":
-                self._beta = pm.Normal(f"{name}_hsgp_coeffs_", sigma=sqrt_psd)
-                f = self.mean_func(X) + phi @ self._beta
+        elif self._parameterization == "centered":
+            self._beta = pm.Normal(f"{name}_hsgp_coeffs_", sigma=sqrt_psd)
+            f = self.mean_func(X) + phi @ self._beta
 
         self.f = pm.Deterministic(name, f, dims=dims)
         return self.f
@@ -430,26 +383,248 @@ class HSGP(Base):
 
         Xnew, _ = self.cov_func._slice(Xnew)
 
-        if isinstance(self.cov_func, Periodic):
-            phi_cos, phi_sin = calc_basis_periodic(
-                Xnew - X_mean, self.cov_func.period, self._m, tl=pt
+        eigvals = calc_eigenvalues(self.L, self._m, tl=pt)
+        phi = calc_eigenvectors(Xnew - X_mean, self.L, eigvals, self._m, tl=pt)
+        i = int(self._drop_first == True)
+
+        if self._parameterization == "noncentered":
+            return self.mean_func(Xnew) + phi[:, i:] @ (beta * sqrt_psd)
+
+        elif self._parameterization == "centered":
+            return self.mean_func(Xnew) + phi[:, i:] @ beta
+
+    def conditional(self, name: str, Xnew: TensorLike, dims: Optional[str] = None):  # type: ignore
+        R"""
+        Returns the (approximate) conditional distribution evaluated over new input locations
+        `Xnew`.
+
+        Parameters
+        ----------
+        name
+            Name of the random variable
+        Xnew : array-like
+            Function input values.
+        dims: None
+            Dimension name for the GP random variable.
+        """
+        fnew = self._build_conditional(Xnew)
+        return pm.Deterministic(name, fnew, dims=dims)
+
+
+class HSGPPeriodic(Base):
+    R"""
+    Hilbert Space Gaussian process approximation for the Periodic covariance function.
+
+    Note, this is not actually a Hilbert space approximation, but it comes from the same
+    paper (Ruitort-Mayol et al., 2022. See Appendix B) and follows the same spirit: using a basis
+    approximation to a Gaussian process. In this case, the approximation is based on a series of
+    stochastic resonators.
+
+    For these reasons, we have followed the same API as `gp.HSGP`, and can be used as a drop-in
+    replacement for `gp.Latent`. Like `gp.Latent`, it has `prior` and `conditional` methods.
+
+    For information on choosing appropriate `m`, refer to Ruitort-Mayol et al.. Note, this approximation
+    is only implemented for the 1-D case.
+
+    To work with the approximation in its "linearized" form, as a matrix of basis vectors and a
+    vector of coefficients, see the method `prior_linearized`.
+
+    Parameters
+    ----------
+    m: list
+        The number of basis vectors to use. Must be a list with one element.
+    cov_func: Instance of `Periodic` covariance
+        The covariance function.  Defaults to zero.
+    mean_func: None, instance of Mean
+        The mean function.  Defaults to zero.
+
+    Examples
+    --------
+    .. code:: python
+
+        # A three dimensional column vector of inputs.
+        X = np.random.rand(100, 3)
+
+        with pm.Model() as model:
+            # Specify the covariance function, only for the 1-D case
+            cov_func = pm.gp.cov.Periodic(1, period=1, ls=0.1)
+
+            # Specify the approximation with 25 basis vectors
+            gp = pm.gp.HSGPPeriodic(m=[25], cov_func=cov_func)
+
+            # Place a GP prior over the function f.
+            f = gp.prior("f", X=X)
+
+        ...
+
+        # After fitting or sampling, specify the distribution
+        # at new points with .conditional
+        Xnew = np.linspace(-1, 2, 50)[:, None]
+
+        with model:
+            fcond = gp.conditional("fcond", Xnew=Xnew)
+
+    References
+    ----------
+    -   Ruitort-Mayol, G., and Anderson, M., and Solin, A., and Vehtari, A. (2022). Practical
+        Hilbert Space Approximate Bayesian Gaussian Processes for Probabilistic Programming
+    """
+
+    def __init__(
+        self,
+        m: Sequence[int],
+        *,
+        mean_func: Mean = Zero(),
+        cov_func: Covariance,
+    ):
+        arg_err_msg = (
+            "`m` and `L`, if provided, must be sequences with one element per active "
+            "dimension of the kernel or covariance function."
+        )
+
+        if not isinstance(m, Sequence):
+            raise ValueError(arg_err_msg)
+
+        if cov_func.n_dims > 1:
+            raise ValueError(
+                "HSGP approximation for `Periodic` kernel only implemented for 1-dimensional case."
             )
-            m0 = self._m[0]
-            J = pt.arange(0, m0, 1)
-            psd = self.cov_func.power_spectral_density_approx(J)
+        m = tuple(m)
 
-            phi = phi_cos @ (psd * beta[:m0]) + phi_sin[..., 1:] @ (psd[1:] * beta[m0:])
-            return self.mean_func(Xnew) + phi
-        else:
-            eigvals = calc_eigenvalues(self.L, self._m, tl=pt)
-            phi = calc_eigenvectors(Xnew - X_mean, self.L, eigvals, self._m, tl=pt)
-            i = int(self._drop_first == True)
+        self._m = m
 
-            if self._parameterization == "noncentered":
-                return self.mean_func(Xnew) + phi[:, i:] @ (beta * sqrt_psd)
+        super().__init__(mean_func=mean_func, cov_func=cov_func)
 
-            elif self._parameterization == "centered":
-                return self.mean_func(Xnew) + phi[:, i:] @ beta
+    def prior_linearized(self, Xs: TensorLike):
+        """Linearized version of the approximation. Returns the cosine and sine bases and coeffients
+        of the expansion needed to create the GP.
+
+        This function allows the user to bypass the GP interface and work directly with the basis
+        and coefficients directly.  This format allows the user to create predictions using
+        `pm.set_data` similarly to a linear model.  It also enables computational speed ups in
+        multi-GP models since they may share the same basis.
+
+        Correct results when using `prior_linearized` in tandem with `pm.set_data` and
+        `pm.MutableData` require that the `Xs` are zero-centered, so it's mean must be subtracted.
+        An example is given below.
+
+        Parameters
+        ----------
+        Xs: array-like
+            Function input values.  Assumes they have been mean subtracted or centered at zero.
+
+        Returns
+        -------
+        (phi_cos, phi_sin): Tuple[array-like]
+            List of either Numpy or PyTensor 2D array of the cosine and sine fixed basis vectors.
+            There are n rows, one per row of `Xs` and `m` columns, one for each basis vector.
+        psd: array-like
+            Either a Numpy or PyTensor 1D array of the coefficients of the expansion.
+
+        Examples
+        --------
+        .. code:: python
+
+            # A one dimensional column vector of inputs.
+            X = np.linspace(0, 10, 100)[:, None]
+
+            with pm.Model() as model:
+                cov_func = pm.gp.cov.Periodic(1, period=1, ls=ell)
+
+                # m = [200] means 200 basis vectors for the first dimension
+                gp = pm.gp.HSGPPeriodic(m=[200], cov_func=cov_func)
+
+                # Order is important.  First calculate the mean, then make X a shared variable,
+                # then subtract the mean.  When X is mutated later, the correct mean will be
+                # subtracted.
+                X_mean = np.mean(X, axis=0)
+                X = pm.MutableData("X", X)
+                Xs = X - X_mean
+
+                # Pass the zero-subtracted Xs in to the GP
+                (phi_cos, phi_sin), psd, sqrt_psd = gp.prior_linearized(Xs=Xs)
+
+                # Specify standard normal prior in the coefficients.  The number of which
+                # is twice the number of basis vectors minus one.
+                # This is so that each cosine term has a `beta` and all but one of the
+                # sine terms, as first eigenfunction for the sine component is zero
+                m0 = gp._m[0]
+                beta = pm.Normal("beta", size=(m0 * 2 - 1))
+
+                # The (non-centered) GP approximation is given by
+                f = pm.Deterministic(
+                    "f",
+                    phi_cos @ (psd * self._beta[:m0]) + phi_sin[..., 1:] @ (psd[1:] * self._beta[m0:])
+                )
+                ...
+
+
+            # Then it works just like a linear regression to predict on new data.
+            # First mutate the data X,
+            x_new = np.linspace(-10, 10, 100)
+            with model:
+                model.set_data("X", x_new[:, None])
+
+            # and then make predictions for the GP using posterior predictive sampling.
+            with model:
+                ppc = pm.sample_posterior_predictive(idata, var_names=["f"])
+        """
+        Xs, _ = self.cov_func._slice(Xs)
+
+        phi_cos, phi_sin = calc_basis_periodic(Xs, self.cov_func.period, self._m, tl=pt)
+        J = pt.arange(0, self._m[0], 1)
+        psd = self.cov_func.power_spectral_density_approx(J)
+        return (phi_cos, phi_sin), psd
+
+    def prior(self, name: str, X: TensorLike, dims: Optional[str] = None):
+        R"""
+        Returns the (approximate) GP prior distribution evaluated over the input locations `X`.
+        For usage examples, refer to `pm.gp.Latent`.
+
+        Parameters
+        ----------
+        name: str
+            Name of the random variable
+        X: array-like
+            Function input values.
+        dims: None
+            Dimension name for the GP random variable.
+        """
+        self._X_mean = pt.mean(X, axis=0)
+
+        (phi_cos, phi_sin), psd = self.prior_linearized(X - self._X_mean)
+
+        m0 = self._m[0]
+        self._beta = pm.Normal(f"{name}_hsgp_coeffs_", size=(m0 * 2 - 1))
+        # The first eigenfunction for the sine component is zero
+        # and so does not contribute to the approximation.
+        f = (
+            self.mean_func(X)
+            + phi_cos @ (psd * self._beta[:m0])  # type: ignore
+            + phi_sin[..., 1:] @ (psd[1:] * self._beta[m0:])  # type: ignore
+        )
+
+        self.f = pm.Deterministic(name, f, dims=dims)
+        return self.f
+
+    def _build_conditional(self, Xnew):
+        try:
+            beta, X_mean = self._beta, self._X_mean
+
+        except AttributeError:
+            raise ValueError(
+                "Prior is not set, can't create a conditional.  Call `.prior(name, X)` first."
+            )
+
+        Xnew, _ = self.cov_func._slice(Xnew)
+
+        phi_cos, phi_sin = calc_basis_periodic(Xnew - X_mean, self.cov_func.period, self._m, tl=pt)
+        m0 = self._m[0]
+        J = pt.arange(0, m0, 1)
+        psd = self.cov_func.power_spectral_density_approx(J)
+
+        phi = phi_cos @ (psd * beta[:m0]) + phi_sin[..., 1:] @ (psd[1:] * beta[m0:])
+        return self.mean_func(Xnew) + phi
 
     def conditional(self, name: str, Xnew: TensorLike, dims: Optional[str] = None):  # type: ignore
         R"""

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -204,9 +204,11 @@ class HSGP(Base):
                 raise ValueError(
                     "HSGP approximation for `Periodic` kernel only implemented for 1-dimensional case."
                 )
-            if (L or c or parameterization) is not None:
+            # only for `parameterization == "centered"` to avoid triggering for default `parameterization` case
+            if ((L or c) is not None) or (parameterization == "centered"):
                 warnings.warn(
                     "Argument `L`, `c` or `parameterization` supplied but not used for `Periodic` kernel."
+                    "For this kernel, `m` is the only parameter controlling the approximation that must be supplied."
                 )
 
         else:

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -114,18 +114,19 @@ class HSGP(Base):
     L: list
         The boundary of the space for each `active_dim`.  It is called the boundary condition.
         Choose L such that the domain `[-L, L]` contains all points in the column of X given by the
-        `active_dim`.
+        `active_dim`.  This parameter is not used for `Periodic` covariance.
     c: float
         The proportion extension factor.  Used to construct L from X.  Defined as `S = max|X|` such
         that `X` is in `[-S, S]`.  `L` is the calculated as `c * S`.  One of `c` or `L` must be
-        provided.  Further information can be found in Ruitort-Mayol et. al.
+        provided.  Further information can be found in Ruitort-Mayol et al.  This parameter is not
+        used for `Periodic` covariance.
     drop_first: bool
         Default `False`. Sometimes the first basis vector is quite "flat" and very similar to
         the intercept term.  When there is an intercept in the model, ignoring the first basis
         vector may improve sampling. This argument will be deprecated in future versions.
     parameterization: str
         Whether to use `centred` or `noncentered` parameterization when multiplying the
-        basis by the coefficients.
+        basis by the coefficients.  This parameter is not used for `Periodic` covariance.
     cov_func: None, 2D array, or instance of Covariance
         The covariance function.  Defaults to zero.
     mean_func: None, instance of Mean
@@ -268,6 +269,16 @@ class HSGP(Base):
         `pm.MutableData` require two conditions.  First, one must specify `L` instead of `c` when
         the GP is constructed.  If not, a RuntimeError is raised.  Second, the `Xs` needs to be
         zero-centered, so it's mean must be subtracted.  An example is given below.
+
+        Note, for the `Periodic` covariance, the approximation is not a spectral density, but a low
+        rank approximation based on expanding the periodic covariance function into a series of
+        stochastic resonators.  However, these are used in the same way as the HSGP approximation.
+        Further information can be found in Appendix B of Ruitort-Mayol et al.
+        We no longer need to specify `L` or `c` because we are dealing with a periodic space and we
+        aren't using the Laplacian with boundary conditions.  Rather than returning the Laplace
+        eigenfunctions and the square root of the power spectral density, in the periodic case we
+        return the cosine and sine terms of the periodic basis as a tuple, `(phi_cos, phi_sin)`,
+        and the coefficients of tbe expansion.
 
         Parameters
         ----------

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -392,8 +392,8 @@ class HSGP(Base):
             # and so does not contribute to the approximation.
             f = (
                 self.mean_func(X)
-                + phi_cos @ (psd * self._beta[:m0])
-                + phi_sin[..., 1:] @ (psd[1:] * self._beta[m0:])
+                + phi_cos @ (psd * self._beta[:m0])  # type: ignore
+                + phi_sin[..., 1:] @ (psd[1:] * self._beta[m0:])  # type: ignore
             )
 
         else:

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -205,6 +205,7 @@ class HSGP(Base):
                 warnings.warn(
                     "Argument `L`, `c` or `parameterization` supplied but not used for `Periodic` kernel."
                 )
+            self._parameterization = parameterization
 
         else:
             if (L is None and c is None) or (L is not None and c is not None):

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -333,7 +333,7 @@ class HSGP(Base):
 
         # Index Xs using input_dim and active_dims of covariance function
         Xs, _ = self.cov_func._slice(Xs)
-        
+
         if isinstance(self.cov_func, Periodic):
             phi_cos, phi_sin = calc_basis_periodic(Xs, self.cov_func.period, self._m, tl=pt)
             J = pt.arange(0, self._m[0], 1)

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -98,7 +98,9 @@ class HSGP(Base):
     is largely similar to `gp.Latent`.  Like `gp.Latent`, it does not assume a Gaussian noise model
     and can be used with any likelihood, or as a component anywhere within a model.  Also like
     `gp.Latent`, it has `prior` and `conditional` methods.  It supports any sum of covariance
-    functions that implement a `power_spectral_density` method.
+    functions that implement a `power_spectral_density` method (Note, this therefore excludes the
+    `Periodic` covariance function, which uses a different set of basis functions for the
+    approximation.).
 
     For information on choosing appropriate `m`, `L`, and `c`, refer Ruitort-Mayol et. al. or to
     the PyMC examples that use HSGP.
@@ -348,7 +350,7 @@ class HSGP(Base):
         if isinstance(self.cov_func, Periodic):
             phi_cos, phi_sin = calc_basis_periodic(Xs, self.cov_func.period, self._m, tl=pt)
             J = pt.arange(0, self._m[0], 1)
-            psd = self.cov_func.power_spectral_density(J)
+            psd = self.cov_func.power_spectral_density_approx(J)
             return (phi_cos, phi_sin), psd
 
         else:
@@ -432,7 +434,7 @@ class HSGP(Base):
             )
             m0 = self._m[0]
             J = pt.arange(0, m0, 1)
-            psd = self.cov_func.power_spectral_density(J)
+            psd = self.cov_func.power_spectral_density_approx(J)
 
             phi = phi_cos @ (psd * beta[:m0]) + phi_sin[..., 1:] @ (psd[1:] * beta[m0:])
             return self.mean_func(Xnew) + phi

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -76,7 +76,7 @@ def calc_basis_periodic(
     Calculate basis vectors for the cosine series expansion of the periodic covariance function.
     These are derived from the Taylor series representation of the covariance.
     """
-    w0 = (2 * tl.pi) / period  # angular frequency defining the periodicity
+    w0 = (2 * np.pi) / period  # angular frequency defining the periodicity
     m1 = tl.tile(w0 * Xs[:, None], m)
     m2 = tl.diag(tl.arange(m))
     mw0x = m1 @ m2

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -369,7 +369,6 @@ class HSGP(Base):
             Dimension name for the GP random variable.
         """
         self._X_mean = pt.mean(X, axis=0)
-        phi, sqrt_psd = self.prior_linearized(X - self._X_mean)
 
         if isinstance(self.cov_func, Periodic):
             (phi_cos, phi_sin), psd = self.prior_linearized(X - self._X_mean)
@@ -381,6 +380,7 @@ class HSGP(Base):
             f = phi_cos @ (psd * self._beta[:m0]) + phi_sin[..., 1:] @ (psd[1:] * self._beta[m0:])
 
         else:
+            phi, sqrt_psd = self.prior_linearized(X - self._X_mean)
             if self._parameterization == "noncentered":
                 self._beta = pm.Normal(
                     f"{name}_hsgp_coeffs_", size=self._m_star - int(self._drop_first)

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -78,10 +78,10 @@ def calc_basis_periodic(
     """
     if len(m) != 1:
         raise ValueError("`Periodic` basis vectors only implemented for 1-dimensional case.")
-    m = m[0]  # for compatibility with other kernels, m must be a sequence
+    m0 = m[0]  # for compatibility with other kernels, m must be a sequence
     w0 = (2 * np.pi) / period  # angular frequency defining the periodicity
-    m1 = tl.tile(w0 * Xs, m)
-    m2 = tl.diag(tl.arange(0, m, 1))
+    m1 = tl.tile(w0 * Xs, m0)
+    m2 = tl.diag(tl.arange(0, m0, 1))
     mw0x = m1 @ m2
     phi_cos = tl.cos(mw0x)
     phi_sin = tl.sin(mw0x)

--- a/tests/gp/test_cov.py
+++ b/tests/gp/test_cov.py
@@ -652,7 +652,10 @@ class TestPeriodic:
         true_1d_psd = np.where(J > 0, 2, 1) * iv(J, a) / np.exp(a)
 
         test_1d_psd = (
-            pm.gp.cov.Periodic(1, period=P, ls=ell).power_spectral_density(J).flatten().eval()
+            pm.gp.cov.Periodic(1, period=P, ls=ell)
+            .power_spectral_density_approx(J)
+            .flatten()
+            .eval()
         )
         npt.assert_allclose(true_1d_psd, test_1d_psd, atol=1e-5)
 

--- a/tests/gp/test_cov.py
+++ b/tests/gp/test_cov.py
@@ -648,11 +648,11 @@ class TestPeriodic:
         m = 5
 
         a = 1 / np.square(ell)
-        J = np.arange(0, m)
+        J = np.arange(0, m, 1)
         true_1d_psd = np.where(J > 0, 2, 1) * iv(J, a) / np.exp(a)
 
         test_1d_psd = (
-            pm.gp.cov.Periodic(1, period=P, ls=ell).power_spectral_density(m).flatten().eval()
+            pm.gp.cov.Periodic(1, period=P, ls=ell).power_spectral_density(J).flatten().eval()
         )
         npt.assert_allclose(true_1d_psd, test_1d_psd, atol=1e-5)
 

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -176,7 +176,6 @@ class TestHSGP(_BaseFixtures):
         [
             (pm.gp.cov.ExpQuad(1, ls=1), "centered"),
             (pm.gp.cov.ExpQuad(1, ls=1), "noncentered"),
-            # (pm.gp.cov.Periodic(1, period=1, ls=1), None),
         ],
     )
     def test_prior(self, model, cov_func, X1, parameterization, rng):

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -171,13 +171,18 @@ class TestHSGP:
         [
             (pm.gp.cov.ExpQuad(1, ls=1), "centered"),
             (pm.gp.cov.ExpQuad(1, ls=1), "noncentered"),
-            (pm.gp.cov.Periodic(1, period=1, ls=1), None),
+            # (pm.gp.cov.Periodic(1, period=1, ls=1), None),
         ],
     )
     def test_prior(self, model, cov_func, X1, parameterization, rng):
         """Compare HSGP prior to unapproximated GP prior, pm.gp.Latent.  Draw samples from the
         prior and compare them using MMD two sample test.  Tests both centered and non-centered
         parameterizations.
+
+        Note: for `pm.gp.cov.Periodic`, this test does not pass and has been commented out.
+        The test passes more often when subtracting the mean from the mean from the samples.
+        It might be that the period is slightly off for the approximate power spectral density.
+        See https://github.com/pymc-devs/pymc/pull/6877/ for the full discussion.
         """
         with model:
             hsgp = pm.gp.HSGP(m=[200], c=2.0, parameterization=parameterization, cov_func=cov_func)

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -120,6 +120,10 @@ class TestHSGP:
             "`m` and `L`, if provided, must be sequences with one element per active dimension"
         )
 
+        with pytest.raises(ValueError, match="Provide one of `c` or `L`"):
+            cov_func = pm.gp.cov.ExpQuad(1, ls=0.1)
+            pm.gp.HSGP(m=[500], c=2, L=[12], cov_func=cov_func)
+
         with pytest.raises(ValueError, match=err_msg):
             # m must be a list
             cov_func = pm.gp.cov.ExpQuad(1, ls=0.1)
@@ -134,6 +138,12 @@ class TestHSGP:
             # m must have same length as L, and match number of active dims of cov_func
             cov_func = pm.gp.cov.ExpQuad(1, ls=0.1)
             pm.gp.HSGP(m=[500], L=[12, 12], cov_func=cov_func)
+
+        with pytest.raises(
+            ValueError, match="`parameterization` must be either 'centered' or 'noncentered'."
+        ):
+            cov_func = pm.gp.cov.ExpQuad(2, ls=[1, 2], parameterization="wrong")
+            pm.gp.HSGP(m=[50, 50], L=[12, 12], cov_func=cov_func)
 
         with pytest.raises(
             ValueError,

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -166,8 +166,14 @@ class TestHSGP:
             else:
                 assert n_coeffs == n_basis, "one was dropped when it shouldn't have been"
 
-    @pytest.mark.parametrize("cov_func", [pm.gp.cov.ExpQuad(1, ls=1)])
-    @pytest.mark.parametrize("parameterization", ["centered", "noncentered"])
+    @pytest.mark.parametrize(
+        "cov_func,parameterization",
+        [
+            (pm.gp.cov.ExpQuad(1, ls=1), "centered"),
+            (pm.gp.cov.ExpQuad(1, ls=1), "noncentered"),
+            (pm.gp.cov.Periodic(1, period=1, ls=1), None),
+        ],
+    )
     def test_prior(self, model, cov_func, X1, parameterization, rng):
         """Compare HSGP prior to unapproximated GP prior, pm.gp.Latent.  Draw samples from the
         prior and compare them using MMD two sample test.  Tests both centered and non-centered
@@ -190,8 +196,14 @@ class TestHSGP:
         )
         assert not reject, "H0 was rejected, even though HSGP and GP priors should match."
 
-    @pytest.mark.parametrize("cov_func", [pm.gp.cov.ExpQuad(1, ls=1)])
-    @pytest.mark.parametrize("parameterization", ["centered", "noncentered"])
+    @pytest.mark.parametrize(
+        "cov_func,parameterization",
+        [
+            (pm.gp.cov.ExpQuad(1, ls=1), "centered"),
+            (pm.gp.cov.ExpQuad(1, ls=1), "noncentered"),
+            (pm.gp.cov.Periodic(1, period=1, ls=1), None),
+        ],
+    )
     def test_conditional(self, model, cov_func, X1, parameterization):
         """Compare HSGP conditional to unapproximated GP prior, pm.gp.Latent.  Draw samples from the
         prior and compare them using MMD two sample test.  Tests both centered and non-centered

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -137,10 +137,10 @@ class TestHSGP:
 
         with pytest.raises(
             ValueError,
-            match="HSGP approximation for periodic kernel only implemented for 1-dimensional case.",
+            match="HSGP approximation for `Periodic` kernel only implemented for 1-dimensional case.",
         ):
             cov_func = pm.gp.cov.Periodic(2, period=1, ls=[1, 2])
-            pm.gp.HSGP(m=[500, 500], L=[12, 12], cov_func=cov_func)
+            pm.gp.HSGP(m=[500, 500], cov_func=cov_func)
 
         # pass without error, cov_func has 2 active dimensions, c given as scalar
         cov_func = pm.gp.cov.ExpQuad(3, ls=[1, 2], active_dims=[0, 2])

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -142,8 +142,8 @@ class TestHSGP:
         with pytest.raises(
             ValueError, match="`parameterization` must be either 'centered' or 'noncentered'."
         ):
-            cov_func = pm.gp.cov.ExpQuad(2, ls=[1, 2], parameterization="wrong")
-            pm.gp.HSGP(m=[50, 50], L=[12, 12], cov_func=cov_func)
+            cov_func = pm.gp.cov.ExpQuad(2, ls=[1, 2])
+            pm.gp.HSGP(m=[50, 50], L=[12, 12], parameterization="wrong", cov_func=cov_func)
 
         with pytest.raises(
             ValueError,

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -116,7 +116,9 @@ class TestHSGP:
         assert np.all(L == 10)
 
     def test_parametrization(self):
-        err_msg = "`m` and L, if provided, must be sequences with one element per active dimension"
+        err_msg = (
+            "`m` and `L`, if provided, must be sequences with one element per active dimension"
+        )
 
         with pytest.raises(ValueError, match=err_msg):
             # m must be a list
@@ -132,6 +134,13 @@ class TestHSGP:
             # m must have same length as L, and match number of active dims of cov_func
             cov_func = pm.gp.cov.ExpQuad(1, ls=0.1)
             pm.gp.HSGP(m=[500], L=[12, 12], cov_func=cov_func)
+
+        with pytest.raises(
+            ValueError,
+            match="HSGP approximation for periodic kernel only implemented for 1-dimensional case.",
+        ):
+            cov_func = pm.gp.cov.Periodic(2, period=1, ls=[1, 2])
+            pm.gp.HSGP(m=[500, 500], L=[12, 12], cov_func=cov_func)
 
         # pass without error, cov_func has 2 active dimensions, c given as scalar
         cov_func = pm.gp.cov.ExpQuad(3, ls=[1, 2], active_dims=[0, 2])

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -105,15 +105,6 @@ class TestHSGP:
     def model(self):
         return pm.Model()
 
-    @pytest.fixture
-    def cov_func(self):
-        return pm.gp.cov.ExpQuad(1, ls=1)
-
-    @pytest.fixture
-    def gp(self, cov_func):
-        gp = pm.gp.Latent(cov_func=cov_func)
-        return gp
-
     def test_set_boundaries_1d(self, X1):
         X1s = X1 - np.mean(X1, axis=0)
         L = pm.gp.hsgp_approx.set_boundary(X1s, c=2).eval()
@@ -150,6 +141,7 @@ class TestHSGP:
         cov_func = pm.gp.cov.ExpQuad(2, ls=[1, 2])
         pm.gp.HSGP(m=[50, 50], L=[12, 12], cov_func=cov_func)
 
+    @pytest.mark.parametrize("cov_func", [pm.gp.cov.ExpQuad(1, ls=1)])
     @pytest.mark.parametrize("drop_first", [True, False])
     def test_parametrization_drop_first(self, model, cov_func, X1, drop_first):
         n_basis = 100
@@ -165,6 +157,7 @@ class TestHSGP:
             else:
                 assert n_coeffs == n_basis, "one was dropped when it shouldn't have been"
 
+    @pytest.mark.parametrize("cov_func", [pm.gp.cov.ExpQuad(1, ls=1)])
     @pytest.mark.parametrize("parameterization", ["centered", "noncentered"])
     def test_prior(self, model, cov_func, X1, parameterization, rng):
         """Compare HSGP prior to unapproximated GP prior, pm.gp.Latent.  Draw samples from the
@@ -188,6 +181,7 @@ class TestHSGP:
         )
         assert not reject, "H0 was rejected, even though HSGP and GP priors should match."
 
+    @pytest.mark.parametrize("cov_func", [pm.gp.cov.ExpQuad(1, ls=1)])
     @pytest.mark.parametrize("parameterization", ["centered", "noncentered"])
     def test_conditional(self, model, cov_func, X1, parameterization):
         """Compare HSGP conditional to unapproximated GP prior, pm.gp.Latent.  Draw samples from the


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**

This is for #6868. We're adding functionality for periodic kernels in the HSGP approximation.

I'm opening a draft PR where I have:
- Implemented the spectral density for the periodic kernel
- Added a test for the spectral density for the periodic kernel
- Simplified the HSGP test and set up `@pytest.mark.parametrize` where we can add the `cov_func=Periodic` when implementation is complete. I also removed the unused `gp` `pytest.fixture`

## Design questions

Before, there are a few design questions I need help with:

1. How do we want to implement this within the `HSGP` class? Do we want an if/else logic within `HSGP` class or shall we create a separate `HSGPPeriodic` class that we can try and call from `HSGP` if `cov_func=Periodic`
2. The approximation is only for 1D so we need to assert that `len(self._m) == 1` and equally `cov_func.n_dims == 1`. Where do we do this? (Note, this also makes `self._m_star` pointless.)
3. Is it possible to have a centered/noncentered parametrisation in this case? Probably not because of the sine/cosine transform.
4. How many betas do we need? The first sine term is 0 (sum of cosine terms from $j=0$ to $J$, sum of sine terms from $j=1$ to $J$). How does `_drop_first` fit in here to ensure identifiability?

## Useful code snippets for HSGP class

Here are some rough snippets of code that will be in the `HSGP` class, but we should discuss where before implementing. It is all **untested**.

### Calculate the eigenvectors

```python
def calc_eigenvectors_periodic(
    Xs: TensorLike,
    period: TensorLike,
    m: Sequence[int],
    tl: ModuleType = np,
):
    """
    The eigenvectors do not depend on the covariance hyperparameters.
    m is just an int here because we are not in multiple dimensions.
    If I'm right, I don't think we need the eigenvalues
    """
    w0 = (2 * tl.pi) / period # angular frequency defining the periodicity
    m1 = tl.tile(w0 * Xs[:, None], m)
    m2 = tl.diag(tl.arange(m))
    mw0x = m1 @ m2
    phi_cos = tl.cos(mw0x)
    phi_sin = tl.sin(mw0x)
    return phi_cos, phi_sin
```

### Attempt at `prior_linearized`

```python
def prior_linearized(self, Xs: TensorLike):
    # Index Xs using input_dim and active_dims of covariance function
    Xs, _ = self.cov_func._slice(Xs)

    phi_cos, phi_sin = calc_eigenvectors_periodic(Xs, self.cov_func.period, self._m, tl=pt)

    psd = self.cov_func.power_spectral_density(self._m)

    return (phi_cos, phi_sin), psd
```

### Attempt at `prior` (ignoring centered/noncentered)

```python
def prior(self, name: str, X: TensorLike, dims: Optional[str] = None):
    self._X_mean = pt.mean(X, axis=0)
    (phi_cos, phi_sin), psd = self.prior_linearized(X - self._X_mean)

    self._beta = pm.Normal(
        f"{name}_hsgp_coeffs_", size=(self._m, 2)
    )
    f = phi_cos @ (psd * self._beta[:, 0]) + phi_sin[1:] @ (psd[1:] * self._beta[1:, 2])

    self.f = pm.Deterministic(name, f, dims=dims)
    return self.f
```

## Resources

- [Original paper](https://arxiv.org/pdf/2004.11408.pdf)
- [Stan implementation](https://github.com/avehtari/casestudies/blob/master/Birthdays/gpbasisfun_functions.stan)
- [numpyro implementation](https://num.pyro.ai/en/stable/examples/hsgp.html)

## TODO

General TODO that I will update:
+ [x] Add documentation for HSGP class with periodic
+ [x] Add test for HSGP periodic
+ [ ] Add assertions so everything is in 1D

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## New features
- Periodic kernel for HSGP implementation

## Bugfixes
- Removed unnecessary GP fixture in HSGP test

## Documentation
- Added docs for PSD of Periodic

## Maintenance

N/A


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6877.org.readthedocs.build/en/6877/

<!-- readthedocs-preview pymc end -->