### PR TITLE
Enable ruff to use Python 3.9 and activate RUF rules

### DIFF
--- a/pymc/_version.py
+++ b/pymc/_version.py
@@ -153,7 +153,7 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
         root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print(f"Tried directories {str(rootdirs)} but none started with prefix {parentdir_prefix}")
+        print(f"Tried directories {rootdirs} but none started with prefix {parentdir_prefix}")
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 

--- a/pymc/_version.py
+++ b/pymc/_version.py
@@ -29,7 +29,7 @@ import re
 import subprocess
 import sys
 
-from typing import Callable, Dict
+from typing import Callable
 
 
 def get_keywords():
@@ -67,8 +67,8 @@ class NotThisMethod(Exception):
     """Exception raised if a method is not valid for the current scenario."""
 
 
-LONG_VERSION_PY: Dict[str, str] = {}
-HANDLERS: Dict[str, Dict[str, Callable]] = {}
+LONG_VERSION_PY: dict[str, str] = {}
+HANDLERS: dict[str, dict[str, Callable]] = {}
 
 
 def register_vcs_handler(vcs, method):  # decorator

--- a/pymc/_version.py
+++ b/pymc/_version.py
@@ -98,10 +98,10 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
 
     for command in commands:
         try:
-            dispcmd = str([command] + args)
+            dispcmd = str([command, *args])
             # remember shell=False, so use git.cmd on windows, not just git
             process = subprocess.Popen(
-                [command] + args,
+                [command, *args],
                 cwd=cwd,
                 env=env,
                 stdout=subprocess.PIPE,

--- a/pymc/backends/__init__.py
+++ b/pymc/backends/__init__.py
@@ -60,8 +60,9 @@ Loading a saved backend
 Saved backends can be loaded using `arviz.from_netcdf`
 
 """
+from collections.abc import Mapping, Sequence
 from copy import copy
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -94,7 +95,7 @@ def _init_trace(
     *,
     expected_length: int,
     chain_number: int,
-    stats_dtypes: List[Dict[str, type]],
+    stats_dtypes: list[dict[str, type]],
     trace: Optional[BaseTrace],
     model: Model,
 ) -> BaseTrace:
@@ -121,7 +122,7 @@ def init_traces(
     step: Union[BlockedStep, CompoundStep],
     initial_point: Mapping[str, np.ndarray],
     model: Model,
-) -> Tuple[Optional[RunType], Sequence[IBaseTrace]]:
+) -> tuple[Optional[RunType], Sequence[IBaseTrace]]:
     """Initializes a trace recorder for each chain."""
     if HAS_MCB and isinstance(backend, Backend):
         return init_chain_adapters(

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -149,7 +149,7 @@ class _DefaultTrace:
 
         # initialize if necessary
         if k not in self.trace_dict:
-            array_shape = (self._len,) + value_shape
+            array_shape = (self._len, *value_shape)
             self.trace_dict[k] = np.empty(array_shape, dtype=np.array(v).dtype)
 
         # do the actual insertion

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -15,15 +15,11 @@
 import logging
 import warnings
 
+from collections.abc import Iterable, Mapping
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
     Optional,
-    Tuple,
     Union,
 )
 
@@ -51,7 +47,7 @@ _log = logging.getLogger(__name__)
 Var = Any
 
 
-def find_observations(model: "Model") -> Dict[str, Var]:
+def find_observations(model: "Model") -> dict[str, Var]:
     """If there are observations available, return them as a dictionary."""
     observations = {}
     for obs in model.observed_RVs:
@@ -68,7 +64,7 @@ def find_observations(model: "Model") -> Dict[str, Var]:
     return observations
 
 
-def find_constants(model: "Model") -> Dict[str, Var]:
+def find_constants(model: "Model") -> dict[str, Var]:
     """If there are constants available, return them as a dictionary."""
 
     # The constant data vars must be either pm.Data or TensorConstant or SharedVariable
@@ -99,7 +95,7 @@ def find_constants(model: "Model") -> Dict[str, Var]:
     return constant_data
 
 
-def coords_and_dims_for_inferencedata(model: Model) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+def coords_and_dims_for_inferencedata(model: Model) -> tuple[dict[str, Any], dict[str, Any]]:
     """Parse PyMC model coords and dims format to one accepted by InferenceData."""
     coords = {
         cname: np.array(cvals) if isinstance(cvals, tuple) else cvals
@@ -134,7 +130,7 @@ class _DefaultTrace:
 
     def __init__(self, samples: int):
         self._len: int = samples
-        self.trace_dict: Dict[str, np.ndarray] = {}
+        self.trace_dict: dict[str, np.ndarray] = {}
 
     def insert(self, k: str, v, idx: int):
         """
@@ -181,7 +177,7 @@ class InferenceDataConverter:
         predictions=None,
         coords: Optional[CoordSpec] = None,
         dims: Optional[DimSpec] = None,
-        sample_dims: Optional[List] = None,
+        sample_dims: Optional[list] = None,
         model=None,
         save_warmup: Optional[bool] = None,
         include_transformed: bool = False,
@@ -239,7 +235,7 @@ class InferenceDataConverter:
 
         self.observations = find_observations(self.model)
 
-    def split_trace(self) -> Tuple[Union[None, "MultiTrace"], Union[None, "MultiTrace"]]:
+    def split_trace(self) -> tuple[Union[None, "MultiTrace"], Union[None, "MultiTrace"]]:
         """Split MultiTrace object into posterior and warmup.
 
         Returns
@@ -461,7 +457,7 @@ def to_inference_data(
     log_likelihood: Union[bool, Iterable[str]] = False,
     coords: Optional[CoordSpec] = None,
     dims: Optional[DimSpec] = None,
-    sample_dims: Optional[List] = None,
+    sample_dims: Optional[list] = None,
     model: Optional["Model"] = None,
     save_warmup: Optional[bool] = None,
     include_transformed: bool = False,
@@ -530,7 +526,7 @@ def predictions_to_inference_data(
     model: Optional["Model"] = None,
     coords: Optional[CoordSpec] = None,
     dims: Optional[DimSpec] = None,
-    sample_dims: Optional[List] = None,
+    sample_dims: Optional[list] = None,
     idata_orig: Optional[InferenceData] = None,
     inplace: bool = False,
 ) -> InferenceData:

--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -21,16 +21,10 @@ import logging
 import warnings
 
 from abc import ABC
+from collections.abc import Mapping, Sequence, Sized
 from typing import (
     Any,
-    Dict,
-    List,
-    Mapping,
     Optional,
-    Sequence,
-    Set,
-    Sized,
-    Tuple,
     TypeVar,
     Union,
     cast,
@@ -55,10 +49,10 @@ class IBaseTrace(ABC, Sized):
     chain: int
     """Chain number."""
 
-    varnames: List[str]
+    varnames: list[str]
     """Names of tracked variables."""
 
-    sampler_vars: List[Dict[str, Union[type, np.dtype]]]
+    sampler_vars: list[dict[str, Union[type, np.dtype]]]
     """Sampler stats for each sampler."""
 
     def __len__(self):
@@ -107,7 +101,7 @@ class IBaseTrace(ABC, Sized):
         """Slice trace object."""
         raise NotImplementedError()
 
-    def point(self, idx: int) -> Dict[str, np.ndarray]:
+    def point(self, idx: int) -> dict[str, np.ndarray]:
         """Return dictionary of point values at `idx` for current chain
         with variables names as keys.
         """
@@ -279,8 +273,8 @@ class BaseTrace(IBaseTrace):
         raise NotImplementedError()
 
     @property
-    def stat_names(self) -> Set[str]:
-        names: Set[str] = set()
+    def stat_names(self) -> set[str]:
+        names: set[str] = set()
         for vars in self.sampler_vars or []:
             names.update(vars.keys())
 
@@ -354,7 +348,7 @@ class MultiTrace:
         return len(self._straces)
 
     @property
-    def chains(self) -> List[int]:
+    def chains(self) -> list[int]:
         return list(sorted(self._straces.keys()))
 
     @property
@@ -423,18 +417,18 @@ class MultiTrace:
         return len(self._straces[chain])
 
     @property
-    def varnames(self) -> List[str]:
+    def varnames(self) -> list[str]:
         chain = self.chains[-1]
         return self._straces[chain].varnames
 
     @property
-    def stat_names(self) -> Set[str]:
+    def stat_names(self) -> set[str]:
         if not self._straces:
             return set()
         sampler_vars = [s.sampler_vars for s in self._straces.values()]
         if not all(svars == sampler_vars[0] for svars in sampler_vars):
             raise ValueError("Inividual chains contain different sampler stats")
-        names: Set[str] = set()
+        names: set[str] = set()
         for trace in self._straces.values():
             if trace.sampler_vars is None:
                 continue
@@ -450,7 +444,7 @@ class MultiTrace:
         combine: bool = True,
         chains: Optional[Union[int, Sequence[int]]] = None,
         squeeze: bool = True,
-    ) -> List[np.ndarray]:
+    ) -> list[np.ndarray]:
         """Get values from traces.
 
         Parameters
@@ -489,7 +483,7 @@ class MultiTrace:
         combine: bool = True,
         chains: Optional[Union[int, Sequence[int]]] = None,
         squeeze: bool = True,
-    ) -> Union[List[np.ndarray], np.ndarray]:
+    ) -> Union[list[np.ndarray], np.ndarray]:
         """Get sampler statistics from the trace.
 
         Note: This implementation attempts to squeeze object arrays into a consistent dtype,
@@ -539,7 +533,7 @@ class MultiTrace:
         trace._report = self._report._slice(*idxs)
         return trace
 
-    def point(self, idx: int, chain: Optional[int] = None) -> Dict[str, np.ndarray]:
+    def point(self, idx: int, chain: Optional[int] = None) -> dict[str, np.ndarray]:
         """Return a dictionary of point values at `idx`.
 
         Parameters
@@ -583,7 +577,7 @@ def _squeeze_cat(results, combine: bool, squeeze: bool):
 S = TypeVar("S", bound=Sized)
 
 
-def _choose_chains(traces: Sequence[S], tune: int) -> Tuple[List[S], int]:
+def _choose_chains(traces: Sequence[S], tune: int) -> tuple[list[S], int]:
     """
     Filter and slice traces such that (n_traces * len(shortest_trace)) is maximized.
 

--- a/pymc/backends/mcbackend.py
+++ b/pymc/backends/mcbackend.py
@@ -16,7 +16,8 @@ import base64
 import logging
 import pickle
 
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union, cast
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional, Union, cast
 
 import hagelkorn
 import mcbackend as mcb
@@ -41,7 +42,7 @@ from pymc.step_methods.compound import (
 _log = logging.getLogger(__name__)
 
 
-def find_data(pmodel: Model) -> List[mcb.DataVariable]:
+def find_data(pmodel: Model) -> list[mcb.DataVariable]:
     """Extracts data variables from a model."""
     observed_rvs = {pmodel.rvs_to_values[rv] for rv in pmodel.observed_RVs}
     dvars = []
@@ -62,7 +63,7 @@ def find_data(pmodel: Model) -> List[mcb.DataVariable]:
 
 def get_variables_and_point_fn(
     model: Model, initial_point: Mapping[str, np.ndarray]
-) -> Tuple[List[mcb.Variable], PointFunc]:
+) -> tuple[list[mcb.Variable], PointFunc]:
     """Get metadata on free, value and deterministic model variables."""
     # The samplers act only on the inputs needed for the log-likelihood,
     # but the user is interested in transformed variables and deterministics.
@@ -196,7 +197,7 @@ class ChainRecordAdapter(IBaseTrace):
             nchain.append(draw, stats)
         return ChainRecordAdapter(nchain, self._point_fn, self._statsbj)
 
-    def point(self, idx: int) -> Dict[str, np.ndarray]:
+    def point(self, idx: int) -> dict[str, np.ndarray]:
         return self._chain.get_draws_at(idx, [v.name for v in self._chain.variables.values()])
 
 
@@ -205,7 +206,7 @@ def make_runmeta_and_point_fn(
     initial_point: Mapping[str, np.ndarray],
     step: Union[CompoundStep, BlockedStep],
     model: Model,
-) -> Tuple[mcb.RunMeta, PointFunc]:
+) -> tuple[mcb.RunMeta, PointFunc]:
     variables, point_fn = get_variables_and_point_fn(model, initial_point)
 
     check_step_emits_tune(step)
@@ -255,7 +256,7 @@ def init_chain_adapters(
     initial_point: Mapping[str, np.ndarray],
     step: Union[CompoundStep, BlockedStep],
     model: Model,
-) -> Tuple[mcb.Run, List[ChainRecordAdapter]]:
+) -> tuple[mcb.Run, list[ChainRecordAdapter]]:
     """Create an McBackend metadata description for the MCMC run.
 
     Parameters

--- a/pymc/backends/mcbackend.py
+++ b/pymc/backends/mcbackend.py
@@ -169,7 +169,7 @@ class ChainRecordAdapter(IBaseTrace):
                 is_ragged = True
                 continue
             else:
-                stats_arrays.append(tuple(sd.values())[0])
+                stats_arrays.append(next(iter(sd.values())))
 
         if is_ragged:
             _log.debug("Stat '%s' was not recorded by all samplers.", stat_name)

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -72,12 +72,12 @@ class NDArray(base.BaseTrace):
             self.draw_idx = old_draws
             for varname, shape in self.var_shapes.items():
                 old_var_samples = self.samples[varname]
-                new_var_samples = np.zeros((draws,) + shape, self.var_dtypes[varname])
+                new_var_samples = np.zeros((draws, *shape), self.var_dtypes[varname])
                 self.samples[varname] = np.concatenate((old_var_samples, new_var_samples), axis=0)
         else:  # Otherwise, make array of zeros for each variable.
             self.draws = draws
             for varname, shape in self.var_shapes.items():
-                self.samples[varname] = np.zeros((draws,) + shape, dtype=self.var_dtypes[varname])
+                self.samples[varname] = np.zeros((draws, *shape), dtype=self.var_dtypes[varname])
 
         if sampler_vars is None:
             return

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -18,7 +18,7 @@ Store sampling values in memory as a NumPy array.
 """
 
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import numpy as np
 
@@ -85,7 +85,7 @@ class NDArray(base.BaseTrace):
         if self._stats is None:
             self._stats = []
             for sampler in sampler_vars:
-                data: Dict[str, np.ndarray] = dict()
+                data: dict[str, np.ndarray] = dict()
                 self._stats.append(data)
                 for varname, dtype in sampler.items():
                     data[varname] = np.zeros(draws, dtype=dtype)
@@ -176,14 +176,14 @@ class NDArray(base.BaseTrace):
             return sliced
         sliced._stats = []
         for vars in self._stats:
-            var_sliced: Dict[str, np.ndarray] = {}
+            var_sliced: dict[str, np.ndarray] = {}
             sliced._stats.append(var_sliced)
             for key, vals in vars.items():
                 var_sliced[key] = vals[idx]
 
         return sliced
 
-    def point(self, idx) -> Dict[str, Any]:
+    def point(self, idx) -> dict[str, Any]:
         """Return dictionary of point values at `idx` for current chain
         with variable names as keys.
         """
@@ -211,7 +211,7 @@ def _slice_as_ndarray(strace, idx):
 
 
 def point_list_to_multitrace(
-    point_list: List[Dict[str, np.ndarray]], model: Optional[Model] = None
+    point_list: list[dict[str, np.ndarray]], model: Optional[Model] = None
 ) -> MultiTrace:
     """transform point list into MultiTrace"""
     _model = modelcontext(model)

--- a/pymc/backends/report.py
+++ b/pymc/backends/report.py
@@ -15,7 +15,7 @@
 import dataclasses
 import logging
 
-from typing import Dict, List, Optional
+from typing import Optional
 
 from pymc.stats.convergence import _LEVELS, SamplerWarning
 
@@ -26,8 +26,8 @@ class SamplerReport:
     """Bundle warnings, convergence stats and metadata of a sampling run."""
 
     def __init__(self) -> None:
-        self._chain_warnings: Dict[int, List[SamplerWarning]] = {}
-        self._global_warnings: List[SamplerWarning] = []
+        self._chain_warnings: dict[int, list[SamplerWarning]] = {}
+        self._global_warnings: list[SamplerWarning] = []
         self._n_tune = None
         self._n_draws = None
         self._t_sampling = None

--- a/pymc/blocking.py
+++ b/pymc/blocking.py
@@ -19,16 +19,14 @@ Classes for working with subsets of parameters.
 """
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import partial
 from typing import (
     Any,
     Callable,
-    Dict,
     Generic,
-    List,
     NamedTuple,
     Optional,
-    Sequence,
     TypeVar,
     Union,
 )
