### PR TITLE
Fix failing VI test due to pytest change

### DIFF
--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -210,7 +210,7 @@ def test_fit_start(inference_spec, simple_model):
             pytest.skip(str(e))
 
     if expected_warning:
-        assert len(record) > 1
+        assert len(record) > 0
         for item in record:
             assert issubclass(item.category, UserWarning)
             assert "Could not extract data from symbolic observation" in str(item.message)

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -197,13 +197,9 @@ def test_fit_start(inference_spec, simple_model):
 
     # Minibatch data can't be extracted into the `observed_data` group in the final InferenceData
     [observed_value] = [simple_model.rvs_to_values[obs] for obs in simple_model.observed_RVs]
-    if observed_value.name.startswith("minibatch"):
-        warn_ctxt = pytest.warns(
-            UserWarning, match="Could not extract data from symbolic observation"
-        )
-    else:
-        warn_ctxt = nullcontext()
 
+    # We can`t use pytest.warns here because after version 8.0 it`s still check for warning when
+    # exception raised and test failed instead being skipped
     warning_raised = False
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -203,11 +203,16 @@ def test_fit_start(inference_spec, simple_model):
     else:
         warn_ctxt = nullcontext()
 
+    warning_raised = False
     try:
-        with warn_ctxt:
-            trace = inference.fit(n=0).sample(10000)
+        trace = inference.fit(n=0).sample(10000)
     except NotImplementedInference as e:
         pytest.skip(str(e))
+    except UserWarning as w:
+        if "Could not extract data from symbolic observation" in str(w):
+            warning_raised = True
+    if observed_value.name.startswith("minibatch"):
+        assert warning_raised
     np.testing.assert_allclose(np.mean(trace.posterior["mu"]), mu_init, rtol=0.05)
     if has_start_sigma:
         np.testing.assert_allclose(np.std(trace.posterior["mu"]), mu_sigma_init, rtol=0.05)

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -213,6 +213,8 @@ def test_fit_start(inference_spec, simple_model):
             warning_raised = True
     if observed_value.name.startswith("minibatch"):
         assert warning_raised
+    else:
+        assert not warning_raised
     np.testing.assert_allclose(np.mean(trace.posterior["mu"]), mu_init, rtol=0.05)
     if has_start_sigma:
         np.testing.assert_allclose(np.std(trace.posterior["mu"]), mu_sigma_init, rtol=0.05)


### PR DESCRIPTION
## Description
In pytest 7 missing warning were ignored if some exception was raised, but pytest 8 checking them and thats why `test_fit_start[SVGD-mini]` fails. I replaced `pytest.warn()` by manual check for warning raised. 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7136

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7144.org.readthedocs.build/en/7144/

<!-- readthedocs-preview pymc end -->