### PR TITLE
Link to updated PyMC port of DBDA in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Learn Bayesian statistics with a book together with PyMC
 --------------------------------------------------------
 
 -  `Probabilistic Programming and Bayesian Methods for Hackers <https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers>`__: Fantastic book with many applied code examples.
--  `PyMC port of the book "Doing Bayesian Data Analysis" by John Kruschke <https://github.com/aloctavodia/Doing_bayesian_data_analysis>`__ as well as the `second edition <https://github.com/JWarmenhoven/DBDA-python>`__: Principled introduction to Bayesian data analysis.
+-  `PyMC port of the book "Doing Bayesian Data Analysis" by John Kruschke <https://github.com/cluhmann/DBDA-python>`__ as well as the `first edition <https://github.com/aloctavodia/Doing_bayesian_data_analysis>`__.
 -  `PyMC port of the book "Statistical Rethinking A Bayesian Course with Examples in R and Stan" by Richard McElreath <https://github.com/pymc-devs/resources/tree/master/Rethinking>`__
 -  `PyMC port of the book "Bayesian Cognitive Modeling" by Michael Lee and EJ Wagenmakers <https://github.com/pymc-devs/resources/tree/master/BCM>`__: Focused on using Bayesian statistics in cognitive modeling.
 -  `Bayesian Analysis with Python  <https://www.packtpub.com/big-data-and-business-intelligence/bayesian-analysis-python-second-edition>`__ (second edition) by Osvaldo Martin: Great introductory book. (`code <https://github.com/aloctavodia/BAP>`__ and errata).


### PR DESCRIPTION
The docs ([here](https://github.com/pymc-devs/pymc/blob/dfb05b6893fef6b2b136018e7c364fc821c24158/docs/source/learn/books.md?plain=1#L53)) were updated some time ago to point to my repo with a more up-to-date implementation of Kruschke's Doing Bayesian Data Analysis repo.  I just realized that the README still had the old link. I also am not sure what the "Principled introduction to Bayesian data analysis" is. Kruschke's second edition is subtitled "A Tutorial with R, JAGS, and Stan". So I removed that and moved the 2nd edition repo so that it's first (but kept the 1st edition link as well).

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6890.org.readthedocs.build/en/6890/

<!-- readthedocs-preview pymc end -->