### PR TITLE
Improve blackjax sampling integration

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -342,6 +342,7 @@ def sample_blackjax_nuts(
     initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]] = None,
     model: Optional[Model] = None,
     var_names: Optional[Sequence[str]] = None,
+    progress_bar: bool = False,
     keep_untransformed: bool = False,
     chain_method: str = "parallel",
     postprocessing_backend: Optional[Literal["cpu", "gpu"]] = None,
@@ -447,14 +448,14 @@ def sample_blackjax_nuts(
     # Adapted from numpyro
     if chain_method == "parallel":
         map_fn = jax.pmap
-        if adaptation_kwargs.get("progress_bar", False):
+        if progress_bar:
             import warnings
 
             warnings.warn(
-                "BlackJax currently only display progress_bar correctly under "
-                "`chain_method == 'vectorized'`. Setting `progress_bar=False`."
+                "BlackJax currently only display progress bar correctly under "
+                "`chain_method == 'vectorized'`. Setting `progressbar=False`."
             )
-            adaptation_kwargs["progress_bar"] = False
+            progress_bar = False
     elif chain_method == "vectorized":
         map_fn = jax.vmap
     else:
@@ -462,6 +463,7 @@ def sample_blackjax_nuts(
             "Only supporting the following methods to draw chains:" ' "parallel" or "vectorized"'
         )
 
+    adaptation_kwargs["progress_bar"] = progress_bar
     get_posterior_samples = partial(
         _blackjax_inference_loop,
         logprob_fn=logprob_fn,

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -297,8 +297,10 @@ def _blackjax_inference_loop(
     algorithm_name = adaptation_kwargs.pop("algorithm", "nuts")
     if algorithm_name == "nuts":
         algorithm = blackjax.nuts
-    else:
+    elif algorithm_name == "hmc":
         algorithm = blackjax.hmc
+    else:
+        raise ValueError("Only supporting 'nuts' or 'hmc' as algorithm to draw samples.")
 
     adapt = blackjax.window_adaptation(
         algorithm=algorithm,
@@ -430,6 +432,8 @@ def sample_blackjax_nuts(
     seed = jax.random.PRNGKey(random_seed)
     keys = jax.random.split(seed, chains)
 
+    if adaptation_kwargs is None:
+        adaptation_kwargs = {}
     get_posterior_samples = partial(
         _blackjax_inference_loop,
         logprob_fn=logprob_fn,

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -290,13 +290,7 @@ def _update_coords_and_dims(
 
 
 def _blackjax_inference_loop(
-    seed,
-    init_position,
-    logprob_fn,
-    draws,
-    tune,
-    target_accept,
-    **adaptation_kwargs
+    seed, init_position, logprob_fn, draws, tune, target_accept, **adaptation_kwargs
 ):
     import blackjax
 

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -372,6 +372,7 @@ def _sample_external_nuts(
             random_seed=random_seed,
             initvals=initvals,
             model=model,
+            progress_bar=progressbar,
             idata_kwargs=idata_kwargs,
             **nuts_sampler_kwargs,
         )


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

Closes #6550 

**What is this PR about?**
Adding more fine tune control in blackjax sampling.

After this PR:
```python
# Use full rank mass matrix in window adaptation 
with model:
    idata2 = pm.sample(
        nuts_sampler="blackjax", 
        nuts_sampler_kwargs={
            "chain_method": "vectorized",
            "adaptation_kwargs": {
                "is_mass_matrix_diagonal": False
                }
            }
        )

# Warm up and sample with HMC (instead of NUTS) with full rank mass matrix adaptation
with model:
    idata2 = pm.sample(
        nuts_sampler="blackjax", 
        nuts_sampler_kwargs={
            "chain_method": "vectorized",
            "adaptation_kwargs": {
                "is_mass_matrix_diagonal": False,
                "algorithm": "hmc",
                "num_integration_steps": 20,
                }
            }
        )

# Enable progress bar (only works for `chain_method =  "vectorized"`)
with model:
    idata2 = pm.sample(
        nuts_sampler="blackjax", 
        progress_bar=True,
        nuts_sampler_kwargs={
            "chain_method": "vectorized",
            # "chain_method": "parallel",
            "adaptation_kwargs": {
                "is_mass_matrix_diagonal": False,
                }
            }
        )
```

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
None

## New features
More option in Blackjax sampling

## Bugfixes
None

## Documentation
None

## Maintenance
None

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6963.org.readthedocs.build/en/6963/

<!-- readthedocs-preview pymc end -->