### PR TITLE
Make VI compatible with JAX backend

### DIFF
--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -22,7 +22,6 @@ import pytensor
 import pytensor.tensor as pt
 import scipy.sparse as sps
 
-from pytensor import scalar
 from pytensor.compile import Function, Mode, get_mode
 from pytensor.compile.builders import OpFromGraph
 from pytensor.gradient import grad
@@ -38,6 +37,7 @@ from pytensor.graph.basic import (
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.op import Op
 from pytensor.scalar.basic import Cast
+from pytensor.scalar.basic import identity as scalar_identity
 from pytensor.scan.op import Scan
 from pytensor.tensor.basic import _as_tensor_variable
 from pytensor.tensor.elemwise import Elemwise
@@ -412,28 +412,6 @@ def hessian_diag(f, vars=None, negate_output=True):
         return empty_gradient
 
 
-class IdentityOp(scalar.UnaryScalarOp):
-    @staticmethod
-    def st_impl(x):
-        return x
-
-    def impl(self, x):
-        return x
-
-    def grad(self, inp, grads):
-        return grads
-
-    def c_code(self, node, name, inp, out, sub):
-        return f"{out[0]} = {inp[0]};"
-
-    def __eq__(self, other):
-        return isinstance(self, type(other))
-
-    def __hash__(self):
-        return hash(type(self))
-
-
-scalar_identity = IdentityOp(scalar.upgrade_to_float, name="scalar_identity")
 identity = Elemwise(scalar_identity, name="identity")
 
 

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -37,9 +37,8 @@ from pytensor.graph.basic import (
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.op import Op
 from pytensor.scalar.basic import Cast
-from pytensor.scalar.basic import identity as scalar_identity
 from pytensor.scan.op import Scan
-from pytensor.tensor.basic import _as_tensor_variable
+from pytensor.tensor.basic import _as_tensor_variable, tensor_copy
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.type import RandomType
@@ -412,7 +411,7 @@ def hessian_diag(f, vars=None, negate_output=True):
         return empty_gradient
 
 
-identity = Elemwise(scalar_identity, name="identity")
+identity = tensor_copy
 
 
 def make_shared_replacements(point, vars, model):

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -46,7 +46,6 @@ from pymc.backends.arviz import (
 from pymc.distributions.multivariate import PosDefMatrix
 from pymc.initial_point import StartDict
 from pymc.logprob.utils import CheckParameterValue
-from pymc.pytensorf import IdentityOp
 from pymc.sampling.mcmc import _init_jitter
 from pymc.stats.convergence import log_warnings, run_convergence_checks
 from pymc.util import (
@@ -68,14 +67,6 @@ __all__ = (
     "sample_blackjax_nuts",
     "sample_numpyro_nuts",
 )
-
-
-@jax_funcify.register(IdentityOp)
-def jax_funcify_Identity(op, **kwargs):
-    def identity_fn(value):
-        return value
-
-    return identity_fn
 
 
 @jax_funcify.register(Assert)

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -46,6 +46,7 @@ from pymc.backends.arviz import (
 from pymc.distributions.multivariate import PosDefMatrix
 from pymc.initial_point import StartDict
 from pymc.logprob.utils import CheckParameterValue
+from pymc.pytensorf import IdentityOp
 from pymc.sampling.mcmc import _init_jitter
 from pymc.stats.convergence import log_warnings, run_convergence_checks
 from pymc.util import (
@@ -67,6 +68,14 @@ __all__ = (
     "sample_blackjax_nuts",
     "sample_numpyro_nuts",
 )
+
+
+@jax_funcify.register(IdentityOp)
+def jax_funcify_Identity(op, **kwargs):
+    def identity_fn(value):
+        return value
+
+    return identity_fn
 
 
 @jax_funcify.register(Assert)

--- a/pymc/variational/approximations.py
+++ b/pymc/variational/approximations.py
@@ -228,7 +228,13 @@ class EmpiricalGroup(Group):
                 for j in range(len(trace)):
                     histogram[i] = DictToArrayBijection.map(trace.point(j, t)).data
                     i += 1
-        return dict(histogram=pytensor.shared(pm.floatX(histogram), "histogram"))
+        return dict(
+            histogram=pytensor.shared(
+                pm.floatX(histogram),
+                "histogram",
+                shape=histogram.shape,
+            )
+        )
 
     def _check_trace(self):
         trace = self._kwargs.get("trace", None)

--- a/pymc/variational/approximations.py
+++ b/pymc/variational/approximations.py
@@ -93,8 +93,8 @@ class MeanFieldGroup(Group):
         rho = rho1
 
         return {
-            "mu": pytensor.shared(pm.floatX(start), "mu"),
-            "rho": pytensor.shared(pm.floatX(rho), "rho"),
+            "mu": pytensor.shared(pm.floatX(start), "mu", shape=start.shape),
+            "rho": pytensor.shared(pm.floatX(rho), "rho", shape=rho.shape),
         }
 
     @node_property
@@ -137,7 +137,10 @@ class FullRankGroup(Group):
         start = self._prepare_start(start)
         n = self.ddim
         L_tril = np.eye(n)[np.tril_indices(n)].astype(pytensor.config.floatX)
-        return {"mu": pytensor.shared(start, "mu"), "L_tril": pytensor.shared(L_tril, "L_tril")}
+        return {
+            "mu": pytensor.shared(start, "mu", shape=start.shape),
+            "L_tril": pytensor.shared(L_tril, "L_tril", shape=L_tril.shape),
+        }
 
     @node_property
     def L(self):

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -87,16 +87,12 @@ def test_jax_PosDefMatrix():
         pytest.param(1),
         pytest.param(
             2,
-            marks=pytest.mark.skipif(
-                len(jax.devices()) < 2, reason="not enough devices"
-            ),
+            marks=pytest.mark.skipif(len(jax.devices()) < 2, reason="not enough devices"),
         ),
     ],
 )
 @pytest.mark.parametrize("postprocessing_vectorize", ["scan", "vmap"])
-def test_transform_samples(
-    sampler, postprocessing_backend, chains, postprocessing_vectorize
-):
+def test_transform_samples(sampler, postprocessing_backend, chains, postprocessing_vectorize):
     pytensor.config.on_opt_error = "raise"
     np.random.seed(13244)
 
@@ -243,9 +239,7 @@ def test_replace_shared_variables():
     x = pytensor.shared(5, name="shared_x")
 
     new_x = _replace_shared_variables([x])
-    shared_variables = [
-        var for var in graph_inputs(new_x) if isinstance(var, SharedVariable)
-    ]
+    shared_variables = [var for var in graph_inputs(new_x) if isinstance(var, SharedVariable)]
     assert not shared_variables
 
     x.default_update = x + 1
@@ -333,30 +327,23 @@ def test_idata_kwargs(
 
     posterior = idata.get("posterior")
     assert posterior is not None
-    x_dim_expected = idata_kwargs.get(
-        "dims", model_test_idata_kwargs.named_vars_to_dims
-    )["x"][0]
+    x_dim_expected = idata_kwargs.get("dims", model_test_idata_kwargs.named_vars_to_dims)["x"][0]
     assert x_dim_expected is not None
     assert posterior["x"].dims[-1] == x_dim_expected
 
-    x_coords_expected = idata_kwargs.get("coords", model_test_idata_kwargs.coords)[
-        x_dim_expected
-    ]
+    x_coords_expected = idata_kwargs.get("coords", model_test_idata_kwargs.coords)[x_dim_expected]
     assert x_coords_expected is not None
     assert list(x_coords_expected) == list(posterior["x"].coords[x_dim_expected].values)
 
     assert posterior["z"].dims[2] == "z_coord"
     assert np.all(
-        posterior["z"].coords["z_coord"].values
-        == np.array(["apple", "banana", "orange"])
+        posterior["z"].coords["z_coord"].values == np.array(["apple", "banana", "orange"])
     )
 
 
 def test_get_batched_jittered_initial_points():
     with pm.Model() as model:
-        x = pm.MvNormal(
-            "x", mu=np.zeros(3), cov=np.eye(3), shape=(2, 3), initval=np.zeros((2, 3))
-        )
+        x = pm.MvNormal("x", mu=np.zeros(3), cov=np.eye(3), shape=(2, 3), initval=np.zeros((2, 3)))
 
     # No jitter
     ips = _get_batched_jittered_initial_points(
@@ -365,17 +352,13 @@ def test_get_batched_jittered_initial_points():
     assert np.all(ips[0] == 0)
 
     # Single chain
-    ips = _get_batched_jittered_initial_points(
-        model=model, chains=1, random_seed=1, initvals=None
-    )
+    ips = _get_batched_jittered_initial_points(model=model, chains=1, random_seed=1, initvals=None)
 
     assert ips[0].shape == (2, 3)
     assert np.all(ips[0] != 0)
 
     # Multiple chains
-    ips = _get_batched_jittered_initial_points(
-        model=model, chains=2, random_seed=1, initvals=None
-    )
+    ips = _get_batched_jittered_initial_points(model=model, chains=2, random_seed=1, initvals=None)
 
     assert ips[0].shape == (2, 2, 3)
     assert np.all(ips[0][0] != ips[0][1])
@@ -395,9 +378,7 @@ def test_get_batched_jittered_initial_points():
         pytest.param(1),
         pytest.param(
             2,
-            marks=pytest.mark.skipif(
-                len(jax.devices()) < 2, reason="not enough devices"
-            ),
+            marks=pytest.mark.skipif(len(jax.devices()) < 2, reason="not enough devices"),
         ),
     ],
 )
@@ -421,12 +402,8 @@ def test_seeding(chains, random_seed, sampler):
         assert all_equal
 
     if chains > 1:
-        assert np.all(
-            result1.posterior["x"].sel(chain=0) != result1.posterior["x"].sel(chain=1)
-        )
-        assert np.all(
-            result2.posterior["x"].sel(chain=0) != result2.posterior["x"].sel(chain=1)
-        )
+        assert np.all(result1.posterior["x"].sel(chain=0) != result1.posterior["x"].sel(chain=1))
+        assert np.all(result2.posterior["x"].sel(chain=0) != result2.posterior["x"].sel(chain=1))
 
 
 @mock.patch("numpyro.infer.MCMC")
@@ -574,7 +551,21 @@ def test_vi_sampling_jax(method):
         pm.fit(10, method=method, fn_kwargs=dict(mode="JAX"))
 
 
-@pytest.mark.xfail(reason="Due to https://github.com/pymc-devs/pytensor/issues/595")
+@pytest.mark.xfail(
+    reason="""
+During equilibrium rewriter this error happens. Probably one of the routines in SVGD is problematic.
+
+TypeError: The broadcast pattern of the output of scan
+(Matrix(float64, shape=(?, 1))) is inconsistent with the one provided in `output_info`
+(Vector(float64, shape=(?,))). The output on axis 0 is `True`, but it is `False` on axis
+1 in `output_info`. This can happen if one of the dimension is fixed to 1 in the input,
+while it is still variable in the output, or vice-verca. You have to make them consistent,
+e.g. using pytensor.tensor.{unbroadcast, specify_broadcastable}.
+
+Instead of fixing this error it makes sense to rework the internals of the variational to utilize
+pytensor vectorize instead of scan.
+"""
+)
 def test_vi_sampling_jax_svgd():
     with pm.Model():
         x = pm.Normal("x")

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -572,3 +572,10 @@ def test_vi_sampling_jax(method):
     with pm.Model() as model:
         x = pm.Normal("x")
         pm.fit(10, method=method, fn_kwargs=dict(mode="JAX"))
+
+
+@pytest.mark.xfail(reason="Due to https://github.com/pymc-devs/pytensor/issues/595")
+def test_vi_sampling_jax_svgd():
+    with pm.Model():
+        x = pm.Normal("x")
+        pm.fit(10, method="svgd", fn_kwargs=dict(mode="JAX"))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7104
- [x] Related to https://github.com/pymc-devs/pytensor/issues/595

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7103.org.readthedocs.build/en/7103/

<!-- readthedocs-preview pymc end -->