### PR TITLE
Better document the 'mr' parameter to 'metrop_select'.

### DIFF
--- a/pymc/step_methods/arraystep.py
+++ b/pymc/step_methods/arraystep.py
@@ -181,7 +181,13 @@ def metrop_select(mr: np.ndarray, q: np.ndarray, q0: np.ndarray) -> tuple[np.nda
 
     Parameters
     ----------
-    mr: float, Metropolis acceptance rate
+    mr: float, Metropolis acceptance rate. In theory, this acceptance rate is the
+               ratio of two probabilities, but as is common in implementations of 
+               MCMC samplers, this function instead works with logarithms. Specifically,
+               mr is the logarithm of the ratio of probabilities associated with q
+               and q0. A logarithmic identity then provides that this is equal to the
+               logarithm of the probability associated with q minus the logarithm of the
+               probability associated with q0.
     q: proposed sample
     q0: current sample
 


### PR DESCRIPTION
I found myself confused why `metrop_select()` has this comparison:
```
    if np.isfinite(mr) and np.log(uniform()) < mr:
```
If `mr` was just a ratio of probabilities, as one would typically see in theoretical descriptions, then it should be compared to `uniform()`, not the log. But `mr` is the *logarithm* of the ratio -- something not clear from the documentation, but that can be added :-)

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7160.org.readthedocs.build/en/7160/

<!-- readthedocs-preview pymc end -->