### PR TITLE
Fix docs formatting in `shape_utils`

### DIFF
--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -59,7 +59,7 @@ def to_tuple(shape):
 
     Returns
     -------
-    shape: 
+    shape : tuple
         If `shape` is None, returns an empty tuple. If it's an int, (shape,) is
         returned. If it is array-like, tuple(shape) is returned.
     """
@@ -322,7 +322,7 @@ def change_dist_size(
 
     Returns
     -------
-    dist: 
+    dist : TensorVariable
         A new distribution variable that is equivalent to the original distribution with
         the new size. The new distribution will not reuse the old RandomState/Generator
         input, so it will be independent from the original distribution.

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -321,9 +321,10 @@ def change_dist_size(
 
     Returns
     -------
-    A new distribution variable that is equivalent to the original distribution with
-    the new size. The new distribution will not reuse the old RandomState/Generator
-    input, so it will be independent from the original distribution.
+    dist: 
+        A new distribution variable that is equivalent to the original distribution with
+        the new size. The new distribution will not reuse the old RandomState/Generator
+        input, so it will be independent from the original distribution.
 
     Examples
     --------

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -59,8 +59,9 @@ def to_tuple(shape):
 
     Returns
     -------
-    If `shape` is None, returns an empty tuple. If it's an int, (shape,) is
-    returned. If it is array-like, tuple(shape) is returned.
+    shape: 
+        If `shape` is None, returns an empty tuple. If it's an int, (shape,) is
+        returned. If it is array-like, tuple(shape) is returned.
     """
     if shape is None:
         return tuple()


### PR DESCRIPTION
Fix docs markup for this [page](https://www.pymc.io/projects/docs/en/stable/api/generated/pymc.distributions.shape_utils.change_dist_size.html#pymc.distributions.shape_utils.change_dist_size) and [this](https://www.pymc.io/projects/docs/en/stable/api/generated/pymc.distributions.shape_utils.to_tuple.html#pymc.distributions.shape_utils.to_tuple)

<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
...

**Checklist**
+ [ ] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇
## Documentation
- Small docs markup fixes
