### PR TITLE
Fix issue with sampling of PartialObservedRVs

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -1337,7 +1337,8 @@ def create_partial_observed_rv(
             ndim_supp=rv.owner.op.ndim_supp,
         )(rv, mask)
 
-    joined_rv = pt.empty(rv.shape, dtype=rv.type.dtype)
+    [rv_shape] = constant_fold([rv.shape], raise_not_constant=False)
+    joined_rv = pt.empty(rv_shape, dtype=rv.type.dtype)
     joined_rv = pt.set_subtensor(joined_rv[mask], unobserved_rv)
     joined_rv = pt.set_subtensor(joined_rv[antimask], observed_rv)
 

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -56,7 +56,6 @@ from pytensor.tensor.random.var import (
     RandomGeneratorSharedVariable,
     RandomStateSharedVariable,
 )
-from pytensor.tensor.rewriting.basic import topo_constant_folding
 from pytensor.tensor.rewriting.shape import ShapeFeature
 from pytensor.tensor.sharedvar import SharedVariable, TensorSharedVariable
 from pytensor.tensor.subtensor import AdvancedIncSubtensor, AdvancedIncSubtensor1
@@ -1015,7 +1014,8 @@ def constant_fold(
     """
     fg = FunctionGraph(outputs=xs, features=[ShapeFeature()], clone=True)
 
-    folded_xs = rewrite_graph(fg, custom_rewrite=topo_constant_folding).outputs
+    # By default, rewrite_graph includes canonicalize which includes constant-folding as the final rewrite
+    folded_xs = rewrite_graph(fg).outputs
 
     if raise_not_constant and not all(isinstance(folded_x, Constant) for folded_x in folded_xs):
         raise NotConstantValueError

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -1061,3 +1061,17 @@ class TestPartialObservedRV:
         invalid_mask = np.zeros((1, 5), dtype=bool)
         with pytest.raises(ValueError, match="mask can't have more dims than rv"):
             create_partial_observed_rv(rv, invalid_mask)
+
+    @pytest.mark.filterwarnings("error")
+    def test_default_updates(self):
+        mask = np.array([True, True, False])
+        rv = pm.Normal.dist(shape=(3,))
+        (obs_rv, _), (unobs_rv, _), joined_rv = create_partial_observed_rv(rv, mask)
+
+        draws_obs_rv, draws_unobs_rv, draws_joined_rv = pm.draw(
+            [obs_rv, unobs_rv, joined_rv], draws=2
+        )
+
+        assert np.all(draws_obs_rv[0] != draws_obs_rv[1])
+        assert np.all(draws_unobs_rv[0] != draws_unobs_rv[1])
+        assert np.all(draws_joined_rv[0] != draws_joined_rv[1])


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
There was issue with PartialObservedRVs in that we used the same RNG in two places: in one of the masked RVs and in the shape of the empty tensor where the two masked RVs are stored as a deterministic.

This would further raise an error in JAX when computing the joined deterministic, because we don't allow RNGs in jaxified graphs.

Constant folding will ensure the shape graph will be introduced instead of the default `ShapeOp(RV)` so the RNG shouldn't be part of that deterministic graph.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
Issue reported in https://discourse.pymc.io/t/shared-randomtype-issue-using-nuts-numpyro-w-r-t-data-containing-nans/13503?u=ricardov94

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7071.org.readthedocs.build/en/7071/

<!-- readthedocs-preview pymc end -->