### PR TITLE
Remove several deprecated model properties and deprecate new ones

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -496,7 +496,13 @@ class Model(WithMemoization, metaclass=ContextMeta):
             instance._parent = kwargs.get("model")
         else:
             instance._parent = cls.get_context(error_if_none=False)
-        instance._pytensor_config = kwargs.get("pytensor_config", {})
+        pytensor_config = kwargs.get("pytensor_config", {})
+        if pytensor_config:
+            warnings.warn(
+                "pytensor_config is deprecated. Use pytensor.config or pytensor.config.change_flags context manager instead.",
+                FutureWarning,
+            )
+        instance._pytensor_config = pytensor_config
         return instance
 
     @staticmethod

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -559,6 +559,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
     @property
     def model(self):
+        warnings.warn("Model.model property is deprecated. Just use Model.", FutureWarning)
         return self
 
     @property
@@ -629,7 +630,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             Whether to sum all logp terms or return elemwise logp for each variable.
             Defaults to True.
         """
-        return self.model.compile_fn(self.logp(vars=vars, jacobian=jacobian, sum=sum))
+        return self.compile_fn(self.logp(vars=vars, jacobian=jacobian, sum=sum))
 
     def compile_dlogp(
         self,
@@ -646,7 +647,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         jacobian:
             Whether to include jacobian terms in logprob graph. Defaults to True.
         """
