### PR TITLE
Fix shape_utils missing functions and misformatted returns

### DIFF
--- a/docs/source/api/shape_utils.rst
+++ b/docs/source/api/shape_utils.rst
@@ -16,4 +16,3 @@ This module introduces functions that are made aware of the requested `size_tupl
    to_tuple
    rv_size_is_none
    change_dist_size
-   broadcast_dist_samples_shape

--- a/docs/source/api/shape_utils.rst
+++ b/docs/source/api/shape_utils.rst
@@ -16,3 +16,4 @@ This module introduces functions that are made aware of the requested `size_tupl
    to_tuple
    rv_size_is_none
    change_dist_size
+   broadcast_dist_samples_shape

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -62,7 +62,7 @@ def to_tuple(shape: Optional[Union[None, int, np.ndarray]]) -> Tuple:
     tuple
         If `shape` is None, returns an empty tuple. If it's an int, (shape,) is
         returned. If it is array-like, `tuple(shape)` is returned.
-        
+
     Examples
     --------
     >>> to_tuple(None)
@@ -97,7 +97,9 @@ def _check_shape_type(shape):
     return tuple(out)
 
 
-def broadcast_dist_samples_shape(shapes: Iterable[Tuple[int, ...]], size: Optional[int] = None) -> Tuple[int, ...]:
+def broadcast_dist_samples_shape(
+    shapes: Iterable[Tuple[int, ...]], size: Optional[int] = None
+) -> Tuple[int, ...]:
     """Apply shape broadcasting to shape tuples for random variables.
 
     Parameters

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -339,7 +339,7 @@ def change_dist_size(
     ----------
     dist : TensorVariable
         The old distribution to be resized.
-    new_size : Union[int, Tuple[int, ...]]
+    new_size : Union[int, Tuple[int, ...], TensorVariable]
         The new size of the distribution.
     expand : bool, optional
         If True, `new_size` is prepended to the existing distribution `size`,


### PR DESCRIPTION

**What is this PR about?**
Fixes #7004 
The shape_utils module was missing functions in the documentation. Additionally, the rendering of returns for certain functions was identified as messy. The focus of this PR is to include type hints in the docstring, in line with the suggested improvement.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Documentation
- Added shape_utils missing functions to documentation
- Improved return formatting for the affected functions to enhance readability.
- Included type hints in the docstring for better display in the documentation.

![image](https://github.com/pymc-devs/pymc/assets/142026166/9d206f58-e1bb-48f9-a645-a0b1d5bbda66)



<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7006.org.readthedocs.build/en/7006/

<!-- readthedocs-preview pymc end -->