### PR TITLE
Adding add_coords function

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -95,6 +95,7 @@ __all__ = [
     "modelcontext",
     "Deterministic",
     "Potential",
+    "add_coords",
     "set_data",
     "Point",
     "compile_fn",
@@ -1905,6 +1906,25 @@ def new_or_existing_block_model_access(*args, **kwargs):
     if isinstance(model, BlockModelAccess):
         return model
     return BlockModelAccess(*args, **kwargs)
+
+
+def add_coords(coords, lengths=None, model=None):
+    """Adds coords to the model
+
+    Parameters
+    ----------
+    coords: dict
+        New coordinate values for dimensions of the shared variable.
+        Must be provided for all named dimensions that change in length
+        and already have coordinate values.
+
+    lengths: dict, optional
+        Dictionary of lengths for the dimensions of each coord
+
+    model: Model (optional if in `with` context)
+    """
+    model = modelcontext(model)
+    model.add_coords(coords=coords, lengths=lengths)
 
 
 def set_data(new_data, model=None, *, coords=None):

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -828,6 +828,13 @@ def test_add_coord_mutable_kwarg():
         assert isinstance(m._dim_lengths["mutable2"], TensorVariable)
 
 
+def test_add_coords():
+    """Test the changing of coords"""
+    with pm.Model() as pmodel:
+        pm.add_coords(coords={"a": range(5)})
+    assert list(pmodel.coords["a"]) == list(range(5))
+
+
 def test_set_dim():
     """Test the conscious re-sizing of dims created through add_coord()."""
     with pm.Model() as pmodel:


### PR DESCRIPTION
This adds the `add_coords` function so that coords can be updated without needing to explicitly mentioning a model

**Checklist**
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇


## New features
- Add a new function



<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7037.org.readthedocs.build/en/7037/

<!-- readthedocs-preview pymc end -->