### PR TITLE
FlatSwitch Op for logprob derivation of arbitrary censoring

### DIFF
--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -415,7 +415,13 @@ def find_measurable_flat_switch_encoding(fgraph: FunctionGraph, node: Node):
     initial_interval = (-np.inf, np.inf)
 
     # gets the base_var in the first switch condition and checks its measurability
-    base_rv = get_measurability_source(node.inputs[0], valued_rvs)
+    base_rv_set = get_measurability_source(node.inputs[0], valued_rvs)
+
+    # Allow only one base_rv. For example, two unmeasurable variables like pt.switch(x > y) not allowed
+    if len(base_rv_set) != 1:
+        return None
+
+    base_rv = list(base_rv_set)[0]
 
     if base_rv is None:
         return None

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -448,6 +448,8 @@ def find_measurable_flat_switch_encoding(fgraph: FunctionGraph, node: Node):
         return None
 
     encoding_list = flat_switch_helper(node, valued_rvs, encoding_list, initial_interval, base_rv)
+    if encoding_list is None:
+        return None
 
     encodings, intervals = [], []
     rv_idx = ()
@@ -485,7 +487,7 @@ def flat_switches_logprob(op, values, base_rv, *inputs, **kwargs):
         encodings, pt.eq(pt.unique(encodings, axis=0).shape[0], len(encodings))
     )
 
-    # TODO: Assert that the base_rv is not discrete
+    # TODO: We do not support the encoding graphs of discrete RVs yet
 
     interval_bounds = pt.broadcast_arrays(*inputs[0 : 2 * encodings_count])
     lower_interval_bounds = interval_bounds[::2]

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -57,9 +57,7 @@ from pytensor.scalar.basic import (
     Switch,
 )
 from pytensor.scalar.basic import clip as scalar_clip
