### PR TITLE
Update links to Welcome bot images

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,6 +1,6 @@
 # Comment to be posted to on first time issues
 newIssueWelcomeComment: >
-  [![Welcome Banner](https://zenodo.org/api/iiif/v2/0c0188d3-d03c-4830-a6e3-00405f5c22fa:8ff47a85-7250-4d86-8e48-2f346b48b2c1:BannerWelcome.jpg/full/750,/0/default.jpg)](https://zenodo.org/record/3695300)
+  ![Welcome Banner](https://raw.githubusercontent.com/pymc-devs/brand/main/welcome-bot/BannerWelcome.jpg)]
 
   :tada: Welcome to _PyMC_! :tada:
   We're really excited to have your input into the project! :sparkling_heart:
@@ -10,7 +10,7 @@ newIssueWelcomeComment: >
 
 # Comment to be posted to on PRs from first time contributors in your repository
 newPRWelcomeComment: >
-  [![Thank You Banner](https://zenodo.org/api/iiif/v2/0c0188d3-d03c-4830-a6e3-00405f5c22fa:7fbd97cf-283b-480c-b8e1-11866e26245c:BannerThanks.jpg/full/750,/0/default.jpg)](https://zenodo.org/record/3695300)
+  ![Thank You Banner](https://raw.githubusercontent.com/pymc-devs/brand/main/welcome-bot/BannerThanks.jpg)]
 
   :sparkling_heart: Thanks for opening this pull request! :sparkling_heart:
   The _PyMC_ community really appreciates your time and effort to contribute to the project.
@@ -19,7 +19,7 @@ newPRWelcomeComment: >
 
 # Comment to be posted to on pull requests merged by a first time user
 firstPRMergeComment: >
-  [![Congratulations Banner](https://zenodo.org/api/iiif/v2/0c0188d3-d03c-4830-a6e3-00405f5c22fa:32fbdb89-ae1b-434e-830c-88ade86724cc:BannerCongratulations.jpg/full/750,/0/default.jpg)](https://zenodo.org/record/3695300)
+  ![Congratulations Banner](https://raw.githubusercontent.com/pymc-devs/brand/main/welcome-bot/BannerCongratulations.jpg)]
 
   Congrats on merging your first pull request! :tada:
   We here at _PyMC_ are proud of you! :sparkling_heart:


### PR DESCRIPTION
## Description
The links to the images for the Welcome Bot for new contributors is broken because the link location has changed. 

a) The images have been copied here: https://github.com/reshamas/brand-pymc-dev/tree/main/welcome-bot
b) The config.yml file has been updated with the correct links now.

Example of broken links:

<img width="981" alt="Screenshot 2024-01-15 at 11 08 16 AM" src="https://github.com/pymc-devs/pymc/assets/2507232/f73b3dc8-20f6-4b24-86ba-b4b7a1eafe7f">


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7107.org.readthedocs.build/en/7107/

<!-- readthedocs-preview pymc end -->