### PR TITLE
 Working on Deprecate SumTo1 Transform

### DIFF
--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -61,9 +61,9 @@ def __getattr__(name):
         warnings.warn(f"{name} has been deprecated, use sum_to_1 instead.", FutureWarning)
         return sum_to_1
 
-    # if name == "sum_to_1":
-    #     warnings.warn("sum_to_1 will be deprecated, use simplex instead.", FutureWarning)
-    #     return sum_to_1
+    if name == "sum_to_1":
+        warnings.warn("sum_to_1 has been deprecated, use simplex instead.", FutureWarning)
+        return simplex
 
     if name == "RVTransform":
         warnings.warn("RVTransform has been renamed to Transform", FutureWarning)
@@ -338,6 +338,7 @@ log.__doc__ = """
 Instantiation of :class:`pymc.logprob.transforms.LogTransform`
 for use in the ``transform`` argument of a random variable."""
 
+# Deprecated
 sum_to_1 = SumTo1()
 sum_to_1.__doc__ = """
 Instantiation of :class:`pymc.distributions.transforms.SumTo1`

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -61,6 +61,10 @@ def __getattr__(name):
         warnings.warn(f"{name} has been deprecated, use sum_to_1 instead.", FutureWarning)
         return sum_to_1
 
+    # if name == "sum_to_1":
+    #     warnings.warn("sum_to_1 will be deprecated, use simplex instead.", FutureWarning)
+    #     return sum_to_1
+
     if name == "RVTransform":
         warnings.warn("RVTransform has been renamed to Transform", FutureWarning)
         return Transform

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -675,3 +675,6 @@ def test_deprecated_ndim_supp_transforms():
 
     with pytest.warns(FutureWarning, match="deprecated"):
         assert tr.multivariate_sum_to_1 == tr.sum_to_1
+
+    with pytest.warns(FutureWarning, match="deprecated"):
+        assert tr.sum_to_1 == tr.simplex


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
FutureWarning when users access sumto1 transform to let them know it's deprecated and will be removed in the future, and a test that verified the warning is working but you can still access it
<!--- -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes issue: #7009 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7059.org.readthedocs.build/en/7059/

<!-- readthedocs-preview pymc end -->