### PR TITLE
Cast `ZeroSumNormal` shape operations to `config.floatX`

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2783,8 +2783,8 @@ def zerosumnormal_logp(op, values, normal_dist, sigma, support_shape, **kwargs):
     n_zerosum_axes = op.ndim_supp
 
     _deg_free_support_shape = pt.inc_subtensor(shape[-n_zerosum_axes:], -1)
-    _full_size = pt.prod(shape)
-    _degrees_of_freedom = pt.prod(_deg_free_support_shape)
+    _full_size = pm.floatX(pt.prod(shape))
+    _degrees_of_freedom = pm.floatX(pt.prod(_deg_free_support_shape))
 
     zerosums = [
         pt.all(pt.isclose(pt.mean(value, axis=-axis - 1), 0, atol=1e-9))

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -22,6 +22,8 @@ from numpy.core.numeric import normalize_axis_tuple  # type: ignore
 from pytensor.graph import Op
 from pytensor.tensor import TensorVariable
 
+import pymc as pm
+
 from pymc.logprob.transforms import (
     CircularTransform,
     IntervalTransform,
@@ -330,7 +332,7 @@ class ZeroSumTransform(RVTransform):
 
 
 def extend_axis(array, axis):
-    n = array.shape[axis] + 1
+    n = pm.floatX(array.shape[axis] + 1)
     sum_vals = array.sum(axis, keepdims=True)
     norm = sum_vals / (pt.sqrt(n) + n)
     fill_val = norm - sum_vals / pt.sqrt(n)
@@ -342,7 +344,7 @@ def extend_axis(array, axis):
 def extend_axis_rev(array, axis):
     normalized_axis = normalize_axis_tuple(axis, array.ndim)[0]
 
-    n = array.shape[normalized_axis]
+    n = pm.floatX(array.shape[normalized_axis])
     last = pt.take(array, [-1], axis=normalized_axis)
 
     sum_vals = -last * pt.sqrt(n)

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -1636,9 +1636,9 @@ class TestZeroSumNormal:
 
     def test_does_not_upcast_to_float64(self):
         with pytensor.config.change_flags(floatX="float32", warn_float64="raise"):
-            with pm.Model():
-                zsn = pm.ZeroSumNormal("b", sigma=1, shape=(2,))
-                pm.logp(zsn, value=np.zeros((2,)))
+            with pm.Model() as m:
+                pm.ZeroSumNormal("b", sigma=1, shape=(2,))
+            m.logp()
 
 
 class TestMvStudentTCov(BaseTestDistributionRandom):

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -1637,8 +1637,8 @@ class TestZeroSumNormal:
     def test_does_not_upcast_to_float64(self):
         with pytensor.config.change_flags(floatX="float32", warn_float64="raise"):
             with pm.Model():
-                pm.ZeroSumNormal("b", sigma=1, shape=(2,))  # runs ZeroSumTransform.forward
-                pm.sample(1, chains=1, tune=1)  # runs ZeroSumTransform.backward and logp
+                zsm = pm.ZeroSumNormal("b", sigma=1, shape=(2,))
+                pm.logp(zsm, value=np.zeros((2,)))
 
 
 class TestMvStudentTCov(BaseTestDistributionRandom):

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -1634,6 +1634,12 @@ class TestZeroSumNormal:
 
         np.testing.assert_allclose(zsn_logp, mvn_logp)
 
+    def test_does_not_upcast_to_float64(self):
+        with pytensor.config.change_flags(floatX="float32", warn_float64="raise"):
+            with pm.Model():
+                pm.ZeroSumNormal("b", sigma=1, shape=(2,))
+                pm.sample(1, chains=1, tune=1)
+
 
 class TestMvStudentTCov(BaseTestDistributionRandom):
     def mvstudentt_rng_fn(self, size, nu, mu, scale, rng):

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -1637,8 +1637,8 @@ class TestZeroSumNormal:
     def test_does_not_upcast_to_float64(self):
         with pytensor.config.change_flags(floatX="float32", warn_float64="raise"):
             with pm.Model():
-                pm.ZeroSumNormal("b", sigma=1, shape=(2,))
-                pm.sample(1, chains=1, tune=1)
+                pm.ZeroSumNormal("b", sigma=1, shape=(2,))  # runs ZeroSumTransform.forward
+                pm.sample(1, chains=1, tune=1)  # runs ZeroSumTransform.backward and logp
 
 
 class TestMvStudentTCov(BaseTestDistributionRandom):

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -1637,8 +1637,8 @@ class TestZeroSumNormal:
     def test_does_not_upcast_to_float64(self):
         with pytensor.config.change_flags(floatX="float32", warn_float64="raise"):
             with pm.Model():
-                zsm = pm.ZeroSumNormal("b", sigma=1, shape=(2,))
-                pm.logp(zsm, value=np.zeros((2,)))
+                zsn = pm.ZeroSumNormal("b", sigma=1, shape=(2,))
+                pm.logp(zsn, value=np.zeros((2,)))
 
 
 class TestMvStudentTCov(BaseTestDistributionRandom):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This PR prevents ZeroSumNormal from upcasting to float64, when `pytensor` is configured with `floatX = float32`.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Bugfixes
- Fixes https://github.com/pymc-devs/pymc/issues/6886


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6889.org.readthedocs.build/en/6889/

<!-- readthedocs-preview pymc end -->