### PR TITLE
Added ReduceLROnPlateau callback for VI.

### DIFF
--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 
 import collections
-
 from typing import Callable, Dict
 
 import numpy as np
@@ -101,8 +100,8 @@ class ReduceLROnPlateau(Callback):
 
     Parameters
     ----------
-    optimiser: callable
-        PyMC optimiser
+    optimizer: callable
+        PyMC optimizer
     factor: float
         factor by which the learning rate will be reduced: `new_lr = lr * factor`
     patience: int
@@ -117,13 +116,13 @@ class ReduceLROnPlateau(Callback):
 
     def __init__(
         self,
-        optimiser,
+        optimizer,
         factor=0.1,
         patience=10,
         min_lr=1e-6,
         cooldown=0,
     ):
-        self.optimiser = optimiser
+        self.optimizer = optimizer
         self.factor = factor
         self.patience = patience
         self.min_lr = min_lr
@@ -156,10 +155,10 @@ class ReduceLROnPlateau(Callback):
                 self.wait = 0
 
     def reduce_lr(self):
-        old_lr = float(self.optimiser.keywords["learning_rate"])
+        old_lr = float(self.optimizer.keywords["learning_rate"])
         if old_lr > self.min_lr:
             new_lr = max(old_lr * self.factor, self.min_lr)
-            self.optimiser.keywords["learning_rate"] = new_lr
+            self.optimizer.keywords["learning_rate"] = new_lr
 
     def in_cooldown(self):
         return self.cooldown_counter > 0

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 import collections
+
 from typing import Callable, Dict
 
 import numpy as np

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -18,7 +18,13 @@ from typing import Callable, Dict
 
 import numpy as np
 
-__all__ = ["Callback", "CheckParametersConvergence", "ReduceLROnPlateau", "Tracker"]
+__all__ = [
+    "Callback",
+    "CheckParametersConvergence",
+    "ExponentialDecay",
+    "ReduceLROnPlateau",
+    "Tracker",
+]
 
 
 class Callback:

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -106,7 +106,7 @@ class LearningRateScheduler(Callback):
         self.optimizer.keywords["learning_rate"] = new_lr
 
 
-class ExponentialScheduler(LearningRateScheduler):
+class ExponentialDecay(LearningRateScheduler):
     """
     Exponentially decays the learning rate.
 

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -18,8 +18,6 @@ from typing import Callable, Dict
 
 import numpy as np
 
-from pytensor import shared
-
 __all__ = ["Callback", "CheckParametersConvergence", "ReduceLROnPlateau", "Tracker"]
 
 
@@ -103,8 +101,8 @@ class ReduceLROnPlateau(Callback):
 
     Parameters
     ----------
-    learning_rate: shared
-        shared variable containing the learning rate
+    optimiser: callable
+        PyMC optimiser
     factor: float
         factor by which the learning rate will be reduced: `new_lr = lr * factor`
     patience: int
@@ -119,13 +117,13 @@ class ReduceLROnPlateau(Callback):
 
     def __init__(
         self,
-        initial_learning_rate: shared,
+        optimiser,
         factor=0.1,
         patience=10,
         min_lr=1e-6,
         cooldown=0,
     ):
-        self.learning_rate = initial_learning_rate
+        self.optimiser = optimiser
         self.factor = factor
         self.patience = patience
         self.min_lr = min_lr
@@ -158,10 +156,10 @@ class ReduceLROnPlateau(Callback):
                 self.wait = 0
 
     def reduce_lr(self):
-        old_lr = float(self.learning_rate.get_value())
+        old_lr = float(self.optimiser.keywords["learning_rate"])
         if old_lr > self.min_lr:
             new_lr = max(old_lr * self.factor, self.min_lr)
-            self.learning_rate.set_value(new_lr)
+            self.optimiser.keywords["learning_rate"] = new_lr
 
     def in_cooldown(self):
         return self.cooldown_counter > 0

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 
 import collections
-
 from typing import Callable, Dict
 
 import numpy as np
@@ -109,6 +108,9 @@ class LearningRateScheduler(Callback):
 class ExponentialDecay(LearningRateScheduler):
     """
     Exponentially decays the learning rate.
+
+    This is inspired by Keras' homonymous callback:
+    https://github.com/keras-team/keras/blob/v2.14.0/keras/optimizers/schedules/learning_rate_schedule.py
 
     Parameters
     ----------

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -132,7 +132,6 @@ class ReduceLROnPlateau(Callback):
         self.cooldown_counter = 0
         self.wait = 0
         self.best = float("inf")
-        self.old_lr = None
 
     def __call__(self, approx, loss_hist, i):
         current = loss_hist[-1]

--- a/pymc/variational/updates.py
+++ b/pymc/variational/updates.py
@@ -110,7 +110,6 @@ Taken from the Lasagne project: http://lasagne.readthedocs.io/en/latest/
 """
 from collections import OrderedDict
 from functools import partial, wraps
-from typing import Callable
 
 import numpy as np
 import pytensor
@@ -1292,7 +1291,7 @@ def _handle_time_updates(updates):
 
 
 def exponential_decay_scheduler(
-    optimizer: Callable,
+    optimizer: partial,
     decay_steps: int,
     decay_rate: float,
     min_lr: float = 1e-6,

--- a/pymc/variational/updates.py
+++ b/pymc/variational/updates.py
@@ -109,7 +109,8 @@ Taken from the Lasagne project: http://lasagne.readthedocs.io/en/latest/
 
 """
 from collections import OrderedDict
-from functools import partial
+from functools import partial, wraps
+from typing import Callable
 
 import numpy as np
 import pytensor
@@ -173,17 +174,101 @@ def get_or_compute_grads(loss_or_grads, params):
             )
         return loss_or_grads
     else:
-        return pytensor.grad(loss_or_grads, params)
+        grads = pytensor.grad(loss_or_grads, params)
+        for grad, param in zip(grads, params):
+            grad.name = f'd_loss/d_{param.name}'
+        return grads
 
 
-def _get_call_kwargs(_locals_):
-    _locals_ = _locals_.copy()
-    _locals_.pop("loss_or_grads")
-    _locals_.pop("params")
-    return _locals_
+def _input_to_shared_variable(x, name):
+    if isinstance(x, pt.sharedvar.SharedVariable):
+        return x
+    return pytensor.shared(x, name=name)
 
 
-def sgd(loss_or_grads=None, params=None, learning_rate=1e-3):
+def _find_variable_among_args_kwargs(args, kwargs, name):
+    """
+    Helper function to find a variable among args and kwargs.
+
+    Notes
+    -----
+    Assumes that the variable being searched for is either a kwarg or the first arg.
+    """
+
+    variable = kwargs.pop(name, None)
+    if not variable:
+        variable = args.pop(0) if len(args) > 0 else None
+    return variable
+
+
+def _partial_initialization_wrapper(optimizer):
+    """
+    Functional wrapper to allow optimizer to be called without both loss_or_grads and params
+
+    Parameters
+    ----------
+    optimizer: callable
+        Optimizer function to wrap
+
+    Returns
+    -------
+    optimizer: callable
+        Optimizer function that returns itself partially initialized if called without both loss_or_grads and params
+    """
+
+    @wraps(optimizer)
+    def make_partial_if_necessary(*args, **kwargs):
+        args = list(args)
+        loss_or_grads = _find_variable_among_args_kwargs(args, kwargs, 'loss_or_grads')
+        params = _find_variable_among_args_kwargs(args, kwargs, 'params')
+
+        if loss_or_grads is None and params is None:
+            return partial(optimizer, **kwargs)
+        elif loss_or_grads is None or params is None:
+            raise ValueError("Please provide both `loss_or_grads` and `params` to get updates")
+
+        return optimizer(loss_or_grads=loss_or_grads, params=params, **kwargs)
+
+    return make_partial_if_necessary
+
+
+def _handle_loss_and_grad_input_wrapper(optimizer):
+    """
+    Functional wrapper to allow optimizer to take a tuple of (loss, grads) as input, and either discard the loss or
+    pass it through.
+
+    Adds a keyword argument to the wrapped optimizer, `discard_loss`, which if True, will discard the loss and only
+    return the updates. If False, the optimizer will return both the updates and the loss.
+
+    Parameters
+    ----------
+    optimizer: callable
+        Optimizer function to wrap
+
+    Returns
+    -------
+    optimizer: callable
+        Wrapped optimizer function
+    """
+
+    @wraps(optimizer)
+    def discard_or_pass_through_loss_optimizer(loss_or_grads, params, discard_loss=True, *args, **kwargs):
+        if isinstance(loss_or_grads, tuple):
+            loss, grads = loss_or_grads
+            updates = optimizer(loss_or_grads=grads, params=params, *args, **kwargs)
+        else:
+            discard_loss, loss = True, None
+            updates = optimizer(loss_or_grads=loss_or_grads, params=params, *args, **kwargs)
+
+        if discard_loss:
+            return updates
+        else:
+            return updates, loss
+
+    return discard_or_pass_through_loss_optimizer
+
+
+def _sgd(loss_or_grads=None, params=None, *, learning_rate=1e-3):
     """Stochastic Gradient Descent (SGD) updates
 
     Generates update expressions of the form:
@@ -223,17 +308,18 @@ def sgd(loss_or_grads=None, params=None, learning_rate=1e-3):
     >>> isinstance(updates, dict)
     True
     """
