### PR TITLE
Gitpod instructions: use latest version of pymc

### DIFF
--- a/docs/source/contributing/using_gitpod.md
+++ b/docs/source/contributing/using_gitpod.md
@@ -106,9 +106,9 @@ These instructions are for contributing specifically to the [pymc-devs/pymc](htt
     git checkout main
     ```
 
-    Sync the repository code: `git pull upstream main`
+    Sync the repository code and version tags: `git pull upstream main --tags`
 
-    Rebuild the source code: `pip install -e .`
+    Update installed version number: `pip install -e .`
 
     Example:
     ```console

--- a/docs/source/contributing/using_gitpod.md
+++ b/docs/source/contributing/using_gitpod.md
@@ -100,18 +100,43 @@ These instructions are for contributing specifically to the [pymc-devs/pymc](htt
 
 8. Syncing the repository
 
+    Ensure you are in the correct place: 
     ```console
     cd /workspace/pymc
     git checkout main
+    ```
+    
+    Sync the repository code: `git pull upstream main`
 
-    # sync the repo
-    git pull upstream main
+    Rebuild the source code: `pip install -e .`
 
-    # rebuild the source code
-    pip install -e .
+    Example:
+    ```console
+    Obtaining file:///workspace/pymc
+    Installing build dependencies ... done
+    Checking if build backend supports build_editable ... done
+    Getting requirements to build editable ... done
+    Preparing editable metadata (pyproject.toml) ... done
+    Requirement already satisfied: arviz>=0.13.0 in /opt/conda/lib/python3.11/site-packages (from pymc==5.1.1+303.g6f8f9eef) (0.15.1)
+    ...
+    Building editable for pymc (pyproject.toml) ... done
+    Created wheel for pymc: filename=pymc-5.1.1+303.g6f8f9eef-0.editable-py3-none-any.whl size=11527 sha256=6211b7149b3ab09813b2badb3010f54d2d4ab014f75054d73f204ac5ea82ed82
+    Stored in directory: /tmp/pip-ephem-wheel-cache-wmkfx8pd/wheels/73/bf/14/341b7fa040e9af1991e12077c13913921be3069fe3bdf78752
+    Successfully built pymc
+    Installing collected packages: pytensor, pymc
+    Attempting uninstall: pytensor
+    Found existing installation: pytensor 2.10.1
+    Uninstalling pytensor-2.10.1:
+      Successfully uninstalled pytensor-2.10.1
+    Successfully installed pymc-5.1.1+303.g6f8f9eef pytensor-2.18.6
+    ```
 
-    # print PyMC version being used
-    python -c "import pymc; print(pymc.__version__)"
+    Check the PyMC version being used: `python -c "import pymc; print(pymc.__version__)"`
+
+    Example:
+    ```console
+    (base) gitpod@reshamas-pymc-syxfrf90fp0:/workspace/pymc$ python -c "import pymc; print(pymc.__version__)"
+    5.1.1+303.g6f8f9eef
     ```
 
 ### Reminder: Git Workflow

--- a/docs/source/contributing/using_gitpod.md
+++ b/docs/source/contributing/using_gitpod.md
@@ -105,7 +105,7 @@ These instructions are for contributing specifically to the [pymc-devs/pymc](htt
     cd /workspace/pymc
     git checkout main
     ```
-    
+
     Sync the repository code: `git pull upstream main`
 
     Rebuild the source code: `pip install -e .`

--- a/docs/source/contributing/using_gitpod.md
+++ b/docs/source/contributing/using_gitpod.md
@@ -98,6 +98,22 @@ These instructions are for contributing specifically to the [pymc-devs/pymc](htt
     Python 3.11.0
     ```
 
+8. Syncing the repository
+
+    ```console
+    cd /workspace/pymc
+    git checkout main
+
+    # sync the repo
+    git pull upstream main
+
+    # rebuild the source code
+    pip install -e .
+
+    # print PyMC version being used
+    python -c "import pymc; print(pymc.__version__)"
+    ```
+
 ### Reminder: Git Workflow
 
 :::{attention}

--- a/docs/source/contributing/using_gitpod.md
+++ b/docs/source/contributing/using_gitpod.md
@@ -100,7 +100,7 @@ These instructions are for contributing specifically to the [pymc-devs/pymc](htt
 
 8. Syncing the repository
 
-    Ensure you are in the correct place: 
+    Ensure you are in the correct place:
     ```console
     cd /workspace/pymc
     git checkout main


### PR DESCRIPTION
## Description
Update Gitpod instructions to rebuild code and show updated version of PyMC

## Related Issue
- [ ] Towards #6600 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7106.org.readthedocs.build/en/7106/

<!-- readthedocs-preview pymc end -->