### PR TITLE
Reduce number of minimum draw in warning message

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -665,8 +665,11 @@ def sample(
     if draws == 0:
         msg = "Tuning was enabled throughout the whole trace."
         _log.warning(msg)
-    elif draws < 500:
-        msg = "Only %s samples in chain." % draws
+    elif draws < 100:
+        msg = (
+            "Only %s samples per chain. Reliable r-hat and ESS diagnostics require longer chains for accurate estimate."
+            % draws
+        )
         _log.warning(msg)
 
     auto_nuts_init = True


### PR DESCRIPTION
The minimum number of draws needed for a reliable computation of ESS and R-hat is ~100 per chain. This number should be lower on the many-chains regime. But I am not aware of a rule of thumb that we can use to compute the minimum value as a function of the number of chains. Hence this is a reasonable default value. 

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7163.org.readthedocs.build/en/7163/

<!-- readthedocs-preview pymc end -->