### PR TITLE
Revert documentation paths in `Sampler` submodule 

### DIFF
--- a/docs/source/api/samplers.rst
+++ b/docs/source/api/samplers.rst
@@ -4,7 +4,7 @@ Samplers
 This submodule contains functions for MCMC and forward sampling.
 
 
-.. currentmodule:: pymc.sampling.forward
+.. currentmodule:: pymc
 
 .. autosummary::
    :toctree: generated/
@@ -14,7 +14,7 @@ This submodule contains functions for MCMC and forward sampling.
    draw
 
 
-.. currentmodule:: pymc.sampling.mcmc
+.. currentmodule:: pymc
 
 .. autosummary::
    :toctree: generated/
@@ -36,7 +36,7 @@ Step methods
 
 HMC family
 ----------
-.. currentmodule:: pymc.step_methods.hmc
+.. currentmodule:: pymc
 
 .. autosummary::
    :toctree: generated/
@@ -46,7 +46,7 @@ HMC family
 
 Metropolis family
 -----------------
-.. currentmodule:: pymc.step_methods
+.. currentmodule:: pymc
 
 .. autosummary::
     :toctree: generated/
@@ -66,7 +66,7 @@ Metropolis family
 
 Other step methods
 ------------------
-.. currentmodule:: pymc.step_methods
+.. currentmodule:: pymc
 
 .. autosummary::
    :toctree: generated/


### PR DESCRIPTION
This PR fixes the path for API entries of `Sampler` submodule.

## Description
Change the `.. currentmodule::` attribute to the old path prior to `v.5.10.1`. The order of entries is maintained as it is for minimal changes.

Documentation after changes are applied:

![Screenshot](https://github.com/pymc-devs/pymc/assets/39026988/738d5a2e-16fe-468c-8068-111051617493)

## Related Issue
- [x] Closes #7070 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7072.org.readthedocs.build/en/7072/

<!-- readthedocs-preview pymc end -->