### PR TITLE
Fix type hints Python 3.9 compatibility

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -336,7 +336,7 @@ def sample_blackjax_nuts(
     var_names: Optional[Sequence[str]] = None,
     keep_untransformed: bool = False,
     chain_method: str = "parallel",
-    postprocessing_backend: Literal["cpu", "gpu"] | None = None,
+    postprocessing_backend: Optional[Literal["cpu", "gpu"]] = None,
     postprocessing_vectorize: Literal["vmap", "scan"] = "scan",
     idata_kwargs: Optional[Dict[str, Any]] = None,
     postprocessing_chunks=None,  # deprecated
@@ -546,7 +546,7 @@ def sample_numpyro_nuts(
     progressbar: bool = True,
     keep_untransformed: bool = False,
     chain_method: str = "parallel",
-    postprocessing_backend: Literal["cpu", "gpu"] | None = None,
+    postprocessing_backend: Optional[Literal["cpu", "gpu"]] = None,
     postprocessing_vectorize: Literal["vmap", "scan"] = "scan",
     idata_kwargs: Optional[Dict] = None,
     nuts_kwargs: Optional[Dict] = None,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Trying to fix _one_ of the reasons why our CIs are going :x:.

Closes #6941

**Checklist**
+ [x] Explain important implementation details 👉 `Literal | None` doesn't work in Python 3.9
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Bugfixes
- Fixed a type hint incompatibility of the `jax` submodule under Python 3.9


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6944.org.readthedocs.build/en/6944/

<!-- readthedocs-preview pymc end -->