### PR TITLE
Support logp derivation of `power(base, rv)`

### DIFF
--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -618,7 +618,7 @@ def measurable_special_exp_to_exp(fgraph, node):
 
 
 @node_rewriter([pow])
-def measurable_power_expotent_to_exp(fgraph, node):
+def measurable_power_exponent_to_exp(fgraph, node):
     """Convert power(base, x) of `MeasurableVariable`s to exp form."""
     base, inp_exponent = node.inputs
 

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -619,10 +619,17 @@ def measurable_special_exp_to_exp(fgraph, node):
 
 @node_rewriter([pow])
 def measurable_power_expotent_to_exp(fgraph, node):
+    """Convert power(base, x) of `MeasurableVariable`s to exp form."""
     base, inp_exponent = node.inputs
-    base = CheckParameterValue("base > 0")(base, pt.all(pt.ge(base, 0.0)))
 
-    # check whether inp is discrete
+    # if base is measurable then it is power(x, exponent) and not power(base, x) as expected
+    # and should use PowerTransform
+    if check_potential_measurability([base], fgraph.preserve_rv_mappings.rv_values.keys()):
+        return None
+
+    base = CheckParameterValue("base >= 0")(base, pt.all(pt.ge(base, 0.0)))
+
+    # check whether inp_exponent is discrete
     if inp_exponent.type.dtype.startswith("int"):
         return None
 

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -620,15 +620,11 @@ def measurable_special_exp_to_exp(fgraph, node):
 @node_rewriter([pow])
 def measurable_power_expotent_to_exp(fgraph, node):
     exponent, inp = node.inputs
-    try:
-        scalar_exponent = pt.get_underlying_scalar_constant_value(exponent).item()
-    except:
-        return None
 
     if inp.type.dtype.startswith("int"):
         return None