-
-from pytensor.tensor import TensorVariable
-from pytensor.tensor import TensorType
+from pytensor.tensor import TensorType, TensorVariable
 from pytensor.tensor.basic import switch as switch
 from pytensor.tensor.math import ceil, clip, floor, round_half_to_even
 from pytensor.tensor.random.op import RandomVariable

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -326,6 +326,14 @@ def flat_switch_helper(node, valued_rvs, encoding_list, outer_interval, base_rv)
     """
     switch_cond, *components = node.inputs
 
+    # deny broadcasting of the switch condition
+    if switch_cond.type.broadcastable != node.outputs[0].type.broadcastable:
+        return None
+
+    # check if the switch_cond is measurable and if measurability sources for all switch conditions are the same
+    if not compare_measurability_source([switch_cond, base_rv], valued_rvs):
+        return None
+
     # Get intervals for true and false components from the condition
     intervals = get_intervals(switch_cond.owner, valued_rvs)
     adjusted_intervals = adjust_intervals(intervals, outer_interval)

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -56,7 +56,9 @@ from pytensor.scalar.basic import (
     Switch,
 )
 from pytensor.scalar.basic import clip as scalar_clip
+
 from pytensor.tensor import TensorVariable
+from pytensor.tensor import TensorType
 from pytensor.tensor.basic import switch as switch
 from pytensor.tensor.math import ceil, clip, floor, round_half_to_even
 from pytensor.tensor.random.op import RandomVariable
@@ -268,7 +270,9 @@ class FlatSwitches(Op):
         self.out_dtype = out_dtype
 
     def make_node(self, *inputs):
-        return Apply(self, list(inputs), [inputs[0].type()])
+        return Apply(
+            self, list(inputs), [TensorType(dtype=self.out_dtype, shape=inputs[0].type.shape)()]
+        )
 
     def perform(self, *args, **kwargs):
         raise NotImplementedError("This Op should not be evaluated")

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -427,6 +427,11 @@ def find_measurable_flat_switch_encoding(fgraph: FunctionGraph, node: Node):
     if base_rv.dtype.startswith("int"):
         return None
 
+    # Since we verify the source of measurability to be the same for switch conditions
+    # and all measurable components, denying broadcastability of the base_var is enough
+    if base_rv.type.broadcastable != node.outputs[0].type.broadcastable:
+        return None
+
     encoding_list = flat_switch_helper(node, valued_rvs, encoding_list, initial_interval, base_rv)
 
     flat_switch_op = FlatSwitches(meta_info=encoding_list)

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -517,6 +517,7 @@ def flat_switches_logprob(op, values, base_rv, *inputs, **kwargs):
             logprob,
         )
 
+    # TODO: Define this before the encoding branch so it can be written more simply
     # Add rv branch (and checks whether it is possible)
     logp_rv = _logprob_helper(base_rv, value, **kwargs)
     for i in op.rv_idx:

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -423,9 +423,6 @@ def find_measurable_flat_switch_encoding(fgraph: FunctionGraph, node: Node):
 
     base_rv = list(base_rv_set)[0]
 
-    if base_rv is None:
-        return None
-
     # We do not allow discrete RVs yet
     if base_rv.dtype.startswith("int"):
         return None

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -265,7 +265,7 @@ def round_logprob(op, values, base_rv, **kwargs):
 
 
 class FlatSwitches(Op):
-    __props__ = ("out_dtype",)
+    __props__ = ("out_dtype", "rv_idx")
 
     def __init__(self, *args, out_dtype, rv_idx, **kwargs):
         super().__init__(*args, **kwargs)
@@ -449,14 +449,15 @@ def find_measurable_flat_switch_encoding(fgraph: FunctionGraph, node: Node):
 
     encoding_list = flat_switch_helper(node, valued_rvs, encoding_list, initial_interval, base_rv)
 
-    encodings, intervals, rv_idx = [], [], []
+    encodings, intervals = [], []
+    rv_idx = ()
 
     # TODO: Some alternative cleaner way to do this
     for idx, item in enumerate(encoding_list):
         encoding = item["encoding"]
         # indices of intervals having base_rv as their "encoding"
         if encoding == base_rv:
-            rv_idx.append(idx)
+            rv_idx += (idx,)
 
         encodings.append(encoding)
         intervals.extend((item["lower"], item["upper"]))

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -382,20 +382,20 @@ def flat_switch_helper(node, valued_rvs, encoding_list, outer_interval, base_rv)
         return encoding_list
 
     else:
-        # There is at least one switch, so measurable components can be at most 1
-        for i in measurable_var_idx:
-            switch_dict = {
-                "lower": adjusted_intervals[i][0],
-                "upper": adjusted_intervals[i][1],
-                "encoding": components[i],
-            }
-            encoding_list.append(switch_dict)
+        for i in range(2):
+            if i in switch_comp_idx:
+                # Recurse through the switch component(es)
+                encoding_list = flat_switch_helper(
+                    components[i].owner, valued_rvs, encoding_list, adjusted_intervals[i], base_rv
+                )
 
-        # Recurse through the switch component(es)
-        for j in switch_comp_idx:
-            encoding_list = flat_switch_helper(
-                components[j].owner, valued_rvs, encoding_list, adjusted_intervals[j], base_rv
-            )
+            else:
+                switch_dict = {
+                    "lower": adjusted_intervals[i][0],
+                    "upper": adjusted_intervals[i][1],
+                    "encoding": components[i],
+                }
+                encoding_list.append(switch_dict)
 
     return encoding_list
 

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -434,6 +434,12 @@ def find_measurable_flat_switch_encoding(fgraph: FunctionGraph, node: Node):
 
     flat_switch_op = FlatSwitches(meta_info=encoding_list, out_dtype=base_rv.dtype)
 
+    # print("\n")
+    # for i in range(len(encoding_list)):
+    #     print("lower:", encoding_list[i]["lower"].eval())
+    #     print("upper:", encoding_list[i]["upper"].eval())
+    #     print("encoding:", encoding_list[i]["encoding"], "\n")
+
     new_outs = flat_switch_op.make_node(base_rv).default_output()
     return [new_outs]
 

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -452,6 +452,8 @@ def get_measurability_source(
     """
     Returns all the sources of measurability in the input boolean condition.
     """
+    from pymc.distributions.distribution import SymbolicRandomVariable
+
     ancestor_var_set = set()
 
     for ancestor_var in walk_model(
@@ -461,7 +463,7 @@ def get_measurability_source(
     ):
         if (
             ancestor_var.owner
-            and isinstance(ancestor_var.owner.op, RandomVariable)
+            and isinstance(ancestor_var.owner.op, (RandomVariable, SymbolicRandomVariable))
             # TODO: Check if MeasurableVariable needs to be added
             and ancestor_var not in valued_rvs
         ):
@@ -495,7 +497,7 @@ def walk_model(
 
         if (
             var.owner
-            and (walk_past_rvs or not isinstance(var.owner.op, RandomVariable))
+            and (walk_past_rvs or not isinstance(var.owner.op, MeasurableVariable))
             and (var not in stop_at_vars)
         ):
             new_vars.extend(reversed(var.owner.inputs))

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -261,11 +261,10 @@ def round_logprob(op, values, base_rv, **kwargs):
 
 
 class FlatSwitches(Op):
-    __props__ = ("meta_info", "out_dtype")
+    __props__ = ("out_dtype",)
 
-    def __init__(self, *args, meta_info, out_dtype, **kwargs):
+    def __init__(self, *args, out_dtype, **kwargs):
         super().__init__(*args, **kwargs)
-        self.meta_info = meta_info
         self.out_dtype = out_dtype
 
     def make_node(self, *inputs):
@@ -445,7 +444,7 @@ def find_measurable_flat_switch_encoding(fgraph: FunctionGraph, node: Node):
 
     encoding_list = flat_switch_helper(node, valued_rvs, encoding_list, initial_interval, base_rv)
 
-    flat_switch_op = FlatSwitches(meta_info=len(encoding_list), out_dtype=base_rv.dtype)
+    flat_switch_op = FlatSwitches(out_dtype=base_rv.dtype)
 
     encodings, intervals = [], []
     for item in encoding_list:

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -260,11 +260,12 @@ def round_logprob(op, values, base_rv, **kwargs):
 
 
 class FlatSwitches(Op):
-    __props__ = ("meta_info",)
+    __props__ = ("meta_info", "out_dtype")
 
-    def __init__(self, *args, meta_info, **kwargs):
+    def __init__(self, *args, meta_info, out_dtype, **kwargs):
         super().__init__(*args, **kwargs)
         self.meta_info = meta_info
+        self.out_dtype = out_dtype
 
     def make_node(self, base_rv):
         assert isinstance(base_rv, Variable) and (base_rv.owner.op, MeasurableVariable)
@@ -434,9 +435,9 @@ def find_measurable_flat_switch_encoding(fgraph: FunctionGraph, node: Node):
 
     encoding_list = flat_switch_helper(node, valued_rvs, encoding_list, initial_interval, base_rv)
 
-    flat_switch_op = FlatSwitches(meta_info=encoding_list)
+    flat_switch_op = FlatSwitches(meta_info=encoding_list, out_dtype=base_rv.dtype)
 
-    new_outs = flat_switch_op.make_node(base_rv).outputs
+    new_outs = flat_switch_op.make_node(base_rv).default_output()
     return [new_outs]
 
 

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -464,7 +464,7 @@ def find_measurable_flat_switch_encoding(fgraph: FunctionGraph, node: Node):
         encodings.append(encoding)
         intervals.extend((item["lower"], item["upper"]))
 
-    flat_switch_op = FlatSwitches(out_dtype=base_rv.dtype, rv_idx=rv_idx)
+    flat_switch_op = FlatSwitches(out_dtype=node.outputs[0].dtype, rv_idx=rv_idx)
 
     new_outs = flat_switch_op.make_node(base_rv, *intervals, *encodings).default_output()
     return [new_outs]

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -482,7 +482,7 @@ def flat_switches_logprob(op, values, base_rv, *inputs, **kwargs):
     encodings = pt.broadcast_arrays(*encodings)
 
     encodings = Assert(msg="all encodings should be unique")(
-        encodings, pt.eq(pt.unique(encodings).shape[0], len(encodings))
+        encodings, pt.eq(pt.unique(encodings, axis=0).shape[0], len(encodings))
     )
 
     # TODO: Assert that the base_rv is not discrete

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -426,6 +426,10 @@ def find_measurable_flat_switch_encoding(fgraph: FunctionGraph, node: Node):
     if base_rv is None:
         return None
 
+    # We do not allow discrete RVs yet
+    if base_rv.dtype.startswith("int"):
+        return None
+
     encoding_list = flat_switch_helper(node, valued_rvs, encoding_list, initial_interval, base_rv)
 
     flat_switch_op = FlatSwitches(meta_info=encoding_list)

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -358,13 +358,10 @@ def flat_switch_helper(node, valued_rvs, encoding_list, outer_interval, base_rv)
             else:
                 switch_comp_idx.append(idx)
 
-    # Deny the broadcasting of any measurable components present other than switch
-    # Check that the measurability source is the same for all
+    # Check that the measurability source is the same for all measurable components within the current branch
     for i in measurable_var_idx:
         component = components[i]
-        if component.type.broadcastable != node.outputs[
-            0
-        ].broadcastable or not compare_measurability_source([base_rv, component], valued_rvs):
+        if not compare_measurability_source([base_rv, component], valued_rvs):
             return None
 
     # Get intervals for true and false components from the condition

--- a/tests/logprob/test_censoring.py
+++ b/tests/logprob/test_censoring.py
@@ -264,6 +264,25 @@ def test_rounding(rounding_op):
     )
 
 
+def test_switch_encoding_no_branch_measurable():
+    x_rv = pt.random.normal(0.5, 1, size=2)
+
+    y_rv = pt.switch(x_rv < 1, [2.0, 2.5], 3.0)
+
+    y_vv1 = y_rv.clone()
+
+    logprob1 = logp(y_rv, y_vv1)
+
+    logp_fn1 = pytensor.function([y_vv1], logprob1)
+
+    ref_scipy = st.norm(0.5, 1)
+
+    np.testing.assert_allclose(
+        logp_fn1([2.0, 1.5]),
+        np.array([ref_scipy.logcdf(1), -np.inf]),
+    )
+
+
 def test_switch_encoding_one_branch_measurable():
     x_rv = pt.random.normal(0.5, 1, size=3)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This PR defines a FlatSwitch Op that aims to extract the intervals and their respective encodings required to infer the logprob of arbitrary censored distributions. It achieves this in the following steps:

1. Extract the intervals defined by the condition in `pt.switch()`recursively.
2. Adjust/limit these intervals to eliminate the overlap from the outer switch.
3. Identify the intervals that the true and false branches correspond to since each condition splits the space into two parts.

It then checks that we don't allow the broadcastability of a switch condition or any measurable branches, and if all the measurable components have the same source of measurability. The logic for these checks is based on #6834.

Once the intervals and their respective encodings are known, they can be used to calculate the log-probability. So, on running something like 
```python
rv2 = pt.switch(
    base_rv < -1,
    -1,
    pt.switch(
        base_rv < 1,  # -inf to 2, 2 to inf
        1,
        base_rv
    ),
)
```
we get something like:
```
lower: -1.0
upper: 1.0
encoding: 1 

lower: 1.0
upper: inf
encoding: normal_rv{0, (0, 0), floatX, False}.out 
```

TO-DO:
+ [x] The checks should work not only on `pt.switch(x>0, x, a)` but also on `pt.switch(pt.exp(x)>0, pt.exp(x), b)`, where a and b are some encodings.
+ [x] In the FlatSwitch Op, add `base_rv`,  intervals list and the corresponding encodings as inputs to the node so that they can be unpacked in the logprob calculation.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

@ricardoV94 @larryshamalama 