### PR TITLE
Add gufunc signature to SymbolicRandomVariables

### DIFF
--- a/pymc/distributions/censored.py
+++ b/pymc/distributions/censored.py
@@ -30,6 +30,8 @@ class CensoredRV(SymbolicRandomVariable):
     """Censored random variable"""
 
     inline_logprob = True
+    signature = "(),(),()->()"
+    ndim_supp = 0
     _print_name = ("Censored", "\\operatorname{Censored}")
 
 
@@ -115,7 +117,6 @@ class Censored(Distribution):
         return CensoredRV(
             inputs=[dist_, lower_, upper_],
             outputs=[censored_rv_],
-            ndim_supp=0,
         )(dist, lower, upper)
 
 

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -296,10 +296,17 @@ class Mixture(Distribution):
         # Output mix_indexes rng update so that it can be updated in place
         mix_indexes_rng_next_ = mix_indexes_.owner.outputs[0]
 
+        s = ",".join(f"s{i}" for i in range(components[0].owner.op.ndim_supp))
+        if len(components) == 1:
+            comp_s = ",".join((*s, "w"))
+            signature = f"(),(w),({comp_s})->({s})"
+        else:
+            comps_s = ",".join(f"({s})" for _ in components)
+            signature = f"(),(w),{comps_s}->({s})"
         mix_op = MarginalMixtureRV(
             inputs=[mix_indexes_rng_, weights_, *components_],
             outputs=[mix_indexes_rng_next_, mix_out_],
-            ndim_supp=components[0].owner.op.ndim_supp,
+            signature=signature,
         )
 
         # Create the actual MarginalMixture variable

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -1163,6 +1163,8 @@ _ljk_cholesky_cov_base = _LKJCholeskyCovBaseRV()
 # be safely resized. Because of this, we add the thin SymbolicRandomVariable wrapper
 class _LKJCholeskyCovRV(SymbolicRandomVariable):
     default_output = 1
+    signature = "(),(),(),(n)->(),(n)"
+    ndim_supp = 1
     _print_name = ("_lkjcholeskycov", "\\operatorname{_lkjcholeskycov}")
 
     def update(self, node):
@@ -1218,7 +1220,6 @@ class _LKJCholeskyCov(Distribution):
         return _LKJCholeskyCovRV(
             inputs=[rng_, n_, eta_, sd_dist_],
             outputs=[next_rng_, lkjcov_],
-            ndim_supp=1,
         )(rng, n, eta, sd_dist)
 
 
@@ -2787,10 +2788,12 @@ class ZeroSumNormal(Distribution):
         for axis in range(n_zerosum_axes):
             zerosum_rv_ -= zerosum_rv_.mean(axis=-axis - 1, keepdims=True)
 
+        support_str = ",".join([f"d{i}" for i in range(n_zerosum_axes)])
+        signature = f"({support_str}),(),(s)->({support_str})"
         return ZeroSumNormalRV(
             inputs=[normal_dist_, sigma_, support_shape_],
-            outputs=[zerosum_rv_, support_shape_],
-            ndim_supp=n_zerosum_axes,
+            outputs=[zerosum_rv_],
+            signature=signature,
         )(normal_dist, sigma, support_shape)
 
 

--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -195,12 +195,17 @@ class RandomWalk(Distribution):
         # shape = (B, T, S)
         grw_ = pt.concatenate([init_dist_dimswapped_, innovation_dist_dimswapped_], axis=-ndim_supp)
         grw_ = pt.cumsum(grw_, axis=-ndim_supp)
+
+        innov_supp_dims = [f"d{i}" for i in range(dist_ndim_supp)]
+        innov_supp_str = ",".join(innov_supp_dims)
+        out_supp_str = ",".join(["t", *innov_supp_dims])
+        signature = f"({innov_supp_str}),({innov_supp_str}),(s)->({out_supp_str})"
         return RandomWalkRV(
             [init_dist_, innovation_dist_, steps_],
             # We pass steps_ through just so we can keep a reference to it, even though
             # it's no longer needed at this point
-            [grw_, steps_],
-            ndim_supp=ndim_supp,
+            [grw_],
+            signature=signature,
         )(init_dist, innovation_dist, steps)
 
 
@@ -417,6 +422,8 @@ class MvStudentTRandomWalk(PredefinedRandomWalk):
 class AutoRegressiveRV(SymbolicRandomVariable):
     """A placeholder used to specify a log-likelihood for an AR sub-graph."""
 
+    signature = "(o),(),(o),(s)->(),(t)"
+    ndim_supp = 1
     default_output = 1
     ar_order: int
     constant_term: bool
