### PR TITLE
Allow batched scalar sigma in ZeroSumNormal

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2591,8 +2591,7 @@ class ZeroSumNormal(Distribution):
     sigma : tensor_like of float
         Scale parameter (sigma > 0).
         It's actually the standard deviation of the underlying, unconstrained Normal distribution.
-        Defaults to 1 if not specified.
-        For now, ``sigma`` has to be a scalar, to ensure the zero-sum constraint.
+        Defaults to 1 if not specified. ``sigma`` cannot have length > 1 across the zero-sum axes.
     n_zerosum_axes: int, defaults to 1
         Number of axes along which the zero-sum constraint is enforced, starting from the rightmost position.
         Defaults to 1, i.e the rightmost axis.
@@ -2606,8 +2605,7 @@ class ZeroSumNormal(Distribution):
 
     Warnings
     --------
-    ``sigma`` has to be a scalar, to ensure the zero-sum constraint.
-    The ability to specify a vector of ``sigma`` may be added in future versions.
+    Currently, ``sigma``cannot have length > 1 across the zero-sum axes to ensure the zero-sum constraint.
 
     ``n_zerosum_axes`` has to be > 0. If you want the behavior of ``n_zerosum_axes = 0``,
     just use ``pm.Normal``.
@@ -2669,8 +2667,8 @@ class ZeroSumNormal(Distribution):
         n_zerosum_axes = cls.check_zerosum_axes(n_zerosum_axes)
 
         sigma = pt.as_tensor_variable(floatX(sigma))
-        if sigma.ndim > 0:
-            raise ValueError("sigma has to be a scalar")
+        if not all(sigma.type.broadcastable[-n_zerosum_axes:]):
+            raise ValueError("sigma must have length one across the zero-sum axes")
 
         support_shape = get_support_shape(
             support_shape=support_shape,
@@ -2681,9 +2679,7 @@ class ZeroSumNormal(Distribution):
         if support_shape is None:
             if n_zerosum_axes > 0:
                 raise ValueError("You must specify dims, shape or support_shape parameter")
-            # TODO: edge-case doesn't work for now, because pt.stack in get_support_shape fails
-            # else:
-            #     support_shape = () # because it's just a Normal in that case
+
         support_shape = pt.as_tensor_variable(intX(support_shape))
 
         assert n_zerosum_axes == pt.get_vector_length(
@@ -2706,7 +2702,12 @@ class ZeroSumNormal(Distribution):
 
     @classmethod
     def rv_op(cls, sigma, n_zerosum_axes, support_shape, size=None):
-        shape = to_tuple(size) + tuple(support_shape)
+        if size is not None:
+            shape = tuple(size) + tuple(support_shape)
+        else:
+            # Size is implied by shape of sigma
+            shape = tuple(sigma.shape[:-n_zerosum_axes]) + tuple(support_shape)
+
         normal_dist = pm.Normal.dist(sigma=sigma, shape=shape)
 
         if n_zerosum_axes > normal_dist.ndim:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
The check that existed before was meant to prevent non-scalar sigma across zero-sum axes, but there is no reason to prevent it across batch dimensions.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7063.org.readthedocs.build/en/7063/

<!-- readthedocs-preview pymc end -->