-    if loss_or_grads is None and params is None:
-        return partial(sgd, **_get_call_kwargs(locals()))
-    elif loss_or_grads is None or params is None:
-        raise ValueError("Please provide both `loss_or_grads` and `params` to get updates")
     grads = get_or_compute_grads(loss_or_grads, params)
     updates = OrderedDict()
 
     for param, grad in zip(params, grads):
-        updates[param] = param - learning_rate * grad
+        updated_param = param - learning_rate * grad
+        updated_param.name = f'{param.name}__updated'
+        updates[param] = updated_param
 
     return updates
+
+
+sgd = _partial_initialization_wrapper(_handle_loss_and_grad_input_wrapper(_sgd))
 
 
 def apply_momentum(updates, params=None, momentum=0.9):
@@ -275,15 +361,21 @@ def apply_momentum(updates, params=None, momentum=0.9):
 
     for param in params:
         value = param.get_value(borrow=True)
-        velocity = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
-        x = momentum * velocity + updates[param]
-        updates[velocity] = x - param
-        updates[param] = x
+        velocity = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape, name='velocity')
+
+        updated_param = momentum * velocity + updates[param]
+        updated_param.name = f'{param}__updated'
+
+        updated_velocity = updated_param - param
+        updated_velocity.name = 'velocity__updated'
+
+        updates[velocity] = updated_velocity
+        updates[param] = updated_param
 
     return updates
 
 
-def momentum(loss_or_grads=None, params=None, learning_rate=1e-3, momentum=0.9):
+def _momentum(loss_or_grads=None, params=None, learning_rate=1e-3, momentum=0.9):
     """Stochastic Gradient Descent (SGD) updates with momentum
 
     Generates update expressions of the form:
@@ -335,12 +427,12 @@ def momentum(loss_or_grads=None, params=None, learning_rate=1e-3, momentum=0.9):
     >>> isinstance(updates, dict)
     True
     """
-    if loss_or_grads is None and params is None:
-        return partial(pm.updates.momentum, **_get_call_kwargs(locals()))
-    elif loss_or_grads is None or params is None:
-        raise ValueError("Please provide both `loss_or_grads` and `params` to get updates")
     updates = sgd(loss_or_grads, params, learning_rate)
+
     return apply_momentum(updates, momentum=momentum)
+
+
+momentum = _partial_initialization_wrapper(_handle_loss_and_grad_input_wrapper(_momentum))
 
 
 def apply_nesterov_momentum(updates, params=None, momentum=0.9):
@@ -389,14 +481,20 @@ def apply_nesterov_momentum(updates, params=None, momentum=0.9):
     for param in params:
         value = param.get_value(borrow=True)
         velocity = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
-        x = momentum * velocity + updates[param] - param
-        updates[velocity] = x
-        updates[param] = momentum * x + updates[param]
+
+        updated_velocity = momentum * velocity + updates[param] - param
+        updated_velocity.name = 'velocity__updated'
+
+        updated_param = momentum * updated_velocity + updates[param]
+        updated_param.name = f'{param.name}__updated'
+
+        updates[velocity] = updated_velocity
+        updates[param] = updated_param
 
     return updates
 
 
-def nesterov_momentum(loss_or_grads=None, params=None, learning_rate=1e-3, momentum=0.9):
+def _nesterov_momentum(loss_or_grads=None, params=None, learning_rate=1e-3, momentum=0.9):
     """Stochastic Gradient Descent (SGD) updates with Nesterov momentum
 
     Generates update expressions of the form:
@@ -453,15 +551,15 @@ def nesterov_momentum(loss_or_grads=None, params=None, learning_rate=1e-3, momen
     >>> isinstance(updates, dict)
     True
     """
-    if loss_or_grads is None and params is None:
-        return partial(nesterov_momentum, **_get_call_kwargs(locals()))
-    elif loss_or_grads is None or params is None:
-        raise ValueError("Please provide both `loss_or_grads` and `params` to get updates")
+
     updates = sgd(loss_or_grads, params, learning_rate)
     return apply_nesterov_momentum(updates, momentum=momentum)
 
 
-def adagrad(loss_or_grads=None, params=None, learning_rate=1.0, epsilon=1e-6):
+nesterov_momentum = _partial_initialization_wrapper(_handle_loss_and_grad_input_wrapper(_nesterov_momentum))
+
+
+def _adagrad(loss_or_grads=None, params=None, learning_rate=1.0, epsilon=1e-6):
     """Adagrad updates
 
     Scale learning rates by dividing with the square root of accumulated
@@ -521,24 +619,30 @@ def adagrad(loss_or_grads=None, params=None, learning_rate=1.0, epsilon=1e-6):
     >>> isinstance(updates, dict)
     True
     """
-    if loss_or_grads is None and params is None:
-        return partial(adagrad, **_get_call_kwargs(locals()))
-    elif loss_or_grads is None or params is None:
-        raise ValueError("Please provide both `loss_or_grads` and `params` to get updates")
     grads = get_or_compute_grads(loss_or_grads, params)
     updates = OrderedDict()
 
     for param, grad in zip(params, grads):
         value = param.get_value(borrow=True)
-        accu = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
-        accu_new = accu + grad**2
+        accu = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape,
+                               name='gradient_squares')
+        accu_new = accu + grad ** 2
+        accu_new.name = 'gradient_squares__updated'
+
         updates[accu] = accu_new
-        updates[param] = param - (learning_rate * grad / pt.sqrt(accu_new + epsilon))
+
+        updated_param = param - (learning_rate * grad / pt.sqrt(accu_new + epsilon))
+        updated_param.name = f'{param.name}__updated'
+
+        updates[param] = updated_param
 
     return updates
 
 
