### PR TITLE
Better float32 sampling support for TruncatedNormal

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -28,6 +28,7 @@ import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
+from pytensor.configdefaults import config
 from pytensor.graph.basic import Apply, Variable
 from pytensor.graph.op import Op
 from pytensor.raise_op import Assert
@@ -569,6 +570,8 @@ class TruncatedNormalRV(RandomVariable):
     ) -> np.ndarray:
         # Upcast to float64 and then downcast if necessary
         #   (Work-around for https://github.com/scipy/scipy/issues/15928)
+        if cls.dtype == "floatX":
+            dtype = config.floatX
         return stats.truncnorm.rvs(
             a=((lower - mu) / sigma).astype("float64"),
             b=((upper - mu) / sigma).astype("float64"),
@@ -576,7 +579,7 @@ class TruncatedNormalRV(RandomVariable):
             scale=(sigma).astype("float64"),
             size=size,
             random_state=rng,
-        ).astype(mu.dtype)
+        ).astype(dtype)
 
 
 truncated_normal = TruncatedNormalRV()

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -567,15 +567,14 @@ class TruncatedNormalRV(RandomVariable):
         upper: Union[np.ndarray, float],
         size: Optional[Union[List[int], int]],
     ) -> np.ndarray:
-        a = (lower - mu) / sigma
-        b = (upper - mu) / sigma
-
-        dist = stats.truncnorm(a=a, b=b, loc=mu, scale=sigma)
-        # Underlying uniform should be of the same dtype as other inputs (`mu` for now)
-        ps = rng.random(size=size, dtype=mu.dtype)
-        ret = dist.ppf(ps)
-        # Enforce bounds b/c precision can violate
-        return ret.clip(lower, upper)
+        return stats.truncnorm.rvs(
+            a=((lower - mu) / sigma).astype("float64"),
+            b=((upper - mu) / sigma).astype("float64"),
+            loc=(mu).astype("float64"),
+            scale=(sigma).astype("float64"),
+            size=size,
+            random_state=rng,
+        ).astype(mu.dtype)
 
 
 truncated_normal = TruncatedNormalRV()

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -567,14 +567,15 @@ class TruncatedNormalRV(RandomVariable):
         upper: Union[np.ndarray, float],
         size: Optional[Union[List[int], int]],
     ) -> np.ndarray:
-        return stats.truncnorm.rvs(
-            a=(lower - mu) / sigma,
-            b=(upper - mu) / sigma,
-            loc=mu,
-            scale=sigma,
-            size=size,
-            random_state=rng,
-        )
+        a = (lower - mu) / sigma
+        b = (upper - mu) / sigma
+
+        dist = stats.truncnorm(a=a, b=b, loc=mu, scale=sigma)
+        # Underlying uniform should be of the same dtype as other inputs (`mu` for now)
+        ps = rng.random(size=size, dtype=mu.dtype)
+        ret = dist.ppf(ps)
+        # Enforce bounds b/c precision can violate
+        return ret.clip(lower, upper)
 
 
 truncated_normal = TruncatedNormalRV()

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -567,6 +567,8 @@ class TruncatedNormalRV(RandomVariable):
         upper: Union[np.ndarray, float],
         size: Optional[Union[List[int], int]],
     ) -> np.ndarray:
+        # Upcast to float64 and then downcast if necessary
+        #   (Work-around for https://github.com/scipy/scipy/issues/15928)
         return stats.truncnorm.rvs(
             a=((lower - mu) / sigma).astype("float64"),
             b=((upper - mu) / sigma).astype("float64"),

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -568,12 +568,8 @@ class TruncatedNormalRV(RandomVariable):
         upper: Union[np.ndarray, float],
         size: Optional[Union[List[int], int]],
     ) -> np.ndarray:
-        # Upcast to float64 and then downcast if necessary
+        # Upcast to float64. (Caller will downcast to desired dtype if needed)
         #   (Work-around for https://github.com/scipy/scipy/issues/15928)
-        if cls.dtype == "floatX":
-            dtype = config.floatX
-        else:
-            dtype = cls.dtype
         return stats.truncnorm.rvs(
             a=((lower - mu) / sigma).astype("float64"),
             b=((upper - mu) / sigma).astype("float64"),
@@ -581,7 +577,7 @@ class TruncatedNormalRV(RandomVariable):
             scale=(sigma).astype("float64"),
             size=size,
             random_state=rng,
-        ).astype(dtype)
+        )
 
 
 truncated_normal = TruncatedNormalRV()

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -28,7 +28,6 @@ import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
-from pytensor.configdefaults import config
 from pytensor.graph.basic import Apply, Variable
 from pytensor.graph.op import Op
 from pytensor.raise_op import Assert

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -572,6 +572,8 @@ class TruncatedNormalRV(RandomVariable):
         #   (Work-around for https://github.com/scipy/scipy/issues/15928)
         if cls.dtype == "floatX":
             dtype = config.floatX
+        else:
+            dtype = cls.dtype
         return stats.truncnorm.rvs(
             a=((lower - mu) / sigma).astype("float64"),
             b=((upper - mu) / sigma).astype("float64"),


### PR DESCRIPTION
When using float32 (via `PYTENSOR_FLAGS='floatX=float32'`), the current usage of `stats.truncnorm.rvs` in `rng_fn` can return `nan` for `TruncatedNormalRV` (and probably other functions that use a scipy flavored rvs). Reason is described in the issue linked below:

An issue was raised here (but will be closed without fix):
https://github.com/scipy/scipy/issues/19554 (and at a higher level, https://github.com/scipy/scipy/issues/15928 )

This PR is meant to just be a draft based on the suggested workaround and a discussion of how to best proceed. For now, I have personally just been using a custom patched distribution class with the changes in the PR.

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7026.org.readthedocs.build/en/7026/

<!-- readthedocs-preview pymc end -->