### PR TITLE
Fix fgraph_from_model with multivariate transformed variables

### DIFF
--- a/pymc/model/fgraph.py
+++ b/pymc/model/fgraph.py
@@ -70,7 +70,7 @@ class ModelValuedVar(ModelVar):
         dims = self._parse_dims(rv, *dims)
         if value is not None:
             assert isinstance(value, Variable)
-            assert rv.type.in_same_class(value.type)
+            assert rv.type.dtype == value.type.dtype
             return Apply(self, [rv, value, *dims], [rv.type(name=rv.name)])
 
 

--- a/tests/model/test_fgraph.py
+++ b/tests/model/test_fgraph.py
@@ -351,3 +351,16 @@ def test_fgraph_rewrite(non_centered_rewrite):
         m_new.compile_logp()(ip),
         m_ref.compile_logp()(ip),
     )
+
+
+def test_multivariate_transform():
+    with pm.Model() as m:
+        x = pm.Dirichlet("x", a=[1, 1, 1])
+        y, *_ = pm.LKJCholeskyCov("y", n=4, eta=1, sd_dist=pm.Exponential.dist(1))
+
+    new_m = clone_model(m)
+
+    ip = m.initial_point()
+    new_ip = new_m.initial_point()
+    np.testing.assert_allclose(ip["x_simplex__"], new_ip["x_simplex__"])
+    np.testing.assert_allclose(ip["y_cholesky-cov-packed__"], new_ip["y_cholesky-cov-packed__"])

--- a/tests/model/transform/test_conditioning.py
+++ b/tests/model/transform/test_conditioning.py
@@ -308,3 +308,16 @@ def test_remove_value_transforms():
     new_p = new_m["p"]
     new_q = new_m["q"]
     assert new_m.rvs_to_transforms == {new_p: logodds, new_q: None}
+
+
+def test_do_transformed():
+    """There was a bug when the shape check compared value vars
+    with actual rv type which can have different shapes"""
+    with pm.Model() as m:
+        pm.ConstantData("data_std", 1)
+        # value var has different number of dimensions
+        pm.LKJCorr("c", 4, 1.0)
+        # value var has different shape
+        pm.Dirichlet("d", [1, 2])
+    m2 = do(m, {"data_std": 2})
+    assert m2["data_std"].eval() == 2

--- a/tests/model/transform/test_conditioning.py
+++ b/tests/model/transform/test_conditioning.py
@@ -308,16 +308,3 @@ def test_remove_value_transforms():
     new_p = new_m["p"]
     new_q = new_m["q"]
     assert new_m.rvs_to_transforms == {new_p: logodds, new_q: None}
-
-
-def test_do_transformed():
-    """There was a bug when the shape check compared value vars
-    with actual rv type which can have different shapes"""
-    with pm.Model() as m:
-        pm.ConstantData("data_std", 1)
-        # value var has different number of dimensions
-        pm.LKJCorr("c", 4, 1.0)
-        # value var has different shape
-        pm.Dirichlet("d", [1, 2])
-    m2 = do(m, {"data_std": 2})
-    assert m2["data_std"].eval() == 2


### PR DESCRIPTION
```python
def test_do_transformed():
    """There was a bug when the shape check compared value vars
    with actual rv type which can have different shapes"""
    with pm.Model() as m:
        pm.ConstantData("data_std", 1)
        # value var has different number of dimensions
        pm.LKJCorr("c", 4, 1.0)
        # value var has different shape
        pm.Dirichlet("d", [1, 2])
    m2 = do(m, {"data_std": 2})
    assert m2["data_std"].eval() == 2
```

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6924.org.readthedocs.build/en/6924/

<!-- readthedocs-preview pymc end -->