-def adagrad_window(loss_or_grads=None, params=None, learning_rate=0.001, epsilon=0.1, n_win=10):
+adagrad = _partial_initialization_wrapper(_handle_loss_and_grad_input_wrapper(_adagrad))
+
+
+def _adagrad_window(loss_or_grads=None, params=None, learning_rate=0.001, epsilon=0.1, n_win=10):
     """Returns a function that returns parameter updates.
     Instead of accumulated estimate, uses running window
 
@@ -560,30 +664,39 @@ def adagrad_window(loss_or_grads=None, params=None, learning_rate=0.001, epsilon
     OrderedDict
         A dictionary mapping each parameter to its update expression
     """
-    if loss_or_grads is None and params is None:
-        return partial(adagrad_window, **_get_call_kwargs(locals()))
-    elif loss_or_grads is None or params is None:
-        raise ValueError("Please provide both `loss_or_grads` and `params` to get updates")
     grads = get_or_compute_grads(loss_or_grads, params)
     updates = OrderedDict()
     for param, grad in zip(params, grads):
-        i = pytensor.shared(pm.floatX(0))
+        i = pytensor.shared(pm.floatX(0), name='window_idx')
         i_int = i.astype("int32")
         value = param.get_value(borrow=True)
-        accu = pytensor.shared(np.zeros(value.shape + (n_win,), dtype=value.dtype))
+
+        accu = pytensor.shared(np.zeros(value.shape + (n_win,), dtype=value.dtype),
+                               name='gradient_squares')
 
         # Append squared gradient vector to accu_new
-        accu_new = pt.set_subtensor(accu[..., i_int], grad**2)
+        accu_new = pt.set_subtensor(accu[..., i_int], grad ** 2)
+        accu_new.name = 'gradient_squares__updated'
+
         i_new = pt.switch((i + 1) < n_win, i + 1, 0)
+        i_new.name = 'window_idx__updated'
+
         updates[accu] = accu_new
         updates[i] = i_new
 
         accu_sum = accu_new.sum(axis=-1)
-        updates[param] = param - (learning_rate * grad / pt.sqrt(accu_sum + epsilon))
+
+        param_updated = param - (learning_rate * grad / pt.sqrt(accu_sum + epsilon))
+        param_updated.name = f'{param.name}__updated'
+        updates[param] = param_updated
+
     return updates
 
 
-def rmsprop(loss_or_grads=None, params=None, learning_rate=1.0, rho=0.9, epsilon=1e-6):
+adagrad_window = _partial_initialization_wrapper(_handle_loss_and_grad_input_wrapper(_adagrad_window))
+
+
+def _rmsprop(loss_or_grads=None, params=None, learning_rate=1.0, rho=0.9, epsilon=1e-6):
     """RMSProp updates
 
     Scale learning rates by dividing with the moving average of the root mean
@@ -644,10 +757,6 @@ def rmsprop(loss_or_grads=None, params=None, learning_rate=1.0, rho=0.9, epsilon
     >>> isinstance(updates, dict)
     True
     """
-    if loss_or_grads is None and params is None:
-        return partial(rmsprop, **_get_call_kwargs(locals()))
-    elif loss_or_grads is None or params is None:
-        raise ValueError("Please provide both `loss_or_grads` and `params` to get updates")
     grads = get_or_compute_grads(loss_or_grads, params)
     updates = OrderedDict()
 
@@ -656,15 +765,25 @@ def rmsprop(loss_or_grads=None, params=None, learning_rate=1.0, rho=0.9, epsilon
 
     for param, grad in zip(params, grads):
         value = param.get_value(borrow=True)
-        accu = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
-        accu_new = rho * accu + (one - rho) * grad**2
+        accu = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape,
+                               name='gradient_squares')
+
+        accu_new = rho * accu + (one - rho) * grad ** 2
+        accu_new.name = 'gradient_squares__updated'
+
         updates[accu] = accu_new
-        updates[param] = param - (learning_rate * grad / pt.sqrt(accu_new + epsilon))
+
+        param_updated = param - (learning_rate * grad / pt.sqrt(accu_new + epsilon))
+        param_updated.name = f'{param.name}__updated'
+        updates[param] = param_updated
 
     return updates
 
 
-def adadelta(loss_or_grads=None, params=None, learning_rate=1.0, rho=0.95, epsilon=1e-6):
+rmsprop = _partial_initialization_wrapper(_handle_loss_and_grad_input_wrapper(_rmsprop))
+
+
+def _adadelta(loss_or_grads=None, params=None, learning_rate=1.0, rho=0.95, epsilon=1e-6):
     r"""Adadelta updates
 
     Scale learning rates by the ratio of accumulated gradients to accumulated
@@ -734,10 +853,6 @@ def adadelta(loss_or_grads=None, params=None, learning_rate=1.0, rho=0.95, epsil
     >>> isinstance(updates, dict)
     True
     """
-    if loss_or_grads is None and params is None:
-        return partial(adadelta, **_get_call_kwargs(locals()))
-    elif loss_or_grads is None or params is None:
-        raise ValueError("Please provide both `loss_or_grads` and `params` to get updates")
     grads = get_or_compute_grads(loss_or_grads, params)
     updates = OrderedDict()
 
@@ -747,14 +862,16 @@ def adadelta(loss_or_grads=None, params=None, learning_rate=1.0, rho=0.95, epsil
     for param, grad in zip(params, grads):
         value = param.get_value(borrow=True)
         # accu: accumulate gradient magnitudes
-        accu = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
+
+        accu = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape,
+                               name='gradient_squares')
         # delta_accu: accumulate update magnitudes (recursively!)
         delta_accu = pytensor.shared(
-            np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape
+            np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape, name=''
         )
 
         # update accu (as in rmsprop)
-        accu_new = rho * accu + (one - rho) * grad**2
+        accu_new = rho * accu + (one - rho) * grad ** 2
         updates[accu] = accu_new
 
         # compute parameter update, using the 'old' delta_accu
@@ -762,14 +879,17 @@ def adadelta(loss_or_grads=None, params=None, learning_rate=1.0, rho=0.95, epsil
         updates[param] = param - learning_rate * update
 
         # update delta_accu (as accu, but accumulating updates)
-        delta_accu_new = rho * delta_accu + (one - rho) * update**2
+        delta_accu_new = rho * delta_accu + (one - rho) * update ** 2
         updates[delta_accu] = delta_accu_new
 
     return updates
 
 
-def adam(
-    loss_or_grads=None, params=None, learning_rate=0.001, beta1=0.9, beta2=0.999, epsilon=1e-8
+adadelta = _partial_initialization_wrapper(_handle_loss_and_grad_input_wrapper(_adadelta))
+
+
+def _adam(
+        loss_or_grads=None, params=None, learning_rate=0.001, beta1=0.9, beta2=0.999, epsilon=1e-8
 ):
     """Adam updates
 
@@ -824,39 +944,48 @@ def adam(
     >>> isinstance(updates, dict)
     True
     """
-    if loss_or_grads is None and params is None:
-        return partial(adam, **_get_call_kwargs(locals()))
-    elif loss_or_grads is None or params is None:
-        raise ValueError("Please provide both `loss_or_grads` and `params` to get updates")
     all_grads = get_or_compute_grads(loss_or_grads, params)
-    t_prev = pytensor.shared(pm.pytensorf.floatX(0.0))
+    t_prev = pytensor.shared(pm.pytensorf.floatX(0.0), name='t')
     updates = OrderedDict()
 
     # Using pytensor constant to prevent upcasting of float32
     one = pt.constant(1)
 
     t = t_prev + 1
-    a_t = learning_rate * pt.sqrt(one - beta2**t) / (one - beta1**t)
+    t.name = 't__updated'
+    a_t = learning_rate * pt.sqrt(one - beta2 ** t) / (one - beta1 ** t)
+    a_t.name = 'a'
 
     for param, g_t in zip(params, all_grads):
+        name = param.name
         value = param.get_value(borrow=True)
-        m_prev = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
-        v_prev = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
+        m_prev = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape, name=f'{name}_m')
+        v_prev = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape, name=f'{name}_v')
 
         m_t = beta1 * m_prev + (one - beta1) * g_t
