### PR TITLE
Fix compute_test_value error when creating observed variables

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1352,7 +1352,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
             if test_value is not None:
                 # We try to reuse the old test value
-                rv_var.tag.test_value = np.broadcast_to(test_value, rv_var.shape)
+                rv_var.tag.test_value = np.broadcast_to(test_value, rv_var.type.shape)
             else:
                 rv_var.tag.test_value = data
 

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1350,10 +1350,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         if pytensor.config.compute_test_value != "off":
             test_value = getattr(rv_var.tag, "test_value", None)
 
-            if test_value is not None:
-                # We try to reuse the old test value
-                rv_var.tag.test_value = np.broadcast_to(test_value, rv_var.type.shape)
-            else:
+            if test_value is None:
                 rv_var.tag.test_value = data
 
         mask = getattr(data, "mask", None)

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1347,12 +1347,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
                 "Dimensionality of data and RV don't match.", actual=data.ndim, expected=rv_var.ndim
             )
 
-        if pytensor.config.compute_test_value != "off":
-            test_value = getattr(rv_var.tag, "test_value", None)
-
-            if test_value is None:
-                rv_var.tag.test_value = data
-
         mask = getattr(data, "mask", None)
         if mask is not None:
             impute_message = (

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -223,16 +223,13 @@ class TestObserved:
         assert x1.type.dtype == X.type.dtype
         assert x2.type.dtype == X.type.dtype
 
+    @pytensor.config.change_flags(compute_test_value="raise")
     def test_observed_compute_test_value(self):
-        with pytensor.config.change_flags(compute_test_value="raise"):
-            rng = np.random.default_rng(123)
-            data = rng.standard_normal(100)
-            with pm.Model():
-                obs = pm.Normal(
-                    "obs", mu=pt.zeros_like(data), sigma=pt.ones_like(data), observed=data
-                )
-                assert obs.tag.test_value.shape == data.shape
-                assert obs.tag.test_value.dtype == data.dtype
+        data = np.zeros(100)
+        with pm.Model():
+            obs = pm.Normal("obs", mu=pt.zeros_like(data), sigma=1, observed=data)
+        assert obs.tag.test_value.shape == data.shape
+        assert obs.tag.test_value.dtype == data.dtype
 
 
 def test_duplicate_vars():

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -223,6 +223,20 @@ class TestObserved:
         assert x1.type.dtype == X.type.dtype
         assert x2.type.dtype == X.type.dtype
 
+    def test_observed_compute_test_value(self):
+        try:
+            with pytensor.config.change_flags(compute_test_value="raise"):
+                rng = np.random.default_rng(123)
+                data = rng.standard_normal(100)
+                with pm.Model():
+                    obs = pm.Normal(
+                        "obs", mu=pt.zeros_like(data), sigma=pt.ones_like(data), observed=data
+                    )
+        except TypeError:
+            pytest.fail(
+                "TypeError raised when trying to add an observed RV with `compute_test_value='false'`"
+            )
+
 
 def test_duplicate_vars():
     with pytest.raises(ValueError) as err:

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -228,7 +228,11 @@ class TestObserved:
             rng = np.random.default_rng(123)
             data = rng.standard_normal(100)
             with pm.Model():
-                pm.Normal("obs", mu=pt.zeros_like(data), sigma=pt.ones_like(data), observed=data)
+                obs = pm.Normal(
+                    "obs", mu=pt.zeros_like(data), sigma=pt.ones_like(data), observed=data
+                )
+                assert obs.tag.test_value.shape == data.shape
+                assert obs.tag.test_value.dtype == data.dtype
 
 
 def test_duplicate_vars():

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -224,18 +224,11 @@ class TestObserved:
         assert x2.type.dtype == X.type.dtype
 
     def test_observed_compute_test_value(self):
-        try:
-            with pytensor.config.change_flags(compute_test_value="raise"):
-                rng = np.random.default_rng(123)
-                data = rng.standard_normal(100)
-                with pm.Model():
-                    obs = pm.Normal(
-                        "obs", mu=pt.zeros_like(data), sigma=pt.ones_like(data), observed=data
-                    )
-        except TypeError:
-            pytest.fail(
-                "TypeError raised when trying to add an observed RV with `compute_test_value='false'`"
-            )
+        with pytensor.config.change_flags(compute_test_value="raise"):
+            rng = np.random.default_rng(123)
+            data = rng.standard_normal(100)
+            with pm.Model():
+                pm.Normal("obs", mu=pt.zeros_like(data), sigma=pt.ones_like(data), observed=data)
 
 
 def test_duplicate_vars():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This fixes #6981. The issue was about observed variables causing a `TypeError` when a model is created with `pytensor.config.compute_test_value != "off"` It adds a small test that reproduces the issue and replaces `rv_var.shape` by `rv_var.type.shape` in the `np.broadcast_to()` call.

Let me know if I should move the test elsewhere or if something else is needed!

Thanks!

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Bugfixes
- Fixes #6981.

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6982.org.readthedocs.build/en/6982/

<!-- readthedocs-preview pymc end -->