### PR TITLE
Reorganize docs API entries

### DIFF
--- a/docs/source/api/math.rst
+++ b/docs/source/api/math.rst
@@ -67,11 +67,7 @@ Functions exposed in pymc.math
    sgn
    ceil
    floor
-   det
    matrix_inverse
-   extract_diag
-   matrix_dot
-   trace
    sigmoid
    logsumexp
    invlogit

--- a/docs/source/api/model/core.rst
+++ b/docs/source/api/model/core.rst
@@ -7,7 +7,6 @@ Model creation and inspection
 
    Model
    model_to_graphviz
-   model_to_networkx
    modelcontext
 
 Others

--- a/docs/source/api/model/core.rst
+++ b/docs/source/api/model/core.rst
@@ -22,7 +22,7 @@ Others
    compile_fn
 
 
-Graph visualisation
+Graph visualization
 -------------------
 
 .. currentmodule:: pymc.model_graph

--- a/docs/source/api/model/core.rst
+++ b/docs/source/api/model/core.rst
@@ -6,7 +6,6 @@ Model creation and inspection
    :toctree: generated/
 
    Model
-   model_to_graphviz
    modelcontext
 
 Others
@@ -21,3 +20,14 @@ Others
    set_data
    Point
    compile_fn
+
+
+Graph visualisation
+-------------------
+
+.. currentmodule:: pymc.model_graph
+.. autosummary::
+   :toctree: generated/
+
+   model_to_networkx
+   model_to_graphviz

--- a/docs/source/api/pytensorf.rst
+++ b/docs/source/api/pytensorf.rst
@@ -1,7 +1,7 @@
 PyTensor utils
 **************
 
-.. currentmodule:: pymc
+.. currentmodule:: pymc.pytensorf
 
 .. autosummary::
    :toctree: generated/
@@ -16,6 +16,7 @@ PyTensor utils
    floatX
    intX
    smartfloatX
+   constant_fold
    CallableTensor
    join_nonshared_inputs
    make_shared_replacements

--- a/docs/source/api/pytensorf.rst
+++ b/docs/source/api/pytensorf.rst
@@ -16,7 +16,6 @@ PyTensor utils
    floatX
    intX
    smartfloatX
-   constant_fold
    CallableTensor
    join_nonshared_inputs
    make_shared_replacements

--- a/docs/source/api/samplers.rst
+++ b/docs/source/api/samplers.rst
@@ -4,25 +4,39 @@ Samplers
 This submodule contains functions for MCMC and forward sampling.
 
 
-.. currentmodule:: pymc
+.. currentmodule:: pymc.sampling.forward
+
+.. autosummary::
+   :toctree: generated/
+
+   sample_prior_predictive
+   sample_posterior_predictive
+   draw
+
+
+.. currentmodule:: pymc.sampling.mcmc
 
 .. autosummary::
    :toctree: generated/
 
    sample
-   sample_prior_predictive
-   sample_posterior_predictive
-   sample_posterior_predictive_w
    init_nuts
-   draw
+
+.. currentmodule:: pymc.sampling.jax
+
+.. autosummary::
+   :toctree: generated/
+
+   sample_blackjax_nuts
+   sample_numpyro_nuts
+
 
 Step methods
 ************
 
-.. currentmodule:: pymc
-
 HMC family
 ----------
+.. currentmodule:: pymc.step_methods.hmc
 
 .. autosummary::
    :toctree: generated/
@@ -32,6 +46,7 @@ HMC family
 
 Metropolis family
 -----------------
+.. currentmodule:: pymc.step_methods
 
 .. autosummary::
     :toctree: generated/
@@ -51,6 +66,7 @@ Metropolis family
 
 Other step methods
 ------------------
+.. currentmodule:: pymc.step_methods
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/api/samplers.rst
+++ b/docs/source/api/samplers.rst
@@ -13,8 +13,6 @@ This submodule contains functions for MCMC and forward sampling.
    sample_prior_predictive
    sample_posterior_predictive
    sample_posterior_predictive_w
-   sampling.jax.sample_blackjax_nuts
-   sampling.jax.sample_numpyro_nuts
    init_nuts
    draw
 

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -57,7 +57,7 @@ def __getattr__(name):
         warnings.warn(f"{name} has been deprecated, use ordered instead.", FutureWarning)
         return ordered
 
-    if name in ("univariate_sum_to_1, multivariate_sum_to_1"):
+    if name in ("univariate_sum_to_1", "multivariate_sum_to_1"):
         warnings.warn(f"{name} has been deprecated, use sum_to_1 instead.", FutureWarning)
         return sum_to_1
 


### PR DESCRIPTION
**What is this PR about?**
Hello, while making previous PR i found what some modules doesn't import at all:
```
WARNING: [autosummary] failed to import pymc.constant_fold.
Possible hints:
* AttributeError: module 'pymc' has no attribute 'constant_fold'
* ModuleNotFoundError: No module named 'pymc.constant_fold'
* ImportError:
WARNING: [autosummary] failed to import pymc.math.det.
Possible hints:
* AttributeError: module 'pymc.math' has no attribute 'det'
* ModuleNotFoundError: No module named 'pymc.math.det'; 'pymc.math' is not a package
* ImportError:
WARNING: [autosummary] failed to import pymc.math.extract_diag.
Possible hints:
* ModuleNotFoundError: No module named 'pymc.math.extract_diag'; 'pymc.math' is not a package
* AttributeError: module 'pymc.math' has no attribute 'extract_diag'
* ImportError:
WARNING: [autosummary] failed to import pymc.math.matrix_dot.
Possible hints:
* ModuleNotFoundError: No module named 'pymc.math.matrix_dot'; 'pymc.math' is not a package
* ImportError:
* AttributeError: module 'pymc.math' has no attribute 'matrix_dot'
WARNING: [autosummary] failed to import pymc.math.trace.
Possible hints:
* ImportError:
* AttributeError: module 'pymc.math' has no attribute 'trace'
* ModuleNotFoundError: No module named 'pymc.math.trace'; 'pymc.math' is not a package
WARNING: [autosummary] failed to import pymc.model.core.model_to_networkx.
Possible hints:
* AttributeError: module 'pymc.model.core' has no attribute 'model_to_networkx'
* ModuleNotFoundError: No module named 'pymc.model.core.model_to_networkx'; 'pymc.model.core' is not a package
* ImportError:

Extension error (sphinx.ext.autosummary):
```

So i am looked in history and found what they removed long ago.

## Bugfixes
- Fixes misspel in import shim around transforms.sum_to_1

## Documentation
- Less errors while docs build


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7030.org.readthedocs.build/en/7030/

<!-- readthedocs-preview pymc end -->