### PR TITLE
Warn on divergences after sampling with JAX 

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -359,6 +359,10 @@ def _sample_external_nuts(
             idata_kwargs=idata_kwargs,
             **nuts_sampler_kwargs,
         )
+
+        warns = run_convergence_checks(idata, model)
+        log_warnings(warns)
+
         return idata
 
     elif sampler == "blackjax":

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -380,6 +380,9 @@ def _sample_external_nuts(
             idata_kwargs=idata_kwargs,
             **nuts_sampler_kwargs,
         )
+        warns = run_convergence_checks(idata, model)
+        log_warnings(warns)
+
         return idata
 
     else:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Closes #7041

This is a draft to add convergence checks to the JAX samplers. 

Right now I'm just calling `run_convergence_checks` after sampling. It might be nice to instead wrap the JAX returns in `_sample_return`, but this was easier. Feedback requested.

**Checklist**
+ [ ] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes
- The blackjax sampler should now issue a warning on divergences

## New features
- None

## Bugfixes
- None

## Documentation
- None

## Maintenance
- None


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7051.org.readthedocs.build/en/7051/

<!-- readthedocs-preview pymc end -->