### PR TITLE
Bump Pytensor dependency to `>=2.18.1,<2.19`

### DIFF
--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.17.0,<2.18
+- pytensor>=2.18.1,<2.19
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.17.0,<2.18
+- pytensor>=2.18.1,<2.19
 - python-graphviz
 - scipy>=1.4.1
 - typing-extensions>=3.7.4

--- a/conda-envs/environment-jax.yml
+++ b/conda-envs/environment-jax.yml
@@ -21,7 +21,7 @@ dependencies:
 - numpyro>=0.8.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.17.0,<2.18
+- pytensor>=2.18.1,<2.19
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -17,7 +17,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.17.0,<2.18
+- pytensor>=2.18.1,<2.19
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.17.0,<2.18
+- pytensor>=2.18.1,<2.19
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -17,7 +17,7 @@ dependencies:
 - numpy>=1.15.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.17.0,<2.18
+- pytensor>=2.18.1,<2.19
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ numpydoc
 pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
-pytensor>=2.17.0,<2.18
+pytensor>=2.18.1,<2.19
 pytest-cov>=2.5
 pytest>=3.0
 scipy>=1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ cloudpickle
 fastprogress>=0.2.0
 numpy>=1.15.0
 pandas>=0.24.0
-pytensor>=2.17.0,<2.18
+pytensor>=2.18.1,<2.19
 scipy>=1.4.1
 typing-extensions>=3.7.4


### PR DESCRIPTION
PyTensor changes: https://github.com/pymc-devs/pytensor/releases/tag/rel-2.18.0

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7020.org.readthedocs.build/en/7020/

<!-- readthedocs-preview pymc end -->