### PR TITLE
Allow jitter boolean to be set through `nuts_sampler_kwargs`

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -568,7 +568,7 @@ def sample_numpyro_nuts(
     target_accept: float = 0.8,
     random_seed: Optional[RandomState] = None,
     initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]] = None,
-    jitter: Optional[bool] = True,
+    jitter: bool = True,
     model: Optional[Model] = None,
     var_names: Optional[Sequence[str]] = None,
     progressbar: bool = True,

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -256,7 +256,7 @@ def _get_batched_jittered_initial_points(
     chains: int,
     initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]],
     random_seed: RandomSeed,
-    jitter: bool = True,
+    jitter: bool,
     jitter_max_retries: int = 10,
 ) -> Union[np.ndarray, List[np.ndarray]]:
     """Get jittered initial point in format expected by NumPyro MCMC kernel
@@ -432,6 +432,7 @@ def sample_blackjax_nuts(
         chains=chains,
         initvals=initvals,
         random_seed=random_seed,
+        jitter=nuts_sampler_kwargs.get("jitter", True),
     )
 
     if chains == 1:
@@ -664,6 +665,7 @@ def sample_numpyro_nuts(
         chains=chains,
         initvals=initvals,
         random_seed=random_seed,
+        jitter=nuts_sampler_kwargs.get("jitter", True),
     )
 
     logp_fn = get_jaxified_logp(model, negative_logp=False)

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -256,7 +256,7 @@ def _get_batched_jittered_initial_points(
     chains: int,
     initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]],
     random_seed: RandomSeed,
-    jitter: bool,
+    jitter: Optional[bool] = True,
     jitter_max_retries: int = 10,
 ) -> Union[np.ndarray, List[np.ndarray]]:
     """Get jittered initial point in format expected by NumPyro MCMC kernel
@@ -340,6 +340,7 @@ def sample_blackjax_nuts(
     target_accept: float = 0.8,
     random_seed: Optional[RandomState] = None,
     initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]] = None,
+    jitter: Optional[bool] = True,
     model: Optional[Model] = None,
     var_names: Optional[Sequence[str]] = None,
     progress_bar: bool = False,
@@ -374,6 +375,8 @@ def sample_blackjax_nuts(
         Initial values for random variables provided as a dictionary (or sequence of
         dictionaries) mapping the random variable (by name or reference) to desired
         starting values.
+    jitter: bool, default True
+        If True, add jitter to initial points.
     model : Model, optional
         Model to sample from. The model needs to have free random variables. When inside
         a ``with`` model context, it defaults to that model, otherwise the model must be
@@ -432,7 +435,7 @@ def sample_blackjax_nuts(
         chains=chains,
         initvals=initvals,
         random_seed=random_seed,
-        jitter=nuts_sampler_kwargs.get("jitter", True),
+        jitter=jitter,
     )
 
     if chains == 1:
@@ -565,6 +568,7 @@ def sample_numpyro_nuts(
     target_accept: float = 0.8,
     random_seed: Optional[RandomState] = None,
     initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]] = None,
+    jitter: Optional[bool] = True,
     model: Optional[Model] = None,
     var_names: Optional[Sequence[str]] = None,
     progressbar: bool = True,
@@ -599,6 +603,8 @@ def sample_numpyro_nuts(
         Initial values for random variables provided as a dictionary (or sequence of
         dictionaries) mapping the random variable (by name or reference) to desired
         starting values.
+    jitter: bool, default True
+        If True, add jitter to initial points.
     model : Model, optional
         Model to sample from. The model needs to have free random variables. When inside
         a ``with`` model context, it defaults to that model, otherwise the model must be
@@ -665,7 +671,7 @@ def sample_numpyro_nuts(
         chains=chains,
         initvals=initvals,
         random_seed=random_seed,
-        jitter=nuts_sampler_kwargs.get("jitter", True),
+        jitter=jitter,
     )
 
     logp_fn = get_jaxified_logp(model, negative_logp=False)

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -256,7 +256,7 @@ def _get_batched_jittered_initial_points(
     chains: int,
     initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]],
     random_seed: RandomSeed,
-    jitter: Optional[bool] = True,
+    jitter: bool = True,
     jitter_max_retries: int = 10,
 ) -> Union[np.ndarray, List[np.ndarray]]:
     """Get jittered initial point in format expected by NumPyro MCMC kernel
@@ -340,7 +340,7 @@ def sample_blackjax_nuts(
     target_accept: float = 0.8,
     random_seed: Optional[RandomState] = None,
     initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]] = None,
-    jitter: Optional[bool] = True,
+    jitter: bool = True,
     model: Optional[Model] = None,
     var_names: Optional[Sequence[str]] = None,
     progress_bar: bool = False,

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -173,17 +173,26 @@ def test_initvals_without_jitter(sampler):
         b = pm.Deterministic("b", a / 2.0)
         c = pm.Normal("c", a, sigma=1.0, observed=obs_at)
 
-        trace = sampler(
+        trace1 = sampler(
             chains=1,
-            tune=0,
+            tune=1,
             draws=1,
             random_seed=1322,
             initvals=initvals,
             jitter=False,
             keep_untransformed=True,
         )
+        trace2 = sampler(
+            chains=1,
+            tune=1,
+            draws=1,
+            random_seed=1322,
+            initvals=initvals,
+            keep_untransformed=True,
+        )
 
-    assert np.allclose(trace.posterior["a"].values[0], -3)
+    assert np.allclose(trace1.posterior["a"].values[0], -3)
+    assert not np.allclose(trace2.posterior["a"].values[0], -3)
 
 
 def test_get_jaxified_graph():

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -157,11 +157,10 @@ def test_deterministic_samples(sampler):
 @pytest.mark.parametrize(
     "sampler",
     [
-        # sample_blackjax_nuts,
+        sample_blackjax_nuts,
         sample_numpyro_nuts,
     ],
 )
-@pytest.mark.skipif(len(jax.devices()) < 2, reason="not enough devices")
 def test_initvals_without_jitter(sampler):
     pytensor.config.on_opt_error = "raise"
     np.random.seed(13244)
@@ -175,9 +174,9 @@ def test_initvals_without_jitter(sampler):
         c = pm.Normal("c", a, sigma=1.0, observed=obs_at)
 
         trace = sampler(
-            chains=2,
+            chains=1,
             tune=0,
-            draws=2,
+            draws=1,
             random_seed=1322,
             initvals=initvals,
             jitter=False,


### PR DESCRIPTION
Currently, initial values to the numpyro and jax nuts samplers are automatically jittered. 

This PR exposes the jitter option and allows the boolean to be set through nuts_sampler_kwargs.

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
There is no issue related to this change.
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7083.org.readthedocs.build/en/7083/

<!-- readthedocs-preview pymc end -->