### PR TITLE
Allow IntervalTransform to handle dynamic infinite bounds

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -664,7 +664,7 @@ class TruncatedNormal(BoundedContinuous):
     @classmethod
     def dist(
         cls,
-        mu: Optional[DIST_PARAMETER_TYPES] = None,
+        mu: Optional[DIST_PARAMETER_TYPES] = 0,
         sigma: Optional[DIST_PARAMETER_TYPES] = None,
         *,
         tau: Optional[DIST_PARAMETER_TYPES] = None,
@@ -674,7 +674,6 @@ class TruncatedNormal(BoundedContinuous):
     ) -> RandomVariable:
         tau, sigma = get_tau_sigma(tau=tau, sigma=sigma)
         sigma = pt.as_tensor_variable(sigma)
-        tau = pt.as_tensor_variable(tau)
         mu = pt.as_tensor_variable(floatX(mu))
 
         lower = pt.as_tensor_variable(floatX(lower)) if lower is not None else pt.constant(-np.inf)

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -2248,7 +2248,7 @@ def test_car_rng_fn(sparse):
     with pm.Model():
         car = pm.CAR("car", mu, W, alpha, tau, size=size)
         mn = pm.MvNormal("mn", mu, cov, size=size)
-        check = pm.sample_prior_predictive(n_fails, return_inferencedata=False, random_seed=1)
+        check = pm.sample_prior_predictive(n_fails, return_inferencedata=False, random_seed=2)
 
     p, f = delta, n_fails
     while p <= delta and f > 0:

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -55,7 +55,6 @@ from pymc.logprob.transforms import (
     ErfcxTransform,
     ErfTransform,
     ExpTransform,
-    IntervalTransform,
     LocTransform,
     LogTransform,
     RVTransform,
@@ -138,23 +137,6 @@ class TestRVTransform:
             NotImplementedError, match=r"only implemented for ndim_supp in \(0, 1\)"
         ):
             SquareTransform().log_jac_det(0)
-
-    def test_invalid_interval_transform(self):
-        x_rv = pt.random.normal(0, 1)
-        x_vv = x_rv.clone()
-
-        msg = "Both edges of IntervalTransform cannot be None"
-        tr = IntervalTransform(lambda *inputs: (None, None))
-        with pytest.raises(ValueError, match=msg):
-            tr.forward(x_vv, *x_rv.owner.inputs)
-
-        tr = IntervalTransform(lambda *inputs: (None, None))
-        with pytest.raises(ValueError, match=msg):
-            tr.backward(x_vv, *x_rv.owner.inputs)
-
-        tr = IntervalTransform(lambda *inputs: (None, None))
-        with pytest.raises(ValueError, match=msg):
-            tr.log_jac_det(x_vv, *x_rv.owner.inputs)
 
     def test_chained_transform(self):
         loc = 5

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -40,7 +40,7 @@ from pytensor.tensor.variable import TensorConstant
 
 import pymc as pm
 
-from pymc import Deterministic, Potential
+from pymc import Deterministic, Model, Potential
 from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.distributions import Normal, transforms
 from pymc.distributions.distribution import PartialObservedRV
@@ -1523,6 +1523,18 @@ class TestImputationMissingData:
             model.compile_logp()({"x_unobserved": [0] * 3}),
             st.norm.logcdf(0) * 10,
         )
+
+    def test_truncated_normal(self):
+        """Test transform of unobserved TruncatedNormal leads to finite logp.
+
+        Regression test for #6999
+        """
+        with Model() as m:
+            mu = pm.TruncatedNormal("mu", mu=1, sigma=2, lower=0)
+            x = pm.TruncatedNormal(
+                "x", mu=mu, sigma=0.5, lower=0, observed=np.array([0.1, 0.2, 0.5, np.nan, np.nan])
+            )
+        m.check_start_vals(m.initial_point())
 
 
 class TestShared:


### PR DESCRIPTION
This way we can also have stuff like `TruncatedNormal("x", lower=[0, 0], upper=[10, np.inf])` which was not possible before.

Closes #6999 

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7001.org.readthedocs.build/en/7001/

<!-- readthedocs-preview pymc end -->