### PR TITLE
Report divergences from JAX samplers

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -342,6 +342,8 @@ def _sample_external_nuts(
             coords=coords,
             dims=dims,
         )
+        warns = run_convergence_checks(idata, model)
+        log_warnings(warns)
         return idata
 
     elif sampler == "numpyro":
@@ -359,6 +361,8 @@ def _sample_external_nuts(
             idata_kwargs=idata_kwargs,
             **nuts_sampler_kwargs,
         )
+        warns = run_convergence_checks(idata, model)
+        log_warnings(warns)
         return idata
 
     elif sampler == "blackjax":
@@ -376,6 +380,8 @@ def _sample_external_nuts(
             idata_kwargs=idata_kwargs,
             **nuts_sampler_kwargs,
         )
+        warns = run_convergence_checks(idata, model)
+        log_warnings(warns)
         return idata
 
     else:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -342,8 +342,6 @@ def _sample_external_nuts(
             coords=coords,
             dims=dims,
         )
-        warns = run_convergence_checks(idata, model)
-        log_warnings(warns)
         return idata
 
     elif sampler == "numpyro":


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
PyMC users are used to getting an immediate report when there are divergences in the standard NUTS sampler. So I added a warning to be printed in case of divergence.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7041

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7094.org.readthedocs.build/en/7094/

<!-- readthedocs-preview pymc end -->