@@ -41,9 +39,9 @@ __all__ = ["DictToArrayBijection"]
 
 
 T = TypeVar("T")
-PointType: TypeAlias = Dict[str, np.ndarray]
-StatsDict: TypeAlias = Dict[str, Any]
-StatsType: TypeAlias = List[StatsDict]
+PointType: TypeAlias = dict[str, np.ndarray]
+StatsDict: TypeAlias = dict[str, Any]
+StatsType: TypeAlias = list[StatsDict]
 StatDtype: TypeAlias = Union[type, np.dtype]
 StatShape: TypeAlias = Optional[Sequence[Optional[int]]]
 

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -16,8 +16,9 @@ import io
 import urllib.request
 import warnings
 
+from collections.abc import Sequence
 from copy import copy
-from typing import Dict, Optional, Sequence, Tuple, Union, cast
+from typing import Optional, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -204,8 +205,8 @@ def determine_coords(
     model,
     value: Union[pd.DataFrame, pd.Series, xr.DataArray],
     dims: Optional[Sequence[Optional[str]]] = None,
-    coords: Optional[Dict[str, Union[Sequence, np.ndarray]]] = None,
-) -> Tuple[Dict[str, Union[Sequence, np.ndarray]], Sequence[Optional[str]]]:
+    coords: Optional[dict[str, Union[Sequence, np.ndarray]]] = None,
+) -> tuple[dict[str, Union[Sequence, np.ndarray]], Sequence[Optional[str]]]:
     """Determines coordinate values from data or the model (via ``dims``)."""
     if coords is None:
         coords = {}
