### PR TITLE
Remove swapaxes before and after scan

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -188,14 +188,13 @@ def _postprocess_samples(
     postprocessing_vectorize: Literal["vmap", "scan"] = "scan",
 ) -> List[TensorVariable]:
     if postprocessing_vectorize == "scan":
-        t_raw_mcmc_samples = [jnp.swapaxes(t, 0, 1) for t in raw_mcmc_samples]
         jax_vfn = jax.vmap(jax_fn)
         _, outs = scan(
             lambda _, x: ((), jax_vfn(*x)),
             (),
-            _device_put(t_raw_mcmc_samples, postprocessing_backend),
+            _device_put(raw_mcmc_samples, postprocessing_backend),
         )
-        return [jnp.swapaxes(t, 0, 1) for t in outs]
+        return outs
     elif postprocessing_vectorize == "vmap":
         return jax.vmap(jax.vmap(jax_fn))(*_device_put(raw_mcmc_samples, postprocessing_backend))
     else:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
Currently, the results of `scan` are evaluated in `_postprocess_samples`, and then the axes are fixed in the list comprehension `[jnp.swapaxes(t, 0, 1) for _, t in outs]`. This seems to unnecessarily double the peak memory footprint of this method. Admittedly, I don't know much about `scan` and the jaxified function, but it seems that the we may not need to transpose before and after.
From what I gather, it doesnt matter if the in/out are of dimension (chains, draws, ...) or (draws, chains, ...). Avoiding the final transpose in the list comp should lower the peak memory footprint by about half (?)
In my testing, outputs were exactly the same after omitting the double transpose.

(But if the axis swaps are indeed necessary, maybe the operations can still be combined in a way that avoids the list comp at the end.)


Memory usage tested with the following:
```python
import pickle
from pathlib import Path

import jax
import jax.numpy as jnp
import pytest
from jax.experimental.maps import SerialLoop, xmap
from jax.lax import scan
from pymc.sampling.jax import _device_put, get_jaxified_graph

CUR_DIR = Path(__file__).parent

DIR_FIXTURES = CUR_DIR / "../fixtures/profiling"

PATH_MODEL = DIR_FIXTURES / "model_pm.p"
PATH_DATA = DIR_FIXTURES / "raw_mcmc_samples.p"

postprocessing_backend = None


@pytest.fixture
def model():
    return pickle.load(open(PATH_MODEL, "rb"))


@pytest.fixture
def raw_mcmc_samples():
    return pickle.load(open(PATH_DATA, "rb"))


def get_jax_fn(model):
    vars_to_sample = [
        v for v in model.unobserved_value_vars if not v.name.endswith("__")
    ]
    jax_fn = get_jaxified_graph(inputs=model.value_vars, outputs=vars_to_sample)
    return jax_fn


def test_scan_vmap(model, raw_mcmc_samples):
    jax_fn = get_jax_fn(model)

    t_raw_mcmc_samples = [jnp.swapaxes(t, 0, 1) for t in raw_mcmc_samples]
    jax_vfn = jax.vmap(jax_fn)
    _, outs = scan(
        lambda _, x: ((), jax_vfn(*x)),
        (),
        _device_put(t_raw_mcmc_samples, postprocessing_backend),
    )
    ret = [jnp.swapaxes(t, 0, 1) for t in outs]


def test_scan_vmap_wo_transpose(model, raw_mcmc_samples):
    jax_fn = get_jax_fn(model)

    jax_vfn = jax.vmap(jax_fn)
    _, outs = scan(
        lambda _, x: ((), jax_vfn(*x)),
        (),
        _device_put(raw_mcmc_samples, postprocessing_backend),
    )
    ret = outs


def test_nested_vmap(model, raw_mcmc_samples):
    jax_fn = get_jax_fn(model)
    ret = jax.vmap(jax.vmap(jax_fn))(
        *_device_put(raw_mcmc_samples, postprocessing_backend)
    )


def test_looped_vmap(model, raw_mcmc_samples, num_chunks=100):
    # https://discourse.pymc.io/t/nameerror-unbound-axis-name-raised-during-transformation-of-variables-after-sample-numpyro-nuts/11167/5
    jax_fn = get_jax_fn(model)

    # dims are vars, chains, draws, ...
    raw_mcmc_samples = _device_put(raw_mcmc_samples, postprocessing_backend)
    f = jax.vmap(jax.vmap(jax_fn))
    draws = len(raw_mcmc_samples[0][0])
    segs = list(range(0, draws, draws // num_chunks)) + [draws]
    # dims are chunks, vars, chains, draws, ...
    outputs = [
        f(*[var_samples[:, i:j] for var_samples in raw_mcmc_samples])
        for i, j in zip(segs[:-1], segs[1:])
    ]
    # dims of var_chunks are chunks, chains, draws, ...
    ret = [jnp.concatenate(var_chunks, axis=1) for var_chunks in zip(*outputs)]
```
(Note: I couldn't get the legacy chunked xmap method to work -- ran into some jax issue I couldn't decipher)