-    if scalar_exponent > 0:
-        return [pt.exp(pt.log(scalar_exponent) * inp)]
+    # if scalar_exponent > 0:
+    return [pt.exp(pt.log(exponent) * inp)]
 
 
 @node_rewriter(
@@ -706,7 +702,7 @@ def find_measurable_transforms(fgraph: FunctionGraph, node: Node) -> Optional[Li
             return None
         try:
             power = pt.get_underlying_scalar_constant_value(node.inputs[1]).item()
-        # Power needs to be a constant
+        # Power needs to be a constant, if not then proceed to the other case power(const, x)
         except NotScalarConstantError:
             return None
         transform_inputs = (measurable_input, power)

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -622,8 +622,8 @@ def measurable_power_exponent_to_exp(fgraph, node):
     """Convert power(base, x) of `MeasurableVariable`s to exp form."""
     base, inp_exponent = node.inputs
 
-    # if base is measurable then it is power(x, exponent) and not power(base, x) as expected
-    # and should use PowerTransform
+    # When the base is measurable we have `power(rv, exponent)`, which should be handled by `PowerTransform` and needs no further rewrite.
+    # Here we change only the cases where exponent is measurable `power(base, rv)` which is not supported by the `PowerTransform`
     if check_potential_measurability([base], fgraph.preserve_rv_mappings.rv_values.keys()):
         return None
 

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -1173,7 +1173,7 @@ def test_measurable_power_exponent_with_constant_base():
     np.testing.assert_allclose(x_logp_fn_pow(0.1), x_logp_fn_exp2(0.1))
 
 
-def test_power_const_exponent_negative_rv_error():
+def def test_measurable_power_exponent_with_variable_base():
     # test when const < 0 we raise error
     # test with RV when logp(<0) we raise error
     base_rv = pt.random.normal([2])

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -1172,8 +1172,13 @@ def test_measurable_power_exponent_with_constant_base():
 
     np.testing.assert_allclose(x_logp_fn_pow(0.1), x_logp_fn_exp2(0.1))
 
+    with pytest.raises(ParameterValueError, match="base >= 0"):
+        x_rv_neg = pt.pow(-2, pt.random.normal())
+        x_vv_neg = x_rv_neg.clone()
+        logp(x_rv_neg, x_vv_neg)
 
-def def test_measurable_power_exponent_with_variable_base():
+
+def test_measurable_power_exponent_with_variable_base():
     # test when const < 0 we raise error
     # test with RV when logp(<0) we raise error
     base_rv = pt.random.normal([2])
@@ -1193,38 +1198,12 @@ def def test_measurable_power_exponent_with_variable_base():
         logp_vals_fn(np.array([-2]), np.array([2]))
 
 
-def test_power_const_exponent_negative_const_error():
-    with pytest.raises(ParameterValueError, match="base >= 0"):
-        x_rv = pt.pow(-2, pt.random.normal())
-        x_vv = x_rv.clone()
-        logp(x_rv, x_vv)
+def test_base_exponent_non_measurable():
+    x_rv = pt.pow(2, 2)
 
-
-def test_power_const_exponent_rv():
-    base_rv = pt.random.normal([2])
-    x_raw_rv = pt.random.normal()
-
-    x_rv = pt.power(base_rv, x_raw_rv)
-    x_rv.name = "x"
-    base_rv.name = "base"
-    base_vv = base_rv.clone()
     x_vv = x_rv.clone()
-
-    res_transform = conditional_logp({base_rv: base_vv, x_rv: x_vv})
-    factors_transform = [factor for factor in res_transform.values()]
-    logp_vals_transform_fn = pytensor.function([base_vv, x_vv], factors_transform[1])
-
-    x_rv_ref = pt.exp(pt.log(base_rv) * x_raw_rv)
-    x_vv_ref = x_rv_ref.clone()
-
-    res_ref = conditional_logp({base_rv: base_vv, x_rv: x_vv_ref})
-    factors_ref = [factor for factor in res_ref.values()]
-    logp_vals_ref_fn = pytensor.function([base_vv, x_vv_ref], factors_ref[1])
-
-    np.testing.assert_allclose(
-        logp_vals_transform_fn(np.array([2]), np.array([2])),
-        logp_vals_ref_fn(np.array([2]), np.array([2])),
-    )
+    with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'op'"):
+        logp(x_rv, x_vv)
 
 
 @pytest.mark.parametrize("shift", [1.5, np.array([-0.5, 1, 0.3])])

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -1161,6 +1161,8 @@ def test_special_log_exp_transforms(transform):
 
 
 def test_measurable_power_exponent_with_constant_base():
+    # test power(2, rv) = exp2(rv)
+    # test negative base fails
     x_rv_pow = pt.pow(2, pt.random.normal())
     x_rv_exp2 = pt.exp2(pt.random.normal())
 
@@ -1179,7 +1181,6 @@ def test_measurable_power_exponent_with_constant_base():
 
 
 def test_measurable_power_exponent_with_variable_base():
-    # test when const < 0 we raise error
     # test with RV when logp(<0) we raise error
     base_rv = pt.random.normal([2])
     x_raw_rv = pt.random.normal()
@@ -1199,11 +1200,19 @@ def test_measurable_power_exponent_with_variable_base():
 
 
 def test_base_exponent_non_measurable():
-    x_rv = pt.pow(2, 2)
+    # test dual sources of measuravility fails
+    base_rv = pt.random.normal([2])
+    x_raw_rv = pt.random.normal()
+    x_rv = pt.power(base_rv, x_raw_rv)
+    x_rv.name = "x"
 
     x_vv = x_rv.clone()
-    with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'op'"):
-        logp(x_rv, x_vv)
+
+    with pytest.raises(
+        RuntimeError,
+        match="The logprob terms of the following value variables could not be derived: {x}",
+    ):
+        conditional_logp({x_rv: x_vv})
 
 
 @pytest.mark.parametrize("shift", [1.5, np.array([-0.5, 1, 0.3])])

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -1191,8 +1191,8 @@ def test_measurable_power_exponent_with_variable_base():
     x_vv = x_rv.clone()
 
     res = conditional_logp({base_rv: base_vv, x_rv: x_vv})
-    factors = [factor for factor in res.values()]
-    logp_vals_fn = pytensor.function([base_vv, x_vv], factors[1])
+    x_logp = res[x_vv]
+    logp_vals_fn = pytensor.function([base_vv, x_vv], x_logp)
 
     with pytest.raises(ParameterValueError, match="base >= 0"):
         logp_vals_fn(np.array([-2]), np.array([2]))

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -1160,7 +1160,7 @@ def test_special_log_exp_transforms(transform):
         assert equal_computations([logp_test], [logp_ref])
 
 
-def test_power_const_exponent_output():
+def test_measurable_power_exponent_with_constant_base():
     x_rv_pow = pt.pow(2, pt.random.normal())
     x_rv_exp2 = pt.exp2(pt.random.normal())
 

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -1159,6 +1159,19 @@ def test_special_log_exp_transforms(transform):
         assert equal_computations([logp_test], [logp_ref])
 
 
+def test_power_const_exponent():
+    x_rv_pow = pt.pow(2, pt.random.normal())
+    x_rv_exp2 = pt.exp2(pt.random.normal())
+
+    x_vv_pow = x_rv_pow.clone()
+    x_vv_exp2 = x_rv_exp2.clone()
+
+    x_logp_fn_pow = pytensor.function([x_vv_pow], pt.sum(logp(x_rv_pow, x_vv_pow)))
+    x_logp_fn_exp2 = pytensor.function([x_vv_exp2], pt.sum(logp(x_rv_exp2, x_vv_exp2)))
+
+    np.testing.assert_allclose(x_logp_fn_pow(0.1), x_logp_fn_exp2(0.1))
+
+
 @pytest.mark.parametrize("shift", [1.5, np.array([-0.5, 1, 0.3])])
 @pytest.mark.parametrize("scale", [2.0, np.array([1.5, 3.3, 1.0])])
 def test_multivariate_rv_transform(shift, scale):


### PR DESCRIPTION
Addresses the first case in #6896, allowing users to evaluate the log prob of generalised bases e.g, power(base, x). This constricts base to be either a constant or a continuous random variable as long as its vaue is greater or equal to 0. 

I've added a node rewrite function to deal with the power(base, x) case. To make sure that power(x, exponent) is unaffected by this rewrite I have made changes to `find_measurable_transform`. This is based upon the ordering of the node inputs which is assumed to always be node.inputs = [base, exponent], where the new rewrite takes the case where index 1 is measurable and PowerTransform takes the case where index 0 is measurable.

Closes #6896 
...

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## New features
- Allows users to evaluate the logp of a generalised power(base, x) or base**x


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6962.org.readthedocs.build/en/6962/

<!-- readthedocs-preview pymc end -->