### PR TITLE
Reject logp derivation of binary operations with broadcasted measurable input

### DIFF
--- a/pymc/logprob/binary.py
+++ b/pymc/logprob/binary.py
@@ -55,6 +55,10 @@ def find_measurable_comparisons(
     [measurable_var] = measurable_inputs
     measurable_var_idx = node.inputs.index(measurable_var)
 
+    # deny broadcasting of the measurable input
+    if measurable_var.type.broadcastable != node.outputs[0].type.broadcastable:
+        return None
+
     # Check that the other input is not potentially measurable, in which case this rewrite
     # would be invalid
     const = node.inputs[(measurable_var_idx + 1) % 2]

--- a/tests/logprob/test_binary.py
+++ b/tests/logprob/test_binary.py
@@ -147,3 +147,15 @@ def test_potentially_measurable_operand():
         match="Logprob method not implemented",
     ):
         logp(y_rv, y_vv).eval({y_vv: y_vv_test})
+
+
+def test_comparison_invalid_broadcast():
+    x_rv = pt.random.normal(0.5, 1, size=(3,))
+
+    const = np.array([[0.1], [0.2], [-0.1]])
+    y_rv_invalid = pt.gt(x_rv, const)
+
+    y_vv_invalid = y_rv_invalid.clone()
+
+    with pytest.raises(NotImplementedError, match="Logprob method not implemented for"):
+        logp(y_rv_invalid, y_vv_invalid)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Resolves #6880.  This PR makes sure that no duplication is done and that the variables are conditionally independent.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Bugfixes
- This PR makes sure that the broadcastability of measurable inputs in binary graphs is disallowed.


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6893.org.readthedocs.build/en/6893/

<!-- readthedocs-preview pymc end -->