### PR TITLE
Add helper functions to calculate required M for hsgp

### DIFF
--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -17,6 +17,7 @@ import warnings
 
 from collections import Counter
 from functools import reduce
+from math import ceil
 from operator import add, mul
 from typing import Any, Callable, List, Optional, Sequence, Union
 
@@ -564,6 +565,10 @@ class Stationary(Covariance):
     def power_spectral_density(self, omega: TensorLike) -> TensorVariable:
         raise NotImplementedError
 
+    @staticmethod
+    def required_num_eigenvectors(L: float, ls: float) -> int:
+        raise NotImplementedError
+
 
 class ExpQuad(Stationary):
     r"""
@@ -594,6 +599,28 @@ class ExpQuad(Stationary):
         c = pt.power(pt.sqrt(2.0 * np.pi), self.n_dims)
         exp = pt.exp(-0.5 * pt.dot(pt.square(omega), pt.square(ls)))
         return c * pt.prod(ls) * exp
+
+    @staticmethod
+    def required_num_eigenvectors(L: float, ls: float) -> int:
+        r"""Number of eigenvectors in Hilbert space that approximate the GP well.
+
+        .. math::
+
+            m \ge 1.75  \frac{L}{ls}
+
+        Parameters
+        ----------
+        L : float
+            Approximation bound
+        ls : float
+            lengthscale
+
+        Returns
+        -------
+        int
+            Number of eigenvectors
+        """
+        return ceil(1.75 * L / ls)
 
 
 class RatQuad(Stationary):
@@ -663,6 +690,28 @@ class Matern52(Stationary):
         pow = pt.power(5.0 + pt.dot(pt.square(omega), pt.square(ls)), -1 * D52)
         return (num / den) * pt.prod(ls) * pow
 
+    @staticmethod
+    def required_num_eigenvectors(L: float, ls: float) -> int:
+        r"""Number of eigenvectors in Hilbert space that approximate the GP well.
+
+        .. math::
+
+            m \ge 2.65  \frac{L}{ls}
+
+        Parameters
+        ----------
+        L : float
+            Approximation bound
+        ls : float
+            lengthscale
+
+        Returns
+        -------
+        int
+            Number of eigenvectors
+        """
+        return ceil(2.65 * L / ls)
+
 
 class Matern32(Stationary):
     r"""
@@ -701,6 +750,28 @@ class Matern32(Stationary):
         den = 0.5 * pt.sqrt(np.pi)
         pow = pt.power(3.0 + pt.dot(pt.square(omega), pt.square(ls)), -1 * D32)
         return (num / den) * pt.prod(ls) * pow
+
+    @staticmethod
+    def required_num_eigenvectors(L: float, ls: float) -> int:
+        r"""Number of eigenvectors in Hilbert space that approximate the GP well.
+
+        .. math::
+
+            m \ge 3.42 \frac{L}{ls}
+
+        Parameters
+        ----------
+        L : float
+            Approximation bound
+        ls : float
+            lengthscale
+
+        Returns
+        -------
+        int
+            Number of eigenvectors
+        """
+        return ceil(3.42 * L / ls)
 
 
 class Matern12(Stationary):

--- a/tests/gp/test_cov.py
+++ b/tests/gp/test_cov.py
@@ -484,6 +484,13 @@ class TestExpQuad:
         print(result, expected)
         npt.assert_allclose(result, expected, atol=1e-5)
 
+    def test_required_num_eigenvectors(self):
+        L = 4
+        l = 1
+        m = 7
+        m_est = pm.gp.cov.ExpQuad.required_num_eigenvectors(L, l)
+        assert m_est == m
+
 
 class TestWhiteNoise:
     def test_1d(self):
@@ -572,6 +579,13 @@ class TestMatern52:
         )
         npt.assert_allclose(true_1d_psd, test_1d_psd, atol=1e-5)
 
+    def test_required_num_eigenvectors(self):
+        L = 4
+        l = 1
+        m = 11
+        m_est = pm.gp.cov.Matern52.required_num_eigenvectors(L, l)
+        assert m_est == m
+
 
 class TestMatern32:
     def test_1d(self):
@@ -597,6 +611,13 @@ class TestMatern32:
             pm.gp.cov.Matern32(1, ls=ell).power_spectral_density(omega[:, None]).flatten().eval()
         )
         npt.assert_allclose(true_1d_psd, test_1d_psd, atol=1e-5)
+
+    def test_required_num_eigenvectors(self):
+        L = 4
+        l = 1
+        m = 14
+        m_est = pm.gp.cov.Matern32.required_num_eigenvectors(L, l)
+        assert m_est == m
 
 
 class TestMatern12:


### PR DESCRIPTION
It is always a trouble to calculate required M for HSGP, adding helper functions to simplify that

**What is this PR about?**
...

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- Calculating HSGP `m` parameter for common kernels

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7058.org.readthedocs.build/en/7058/

<!-- readthedocs-preview pymc end -->