-        v_t = beta2 * v_prev + (one - beta2) * g_t**2
+        m_t.name = f'{name}_m__updated'
+        v_t = beta2 * v_prev + (one - beta2) * g_t ** 2
+        v_t.name = f'{name}_v__updated'
+
         step = a_t * m_t / (pt.sqrt(v_t) + epsilon)
+        step.name = f'{name}_step_size'
 
         updates[m_prev] = m_t
         updates[v_prev] = v_t
-        updates[param] = param - step
+
+        param_updated = param - step
+        param_updated.name = f'{name}__updated'
+        updates[param] = param_updated
 
     updates[t_prev] = t
     return updates
 
 
-def adamax(
-    loss_or_grads=None, params=None, learning_rate=0.002, beta1=0.9, beta2=0.999, epsilon=1e-8
+adam = _partial_initialization_wrapper(_handle_loss_and_grad_input_wrapper(_adam))
+
+
+def _adamax(
+        loss_or_grads=None, params=None, learning_rate=0.002, beta1=0.9, beta2=0.999, epsilon=1e-8
 ):
     """Adamax updates
 
@@ -908,35 +1037,46 @@ def adamax(
     >>> isinstance(updates, dict)
     True
     """
-    if loss_or_grads is None and params is None:
-        return partial(adamax, **_get_call_kwargs(locals()))
-    elif loss_or_grads is None or params is None:
-        raise ValueError("Please provide both `loss_or_grads` and `params` to get updates")
     all_grads = get_or_compute_grads(loss_or_grads, params)
-    t_prev = pytensor.shared(pm.pytensorf.floatX(0.0))
+    t_prev = pytensor.shared(pm.pytensorf.floatX(0.0), name='t')
     updates = OrderedDict()
 
     # Using pytensor constant to prevent upcasting of float32
     one = pt.constant(1)
 
     t = t_prev + 1
-    a_t = learning_rate / (one - beta1**t)
+    t.name = 't__updated'
+
+    a_t = learning_rate / (one - beta1 ** t)
+    a_t.name = 'a'
 
     for param, g_t in zip(params, all_grads):
+        name = param.name
         value = param.get_value(borrow=True)
-        m_prev = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
-        u_prev = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape)
+        m_prev = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape, name=f'{name}_m')
+        u_prev = pytensor.shared(np.zeros(value.shape, dtype=value.dtype), shape=param.type.shape, name=f'{name}_u')
 
         m_t = beta1 * m_prev + (one - beta1) * g_t
+        m_t.name = f'{name}_m__updated'
+
         u_t = pt.maximum(beta2 * u_prev, abs(g_t))
+        u_t.name = f'{name}_u__updated'
+
         step = a_t * m_t / (u_t + epsilon)
+        step.name = f'{name}_step_size'
 
         updates[m_prev] = m_t
         updates[u_prev] = u_t
-        updates[param] = param - step
+
+        param_updated = param - step
+        param_updated.name = f'{name}__updated'
+        updates[param] = param_updated
 
     updates[t_prev] = t
     return updates
+
+
+adamax = _partial_initialization_wrapper(_handle_loss_and_grad_input_wrapper(_adamax))
 
 
 def norm_constraint(tensor_var, max_norm, norm_axes=None, epsilon=1e-7):
