### PR TITLE
fix typo in notebook about Distribution Dimensionality

### DIFF
--- a/docs/source/learn/core_notebooks/dimensionality.ipynb
+++ b/docs/source/learn/core_notebooks/dimensionality.ipynb
@@ -533,7 +533,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you needed the Normal variables to have `shape=(4, 3)`, you can transpose it after defining it."
+    "If you needed the Normal variables to have `shape=(3, 4)`, you can transpose it after defining it."
    ]
   },
   {


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
This is a simple typo correction in the documentation. In the notebook about [Distribution Dimensionality](https://www.pymc.io/projects/docs/en/stable/learn/core_notebooks/dimensionality.html#combining-implicit-and-explicit-batch-dimensions) there seems to be a simple mix-up in the dimension order.

> If you needed the Normal variables to have shape=(4, 3), you can transpose it after defining it.

To my understanding, it should be "shape=(3, 4)", as  underlined by the fact the the following cell produces an output of shape (3, 4).

**Checklist**
+ [x] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
None

## New features
None

## Bugfixes
None

## Documentation
- fix typo in the [Distribution Dimensionality](https://www.pymc.io/projects/docs/en/stable/learn/core_notebooks/dimensionality.html#combining-implicit-and-explicit-batch-dimensions) notebook

## Maintenance
None


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7005.org.readthedocs.build/en/7005/

<!-- readthedocs-preview pymc end -->