### PR TITLE
Remove message about JAX not being supported on Windows in installation instructions

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -31,8 +31,6 @@ Similarly, to use BlackJAX sampler instead:
 conda install blackjax
 ```
 
-Note that JAX is not directly supported on Windows systems at the moment.
-
 ## Nutpie sampling
 
 You can also enable sampling with [nutpie](https://github.com/pymc-devs/nutpie).
@@ -41,5 +39,3 @@ Nutpie uses numba as the compiler and a sampler written in Rust for faster perfo
 ```console
 conda install -c conda-forge nutpie
 ```
-
-Unlike JAX, nutpie is directly supported on Windows.


### PR DESCRIPTION
Refer to #7036 
Removed section in the installation instructions that warned about incompatibility of JAX on windows, as this has now been resolved.

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7039.org.readthedocs.build/en/7039/

<!-- readthedocs-preview pymc end -->