### PR TITLE
Suppressed pip install bambi output in GLM core notebook

### DIFF
--- a/docs/source/learn/core_notebooks/GLM_linear.ipynb
+++ b/docs/source/learn/core_notebooks/GLM_linear.ipynb
@@ -268,7 +268,7 @@
     "try:\n",
     "    import bambi as bmb\n",
     "except ImportError:\n",
-    "    !{sys.executable} -m pip install --upgrade bambi\n",
+    "    !{sys.executable} -m pip install -q --upgrade bambi\n",
     "    import bambi as bmb"
    ]
   },
@@ -553,7 +553,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.12"
   },
   "latex_envs": {
    "bibliofile": "biblio.bib",


### PR DESCRIPTION
## Description
Suppressed the output from the pip install bambi in the GLM core notebook #7086 

## Related Issue
- [x] Closes #7086 
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7090.org.readthedocs.build/en/7090/

<!-- readthedocs-preview pymc end -->