### PR TITLE
Remove experimental warning from external nuts samplers.

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -270,8 +270,6 @@ def _sample_external_nuts(
     nuts_sampler_kwargs: Optional[Dict],
     **kwargs,
 ):
-    warnings.warn("Use of external NUTS sampler is still experimental", UserWarning)
-
     if nuts_sampler_kwargs is None:
         nuts_sampler_kwargs = {}
 

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -46,8 +46,6 @@ def test_external_nuts_sampler(recwarn, nuts_sampler):
         if warn.category is not FutureWarning
     }
     expected = set()
-    if nuts_sampler != "pymc":
-        expected.add((UserWarning, "Use of external NUTS sampler is still experimental"))
     if nuts_sampler == "nutpie":
         expected.add(
             (


### PR DESCRIPTION


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6887.org.readthedocs.build/en/6887/

<!-- readthedocs-preview pymc end -->