### PR TITLE
Fix HurdleLogNormal Docstring

### DIFF
--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -1009,7 +1009,7 @@ class HurdleLogNormal:
     Parameters
     ----------
     psi : tensor_like of float
-        Expected proportion of Gamma variates (0 < psi < 1)
+        Expected proportion of LogNormal variates (0 < psi < 1)
     mu : tensor_like of float, default 0
         Location parameter.
     sigma : tensor_like of float, optional


### PR DESCRIPTION
Correct the psi parameter description so that it refers to the correct distribution for this class.

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Making a small change to the HurdleLogNormal class docstring

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- none

## New features
- none

## Bugfixes
- none

## Documentation
- update docstring

## Maintenance
- none


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6958.org.readthedocs.build/en/6958/

<!-- readthedocs-preview pymc end -->