### PR TITLE
Fix copying of shared variables in `fgraph_from_model`

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -44,7 +44,6 @@ from pytensor.scalar import Cast
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.type import RandomType
-from pytensor.tensor.sharedvar import ScalarSharedVariable
 from pytensor.tensor.variable import TensorConstant, TensorVariable
 from typing_extensions import Self
 
@@ -999,6 +998,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
                 length = pytensor.shared(length, name=name)
             else:
                 length = pytensor.tensor.constant(length)
+        assert length.type.ndim == 0
         self._dim_lengths[name] = length
         self._coords[name] = values
 
@@ -1028,7 +1028,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         coord_values
             Optional sequence of coordinate values.
         """
-        if not isinstance(self.dim_lengths[name], ScalarSharedVariable):
+        if not isinstance(self.dim_lengths[name], SharedVariable):
             raise ValueError(f"The dimension '{name}' is immutable.")
         if coord_values is None and self.coords.get(name, None) is not None:
             raise ValueError(
@@ -1188,7 +1188,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
                             actual=new_length,
                             expected=old_length,
                         )
-                if isinstance(length_tensor, ScalarSharedVariable):
+                if isinstance(length_tensor, SharedVariable):
                     # The dimension is mutable, but was defined without being linked
                     # to a shared variable. This is allowed, but a little less robust.
                     self.set_dim(dname, new_length, coord_values=new_coords)

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -35,7 +35,7 @@ from pytensor.graph import graph_inputs
 from pytensor.raise_op import Assert
 from pytensor.tensor import TensorVariable
 from pytensor.tensor.random.op import RandomVariable
-from pytensor.tensor.sharedvar import ScalarSharedVariable
+from pytensor.tensor.sharedvar import TensorSharedVariable
 from pytensor.tensor.variable import TensorConstant
 
 import pymc as pm
@@ -823,7 +823,7 @@ def test_add_coord_mutable_kwarg():
         m.add_coord("fixed", values=[1], mutable=False)
         m.add_coord("mutable1", values=[1, 2], mutable=True)
         assert isinstance(m._dim_lengths["fixed"], TensorConstant)
-        assert isinstance(m._dim_lengths["mutable1"], ScalarSharedVariable)
+        assert isinstance(m._dim_lengths["mutable1"], TensorSharedVariable)
         pm.MutableData("mdata", np.ones((1, 2, 3)), dims=("fixed", "mutable1", "mutable2"))
         assert isinstance(m._dim_lengths["mutable2"], TensorVariable)
 


### PR DESCRIPTION
Closes #7105 

Also removes use of deprecated ScalarSharedVariable class https://github.com/pymc-devs/pytensor/pull/629

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7153.org.readthedocs.build/en/7153/

<!-- readthedocs-preview pymc end -->