### PR TITLE
Implement logcdf for TruncatedNormal

### DIFF
--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -37,6 +37,7 @@ from pymc.testing import (
     Circ,
     Domain,
     R,
+    Rminusbig,
     Rplus,
     Rplusbig,
     Rplusunif,
@@ -934,6 +935,11 @@ class TestMatchesScipy:
                 value, (lower - mu) / sigma, (upper - mu) / sigma, loc=mu, scale=sigma
             )
 
+        def scipy_logcdf(value, mu, sigma, lower, upper):
+            return st.truncnorm.logcdf(
+                value, (lower - mu) / sigma, (upper - mu) / sigma, loc=mu, scale=sigma
+            )
+
         check_logp(
             pm.TruncatedNormal,
             R,
@@ -957,6 +963,33 @@ class TestMatchesScipy:
             R,
             {"mu": R, "sigma": Rplusbig, "lower": -Rplusbig},
             ft.partial(scipy_logp, upper=np.inf),
+            decimal=select_by_precision(float64=6, float32=1),
+            skip_paramdomain_outside_edge_test=True,
+        )
+
+        check_logcdf(
+            pm.TruncatedNormal,
+            R,
+            {"mu": R, "sigma": Rplusbig, "lower": -Rplusbig, "upper": Rplusbig},
+            scipy_logcdf,
+            decimal=select_by_precision(float64=6, float32=1),
+            skip_paramdomain_outside_edge_test=True,
+        )
+
+        check_logcdf(
+            pm.TruncatedNormal,
+            R,
+            {"mu": R, "sigma": Rplusbig, "upper": Rplusbig},
+            ft.partial(scipy_logcdf, lower=-np.inf),
+            decimal=select_by_precision(float64=6, float32=1),
+            skip_paramdomain_outside_edge_test=True,
+        )
+
+        check_logcdf(
+            pm.TruncatedNormal,
+            R,
+            {"mu": R, "sigma": Rplusbig, "lower": -Rplusbig},
+            ft.partial(scipy_logcdf, upper=np.inf),
             decimal=select_by_precision(float64=6, float32=1),
             skip_paramdomain_outside_edge_test=True,
         )


### PR DESCRIPTION
Closes #7003 first highlighted by a user on discord (https://discourse.pymc.io/t/censoring-a-truncated-distribution/13261) when trying to use the following model,
```python
with pm.Model() as m:
    mu = pm.Normal("mu", 0, 1)
    sigma = pm.Normal("sigma", 0, 1)
    normal_ = pm.Normal.dist(mu, sigma)
    trunc_normal = pm.Truncated.dist(normal_, lower=0)
    censored = pm.Censored("censored", trunc_normal, lower=None, upper=upper_bounds, observed=cy)
```
By refactoring the truncated `truncated_logcdf` to take a `base_rv_op` we can now call it from `TruncatedNormal`. I've also moved the `truncated_logcdf_from_base_rv` out of truncated.py and into dist_math.py as I was having curcular import errors.

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇


## New features
-TruncatedNormal logcdf

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7034.org.readthedocs.build/en/7034/

<!-- readthedocs-preview pymc end -->