With the following results using [memray](https://github.com/bloomberg/memray):
```
========================================================================= MEMRAY REPORT =========================================================================
Allocation results for src/tests/profiling/test_jax_postproc_profile.py::test_looped_vmap at the high watermark

         📦 Total memory allocated: 3.4GiB
         📏 Total allocations: 5272432
         📊 Histogram of allocation sizes: |  █ ▁    |
         🥇 Biggest allocating functions:
                - <lambda>:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/dispatch.py:164 -> 1.3GiB
                - __call__:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/interpreters/pxla.py:1149 -> 761.9MiB
                - _pjit_call_impl:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/pjit.py:1214 -> 653.7MiB
                - _pjit_call_impl:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/pjit.py:1214 -> 653.7MiB
                - _pjit_call_impl:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/pjit.py:1214 -> 90.3MiB


Allocation results for src/tests/profiling/test_jax_postproc_profile.py::test_nested_vmap at the high watermark

         📦 Total memory allocated: 2.9GiB
         📏 Total allocations: 1657858
         📊 Histogram of allocation sizes: |  █ ▁    |
         🥇 Biggest allocating functions:
                - _pjit_call_impl:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/pjit.py:1214 -> 653.4MiB
                - __call__:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/interpreters/pxla.py:1149 -> 653.4MiB
                - __call__:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/interpreters/pxla.py:1149 -> 653.4MiB
                - __call__:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/interpreters/pxla.py:1149 -> 653.4MiB
                - __call__:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/interpreters/pxla.py:1149 -> 163.3MiB


Allocation results for src/tests/profiling/test_jax_postproc_profile.py::test_scan_vmap at the high watermark

         📦 Total memory allocated: 2.8GiB
         📏 Total allocations: 1416835
         📊 Histogram of allocation sizes: |  █ ▁    |
         🥇 Biggest allocating functions:
                - __call__:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/interpreters/pxla.py:1149 -> 1.4GiB
                - __call__:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/interpreters/pxla.py:1149 -> 761.9MiB
                - <listcomp>:/Users/jason/Wonder/  -ds/src/tests/profiling/test_jax_postproc_profile.py:50 -> 653.4MiB
                - __call__:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/interpreters/pxla.py:1149 -> 18.6MiB
                - <lambda>:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/dispatch.py:164 -> 4.1MiB


Allocation results for src/tests/profiling/test_jax_postproc_profile.py::test_scan_vmap_wo_transpose at the high watermark

         📦 Total memory allocated: 1.6GiB
         📏 Total allocations: 605385
         📊 Histogram of allocation sizes: |▁ █ ▁    |
         🥇 Biggest allocating functions:
                - __call__:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/interpreters/pxla.py:1149 -> 1.6GiB
                - <lambda>:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/dispatch.py:164 -> 6.6MiB
                - __call__:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/pytensor/link/c/basic.py:1767 -> 3.3MiB
                - backend_compile:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/jax/_src/compiler.py:251 -> 1.6MiB
                - __init__:/Users/jason/mambaforge/envs/  /lib/python3.10/site-packages/pytensor/graph/rewriting/basic.py:2277 -> 1.0MiB

```
(Notice: 2.8GiB for `test_scan_vmap` and 1.6GiB for `test_scan_vmap_wo_transpose`)

Aside: I originally sought to bring back some notion of a `n_chunks` param to tradeoff runtime vs peak memory. But I guess that didn't really work out. Even at half the memory footprint, `_postprocess_samples` seems very peaky.


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #6744

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7116.org.readthedocs.build/en/7116/

<!-- readthedocs-preview pymc end -->