-        return self.model.compile_fn(self.dlogp(vars=vars, jacobian=jacobian))
+        return self.compile_fn(self.dlogp(vars=vars, jacobian=jacobian))
 
     def compile_d2logp(
         self,
@@ -663,7 +664,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         jacobian:
             Whether to include jacobian terms in logprob graph. Defaults to True.
         """
-        return self.model.compile_fn(self.d2logp(vars=vars, jacobian=jacobian))
+        return self.compile_fn(self.d2logp(vars=vars, jacobian=jacobian))
 
     def logp(
         self,

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -887,25 +887,9 @@ class Model(WithMemoization, metaclass=ContextMeta):
         return vars + untransformed_vars + deterministics
 
     @property
-    def disc_vars(self):
-        warnings.warn(
-            "Model.disc_vars has been deprecated. Use Model.discrete_value_vars instead.",
-            FutureWarning,
-        )
-        return self.discrete_value_vars
-
-    @property
     def discrete_value_vars(self):
         """All the discrete value variables in the model"""
         return list(typefilter(self.value_vars, discrete_types))
-
-    @property
-    def cont_vars(self):
-        warnings.warn(
-            "Model.cont_vars has been deprecated. Use Model.continuous_value_vars instead.",
-            FutureWarning,
-        )
-        return self.continuous_value_vars
 
     @property
     def continuous_value_vars(self):
@@ -934,18 +918,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
         use `var.unobserved_value_vars` instead.
         """
         return self.free_RVs + self.deterministics
-
-    @property
-    def RV_dims(self) -> Dict[str, Tuple[Union[str, None], ...]]:
-        """Tuples of dimension names for specific model variables.
-
-        Entries in the tuples may be ``None``, if the RV dimension was not given a name.
-        """
-        warnings.warn(
-            "Model.RV_dims is deprecated. Use Model.named_vars_to_dims instead.",
-            FutureWarning,
-        )
-        return self.named_vars_to_dims
 
     @property
     def coords(self) -> Dict[str, Union[Tuple, None]]:
@@ -1089,18 +1061,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
         """
         fn = make_initial_point_fn(model=self, return_transformed=True)
         return Point(fn(random_seed), model=self)
-
-    @property
-    def initial_values(self) -> Dict[TensorVariable, Optional[Union[np.ndarray, Variable, str]]]:
-        """Maps transformed variables to initial value placeholders.
-
-        Keys are the random variables (as returned by e.g. ``pm.Uniform()``) and
-        values are the numeric/symbolic initial values, strings denoting the strategy to get them, or None.
-        """
-        warnings.warn(
-            "Model.initial_values is deprecated. Use Model.rvs_to_initial_values instead."
-        )
-        return self.rvs_to_initial_values
 
     def set_initval(self, rv_var, initval):
         """Sets an initial value (strategy) for a random variable."""

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -1102,7 +1102,9 @@ def test_compile_fn():
 
 def test_model_pytensor_config():
     assert pytensor.config.mode != "JAX"
-    with pm.Model(pytensor_config=dict(mode="JAX")) as model:
+    with pytest.warns(FutureWarning, match="pytensor_config is deprecated"):
+        m = pm.Model(pytensor_config=dict(mode="JAX"))
+    with m:
         assert pytensor.config.mode == "JAX"
     assert pytensor.config.mode != "JAX"
 

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -1107,6 +1107,13 @@ def test_model_pytensor_config():
     assert pytensor.config.mode != "JAX"
 
 
+def test_deprecated_model_property():
+    m = pm.Model()
+    with pytest.warns(FutureWarning, match="Model.model property is deprecated"):
+        m_property = m.model
+    assert m is m_property
+
+
 def test_model_parent_set_programmatically():
     with pm.Model() as model:
         x = pm.Normal("x")

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -705,9 +705,9 @@ def test_set_initval():
         alpha = pm.HalfNormal("alpha", initval=100)
         value = pm.NegativeBinomial("value", mu=mu, alpha=alpha)
 
-    assert np.array_equal(model.initial_values[mu], np.array([[100.0]]))
-    np.testing.assert_array_equal(model.initial_values[alpha], np.array(100))
-    assert model.initial_values[value] is None
+    assert np.array_equal(model.rvs_to_initial_values[mu], np.array([[100.0]]))
+    np.testing.assert_array_equal(model.rvs_to_initial_values[alpha], np.array(100))
+    assert model.rvs_to_initial_values[value] is None
 
     # `Flat` cannot be sampled, so let's make sure that doesn't break initial
     # value computations
@@ -715,7 +715,7 @@ def test_set_initval():
         x = pm.Flat("x")
         y = pm.Normal("y", x, 1)
 
-    assert y in model.initial_values
+    assert y in model.rvs_to_initial_values
 
 
 def test_datalogp_multiple_shapes():
@@ -972,18 +972,6 @@ def test_set_data_constant_shape_error():
     msg = "because the dimension was initialized from 'x'"
     with pytest.raises(ShapeError, match=msg):
         pmodel.set_data("y", np.arange(10))
-
-
-def test_model_deprecation_warning():
-    with pm.Model() as m:
-        x = pm.Normal("x", 0, 1, size=2)
-        y = pm.LogNormal("y", 0, 1, size=2)
-
-    with pytest.warns(FutureWarning):
-        m.disc_vars
-
-    with pytest.warns(FutureWarning):
-        m.cont_vars
 
 
 @pytest.mark.parametrize("jacobian", [True, False])

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -797,14 +797,6 @@ class TestAssignStepMethods:
 class TestType:
     samplers = (Metropolis, Slice, HamiltonianMC, NUTS)
 
-    def setup_method(self):
-        # save PyTensor config object
-        self.pytensor_config = copy(pytensor.config)
-
-    def teardown_method(self):
-        # restore pytensor config
-        pytensor.config = self.pytensor_config
-
     @pytensor.config.change_flags({"floatX": "float64", "warn_float64": "ignore"})
     def test_float64(self):
         with pm.Model() as model:

--- a/tests/variational/test_approximations.py
+++ b/tests/variational/test_approximations.py
@@ -84,10 +84,6 @@ def test_scale_cost_to_minibatch_works(aux_total_size):
     y_obs = np.array([1.6, 1.4])
     beta = len(y_obs) / float(aux_total_size)
 
-    # TODO: pytensor_config
-    # with pm.Model(pytensor_config=dict(floatX='float64')):
-    # did not not work as expected
-    # there were some numeric problems, so float64 is forced
     with pytensor.config.change_flags(floatX="float64", warn_float64="ignore"):
         assert pytensor.config.floatX == "float64"
         assert pytensor.config.warn_float64 == "ignore"


### PR DESCRIPTION
Sometimes less is more...

The `self.model` seems to have been introduced with ancient GLM / ModelBuilder ideas: https://github.com/pymc-devs/pymc/pull/1525

@lucianopaz  and I were surprised when we found it today. We thought we were getting a wrong object that wrapped model, but no, model does in fact have the most useless property ever :)

The deprecation of `pytensor_config` was discussed in https://github.com/pymc-devs/pymc/pull/5915 and I think it's as good time as any to deprecate it. 

@ferrine was the proponent of this functionality. This only seems relevant if you want different modes for different models, but I say power-users can just use `pytensor.config.change_flags` manually or build a helper that achieves the same functionality. The goal here is less magic. Note that this wouldn't work for nested models nor after cloning from fgraph as `do` and `observe` do.

Removed a bunch of methods that were deprecated sometime ago

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7033.org.readthedocs.build/en/7033/

<!-- readthedocs-preview pymc end -->