### PR TITLE
Add constant and observed data to nutpie idata

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -39,7 +39,8 @@ from typing import (
 import numpy as np
 import pytensor.gradient as tg
 
-from arviz import InferenceData
+from arviz import InferenceData, dict_to_dataset
+from arviz.data.base import make_attrs
 from fastprogress.fastprogress import progress_bar
 from pytensor.graph.basic import Variable
 from typing_extensions import Protocol, TypeAlias
@@ -47,6 +48,11 @@ from typing_extensions import Protocol, TypeAlias
 import pymc as pm
 
 from pymc.backends import RunType, TraceOrBackend, init_traces
+from pymc.backends.arviz import (
+    coords_and_dims_for_inferencedata,
+    find_constants,
+    find_observations,
+)
 from pymc.backends.base import IBaseTrace, MultiTrace, _choose_chains
 from pymc.blocking import DictToArrayBijection
 from pymc.exceptions import SamplingError
@@ -293,8 +299,24 @@ def _sample_external_nuts(
                 "`idata_kwargs` are currently ignored by the nutpie sampler",
                 UserWarning,
             )
-
+        # gather observed and constant data as nutpie.sample() has no access to the PyMC model
+        coords, dims = coords_and_dims_for_inferencedata(model)
+        constant_data = dict_to_dataset(
+            find_constants(model),
+            library=pm,
+            coords=coords,
+            dims=dims,
+            default_dims=[],
+        )
+        observed_data = dict_to_dataset(
+            find_observations(model),
+            library=pm,
+            coords=coords,
+            dims=dims,
+            default_dims=[],
+        )
         compiled_model = nutpie.compile_pymc_model(model)
+        t_start = time.time()
         idata = nutpie.sample(
             compiled_model,
             draws=draws,
@@ -304,6 +326,20 @@ def _sample_external_nuts(
             seed=_get_seeds_per_chain(random_seed, 1)[0],
             progress_bar=progressbar,
             **nuts_sampler_kwargs,
+        )
+        t_sample = time.time() - t_start
+        attrs = make_attrs(
+            {
+                "sampling_time": t_sample,
+            },
+            library=nutpie,
+        )
+        for k, v in attrs.items():
+            idata.posterior.attrs[k] = v
+        idata.add_groups(
+            {"constant_data": constant_data, "observed_data": observed_data},
+            coords=coords,
+            dims=dims,
         )
         return idata
 

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -299,6 +299,20 @@ def _sample_external_nuts(
                 "`idata_kwargs` are currently ignored by the nutpie sampler",
                 UserWarning,
             )
+        compiled_model = nutpie.compile_pymc_model(model)
+        t_start = time.time()
+        idata = nutpie.sample(
+            compiled_model,
+            draws=draws,
+            tune=tune,
+            chains=chains,
+            target_accept=target_accept,
+            seed=_get_seeds_per_chain(random_seed, 1)[0],
+            progress_bar=progressbar,
+            **nuts_sampler_kwargs,
+        )
+        t_sample = time.time() - t_start
+        # Temporary work-around. Revert once https://github.com/pymc-devs/nutpie/issues/74 is fixed
         # gather observed and constant data as nutpie.sample() has no access to the PyMC model
         coords, dims = coords_and_dims_for_inferencedata(model)
         constant_data = dict_to_dataset(
@@ -315,19 +329,6 @@ def _sample_external_nuts(
             dims=dims,
             default_dims=[],
         )
-        compiled_model = nutpie.compile_pymc_model(model)
-        t_start = time.time()
-        idata = nutpie.sample(
-            compiled_model,
-            draws=draws,
-            tune=tune,
-            chains=chains,
-            target_accept=target_accept,
-            seed=_get_seeds_per_chain(random_seed, 1)[0],
-            progress_bar=progressbar,
-            **nuts_sampler_kwargs,
-        )
-        t_sample = time.time() - t_start
         attrs = make_attrs(
             {
                 "sampling_time": t_sample,


### PR DESCRIPTION
Temporary work-around for https://github.com/pymc-devs/nutpie/issues/74.  
With gracious assistance from Michael Osthege.

**What is this PR about?**
When sampling with the external NUTS sampler "nutpie", idata was not updated with neither attributes nor constant or observed data. Using pre-existing methods, this was fixed.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Bugfixes
- Observed and constant data are now included in the inference data object resulting from nutpie sampling.


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6943.org.readthedocs.build/en/6943/

<!-- readthedocs-preview pymc end -->