### PR TITLE
Rectify Return type hint

### DIFF
--- a/pymc/logprob/binary.py
+++ b/pymc/logprob/binary.py
@@ -20,6 +20,7 @@ from pytensor.graph.basic import Node
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.rewriting.basic import node_rewriter
 from pytensor.scalar.basic import GE, GT, LE, LT, Invert
+from pytensor.tensor import TensorVariable
 from pytensor.tensor.math import ge, gt, invert, le, lt
 
 from pymc.logprob.abstract import (
@@ -41,7 +42,7 @@ class MeasurableComparison(MeasurableElemwise):
 @node_rewriter(tracks=[gt, lt, ge, le])
 def find_measurable_comparisons(
     fgraph: FunctionGraph, node: Node
-) -> Optional[List[MeasurableComparison]]:
+) -> Optional[List[TensorVariable]]:
     rv_map_feature: Optional[PreserveRVMappings] = getattr(fgraph, "preserve_rv_mappings", None)
     if rv_map_feature is None:
         return None  # pragma: no cover


### PR DESCRIPTION
Fixes #6811 

Rectify Return type hint for `find_measurable_comparisons`

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7013.org.readthedocs.build/en/7013/

<!-- readthedocs-preview pymc end -->