@@ -655,7 +662,6 @@ class AR(Distribution):
             outputs=[noise_next_rng, ar_],
             ar_order=ar_order,
             constant_term=constant_term,
-            ndim_supp=1,
         )
 
         ar = ar_op(rhos, sigma, init_dist, steps)
@@ -719,6 +725,8 @@ class GARCH11RV(SymbolicRandomVariable):
     """A placeholder used to specify a GARCH11 graph."""
 
     default_output = 1
+    signature = "(),(),(),(),(),(s)->(),(t)"
+    ndim_supp = 1
     _print_name = ("GARCH11", "\\operatorname{GARCH11}")
 
     def update(self, node: Node):
@@ -825,7 +833,6 @@ class GARCH11(Distribution):
         garch11_op = GARCH11RV(
             inputs=[omega_, alpha_1_, beta_1_, initial_vol_, init_, steps_],
             outputs=[noise_next_rng, garch11_],
-            ndim_supp=1,
         )
 
         garch11 = garch11_op(omega, alpha_1, beta_1, initial_vol, init_dist, steps)
@@ -881,6 +888,7 @@ class EulerMaruyamaRV(SymbolicRandomVariable):
     default_output = 1
     dt: float
     sde_fn: Callable
+    ndim_supp = 1
     _print_name = ("EulerMaruyama", "\\operatorname{EulerMaruyama}")
 
     def __init__(self, *args, dt, sde_fn, **kwargs):
@@ -1006,7 +1014,7 @@ class EulerMaruyama(Distribution):
             outputs=[noise_next_rng, sde_out_],
             dt=dt,
             sde_fn=sde_fn,
-            ndim_supp=1,
+            signature=f"(),(s),{','.join('()' for _ in sde_pars_)}->(),(t)",
         )
 
         eulermaruyama = eulermaruyama_op(init_dist, steps, *sde_pars)

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -744,6 +744,34 @@ class TestCustomSymbolicDist:
             pm.logp(pm.LogNormal.dist(), 1.0).eval(),
         )
 
+    def test_signature(self):
+        def dist(p, size):
+            return -pm.Categorical.dist(p=p, size=size)
+
+        out = CustomDist.dist([0.25, 0.75], dist=dist, signature="(p)->()")
+        # Size and updates are added automatically to the signature
+        assert out.owner.op.signature == "(),(p)->(),()"
+        assert out.owner.op.ndim_supp == 0
+        assert out.owner.op.ndims_params == [0, 1]
+
+        # When recreated internally, the whole signature may already be known
+        out = CustomDist.dist([0.25, 0.75], dist=dist, signature="(),(p)->(),()")
+        assert out.owner.op.signature == "(),(p)->(),()"
+        assert out.owner.op.ndim_supp == 0
+        assert out.owner.op.ndims_params == [0, 1]
+
+        # A safe signature can be inferred from ndim_supp and ndims_params
+        out = CustomDist.dist([0.25, 0.75], dist=dist, ndim_supp=0, ndims_params=[0, 1])
+        assert out.owner.op.signature == "(),(i10)->(),()"
+        assert out.owner.op.ndim_supp == 0
+        assert out.owner.op.ndims_params == [0, 1]
+
+        # Otherwise be default we assume everything is scalar, even though it's wrong in this case
+        out = CustomDist.dist([0.25, 0.75], dist=dist)
+        assert out.owner.op.signature == "(),()->(),()"
+        assert out.owner.op.ndim_supp == 0
+        assert out.owner.op.ndims_params == [0, 0]
+
 
 class TestSymbolicRandomVariable:
     def test_inline(self):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
This meta-info is necessary to reason about batch dims of SymbolicRandomVariables in the context of https://github.com/pymc-devs/pymc-experimental/pull/300

This is probably what we should use for RandomVariables, instead of defining `ndims_params` and `ndim_supp`. Those can be properties derived from the gufunc signature.

There is however a limitation with gufunc signatures, which has to do with inputs and outputs that are not tensors, such as RNGs and the size vector which obviously cannot have batch dimensions. For now I am treating those as scalars so in the signature they show up as `()`, but perhaps it makes sense to deviate a bit from numpy and use `[]` or `None`? 

For vanilla RandomVariables like Normal. the signature would be `None,None,None,(),()->None,()`, for the inputs: rng, size, dtype, mu, sigma and outputs: next_rng, draws.


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to https://github.com/pymc-devs/pymc-experimental/pull/300

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7159.org.readthedocs.build/en/7159/

<!-- readthedocs-preview pymc end -->