### PR TITLE
Update link of Bayesian Analysis with Python book to third edition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,11 +46,11 @@ If you already know about Bayesian statistics:
 Learn Bayesian statistics with a book together with PyMC
 --------------------------------------------------------
 
+-  `Bayesian Analysis with Python  <http://bap.com.ar/>`__ (third edition) by Osvaldo Martin: Great introductory book.
 -  `Probabilistic Programming and Bayesian Methods for Hackers <https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers>`__: Fantastic book with many applied code examples.
 -  `PyMC port of the book "Doing Bayesian Data Analysis" by John Kruschke <https://github.com/cluhmann/DBDA-python>`__ as well as the `first edition <https://github.com/aloctavodia/Doing_bayesian_data_analysis>`__.
 -  `PyMC port of the book "Statistical Rethinking A Bayesian Course with Examples in R and Stan" by Richard McElreath <https://github.com/pymc-devs/resources/tree/master/Rethinking>`__
 -  `PyMC port of the book "Bayesian Cognitive Modeling" by Michael Lee and EJ Wagenmakers <https://github.com/pymc-devs/resources/tree/master/BCM>`__: Focused on using Bayesian statistics in cognitive modeling.
--  `Bayesian Analysis with Python  <https://www.packtpub.com/big-data-and-business-intelligence/bayesian-analysis-python-second-edition>`__ (second edition) by Osvaldo Martin: Great introductory book. (`code <https://github.com/aloctavodia/BAP>`__ and errata).
 
 Audio & Video
 -------------

--- a/docs/source/learn.md
+++ b/docs/source/learn.md
@@ -13,8 +13,9 @@ glossary
 
 ## At a glance
 ### Beginner
+  - Book: [Bayesian Analysis with Python](http://bap.com.ar/)
   - Book: [Bayesian Methods for Hackers](https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers)
-  - Book: [Bayesian Analysis with Python](https://www.packtpub.com/big-data-and-business-intelligence/bayesian-analysis-python-second-edition)
+
 
 ### Intermediate
   - {ref}`pymc_overview` shows PyMC 4.0 code in action


### PR DESCRIPTION
I moved the links to be the first item on the lists. It makes sense to me given that is the most up-to-date book using PyMC, but I can move it back too, but of course, I have conflicting interests  :-P

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7161.org.readthedocs.build/en/7161/

<!-- readthedocs-preview pymc end -->