@@ -1072,7 +1212,7 @@ def total_norm_constraint(tensor_vars, max_norm, epsilon=1e-7, return_norm=False
        learning with neural networks. In Advances in Neural Information
        Processing Systems (pp. 3104-3112).
     """
-    norm = pt.sqrt(sum(pt.sum(tensor**2) for tensor in tensor_vars))
+    norm = pt.sqrt(sum(pt.sum(tensor ** 2) for tensor in tensor_vars))
     dtype = np.dtype(pytensor.config.floatX).type
     target_norm = pt.clip(norm, 0, dtype(max_norm))
     multiplier = target_norm / (dtype(epsilon) + norm)
@@ -1082,3 +1222,172 @@ def total_norm_constraint(tensor_vars, max_norm, epsilon=1e-7, return_norm=False
         return tensor_vars_scaled, norm
     else:
         return tensor_vars_scaled
+
+
+def _handle_time_updates(updates):
+    """
+    Create a shared time variable and its update if one does not already exist in the updates dictionary, otherwise
+    extract it and delete the entry from the updates dictionary.
+
+    Parameters
+    ----------
+    updates: dict
+        update dictionary created by an optimizer function
+
+    Returns
+    -------
+    t: pt.shared.SharedVariable
+        shared variable representing the current time step
+    new_t: pt.shared.SharedVariable
+        shared variable representing the next time step
+
+    Notes
+    -----
+    This function potentially modifies the update dictionary in-place by deleting the entry for the time variable, if
+    it exists. This is done to ensure that the time variable is always the last update applied. All schedulers need
+    to add this update back in to the update dictionary before returning it.
+    """
+    old_values = list(updates.keys())
+    old_names = [shared_var.name for shared_var in old_values]
+
+    t_idx = old_names.index('t') if 't' in old_names else None
+    if t_idx is None:
+        t = pytensor.shared(pm.pytensorf.floatX(0.0), name='t')
+        new_t = t + 1
+        new_t.name = 't__updated'
+    else:
+        # If t is already present, we will reuse it, but we also need to delete it from the update dict temporarily.
+        # We always want it to be the last update applied.
+        t = old_values[t_idx]
+        new_t = updates[t]
+        del updates[t]
+
+    return t, new_t
+
+
+def exponential_decay_scheduler(optimizer: Callable, decay_steps: int, decay_rate: float, min_lr: float = 1e-6,
+                                staircase: bool = False):
+    """
+    Returns a new optimizer that applies exponential decay to the learning rate.
+
+    Parameters
+    ----------
+    optimizer: Callable
+        Optimizer to apply exponential decay to
+    decay_steps: int
+        Number of steps between application of a decay.
+    decay_rate: float
+        Decay factor used to compute new learning rate, with new_lr = max(lr * decay_rate, min_lr). Must be between 0
+        and 1.
+    min_lr: float
+        Minimum learning rate, after which no additional decay is applied. Defaults to 1e-6.
+    staircase: bool
+        If True, learning rate is decayed in discrete intervals, otherwise decay is applied continuously.
+        Defaults to False.
+
+    Returns
+    -------
+    scheduled_optimizer: Callable
+        Optimizer with exponential decay applied to learning rate.
+    """
+    if not 0 < decay_rate <= 1:
+        raise ValueError('decay_rate must be between 0 and 1')
+
+    kwargs = optimizer.keywords
+    _initial_lr = pm.floatX(optimizer.keywords['learning_rate'])
+
+    initial_lr = pt.constant(_initial_lr, name='initial_learning_rate')
+    shared_lr = _input_to_shared_variable(_initial_lr, 'learning_rate')
+    kwargs['learning_rate'] = shared_lr
+
+    @wraps(optimizer)
+    def optimizer_with_exponential_decay(loss_or_grads, params, *args, **kwargs):
+        updates = optimizer(loss_or_grads, params, *args, **kwargs)
+        t, new_t = _handle_time_updates(updates)
+
+        if staircase:
+            new_lr = initial_lr * decay_rate ** (t // decay_steps)
+        else:
+            new_lr = initial_lr * decay_rate ** (t / decay_steps)
+
+        new_lr = pt.maximum(new_lr, min_lr)
+
+        new_lr.name = 'learning_rate__updated'
+        updates[shared_lr] = new_lr
+        updates[t] = new_t
+
+        return updates
+
+    return optimizer_with_exponential_decay
+
+
+def reduce_lr_on_plateau_scheduler(optimizer, factor=0.1, patience=10, min_lr=1e-6, cooldown=0):
+    kwargs = optimizer.keywords
+    _initial_lr = pm.floatX(optimizer.keywords['learning_rate'])
+    shared_lr = _input_to_shared_variable(_initial_lr, 'learning_rate')
+    kwargs['learning_rate'] = shared_lr
+
+    @wraps(optimizer)
+    def optimizer_with_reduce_lr_on_plateau(loss_or_grads, params, *args, **kwargs):
+        updates, loss = optimizer(loss_or_grads, params, *args, discard_loss=False, **kwargs)
+
+        cooldown_counter = pytensor.shared(np.zeros((), dtype='int32'), name='cooldown_counter')
+        wait = pytensor.shared(np.zeros((), dtype='int32'), name='wait')
+        best_loss = pytensor.shared(np.inf, name='best_loss')
+
+        loss_is_inf = pt.isinf(loss)
+
+        in_cooldown = pt.gt(cooldown_counter, 0)
+        improving_loss = pt.lt(loss, best_loss)
+        patience_exceeded = pt.ge(wait, patience)
+
+        updated_best_loss = pt.switch(loss_is_inf,
+                                      best_loss,
+                                      pt.switch(improving_loss,
+                                                loss,
+                                                best_loss))
+
+        updated_best_loss.name = 'best_loss__updated'
+
+        updated_cooldown_counter = pt.switch(loss_is_inf,
+                                             cooldown_counter,
+                                             pt.switch(in_cooldown,
+                                                       cooldown_counter - 1,
+                                                       pt.switch(improving_loss,
+                                                                 cooldown_counter,
+                                                                 pt.switch(patience_exceeded,
+                                                                           cooldown,
+                                                                           cooldown_counter))))
+        updated_cooldown_counter.name = 'cooldown_counter__updated'
+
+        updated_lr = pt.switch(loss_is_inf,
+                           shared_lr,
+                           pt.switch(in_cooldown,
+                                     shared_lr,
+                                     pt.switch(improving_loss,
+                                               shared_lr,
+                                               pt.switch(patience_exceeded,
+                                                         pt.maximum(min_lr, shared_lr * factor),
+                                                         shared_lr))))
+
+        updated_lr.name = 'learning_rate__updated'
+
+        updated_wait = pt.switch(loss_is_inf,
+                              wait,
+                              pt.switch(in_cooldown,
+                                        0,
+                                        pt.switch(improving_loss,
+                                                  0,
+                                                  pt.switch(patience_exceeded,
+                                                            0,
+                                                            wait + 1))))
+        updated_wait.name = 'wait__updated'
+
+        updates[best_loss] = updated_best_loss
+        updates[cooldown_counter] = updated_cooldown_counter
+        updates[wait] = updated_wait
+        updates[shared_lr] = updated_lr
+
+        return updates
+
+    return optimizer_with_reduce_lr_on_plateau

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -67,7 +67,7 @@ def test_tracker_callback():
         pm.adamax(learning_rate=0.1),
     ],
 )
-def test_reducelronplateau_callback(optimizer):
+def test_reduce_lr_on_plateau(optimizer):
     cb = pm.variational.callbacks.ReduceLROnPlateau(
         optimizer=optimizer,
         patience=1,
@@ -76,21 +76,52 @@ def test_reducelronplateau_callback(optimizer):
     cb(None, [float("inf")], 1)
     np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.1)
     assert cb.best == float("inf")
-    cb(None, [float("inf"), 2], 1)
+    cb(None, [float("inf"), 2], 2)
     np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.1)
     assert cb.best == 2
-    cb(None, [float("inf"), 2, 1], 1)
+    cb(None, [float("inf"), 2, 1], 3)
     np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.1)
     assert cb.best == 1
-    cb(None, [float("inf"), 2, 1, 99], 1)
+    cb(None, [float("inf"), 2, 1, 99], 4)
     np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.01)
     assert cb.best == 1
-    cb(None, [float("inf"), 2, 1, 99, 0.9], 1)
+    cb(None, [float("inf"), 2, 1, 99, 0.9], 5)
     np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.01)
     assert cb.best == 0.9
-    cb(None, [float("inf"), 2, 1, 99, 0.9, 99], 1)
+    cb(None, [float("inf"), 2, 1, 99, 0.9, 99], 6)
     np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.001)
     assert cb.best == 0.9
-    cb(None, [float("inf"), 2, 1, 99, 0.9, 99, 99], 1)
+    cb(None, [float("inf"), 2, 1, 99, 0.9, 99, 99], 7)
     np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.001)
     assert cb.best == 0.9
+
+
+@pytest.mark.parametrize(
+    "optimizer",
+    [
+        pm.sgd(learning_rate=0.1),
+        pm.momentum(learning_rate=0.1),
+        pm.nesterov_momentum(learning_rate=0.1),
+        pm.adagrad(learning_rate=0.1),
+        pm.rmsprop(learning_rate=0.1),
+        pm.adadelta(learning_rate=0.1),
+        pm.adam(learning_rate=0.1),
+        pm.adamax(learning_rate=0.1),
+    ],
+)
+def test_exponential_decay(optimizer):
+    cb = pm.variational.callbacks.ExponentialDecay(
+        optimizer=optimizer,
+        decay_steps=1,
+        decay_rate=0.1,
+        min_lr=0.001,
+    )
+    np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.1)
+    cb(None, [float("inf")], 1)
+    np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.01)
+    cb(None, [float("inf"), 2, 2], 2)
+    np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.001)
+    cb(None, [float("inf"), 2, 2, 2], 3)
+    np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.001)
+    cb(None, [float("inf"), 2, 2, 2, 2], 4)
+    np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.001)

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -54,8 +54,20 @@ def test_tracker_callback():
         tracker(None, None, 1)
 
 
-def test_reducelronplateau_callback():
-    optimizer = pm.adam(learning_rate=0.1)
+@pytest.mark.parametrize(
+    "optimizer",
+    [
+        pm.sgd(learning_rate=0.1),
+        pm.momentum(learning_rate=0.1),
+        pm.nesterov_momentum(learning_rate=0.1),
+        pm.adagrad(learning_rate=0.1),
+        pm.rmsprop(learning_rate=0.1),
+        pm.adadelta(learning_rate=0.1),
+        pm.adam(learning_rate=0.1),
+        pm.adamax(learning_rate=0.1),
+    ],
+)
+def test_reducelronplateau_callback(optimizer):
     cb = pm.variational.callbacks.ReduceLROnPlateau(
         optimizer=optimizer,
         patience=1,

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -54,19 +54,19 @@ def test_tracker_callback():
         tracker(None, None, 1)
 
 
-OPTIMIZERS = [pm.sgd,
-              pm.momentum,
-              pm.nesterov_momentum,
-              pm.adagrad,
-              pm.rmsprop,
-              pm.adadelta,
-              pm.adam,
-              pm.adamax]
+OPTIMIZERS = [pm.sgd(learning_rate=0.1),
+              pm.momentum(learning_rate=0.1),
+              pm.nesterov_momentum(learning_rate=0.1),
+              pm.adagrad(learning_rate=0.1),
+              pm.rmsprop(learning_rate=0.1),
+              pm.adadelta(learning_rate=0.1),
+              pm.adam(learning_rate=0.1),
+              pm.adamax(learning_rate=0.1),]
 
 @pytest.mark.parametrize("optimizer", OPTIMIZERS)
 def test_reduce_lr_on_plateau(optimizer):
     cb = pm.variational.callbacks.ReduceLROnPlateau(
-        optimizer=optimizer(learning_rate=0.1),
+        optimizer=optimizer,
         patience=1,
         min_lr=0.001,
     )

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -110,30 +110,3 @@ def test_exponential_decay(optimizer):
     np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.001)
     cb(None, [float("inf"), 2, 2, 2, 2], 4)
     np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.001)
-
-
-def test_learning_rate_scheduler():
-    X = np.random.normal(size=(100, 5))
-    beta = np.random.normal(size=(5,))
-    alpha = np.random.normal()
-    noise = np.random.normal(size=(100,))
-    y = alpha + X @ beta + noise
-
-    optimizer = pm.sgd()
-    scheduler = pm.callbacks.ExponentialDecay(optimizer=optimizer, decay_steps=10, decay_rate=0.5)
-
-    with pm.Model() as mod:
-        b = pm.Normal('b', shape=(5,))
-        a = pm.Normal('a')
-        sigma = pm.HalfNormal('sigma')
-
-        mu = a + X @ b
-        y_hat = pm.Normal('y_hat', mu, sigma, observed=y)
-        advi = pm.ADVI(optimizer=optimizer)
-
-        tracker = pm.callbacks.Tracker(mean=advi.approx.mean.eval)
-        approx = advi.fit(100, callbacks=[scheduler, tracker])
-
-        mean_history = tracker['mean']
-
-

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -54,14 +54,17 @@ def test_tracker_callback():
         tracker(None, None, 1)
 
 
-OPTIMIZERS = [pm.sgd(learning_rate=0.1),
-              pm.momentum(learning_rate=0.1),
-              pm.nesterov_momentum(learning_rate=0.1),
-              pm.adagrad(learning_rate=0.1),
-              pm.rmsprop(learning_rate=0.1),
-              pm.adadelta(learning_rate=0.1),
-              pm.adam(learning_rate=0.1),
-              pm.adamax(learning_rate=0.1),]
+OPTIMIZERS = [
+    pm.sgd(learning_rate=0.1),
+    pm.momentum(learning_rate=0.1),
+    pm.nesterov_momentum(learning_rate=0.1),
+    pm.adagrad(learning_rate=0.1),
+    pm.rmsprop(learning_rate=0.1),
+    pm.adadelta(learning_rate=0.1),
+    pm.adam(learning_rate=0.1),
+    pm.adamax(learning_rate=0.1),
+]
+
 
 @pytest.mark.parametrize("optimizer", OPTIMIZERS)
 def test_reduce_lr_on_plateau(optimizer):

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -55,30 +55,30 @@ def test_tracker_callback():
 
 
 def test_reducelronplateau_callback():
-    optimiser = pm.adam(learning_rate=0.1)
+    optimizer = pm.adam(learning_rate=0.1)
     cb = pm.variational.callbacks.ReduceLROnPlateau(
-        optimiser=optimiser,
+        optimizer=optimizer,
         patience=1,
         min_lr=0.001,
     )
     cb(None, [float("inf")], 1)
-    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.1)
+    np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.1)
     assert cb.best == float("inf")
     cb(None, [float("inf"), 2], 1)
-    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.1)
+    np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.1)
     assert cb.best == 2
     cb(None, [float("inf"), 2, 1], 1)
-    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.1)
+    np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.1)
     assert cb.best == 1
     cb(None, [float("inf"), 2, 1, 99], 1)
-    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.01)
+    np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.01)
     assert cb.best == 1
     cb(None, [float("inf"), 2, 1, 99, 0.9], 1)
-    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.01)
+    np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.01)
     assert cb.best == 0.9
     cb(None, [float("inf"), 2, 1, 99, 0.9, 99], 1)
-    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.001)
+    np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.001)
     assert cb.best == 0.9
     cb(None, [float("inf"), 2, 1, 99, 0.9, 99, 99], 1)
-    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.001)
+    np.testing.assert_almost_equal(optimizer.keywords["learning_rate"], 0.001)
     assert cb.best == 0.9

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -55,30 +55,30 @@ def test_tracker_callback():
 
 
 def test_reducelronplateau_callback():
-    lr = pytensor.shared(0.1)
+    optimiser = pm.adam(learning_rate=0.1)
     cb = pm.variational.callbacks.ReduceLROnPlateau(
-        initial_learning_rate=lr,
+        optimiser=optimiser,
         patience=1,
         min_lr=0.001,
     )
     cb(None, [float("inf")], 1)
-    np.testing.assert_almost_equal(lr.get_value(), 0.1)
+    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.1)
     assert cb.best == float("inf")
     cb(None, [float("inf"), 2], 1)
-    np.testing.assert_almost_equal(lr.get_value(), 0.1)
+    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.1)
     assert cb.best == 2
     cb(None, [float("inf"), 2, 1], 1)
-    np.testing.assert_almost_equal(lr.get_value(), 0.1)
+    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.1)
     assert cb.best == 1
     cb(None, [float("inf"), 2, 1, 99], 1)
-    np.testing.assert_almost_equal(lr.get_value(), 0.01)
+    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.01)
     assert cb.best == 1
     cb(None, [float("inf"), 2, 1, 99, 0.9], 1)
-    np.testing.assert_almost_equal(lr.get_value(), 0.01)
+    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.01)
     assert cb.best == 0.9
     cb(None, [float("inf"), 2, 1, 99, 0.9, 99], 1)
-    np.testing.assert_almost_equal(lr.get_value(), 0.001)
+    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.001)
     assert cb.best == 0.9
     cb(None, [float("inf"), 2, 1, 99, 0.9, 99, 99], 1)
-    np.testing.assert_almost_equal(lr.get_value(), 0.001)
+    np.testing.assert_almost_equal(optimiser.keywords["learning_rate"], 0.001)
     assert cb.best == 0.9

--- a/tests/variational/test_updates.py
+++ b/tests/variational/test_updates.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytensor
 import pytest
 
+import pymc as pm
 from pymc.variational.updates import (
     adadelta,
     adagrad,
@@ -25,8 +26,21 @@ from pymc.variational.updates import (
     momentum,
     nesterov_momentum,
     rmsprop,
-    sgd,
+    sgd, exponential_decay_scheduler, reduce_lr_on_plateau_scheduler,
 )
+
+OPTIMIZERS = [sgd,
+              momentum,
+              nesterov_momentum,
+              adagrad,
+              rmsprop,
+              adadelta,
+              adam,
+              adamax,
+              adagrad_window]
+
+OPTIMIZER_NAMES = ["sgd", "momentum", "nesterov_momentum", "adagrad", "rmsprop",
+                   "adadelta", "adam", "adamax", "adagrad_window"]
 
 _a = pytensor.shared(1.0)
 _b = _a * 2
@@ -37,21 +51,7 @@ _m2 = pytensor.shared(np.empty((10, 10, 10), pytensor.config.floatX))
 _n2 = _b + _n + _m2.sum()
 
 
-@pytest.mark.parametrize(
-    "opt",
-    [sgd, momentum, nesterov_momentum, adagrad, rmsprop, adadelta, adam, adamax, adagrad_window],
-    ids=[
-        "sgd",
-        "momentum",
-        "nesterov_momentum",
-        "adagrad",
-        "rmsprop",
-        "adadelta",
-        "adam",
-        "adamax",
-        "adagrad_window",
-    ],
-)
+@pytest.mark.parametrize("opt", OPTIMIZERS, ids=OPTIMIZER_NAMES)
 @pytest.mark.parametrize(
     "getter",
     [
@@ -93,3 +93,116 @@ def test_updates_fast(opt, loss_and_params, kwargs, getter):
             # Usual call to optimizer, old behaviour
             updates = opt(**args)
             assert isinstance(updates, dict)
+
+
+@pytest.fixture()
+def regression_model():
+    rng = np.random.default_rng(1)
+
+    X = rng.normal(size=(100,))
+    intercept, coef = rng.normal(100, size=(2,))
+    noise = rng.normal(size=(100,))
+    y = intercept + coef * X + noise
+
+    with pm.Model() as model:
+        a = pm.Normal("a", )
+        b = pm.Normal("b")
+
+        mu = a + b * X
+        pm.Normal("y", mu=mu, sigma=1, observed=y)
+
+    return model
+
+
+SCHEDULER_PARAMS = [(1, 0.5, 1, 1e-8, False),
+                    (1, 0.5, 1, 1e-8, True),
+                    (1, 0.5, 2, 1e-8, False),
+                    (1, 0.5, 2, 1e-8, True)]
+SCHEDULER_IDS = [f"initial_lr={x[0]}, decay_rate={x[1]}, decay_steps={x[2]}, min_lr={x[3]}, staircase={x[4]}"
+                 for x in SCHEDULER_PARAMS]
+
+
+@pytest.mark.parametrize("optimizer", OPTIMIZERS, ids=OPTIMIZER_NAMES)
+@pytest.mark.parametrize('scheduler_args', SCHEDULER_PARAMS, ids=SCHEDULER_IDS)
+def test_exponential_decay_scheduler(regression_model, optimizer, scheduler_args):
+    initial_lr, decay_rate, decay_steps, min_lr, staircase = scheduler_args
+    opt = optimizer(learning_rate=initial_lr)
+    scheduled_optimizer = exponential_decay_scheduler(opt, decay_steps, decay_rate, min_lr, staircase)
+
+    with regression_model:
+        advi = pm.ADVI()
+
+    updates = advi.objective.updates(obj_optimizer=scheduled_optimizer)
+    inputs = list(updates.keys())
+    outputs = list(updates.values())
+
+    old_names = [x.name for x in inputs]
+    new_names = [x.name for x in outputs]
+
+    assert all([expected_name in old_names for expected_name in ['learning_rate', 't']])
+    assert all([expected_name in new_names for expected_name in ['learning_rate__updated', 't__updated']])
+
+    lr_idx = old_names.index('learning_rate')
+    t_idx = old_names.index('t')
+
+    step_func = pytensor.function([], [outputs[lr_idx], outputs[t_idx]],
+                                  updates=updates,
+                                  mode='FAST_COMPILE')
+
+    steps = np.vstack([step_func() for _ in range(10)])
+
+    def floor_div(x, y):
+        return x // y
+
+    div_func = floor_div if staircase else np.divide
+
+    expected_decay = np.maximum(initial_lr * decay_rate ** (div_func(np.arange(10), decay_steps)), min_lr)
+
+    np.testing.assert_allclose(steps[:, 0], expected_decay)
+    np.testing.assert_allclose(steps[:, 1], np.arange(1, 11))
+
+
+def test_reduce_lr_on_plateau_scheduler(regression_model):
+    opt = pm.adam(learning_rate=1)
+    factor = 0.1
+    patience = 10
+    min_lr = 1e-6
+    cooldown = 10
+    scheduled_optimizer = reduce_lr_on_plateau_scheduler(opt,
+                                                         factor=factor, patience=patience,
+                                                         min_lr=min_lr, cooldown=cooldown)
+    with regression_model:
+        advi = pm.ADVI()
+
+        updates = advi.objective.updates(obj_optimizer=scheduled_optimizer)
+        inputs = list(updates.keys())
+        outputs = list(updates.values())
+
+        old_names = [x.name for x in inputs]
+        new_names = [x.name for x in outputs]
+
+        expected_names = ['best_loss', 'cooldown_counter', 'wait', 'learning_rate']
+
+        assert all([expected_name in old_names for expected_name in expected_names])
+        assert all([f'{expected_name}__updated' in new_names for expected_name in expected_names])
+
+        outputs_of_interest = [outputs[new_names.index(f'{expected_name}__updated')] for expected_name in
+                               expected_names]
+
+        tracker = pm.callbacks.Tracker(best_loss=outputs_of_interest[0].eval,
+                                       cooldown_counter=outputs_of_interest[1].eval,
+                                       wait=outputs_of_interest[2].eval,
+                                       learning_rate=outputs_of_interest[3].eval)
+        approx = advi.fit(1000, callbacks=[tracker], obj_optimizer=scheduled_optimizer)
+
+    # Best loss only decreases
+    assert np.all(np.diff(np.stack(tracker.hist['best_loss'])) <= 0)
+
+    # Learning_rate only decreases
+    assert np.all(np.diff(np.stack(tracker.hist['learning_rate'])) <= 0)
+
+    # Wait is never greater than patience
+    assert np.all(np.stack(tracker.hist['wait']) <= patience)
+
+    # Cooldown_counter is never greater than cooldown
+    assert np.all(np.stack(tracker.hist['cooldown_counter']) <= cooldown)

--- a/tests/variational/test_updates.py
+++ b/tests/variational/test_updates.py
@@ -17,30 +17,44 @@ import pytensor
 import pytest
 
 import pymc as pm
+
 from pymc.variational.updates import (
     adadelta,
     adagrad,
     adagrad_window,
     adam,
     adamax,
+    exponential_decay_scheduler,
     momentum,
     nesterov_momentum,
+    reduce_lr_on_plateau_scheduler,
     rmsprop,
-    sgd, exponential_decay_scheduler, reduce_lr_on_plateau_scheduler,
+    sgd,
 )
 
-OPTIMIZERS = [sgd,
-              momentum,
-              nesterov_momentum,
-              adagrad,
-              rmsprop,
-              adadelta,
-              adam,
-              adamax,
-              adagrad_window]
+OPTIMIZERS = [
+    sgd,
+    momentum,
+    nesterov_momentum,
+    adagrad,
+    rmsprop,
+    adadelta,
+    adam,
+    adamax,
+    adagrad_window,
+]
 
-OPTIMIZER_NAMES = ["sgd", "momentum", "nesterov_momentum", "adagrad", "rmsprop",
-                   "adadelta", "adam", "adamax", "adagrad_window"]
+OPTIMIZER_NAMES = [
+    "sgd",
+    "momentum",
+    "nesterov_momentum",
+    "adagrad",
+    "rmsprop",
+    "adadelta",
+    "adam",
+    "adamax",
+    "adagrad_window",
+]
 
 _a = pytensor.shared(1.0)
 _b = _a * 2
@@ -105,7 +119,9 @@ def regression_model():
     y = intercept + coef * X + noise
 
     with pm.Model() as model:
-        a = pm.Normal("a", )
+        a = pm.Normal(
+            "a",
+        )
         b = pm.Normal("b")
 
         mu = a + b * X
@@ -114,20 +130,26 @@ def regression_model():
     return model
 
 
-SCHEDULER_PARAMS = [(1, 0.5, 1, 1e-8, False),
-                    (1, 0.5, 1, 1e-8, True),
-                    (1, 0.5, 2, 1e-8, False),
-                    (1, 0.5, 2, 1e-8, True)]
-SCHEDULER_IDS = [f"initial_lr={x[0]}, decay_rate={x[1]}, decay_steps={x[2]}, min_lr={x[3]}, staircase={x[4]}"
-                 for x in SCHEDULER_PARAMS]
+SCHEDULER_PARAMS = [
+    (1, 0.5, 1, 1e-8, False),
+    (1, 0.5, 1, 1e-8, True),
+    (1, 0.5, 2, 1e-8, False),
+    (1, 0.5, 2, 1e-8, True),
+]
+SCHEDULER_IDS = [
+    f"initial_lr={x[0]}, decay_rate={x[1]}, decay_steps={x[2]}, min_lr={x[3]}, staircase={x[4]}"
+    for x in SCHEDULER_PARAMS
+]
 
 
 @pytest.mark.parametrize("optimizer", OPTIMIZERS, ids=OPTIMIZER_NAMES)
-@pytest.mark.parametrize('scheduler_args', SCHEDULER_PARAMS, ids=SCHEDULER_IDS)
+@pytest.mark.parametrize("scheduler_args", SCHEDULER_PARAMS, ids=SCHEDULER_IDS)
 def test_exponential_decay_scheduler(regression_model, optimizer, scheduler_args):
     initial_lr, decay_rate, decay_steps, min_lr, staircase = scheduler_args
     opt = optimizer(learning_rate=initial_lr)
-    scheduled_optimizer = exponential_decay_scheduler(opt, decay_steps, decay_rate, min_lr, staircase)
+    scheduled_optimizer = exponential_decay_scheduler(
+        opt, decay_steps, decay_rate, min_lr, staircase
+    )
 
     with regression_model:
         advi = pm.ADVI()
@@ -139,15 +161,17 @@ def test_exponential_decay_scheduler(regression_model, optimizer, scheduler_args
     old_names = [x.name for x in inputs]
     new_names = [x.name for x in outputs]
 
-    assert all([expected_name in old_names for expected_name in ['learning_rate', 't']])
-    assert all([expected_name in new_names for expected_name in ['learning_rate__updated', 't__updated']])
+    assert all([expected_name in old_names for expected_name in ["learning_rate", "t"]])
+    assert all(
+        [expected_name in new_names for expected_name in ["learning_rate__updated", "t__updated"]]
+    )
 
-    lr_idx = old_names.index('learning_rate')
-    t_idx = old_names.index('t')
+    lr_idx = old_names.index("learning_rate")
+    t_idx = old_names.index("t")
 
-    step_func = pytensor.function([], [outputs[lr_idx], outputs[t_idx]],
-                                  updates=updates,
-                                  mode='FAST_COMPILE')
+    step_func = pytensor.function(
+        [], [outputs[lr_idx], outputs[t_idx]], updates=updates, mode="FAST_COMPILE"
+    )
 
     steps = np.vstack([step_func() for _ in range(10)])
 
@@ -156,7 +180,9 @@ def test_exponential_decay_scheduler(regression_model, optimizer, scheduler_args
 
     div_func = floor_div if staircase else np.divide
 
-    expected_decay = np.maximum(initial_lr * decay_rate ** (div_func(np.arange(10), decay_steps)), min_lr)
+    expected_decay = np.maximum(
+        initial_lr * decay_rate ** (div_func(np.arange(10), decay_steps)), min_lr
+    )
 
     np.testing.assert_allclose(steps[:, 0], expected_decay)
     np.testing.assert_allclose(steps[:, 1], np.arange(1, 11))
@@ -168,9 +194,9 @@ def test_reduce_lr_on_plateau_scheduler(regression_model):
     patience = 10
     min_lr = 1e-6
     cooldown = 10
-    scheduled_optimizer = reduce_lr_on_plateau_scheduler(opt,
-                                                         factor=factor, patience=patience,
-                                                         min_lr=min_lr, cooldown=cooldown)
+    scheduled_optimizer = reduce_lr_on_plateau_scheduler(
+        opt, factor=factor, patience=patience, min_lr=min_lr, cooldown=cooldown
+    )
     with regression_model:
         advi = pm.ADVI()
 
@@ -181,28 +207,32 @@ def test_reduce_lr_on_plateau_scheduler(regression_model):
         old_names = [x.name for x in inputs]
         new_names = [x.name for x in outputs]
 
-        expected_names = ['best_loss', 'cooldown_counter', 'wait', 'learning_rate']
+        expected_names = ["best_loss", "cooldown_counter", "wait", "learning_rate"]
 
         assert all([expected_name in old_names for expected_name in expected_names])
-        assert all([f'{expected_name}__updated' in new_names for expected_name in expected_names])
+        assert all([f"{expected_name}__updated" in new_names for expected_name in expected_names])
 
-        outputs_of_interest = [outputs[new_names.index(f'{expected_name}__updated')] for expected_name in
-                               expected_names]
+        outputs_of_interest = [
+            outputs[new_names.index(f"{expected_name}__updated")]
+            for expected_name in expected_names
+        ]
 
-        tracker = pm.callbacks.Tracker(best_loss=outputs_of_interest[0].eval,
-                                       cooldown_counter=outputs_of_interest[1].eval,
-                                       wait=outputs_of_interest[2].eval,
-                                       learning_rate=outputs_of_interest[3].eval)
+        tracker = pm.callbacks.Tracker(
+            best_loss=outputs_of_interest[0].eval,
+            cooldown_counter=outputs_of_interest[1].eval,
+            wait=outputs_of_interest[2].eval,
+            learning_rate=outputs_of_interest[3].eval,
+        )
         approx = advi.fit(1000, callbacks=[tracker], obj_optimizer=scheduled_optimizer)
 
     # Best loss only decreases
-    assert np.all(np.diff(np.stack(tracker.hist['best_loss'])) <= 0)
+    assert np.all(np.diff(np.stack(tracker.hist["best_loss"])) <= 0)
 
     # Learning_rate only decreases
-    assert np.all(np.diff(np.stack(tracker.hist['learning_rate'])) <= 0)
+    assert np.all(np.diff(np.stack(tracker.hist["learning_rate"])) <= 0)
 
     # Wait is never greater than patience
-    assert np.all(np.stack(tracker.hist['wait']) <= patience)
+    assert np.all(np.stack(tracker.hist["wait"]) <= patience)
 
     # Cooldown_counter is never greater than cooldown
-    assert np.all(np.stack(tracker.hist['cooldown_counter']) <= cooldown)
+    assert np.all(np.stack(tracker.hist["cooldown_counter"]) <= cooldown)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

This has been discussed in the [forums](https://discourse.pymc.io/t/learning-rate-scheduling-for-variational-inference/13075/25) and in this [issue](https://github.com/pymc-devs/pymc/issues/7010).

There’s big parallels between PyMC’s variational inference and training neural networks, where the choice of optimiser and learning rate have a huge impact on training quality and speed. A common technique for training neural networks is using learning rate schedulers which reduce the learning rate on a schedule, to get faster convergence by starting high and reducing it in successive epochs where you want to be more precise.

Currently, in PyMC, you need to specify a suitable learning rate that is used for fitting the model. Too large and it won't converge, too small and it will be too slow. Training once with a large-ish learning rate and then taking the results of that training round as a starting point for another training round with a smaller learning rate is not trivial and not very elegant.

To address this issue, I've implemented a new callback for pymc.variational, following Keras' [ReduceLROnPlateau](https://github.com/keras-team/keras/blob/v2.14.0/keras/callbacks.py). Basically it monitors the model loss at every iteration of VI.fit() and it reduces the learning rate by a user-specified amount if the loss doesn't improve after a user-specified number of iterations.

## Major / Breaking Changes
None (I think!)

## New features
Added a ReduceLROnPlateau callback.

## Bugfixes
None.

## Documentation
None so far, but it would be nice to add an example.

## Maintenance
None.


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7011.org.readthedocs.build/en/7011/

<!-- readthedocs-preview pymc end -->