### PR TITLE
GP do not fail when xdims cannot be constant folded

### DIFF
--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -180,14 +180,15 @@ class Covariance(BaseCovariance):
         """The dimensionality of the input, as taken from the
         `active_dims`.
         """
-        # Evaluate lazily in-case this changes.
+        # Evaluate lazily in case this changes.
         return len(self.active_dims)
 
     def _slice(self, X, Xs=None):
         xdims = X.shape[-1]
         if isinstance(xdims, Variable):
-            [xdims] = constant_fold([xdims])
-        if self.input_dim != xdims:
+            [xdims] = constant_fold([xdims], raise_not_constant=False)
+        # If xdims can't be fully constant folded, it will be a TensorVariable
+        if isinstance(xdims, int) and self.input_dim != xdims:
             warnings.warn(
                 f"Only {self.input_dim} column(s) out of {xdims} are"
                 " being used to compute the covariance function. If this"

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -446,7 +446,7 @@ class HSGPPeriodic(Base):
 
         with pm.Model() as model:
             # Specify the covariance function, only for the 1-D case
-            scale = pm.HalfNormal(10)
+            scale = pm.HalfNormal("scale", 10)
             cov_func = pm.gp.cov.Periodic(1, period=1, ls=0.1)
 
             # Specify the approximation with 25 basis vectors
@@ -535,8 +535,8 @@ class HSGPPeriodic(Base):
             X = np.linspace(0, 10, 100)[:, None]
 
             with pm.Model() as model:
-                scale = pm.HalfNormal(10)
-                cov_func = pm.gp.cov.Periodic(1, period=1, ls=ell)
+                scale = pm.HalfNormal("scale", 10)
+                cov_func = pm.gp.cov.Periodic(1, period=1.0, ls=2.0)
 
                 # m=200 means 200 basis vectors
                 gp = pm.gp.HSGPPeriodic(m=200, scale=scale, cov_func=cov_func)


### PR DESCRIPTION
## Description
Closes #7000.  Going with @ricardoV94's suggestion of try/except, from the comments in that issue.

## Related Issue
- [x] Closes #7000

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change]

## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7111.org.readthedocs.build/en/7111/

<!-- readthedocs-preview pymc end -->