@@ -260,7 +261,7 @@ def ConstantData(
     value,
     *,
     dims: Optional[Sequence[str]] = None,
-    coords: Optional[Dict[str, Union[Sequence, np.ndarray]]] = None,
+    coords: Optional[dict[str, Union[Sequence, np.ndarray]]] = None,
     export_index_as_coords=False,
     infer_dims_and_coords=False,
     **kwargs,
@@ -294,7 +295,7 @@ def MutableData(
     value,
     *,
     dims: Optional[Sequence[str]] = None,
-    coords: Optional[Dict[str, Union[Sequence, np.ndarray]]] = None,
+    coords: Optional[dict[str, Union[Sequence, np.ndarray]]] = None,
     export_index_as_coords=False,
     infer_dims_and_coords=False,
     **kwargs,
@@ -328,7 +329,7 @@ def Data(
     value,
     *,
     dims: Optional[Sequence[str]] = None,
-    coords: Optional[Dict[str, Union[Sequence, np.ndarray]]] = None,
+    coords: Optional[dict[str, Union[Sequence, np.ndarray]]] = None,
     export_index_as_coords=False,
     infer_dims_and_coords=False,
     mutable: Optional[bool] = None,

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -22,7 +22,7 @@ nodes in PyMC.
 
 import warnings
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import numpy as np
 import pytensor
@@ -151,7 +151,7 @@ class BoundedContinuous(Continuous):
     """Base class for bounded continuous distributions"""
 
     # Indices of the arguments that define the lower and upper bounds of the distribution
-    bound_args_indices: Optional[List[int]] = None
+    bound_args_indices: Optional[list[int]] = None
 
 
 @_default_transform.register(PositiveContinuous)
@@ -569,7 +569,7 @@ class TruncatedNormalRV(RandomVariable):
         sigma: Union[np.ndarray, float],
         lower: Union[np.ndarray, float],
         upper: Union[np.ndarray, float],
-        size: Optional[Union[List[int], int]],
+        size: Optional[Union[list[int], int]],
     ) -> np.ndarray:
         # Upcast to float64. (Caller will downcast to desired dtype if needed)
         #   (Work-around for https://github.com/scipy/scipy/issues/15928)

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1159,7 +1159,7 @@ class Categorical(Discrete):
                 value_clip = pt.shape_padleft(value_clip, p_.ndim - value_clip.ndim)
             elif p.ndim < value_clip.ndim:
                 p = pt.shape_padleft(p, value_clip.ndim - p_.ndim)
-            pattern = (p.ndim - 1,) + tuple(range(p.ndim - 1))
+            pattern = (p.ndim - 1, *range(p.ndim - 1))
             a = pt.log(
                 pt.take_along_axis(
                     p.dimshuffle(pattern),

--- a/pymc/distributions/dist_math.py
+++ b/pymc/distributions/dist_math.py
@@ -334,7 +334,7 @@ def random_choice(p, size):
         # probability. We must iterate over the elements of all the other
         # dimensions.
         # We first ensure that p is broadcasted to the output's shape
-        size = to_tuple(size) + (1,)
+        size = (*to_tuple(size), 1)
         p = np.broadcast_arrays(p, np.empty(size))[0]
         out_shape = p.shape[:-1]
         # np.random.choice accepts 1D p arrays, so we semiflatten p to

--- a/pymc/distributions/dist_math.py
+++ b/pymc/distributions/dist_math.py
@@ -19,8 +19,8 @@ Created on Mar 7, 2011
 """
 import warnings
 
+from collections.abc import Iterable
 from functools import partial
-from typing import Iterable
 
 import numpy as np
 import pytensor

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -722,7 +722,7 @@ class _CustomSymbolicDist(Distribution):
             error_msg_on_access="Model variables cannot be created in the dist function. Use the `.dist` API"
         ):
             dummy_rv = dist(*dummy_dist_params, dummy_size_param)
-        dummy_params = [dummy_size_param] + dummy_dist_params
+        dummy_params = [dummy_size_param, *dummy_dist_params]
         dummy_updates_dict = collect_default_updates(inputs=dummy_params, outputs=(dummy_rv,))
 
         rv_type = type(
@@ -777,7 +777,7 @@ class _CustomSymbolicDist(Distribution):
             dummy_size_param = new_size.type()
             dummy_dist_params = [dist_param.type() for dist_param in old_dist_params]
             dummy_rv = dist(*dummy_dist_params, dummy_size_param)
-            dummy_params = [dummy_size_param] + dummy_dist_params
+            dummy_params = [dummy_size_param, *dummy_dist_params]
             dummy_updates_dict = collect_default_updates(inputs=dummy_params, outputs=(dummy_rv,))
             new_rv_op = rv_type(
                 inputs=dummy_params,

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -18,8 +18,9 @@ import types
 import warnings
 
 from abc import ABCMeta
+from collections.abc import Sequence
 from functools import singledispatch
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 
@@ -255,7 +256,7 @@ class SymbolicRandomVariable(OpFromGraph):
     If `False`, a logprob function must be dispatched directly to the subclass type.
     """
 
-    _print_name: Tuple[str, str] = ("Unknown", "\\operatorname{Unknown}")
+    _print_name: tuple[str, str] = ("Unknown", "\\operatorname{Unknown}")
     """Tuple of (name, latex name) used for for pretty-printing variables of this type"""
 
     def __init__(self, *args, ndim_supp, **kwargs):
@@ -1244,8 +1245,8 @@ class PartialObservedRV(SymbolicRandomVariable):
 def create_partial_observed_rv(
     rv: TensorVariable,
     mask: Union[np.ndarray, TensorVariable],
-) -> Tuple[
-    Tuple[TensorVariable, TensorVariable], Tuple[TensorVariable, TensorVariable], TensorVariable
+) -> tuple[
+    tuple[TensorVariable, TensorVariable], tuple[TensorVariable, TensorVariable], TensorVariable
 ]:
     """Separate observed and unobserved components of a RandomVariable.
 

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -315,7 +315,7 @@ class Mixture(Distribution):
             # axis intact, because that's what determines the number of mixture components
             mix_axis = -components[0].owner.op.ndim_supp - 1
             mix_size = components[0].shape[mix_axis]
-            size = tuple(size) + (mix_size,)
+            size = (*size, mix_size)
 
         return [change_dist_size(component, size) for component in components]
 

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -616,7 +616,7 @@ class DirichletMultinomialRV(RandomVariable):
 
             if size:
                 n = np.broadcast_to(n, size)
-                a = np.broadcast_to(a, size + (a.shape[-1],))
+                a = np.broadcast_to(a, (*size, a.shape[-1]))
 
             res = np.empty(a.shape)
             for idx in np.ndindex(a.shape[:-1]):
@@ -1205,7 +1205,7 @@ class _LKJCholeskyCov(Distribution):
         # implied batched dimensions from those for the time being.
         if size is None:
             size = sd_dist.shape[:-1]
-        shape = tuple(size) + (n,)
+        shape = (*size, n)
         if sd_dist.owner.op.ndim_supp == 0:
             sd_dist = change_dist_size(sd_dist, shape)
         else:
@@ -1685,7 +1685,7 @@ class LKJCorr:
     @classmethod
     def vec_to_corr_mat(cls, vec, n):
         tri = pt.zeros(pt.concatenate([vec.shape[:-1], (n, n)]))
-        tri = pt.subtensor.set_subtensor(tri[(...,) + np.triu_indices(n, 1)], vec)
+        tri = pt.subtensor.set_subtensor(tri[(..., *np.triu_indices(n, 1))], vec)
         return tri + pt.moveaxis(tri, -2, -1) + pt.diag(pt.ones(n))
 
 
@@ -2183,7 +2183,7 @@ class CARRV(RandomVariable):
 
         size = tuple(size or ())
         if size:
-            mu = np.broadcast_to(mu, size + (mu.shape[-1],))
+            mu = np.broadcast_to(mu, (*size, mu.shape[-1]))
         z = rng.normal(size=mu.shape)
         samples = np.empty(z.shape)
         for idx in np.ndindex(mu.shape[:-1]):
@@ -2492,7 +2492,7 @@ class StickBreakingWeightsRV(RandomVariable):
             raise ValueError("K needs to be positive.")
 
         size = to_tuple(size) if size is not None else alpha.shape
-        size = size + (K,)
+        size = (*size, K)
         alpha = alpha[..., np.newaxis]
 
         betas = rng.beta(1, alpha, size=size)

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -19,8 +19,9 @@ samples from probability distributions for stochastic nodes in PyMC.
 """
 import warnings
 
+from collections.abc import Sequence
 from functools import singledispatch
-from typing import Any, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Optional, Union, cast
 
 import numpy as np
 
@@ -175,9 +176,9 @@ Dims: TypeAlias = Union[str, Sequence[Optional[str]]]
 Size: TypeAlias = Union[int, TensorVariable, Sequence[Union[int, Variable]]]
 
 # After conversion to vectors
-StrongShape: TypeAlias = Union[TensorVariable, Tuple[Union[int, Variable], ...]]
+StrongShape: TypeAlias = Union[TensorVariable, tuple[Union[int, Variable], ...]]
 StrongDims: TypeAlias = Sequence[Optional[str]]
-StrongSize: TypeAlias = Union[TensorVariable, Tuple[Union[int, Variable], ...]]
+StrongSize: TypeAlias = Union[TensorVariable, tuple[Union[int, Variable], ...]]
 
 
 def convert_dims(dims: Optional[Dims]) -> Optional[StrongDims]:

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -420,7 +420,7 @@ def get_support_shape(
     shape: Optional[Shape] = None,
     dims: Optional[Dims] = None,
     observed: Optional[Any] = None,
-    support_shape_offset: Sequence[int] = None,
+    support_shape_offset: Optional[Sequence[int]] = None,
     ndim_supp: int = 1,
 ) -> Optional[TensorVariable]:
     """Extract the support shapes from shape / dims / observed information

--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -819,7 +819,7 @@ class GARCH11(Distribution):
         (noise_next_rng,) = tuple(innov_updates_.values())
 
         garch11_ = pt.concatenate([init_[None, ...], y_t], axis=0).dimshuffle(
-            tuple(range(1, y_t.ndim)) + (0,)
+            (*range(1, y_t.ndim), 0)
         )
 
         garch11_op = GARCH11RV(
@@ -850,7 +850,7 @@ def garch11_logp(
 ):
     (value,) = values
     # Move the time axis to the first dimension
-    value_dimswapped = value.dimshuffle((value.ndim - 1,) + tuple(range(0, value.ndim - 1)))
+    value_dimswapped = value.dimshuffle((value.ndim - 1, *range(0, value.ndim - 1)))
     initial_vol = initial_vol * pt.ones_like(value_dimswapped[0])
 
     def volatility_update(x, vol, w, a, b):
@@ -991,18 +991,18 @@ class EulerMaruyama(Distribution):
         y_t, innov_updates_ = pytensor.scan(
             fn=step,
             outputs_info=[init_],
-            non_sequences=sde_pars_ + [noise_rng],
+            non_sequences=[*sde_pars_, noise_rng],
             n_steps=steps_,
             strict=True,
         )
         (noise_next_rng,) = tuple(innov_updates_.values())
 
         sde_out_ = pt.concatenate([init_[None, ...], y_t], axis=0).dimshuffle(
-            tuple(range(1, y_t.ndim)) + (0,)
+            (*range(1, y_t.ndim), 0)
         )
 
         eulermaruyama_op = EulerMaruyamaRV(
-            inputs=[init_, steps_] + sde_pars_,
+            inputs=[init_, steps_, *sde_pars_],
             outputs=[noise_next_rng, sde_out_],
             dt=dt,
             sde_fn=sde_fn,

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -303,7 +303,7 @@ class ZeroSumTransform(Transform):
         norm = sum_vals / (pt.sqrt(n) + n)
         slice_before = (slice(None, None),) * normalized_axis
 
-        return array[slice_before + (slice(None, -1),)] + norm
+        return array[(*slice_before, slice(None, -1))] + norm
 
     def forward(self, value, *rv_inputs):
         for axis in self.zerosum_axes:

--- a/pymc/distributions/truncated.py
+++ b/pymc/distributions/truncated.py
@@ -247,7 +247,7 @@ class Truncated(Distribution):
         return TruncatedRV(
             base_rv_op=dist.owner.op,
             inputs=graph_inputs_,
-            outputs=[tuple(updates.values())[0], truncated_rv_],
+            outputs=[next(iter(updates.values())), truncated_rv_],
             ndim_supp=0,
             max_n_steps=max_n_steps,
         )(*graph_inputs)

--- a/pymc/func_utils.py
+++ b/pymc/func_utils.py
@@ -11,7 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import pytensor.tensor as pt
@@ -28,12 +28,12 @@ def find_constrained_prior(
     distribution: pm.Distribution,
     lower: float,
     upper: float,
-    init_guess: Dict[str, float],
+    init_guess: dict[str, float],
     mass: float = 0.95,
-    fixed_params: Optional[Dict[str, float]] = None,
+    fixed_params: Optional[dict[str, float]] = None,
     mass_below_lower: Optional[float] = None,
     **kwargs,
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """
     Find optimal parameters to get `mass` % of probability
     of a :ref:`distribution <api_distributions>` between `lower` and `upper`.

--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -16,9 +16,10 @@ import numbers
 import warnings
 
 from collections import Counter
+from collections.abc import Sequence
 from functools import reduce
 from operator import add, mul
-from typing import Any, Callable, List, Optional, Sequence, Union
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
 import pytensor.tensor as pt
@@ -229,7 +230,7 @@ class Combination(Covariance):
         super().__init__(input_dim=input_dim, active_dims=active_dims)
 
         # Set up combination kernel, flatten out factor_list so that
-        self._factor_list: List[Any] = []
+        self._factor_list: list[Any] = []
         for factor in factor_list:
             if isinstance(factor, self.__class__):
                 self._factor_list.extend(factor._factor_list)

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -15,8 +15,9 @@
 import numbers
 import warnings
 
+from collections.abc import Sequence
 from types import ModuleType
-from typing import Optional, Sequence, Union
+from typing import Optional, Union
 
 import numpy as np
 import pytensor.tensor as pt

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -14,7 +14,8 @@
 import functools
 import warnings
 
-from typing import Callable, Dict, List, Optional, Sequence, Set, Union
+from collections.abc import Sequence
+from typing import Callable, Optional, Union
 
 import numpy as np
 import pytensor
@@ -28,13 +29,13 @@ from pymc.logprob.transforms import Transform
 from pymc.pytensorf import compile_pymc, find_rng_nodes, replace_rng_nodes, reseed_rngs
 from pymc.util import get_transformed_name, get_untransformed_name, is_transformed_name
 
-StartDict = Dict[Union[Variable, str], Union[np.ndarray, Variable, str]]
-PointType = Dict[str, np.ndarray]
+StartDict = dict[Union[Variable, str], Union[np.ndarray, Variable, str]]
+PointType = dict[str, np.ndarray]
 
 
 def convert_str_to_rv_dict(
     model, start: StartDict
-) -> Dict[TensorVariable, Optional[Union[np.ndarray, Variable, str]]]:
+) -> dict[TensorVariable, Optional[Union[np.ndarray, Variable, str]]]:
     """Helper function for converting a user-provided start dict with str keys of (transformed) variable names
     to a dict mapping the RV tensors to untransformed initvals.
     TODO: Deprecate this functionality and only accept TensorVariables as keys
@@ -56,9 +57,9 @@ def make_initial_point_fns_per_chain(
     *,
     model,
     overrides: Optional[Union[StartDict, Sequence[Optional[StartDict]]]],
-    jitter_rvs: Optional[Set[TensorVariable]] = None,
+    jitter_rvs: Optional[set[TensorVariable]] = None,
     chains: int,
-) -> List[Callable]:
+) -> list[Callable]:
     """Create an initial point function for each chain, as defined by initvals
 
     If a single initval dictionary is passed, the function is replicated for each
@@ -112,7 +113,7 @@ def make_initial_point_fn(
     *,
     model,
     overrides: Optional[StartDict] = None,
-    jitter_rvs: Optional[Set[TensorVariable]] = None,
+    jitter_rvs: Optional[set[TensorVariable]] = None,
     default_strategy: str = "moment",
     return_transformed: bool = True,
 ) -> Callable:
@@ -177,12 +178,12 @@ def make_initial_point_fn(
 def make_initial_point_expression(
     *,
     free_rvs: Sequence[TensorVariable],
-    rvs_to_transforms: Dict[TensorVariable, Transform],
-    initval_strategies: Dict[TensorVariable, Optional[Union[np.ndarray, Variable, str]]],
-    jitter_rvs: Set[TensorVariable] = None,
+    rvs_to_transforms: dict[TensorVariable, Transform],
+    initval_strategies: dict[TensorVariable, Optional[Union[np.ndarray, Variable, str]]],
+    jitter_rvs: set[TensorVariable] = None,
     default_strategy: str = "moment",
     return_transformed: bool = False,
-) -> List[TensorVariable]:
+) -> list[TensorVariable]:
     """Creates the tensor variables that need to be evaluated to obtain an initial point.
 
     Parameters
@@ -263,7 +264,7 @@ def make_initial_point_expression(
 
         initial_values.append(value)
 
-    all_outputs: List[TensorVariable] = []
+    all_outputs: list[TensorVariable] = []
     all_outputs.extend(free_rvs)
     all_outputs.extend(initial_values)
     all_outputs.extend(initial_values_transformed)

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -180,7 +180,7 @@ def make_initial_point_expression(
     free_rvs: Sequence[TensorVariable],
     rvs_to_transforms: dict[TensorVariable, Transform],
     initval_strategies: dict[TensorVariable, Optional[Union[np.ndarray, Variable, str]]],
-    jitter_rvs: set[TensorVariable] = None,
+    jitter_rvs: Optional[set[TensorVariable]] = None,
     default_strategy: str = "moment",
     return_transformed: bool = False,
 ) -> list[TensorVariable]:

--- a/pymc/logprob/abstract.py
+++ b/pymc/logprob/abstract.py
@@ -36,8 +36,8 @@
 
 import abc
 
+from collections.abc import Sequence
 from functools import singledispatch
-from typing import Sequence, Tuple
 
 from pytensor.graph.op import Op
 from pytensor.graph.utils import MetaType
@@ -141,7 +141,7 @@ MeasurableVariable.register(RandomVariable)
 class MeasurableElemwise(Elemwise):
     """Base class for Measurable Elemwise variables"""
 
-    valid_scalar_types: Tuple[MetaType, ...] = ()
+    valid_scalar_types: tuple[MetaType, ...] = ()
 
     def __init__(self, scalar_op, *args, **kwargs):
         if not isinstance(scalar_op, self.valid_scalar_types):

--- a/pymc/logprob/basic.py
+++ b/pymc/logprob/basic.py
@@ -37,7 +37,8 @@
 import warnings
 
 from collections import deque
-from typing import Dict, List, Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import Optional, Union
 
 import numpy as np
 import pytensor.tensor as pt
@@ -407,12 +408,12 @@ RVS_IN_JOINT_LOGP_GRAPH_MSG = (
 
 
 def conditional_logp(
-    rv_values: Dict[TensorVariable, TensorVariable],
+    rv_values: dict[TensorVariable, TensorVariable],
     warn_rvs=None,
     ir_rewriter: Optional[GraphRewriter] = None,
     extra_rewrites: Optional[Union[GraphRewriter, NodeRewriter]] = None,
     **kwargs,
-) -> Dict[TensorVariable, TensorVariable]:
+) -> dict[TensorVariable, TensorVariable]:
     r"""Create a map between variables and conditional log-probabilities
     such that the sum is their joint log-probability.
 
@@ -586,11 +587,11 @@ def conditional_logp(
 def transformed_conditional_logp(
     rvs: Sequence[TensorVariable],
     *,
-    rvs_to_values: Dict[TensorVariable, TensorVariable],
-    rvs_to_transforms: Dict[TensorVariable, Transform],
+    rvs_to_values: dict[TensorVariable, TensorVariable],
+    rvs_to_transforms: dict[TensorVariable, Transform],
     jacobian: bool = True,
     **kwargs,
-) -> List[TensorVariable]:
+) -> list[TensorVariable]:
     """Thin wrapper around conditional_logprob, which creates a value transform rewrite.
 
     This helper will only return the subset of logprob terms corresponding to `rvs`.

--- a/pymc/logprob/binary.py
+++ b/pymc/logprob/binary.py
@@ -11,7 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import pytensor.tensor as pt
@@ -41,7 +41,7 @@ class MeasurableComparison(MeasurableElemwise):
 @node_rewriter(tracks=[gt, lt, ge, le])
 def find_measurable_comparisons(
     fgraph: FunctionGraph, node: Node
-) -> Optional[List[MeasurableComparison]]:
+) -> Optional[list[MeasurableComparison]]:
     rv_map_feature: Optional[PreserveRVMappings] = getattr(fgraph, "preserve_rv_mappings", None)
     if rv_map_feature is None:
         return None  # pragma: no cover
@@ -133,7 +133,7 @@ class MeasurableBitwise(MeasurableElemwise):
 
 
 @node_rewriter(tracks=[invert])
-def find_measurable_bitwise(fgraph: FunctionGraph, node: Node) -> Optional[List[MeasurableBitwise]]:
+def find_measurable_bitwise(fgraph: FunctionGraph, node: Node) -> Optional[list[MeasurableBitwise]]:
     rv_map_feature: Optional[PreserveRVMappings] = getattr(fgraph, "preserve_rv_mappings", None)
     if rv_map_feature is None:
         return None  # pragma: no cover

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -34,7 +34,7 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import pytensor.tensor as pt
@@ -62,7 +62,7 @@ measurable_clip = MeasurableClip(scalar_clip)
 
 
 @node_rewriter(tracks=[clip])
-def find_measurable_clips(fgraph: FunctionGraph, node: Node) -> Optional[List[MeasurableClip]]:
+def find_measurable_clips(fgraph: FunctionGraph, node: Node) -> Optional[list[MeasurableClip]]:
     # TODO: Canonicalize x[x>ub] = ub -> clip(x, x, ub)
 
     rv_map_feature: Optional[PreserveRVMappings] = getattr(fgraph, "preserve_rv_mappings", None)
@@ -157,7 +157,7 @@ class MeasurableRound(MeasurableElemwise):
 
 
 @node_rewriter(tracks=[ceil, floor, round_half_to_even])
-def find_measurable_roundings(fgraph: FunctionGraph, node: Node) -> Optional[List[MeasurableRound]]:
+def find_measurable_roundings(fgraph: FunctionGraph, node: Node) -> Optional[list[MeasurableRound]]:
     rv_map_feature: Optional[PreserveRVMappings] = getattr(fgraph, "preserve_rv_mappings", None)
     if rv_map_feature is None:
         return None  # pragma: no cover

--- a/pymc/logprob/checks.py
+++ b/pymc/logprob/checks.py
@@ -34,7 +34,7 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
-from typing import List, Optional
+from typing import Optional
 
 import pytensor.tensor as pt
 
@@ -63,7 +63,7 @@ def logprob_specify_shape(op, values, inner_rv, *shapes, **kwargs):
 
 
 @node_rewriter([SpecifyShape])
-def find_measurable_specify_shapes(fgraph, node) -> Optional[List[MeasurableSpecifyShape]]:
+def find_measurable_specify_shapes(fgraph, node) -> Optional[list[MeasurableSpecifyShape]]:
     r"""Finds `SpecifyShapeOp`\s for which a `logprob` can be computed."""
 
     if isinstance(node.op, MeasurableSpecifyShape):
@@ -116,7 +116,7 @@ def logprob_check_and_raise(op, values, inner_rv, *assertions, **kwargs):
 
 
 @node_rewriter([CheckAndRaise])
-def find_measurable_check_and_raise(fgraph, node) -> Optional[List[MeasurableCheckAndRaise]]:
+def find_measurable_check_and_raise(fgraph, node) -> Optional[list[MeasurableCheckAndRaise]]:
     r"""Finds `AssertOp`\s for which a `logprob` can be computed."""
 
     if isinstance(node.op, MeasurableCheckAndRaise):

--- a/pymc/logprob/cumsum.py
+++ b/pymc/logprob/cumsum.py
@@ -34,7 +34,7 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
-from typing import List, Optional
+from typing import Optional
 
 import pytensor.tensor as pt
 
@@ -77,7 +77,7 @@ def logprob_cumsum(op, values, base_rv, **kwargs):
 
 
 @node_rewriter([CumOp])
-def find_measurable_cumsums(fgraph, node) -> Optional[List[MeasurableCumsum]]:
+def find_measurable_cumsums(fgraph, node) -> Optional[list[MeasurableCumsum]]:
     r"""Finds `Cumsums`\s for which a `logprob` can be computed."""
 
     if not (isinstance(node.op, CumOp) and node.op.mode == "add"):

--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -310,7 +310,7 @@ def find_measurable_index_mixture(fgraph, node):
         old_mixture_rv.dtype,
         old_mixture_rv.broadcastable,
     )
-    new_node = mix_op.make_node(*([join_axis] + mixing_indices + mixture_rvs))
+    new_node = mix_op.make_node(*([join_axis, *mixing_indices, *mixture_rvs]))
 
     new_mixture_rv = new_node.default_output()
 

--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -34,7 +34,7 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
-from typing import List, Optional, Tuple, Union, cast
+from typing import Optional, Union, cast
 
 import pytensor
 import pytensor.tensor as pt
@@ -87,8 +87,8 @@ def is_newaxis(x):
 
 
 def expand_indices(
-    indices: Tuple[Optional[Union[Variable, slice]], ...], shape: Tuple[TensorVariable]
-) -> Tuple[TensorVariable]:
+    indices: tuple[Optional[Union[Variable, slice]], ...], shape: tuple[TensorVariable]
+) -> tuple[TensorVariable]:
     """Convert basic and/or advanced indices into a single, broadcasted advanced indexing operation.
 
     Parameters
@@ -201,7 +201,7 @@ def expand_indices(
 
         adv_indices.append(expanded_idx)
 
-    return cast(Tuple[TensorVariable], tuple(pt.broadcast_arrays(*adv_indices)))
+    return cast(tuple[TensorVariable], tuple(pt.broadcast_arrays(*adv_indices)))
 
 
 def rv_pull_down(x: TensorVariable) -> TensorVariable:
@@ -240,7 +240,7 @@ MeasurableVariable.register(MixtureRV)
 
 def get_stack_mixture_vars(
     node: Apply,
-) -> Tuple[Optional[List[TensorVariable]], Optional[int]]:
+) -> tuple[Optional[list[TensorVariable]], Optional[int]]:
     r"""Extract the mixture terms from a `*Subtensor*` applied to stacked `MeasurableVariable`\s."""
 
     assert isinstance(node.op, subtensor_ops)

--- a/pymc/logprob/order.py
+++ b/pymc/logprob/order.py
@@ -34,7 +34,7 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
-from typing import List, Optional
+from typing import Optional
 
 import pytensor.tensor as pt
 
@@ -75,7 +75,7 @@ MeasurableVariable.register(MeasurableMaxDiscrete)
 
 
 @node_rewriter([Max])
-def find_measurable_max(fgraph: FunctionGraph, node: Node) -> Optional[List[TensorVariable]]:
+def find_measurable_max(fgraph: FunctionGraph, node: Node) -> Optional[list[TensorVariable]]:
     rv_map_feature = getattr(fgraph, "preserve_rv_mappings", None)
     if rv_map_feature is None:
         return None  # pragma: no cover
@@ -169,7 +169,7 @@ MeasurableVariable.register(MeasurableMaxNeg)
 
 
 @node_rewriter(tracks=[Max])
-def find_measurable_max_neg(fgraph: FunctionGraph, node: Node) -> Optional[List[TensorVariable]]:
+def find_measurable_max_neg(fgraph: FunctionGraph, node: Node) -> Optional[list[TensorVariable]]:
     rv_map_feature = getattr(fgraph, "preserve_rv_mappings", None)
 
     if rv_map_feature is None:

--- a/pymc/logprob/rewriting.py
+++ b/pymc/logprob/rewriting.py
@@ -285,7 +285,7 @@ class PreserveRVMappings(Feature):
 
 
 @register_canonicalize
-@node_rewriter((Elemwise, Alloc, DimShuffle) + subtensor_ops)
+@node_rewriter((Elemwise, Alloc, DimShuffle, *subtensor_ops))
 def local_lift_DiracDelta(fgraph, node):
     r"""Lift basic `Op`\s through `DiracDelta`\s."""
 

--- a/pymc/logprob/rewriting.py
+++ b/pymc/logprob/rewriting.py
@@ -36,7 +36,8 @@
 import warnings
 
 from collections import deque
-from typing import Dict, List, Optional, Sequence, Tuple
+from collections.abc import Sequence
+from typing import Optional
 
 import pytensor.tensor as pt
 
@@ -208,7 +209,7 @@ class PreserveRVMappings(Feature):
 
     """
 
-    def __init__(self, rv_values: Dict[TensorVariable, TensorVariable]):
+    def __init__(self, rv_values: dict[TensorVariable, TensorVariable]):
         """
         Parameters
         ----------
@@ -270,7 +271,7 @@ class PreserveRVMappings(Feature):
             if new_r.name is None:
                 new_r.name = r.name
 
-    def request_measurable(self, vars: Sequence[Variable]) -> List[Variable]:
+    def request_measurable(self, vars: Sequence[Variable]) -> list[Variable]:
         measurable = []
         for var in vars:
             # Input vars or valued vars can't be measured for derived expressions
@@ -397,9 +398,9 @@ cleanup_ir_rewrites_db.register("remove_DiracDelta", remove_DiracDelta, "cleanup
 
 
 def construct_ir_fgraph(
-    rv_values: Dict[Variable, Variable],
+    rv_values: dict[Variable, Variable],
     ir_rewriter: Optional[GraphRewriter] = None,
-) -> Tuple[FunctionGraph, Dict[Variable, Variable], Dict[Variable, Variable]]:
+) -> tuple[FunctionGraph, dict[Variable, Variable], dict[Variable, Variable]]:
     r"""Construct a `FunctionGraph` in measurable IR form for the keys in `rv_values`.
 
     A custom IR rewriter can be specified. By default,

--- a/pymc/logprob/scan.py
+++ b/pymc/logprob/scan.py
@@ -164,14 +164,14 @@ def convert_outer_out_to_in(
             inner_in_mit_sot_var = cast(
                 tuple[int, ...], tuple(output_scan_args.inner_in_mit_sot[var_idx])
             )
-            new_inner_in_seqs = inner_in_mit_sot_var + (new_inner_in_var,)
+            new_inner_in_seqs = (*inner_in_mit_sot_var, new_inner_in_var)
             new_inner_in_mit_sot = remove(output_scan_args.inner_in_mit_sot, var_idx)
             new_outer_in_mit_sot = remove(output_scan_args.outer_in_mit_sot, var_idx)
             new_inner_in_sit_sot = tuple(output_scan_args.inner_in_sit_sot)
             new_outer_in_sit_sot = tuple(output_scan_args.outer_in_sit_sot)
             add_nit_sot = True
         elif inner_out_info.name.endswith("sit_sot"):
-            new_inner_in_seqs = (output_scan_args.inner_in_sit_sot[var_idx],) + (new_inner_in_var,)
+            new_inner_in_seqs = (output_scan_args.inner_in_sit_sot[var_idx], new_inner_in_var)
             new_inner_in_sit_sot = remove(output_scan_args.inner_in_sit_sot, var_idx)
             new_outer_in_sit_sot = remove(output_scan_args.outer_in_sit_sot, var_idx)
             new_inner_in_mit_sot = tuple(output_scan_args.inner_in_mit_sot)
@@ -193,7 +193,7 @@ def convert_outer_out_to_in(
             mit_sot_var_taps = cast(
                 tuple[int, ...], tuple(output_scan_args.mit_sot_in_slices[var_idx])
             )
-            taps = mit_sot_var_taps + (0,)
+            taps = (*mit_sot_var_taps, 0)
             new_mit_sot_in_slices = remove(output_scan_args.mit_sot_in_slices, var_idx)
         elif inner_out_info.name.endswith("sit_sot"):
             taps = (-1, 0)
@@ -230,7 +230,7 @@ def convert_outer_out_to_in(
         output_scan_args.outer_in_seqs = list(new_outer_in_seqs)
 
         if add_nit_sot:
-            new_outer_in_nit_sot = tuple(output_scan_args.outer_in_nit_sot) + (n_steps,)
+            new_outer_in_nit_sot = (*output_scan_args.outer_in_nit_sot, n_steps)
         else:
             new_outer_in_nit_sot = tuple(output_scan_args.outer_in_nit_sot)
 

--- a/pymc/logprob/scan.py
+++ b/pymc/logprob/scan.py
@@ -34,8 +34,9 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
+from collections.abc import Iterable
 from copy import copy
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, cast
+from typing import Callable, Optional, cast
 
 import numpy as np
 import pytensor
@@ -78,8 +79,8 @@ MeasurableVariable.register(MeasurableScan)
 def convert_outer_out_to_in(
     input_scan_args: ScanArgs,
     outer_out_vars: Iterable[TensorVariable],
-    new_outer_input_vars: Dict[TensorVariable, TensorVariable],
-    inner_out_fn: Callable[[Dict[TensorVariable, TensorVariable]], Iterable[TensorVariable]],
+    new_outer_input_vars: dict[TensorVariable, TensorVariable],
+    inner_out_fn: Callable[[dict[TensorVariable, TensorVariable]], Iterable[TensorVariable]],
 ) -> ScanArgs:
     r"""Convert outer-graph outputs into outer-graph inputs.
 
@@ -161,7 +162,7 @@ def convert_outer_out_to_in(
         add_nit_sot = False
         if inner_out_info.name.endswith("mit_sot"):
             inner_in_mit_sot_var = cast(
-                Tuple[int, ...], tuple(output_scan_args.inner_in_mit_sot[var_idx])
+                tuple[int, ...], tuple(output_scan_args.inner_in_mit_sot[var_idx])
             )
             new_inner_in_seqs = inner_in_mit_sot_var + (new_inner_in_var,)
             new_inner_in_mit_sot = remove(output_scan_args.inner_in_mit_sot, var_idx)
@@ -190,7 +191,7 @@ def convert_outer_out_to_in(
 
         if inner_out_info.name.endswith("mit_sot"):
             mit_sot_var_taps = cast(
-                Tuple[int, ...], tuple(output_scan_args.mit_sot_in_slices[var_idx])
+                tuple[int, ...], tuple(output_scan_args.mit_sot_in_slices[var_idx])
             )
             taps = mit_sot_var_taps + (0,)
             new_mit_sot_in_slices = remove(output_scan_args.mit_sot_in_slices, var_idx)
@@ -270,7 +271,7 @@ def convert_outer_out_to_in(
 
 def get_random_outer_outputs(
     scan_args: ScanArgs,
-) -> List[Tuple[int, TensorVariable, TensorVariable]]:
+) -> list[tuple[int, TensorVariable, TensorVariable]]:
     """Get the `MeasurableVariable` outputs of a `Scan` (well, its `ScanArgs`).
 
     Returns
@@ -292,7 +293,7 @@ def get_random_outer_outputs(
     return rv_vars
 
 
-def construct_scan(scan_args: ScanArgs, **kwargs) -> Tuple[List[TensorVariable], OrderedUpdates]:
+def construct_scan(scan_args: ScanArgs, **kwargs) -> tuple[list[TensorVariable], OrderedUpdates]:
     scan_op = Scan(scan_args.inner_inputs, scan_args.inner_outputs, scan_args.info, **kwargs)
     node = scan_op.make_node(*scan_args.outer_inputs)
     updates = OrderedUpdates(zip(scan_args.outer_in_shared, scan_args.outer_out_shared))
@@ -308,7 +309,7 @@ def logprob_ScanRV(op, values, *inputs, name=None, **kwargs):
     var_indices, rv_vars, io_vars = zip(*rv_outer_outs)
     value_map = {_rv: _val for _rv, _val in zip(rv_vars, values)}
 
-    def create_inner_out_logp(value_map: Dict[TensorVariable, TensorVariable]) -> TensorVariable:
+    def create_inner_out_logp(value_map: dict[TensorVariable, TensorVariable]) -> TensorVariable:
         """Create a log-likelihood inner-output for a `Scan`."""
         logp_parts = conditional_logp(value_map, warn_rvs=False)
         return logp_parts.values()
@@ -394,7 +395,7 @@ def find_measurable_scans(fgraph, node):
         # Get any `Subtensor` outputs that have been applied to outputs of this
         # `Scan` (and get the corresponding indices of the outputs from this
         # `Scan`)
-        output_clients: List[Tuple[Variable, int]] = sum(
+        output_clients: list[tuple[Variable, int]] = sum(
             [
                 [
                     # This is expected to work for `Subtensor` `Op`s,

--- a/pymc/logprob/tensor.py
+++ b/pymc/logprob/tensor.py
@@ -34,7 +34,7 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import pytensor
 
@@ -199,7 +199,7 @@ def logprob_join(op, values, axis, *base_rvs, **kwargs):
 @node_rewriter([MakeVector, Join])
 def find_measurable_stacks(
     fgraph, node
-) -> Optional[List[Union[MeasurableMakeVector, MeasurableJoin]]]:
+) -> Optional[list[Union[MeasurableMakeVector, MeasurableJoin]]]:
     r"""Finds `Joins`\s and `MakeVector`\s for which a `logprob` can be computed."""
 
     rv_map_feature: Optional[PreserveRVMappings] = getattr(fgraph, "preserve_rv_mappings", None)
@@ -248,7 +248,7 @@ def logprob_dimshuffle(op, values, base_var, **kwargs):
 
     # Reverse the effects of dimshuffle on the value variable
     # First, drop any augmented dimensions and reinsert any dropped dimensions
-    undo_ds: List[Union[int, str]] = [i for i, o in enumerate(op.new_order) if o != "x"]
+    undo_ds: list[Union[int, str]] = [i for i, o in enumerate(op.new_order) if o != "x"]
     dropped_dims = tuple(sorted(set(op.transposition) - set(op.shuffle)))
     for dropped_dim in dropped_dims:
         undo_ds.insert(dropped_dim, "x")
@@ -273,7 +273,7 @@ def logprob_dimshuffle(op, values, base_var, **kwargs):
 
 
 @node_rewriter([DimShuffle])
-def find_measurable_dimshuffles(fgraph, node) -> Optional[List[MeasurableDimShuffle]]:
+def find_measurable_dimshuffles(fgraph, node) -> Optional[list[MeasurableDimShuffle]]:
     r"""Finds `Dimshuffle`\s for which a `logprob` can be computed."""
 
     rv_map_feature: Optional[PreserveRVMappings] = getattr(fgraph, "preserve_rv_mappings", None)

--- a/pymc/logprob/transform_value.py
+++ b/pymc/logprob/transform_value.py
@@ -12,7 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from typing import Dict, Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import Optional, Union
 
 import numpy as np
 
@@ -319,7 +320,7 @@ class TransformValuesRewrite(GraphRewriter):
 
     def __init__(
         self,
-        values_to_transforms: Dict[TensorVariable, Union[Transform, None]],
+        values_to_transforms: dict[TensorVariable, Union[Transform, None]],
     ):
         """
         Parameters

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -35,7 +35,7 @@
 #   SOFTWARE.
 import abc
 
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import pytensor.tensor as pt
@@ -130,7 +130,7 @@ class Transform(abc.ABC):
     @abc.abstractmethod
     def backward(
         self, value: TensorVariable, *inputs: Variable
-    ) -> Union[TensorVariable, Tuple[TensorVariable, ...]]:
+    ) -> Union[TensorVariable, tuple[TensorVariable, ...]]:
         """Invert the transformation. Multiple values may be returned when the
         transformation is not 1-to-1"""
 
@@ -411,7 +411,7 @@ def measurable_power_exponent_to_exp(fgraph, node):
         erfcx,
     ]
 )
-def find_measurable_transforms(fgraph: FunctionGraph, node: Node) -> Optional[List[Node]]:
+def find_measurable_transforms(fgraph: FunctionGraph, node: Node) -> Optional[list[Node]]:
     """Find measurable transformations from Elemwise operators."""
 
     # Node was already converted
@@ -443,7 +443,7 @@ def find_measurable_transforms(fgraph: FunctionGraph, node: Node) -> Optional[Li
 
     scalar_op = node.op.scalar_op
     measurable_input_idx = 0
-    transform_inputs: Tuple[TensorVariable, ...] = (measurable_input,)
+    transform_inputs: tuple[TensorVariable, ...] = (measurable_input,)
     transform: Transform
 
     transform_dict = {
@@ -804,7 +804,7 @@ class PowerTransform(Transform):
 class IntervalTransform(Transform):
     name = "interval"
 
-    def __init__(self, args_fn: Callable[..., Tuple[Optional[Variable], Optional[Variable]]]):
+    def __init__(self, args_fn: Callable[..., tuple[Optional[Variable], Optional[Variable]]]):
         """
 
         Parameters

--- a/pymc/logprob/utils.py
+++ b/pymc/logprob/utils.py
@@ -36,7 +36,8 @@
 import typing
 import warnings
 
-from typing import Container, Dict, List, Optional, Sequence, Set, Tuple, Union
+from collections.abc import Container, Sequence
+from typing import Optional, Union
 
 import numpy as np
 import pytensor
@@ -62,9 +63,9 @@ if typing.TYPE_CHECKING:
 def replace_rvs_by_values(
     graphs: Sequence[TensorVariable],
     *,
-    rvs_to_values: Dict[TensorVariable, TensorVariable],
-    rvs_to_transforms: Optional[Dict[TensorVariable, "Transform"]] = None,
-) -> List[TensorVariable]:
+    rvs_to_values: dict[TensorVariable, TensorVariable],
+    rvs_to_transforms: Optional[dict[TensorVariable, "Transform"]] = None,
+) -> list[TensorVariable]:
     """Clone and replace random variables in graphs with their value variables.
 
     Parameters
@@ -127,7 +128,7 @@ def replace_rvs_by_values(
     return replace_vars_in_graphs(graphs, replacements)
 
 
-def rvs_in_graph(vars: Union[Variable, Sequence[Variable]]) -> Set[Variable]:
+def rvs_in_graph(vars: Union[Variable, Sequence[Variable]]) -> set[Variable]:
     """Assert that there are no `MeasurableVariable` nodes in a graph."""
 
     def expand(r):
@@ -169,7 +170,7 @@ def indices_from_subtensor(idx_list, indices):
 
 
 def check_potential_measurability(
-    inputs: Tuple[TensorVariable], valued_rvs: Container[TensorVariable]
+    inputs: tuple[TensorVariable], valued_rvs: Container[TensorVariable]
 ) -> bool:
     valued_rvs = set(valued_rvs)
 

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -334,7 +334,7 @@ class ValueGradFunction:
             grads = pytensor.grad(cost, grad_vars, disconnected_inputs="ignore")
             for grad_wrt, var in zip(grads, grad_vars):
                 grad_wrt.name = f"{var.name}_grad"
-            outputs = [cost] + grads
+            outputs = [cost, *grads]
         else:
             outputs = [cost]
 

--- a/pymc/model/fgraph.py
+++ b/pymc/model/fgraph.py
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 from copy import copy
-from typing import Dict, Optional, Tuple
+from typing import Optional
 
 import pytensor
 
@@ -115,7 +115,7 @@ remove_identity_rewrite = out2in(local_remove_identity)
 
 def fgraph_from_model(
     model: Model, inlined_views=False
-) -> Tuple[FunctionGraph, Dict[Variable, Variable]]:
+) -> tuple[FunctionGraph, dict[Variable, Variable]]:
     """Convert Model to FunctionGraph.
 
     See: model_from_fgraph
@@ -378,7 +378,7 @@ def clone_model(model: Model) -> Model:
     return model_from_fgraph(fgraph_from_model(model)[0])
 
 
-def extract_dims(var) -> Tuple:
+def extract_dims(var) -> tuple:
     dims = ()
     node = var.owner
     if node and isinstance(node.op, ModelVar):

--- a/pymc/model/transform/basic.py
+++ b/pymc/model/transform/basic.py
@@ -11,7 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from typing import List, Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 from pytensor import Variable
 from pytensor.graph import ancestors
@@ -53,7 +54,7 @@ def prune_vars_detached_from_observed(model: Model) -> Model:
     return model_from_fgraph(fgraph)
 
 
-def parse_vars(model: Model, vars: Union[ModelVariable, Sequence[ModelVariable]]) -> List[Variable]:
+def parse_vars(model: Model, vars: Union[ModelVariable, Sequence[ModelVariable]]) -> list[Variable]:
     if isinstance(vars, (list, tuple)):
         vars_seq = vars
     else:

--- a/pymc/model/transform/conditioning.py
+++ b/pymc/model/transform/conditioning.py
@@ -13,7 +13,8 @@
 #   limitations under the License.
 import warnings
 
-from typing import Any, Mapping, Optional, Sequence, Union
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional, Union
 
 from pytensor.graph import ancestors
 from pytensor.tensor import TensorVariable

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -14,7 +14,8 @@
 import warnings
 
 from collections import defaultdict
-from typing import Dict, Iterable, List, Optional, Sequence, Set
+from collections.abc import Iterable, Sequence
+from typing import Optional
 
 from pytensor import function
 from pytensor.compile.sharedvalue import SharedVariable
@@ -47,7 +48,7 @@ class ModelGraph:
         self._all_var_names = get_default_varnames(self.model.named_vars, include_transformed=False)
         self.var_list = self.model.named_vars.values()
 
-    def get_parent_names(self, var: TensorVariable) -> Set[VarName]:
+    def get_parent_names(self, var: TensorVariable) -> set[VarName]:
         if var.owner is None or var.owner.inputs is None:
             return set()
 
@@ -82,7 +83,7 @@ class ModelGraph:
 
         return parents
 
-    def vars_to_plot(self, var_names: Optional[Iterable[VarName]] = None) -> List[VarName]:
+    def vars_to_plot(self, var_names: Optional[Iterable[VarName]] = None) -> list[VarName]:
         if var_names is None:
             return self._all_var_names
 
@@ -114,9 +115,9 @@ class ModelGraph:
 
     def make_compute_graph(
         self, var_names: Optional[Iterable[VarName]] = None
-    ) -> Dict[VarName, Set[VarName]]:
+    ) -> dict[VarName, set[VarName]]:
         """Get map of var_name -> set(input var names) for the model"""
-        input_map: Dict[VarName, Set[VarName]] = defaultdict(set)
+        input_map: dict[VarName, set[VarName]] = defaultdict(set)
 
         for var_name in self.vars_to_plot(var_names):
             var = self.model[var_name]
@@ -197,7 +198,7 @@ class ModelGraph:
         else:
             graph.node(var_name.replace(":", "&"), **kwargs)
 
-    def get_plates(self, var_names: Optional[Iterable[VarName]] = None) -> Dict[str, Set[VarName]]:
+    def get_plates(self, var_names: Optional[Iterable[VarName]] = None) -> dict[str, set[VarName]]:
         """Rough but surprisingly accurate plate detection.
 
         Just groups by the shape of the underlying distribution.  Will be wrong

--- a/pymc/plots/__init__.py
+++ b/pymc/plots/__init__.py
@@ -56,7 +56,8 @@ traceplot = alias_deprecation(az.plot_trace, alias="traceplot")
 compareplot = alias_deprecation(az.plot_compare, alias="compareplot")
 
 
-__all__ = tuple(az.plots.__all__) + (
+__all__ = (
+    *az.plots.__all__,
     "autocorrplot",
     "compareplot",
     "forestplot",

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -13,16 +13,10 @@
 #   limitations under the License.
 import warnings
 
+from collections.abc import Generator, Iterable, Sequence
 from typing import (
     Callable,
-    Dict,
-    Generator,
-    Iterable,
-    List,
     Optional,
-    Sequence,
-    Set,
-    Tuple,
     Union,
 )
 
@@ -175,7 +169,7 @@ def extract_obs_data(x: TensorVariable) -> np.ndarray:
 
 def walk_model(
     graphs: Iterable[TensorVariable],
-    stop_at_vars: Optional[Set[TensorVariable]] = None,
+    stop_at_vars: Optional[set[TensorVariable]] = None,
     expand_fn: Callable[[TensorVariable], Iterable[TensorVariable]] = lambda var: [],
 ) -> Generator[TensorVariable, None, None]:
     """Walk model graphs and yield their nodes.
@@ -207,8 +201,8 @@ def walk_model(
 
 def replace_vars_in_graphs(
     graphs: Iterable[Variable],
-    replacements: Dict[Variable, Variable],
-) -> List[Variable]:
+    replacements: dict[Variable, Variable],
+) -> list[Variable]:
     """Replace variables in graphs.
 
     Graphs are cloned and not modified in place, unless the replacement expressions include variables from the original graphs.
@@ -437,12 +431,12 @@ def make_shared_replacements(point, vars, model):
 
 
 def join_nonshared_inputs(
-    point: Dict[str, np.ndarray],
-    outputs: List[TensorVariable],
-    inputs: List[TensorVariable],
-    shared_inputs: Optional[Dict[TensorVariable, TensorSharedVariable]] = None,
+    point: dict[str, np.ndarray],
+    outputs: list[TensorVariable],
+    inputs: list[TensorVariable],
+    shared_inputs: Optional[dict[TensorVariable, TensorSharedVariable]] = None,
     make_inputs_shared: bool = False,
-) -> Tuple[List[TensorVariable], TensorVariable]:
+) -> tuple[list[TensorVariable], TensorVariable]:
     """
     Create new outputs and input TensorVariables where the non-shared inputs are joined
     in a single raveled vector input.
@@ -572,7 +566,7 @@ def join_nonshared_inputs(
     if pytensor.config.compute_test_value != "off":
         joined_inputs.tag.test_value = raveled_inputs.tag.test_value
 
-    replace: Dict[TensorVariable, TensorVariable] = {}
+    replace: dict[TensorVariable, TensorVariable] = {}
     last_idx = 0
     for var in inputs:
         shape = point[var.name].shape
@@ -738,7 +732,7 @@ def largest_common_dtype(tensors):
 
 def find_rng_nodes(
     variables: Iterable[Variable],
-) -> List[Union[RandomStateSharedVariable, RandomGeneratorSharedVariable]]:
+) -> list[Union[RandomStateSharedVariable, RandomGeneratorSharedVariable]]:
     """Return RNG variables in a graph"""
     return [
         node
@@ -760,7 +754,7 @@ def replace_rng_nodes(outputs: Sequence[TensorVariable]) -> Sequence[TensorVaria
         return outputs
 
     graph = FunctionGraph(outputs=outputs, clone=False)
-    new_rng_nodes: List[Union[np.random.RandomState, np.random.Generator]] = []
+    new_rng_nodes: list[Union[np.random.RandomState, np.random.Generator]] = []
     for rng_node in rng_nodes:
         rng_cls: type
         if isinstance(rng_node, pt.random.var.RandomStateSharedVariable):
@@ -797,7 +791,7 @@ def collect_default_updates(
     *,
     inputs: Optional[Sequence[Variable]] = None,
     must_be_shared: bool = True,
-) -> Dict[Variable, Variable]:
+) -> dict[Variable, Variable]:
     """Collect default update expression for shared-variable RNGs used by RVs between inputs and outputs.
 
     Parameters
@@ -999,7 +993,7 @@ def compile_pymc(
 
 def constant_fold(
     xs: Sequence[TensorVariable], raise_not_constant: bool = True
-) -> Tuple[np.ndarray, ...]:
+) -> tuple[np.ndarray, ...]:
     """Use constant folding to get constant values of a graph.
 
     Parameters
@@ -1063,7 +1057,7 @@ def as_symbolic_string(x, **kwargs):
 
 
 def toposort_replace(
-    fgraph: FunctionGraph, replacements: Sequence[Tuple[Variable, Variable]], reverse: bool = False
+    fgraph: FunctionGraph, replacements: Sequence[tuple[Variable, Variable]], reverse: bool = False
 ) -> None:
     """Replace multiple variables in place in topological order."""
     toposort = fgraph.toposort()

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -345,8 +345,8 @@ def sample_prior_predictive(
     var_names: Optional[Iterable[str]] = None,
     random_seed: RandomState = None,
     return_inferencedata: bool = True,
-    idata_kwargs: dict = None,
-    compile_kwargs: dict = None,
+    idata_kwargs: Optional[dict] = None,
+    compile_kwargs: Optional[dict] = None,
 ) -> Union[InferenceData, dict[str, np.ndarray]]:
     """Generate samples from the prior predictive distribution.
 
@@ -446,8 +446,8 @@ def sample_posterior_predictive(
     return_inferencedata: bool = True,
     extend_inferencedata: bool = False,
     predictions: bool = False,
-    idata_kwargs: dict = None,
-    compile_kwargs: dict = None,
+    idata_kwargs: Optional[dict] = None,
+    compile_kwargs: Optional[dict] = None,
 ) -> Union[InferenceData, dict[str, np.ndarray]]:
     """Generate posterior predictive samples from a model given a trace.
 
@@ -681,7 +681,7 @@ def sample_posterior_predictive_w(
     random_seed: RandomState = None,
     progressbar: bool = True,
     return_inferencedata: bool = True,
-    idata_kwargs: dict = None,
+    idata_kwargs: Optional[dict] = None,
 ):
     """Generate weighted posterior predictive samples from a list of models and
     a list of traces according to a set of weights.

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 
 xla_flags_env = os.getenv("XLA_FLAGS", "")
 xla_flags = re.sub(r"--xla_force_host_platform_device_count=.+\s", "", xla_flags_env).split()
-os.environ["XLA_FLAGS"] = " ".join([f"--xla_force_host_platform_device_count={100}"] + xla_flags)
+os.environ["XLA_FLAGS"] = " ".join([f"--xla_force_host_platform_device_count={100}", *xla_flags])
 
 __all__ = (
     "get_jaxified_graph",

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -20,18 +20,11 @@ import sys
 import time
 import warnings
 
+from collections.abc import Iterator, Mapping, Sequence
 from typing import (
     Any,
-    Dict,
-    Iterator,
-    List,
     Literal,
-    Mapping,
     Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Type,
     Union,
     overload,
 )
@@ -100,10 +93,10 @@ _log = logging.getLogger(__name__)
 
 def instantiate_steppers(
     model: Model,
-    steps: List[Step],
-    selected_steps: Mapping[Type[BlockedStep], List[Any]],
-    step_kwargs: Optional[Dict[str, Dict]] = None,
-) -> Union[Step, List[Step]]:
+    steps: list[Step],
+    selected_steps: Mapping[type[BlockedStep], list[Any]],
+    step_kwargs: Optional[dict[str, dict]] = None,
+) -> Union[Step, list[Step]]:
     """Instantiate steppers assigned to the model variables.
 
     This function is intended to be called automatically from ``sample()``, but
@@ -161,9 +154,9 @@ def instantiate_steppers(
 def assign_step_methods(
     model: Model,
     step: Optional[Union[Step, Sequence[Step]]] = None,
-    methods: Optional[Sequence[Type[BlockedStep]]] = None,
-    step_kwargs: Optional[Dict[str, Any]] = None,
-) -> Union[Step, List[Step]]:
+    methods: Optional[Sequence[type[BlockedStep]]] = None,
+    step_kwargs: Optional[dict[str, Any]] = None,
+) -> Union[Step, list[Step]]:
     """Assign model variables to appropriate step methods.
 
     Passing a specified model will auto-assign its constituent stochastic
@@ -193,8 +186,8 @@ def assign_step_methods(
     methods : list
         List of step methods associated with the model's variables.
     """
-    steps: List[Step] = []
-    assigned_vars: Set[Variable] = set()
+    steps: list[Step] = []
+    assigned_vars: set[Variable] = set()
 
     if step is not None:
         if isinstance(step, (BlockedStep, CompoundStep)):
@@ -212,8 +205,8 @@ def assign_step_methods(
 
     # Use competence classmethods to select step methods for remaining
     # variables
-    methods_list: List[Type[BlockedStep]] = list(methods or pm.STEP_METHODS)
-    selected_steps: Dict[Type[BlockedStep], List] = {}
+    methods_list: list[type[BlockedStep]] = list(methods or pm.STEP_METHODS)
+    selected_steps: dict[type[BlockedStep], list] = {}
     model_logp = model.logp()
 
     for var in model.value_vars:
@@ -272,8 +265,8 @@ def _sample_external_nuts(
     initvals: Union[StartDict, Sequence[Optional[StartDict]], None],
     model: Model,
     progressbar: bool,
-    idata_kwargs: Optional[Dict],
-    nuts_sampler_kwargs: Optional[Dict],
+    idata_kwargs: Optional[dict],
+    nuts_sampler_kwargs: Optional[dict],
     **kwargs,
 ):
     if nuts_sampler_kwargs is None:
@@ -404,8 +397,8 @@ def sample(
     compute_convergence_checks: bool = True,
     keep_warning_stat: bool = False,
     return_inferencedata: Literal[True] = True,
-    idata_kwargs: Optional[Dict[str, Any]] = None,
-    nuts_sampler_kwargs: Optional[Dict[str, Any]] = None,
+    idata_kwargs: Optional[dict[str, Any]] = None,
+    nuts_sampler_kwargs: Optional[dict[str, Any]] = None,
     callback=None,
     mp_ctx=None,
     **kwargs,
@@ -433,8 +426,8 @@ def sample(
     compute_convergence_checks: bool = True,
     keep_warning_stat: bool = False,
     return_inferencedata: Literal[False],
-    idata_kwargs: Optional[Dict[str, Any]] = None,
-    nuts_sampler_kwargs: Optional[Dict[str, Any]] = None,
+    idata_kwargs: Optional[dict[str, Any]] = None,
+    nuts_sampler_kwargs: Optional[dict[str, Any]] = None,
     callback=None,
     mp_ctx=None,
     model: Optional[Model] = None,
@@ -462,8 +455,8 @@ def sample(
     compute_convergence_checks: bool = True,
     keep_warning_stat: bool = False,
     return_inferencedata: bool = True,
-    idata_kwargs: Optional[Dict[str, Any]] = None,
-    nuts_sampler_kwargs: Optional[Dict[str, Any]] = None,
+    idata_kwargs: Optional[dict[str, Any]] = None,
+    nuts_sampler_kwargs: Optional[dict[str, Any]] = None,
     callback=None,
     mp_ctx=None,
     model: Optional[Model] = None,
@@ -739,7 +732,7 @@ def sample(
         initial_points = [ipfn(seed) for ipfn, seed in zip(ipfns, random_seed_list)]
 
     # One final check that shapes and logps at the starting points are okay.
-    ip: Dict[str, np.ndarray]
+    ip: dict[str, np.ndarray]
     for ip in initial_points:
         model.check_start_vals(ip)
         _check_start_shape(model, ip)
@@ -848,7 +841,7 @@ def _sample_return(
     compute_convergence_checks: bool,
     return_inferencedata: bool,
     keep_warning_stat: bool,
-    idata_kwargs: Dict[str, Any],
+    idata_kwargs: dict[str, Any],
     model: Model,
 ) -> Union[InferenceData, MultiTrace]:
     """Final step of `pm.sampler` that picks/slices chains,
@@ -890,7 +883,7 @@ def _sample_return(
 
     idata = None
     if compute_convergence_checks or return_inferencedata:
-        ikwargs: Dict[str, Any] = dict(model=model, save_warmup=not discard_tuned_samples)
+        ikwargs: dict[str, Any] = dict(model=model, save_warmup=not discard_tuned_samples)
         ikwargs.update(idata_kwargs)
         idata = pm.to_inference_data(mtrace, **ikwargs)
 
@@ -1216,7 +1209,7 @@ def _init_jitter(
     seeds: Union[Sequence[int], np.ndarray],
     jitter: bool,
     jitter_max_retries: int,
-) -> List[PointType]:
+) -> list[PointType]:
     """Apply a uniform jitter in [-1, 1] to the test value as starting point in each chain.
 
     ``model.check_start_vals`` is used to test whether the jittered starting
@@ -1276,7 +1269,7 @@ def init_nuts(
     tune: Optional[int] = None,
     initvals: Optional[Union[StartDict, Sequence[Optional[StartDict]]]] = None,
     **kwargs,
-) -> Tuple[Sequence[PointType], NUTS]:
+) -> tuple[Sequence[PointType], NUTS]:
     """Set up the mass matrix initialization for NUTS.
 
     NUTS convergence and sampling speed is extremely dependent on the

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -21,7 +21,7 @@ import time
 import traceback
 
 from collections import namedtuple
-from typing import Dict, List, Sequence
+from collections.abc import Sequence
 
 import cloudpickle
 import numpy as np
@@ -205,7 +205,7 @@ class ProcessAdapter:
         step_method_pickled,
         chain: int,
         seed,
-        start: Dict[str, np.ndarray],
+        start: dict[str, np.ndarray],
         mp_ctx,
     ):
         self.chain = chain
@@ -372,7 +372,7 @@ class ParallelSampler:
         chains: int,
         cores: int,
         seeds: Sequence["RandomSeed"],
-        start_points: Sequence[Dict[str, np.ndarray]],
+        start_points: Sequence[dict[str, np.ndarray]],
         step_method,
         progressbar: bool = True,
         mp_ctx=None,
@@ -414,8 +414,8 @@ class ParallelSampler:
         ]
 
         self._inactive = self._samplers.copy()
-        self._finished: List[ProcessAdapter] = []
-        self._active: List[ProcessAdapter] = []
+        self._finished: list[ProcessAdapter] = []
+        self._active: list[ProcessAdapter] = []
         self._max_active = cores
 
         self._in_context = False

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -17,8 +17,9 @@
 import logging
 import warnings
 
+from collections.abc import Iterator, Sequence
 from copy import copy
-from typing import Iterator, List, Sequence, Tuple, Union
+from typing import Union
 
 import cloudpickle
 import numpy as np
@@ -265,7 +266,7 @@ class PopulationStepper:
             _log.exception(f"ChainWalker{c}")
         return
 
-    def step(self, tune_stop: bool, population) -> List[Tuple[PointType, StatsType]]:
+    def step(self, tune_stop: bool, population) -> list[tuple[PointType, StatsType]]:
         """Step the entire population of chains.
 
         Parameters
@@ -280,7 +281,7 @@ class PopulationStepper:
         update : list
             List of (Point, stats) tuples for all chains
         """
-        updates: List[Tuple[PointType, StatsType]] = []
+        updates: list[tuple[PointType, StatsType]] = []
         if self.is_parallelized:
             for c in range(self.nchains):
                 self._primary_ends[c].send((tune_stop, population))
@@ -351,7 +352,7 @@ def _prepare_iter_population(
     population = [start[c] for c in range(nchains)]
 
     # 2. Set up the steppers
-    steppers: List[Step] = []
+    steppers: list[Step] = []
     for c in range(nchains):
         # need independent samplers for each chain
         # it is important to copy the actual steppers (but not the delta_logp)

--- a/pymc/smc/kernels.py
+++ b/pymc/smc/kernels.py
@@ -16,7 +16,7 @@ import sys
 import warnings
 
 from abc import ABC
-from typing import Dict, Union, cast
+from typing import Union, cast
 
 import numpy as np
 import pytensor.tensor as pt
@@ -40,8 +40,8 @@ from pymc.sampling.forward import draw
 from pymc.step_methods.metropolis import MultivariateNormalProposal
 from pymc.vartypes import discrete_types
 
-SMCStats: TypeAlias = Dict[str, Union[int, float]]
-SMCSettings: TypeAlias = Dict[str, Union[int, float]]
+SMCStats: TypeAlias = dict[str, Union[int, float]]
+SMCSettings: TypeAlias = dict[str, Union[int, float]]
 
 
 class SMC_KERNEL(ABC):
@@ -185,7 +185,7 @@ class SMC_KERNEL(ABC):
         self.resampling_indexes = None
         self.weights = np.ones(self.draws) / self.draws
 
-    def initialize_population(self) -> Dict[str, np.ndarray]:
+    def initialize_population(self) -> dict[str, np.ndarray]:
         """Create an initial population from the prior distribution"""
         sys.stdout.write(" ")  # see issue #5828
         with warnings.catch_warnings():
@@ -206,7 +206,7 @@ class SMC_KERNEL(ABC):
             names = [model.rvs_to_values[rv].name for rv in model.free_RVs]
             dict_prior = {k: np.stack(v) for k, v in zip(names, prior_values)}
 
-        return cast(Dict[str, np.ndarray], dict_prior)
+        return cast(dict[str, np.ndarray], dict_prior)
 
     def _initialize_kernel(self):
         """Create variables and logp function necessary to run SMC kernel

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -19,7 +19,7 @@ import warnings
 
 from collections import defaultdict
 from itertools import repeat
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import cloudpickle
 import numpy as np
@@ -259,7 +259,7 @@ def _save_sample_stats(
     _t_sampling,
     idata_kwargs,
     model: Model,
-) -> Tuple[Optional[Any], Optional[InferenceData]]:
+) -> tuple[Optional[Any], Optional[InferenceData]]:
     sample_settings_dict = sample_settings[0]
     sample_settings_dict["_t_sampling"] = _t_sampling
     sample_stats_dict = sample_stats[0]
@@ -294,7 +294,7 @@ def _save_sample_stats(
             library=pymc,
         )
 
-        ikwargs: Dict[str, Any] = dict(model=model)
+        ikwargs: dict[str, Any] = dict(model=model)
         if idata_kwargs is not None:
             ikwargs.update(idata_kwargs)
         idata = to_inference_data(trace, **ikwargs)

--- a/pymc/stats/__init__.py
+++ b/pymc/stats/__init__.py
@@ -29,4 +29,4 @@ for attr in az.stats.__all__:
 
 from pymc.stats.log_likelihood import compute_log_likelihood
 
-__all__ = ("compute_log_likelihood",) + tuple(az.stats.__all__)
+__all__ = ("compute_log_likelihood", *az.stats.__all__)

--- a/pymc/stats/convergence.py
+++ b/pymc/stats/convergence.py
@@ -15,7 +15,8 @@ import dataclasses
 import enum
 import logging
 
-from typing import Any, Dict, List, Optional, Sequence
+from collections.abc import Sequence
+from typing import Any, Optional
 
 import arviz
 
@@ -60,7 +61,7 @@ class SamplerWarning:
     divergence_info: Optional[Any] = None
 
 
-def run_convergence_checks(idata: arviz.InferenceData, model) -> List[SamplerWarning]:
+def run_convergence_checks(idata: arviz.InferenceData, model) -> list[SamplerWarning]:
     if not hasattr(idata, "posterior"):
         msg = "No posterior samples. Unable to run convergence checks"
         warn = SamplerWarning(WarningType.BAD_PARAMS, msg, "info", None, None, None)
@@ -84,7 +85,7 @@ def run_convergence_checks(idata: arviz.InferenceData, model) -> List[SamplerWar
         warn = SamplerWarning(WarningType.BAD_PARAMS, msg, "info")
         return [warn]
 
-    warnings: List[SamplerWarning] = []
+    warnings: list[SamplerWarning] = []
     valid_name = [rv.name for rv in model.free_RVs + model.deterministics]
     varnames = []
     for rv in model.free_RVs:
@@ -126,7 +127,7 @@ def run_convergence_checks(idata: arviz.InferenceData, model) -> List[SamplerWar
     return warnings
 
 
-def warn_divergences(idata: arviz.InferenceData) -> List[SamplerWarning]:
+def warn_divergences(idata: arviz.InferenceData) -> list[SamplerWarning]:
     """Checks sampler stats and creates a list of warnings about divergences."""
     sampler_stats = idata.get("sample_stats", None)
     if sampler_stats is None:
@@ -148,7 +149,7 @@ def warn_divergences(idata: arviz.InferenceData) -> List[SamplerWarning]:
     return [warning]
 
 
-def warn_treedepth(idata: arviz.InferenceData) -> List[SamplerWarning]:
+def warn_treedepth(idata: arviz.InferenceData) -> list[SamplerWarning]:
     """Checks sampler stats and creates a list of warnings about tree depth."""
     sampler_stats = idata.get("sample_stats", None)
     if sampler_stats is None:
@@ -182,7 +183,7 @@ def log_warnings(warnings: Sequence[SamplerWarning]):
         log_warning(warn)
 
 
-def log_warning_stats(stats: Sequence[Dict[str, Any]]):
+def log_warning_stats(stats: Sequence[dict[str, Any]]):
     """Logs 'warning' stats if present."""
     if stats is None:
         return

--- a/pymc/stats/log_likelihood.py
+++ b/pymc/stats/log_likelihood.py
@@ -11,7 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from typing import Optional, Sequence, cast
+from collections.abc import Sequence
+from typing import Optional, cast
 
 from arviz import InferenceData, dict_to_dataset
 from fastprogress import progress_bar

--- a/pymc/step_methods/arraystep.py
+++ b/pymc/step_methods/arraystep.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 from abc import abstractmethod
-from typing import Callable, List, Tuple, Union, cast
+from typing import Callable, Union, cast
 
 import numpy as np
 
@@ -46,8 +46,8 @@ class ArrayStep(BlockedStep):
         self.allvars = allvars
         self.blocked = blocked
 
-    def step(self, point: PointType) -> Tuple[PointType, StatsType]:
-        partial_funcs_and_point: List[Union[Callable, PointType]] = [
+    def step(self, point: PointType) -> tuple[PointType, StatsType]:
+        partial_funcs_and_point: list[Union[Callable, PointType]] = [
             DictToArrayBijection.mapf(x, start_point=point) for x in self.fs
         ]
         if self.allvars:
@@ -66,7 +66,7 @@ class ArrayStep(BlockedStep):
         return point_new, stats
 
     @abstractmethod
-    def astep(self, apoint: RaveledVars, *args) -> Tuple[RaveledVars, StatsType]:
+    def astep(self, apoint: RaveledVars, *args) -> tuple[RaveledVars, StatsType]:
         """Perform a single sample step in a raveled and concatenated parameter space."""
 
 
@@ -90,7 +90,7 @@ class ArrayStepShared(BlockedStep):
         self.shared = {get_var_name(var): shared for var, shared in shared.items()}
         self.blocked = blocked
 
-    def step(self, point: PointType) -> Tuple[PointType, StatsType]:
+    def step(self, point: PointType) -> tuple[PointType, StatsType]:
         for name, shared_var in self.shared.items():
             shared_var.set_value(point[name])
 
@@ -108,7 +108,7 @@ class ArrayStepShared(BlockedStep):
         return new_point, stats
 
     @abstractmethod
-    def astep(self, q0: RaveledVars) -> Tuple[RaveledVars, StatsType]:
+    def astep(self, q0: RaveledVars) -> tuple[RaveledVars, StatsType]:
         """Perform a single sample step in a raveled and concatenated parameter space."""
 
 
@@ -167,12 +167,12 @@ class GradientSharedStep(ArrayStepShared):
 
         super().__init__(vars, func._extra_vars_shared, blocked)
 
-    def step(self, point) -> Tuple[PointType, StatsType]:
+    def step(self, point) -> tuple[PointType, StatsType]:
         self._logp_dlogp_func._extra_are_set = True
         return super().step(point)
 
 
-def metrop_select(mr: np.ndarray, q: np.ndarray, q0: np.ndarray) -> Tuple[np.ndarray, bool]:
+def metrop_select(mr: np.ndarray, q: np.ndarray, q0: np.ndarray) -> tuple[np.ndarray, bool]:
     """Perform rejection/acceptance step for Metropolis class samplers.
 
     Returns the new sample q if a uniform random number is less than the

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -21,8 +21,9 @@ Created on Mar 7, 2011
 import warnings
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Mapping, Sequence
 from enum import IntEnum, unique
-from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple, Union
+from typing import Any, Union
 
 import numpy as np
 
@@ -51,10 +52,10 @@ class Competence(IntEnum):
 
 
 def infer_warn_stats_info(
-    stats_dtypes: List[Dict[str, StatDtype]],
-    sds: Dict[str, Tuple[StatDtype, StatShape]],
+    stats_dtypes: list[dict[str, StatDtype]],
+    sds: dict[str, tuple[StatDtype, StatShape]],
     stepname: str,
-) -> Tuple[List[Dict[str, StatDtype]], Dict[str, Tuple[StatDtype, StatShape]]]:
+) -> tuple[list[dict[str, StatDtype]], dict[str, tuple[StatDtype, StatShape]]]:
     """Helper function to get `stats_dtypes` and `stats_dtypes_shapes` from either of them."""
     # Avoid side-effects on the original lists/dicts
     stats_dtypes = [d.copy() for d in stats_dtypes]
@@ -86,14 +87,14 @@ def infer_warn_stats_info(
 
 
 class BlockedStep(ABC):
-    stats_dtypes: List[Dict[str, type]] = []
+    stats_dtypes: list[dict[str, type]] = []
     """A list containing <=1 dictionary that maps stat names to dtypes.
 
     This attribute is deprecated.
     Use `stats_dtypes_shapes` instead.
     """
 
-    stats_dtypes_shapes: Dict[str, Tuple[StatDtype, StatShape]] = {}
+    stats_dtypes_shapes: dict[str, tuple[StatDtype, StatShape]] = {}
     """Maps stat names to dtypes and shapes.
 
     Shapes are interpreted in the following ways:
@@ -103,7 +104,7 @@ class BlockedStep(ABC):
     - `None` is a sparse stat (i.e. not always present) or a NumPy array with varying `ndim`.
     """
 
-    vars: List[Variable] = []
+    vars: list[Variable] = []
     """Variables that the step method is assigned to."""
 
     def __new__(cls, *args, **kwargs):
@@ -167,7 +168,7 @@ class BlockedStep(ABC):
         return self.__newargs
 
     @abstractmethod
-    def step(self, point: PointType) -> Tuple[PointType, StatsType]:
+    def step(self, point: PointType) -> tuple[PointType, StatsType]:
         """Perform a single step of the sampler."""
 
     @staticmethod
@@ -198,7 +199,7 @@ def flat_statname(sampler_idx: int, sname: str) -> str:
 
 def get_stats_dtypes_shapes_from_steps(
     steps: Iterable[BlockedStep],
-) -> Dict[str, Tuple[StatDtype, StatShape]]:
+) -> dict[str, tuple[StatDtype, StatShape]]:
     """Combines stats dtype shape dictionaries from multiple step methods.
 
     In the resulting stats dict, each sampler stat is prefixed by `sampler_#__`.
@@ -225,7 +226,7 @@ class CompoundStep:
         )
         self.tune = True
 
-    def step(self, point) -> Tuple[PointType, StatsType]:
+    def step(self, point) -> tuple[PointType, StatsType]:
         stats = []
         for method in self.methods:
             point, sts = method.step(point)
@@ -246,11 +247,11 @@ class CompoundStep:
                 method.reset_tuning()
 
     @property
-    def vars(self) -> List[Variable]:
+    def vars(self) -> list[Variable]:
         return [var for method in self.methods for var in method.vars]
 
 
-def flatten_steps(step: Union[BlockedStep, CompoundStep]) -> List[BlockedStep]:
+def flatten_steps(step: Union[BlockedStep, CompoundStep]) -> list[BlockedStep]:
     """Flatten a hierarchy of step methods to a list."""
     if isinstance(step, BlockedStep):
         return [step]
@@ -285,7 +286,7 @@ class StatsBijection:
                 is_obj = np.dtype(dtype) == np.dtype(object)
                 group.append((flatname, statname, is_obj))
             stat_groups.append(group)
-        self._stat_groups: List[List[Tuple[str, str, bool]]] = stat_groups
+        self._stat_groups: list[list[tuple[str, str, bool]]] = stat_groups
         self.object_stats = {
             fname: (s, sname)
             for s, group in enumerate(self._stat_groups)

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -151,7 +151,7 @@ class BlockedStep(ABC):
                 # call __init__
                 step.__init__([var], *args, **kwargs)
                 # Hack for creating the class correctly when unpickling.
-                step.__newargs = ([var],) + args, kwargs
+                step.__newargs = ([var], *args), kwargs
                 steps.append(step)
 
             return CompoundStep(steps)
@@ -160,7 +160,7 @@ class BlockedStep(ABC):
             step.stats_dtypes = stats_dtypes
             step.stats_dtypes_shapes = stats_dtypes_shapes
             # Hack for creating the class correctly when unpickling.
-            step.__newargs = (vars,) + args, kwargs
+            step.__newargs = (vars, *args), kwargs
             return step
 
     # Hack for creating the class correctly when unpickling.

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -11,7 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Optional
 
 import numpy as np
 import numpy.random as nr
@@ -232,7 +232,7 @@ class Metropolis(ArrayStepShared):
         self.accepted_sum[:] = 0
         return
 
-    def astep(self, q0: RaveledVars) -> Tuple[RaveledVars, StatsType]:
+    def astep(self, q0: RaveledVars) -> tuple[RaveledVars, StatsType]:
         point_map_info = q0.point_map_info
         q0d = q0.data
 
@@ -384,7 +384,7 @@ class BinaryMetropolis(ArrayStep):
 
         super().__init__(vars, [model.compile_logp()])
 
-    def astep(self, apoint: RaveledVars, *args) -> Tuple[RaveledVars, StatsType]:
+    def astep(self, apoint: RaveledVars, *args) -> tuple[RaveledVars, StatsType]:
         logp = args[0]
         logp_q0 = logp(apoint)
         point_map_info = apoint.point_map_info
@@ -494,7 +494,7 @@ class BinaryGibbsMetropolis(ArrayStep):
         # There are no tuning parameters in this step method.
         return
 
-    def astep(self, apoint: RaveledVars, *args) -> Tuple[RaveledVars, StatsType]:
+    def astep(self, apoint: RaveledVars, *args) -> tuple[RaveledVars, StatsType]:
         logp: Callable[[RaveledVars], np.ndarray] = args[0]
         order = self.order
         if self.shuffle_dims:
@@ -621,7 +621,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
         # There are no tuning parameters in this step method.
         return
 
-    def astep_unif(self, apoint: RaveledVars, *args) -> Tuple[RaveledVars, StatsType]:
+    def astep_unif(self, apoint: RaveledVars, *args) -> tuple[RaveledVars, StatsType]:
         logp = args[0]
         point_map_info = apoint.point_map_info
         q0 = apoint.data
@@ -645,7 +645,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
         }
         return q, [stats]
 
-    def astep_prop(self, apoint: RaveledVars, *args) -> Tuple[RaveledVars, StatsType]:
+    def astep_prop(self, apoint: RaveledVars, *args) -> tuple[RaveledVars, StatsType]:
         logp = args[0]
         point_map_info = apoint.point_map_info
         q0 = apoint.data
@@ -662,7 +662,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
 
         return q, []
 
-    def astep(self, apoint: RaveledVars, *args) -> Tuple[RaveledVars, StatsType]:
+    def astep(self, apoint: RaveledVars, *args) -> tuple[RaveledVars, StatsType]:
         raise NotImplementedError()
 
     def metropolis_proportional(self, q, logp, logp_curr, dim, k):
@@ -808,7 +808,7 @@ class DEMetropolis(PopulationArrayStepShared):
         self.delta_logp = delta_logp(initial_values, model.logp(), vars, shared)
         super().__init__(vars, shared)
 
-    def astep(self, q0: RaveledVars) -> Tuple[RaveledVars, StatsType]:
+    def astep(self, q0: RaveledVars) -> tuple[RaveledVars, StatsType]:
         point_map_info = q0.point_map_info
         q0d = q0.data
 
@@ -949,7 +949,7 @@ class DEMetropolisZ(ArrayStepShared):
         self.accepted = 0
 
         # cache local history for the Z-proposals
-        self._history: List[np.ndarray] = []
+        self._history: list[np.ndarray] = []
         # remember initial settings before tuning so they can be reset
         self._untuned_settings = dict(
             scaling=self.scaling,
@@ -972,7 +972,7 @@ class DEMetropolisZ(ArrayStepShared):
             setattr(self, attr, initial_value)
         return
 
-    def astep(self, q0: RaveledVars) -> Tuple[RaveledVars, StatsType]:
+    def astep(self, q0: RaveledVars) -> tuple[RaveledVars, StatsType]:
         point_map_info = q0.point_map_info
         q0d = q0.data
 
@@ -1047,10 +1047,10 @@ def sample_except(limit, excluded):
 
 
 def delta_logp(
-    point: Dict[str, np.ndarray],
+    point: dict[str, np.ndarray],
     logp: pt.TensorVariable,
-    vars: List[pt.TensorVariable],
-    shared: Dict[pt.TensorVariable, pt.sharedvar.TensorSharedVariable],
+    vars: list[pt.TensorVariable],
+    shared: dict[pt.TensorVariable, pt.sharedvar.TensorSharedVariable],
 ) -> pytensor.compile.Function:
     [logp0], inarray0 = join_nonshared_inputs(
         point=point, outputs=[logp], inputs=vars, shared_inputs=shared

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -14,7 +14,6 @@
 
 # Modified from original implementation by Dominik Wabersich (2013)
 
-from typing import Tuple
 
 import numpy as np
 import numpy.random as nr
@@ -79,7 +78,7 @@ class Slice(ArrayStepShared):
 
         super().__init__(vars, shared)
 
-    def astep(self, apoint: RaveledVars) -> Tuple[RaveledVars, StatsType]:
+    def astep(self, apoint: RaveledVars) -> tuple[RaveledVars, StatsType]:
         # The arguments are determined by the list passed via `super().__init__(..., fs, ...)`
         q0_val = apoint.data
 

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -143,7 +143,7 @@ class Domain:
 class ProductDomain:
     def __init__(self, domains):
         self.vals = list(it.product(*(d.vals for d in domains)))
-        self.shape = (len(domains),) + domains[0].shape
+        self.shape = (len(domains), *domains[0].shape)
         self.lower = [d.lower for d in domains]
         self.upper = [d.upper for d in domains]
         self.dtype = domains[0].dtype

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -14,7 +14,8 @@
 import functools as ft
 import itertools as it
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
 import pytensor
@@ -247,8 +248,8 @@ def build_model(distfam, valuedomain, vardomains, extra_args=None):
 
 def create_dist_from_paramdomains(
     pymc_dist: Distribution,
-    paramdomains: Dict[str, Domain],
-    extra_args: Optional[Dict[str, Any]] = None,
+    paramdomains: dict[str, Domain],
+    extra_args: Optional[dict[str, Any]] = None,
 ) -> TensorVariable:
     """Create a PyMC distribution from a dictionary of parameter domains.
 
@@ -270,8 +271,8 @@ def create_dist_from_paramdomains(
 
 
 def find_invalid_scalar_params(
-    paramdomains: Dict["str", Domain],
-) -> Dict["str", Tuple[Union[None, float], Union[None, float]]]:
+    paramdomains: dict["str", Domain],
+) -> dict["str", tuple[Union[None, float], Union[None, float]]]:
     """Find invalid parameter values from bounded scalar parameter domains.
 
     For use in `check_logp`-like testing helpers.
@@ -300,12 +301,12 @@ def find_invalid_scalar_params(
 def check_logp(
     pymc_dist: Distribution,
     domain: Domain,
-    paramdomains: Dict[str, Domain],
+    paramdomains: dict[str, Domain],
     scipy_logp: Callable,
     decimal: Optional[int] = None,
     n_samples: int = 100,
-    extra_args: Optional[Dict[str, Any]] = None,
-    scipy_args: Optional[Dict[str, Any]] = None,
+    extra_args: Optional[dict[str, Any]] = None,
+    scipy_args: Optional[dict[str, Any]] = None,
     skip_paramdomain_outside_edge_test: bool = False,
 ) -> None:
     """
@@ -406,7 +407,7 @@ def check_logp(
 def check_logcdf(
     pymc_dist: Distribution,
     domain: Domain,
-    paramdomains: Dict[str, Domain],
+    paramdomains: dict[str, Domain],
     scipy_logcdf: Callable,
     decimal: Optional[int] = None,
     n_samples: int = 100,
@@ -519,7 +520,7 @@ def check_logcdf(
 
 def check_icdf(
     pymc_dist: Distribution,
-    paramdomains: Dict[str, Domain],
+    paramdomains: dict[str, Domain],
     scipy_icdf: Callable,
     skip_paramdomain_outside_edge_test=False,
     decimal: Optional[int] = None,
@@ -616,7 +617,7 @@ def check_icdf(
 def check_selfconsistency_discrete_logcdf(
     distribution: Distribution,
     domain: Domain,
-    paramdomains: Dict[str, Domain],
+    paramdomains: dict[str, Domain],
     decimal: Optional[int] = None,
     n_samples: int = 100,
 ) -> None:
@@ -837,12 +838,12 @@ class BaseTestDistributionRandom:
     reference_dist: Optional[Callable] = None
     reference_dist_params: Optional[dict] = None
     expected_rv_op_params: Optional[dict] = None
-    checks_to_run: List[str] = []
+    checks_to_run: list[str] = []
     size = 15
     decimal = select_by_precision(float64=6, float32=3)
 
-    sizes_to_check: Optional[List] = None
-    sizes_expected: Optional[List] = None
+    sizes_to_check: Optional[list] = None
+    sizes_expected: Optional[list] = None
     repeated_params_shape = 5
     random_state = None
 

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -20,7 +20,8 @@ Created on Mar 12, 2011
 import sys
 import warnings
 
-from typing import Optional, Sequence
+from collections.abc import Sequence
+from typing import Optional
 
 import numpy as np
 import pytensor.gradient as tg

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -15,7 +15,8 @@
 import functools
 import warnings
 
-from typing import Any, Dict, List, NewType, Optional, Sequence, Tuple, Union, cast
+from collections.abc import Sequence
+from typing import Any, NewType, Optional, Union, cast
 
 import arviz
 import cloudpickle
@@ -240,9 +241,9 @@ def biwrap(wrapper):
 
 def dataset_to_point_list(
     ds: Union[xarray.Dataset, dict[str, xarray.DataArray]], sample_dims: Sequence[str]
-) -> Tuple[List[Dict[str, np.ndarray]], Dict[str, Any]]:
+) -> tuple[list[dict[str, np.ndarray]], dict[str, Any]]:
     # All keys of the dataset must be a str
-    var_names = cast(List[str], list(ds.keys()))
+    var_names = cast(list[str], list(ds.keys()))
     for vn in var_names:
         if not isinstance(vn, str):
             raise ValueError(f"Variable names must be str, but dataset key {vn} is a {type(vn)}.")
@@ -257,7 +258,7 @@ def dataset_to_point_list(
         for i in range(np.prod([len(coords) for coords in stacked_dims.values()]))
     ]
     # use the list of points
-    return cast(List[Dict[str, np.ndarray]], points), stacked_dims
+    return cast(list[dict[str, np.ndarray]], points), stacked_dims
 
 
 def drop_warning_stat(idata: arviz.InferenceData) -> arviz.InferenceData:
@@ -274,7 +275,7 @@ def drop_warning_stat(idata: arviz.InferenceData) -> arviz.InferenceData:
     return nidata
 
 
-def chains_and_samples(data: Union[xarray.Dataset, arviz.InferenceData]) -> Tuple[int, int]:
+def chains_and_samples(data: Union[xarray.Dataset, arviz.InferenceData]) -> tuple[int, int]:
     """Extract and return number of chains and samples in xarray or arviz traces."""
     dataset: xarray.Dataset
     if isinstance(data, xarray.Dataset):
@@ -451,7 +452,7 @@ def _get_seeds_per_chain(
 
 def get_value_vars_from_user_vars(
     vars: Union[Variable, Sequence[Variable]], model
-) -> List[Variable]:
+) -> list[Variable]:
     """Converts user "vars" input into value variables.
 
     More often than not, users will pass random variables, and we will extract the

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -14,7 +14,7 @@
 
 import collections
 
-from typing import Callable, Dict
+from typing import Callable
 
 import numpy as np
 
@@ -36,7 +36,7 @@ def absolute(current: np.ndarray, prev: np.ndarray) -> np.ndarray:
     return np.abs(diff)
 
 
-_diff: Dict[str, Callable[[np.ndarray, np.ndarray], np.ndarray]] = dict(
+_diff: dict[str, Callable[[np.ndarray, np.ndarray], np.ndarray]] = dict(
     relative=relative, absolute=absolute
 )
 

--- a/pymc/variational/minibatch_rv.py
+++ b/pymc/variational/minibatch_rv.py
@@ -11,7 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from typing import Any, Sequence, Union, cast
+from collections.abc import Sequence
+from typing import Any, Union, cast
 
 import pytensor.tensor as pt
 

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1511,7 +1511,7 @@ class Approximation(WithMemoization):
         ):
             if name in vars_names(vars_):
                 name_, slc, shape, dtype = ordering[name]
-                found = random[..., slc].reshape((random.shape[0],) + shape).astype(dtype)
+                found = random[..., slc].reshape((random.shape[0], *shape)).astype(dtype)
                 found.name = name + "_vi_random_slice"
                 break
         else:

--- a/pymc/variational/updates.py
+++ b/pymc/variational/updates.py
@@ -570,7 +570,7 @@ def adagrad_window(loss_or_grads=None, params=None, learning_rate=0.001, epsilon
         i = pytensor.shared(pm.floatX(0))
         i_int = i.astype("int32")
         value = param.get_value(borrow=True)
-        accu = pytensor.shared(np.zeros(value.shape + (n_win,), dtype=value.dtype))
+        accu = pytensor.shared(np.zeros((*value.shape, n_win), dtype=value.dtype))
 
         # Append squared gradient vector to accu_new
         accu_new = pt.set_subtensor(accu[..., i_int], grad**2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ addopts = ["--color=yes"]
 
 [tool.ruff]
 line-length = 100
+target-version = "py39"
+exclude = ["versioneer.py"]
 
 [tool.ruff.lint]
 select = ["D", "E", "F", "I", "UP", "W"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,14 @@ target-version = "py39"
 exclude = ["versioneer.py"]
 
 [tool.ruff.lint]
-select = ["D", "E", "F", "I", "UP", "W"]
+select = ["D", "E", "F", "I", "UP", "W", "RUF"]
 ignore-init-module-imports = true
 ignore = [
   "E501",
   "F841", # Local variable name is assigned to but never used
+  "RUF001", # String contains ambiguous character (such as Greek letters)
+  "RUF002", # Docstring contains ambiguous character (such as Greek letters)
+  "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
   "D100",
   "D101",
   "D102",

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -15,7 +15,7 @@ import pathlib
 import subprocess
 import sys
 
-from typing import Iterator
+from collections.abc import Iterator
 
 import pandas
 

--- a/tests/backends/fixtures.py
+++ b/tests/backends/fixtures.py
@@ -60,7 +60,7 @@ class ModelBackendSetupTestCase:
             with pytest.raises(ValueError):
                 self.strace.setup(self.draws, self.chain)
             with pytest.raises(ValueError):
-                vars = self.sampler_vars + [{"a": bool}]
+                vars = [*self.sampler_vars, {"a": bool}]
                 self.strace.setup(self.draws, self.chain, vars)
         else:
             with pytest.raises((ValueError, TypeError)):

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -13,8 +13,6 @@
 #   limitations under the License.
 import warnings
 
-from typing import Dict, Tuple
-
 import numpy as np
 import pytensor.tensor as pt
 import pytest
@@ -105,7 +103,7 @@ class TestDataPyMC:
 
     def get_predictions_inference_data(
         self, data, eight_schools_params, inplace
-    ) -> Tuple[InferenceData, Dict[str, np.ndarray]]:
+    ) -> tuple[InferenceData, dict[str, np.ndarray]]:
         with data.model:
             prior = pm.sample_prior_predictive(return_inferencedata=False)
             posterior_predictive = pm.sample_posterior_predictive(
@@ -128,7 +126,7 @@ class TestDataPyMC:
 
     def make_predictions_inference_data(
         self, data, eight_schools_params
-    ) -> Tuple[InferenceData, Dict[str, np.ndarray]]:
+    ) -> tuple[InferenceData, dict[str, np.ndarray]]:
         with data.model:
             posterior_predictive = pm.sample_posterior_predictive(
                 data.obj, return_inferencedata=False

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -156,7 +156,7 @@ class TestDataPyMC:
         chains = inference_data.posterior.sizes["chain"]
         draws = inference_data.posterior.sizes["draw"]
         obs = inference_data.observed_data["obs"]
-        assert inference_data.log_likelihood["obs"].shape == (chains, draws) + obs.shape
+        assert inference_data.log_likelihood["obs"].shape == (chains, draws, *obs.shape)
 
     def test_predictions_to_idata(self, data, eight_schools_params):
         "Test that we can add predictions to a previously-existing InferenceData."

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -455,9 +455,9 @@ def test_orderedlogistic_dimensions(shape):
     # Test for issue #3535
     loge = np.log10(np.exp(1))
     size = 7
-    p = np.ones(shape + (10,)) / 10
-    cutpoints = np.tile(sp.logit(np.linspace(0, 1, 11)[1:-1]), shape + (1,))
-    obs = np.random.randint(0, 2, size=(size,) + shape)
+    p = np.ones((*shape, 10)) / 10
+    cutpoints = np.tile(sp.logit(np.linspace(0, 1, 11)[1:-1]), (*shape, 1))
+    obs = np.random.randint(0, 2, size=(size, *shape))
     with pm.Model():
         ol = pm.OrderedLogistic(
             "ol",
@@ -472,7 +472,7 @@ def test_orderedlogistic_dimensions(shape):
         )
     ologp = pm.logp(ol, np.ones_like(obs)).sum().eval() * loge
     clogp = pm.logp(c, np.ones_like(obs)).sum().eval() * loge
-    expected = -np.prod((size,) + shape)
+    expected = -np.prod((size, *shape))
 
     assert c.owner.inputs[3].ndim == (len(shape) + 1)
     assert np.allclose(clogp, expected)

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -177,7 +177,7 @@ class TestCustomDist:
                 observed=np.random.randn(100, *size),
             )
         assert isinstance(obs.owner.op, CustomDistRV)
-        assert obs.eval().shape == (100,) + size
+        assert obs.eval().shape == (100, *size)
 
     def test_custom_dist_with_random_invalid_observed(self):
         with pytest.raises(
@@ -237,7 +237,7 @@ class TestCustomDist:
             )
 
         assert isinstance(obs.owner.op, CustomDistRV)
-        assert obs.eval().shape == (100,) + size + (supp_shape,)
+        assert obs.eval().shape == (100, *size, supp_shape)
 
     def test_serialize_custom_dist(self):
         def func(x):
@@ -285,7 +285,7 @@ class TestCustomDist:
         assert isinstance(a.owner.op, CustomDistRV)
         mu_test_value = npr.normal(loc=0, scale=1, size=supp_shape).astype(pytensor.config.floatX)
         a_test_value = npr.normal(
-            loc=mu_test_value, scale=1, size=to_tuple(size) + (supp_shape,)
+            loc=mu_test_value, scale=1, size=(*to_tuple(size), supp_shape)
         ).astype(pytensor.config.floatX)
         log_densityf = model.compile_logp(vars=[a], sum=False)
         assert log_densityf({"a": a_test_value, "mu": mu_test_value})[0].shape == to_tuple(size)
@@ -336,7 +336,7 @@ class TestCustomDist:
             a = CustomDist("a", mu, moment=density_moment, ndims_params=[1], ndim_supp=1, size=size)
         assert isinstance(a.owner.op, CustomDistRV)
         evaled_moment = moment(a).eval({mu: mu_val})
-        assert evaled_moment.shape == to_tuple(size) + (5,)
+        assert evaled_moment.shape == (*to_tuple(size), 5)
         assert np.all(evaled_moment == mu_val)
 
     @pytest.mark.xfail(
@@ -369,7 +369,7 @@ class TestCustomDist:
         assert isinstance(a.owner.op, CustomDistRV)
         if with_random:
             evaled_moment = moment(a).eval({mu: mu_val})
-            assert evaled_moment.shape == to_tuple(size) + (5,)
+            assert evaled_moment.shape == (*to_tuple(size), 5)
             assert np.all(evaled_moment == 0)
         else:
             with pytest.raises(
@@ -441,7 +441,7 @@ class TestCustomSymbolicDist:
             (
                 (2, np.ones(5)),
                 None,
-                np.exp([2, 2, 2, 2, 2] + np.ones(5)),
+                np.exp(2 + np.ones(5)),
                 lambda mu, sigma, size: pt.exp(
                     pm.Normal.dist(mu, sigma, size=size) + pt.ones(size)
                 ),

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -264,7 +264,7 @@ class TestMixture:
         # component shape is either (4, 2, 3), (2, 3)
         # weights shape is either (4, 2) or (2,)
         if size is not None:
-            expected_shape = size + (3,)
+            expected_shape = (*size, 3)
         elif component.ndim == 3 or weights.ndim == 2:
             expected_shape = (4, 3)
         else:
@@ -316,7 +316,7 @@ class TestMixture:
         # components[0] shape is either (4, 3) or (3,)
         # weights shape is either (4, 2) or (2,)
         if size is not None:
-            expected_shape = size + (3,)
+            expected_shape = (*size, 3)
         elif components[0].ndim == 2 or weights.ndim == 2:
             expected_shape = (4, 3)
         else:
@@ -422,7 +422,7 @@ class TestMixture:
         draws = mix.eval()
         expected_shape = (5, 4) if univariate else (5, 4, 3)
         if expand:
-            expected_shape = expected_shape + (3,)
+            expected_shape = (*expected_shape, 3)
         assert draws.shape == expected_shape
         assert np.unique(draws).size == draws.size
 
@@ -611,15 +611,8 @@ class TestMixture:
             ppc = sample_posterior_predictive(
                 n_samples * [self.get_initial_point(model)], return_inferencedata=False
             )
-        assert (
-            ppc["x_obs"].shape
-            == (
-                1,
-                n_samples,
-            )
-            + X.shape
-        )
-        assert prior["x_obs"].shape == (n_samples,) + X.shape
+        assert ppc["x_obs"].shape == (1, n_samples, *X.shape)
+        assert prior["x_obs"].shape == (n_samples, *X.shape)
         assert prior["mu0"].shape == (n_samples, D)
         assert prior["chol_cov_0"].shape == (n_samples, D * (D + 1) // 2)
 
@@ -816,7 +809,7 @@ class TestNormalMixture:
     def test_normal_mixture_nd(self, seeded_test, nd, ncomp):
         nd = to_tuple(nd)
         ncomp = int(ncomp)
-        comp_shape = nd + (ncomp,)
+        comp_shape = (*nd, ncomp)
         test_mus = np.random.randn(*comp_shape)
         test_taus = np.random.gamma(1, 1, size=comp_shape)
         observed = generate_normal_mixture_data(

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -2013,7 +2013,7 @@ class TestWishart(BaseTestDistributionRandom):
             if size is None:
                 expected_shape = (2, 3, 3)
             else:
-                expected_shape = size + (3, 3)
+                expected_shape = (*size, 3, 3)
 
             assert tuple(x.shape.eval()) == expected_shape
 

--- a/tests/logprob/test_basic.py
+++ b/tests/logprob/test_basic.py
@@ -71,7 +71,7 @@ def test_factorized_joint_logprob_basic():
     a_value_var = a.clone()
 
     a_logp = conditional_logp({a: a_value_var})
-    a_logp_comb = tuple(a_logp.values())[0]
+    a_logp_comb = next(iter(a_logp.values()))
     a_logp_exp = logp(a, a_value_var)
 
     assert equal_computations([a_logp_comb], [a_logp_exp])

--- a/tests/logprob/utils.py
+++ b/tests/logprob/utils.py
@@ -50,7 +50,7 @@ def scipy_logprob(obs, p):
         elif p.ndim < obs.ndim:
             p = p[((None,) * (obs.ndim - p.ndim) + (Ellipsis,))]
 
-        pattern = (p.ndim - 1,) + tuple(range(p.ndim - 1))
+        pattern = (p.ndim - 1, *range(p.ndim - 1))
         return np.log(np.take_along_axis(p.transpose(pattern), obs, 0))
     else:
         return np.log(p[obs])

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -14,8 +14,6 @@
 import logging
 import warnings
 
-from typing import Tuple
-
 import numpy as np
 import numpy.random as npr
 import numpy.testing as npt
@@ -1029,7 +1027,7 @@ class TestSamplePPC:
 
 
 @pytest.fixture(scope="class")
-def point_list_arg_bug_fixture() -> Tuple[pm.Model, pm.backends.base.MultiTrace]:
+def point_list_arg_bug_fixture() -> tuple[pm.Model, pm.backends.base.MultiTrace]:
     with pm.Model() as pmodel:
         n = pm.Normal("n")
         trace = pm.sample(return_inferencedata=False)

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -1069,8 +1069,8 @@ class TestSamplePriorPredictive:
                 )
             if shape == 2:  # want to test shape as an int
                 shape = (2,)
-            assert trace1["goals"].shape == (10,) + shape
-            assert trace2["goals"].shape == (10,) + shape
+            assert trace1["goals"].shape == (10, *shape)
+            assert trace2["goals"].shape == (10, *shape)
 
     def test_multivariate(self):
         with pm.Model():
@@ -1100,8 +1100,8 @@ class TestSamplePriorPredictive:
             burned_trace, return_inferencedata=False, model=dm_model
         )
         assert sim_priors["probs"].shape == (20, 6)
-        assert sim_priors["obs"].shape == (20,) + mn_data.shape
-        assert sim_ppc["obs"].shape == (1, 20) + mn_data.shape
+        assert sim_priors["obs"].shape == (20, *mn_data.shape)
+        assert sim_ppc["obs"].shape == (1, 20, *mn_data.shape)
 
     def test_layers(self):
         with pm.Model() as model:
@@ -1416,7 +1416,7 @@ class TestNestedRandom:
             nested_rvs_info=dict(mu=mu, alpha=alpha),
             prior_samples=prior_samples,
         )
-        assert prior["target"].shape == (prior_samples,) + shape
+        assert prior["target"].shape == (prior_samples, *shape)
 
     @pytest.mark.parametrize(
         ["prior_samples", "shape", "psi", "mu", "alpha"],
@@ -1462,7 +1462,7 @@ class TestNestedRandom:
             nested_rvs_info=dict(psi=psi, mu=mu, alpha=alpha),
             prior_samples=prior_samples,
         )
-        assert prior["target"].shape == (prior_samples,) + shape
+        assert prior["target"].shape == (prior_samples, *shape)
 
     @pytest.mark.parametrize(
         ["prior_samples", "shape", "nu", "sigma"],
@@ -1505,7 +1505,7 @@ class TestNestedRandom:
             nested_rvs_info=dict(nu=nu, sigma=sigma),
             prior_samples=prior_samples,
         )
-        assert prior["target"].shape == (prior_samples,) + shape
+        assert prior["target"].shape == (prior_samples, *shape)
 
     @pytest.mark.parametrize(
         ["prior_samples", "shape", "mu", "sigma", "lower", "upper"],
@@ -1580,7 +1580,7 @@ class TestNestedRandom:
             nested_rvs_info=dict(mu=mu, sigma=sigma, lower=lower, upper=upper),
             prior_samples=prior_samples,
         )
-        assert prior["target"].shape == (prior_samples,) + shape
+        assert prior["target"].shape == (prior_samples, *shape)
 
     @pytest.mark.parametrize(
         ["prior_samples", "shape", "c", "lower", "upper"],
@@ -1625,7 +1625,7 @@ class TestNestedRandom:
             nested_rvs_info=dict(c=c, lower=lower, upper=upper),
             prior_samples=prior_samples,
         )
-        assert prior["target"].shape == (prior_samples,) + shape
+        assert prior["target"].shape == (prior_samples, *shape)
 
 
 def test_get_vars_in_point_list():

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import warnings
 
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Optional
 from unittest import mock
 
 import arviz as az
@@ -297,7 +297,7 @@ def model_test_idata_kwargs() -> pm.Model:
 def test_idata_kwargs(
     model_test_idata_kwargs: pm.Model,
     sampler: Callable[..., az.InferenceData],
-    idata_kwargs: Dict[str, Any],
+    idata_kwargs: dict[str, Any],
     postprocessing_backend: Optional[str],
 ):
     idata: Optional[az.InferenceData] = None
@@ -410,7 +410,7 @@ def test_seeding(chains, random_seed, sampler):
         {"fake-key": "fake-value"},
     ],
 )
-def test_update_numpyro_nuts_kwargs(nuts_kwargs: Dict[str, Any]):
+def test_update_numpyro_nuts_kwargs(nuts_kwargs: dict[str, Any]):
     original_kwargs = nuts_kwargs.copy()
     new_kwargs = _update_numpyro_nuts_kwargs(nuts_kwargs)
 

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -767,7 +767,7 @@ class TestAssignStepMethods:
         assert not isinstance(steps, NUTS)
 
         # add back nuts
-        pm.STEP_METHODS = step_methods + [NUTS]
+        pm.STEP_METHODS = [*step_methods, NUTS]
 
         with pm.Model() as model:
             pm.Normal("x", 0, 1)

--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -117,7 +117,7 @@ def _make_along_axis_idx(arr_shape, indices, axis):
     if str(indices.dtype) not in int_types:
         raise IndexError("`indices` must be an integer array")
     shape_ones = (1,) * indices.ndim
-    dest_dims = list(range(axis)) + [None] + list(range(axis + 1, indices.ndim))
+    dest_dims = [*list(range(axis)), None, *list(range(axis + 1, indices.ndim))]
 
     # build a fancy index, consisting of orthogonal aranges, with the
     # requested index inserted at the right location

--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -583,7 +583,7 @@ class TestCompilePyMC:
             n_steps=10,
         )
 
-        assert collect_default_updates([ys]) == {rng: tuple(next_rng.values())[0]}
+        assert collect_default_updates([ys]) == {rng: next(iter(next_rng.values()))}
 
         fn = compile_pymc([], ys, random_seed=1)
         assert not (set(fn()) & set(fn()))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -108,7 +108,7 @@ def test_hashing_of_rv_tuples():
         mu = pm.Normal("mu", 0, 1)
         sigma = pm.Gamma("sigma", 1, 2)
         dd = pm.Normal("dd", observed=obs)
-        for freerv in [mu, sigma, dd] + pmodel.free_RVs:
+        for freerv in [mu, sigma, dd, *pmodel.free_RVs]:
             for structure in [
                 freerv,
                 {"alpha": freerv, "omega": None},

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -315,7 +315,7 @@ def test_sample_replacements(binomial_model_inference):
     p_t = p**3
     p_s = approx.sample_node(p_t, size=100)
     if pytensor.config.compute_test_value != "off":
-        assert p_s.tag.test_value.shape == (100,) + p_t.tag.test_value.shape
+        assert p_s.tag.test_value.shape == (100, *p_t.tag.test_value.shape)
     sampled = p_s.eval()
     assert any(map(operator.ne, sampled[1:], sampled[:-1]))  # stochastic
     assert sampled.shape[0] == 100


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Because we are still using a `setup.py`, ruff doesn't see the `python-requires` setting, so it needs to be configured separately. This is what the first commit does (and fixes resulting type hints).
Then, I activated and fixed the `RUF` category of rules (echoing a comment made by @maresb in https://github.com/pymc-devs/pytensor/pull/616).

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7117.org.readthedocs.build/en/7117/

<!-- readthedocs-preview pymc end -->