### PR TITLE
Rename `moment` to `support_point`

### DIFF
--- a/docs/source/contributing/implementing_distribution.md
+++ b/docs/source/contributing/implementing_distribution.md
@@ -5,7 +5,7 @@ This guide provides an overview on how to implement a distribution for PyMC.
 It is designed for developers who wish to add a new distribution to the library.
 Users will not be aware of all this complexity and should instead make use of helper methods such as `~pymc.CustomDist`.
 
-PyMC {class}`~pymc.Distribution` builds on top of PyTensor's {class}`~pytensor.tensor.random.op.RandomVariable`, and implements `logp`, `logcdf`, `icdf` and `moment` methods as well as other initialization and validation helpers.
+PyMC {class}`~pymc.Distribution` builds on top of PyTensor's {class}`~pytensor.tensor.random.op.RandomVariable`, and implements `logp`, `logcdf`, `icdf` and `finite_logp_point` methods as well as other initialization and validation helpers.
 Most notably `shape/dims/observed` kwargs, alternative parametrizations, and default `transform`.
 
 Here is a summary check-list of the steps needed to implement a new distribution.
@@ -14,7 +14,7 @@ Each section will be expanded below:
 1. Creating a new `RandomVariable` `Op`
 1. Implementing the corresponding `Distribution` class
 1. Adding tests for the new `RandomVariable`
-1. Adding tests for `logp` / `logcdf` / `icdf` and `moment` methods
+1. Adding tests for `logp` / `logcdf` / `icdf` and `finite_logp_point` methods
 1. Documenting the new `Distribution`.
 
 This guide does not attempt to explain the rationale behind the `Distributions` current implementation, and details are provided only insofar as they help to implement new "standard" distributions.
@@ -120,7 +120,7 @@ After implementing the new `RandomVariable` `Op`, it's time to make use of it in
 PyMC works in a very {term}`functional <Functional Programming>` way, and the `distribution` classes are there mostly to add PyMC API features and keep related methods organized together.
 In practice, they take care of:
 
-1. Linking ({term}`Dispatching`) an `rv_op` class with the corresponding `moment`, `logp`, `logcdf` and `icdf` methods.
+1. Linking ({term}`Dispatching`) an `rv_op` class with the corresponding `finite_logp_point`, `logp`, `logcdf` and `icdf` methods.
 1. Defining a standard transformation (for continuous distributions) that converts a bounded variable domain (e.g., positive line) to an unbounded domain (i.e., the real line), which many samplers prefer.
 1. Validating the parametrization of a distribution and converting non-symbolic inputs (i.e., numeric literals or NumPy arrays) to symbolic variables.
 1. Converting multiple alternative parametrizations to the standard parametrization that the `RandomVariable` is defined in terms of.
@@ -156,14 +156,14 @@ class Blah(PositiveContinuous):
         # the rv_op needs in order to be instantiated
         return super().dist([param1, param2], **kwargs)
 
-    # moment returns a symbolic expression for the stable moment from which to start sampling
+    # finite_logp_point returns a symbolic expression for the stable point from which to start sampling
     # the variable, given the implicit `rv`, `size` and `param1` ... `paramN`.
     # This is typically a "representative" point such as the the mean or mode.
-    def moment(rv, size, param1, param2):
-        moment, _ = pt.broadcast_arrays(param1, param2)
+    def finite_logp_point(rv, size, param1, param2):
+        finite_logp_point, _ = pt.broadcast_arrays(param1, param2)
         if not rv_size_is_none(size):
-            moment = pt.full(size, moment)
-        return moment
+            finite_logp_point = pt.full(size, finite_logp_point)
+        return finite_logp_point
 
     # Logp returns a symbolic expression for the elementwise log-pdf or log-pmf evaluation
     # of the variable given the `value` of the variable and the parameters `param1` ... `paramN`.
@@ -200,18 +200,18 @@ class Blah(PositiveContinuous):
 Some notes:
 
 1. A distribution should at the very least inherit from {class}`~pymc.Discrete` or {class}`~pymc.Continuous`. For the latter, more specific subclasses exist: `PositiveContinuous`, `UnitContinuous`, `BoundedContinuous`, `CircularContinuous`, `SimplexContinuous`, which specify default transformations for the variables. If you need to specify a one-time custom transform you can also create a `_default_transform` dispatch function as is done for the {class}`~pymc.distributions.multivariate.LKJCholeskyCov`.
-1. If a distribution does not have a corresponding `rng_fn` implementation, a `RandomVariable` should still be created to raise a `NotImplementedError`. This is, for example, the case in {class}`~pymc.distributions.continuous.Flat`. In this case it will be necessary to provide a `moment` method, because without a `rng_fn`, PyMC can't fall back to a random draw to use as an initial point for MCMC.
-1. As mentioned above, PyMC works in a very {term}`functional <Functional Programming>` way, and all the information that is needed in the `logp`, `logcdf`, `icdf` and `moment` methods is expected to be "carried" via the `RandomVariable` inputs. You may pass numerical arguments that are not strictly needed for the `rng_fn` method but are used in the those methods. Just keep in mind whether this affects the correct shape inference behavior of the `RandomVariable`.
+1. If a distribution does not have a corresponding `rng_fn` implementation, a `RandomVariable` should still be created to raise a `NotImplementedError`. This is, for example, the case in {class}`~pymc.distributions.continuous.Flat`. In this case it will be necessary to provide a `finite_logp_point` method, because without a `rng_fn`, PyMC can't fall back to a random draw to use as an initial point for MCMC.
+1. As mentioned above, PyMC works in a very {term}`functional <Functional Programming>` way, and all the information that is needed in the `logp`, `logcdf`, `icdf` and `finite_logp_point` methods is expected to be "carried" via the `RandomVariable` inputs. You may pass numerical arguments that are not strictly needed for the `rng_fn` method but are used in the those methods. Just keep in mind whether this affects the correct shape inference behavior of the `RandomVariable`.
 1. The `logcdf`, and `icdf` methods is not a requirement, but it's a nice plus!
-1. Currently, only one moment is supported in the `moment` method, and probably the "higher-order" one is the most useful (that is `mean` > `median` > `mode`)... You might need to truncate the moment if you are dealing with a discrete distribution. `moment` should return a valid point for the random variable (i.e., it always has non-zero probability when evaluated at that point)
-1. When creating the `moment` method, be careful with `size != None` and broadcast properly also based on parameters that are not necessarily used to calculate the moment. For example, the `sigma` in `pm.Normal.dist(mu=0, sigma=np.arange(1, 6))` is irrelevant for the moment, but may nevertheless inform about the shape. In this case, the `moment` should return `[mu, mu, mu, mu, mu]`.
+1. Currently, only one moment is supported in the `finite_logp_point` method, and probably the "higher-order" one is the most useful (that is `mean` > `median` > `mode`)... You might need to truncate the moment if you are dealing with a discrete distribution. `finite_logp_point` should return a valid point for the random variable (i.e., it always has non-zero probability when evaluated at that point)
+1. When creating the `finite_logp_point` method, be careful with `size != None` and broadcast properly also based on parameters that are not necessarily used to calculate the moment. For example, the `sigma` in `pm.Normal.dist(mu=0, sigma=np.arange(1, 6))` is irrelevant for the moment, but may nevertheless inform about the shape. In this case, the `finite_logp_point` should return `[mu, mu, mu, mu, mu]`.
 
 For a quick check that things are working you can try the following:
 
 ```python
 
 import pymc as pm
-from pymc.distributions.distribution import moment
+from pymc.distributions.distribution import finite_logp_point
 
 # pm.blah = pm.Normal in this example
 blah = pm.blah.dist(mu=0, sigma=1)
@@ -220,8 +220,8 @@ blah = pm.blah.dist(mu=0, sigma=1)
 pm.draw(blah, random_seed=1)
 # array(-1.01397228)
 
-# Test the moment method
-moment(blah).eval()
+# Test the finite_logp_point method
+finite_logp_point(blah).eval()
 # array(0.)
 
 # Test the logp method
@@ -371,9 +371,9 @@ def test_blah_logcdf(self):
 
 ```
 
-## 5. Adding tests for the `moment` method
+## 5. Adding tests for the `finite_logp_point` method
 
-Tests for the `moment` make use of the function `assert_moment_is_expected`
+Tests for the `finite_logp_point` make use of the function `assert_finite_logp_point_is_expected`
 which checks if:
 1. Moments return the `expected` values
 1. Moments have the expected size and shape
@@ -383,7 +383,7 @@ which checks if:
 
 import pytest
 from pymc.distributions import Blah
-from pymc.testing import assert_moment_is_expected
+from pymc.testing import assert_finite_logp_point_is_expected
 
 
 @pytest.mark.parametrize(
@@ -395,10 +395,10 @@ from pymc.testing import assert_moment_is_expected
         (np.arange(5), np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(5))),
     ],
 )
-def test_blah_moment(param1, param2, size, expected):
+def test_blah_finite_logp_point(param1, param2, size, expected):
     with Model() as model:
         Blah("x", param1=param1, param2=param2, size=size)
-    assert_moment_is_expected(model, expected)
+    assert_finite_logp_point_is_expected(model, expected)
 
 ```
 

--- a/docs/source/contributing/implementing_distribution.md
+++ b/docs/source/contributing/implementing_distribution.md
@@ -5,7 +5,7 @@ This guide provides an overview on how to implement a distribution for PyMC.
 It is designed for developers who wish to add a new distribution to the library.
 Users will not be aware of all this complexity and should instead make use of helper methods such as `~pymc.CustomDist`.
 
-PyMC {class}`~pymc.Distribution` builds on top of PyTensor's {class}`~pytensor.tensor.random.op.RandomVariable`, and implements `logp`, `logcdf`, `icdf` and `finite_logp_point` methods as well as other initialization and validation helpers.
+PyMC {class}`~pymc.Distribution` builds on top of PyTensor's {class}`~pytensor.tensor.random.op.RandomVariable`, and implements `logp`, `logcdf`, `icdf` and `support_point` methods as well as other initialization and validation helpers.
 Most notably `shape/dims/observed` kwargs, alternative parametrizations, and default `transform`.
 
 Here is a summary check-list of the steps needed to implement a new distribution.
@@ -14,7 +14,7 @@ Each section will be expanded below:
 1. Creating a new `RandomVariable` `Op`
 1. Implementing the corresponding `Distribution` class
 1. Adding tests for the new `RandomVariable`
-1. Adding tests for `logp` / `logcdf` / `icdf` and `finite_logp_point` methods
+1. Adding tests for `logp` / `logcdf` / `icdf` and `support_point` methods
 1. Documenting the new `Distribution`.
 
 This guide does not attempt to explain the rationale behind the `Distributions` current implementation, and details are provided only insofar as they help to implement new "standard" distributions.
@@ -120,7 +120,7 @@ After implementing the new `RandomVariable` `Op`, it's time to make use of it in
 PyMC works in a very {term}`functional <Functional Programming>` way, and the `distribution` classes are there mostly to add PyMC API features and keep related methods organized together.
 In practice, they take care of:
 
-1. Linking ({term}`Dispatching`) an `rv_op` class with the corresponding `finite_logp_point`, `logp`, `logcdf` and `icdf` methods.
+1. Linking ({term}`Dispatching`) an `rv_op` class with the corresponding `support_point`, `logp`, `logcdf` and `icdf` methods.
 1. Defining a standard transformation (for continuous distributions) that converts a bounded variable domain (e.g., positive line) to an unbounded domain (i.e., the real line), which many samplers prefer.
 1. Validating the parametrization of a distribution and converting non-symbolic inputs (i.e., numeric literals or NumPy arrays) to symbolic variables.
 1. Converting multiple alternative parametrizations to the standard parametrization that the `RandomVariable` is defined in terms of.
@@ -156,14 +156,14 @@ class Blah(PositiveContinuous):
         # the rv_op needs in order to be instantiated
         return super().dist([param1, param2], **kwargs)
 
-    # finite_logp_point returns a symbolic expression for the stable point from which to start sampling
+    # support_point returns a symbolic expression for the stable point from which to start sampling
     # the variable, given the implicit `rv`, `size` and `param1` ... `paramN`.
     # This is typically a "representative" point such as the the mean or mode.
-    def finite_logp_point(rv, size, param1, param2):
-        finite_logp_point, _ = pt.broadcast_arrays(param1, param2)
+    def support_point(rv, size, param1, param2):
+        support_point, _ = pt.broadcast_arrays(param1, param2)
         if not rv_size_is_none(size):
-            finite_logp_point = pt.full(size, finite_logp_point)
-        return finite_logp_point
+            support_point = pt.full(size, support_point)
+        return support_point
 
     # Logp returns a symbolic expression for the elementwise log-pdf or log-pmf evaluation
     # of the variable given the `value` of the variable and the parameters `param1` ... `paramN`.
@@ -200,18 +200,18 @@ class Blah(PositiveContinuous):
 Some notes:
 
 1. A distribution should at the very least inherit from {class}`~pymc.Discrete` or {class}`~pymc.Continuous`. For the latter, more specific subclasses exist: `PositiveContinuous`, `UnitContinuous`, `BoundedContinuous`, `CircularContinuous`, `SimplexContinuous`, which specify default transformations for the variables. If you need to specify a one-time custom transform you can also create a `_default_transform` dispatch function as is done for the {class}`~pymc.distributions.multivariate.LKJCholeskyCov`.
-1. If a distribution does not have a corresponding `rng_fn` implementation, a `RandomVariable` should still be created to raise a `NotImplementedError`. This is, for example, the case in {class}`~pymc.distributions.continuous.Flat`. In this case it will be necessary to provide a `finite_logp_point` method, because without a `rng_fn`, PyMC can't fall back to a random draw to use as an initial point for MCMC.
-1. As mentioned above, PyMC works in a very {term}`functional <Functional Programming>` way, and all the information that is needed in the `logp`, `logcdf`, `icdf` and `finite_logp_point` methods is expected to be "carried" via the `RandomVariable` inputs. You may pass numerical arguments that are not strictly needed for the `rng_fn` method but are used in the those methods. Just keep in mind whether this affects the correct shape inference behavior of the `RandomVariable`.
+1. If a distribution does not have a corresponding `rng_fn` implementation, a `RandomVariable` should still be created to raise a `NotImplementedError`. This is, for example, the case in {class}`~pymc.distributions.continuous.Flat`. In this case it will be necessary to provide a `support_point` method, because without a `rng_fn`, PyMC can't fall back to a random draw to use as an initial point for MCMC.
+1. As mentioned above, PyMC works in a very {term}`functional <Functional Programming>` way, and all the information that is needed in the `logp`, `logcdf`, `icdf` and `support_point` methods is expected to be "carried" via the `RandomVariable` inputs. You may pass numerical arguments that are not strictly needed for the `rng_fn` method but are used in the those methods. Just keep in mind whether this affects the correct shape inference behavior of the `RandomVariable`.
 1. The `logcdf`, and `icdf` methods is not a requirement, but it's a nice plus!
-1. Currently, only one moment is supported in the `finite_logp_point` method, and probably the "higher-order" one is the most useful (that is `mean` > `median` > `mode`)... You might need to truncate the moment if you are dealing with a discrete distribution. `finite_logp_point` should return a valid point for the random variable (i.e., it always has non-zero probability when evaluated at that point)
-1. When creating the `finite_logp_point` method, be careful with `size != None` and broadcast properly also based on parameters that are not necessarily used to calculate the moment. For example, the `sigma` in `pm.Normal.dist(mu=0, sigma=np.arange(1, 6))` is irrelevant for the moment, but may nevertheless inform about the shape. In this case, the `finite_logp_point` should return `[mu, mu, mu, mu, mu]`.
+1. Currently, only one moment is supported in the `support_point` method, and probably the "higher-order" one is the most useful (that is `mean` > `median` > `mode`)... You might need to truncate the moment if you are dealing with a discrete distribution. `support_point` should return a valid point for the random variable (i.e., it always has non-zero probability when evaluated at that point)
+1. When creating the `support_point` method, be careful with `size != None` and broadcast properly also based on parameters that are not necessarily used to calculate the moment. For example, the `sigma` in `pm.Normal.dist(mu=0, sigma=np.arange(1, 6))` is irrelevant for the moment, but may nevertheless inform about the shape. In this case, the `support_point` should return `[mu, mu, mu, mu, mu]`.
 
 For a quick check that things are working you can try the following:
 
 ```python
 
 import pymc as pm
-from pymc.distributions.distribution import finite_logp_point
+from pymc.distributions.distribution import support_point
 
 # pm.blah = pm.Normal in this example
 blah = pm.blah.dist(mu=0, sigma=1)
@@ -220,8 +220,8 @@ blah = pm.blah.dist(mu=0, sigma=1)
 pm.draw(blah, random_seed=1)
 # array(-1.01397228)
 
-# Test the finite_logp_point method
-finite_logp_point(blah).eval()
+# Test the support_point method
+support_point(blah).eval()
 # array(0.)
 
 # Test the logp method
@@ -371,9 +371,9 @@ def test_blah_logcdf(self):
 
 ```
 
-## 5. Adding tests for the `finite_logp_point` method
+## 5. Adding tests for the `support_point` method
 
-Tests for the `finite_logp_point` make use of the function `assert_finite_logp_point_is_expected`
+Tests for the `support_point` make use of the function `assert_support_point_is_expected`
 which checks if:
 1. Moments return the `expected` values
 1. Moments have the expected size and shape
@@ -383,7 +383,7 @@ which checks if:
 
 import pytest
 from pymc.distributions import Blah
-from pymc.testing import assert_finite_logp_point_is_expected
+from pymc.testing import assert_support_point_is_expected
 
 
 @pytest.mark.parametrize(
@@ -395,10 +395,10 @@ from pymc.testing import assert_finite_logp_point_is_expected
         (np.arange(5), np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(5))),
     ],
 )
-def test_blah_finite_logp_point(param1, param2, size, expected):
+def test_blah_support_point(param1, param2, size, expected):
     with Model() as model:
         Blah("x", param1=param1, param2=param2, size=size)
-    assert_finite_logp_point_is_expected(model, expected)
+    assert_support_point_is_expected(model, expected)
 
 ```
 

--- a/pymc/distributions/censored.py
+++ b/pymc/distributions/censored.py
@@ -20,7 +20,7 @@ from pytensor.tensor.random.op import RandomVariable
 from pymc.distributions.distribution import (
     Distribution,
     SymbolicRandomVariable,
-    _moment,
+    _finite_logp_point,
 )
 from pymc.distributions.shape_utils import _change_dist_size, change_dist_size
 from pymc.util import check_dist_not_registered
@@ -127,9 +127,9 @@ def change_censored_size(cls, dist, new_size, expand=False):
     return Censored.rv_op(uncensored_dist, lower, upper, size=new_size)
 
 
-@_moment.register(CensoredRV)
-def moment_censored(op, rv, dist, lower, upper):
-    moment = pt.switch(
+@_finite_logp_point.register(CensoredRV)
+def finite_logp_point_censored(op, rv, dist, lower, upper):
+    finite_logp_point = pt.switch(
         pt.eq(lower, -np.inf),
         pt.switch(
             pt.isinf(upper),
@@ -146,5 +146,5 @@ def moment_censored(op, rv, dist, lower, upper):
             (lower + upper) / 2,
         ),
     )
-    moment = pt.full_like(dist, moment)
-    return moment
+    finite_logp_point = pt.full_like(dist, finite_logp_point)
+    return finite_logp_point

--- a/pymc/distributions/censored.py
+++ b/pymc/distributions/censored.py
@@ -20,7 +20,7 @@ from pytensor.tensor.random.op import RandomVariable
 from pymc.distributions.distribution import (
     Distribution,
     SymbolicRandomVariable,
-    _finite_logp_point,
+    _support_point,
 )
 from pymc.distributions.shape_utils import _change_dist_size, change_dist_size
 from pymc.util import check_dist_not_registered
@@ -127,9 +127,9 @@ def change_censored_size(cls, dist, new_size, expand=False):
     return Censored.rv_op(uncensored_dist, lower, upper, size=new_size)
 
 
-@_finite_logp_point.register(CensoredRV)
-def finite_logp_point_censored(op, rv, dist, lower, upper):
-    finite_logp_point = pt.switch(
+@_support_point.register(CensoredRV)
+def support_point_censored(op, rv, dist, lower, upper):
+    support_point = pt.switch(
         pt.eq(lower, -np.inf),
         pt.switch(
             pt.isinf(upper),
@@ -146,5 +146,5 @@ def finite_logp_point_censored(op, rv, dist, lower, upper):
             (lower + upper) / 2,
         ),
     )
-    finite_logp_point = pt.full_like(dist, finite_logp_point)
-    return finite_logp_point
+    support_point = pt.full_like(dist, support_point)
+    return support_point

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -312,12 +312,12 @@ class Uniform(BoundedContinuous):
         upper = pt.as_tensor_variable(upper)
         return super().dist([lower, upper], **kwargs)
 
-    def moment(rv, size, lower, upper):
+    def finite_logp_point(rv, size, lower, upper):
         lower, upper = pt.broadcast_arrays(lower, upper)
-        moment = (lower + upper) / 2
+        finite_logp_point = (lower + upper) / 2
         if not rv_size_is_none(size):
-            moment = pt.full(size, moment)
-        return moment
+            finite_logp_point = pt.full(size, finite_logp_point)
+        return finite_logp_point
 
     def logp(value, lower, upper):
         res = pt.switch(
@@ -384,7 +384,7 @@ class Flat(Continuous):
     rv_op = flat
 
     def __new__(cls, *args, **kwargs):
-        kwargs.setdefault("initval", "moment")
+        kwargs.setdefault("initval", "finite_logp_point")
         return super().__new__(cls, *args, **kwargs)
 
     @classmethod
@@ -392,7 +392,7 @@ class Flat(Continuous):
         res = super().dist([], **kwargs)
         return res
 
-    def moment(rv, size):
+    def finite_logp_point(rv, size):
         return pt.zeros(size)
 
     def logp(value):
@@ -425,7 +425,7 @@ class HalfFlat(PositiveContinuous):
     rv_op = halfflat
 
     def __new__(cls, *args, **kwargs):
-        kwargs.setdefault("initval", "moment")
+        kwargs.setdefault("initval", "finite_logp_point")
         return super().__new__(cls, *args, **kwargs)
 
     @classmethod
@@ -433,7 +433,7 @@ class HalfFlat(PositiveContinuous):
         res = super().dist([], **kwargs)
         return res
 
-    def moment(rv, size):
+    def finite_logp_point(rv, size):
         return pt.ones(size)
 
     def logp(value):
@@ -522,7 +522,7 @@ class Normal(Continuous):
 
         return super().dist([mu, sigma], **kwargs)
 
-    def moment(rv, size, mu, sigma):
+    def finite_logp_point(rv, size, mu, sigma):
         mu, _ = pt.broadcast_arrays(mu, sigma)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -684,9 +684,9 @@ class TruncatedNormal(BoundedContinuous):
         upper = pt.as_tensor_variable(upper) if upper is not None else pt.constant(np.inf)
         return super().dist([mu, sigma, lower, upper], **kwargs)
 
-    def moment(rv, size, mu, sigma, lower, upper):
+    def finite_logp_point(rv, size, mu, sigma, lower, upper):
         mu, _, lower, upper = pt.broadcast_arrays(mu, sigma, lower, upper)
-        moment = pt.switch(
+        finite_logp_point = pt.switch(
             pt.eq(lower, -np.inf),
             pt.switch(
                 pt.eq(upper, np.inf),
@@ -705,9 +705,9 @@ class TruncatedNormal(BoundedContinuous):
         )
 
         if not rv_size_is_none(size):
-            moment = pt.full(size, moment)
+            finite_logp_point = pt.full(size, finite_logp_point)
 
-        return moment
+        return finite_logp_point
 
     def logp(value, mu, sigma, lower, upper):
         is_lower_bounded = not (
@@ -857,11 +857,11 @@ class HalfNormal(PositiveContinuous):
 
         return super().dist([0.0, sigma], **kwargs)
 
-    def moment(rv, size, loc, sigma):
-        moment = loc + sigma
+    def finite_logp_point(rv, size, loc, sigma):
+        finite_logp_point = loc + sigma
         if not rv_size_is_none(size):
-            moment = pt.full(size, moment)
-        return moment
+            finite_logp_point = pt.full(size, finite_logp_point)
+        return finite_logp_point
 
     def logp(value, loc, sigma):
         res = -0.5 * pt.pow((value - loc) / sigma, 2) + pt.log(pt.sqrt(2.0 / np.pi)) - pt.log(sigma)
@@ -1004,7 +1004,7 @@ class Wald(PositiveContinuous):
         lam = pt.as_tensor_variable(lam)
         return super().dist([mu, lam, alpha], **kwargs)
 
-    def moment(rv, size, mu, lam, alpha):
+    def finite_logp_point(rv, size, mu, lam, alpha):
         mu, _, _ = pt.broadcast_arrays(mu, lam, alpha)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -1180,7 +1180,7 @@ class Beta(UnitContinuous):
 
         return super().dist([alpha, beta], **kwargs)
 
-    def moment(rv, size, alpha, beta):
+    def finite_logp_point(rv, size, alpha, beta):
         mean = alpha / (alpha + beta)
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -1308,7 +1308,7 @@ class Kumaraswamy(UnitContinuous):
 
         return super().dist([a, b], *args, **kwargs)
 
-    def moment(rv, size, a, b):
+    def finite_logp_point(rv, size, a, b):
         mean = pt.exp(pt.log(b) + pt.gammaln(1 + 1 / a) + pt.gammaln(b) - pt.gammaln(1 + 1 / a + b))
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -1404,7 +1404,7 @@ class Exponential(PositiveContinuous):
         # PyTensor exponential op is parametrized in terms of mu (1/lam)
         return super().dist([scale], **kwargs)
 
-    def moment(rv, size, mu):
+    def finite_logp_point(rv, size, mu):
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
         return mu
@@ -1495,7 +1495,7 @@ class Laplace(Continuous):
 
         return super().dist([mu, b], *args, **kwargs)
 
-    def moment(rv, size, mu, b):
+    def finite_logp_point(rv, size, mu, b):
         mu, _ = pt.broadcast_arrays(mu, b)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -1629,7 +1629,7 @@ class AsymmetricLaplace(Continuous):
 
         return kappa
 
-    def moment(rv, size, b, kappa, mu):
+    def finite_logp_point(rv, size, b, kappa, mu):
         mean = mu - (kappa - 1 / kappa) / b
 
         if not rv_size_is_none(size):
@@ -1728,7 +1728,7 @@ class LogNormal(PositiveContinuous):
 
         return super().dist([mu, sigma], *args, **kwargs)
 
-    def moment(rv, size, mu, sigma):
+    def finite_logp_point(rv, size, mu, sigma):
         mean = pt.exp(mu + 0.5 * sigma**2)
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -1844,7 +1844,7 @@ class StudentT(Continuous):
 
         return super().dist([nu, mu, sigma], **kwargs)
 
-    def moment(rv, size, nu, mu, sigma):
+    def finite_logp_point(rv, size, nu, mu, sigma):
         mu, _, _ = pt.broadcast_arrays(mu, nu, sigma)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -1941,7 +1941,7 @@ class Pareto(BoundedContinuous):
 
         return super().dist([alpha, m], **kwargs)
 
-    def moment(rv, size, alpha, m):
+    def finite_logp_point(rv, size, alpha, m):
         median = m * 2 ** (1 / alpha)
         if not rv_size_is_none(size):
             median = pt.full(size, median)
@@ -2049,7 +2049,7 @@ class Cauchy(Continuous):
 
         return super().dist([alpha, beta], **kwargs)
 
-    def moment(rv, size, alpha, beta):
+    def finite_logp_point(rv, size, alpha, beta):
         alpha, _ = pt.broadcast_arrays(alpha, beta)
         if not rv_size_is_none(size):
             alpha = pt.full(size, alpha)
@@ -2128,7 +2128,7 @@ class HalfCauchy(PositiveContinuous):
         beta = pt.as_tensor_variable(beta)
         return super().dist([0.0, beta], **kwargs)
 
-    def moment(rv, size, loc, beta):
+    def finite_logp_point(rv, size, loc, beta):
         if not rv_size_is_none(size):
             beta = pt.full(size, beta)
         return beta
@@ -2257,7 +2257,7 @@ class Gamma(PositiveContinuous):
 
         return alpha, beta
 
-    def moment(rv, size, alpha, scale):
+    def finite_logp_point(rv, size, alpha, scale):
         mean = alpha * scale
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -2344,13 +2344,13 @@ class InverseGamma(PositiveContinuous):
 
         return super().dist([alpha, beta], **kwargs)
 
-    def moment(rv, size, alpha, beta):
+    def finite_logp_point(rv, size, alpha, beta):
         mean = beta / (alpha - 1.0)
         mode = beta / (alpha + 1.0)
-        moment = pt.switch(alpha > 1, mean, mode)
+        finite_logp_point = pt.switch(alpha > 1, mean, mode)
         if not rv_size_is_none(size):
-            moment = pt.full(size, moment)
-        return moment
+            finite_logp_point = pt.full(size, finite_logp_point)
+        return finite_logp_point
 
     @classmethod
     def _get_alpha_beta(cls, alpha, beta, mu, sigma):
@@ -2527,7 +2527,7 @@ class Weibull(PositiveContinuous):
 
         return super().dist([alpha, beta], *args, **kwargs)
 
-    def moment(rv, size, alpha, beta):
+    def finite_logp_point(rv, size, alpha, beta):
         mean = beta * pt.gamma(1 + 1 / alpha)
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -2659,7 +2659,7 @@ class HalfStudentT(PositiveContinuous):
 
         return super().dist([nu, sigma], *args, **kwargs)
 
-    def moment(rv, size, nu, sigma):
+    def finite_logp_point(rv, size, nu, sigma):
         sigma, _ = pt.broadcast_arrays(sigma, nu)
         if not rv_size_is_none(size):
             sigma = pt.full(size, sigma)
@@ -2780,12 +2780,12 @@ class ExGaussian(Continuous):
 
         return super().dist([mu, sigma, nu], *args, **kwargs)
 
-    def moment(rv, size, mu, sigma, nu):
+    def finite_logp_point(rv, size, mu, sigma, nu):
         mu, nu, _ = pt.broadcast_arrays(mu, nu, sigma)
-        moment = mu + nu
+        finite_logp_point = mu + nu
         if not rv_size_is_none(size):
-            moment = pt.full(size, moment)
-        return moment
+            finite_logp_point = pt.full(size, finite_logp_point)
+        return finite_logp_point
 
     def logp(value, mu, sigma, nu):
         # Alogithm is adapted from dexGAUS.R from gamlss
@@ -2883,7 +2883,7 @@ class VonMises(CircularContinuous):
         kappa = pt.as_tensor_variable(kappa)
         return super().dist([mu, kappa], *args, **kwargs)
 
-    def moment(rv, size, mu, kappa):
+    def finite_logp_point(rv, size, mu, kappa):
         mu, _ = pt.broadcast_arrays(mu, kappa)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -2990,7 +2990,7 @@ class SkewNormal(Continuous):
 
         return super().dist([mu, sigma, alpha], *args, **kwargs)
 
-    def moment(rv, size, mu, sigma, alpha):
+    def finite_logp_point(rv, size, mu, sigma, alpha):
         mean = mu + sigma * (2 / np.pi) ** 0.5 * alpha / (1 + alpha**2) ** 0.5
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -3078,7 +3078,7 @@ class Triangular(BoundedContinuous):
 
         return super().dist([lower, c, upper], *args, **kwargs)
 
-    def moment(rv, size, lower, c, upper):
+    def finite_logp_point(rv, size, lower, c, upper):
         mean = (lower + upper + c) / 3
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -3203,7 +3203,7 @@ class Gumbel(Continuous):
 
         return super().dist([mu, beta], **kwargs)
 
-    def moment(rv, size, mu, beta):
+    def finite_logp_point(rv, size, mu, beta):
         mean = mu + beta * np.euler_gamma
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -3335,7 +3335,7 @@ class Rice(PositiveContinuous):
             return nu, b, sigma
         raise ValueError("Rice distribution must specify either nu" " or b.")
 
-    def moment(rv, size, nu, sigma):
+    def finite_logp_point(rv, size, nu, sigma):
         nu_sigma_ratio = -(nu**2) / (2 * sigma**2)
         mean = (
             sigma
@@ -3421,7 +3421,7 @@ class Logistic(Continuous):
         s = pt.as_tensor_variable(s)
         return super().dist([mu, s], *args, **kwargs)
 
-    def moment(rv, size, mu, s):
+    def finite_logp_point(rv, size, mu, s):
         mu, _ = pt.broadcast_arrays(mu, s)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -3529,7 +3529,7 @@ class LogitNormal(UnitContinuous):
 
         return super().dist([mu, sigma], **kwargs)
 
-    def moment(rv, size, mu, sigma):
+    def finite_logp_point(rv, size, mu, sigma):
         median, _ = pt.broadcast_arrays(invlogit(mu), sigma)
         if not rv_size_is_none(size):
             median = pt.full(size, median)
@@ -3663,17 +3663,17 @@ class Interpolated(BoundedContinuous):
 
         return super().dist([x_points, pdf_points, cdf_points], **kwargs)
 
-    def moment(rv, size, x_points, pdf_points, cdf_points):
+    def finite_logp_point(rv, size, x_points, pdf_points, cdf_points):
         """
         Estimates the expectation integral using the trapezoid rule; cdf_points are not used.
         """
         x_fx = pt.mul(x_points, pdf_points)  # x_i * f(x_i) for all xi's in x_points
-        moment = pt.sum(pt.mul(pt.diff(x_points), x_fx[1:] + x_fx[:-1])) / 2
+        finite_logp_point = pt.sum(pt.mul(pt.diff(x_points), x_fx[1:] + x_fx[:-1])) / 2
 
         if not rv_size_is_none(size):
-            moment = pt.full(size, moment)
+            finite_logp_point = pt.full(size, finite_logp_point)
 
-        return moment
+        return finite_logp_point
 
     def logp(value, x_points, pdf_points, cdf_points):
         # x_points and pdf_points are expected to be non-symbolic arrays wrapped
@@ -3770,7 +3770,7 @@ class Moyal(Continuous):
 
         return super().dist([mu, sigma], *args, **kwargs)
 
-    def moment(rv, size, mu, sigma):
+    def finite_logp_point(rv, size, mu, sigma):
         mean = mu + sigma * (np.euler_gamma + pt.log(2))
 
         if not rv_size_is_none(size):
@@ -3973,7 +3973,7 @@ class PolyaGamma(PositiveContinuous):
 
         return super().dist([h, z], **kwargs)
 
-    def moment(rv, size, h, z):
+    def finite_logp_point(rv, size, h, z):
         mean = pt.switch(pt.eq(z, 0), h / 4, tanh(z / 2) * (h / (2 * z)))
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -312,12 +312,12 @@ class Uniform(BoundedContinuous):
         upper = pt.as_tensor_variable(upper)
         return super().dist([lower, upper], **kwargs)
 
-    def finite_logp_point(rv, size, lower, upper):
+    def support_point(rv, size, lower, upper):
         lower, upper = pt.broadcast_arrays(lower, upper)
-        finite_logp_point = (lower + upper) / 2
+        support_point = (lower + upper) / 2
         if not rv_size_is_none(size):
-            finite_logp_point = pt.full(size, finite_logp_point)
-        return finite_logp_point
+            support_point = pt.full(size, support_point)
+        return support_point
 
     def logp(value, lower, upper):
         res = pt.switch(
@@ -384,7 +384,7 @@ class Flat(Continuous):
     rv_op = flat
 
     def __new__(cls, *args, **kwargs):
-        kwargs.setdefault("initval", "finite_logp_point")
+        kwargs.setdefault("initval", "support_point")
         return super().__new__(cls, *args, **kwargs)
 
     @classmethod
@@ -392,7 +392,7 @@ class Flat(Continuous):
         res = super().dist([], **kwargs)
         return res
 
-    def finite_logp_point(rv, size):
+    def support_point(rv, size):
         return pt.zeros(size)
 
     def logp(value):
@@ -425,7 +425,7 @@ class HalfFlat(PositiveContinuous):
     rv_op = halfflat
 
     def __new__(cls, *args, **kwargs):
-        kwargs.setdefault("initval", "finite_logp_point")
+        kwargs.setdefault("initval", "support_point")
         return super().__new__(cls, *args, **kwargs)
 
     @classmethod
@@ -433,7 +433,7 @@ class HalfFlat(PositiveContinuous):
         res = super().dist([], **kwargs)
         return res
 
-    def finite_logp_point(rv, size):
+    def support_point(rv, size):
         return pt.ones(size)
 
     def logp(value):
@@ -522,7 +522,7 @@ class Normal(Continuous):
 
         return super().dist([mu, sigma], **kwargs)
 
-    def finite_logp_point(rv, size, mu, sigma):
+    def support_point(rv, size, mu, sigma):
         mu, _ = pt.broadcast_arrays(mu, sigma)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -684,9 +684,9 @@ class TruncatedNormal(BoundedContinuous):
         upper = pt.as_tensor_variable(upper) if upper is not None else pt.constant(np.inf)
         return super().dist([mu, sigma, lower, upper], **kwargs)
 
-    def finite_logp_point(rv, size, mu, sigma, lower, upper):
+    def support_point(rv, size, mu, sigma, lower, upper):
         mu, _, lower, upper = pt.broadcast_arrays(mu, sigma, lower, upper)
-        finite_logp_point = pt.switch(
+        support_point = pt.switch(
             pt.eq(lower, -np.inf),
             pt.switch(
                 pt.eq(upper, np.inf),
@@ -705,9 +705,9 @@ class TruncatedNormal(BoundedContinuous):
         )
 
         if not rv_size_is_none(size):
-            finite_logp_point = pt.full(size, finite_logp_point)
+            support_point = pt.full(size, support_point)
 
-        return finite_logp_point
+        return support_point
 
     def logp(value, mu, sigma, lower, upper):
         is_lower_bounded = not (
@@ -857,11 +857,11 @@ class HalfNormal(PositiveContinuous):
 
         return super().dist([0.0, sigma], **kwargs)
 
-    def finite_logp_point(rv, size, loc, sigma):
-        finite_logp_point = loc + sigma
+    def support_point(rv, size, loc, sigma):
+        support_point = loc + sigma
         if not rv_size_is_none(size):
-            finite_logp_point = pt.full(size, finite_logp_point)
-        return finite_logp_point
+            support_point = pt.full(size, support_point)
+        return support_point
 
     def logp(value, loc, sigma):
         res = -0.5 * pt.pow((value - loc) / sigma, 2) + pt.log(pt.sqrt(2.0 / np.pi)) - pt.log(sigma)
@@ -1004,7 +1004,7 @@ class Wald(PositiveContinuous):
         lam = pt.as_tensor_variable(lam)
         return super().dist([mu, lam, alpha], **kwargs)
 
-    def finite_logp_point(rv, size, mu, lam, alpha):
+    def support_point(rv, size, mu, lam, alpha):
         mu, _, _ = pt.broadcast_arrays(mu, lam, alpha)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -1180,7 +1180,7 @@ class Beta(UnitContinuous):
 
         return super().dist([alpha, beta], **kwargs)
 
-    def finite_logp_point(rv, size, alpha, beta):
+    def support_point(rv, size, alpha, beta):
         mean = alpha / (alpha + beta)
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -1308,7 +1308,7 @@ class Kumaraswamy(UnitContinuous):
 
         return super().dist([a, b], *args, **kwargs)
 
-    def finite_logp_point(rv, size, a, b):
+    def support_point(rv, size, a, b):
         mean = pt.exp(pt.log(b) + pt.gammaln(1 + 1 / a) + pt.gammaln(b) - pt.gammaln(1 + 1 / a + b))
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -1404,7 +1404,7 @@ class Exponential(PositiveContinuous):
         # PyTensor exponential op is parametrized in terms of mu (1/lam)
         return super().dist([scale], **kwargs)
 
-    def finite_logp_point(rv, size, mu):
+    def support_point(rv, size, mu):
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
         return mu
@@ -1495,7 +1495,7 @@ class Laplace(Continuous):
 
         return super().dist([mu, b], *args, **kwargs)
 
-    def finite_logp_point(rv, size, mu, b):
+    def support_point(rv, size, mu, b):
         mu, _ = pt.broadcast_arrays(mu, b)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -1629,7 +1629,7 @@ class AsymmetricLaplace(Continuous):
 
         return kappa
 
-    def finite_logp_point(rv, size, b, kappa, mu):
+    def support_point(rv, size, b, kappa, mu):
         mean = mu - (kappa - 1 / kappa) / b
 
         if not rv_size_is_none(size):
@@ -1728,7 +1728,7 @@ class LogNormal(PositiveContinuous):
 
         return super().dist([mu, sigma], *args, **kwargs)
 
-    def finite_logp_point(rv, size, mu, sigma):
+    def support_point(rv, size, mu, sigma):
         mean = pt.exp(mu + 0.5 * sigma**2)
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -1844,7 +1844,7 @@ class StudentT(Continuous):
 
         return super().dist([nu, mu, sigma], **kwargs)
 
-    def finite_logp_point(rv, size, nu, mu, sigma):
+    def support_point(rv, size, nu, mu, sigma):
         mu, _, _ = pt.broadcast_arrays(mu, nu, sigma)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -1941,7 +1941,7 @@ class Pareto(BoundedContinuous):
 
         return super().dist([alpha, m], **kwargs)
 
-    def finite_logp_point(rv, size, alpha, m):
+    def support_point(rv, size, alpha, m):
         median = m * 2 ** (1 / alpha)
         if not rv_size_is_none(size):
             median = pt.full(size, median)
@@ -2049,7 +2049,7 @@ class Cauchy(Continuous):
 
         return super().dist([alpha, beta], **kwargs)
 
-    def finite_logp_point(rv, size, alpha, beta):
+    def support_point(rv, size, alpha, beta):
         alpha, _ = pt.broadcast_arrays(alpha, beta)
         if not rv_size_is_none(size):
             alpha = pt.full(size, alpha)
@@ -2128,7 +2128,7 @@ class HalfCauchy(PositiveContinuous):
         beta = pt.as_tensor_variable(beta)
         return super().dist([0.0, beta], **kwargs)
 
-    def finite_logp_point(rv, size, loc, beta):
+    def support_point(rv, size, loc, beta):
         if not rv_size_is_none(size):
             beta = pt.full(size, beta)
         return beta
@@ -2257,7 +2257,7 @@ class Gamma(PositiveContinuous):
 
         return alpha, beta
 
-    def finite_logp_point(rv, size, alpha, scale):
+    def support_point(rv, size, alpha, scale):
         mean = alpha * scale
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -2344,13 +2344,13 @@ class InverseGamma(PositiveContinuous):
 
         return super().dist([alpha, beta], **kwargs)
 
-    def finite_logp_point(rv, size, alpha, beta):
+    def support_point(rv, size, alpha, beta):
         mean = beta / (alpha - 1.0)
         mode = beta / (alpha + 1.0)
-        finite_logp_point = pt.switch(alpha > 1, mean, mode)
+        support_point = pt.switch(alpha > 1, mean, mode)
         if not rv_size_is_none(size):
-            finite_logp_point = pt.full(size, finite_logp_point)
-        return finite_logp_point
+            support_point = pt.full(size, support_point)
+        return support_point
 
     @classmethod
     def _get_alpha_beta(cls, alpha, beta, mu, sigma):
@@ -2527,7 +2527,7 @@ class Weibull(PositiveContinuous):
 
         return super().dist([alpha, beta], *args, **kwargs)
 
-    def finite_logp_point(rv, size, alpha, beta):
+    def support_point(rv, size, alpha, beta):
         mean = beta * pt.gamma(1 + 1 / alpha)
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -2659,7 +2659,7 @@ class HalfStudentT(PositiveContinuous):
 
         return super().dist([nu, sigma], *args, **kwargs)
 
-    def finite_logp_point(rv, size, nu, sigma):
+    def support_point(rv, size, nu, sigma):
         sigma, _ = pt.broadcast_arrays(sigma, nu)
         if not rv_size_is_none(size):
             sigma = pt.full(size, sigma)
@@ -2780,12 +2780,12 @@ class ExGaussian(Continuous):
 
         return super().dist([mu, sigma, nu], *args, **kwargs)
 
-    def finite_logp_point(rv, size, mu, sigma, nu):
+    def support_point(rv, size, mu, sigma, nu):
         mu, nu, _ = pt.broadcast_arrays(mu, nu, sigma)
-        finite_logp_point = mu + nu
+        support_point = mu + nu
         if not rv_size_is_none(size):
-            finite_logp_point = pt.full(size, finite_logp_point)
-        return finite_logp_point
+            support_point = pt.full(size, support_point)
+        return support_point
 
     def logp(value, mu, sigma, nu):
         # Alogithm is adapted from dexGAUS.R from gamlss
@@ -2883,7 +2883,7 @@ class VonMises(CircularContinuous):
         kappa = pt.as_tensor_variable(kappa)
         return super().dist([mu, kappa], *args, **kwargs)
 
-    def finite_logp_point(rv, size, mu, kappa):
+    def support_point(rv, size, mu, kappa):
         mu, _ = pt.broadcast_arrays(mu, kappa)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -2990,7 +2990,7 @@ class SkewNormal(Continuous):
 
         return super().dist([mu, sigma, alpha], *args, **kwargs)
 
-    def finite_logp_point(rv, size, mu, sigma, alpha):
+    def support_point(rv, size, mu, sigma, alpha):
         mean = mu + sigma * (2 / np.pi) ** 0.5 * alpha / (1 + alpha**2) ** 0.5
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -3078,7 +3078,7 @@ class Triangular(BoundedContinuous):
 
         return super().dist([lower, c, upper], *args, **kwargs)
 
-    def finite_logp_point(rv, size, lower, c, upper):
+    def support_point(rv, size, lower, c, upper):
         mean = (lower + upper + c) / 3
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -3203,7 +3203,7 @@ class Gumbel(Continuous):
 
         return super().dist([mu, beta], **kwargs)
 
-    def finite_logp_point(rv, size, mu, beta):
+    def support_point(rv, size, mu, beta):
         mean = mu + beta * np.euler_gamma
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -3335,7 +3335,7 @@ class Rice(PositiveContinuous):
             return nu, b, sigma
         raise ValueError("Rice distribution must specify either nu" " or b.")
 
-    def finite_logp_point(rv, size, nu, sigma):
+    def support_point(rv, size, nu, sigma):
         nu_sigma_ratio = -(nu**2) / (2 * sigma**2)
         mean = (
             sigma
@@ -3421,7 +3421,7 @@ class Logistic(Continuous):
         s = pt.as_tensor_variable(s)
         return super().dist([mu, s], *args, **kwargs)
 
-    def finite_logp_point(rv, size, mu, s):
+    def support_point(rv, size, mu, s):
         mu, _ = pt.broadcast_arrays(mu, s)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -3529,7 +3529,7 @@ class LogitNormal(UnitContinuous):
 
         return super().dist([mu, sigma], **kwargs)
 
-    def finite_logp_point(rv, size, mu, sigma):
+    def support_point(rv, size, mu, sigma):
         median, _ = pt.broadcast_arrays(invlogit(mu), sigma)
         if not rv_size_is_none(size):
             median = pt.full(size, median)
@@ -3663,17 +3663,17 @@ class Interpolated(BoundedContinuous):
 
         return super().dist([x_points, pdf_points, cdf_points], **kwargs)
 
-    def finite_logp_point(rv, size, x_points, pdf_points, cdf_points):
+    def support_point(rv, size, x_points, pdf_points, cdf_points):
         """
         Estimates the expectation integral using the trapezoid rule; cdf_points are not used.
         """
         x_fx = pt.mul(x_points, pdf_points)  # x_i * f(x_i) for all xi's in x_points
-        finite_logp_point = pt.sum(pt.mul(pt.diff(x_points), x_fx[1:] + x_fx[:-1])) / 2
+        support_point = pt.sum(pt.mul(pt.diff(x_points), x_fx[1:] + x_fx[:-1])) / 2
 
         if not rv_size_is_none(size):
-            finite_logp_point = pt.full(size, finite_logp_point)
+            support_point = pt.full(size, support_point)
 
-        return finite_logp_point
+        return support_point
 
     def logp(value, x_points, pdf_points, cdf_points):
         # x_points and pdf_points are expected to be non-symbolic arrays wrapped
@@ -3770,7 +3770,7 @@ class Moyal(Continuous):
 
         return super().dist([mu, sigma], *args, **kwargs)
 
-    def finite_logp_point(rv, size, mu, sigma):
+    def support_point(rv, size, mu, sigma):
         mean = mu + sigma * (np.euler_gamma + pt.log(2))
 
         if not rv_size_is_none(size):
@@ -3973,7 +3973,7 @@ class PolyaGamma(PositiveContinuous):
 
         return super().dist([h, z], **kwargs)
 
-    def finite_logp_point(rv, size, h, z):
+    def support_point(rv, size, h, z):
         mean = pt.switch(pt.eq(z, 0), h / 4, tanh(z / 2) * (h / (2 * z)))
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -128,7 +128,7 @@ class Binomial(Discrete):
         p = pt.as_tensor_variable(p)
         return super().dist([n, p], **kwargs)
 
-    def finite_logp_point(rv, size, n, p):
+    def support_point(rv, size, n, p):
         mean = pt.round(n * p)
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -237,7 +237,7 @@ class BetaBinomial(Discrete):
         n = pt.as_tensor_variable(n, dtype=int)
         return super().dist([n, alpha, beta], **kwargs)
 
-    def finite_logp_point(rv, size, n, alpha, beta):
+    def support_point(rv, size, n, alpha, beta):
         mean = pt.round((n * alpha) / (alpha + beta))
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -350,7 +350,7 @@ class Bernoulli(Discrete):
         p = pt.as_tensor_variable(p)
         return super().dist([p], **kwargs)
 
-    def finite_logp_point(rv, size, p):
+    def support_point(rv, size, p):
         if not rv_size_is_none(size):
             p = pt.full(size, p)
         return pt.switch(p < 0.5, 0, 1)
@@ -460,7 +460,7 @@ class DiscreteWeibull(Discrete):
         beta = pt.as_tensor_variable(beta)
         return super().dist([q, beta], **kwargs)
 
-    def finite_logp_point(rv, size, q, beta):
+    def support_point(rv, size, q, beta):
         median = pt.power(pt.log(0.5) / pt.log(q), 1 / beta) - 1
         if not rv_size_is_none(size):
             median = pt.full(size, median)
@@ -549,7 +549,7 @@ class Poisson(Discrete):
         mu = pt.as_tensor_variable(mu)
         return super().dist([mu], *args, **kwargs)
 
-    def finite_logp_point(rv, size, mu):
+    def support_point(rv, size, mu):
         mu = pt.floor(mu)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -695,7 +695,7 @@ class NegativeBinomial(Discrete):
 
         return n, p
 
-    def finite_logp_point(rv, size, n, p):
+    def support_point(rv, size, n, p):
         mu = pt.floor(n * (1 - p) / p)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -786,7 +786,7 @@ class Geometric(Discrete):
         p = pt.as_tensor_variable(p)
         return super().dist([p], *args, **kwargs)
 
-    def finite_logp_point(rv, size, p):
+    def support_point(rv, size, p):
         mean = pt.round(1.0 / p)
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -889,7 +889,7 @@ class HyperGeometric(Discrete):
         n = pt.as_tensor_variable(n, dtype=int)
         return super().dist([good, bad, n], *args, **kwargs)
 
-    def finite_logp_point(rv, size, good, bad, n):
+    def support_point(rv, size, good, bad, n):
         N, k = good + bad, good
         mode = pt.floor((n + 1) * (k + 1) / (N + 2))
         if not rv_size_is_none(size):
@@ -1025,7 +1025,7 @@ class DiscreteUniform(Discrete):
         upper = pt.floor(upper)
         return super().dist([lower, upper], **kwargs)
 
-    def finite_logp_point(rv, size, lower, upper):
+    def support_point(rv, size, lower, upper):
         mode = pt.maximum(pt.floor((upper + lower) / 2.0), lower)
         if not rv_size_is_none(size):
             mode = pt.full(size, mode)
@@ -1142,7 +1142,7 @@ class Categorical(Discrete):
                 p = pt.as_tensor_variable(p_)
         return super().dist([p], **kwargs)
 
-    def finite_logp_point(rv, size, p):
+    def support_point(rv, size, p):
         mode = pt.argmax(p, axis=-1)
         if not rv_size_is_none(size):
             mode = pt.full(size, mode)

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -128,7 +128,7 @@ class Binomial(Discrete):
         p = pt.as_tensor_variable(p)
         return super().dist([n, p], **kwargs)
 
-    def moment(rv, size, n, p):
+    def finite_logp_point(rv, size, n, p):
         mean = pt.round(n * p)
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -237,7 +237,7 @@ class BetaBinomial(Discrete):
         n = pt.as_tensor_variable(n, dtype=int)
         return super().dist([n, alpha, beta], **kwargs)
 
-    def moment(rv, size, n, alpha, beta):
+    def finite_logp_point(rv, size, n, alpha, beta):
         mean = pt.round((n * alpha) / (alpha + beta))
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -350,7 +350,7 @@ class Bernoulli(Discrete):
         p = pt.as_tensor_variable(p)
         return super().dist([p], **kwargs)
 
-    def moment(rv, size, p):
+    def finite_logp_point(rv, size, p):
         if not rv_size_is_none(size):
             p = pt.full(size, p)
         return pt.switch(p < 0.5, 0, 1)
@@ -460,7 +460,7 @@ class DiscreteWeibull(Discrete):
         beta = pt.as_tensor_variable(beta)
         return super().dist([q, beta], **kwargs)
 
-    def moment(rv, size, q, beta):
+    def finite_logp_point(rv, size, q, beta):
         median = pt.power(pt.log(0.5) / pt.log(q), 1 / beta) - 1
         if not rv_size_is_none(size):
             median = pt.full(size, median)
@@ -549,7 +549,7 @@ class Poisson(Discrete):
         mu = pt.as_tensor_variable(mu)
         return super().dist([mu], *args, **kwargs)
 
-    def moment(rv, size, mu):
+    def finite_logp_point(rv, size, mu):
         mu = pt.floor(mu)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -695,7 +695,7 @@ class NegativeBinomial(Discrete):
 
         return n, p
 
-    def moment(rv, size, n, p):
+    def finite_logp_point(rv, size, n, p):
         mu = pt.floor(n * (1 - p) / p)
         if not rv_size_is_none(size):
             mu = pt.full(size, mu)
@@ -786,7 +786,7 @@ class Geometric(Discrete):
         p = pt.as_tensor_variable(p)
         return super().dist([p], *args, **kwargs)
 
-    def moment(rv, size, p):
+    def finite_logp_point(rv, size, p):
         mean = pt.round(1.0 / p)
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
@@ -889,7 +889,7 @@ class HyperGeometric(Discrete):
         n = pt.as_tensor_variable(n, dtype=int)
         return super().dist([good, bad, n], *args, **kwargs)
 
-    def moment(rv, size, good, bad, n):
+    def finite_logp_point(rv, size, good, bad, n):
         N, k = good + bad, good
         mode = pt.floor((n + 1) * (k + 1) / (N + 2))
         if not rv_size_is_none(size):
@@ -1025,7 +1025,7 @@ class DiscreteUniform(Discrete):
         upper = pt.floor(upper)
         return super().dist([lower, upper], **kwargs)
 
-    def moment(rv, size, lower, upper):
+    def finite_logp_point(rv, size, lower, upper):
         mode = pt.maximum(pt.floor((upper + lower) / 2.0), lower)
         if not rv_size_is_none(size):
             mode = pt.full(size, mode)
@@ -1142,7 +1142,7 @@ class Categorical(Discrete):
                 p = pt.as_tensor_variable(p_)
         return super().dist([p], **kwargs)
 
-    def moment(rv, size, p):
+    def finite_logp_point(rv, size, p):
         mode = pt.argmax(p, axis=-1)
         if not rv_size_is_none(size):
             mode = pt.full(size, mode)

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -86,8 +86,8 @@ vectorized_ppc: contextvars.ContextVar[Optional[Callable]] = contextvars.Context
 PLATFORM = sys.platform
 
 
-class MomentRewrite(GraphRewriter):
-    def rewrite_moment_scan_node(self, node):
+class FiniteLogpPointRewrite(GraphRewriter):
+    def rewrite_finet_logp_point_scan_node(self, node):
         if not isinstance(node.op, Scan):
             return
 
@@ -96,19 +96,19 @@ class MomentRewrite(GraphRewriter):
 
         local_fgraph_topo = io_toposort(node_inputs, node_outputs)
 
-        replace_with_moment = []
+        replace_with_finite_logp_point = []
         to_replace_set = set()
 
         for nd in local_fgraph_topo:
             if nd not in to_replace_set and isinstance(
                 nd.op, (RandomVariable, SymbolicRandomVariable)
             ):
-                replace_with_moment.append(nd.out)
+                replace_with_finite_logp_point.append(nd.out)
                 to_replace_set.add(nd)
         givens = {}
-        if len(replace_with_moment) > 0:
-            for item in replace_with_moment:
-                givens[item] = moment(item)
+        if len(replace_with_finite_logp_point) > 0:
+            for item in replace_with_finite_logp_point:
+                givens[item] = finite_logp_point(item)
         else:
             return
         op_outs = clone_replace(node_outputs, replace=givens)
@@ -132,9 +132,9 @@ class MomentRewrite(GraphRewriter):
     def apply(self, fgraph):
         for node in fgraph.toposort():
             if isinstance(node.op, (RandomVariable, SymbolicRandomVariable)):
-                fgraph.replace(node.out, moment(node.out))
+                fgraph.replace(node.out, finite_logp_point(node.out))
             elif isinstance(node.op, Scan):
-                new_node = self.rewrite_moment_scan_node(node)
+                new_node = self.rewrite_finite_logp_point_scan_node(node)
                 if new_node is not None:
                     fgraph.replace_all(tuple(zip(node.outputs, new_node.outputs)))
 
@@ -209,12 +209,12 @@ class DistributionMeta(ABCMeta):
                     dist_params = dist_params[3:]
                     return class_icdf(value, *dist_params)
 
-            class_moment = clsdict.get("moment")
-            if class_moment:
+            class_finite_logp_point = clsdict.get("finite_logp_point")
+            if class_finite_logp_point:
 
-                @_moment.register(rv_type)
-                def moment(op, rv, rng, size, dtype, *dist_params):
-                    return class_moment(rv, size, *dist_params)
+                @_finite_logp_point.register(rv_type)
+                def finite_logp_poin(op, rv, rng, size, dtype, *dist_params):
+                    return class_finite_logp_point(rv, size, *dist_params)
 
             # Register the PyTensor rv_type as a subclass of this
             # PyMC Distribution type.
@@ -310,9 +310,9 @@ class Distribution(metaclass=DistributionMeta):
             the shape of dims is used to define the shape of the variable.
         initval : optional
             Numeric or symbolic untransformed initial value of matching shape,
-            or one of the following initial value strategies: "moment", "prior".
+            or one of the following initial value strategies: "finite_logp_point", "prior".
             Depending on the sampler's settings, a random jitter may be added to numeric, symbolic
-            or moment-based initial values in the transformed space.
+            or finite_logp_point-based initial values in the transformed space.
         observed : optional
             Observed data to be passed when registering the random variable in the model.
             When neither shape nor dims is provided, the shape of observed is used to
@@ -480,18 +480,20 @@ logprob_rewrites_db.register(
 
 
 @singledispatch
-def _moment(op, rv, *rv_inputs) -> TensorVariable:
-    raise NotImplementedError(f"Variable {rv} of type {op} has no moment implementation.")
+def _finite_logp_point(op, rv, *rv_inputs) -> TensorVariable:
+    raise NotImplementedError(
+        f"Variable {rv} of type {op} has no finite_logp_point implementation."
+    )
 
 
-def moment(rv: TensorVariable) -> TensorVariable:
+def finite_logp_point(rv: TensorVariable) -> TensorVariable:
     """Method for choosing a representative point/value
     that can be used to start optimization or MCMC sampling.
 
     The only parameter to this function is the RandomVariable
     for which the value is to be derived.
     """
-    return _moment(rv.owner.op, rv, *rv.owner.inputs).astype(rv.dtype)
+    return _finite_logp_point(rv.owner.op, rv, *rv.owner.inputs).astype(rv.dtype)
 
 
 class Discrete(Distribution):
@@ -537,7 +539,7 @@ class _CustomDist(Distribution):
         logp: Optional[Callable] = None,
         logcdf: Optional[Callable] = None,
         random: Optional[Callable] = None,
-        moment: Optional[Callable] = None,
+        finite_logp_point: Optional[Callable] = None,
         ndim_supp: int = 0,
         ndims_params: Optional[Sequence[int]] = None,
         dtype: str = "floatX",
@@ -561,9 +563,9 @@ class _CustomDist(Distribution):
         if logcdf is None:
             logcdf = default_not_implemented(class_name, "logcdf")
 
-        if moment is None:
-            moment = functools.partial(
-                default_moment,
+        if finite_logp_point is None:
+            finite_logp_point = functools.partial(
+                default_finite_logp_point,
                 rv_name=class_name,
                 has_fallback=random is not None,
                 ndim_supp=ndim_supp,
@@ -577,7 +579,7 @@ class _CustomDist(Distribution):
             logp=logp,
             logcdf=logcdf,
             random=random,
-            moment=moment,
+            finite_logp_point=finite_logp_point,
             ndim_supp=ndim_supp,
             ndims_params=ndims_params,
             dtype=dtype,
@@ -592,7 +594,7 @@ class _CustomDist(Distribution):
         logp: Optional[Callable],
         logcdf: Optional[Callable],
         random: Optional[Callable],
-        moment: Optional[Callable],
+        finite_logp_point: Optional[Callable],
         ndim_supp: int,
         ndims_params: Optional[Sequence[int]],
         dtype: str,
@@ -622,9 +624,9 @@ class _CustomDist(Distribution):
         def density_dist_logcdf(op, value, rng, size, dtype, *dist_params, **kwargs):
             return logcdf(value, *dist_params, **kwargs)
 
-        @_moment.register(rv_type)
-        def density_dist_get_moment(op, rv, rng, size, dtype, *dist_params):
-            return moment(rv, size, *dist_params)
+        @_finite_logp_point.register(rv_type)
+        def density_dist_get_finite_logp_point(op, rv, rng, size, dtype, *dist_params):
+            return finite_logp_point(rv, size, *dist_params)
 
         rv_op = rv_type()
         return rv_op(*dist_params, **kwargs)
@@ -657,18 +659,18 @@ class CustomSymbolicDistRV(SymbolicRandomVariable):
         return updates
 
 
-@_moment.register(CustomSymbolicDistRV)
-def dist_moment(op, rv, *args):
+@_finite_logp_point.register(CustomSymbolicDistRV)
+def dist_finite_logp_point(op, rv, *args):
     node = rv.owner
     rv_out_idx = node.outputs.index(rv)
 
     fgraph = op.fgraph.clone()
-    replace_moments = MomentRewrite()
-    replace_moments.rewrite(fgraph)
+    replace_finite_logp_point = FiniteLogpPointRewrite()
+    replace_finite_logp_point.rewrite(fgraph)
     # Replace dummy inner inputs by outer inputs
     fgraph.replace_all(tuple(zip(op.inner_inputs, args)), import_missing=True)
-    moment = fgraph.outputs[rv_out_idx]
-    return moment
+    finite_logp_point = fgraph.outputs[rv_out_idx]
+    return finite_logp_point
 
 
 class _CustomSymbolicDist(Distribution):
@@ -681,7 +683,7 @@ class _CustomSymbolicDist(Distribution):
         dist: Callable,
         logp: Optional[Callable] = None,
         logcdf: Optional[Callable] = None,
-        moment: Optional[Callable] = None,
+        finite_logp_point: Optional[Callable] = None,
         ndim_supp: int = 0,
         dtype: str = "floatX",
         class_name: str = "CustomDist",
@@ -698,7 +700,7 @@ class _CustomSymbolicDist(Distribution):
             logp=logp,
             logcdf=logcdf,
             dist=dist,
-            moment=moment,
+            finite_logp_point=finite_logp_point,
             ndim_supp=ndim_supp,
             **kwargs,
         )
@@ -710,7 +712,7 @@ class _CustomSymbolicDist(Distribution):
         dist: Callable,
         logp: Optional[Callable],
         logcdf: Optional[Callable],
-        moment: Optional[Callable],
+        finite_logp_point: Optional[Callable],
         size=None,
         ndim_supp: int,
         class_name: str,
@@ -747,11 +749,11 @@ class _CustomSymbolicDist(Distribution):
             def custom_dist_logcdf(op, value, size, *params, **kwargs):
                 return logcdf(value, *params[: len(dist_params)])
 
-        if moment is not None:
+        if finite_logp_point is not None:
 
-            @_moment.register(rv_type)
-            def custom_dist_get_moment(op, rv, size, *params):
-                return moment(
+            @_finite_logp_point.register(rv_type)
+            def custom_dist_get_finite_logp_point(op, rv, size, *params):
+                return finite_logp_point(
                     rv,
                     size,
                     *[
@@ -812,7 +814,7 @@ class CustomDist:
     Python graph that represents the logp graph when evaluated. This is used for
     mcmc sampling.
 
-    Additionally, a user can provide a `logcdf` and `moment` functions that must return
+    Additionally, a user can provide a `logcdf` and `finite_logp_point` functions that must return
     an PyTensor graph that computes those quantities. These may be used by other PyMC
     routines.
 
@@ -865,14 +867,14 @@ class CustomDist:
         are the tensors that hold the values of the distribution parameters.
         This function must return an PyTensor tensor. If ``None``, a ``NotImplementedError``
         will be raised when trying to compute the distribution's logcdf.
-    moment : Optional[Callable]
-        A callable that can be used to compute the moments of the distribution.
-        It must have the following signature: ``moment(rv, size, *rv_inputs)``.
+    finite_logp_point : Optional[Callable]
+        A callable that can be used to compute the finete logp point of the distribution.
+        It must have the following signature: ``finite_logp_point(rv, size, *rv_inputs)``.
         The distribution's variable is passed as the first argument ``rv``. ``size``
         is the random variable's size implied by the ``dims``, ``size`` and parameters
         supplied to the distribution. Finally, ``rv_inputs`` is the sequence of the
         distribution parameters, in the same order as they were supplied when the
-        CustomDist was created. If ``None``, a default  ``moment`` function will be
+        CustomDist was created. If ``None``, a default  ``finite_logp_point`` function will be
         assigned that will always return 0, or an array of zeros.
     ndim_supp : int
         The number of dimensions in the support of the distribution. Defaults to assuming
@@ -1020,7 +1022,7 @@ class CustomDist:
         random: Optional[Callable] = None,
         logp: Optional[Callable] = None,
         logcdf: Optional[Callable] = None,
-        moment: Optional[Callable] = None,
+        finite_logp_point: Optional[Callable] = None,
         ndim_supp: int = 0,
         ndims_params: Optional[Sequence[int]] = None,
         dtype: str = "floatX",
@@ -1044,7 +1046,7 @@ class CustomDist:
                 dist=dist,
                 logp=logp,
                 logcdf=logcdf,
-                moment=moment,
+                finite_logp_point=finite_logp_point,
                 ndim_supp=ndim_supp,
                 **kwargs,
             )
@@ -1056,7 +1058,7 @@ class CustomDist:
                 random=random,
                 logp=logp,
                 logcdf=logcdf,
-                moment=moment,
+                finite_logp_point=finite_logp_point,
                 ndim_supp=ndim_supp,
                 ndims_params=ndims_params,
                 dtype=dtype,
@@ -1071,7 +1073,7 @@ class CustomDist:
         random: Optional[Callable] = None,
         logp: Optional[Callable] = None,
         logcdf: Optional[Callable] = None,
-        moment: Optional[Callable] = None,
+        finite_logp_point: Optional[Callable] = None,
         ndim_supp: int = 0,
         ndims_params: Optional[Sequence[int]] = None,
         dtype: str = "floatX",
@@ -1085,7 +1087,7 @@ class CustomDist:
                 dist=dist,
                 logp=logp,
                 logcdf=logcdf,
-                moment=moment,
+                finite_logp_point=finite_logp_point,
                 ndim_supp=ndim_supp,
                 **kwargs,
             )
@@ -1095,7 +1097,7 @@ class CustomDist:
                 random=random,
                 logp=logp,
                 logcdf=logcdf,
-                moment=moment,
+                finite_logp_point=finite_logp_point,
                 ndim_supp=ndim_supp,
                 ndims_params=ndims_params,
                 dtype=dtype,
@@ -1161,15 +1163,15 @@ def default_not_implemented(rv_name, method_name):
     return func
 
 
-def default_moment(rv, size, *rv_inputs, rv_name=None, has_fallback=False, ndim_supp=0):
+def default_finite_logp_point(rv, size, *rv_inputs, rv_name=None, has_fallback=False, ndim_supp=0):
     if ndim_supp == 0:
         return pt.zeros(size, dtype=rv.dtype)
     elif has_fallback:
         return pt.zeros_like(rv)
     else:
         raise TypeError(
-            "Cannot safely infer the size of a multivariate random variable's moment. "
-            f"Please provide a moment function when instantiating the {rv_name} "
+            "Cannot safely infer the size of a multivariate random variable's finite_logp_point. "
+            f"Please provide a finite_logp_point function when instantiating the {rv_name} "
             "random variable."
         )
 
@@ -1215,7 +1217,7 @@ class DiracDelta(Discrete):
             c = floatX(c)
         return super().dist([c], **kwargs)
 
-    def moment(rv, size, c):
+    def finite_logp_point(rv, size, c):
         if not rv_size_is_none(size):
             c = pt.full(size, c)
         return c
@@ -1365,11 +1367,11 @@ def partial_observed_rv_logprob(op, values, dist, mask, **kwargs):
         return joined_logp.ravel(), pt.zeros((0,), dtype=joined_logp.type.dtype)
 
 
-@_moment.register(PartialObservedRV)
-def partial_observed_rv_moment(op, partial_obs_rv, rv, mask):
+@_finite_logp_point.register(PartialObservedRV)
+def partial_observed_rv_finite_logp_point(op, partial_obs_rv, rv, mask):
     # Unobserved output
     if partial_obs_rv.owner.outputs.index(partial_obs_rv) == 1:
-        return moment(rv)[mask]
+        return finite_logp_point(rv)[mask]
     # Observed output
     else:
-        return moment(rv)[~mask]
+        return finite_logp_point(rv)[~mask]

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -1040,6 +1040,7 @@ class CustomDist:
         random: Optional[Callable] = None,
         logp: Optional[Callable] = None,
         logcdf: Optional[Callable] = None,
+        moment: Optional[Callable] = None,
         support_point: Optional[Callable] = None,
         ndim_supp: int = 0,
         ndims_params: Optional[Sequence[int]] = None,
@@ -1056,6 +1057,12 @@ class CustomDist:
             )
         dist_params = cls.parse_dist_params(dist_params)
         cls.check_valid_dist_random(dist, random, dist_params)
+        if moment is not None:
+            warnings.warn(
+                "`moment` argument is deprecated. Use `support_point` instead.",
+                FutureWarning,
+            )
+            support_point = moment
         if dist is not None:
             kwargs.setdefault("class_name", f"CustomDist_{name}")
             return _CustomSymbolicDist(

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -87,7 +87,7 @@ PLATFORM = sys.platform
 
 
 class FiniteLogpPointRewrite(GraphRewriter):
-    def rewrite_finet_logp_point_scan_node(self, node):
+    def rewrite_finite_logp_point_scan_node(self, node):
         if not isinstance(node.op, Scan):
             return
 

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -209,11 +209,23 @@ class DistributionMeta(ABCMeta):
                     dist_params = dist_params[3:]
                     return class_icdf(value, *dist_params)
 
+            class_moment = clsdict.get("moment")
+            if class_moment:
+                warnings.warn(
+                    "The moment() method is deprecated. Use support_point() instead.",
+                    DeprecationWarning,
+                )
+
+                @_support_point.register(rv_type)
+                def support_point(op, rv, rng, size, dtype, *dist_params):
+                    return class_moment(rv, size, *dist_params)
+
             class_support_point = clsdict.get("support_point")
+
             if class_support_point:
 
                 @_support_point.register(rv_type)
-                def finite_logp_poin(op, rv, rng, size, dtype, *dist_params):
+                def support_point(op, rv, rng, size, dtype, *dist_params):
                     return class_support_point(rv, size, *dist_params)
 
             # Register the PyTensor rv_type as a subclass of this
@@ -492,6 +504,14 @@ def support_point(rv: TensorVariable) -> TensorVariable:
     for which the value is to be derived.
     """
     return _support_point(rv.owner.op, rv, *rv.owner.inputs).astype(rv.dtype)
+
+
+def moment(rv: TensorVariable) -> TensorVariable:
+    warnings.warn(
+        "The moment() method is deprecated. Use support_point() instead.",
+        DeprecationWarning,
+    )
+    return support_point(rv)
 
 
 class Discrete(Distribution):

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -29,8 +29,8 @@ from pymc.distributions.distribution import (
     DiracDelta,
     Distribution,
     SymbolicRandomVariable,
-    _finite_logp_point,
-    finite_logp_point,
+    _support_point,
+    support_point,
 )
 from pymc.distributions.shape_utils import _change_dist_size, change_dist_size
 from pymc.distributions.transforms import _default_transform
@@ -391,25 +391,25 @@ def marginal_mixture_logcdf(op, value, rng, weights, *components, **kwargs):
     return mix_logcdf
 
 
-@_finite_logp_point.register(MarginalMixtureRV)
-def marginal_mixture_finite_logp_point(op, rv, rng, weights, *components):
+@_support_point.register(MarginalMixtureRV)
+def marginal_mixture_support_point(op, rv, rng, weights, *components):
     ndim_supp = components[0].owner.op.ndim_supp
     weights = pt.shape_padright(weights, ndim_supp)
     mix_axis = -ndim_supp - 1
 
     if len(components) == 1:
-        finite_logp_point_components = finite_logp_point(components[0])
+        support_point_components = support_point(components[0])
 
     else:
-        finite_logp_point_components = pt.stack(
-            [finite_logp_point(component) for component in components],
+        support_point_components = pt.stack(
+            [support_point(component) for component in components],
             axis=mix_axis,
         )
 
-    mix_finite_logp_point = pt.sum(weights * finite_logp_point_components, axis=mix_axis)
+    mix_support_point = pt.sum(weights * support_point_components, axis=mix_axis)
     if components[0].dtype in discrete_types:
-        mix_finite_logp_point = pt.round(mix_finite_logp_point)
-    return mix_finite_logp_point
+        mix_support_point = pt.round(mix_support_point)
+    return mix_support_point
 
 
 # List of transforms that can be used by Mixture, either because they do not require

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -29,8 +29,8 @@ from pymc.distributions.distribution import (
     DiracDelta,
     Distribution,
     SymbolicRandomVariable,
-    _moment,
-    moment,
+    _finite_logp_point,
+    finite_logp_point,
 )
 from pymc.distributions.shape_utils import _change_dist_size, change_dist_size
 from pymc.distributions.transforms import _default_transform
@@ -391,25 +391,25 @@ def marginal_mixture_logcdf(op, value, rng, weights, *components, **kwargs):
     return mix_logcdf
 
 
-@_moment.register(MarginalMixtureRV)
-def marginal_mixture_moment(op, rv, rng, weights, *components):
+@_finite_logp_point.register(MarginalMixtureRV)
+def marginal_mixture_finite_logp_point(op, rv, rng, weights, *components):
     ndim_supp = components[0].owner.op.ndim_supp
     weights = pt.shape_padright(weights, ndim_supp)
     mix_axis = -ndim_supp - 1
 
     if len(components) == 1:
-        moment_components = moment(components[0])
+        finite_logp_point_components = finite_logp_point(components[0])
 
     else:
-        moment_components = pt.stack(
-            [moment(component) for component in components],
+        finite_logp_point_components = pt.stack(
+            [finite_logp_point(component) for component in components],
             axis=mix_axis,
         )
 
-    mix_moment = pt.sum(weights * moment_components, axis=mix_axis)
+    mix_finite_logp_point = pt.sum(weights * finite_logp_point_components, axis=mix_axis)
     if components[0].dtype in discrete_types:
-        mix_moment = pt.round(mix_moment)
-    return mix_moment
+        mix_finite_logp_point = pt.round(mix_finite_logp_point)
+    return mix_finite_logp_point
 
 
 # List of transforms that can be used by Mixture, either because they do not require

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -57,8 +57,8 @@ from pymc.distributions.distribution import (
     Discrete,
     Distribution,
     SymbolicRandomVariable,
-    _moment,
-    moment,
+    _finite_logp_point,
+    finite_logp_point,
 )
 from pymc.distributions.shape_utils import (
     _change_dist_size,
@@ -245,13 +245,13 @@ class MvNormal(Continuous):
         mu, _ = pt.broadcast_arrays(mu, cov[..., -1])
         return super().dist([mu, cov], **kwargs)
 
-    def moment(rv, size, mu, cov):
+    def finite_logp_point(rv, size, mu, cov):
         # mu is broadcasted to the potential length of cov in `dist`
-        moment = mu
+        finite_logp_point = mu
         if not rv_size_is_none(size):
-            moment_size = pt.concatenate([size, [mu.shape[-1]]])
-            moment = pt.full(moment_size, mu)
-        return moment
+            finite_logp_point_size = pt.concatenate([size, [mu.shape[-1]]])
+            finite_logp_point = pt.full(finite_logp_point_size, mu)
+        return finite_logp_point
 
     def logp(value, mu, cov):
         """
@@ -380,14 +380,14 @@ class MvStudentT(Continuous):
 
         return super().dist([nu, mu, scale], **kwargs)
 
-    def moment(rv, size, nu, mu, scale):
+    def finite_logp_point(rv, size, nu, mu, scale):
         # mu is broadcasted to the potential length of scale in `dist`
         mu, _ = pt.random.utils.broadcast_params([mu, nu], ndims_params=[1, 0])
-        moment = mu
+        finite_logp_point = mu
         if not rv_size_is_none(size):
-            moment_size = pt.concatenate([size, [mu.shape[-1]]])
-            moment = pt.full(moment_size, moment)
-        return moment
+            finite_logp_point_size = pt.concatenate([size, [mu.shape[-1]]])
+            finite_logp_point = pt.full(finite_logp_point_size, finite_logp_point)
+        return finite_logp_point
 
     def logp(value, nu, mu, scale):
         """
@@ -448,12 +448,12 @@ class Dirichlet(SimplexContinuous):
 
         return super().dist([a], **kwargs)
 
-    def moment(rv, size, a):
+    def finite_logp_point(rv, size, a):
         norm_constant = pt.sum(a, axis=-1)[..., None]
-        moment = a / norm_constant
+        finite_logp_point = a / norm_constant
         if not rv_size_is_none(size):
-            moment = pt.full(pt.concatenate([size, [a.shape[-1]]]), moment)
-        return moment
+            finite_logp_point = pt.full(pt.concatenate([size, [a.shape[-1]]]), finite_logp_point)
+        return finite_logp_point
 
     def logp(value, a):
         """
@@ -541,7 +541,7 @@ class Multinomial(Discrete):
         p = pt.as_tensor_variable(p)
         return super().dist([n, p], *args, **kwargs)
 
-    def moment(rv, size, n, p):
+    def finite_logp_point(rv, size, n, p):
         n = pt.shape_padright(n)
         mean = n * p
         mode = pt.round(mean)
@@ -557,7 +557,7 @@ class Multinomial(Discrete):
             output_size = pt.concatenate([size, [p.shape[-1]]])
             mode = pt.full(output_size, mode)
         return Assert(
-            "Negative value in computed moment of Multinomial."
+            "Negative value in computed finite_logp_point of Multinomial."
             "It is a known limitation that can arise when the expected largest count is small."
             "Please provide an initial value manually."
         )(mode, pt.all(mode >= 0))
@@ -672,9 +672,9 @@ class DirichletMultinomial(Discrete):
     def dist(cls, n, a, *args, **kwargs):
         return super().dist([n, a], **kwargs)
 
-    def moment(rv, size, n, a):
+    def finite_logp_point(rv, size, n, a):
         p = a / pt.sum(a, axis=-1, keepdims=True)
-        return moment(Multinomial.dist(n=n, p=p, size=size))
+        return finite_logp_point(Multinomial.dist(n=n, p=p, size=size))
 
     def logp(value, n, a):
         """
@@ -1233,12 +1233,12 @@ def change_LKJCholeksyCovRV_size(op, dist, new_size, expand=False):
     return _LKJCholeskyCov.rv_op(n, eta, sd_dist, size=new_size)
 
 
-@_moment.register(_LKJCholeskyCovRV)
-def _LKJCholeksyCovRV_moment(op, rv, rng, n, eta, sd_dist):
+@_finite_logp_point.register(_LKJCholeskyCovRV)
+def _LKJCholeksyCovRV_finite_logp_point(op, rv, rng, n, eta, sd_dist):
     diag_idxs = (pt.cumsum(pt.arange(1, n + 1)) - 1).astype("int32")
-    moment = pt.zeros_like(rv)
-    moment = pt.set_subtensor(moment[..., diag_idxs], 1)
-    return moment
+    finite_logp_point = pt.zeros_like(rv)
+    finite_logp_point = pt.set_subtensor(finite_logp_point[..., diag_idxs], 1)
+    return finite_logp_point
 
 
 @_default_transform.register(_LKJCholeskyCovRV)
@@ -1545,7 +1545,7 @@ class _LKJCorr(BoundedContinuous):
         eta = pt.as_tensor_variable(eta)
         return super().dist([n, eta], **kwargs)
 
-    def moment(rv, *args):
+    def finite_logp_point(rv, *args):
         return pt.zeros_like(rv)
 
     def logp(value, n, eta):
@@ -1866,7 +1866,7 @@ class MatrixNormal(Continuous):
 
         return super().dist([mu, rowchol_cov, colchol_cov], **kwargs)
 
-    def moment(rv, size, mu, rowchol, colchol):
+    def finite_logp_point(rv, size, mu, rowchol, colchol):
         return pt.full_like(rv, mu)
 
     def logp(value, mu, rowchol, colchol):
@@ -2054,11 +2054,11 @@ class KroneckerNormal(Continuous):
 
         return super().dist([mu, sigma, *covs], **kwargs)
 
-    def moment(rv, size, mu, covs, chols, evds):
+    def finite_logp_point(rv, size, mu, covs, chols, evds):
         mean = mu
         if not rv_size_is_none(size):
-            moment_size = pt.concatenate([size, mu.shape])
-            mean = pt.full(moment_size, mu)
+            finite_logp_point_size = pt.concatenate([size, mu.shape])
+            mean = pt.full(finite_logp_point_size, mu)
         return mean
 
     def logp(value, mu, sigma, *covs):
@@ -2242,7 +2242,7 @@ class CAR(Continuous):
     def dist(cls, mu, W, alpha, tau, *args, **kwargs):
         return super().dist([mu, W, alpha, tau], **kwargs)
 
-    def moment(rv, size, mu, W, alpha, tau):
+    def finite_logp_point(rv, size, mu, W, alpha, tau):
         return pt.full_like(rv, mu)
 
     def logp(value, mu, W, alpha, tau):
@@ -2449,7 +2449,7 @@ class ICAR(Continuous):
 
         return super().dist([W, node1, node2, N, sigma, zero_sum_stdev], **kwargs)
 
-    def moment(rv, size, W, node1, node2, N, sigma, zero_sum_stdev):
+    def finite_logp_point(rv, size, W, node1, node2, N, sigma, zero_sum_stdev):
         return pt.zeros(N)
 
     def logp(value, W, node1, node2, N, sigma, zero_sum_stdev):
@@ -2559,13 +2559,13 @@ class StickBreakingWeights(SimplexContinuous):
 
         return super().dist([alpha, K], **kwargs)
 
-    def moment(rv, size, alpha, K):
+    def finite_logp_point(rv, size, alpha, K):
         alpha = alpha[..., np.newaxis]
-        moment = (alpha / (1 + alpha)) ** pt.arange(K)
-        moment *= 1 / (1 + alpha)
-        moment = pt.concatenate([moment, (alpha / (1 + alpha)) ** K], axis=-1)
+        finite_logp_point = (alpha / (1 + alpha)) ** pt.arange(K)
+        finite_logp_point *= 1 / (1 + alpha)
+        finite_logp_point = pt.concatenate([finite_logp_point, (alpha / (1 + alpha)) ** K], axis=-1)
         if not rv_size_is_none(size):
-            moment_size = pt.concatenate(
+            finite_logp_point_size = pt.concatenate(
                 [
                     size,
                     [
@@ -2573,9 +2573,9 @@ class StickBreakingWeights(SimplexContinuous):
                     ],
                 ]
             )
-            moment = pt.full(moment_size, moment)
+            finite_logp_point = pt.full(finite_logp_point_size, finite_logp_point)
 
-        return moment
+        return finite_logp_point
 
     def logp(value, alpha, K):
         """
@@ -2808,8 +2808,8 @@ def change_zerosum_size(op, normal_dist, new_size, expand=False):
     )
 
 
-@_moment.register(ZeroSumNormalRV)
-def zerosumnormal_moment(op, rv, *rv_inputs):
+@_finite_logp_point.register(ZeroSumNormalRV)
+def zerosumnormal_finite_logp_point(op, rv, *rv_inputs):
     return pt.zeros_like(rv)
 
 

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -57,8 +57,8 @@ from pymc.distributions.distribution import (
     Discrete,
     Distribution,
     SymbolicRandomVariable,
-    _finite_logp_point,
-    finite_logp_point,
+    _support_point,
+    support_point,
 )
 from pymc.distributions.shape_utils import (
     _change_dist_size,
@@ -245,13 +245,13 @@ class MvNormal(Continuous):
         mu, _ = pt.broadcast_arrays(mu, cov[..., -1])
         return super().dist([mu, cov], **kwargs)
 
-    def finite_logp_point(rv, size, mu, cov):
+    def support_point(rv, size, mu, cov):
         # mu is broadcasted to the potential length of cov in `dist`
-        finite_logp_point = mu
+        support_point = mu
         if not rv_size_is_none(size):
-            finite_logp_point_size = pt.concatenate([size, [mu.shape[-1]]])
-            finite_logp_point = pt.full(finite_logp_point_size, mu)
-        return finite_logp_point
+            support_point_size = pt.concatenate([size, [mu.shape[-1]]])
+            support_point = pt.full(support_point_size, mu)
+        return support_point
 
     def logp(value, mu, cov):
         """
@@ -380,14 +380,14 @@ class MvStudentT(Continuous):
 
         return super().dist([nu, mu, scale], **kwargs)
 
-    def finite_logp_point(rv, size, nu, mu, scale):
+    def support_point(rv, size, nu, mu, scale):
         # mu is broadcasted to the potential length of scale in `dist`
         mu, _ = pt.random.utils.broadcast_params([mu, nu], ndims_params=[1, 0])
-        finite_logp_point = mu
+        support_point = mu
         if not rv_size_is_none(size):
-            finite_logp_point_size = pt.concatenate([size, [mu.shape[-1]]])
-            finite_logp_point = pt.full(finite_logp_point_size, finite_logp_point)
-        return finite_logp_point
+            support_point_size = pt.concatenate([size, [mu.shape[-1]]])
+            support_point = pt.full(support_point_size, support_point)
+        return support_point
 
     def logp(value, nu, mu, scale):
         """
@@ -448,12 +448,12 @@ class Dirichlet(SimplexContinuous):
 
         return super().dist([a], **kwargs)
 
-    def finite_logp_point(rv, size, a):
+    def support_point(rv, size, a):
         norm_constant = pt.sum(a, axis=-1)[..., None]
-        finite_logp_point = a / norm_constant
+        support_point = a / norm_constant
         if not rv_size_is_none(size):
-            finite_logp_point = pt.full(pt.concatenate([size, [a.shape[-1]]]), finite_logp_point)
-        return finite_logp_point
+            support_point = pt.full(pt.concatenate([size, [a.shape[-1]]]), support_point)
+        return support_point
 
     def logp(value, a):
         """
@@ -541,7 +541,7 @@ class Multinomial(Discrete):
         p = pt.as_tensor_variable(p)
         return super().dist([n, p], *args, **kwargs)
 
-    def finite_logp_point(rv, size, n, p):
+    def support_point(rv, size, n, p):
         n = pt.shape_padright(n)
         mean = n * p
         mode = pt.round(mean)
@@ -557,7 +557,7 @@ class Multinomial(Discrete):
             output_size = pt.concatenate([size, [p.shape[-1]]])
             mode = pt.full(output_size, mode)
         return Assert(
-            "Negative value in computed finite_logp_point of Multinomial."
+            "Negative value in computed support_point of Multinomial."
             "It is a known limitation that can arise when the expected largest count is small."
             "Please provide an initial value manually."
         )(mode, pt.all(mode >= 0))
@@ -672,9 +672,9 @@ class DirichletMultinomial(Discrete):
     def dist(cls, n, a, *args, **kwargs):
         return super().dist([n, a], **kwargs)
 
-    def finite_logp_point(rv, size, n, a):
+    def support_point(rv, size, n, a):
         p = a / pt.sum(a, axis=-1, keepdims=True)
-        return finite_logp_point(Multinomial.dist(n=n, p=p, size=size))
+        return support_point(Multinomial.dist(n=n, p=p, size=size))
 
     def logp(value, n, a):
         """
@@ -1233,12 +1233,12 @@ def change_LKJCholeksyCovRV_size(op, dist, new_size, expand=False):
     return _LKJCholeskyCov.rv_op(n, eta, sd_dist, size=new_size)
 
 
-@_finite_logp_point.register(_LKJCholeskyCovRV)
-def _LKJCholeksyCovRV_finite_logp_point(op, rv, rng, n, eta, sd_dist):
+@_support_point.register(_LKJCholeskyCovRV)
+def _LKJCholeksyCovRV_support_point(op, rv, rng, n, eta, sd_dist):
     diag_idxs = (pt.cumsum(pt.arange(1, n + 1)) - 1).astype("int32")
-    finite_logp_point = pt.zeros_like(rv)
-    finite_logp_point = pt.set_subtensor(finite_logp_point[..., diag_idxs], 1)
-    return finite_logp_point
+    support_point = pt.zeros_like(rv)
+    support_point = pt.set_subtensor(support_point[..., diag_idxs], 1)
+    return support_point
 
 
 @_default_transform.register(_LKJCholeskyCovRV)
@@ -1545,7 +1545,7 @@ class _LKJCorr(BoundedContinuous):
         eta = pt.as_tensor_variable(eta)
         return super().dist([n, eta], **kwargs)
 
-    def finite_logp_point(rv, *args):
+    def support_point(rv, *args):
         return pt.zeros_like(rv)
 
     def logp(value, n, eta):
@@ -1866,7 +1866,7 @@ class MatrixNormal(Continuous):
 
         return super().dist([mu, rowchol_cov, colchol_cov], **kwargs)
 
-    def finite_logp_point(rv, size, mu, rowchol, colchol):
+    def support_point(rv, size, mu, rowchol, colchol):
         return pt.full_like(rv, mu)
 
     def logp(value, mu, rowchol, colchol):
@@ -2054,11 +2054,11 @@ class KroneckerNormal(Continuous):
 
         return super().dist([mu, sigma, *covs], **kwargs)
 
-    def finite_logp_point(rv, size, mu, covs, chols, evds):
+    def support_point(rv, size, mu, covs, chols, evds):
         mean = mu
         if not rv_size_is_none(size):
-            finite_logp_point_size = pt.concatenate([size, mu.shape])
-            mean = pt.full(finite_logp_point_size, mu)
+            support_point_size = pt.concatenate([size, mu.shape])
+            mean = pt.full(support_point_size, mu)
         return mean
 
     def logp(value, mu, sigma, *covs):
@@ -2242,7 +2242,7 @@ class CAR(Continuous):
     def dist(cls, mu, W, alpha, tau, *args, **kwargs):
         return super().dist([mu, W, alpha, tau], **kwargs)
 
-    def finite_logp_point(rv, size, mu, W, alpha, tau):
+    def support_point(rv, size, mu, W, alpha, tau):
         return pt.full_like(rv, mu)
 
     def logp(value, mu, W, alpha, tau):
@@ -2449,7 +2449,7 @@ class ICAR(Continuous):
 
         return super().dist([W, node1, node2, N, sigma, zero_sum_stdev], **kwargs)
 
-    def finite_logp_point(rv, size, W, node1, node2, N, sigma, zero_sum_stdev):
+    def support_point(rv, size, W, node1, node2, N, sigma, zero_sum_stdev):
         return pt.zeros(N)
 
     def logp(value, W, node1, node2, N, sigma, zero_sum_stdev):
@@ -2559,13 +2559,13 @@ class StickBreakingWeights(SimplexContinuous):
 
         return super().dist([alpha, K], **kwargs)
 
-    def finite_logp_point(rv, size, alpha, K):
+    def support_point(rv, size, alpha, K):
         alpha = alpha[..., np.newaxis]
-        finite_logp_point = (alpha / (1 + alpha)) ** pt.arange(K)
-        finite_logp_point *= 1 / (1 + alpha)
-        finite_logp_point = pt.concatenate([finite_logp_point, (alpha / (1 + alpha)) ** K], axis=-1)
+        support_point = (alpha / (1 + alpha)) ** pt.arange(K)
+        support_point *= 1 / (1 + alpha)
+        support_point = pt.concatenate([support_point, (alpha / (1 + alpha)) ** K], axis=-1)
         if not rv_size_is_none(size):
-            finite_logp_point_size = pt.concatenate(
+            support_point_size = pt.concatenate(
                 [
                     size,
                     [
@@ -2573,9 +2573,9 @@ class StickBreakingWeights(SimplexContinuous):
                     ],
                 ]
             )
-            finite_logp_point = pt.full(finite_logp_point_size, finite_logp_point)
+            support_point = pt.full(support_point_size, support_point)
 
-        return finite_logp_point
+        return support_point
 
     def logp(value, alpha, K):
         """
@@ -2808,8 +2808,8 @@ def change_zerosum_size(op, normal_dist, new_size, expand=False):
     )
 
 
-@_finite_logp_point.register(ZeroSumNormalRV)
-def zerosumnormal_finite_logp_point(op, rv, *rv_inputs):
+@_support_point.register(ZeroSumNormalRV)
+def zerosumnormal_support_point(op, rv, *rv_inputs):
     return pt.zeros_like(rv)
 
 

--- a/pymc/distributions/simulator.py
+++ b/pymc/distributions/simulator.py
@@ -23,7 +23,7 @@ from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.variable import TensorVariable
 from scipy.spatial import cKDTree
 
-from pymc.distributions.distribution import Distribution, _finite_logp_point
+from pymc.distributions.distribution import Distribution, _support_point
 from pymc.logprob.abstract import _logprob
 
 __all__ = ["Simulator"]
@@ -248,8 +248,8 @@ class Simulator(Distribution):
         return sim_op(*params, **kwargs)
 
 
-@_finite_logp_point.register(SimulatorRV)  # type: ignore
-def simulator_finite_logp_point(op, rv, *inputs):
+@_support_point.register(SimulatorRV)  # type: ignore
+def simulator_support_point(op, rv, *inputs):
     sim_inputs = inputs[3:]
     # Take the mean of 10 draws
     multiple_sim = rv.owner.op(*sim_inputs, size=pt.concatenate([[10], rv.shape]))

--- a/pymc/distributions/simulator.py
+++ b/pymc/distributions/simulator.py
@@ -23,7 +23,7 @@ from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.variable import TensorVariable
 from scipy.spatial import cKDTree
 
-from pymc.distributions.distribution import Distribution, _moment
+from pymc.distributions.distribution import Distribution, _finite_logp_point
 from pymc.logprob.abstract import _logprob
 
 __all__ = ["Simulator"]
@@ -248,8 +248,8 @@ class Simulator(Distribution):
         return sim_op(*params, **kwargs)
 
 
-@_moment.register(SimulatorRV)  # type: ignore
-def simulator_moment(op, rv, *inputs):
+@_finite_logp_point.register(SimulatorRV)  # type: ignore
+def simulator_finite_logp_point(op, rv, *inputs):
     sim_inputs = inputs[3:]
     # Take the mean of 10 draws
     multiple_sim = rv.owner.op(*sim_inputs, size=pt.concatenate([[10], rv.shape]))

--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -30,8 +30,8 @@ from pymc.distributions.continuous import Normal, get_tau_sigma
 from pymc.distributions.distribution import (
     Distribution,
     SymbolicRandomVariable,
-    _finite_logp_point,
-    finite_logp_point,
+    _support_point,
+    support_point,
 )
 from pymc.distributions.multivariate import MvNormal, MvStudentT
 from pymc.distributions.shape_utils import (
@@ -214,20 +214,18 @@ def change_random_walk_size(op, dist, new_size, expand):
     return RandomWalk.rv_op(init_dist, innovation_dist, steps, size=new_size)
 
 
-@_finite_logp_point.register(RandomWalkRV)
-def random_walk_finite_logp_point(op, rv, init_dist, innovation_dist, steps):
+@_support_point.register(RandomWalkRV)
+def random_walk_support_point(op, rv, init_dist, innovation_dist, steps):
     # shape = (1, B, S)
-    init_finite_logp_point = finite_logp_point(init_dist)
+    init_support_point = support_point(init_dist)
     # shape = (T-1, B, S)
-    innovation_finite_logp_point = finite_logp_point(innovation_dist)
+    innovation_support_point = support_point(innovation_dist)
     # shape = (T, B, S)
-    grw_finite_logp_point = pt.concatenate(
-        [init_finite_logp_point, innovation_finite_logp_point], axis=0
-    )
-    grw_finite_logp_point = pt.cumsum(grw_finite_logp_point, axis=0)
+    grw_support_point = pt.concatenate([init_support_point, innovation_support_point], axis=0)
+    grw_support_point = pt.cumsum(grw_support_point, axis=0)
     # shape = (B, T, S)
-    grw_finite_logp_point = pt.moveaxis(grw_finite_logp_point, 0, -op.ndim_supp)
-    return grw_finite_logp_point
+    grw_support_point = pt.moveaxis(grw_support_point, 0, -op.ndim_supp)
+    return grw_support_point
 
 
 @_logprob.register(RandomWalkRV)
@@ -711,10 +709,10 @@ def ar_logp(op, values, rhos, sigma, init_dist, steps, noise_rng, **kwargs):
     return init_logp + innov_logp
 
 
-@_finite_logp_point.register(AutoRegressiveRV)
-def ar_finite_logp_point(op, rv, rhos, sigma, init_dist, steps, noise_rng):
-    # Use last entry of init_dist finite_logp_point as the moment for the whole AR
-    return pt.full_like(rv, finite_logp_point(init_dist)[..., -1, None])
+@_support_point.register(AutoRegressiveRV)
+def ar_support_point(op, rv, rhos, sigma, init_dist, steps, noise_rng):
+    # Use last entry of init_dist support_point as the moment for the whole AR
+    return pt.full_like(rv, support_point(init_dist)[..., -1, None])
 
 
 class GARCH11RV(SymbolicRandomVariable):
@@ -871,10 +869,8 @@ def garch11_logp(
     return innov_logp
 
 
-@_finite_logp_point.register(GARCH11RV)
-def garch11_finite_logp_point(
-    op, rv, omega, alpha_1, beta_1, initial_vol, init_dist, steps, noise_rng
-):
+@_support_point.register(GARCH11RV)
+def garch11_support_point(op, rv, omega, alpha_1, beta_1, initial_vol, init_dist, steps, noise_rng):
     # GARCH(1,1) mean is zero
     return pt.zeros_like(rv)
 

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -223,6 +223,12 @@ def make_initial_point_expression(
             strategy = default_strategy
 
         if isinstance(strategy, str):
+            if strategy == "moment":
+                strategy = "support_point"
+                warnings.warn(
+                    "The 'moment' strategy is deprecated. Use 'support_point' instead.",
+                    FutureWarning,
+                )
             if strategy == "support_point":
                 try:
                     value = support_point(variable)

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -114,7 +114,7 @@ def make_initial_point_fn(
     model,
     overrides: Optional[StartDict] = None,
     jitter_rvs: Optional[set[TensorVariable]] = None,
-    default_strategy: str = "moment",
+    default_strategy: str = "finite_logp_point",
     return_transformed: bool = True,
 ) -> Callable:
     """Create seeded function that computes initial values for all free model variables.
@@ -125,7 +125,7 @@ def make_initial_point_fn(
         The set (or list or tuple) of random variables for which a U(-1, +1) jitter should be
         added to the initial value. Only available for variables that have a transform or real-valued support.
     default_strategy : str
-        Which of { "moment", "prior" } to prefer if the initval setting for an RV is None.
+        Which of { "finite_logp_point", "prior" } to prefer if the initval setting for an RV is None.
     overrides : dict
         Initial value (strategies) to use instead of what's specified in `Model.initial_values`.
     return_transformed : bool
@@ -181,7 +181,7 @@ def make_initial_point_expression(
     rvs_to_transforms: dict[TensorVariable, Transform],
     initval_strategies: dict[TensorVariable, Optional[Union[np.ndarray, Variable, str]]],
     jitter_rvs: Optional[set[TensorVariable]] = None,
-    default_strategy: str = "moment",
+    default_strategy: str = "finite_logp_point",
     return_transformed: bool = False,
 ) -> list[TensorVariable]:
     """Creates the tensor variables that need to be evaluated to obtain an initial point.
@@ -199,7 +199,7 @@ def make_initial_point_expression(
         The set (or list or tuple) of random variables for which a U(-1, +1) jitter should be
         added to the initial value. Only available for variables that have a transform or real-valued support.
     default_strategy : str
-        Which of { "moment", "prior" } to prefer if the initval strategy setting for an RV is None.
+        Which of { "finite_logp_point", "prior" } to prefer if the initval strategy setting for an RV is None.
     return_transformed : bool
         Switches between returning the tensors for untransformed or transformed initial points.
 
@@ -208,7 +208,7 @@ def make_initial_point_expression(
     initial_points : list of TensorVariable
         PyTensor expressions for initial values of the free random variables.
     """
-    from pymc.distributions.distribution import moment
+    from pymc.distributions.distribution import finite_logp_point
 
     if jitter_rvs is None:
         jitter_rvs = set()
@@ -223,16 +223,16 @@ def make_initial_point_expression(
             strategy = default_strategy
 
         if isinstance(strategy, str):
-            if strategy == "moment":
+            if strategy == "finite_logp_point":
                 try:
-                    value = moment(variable)
+                    value = finite_logp_point(variable)
                 except NotImplementedError:
                     warnings.warn(
                         f"Moment not defined for variable {variable} of type "
                         f"{variable.owner.op.__class__.__name__}, defaulting to "
                         f"a draw from the prior. This can lead to difficulties "
                         f"during tuning. You can manually define an initval or "
-                        f"implement a moment dispatched function for this "
+                        f"implement a finite_logp_point dispatched function for this "
                         f"distribution.",
                         UserWarning,
                     )
@@ -241,7 +241,7 @@ def make_initial_point_expression(
                 value = variable
             else:
                 raise ValueError(
-                    f'Invalid string strategy: {strategy}. It must be one of ["moment", "prior"]'
+                    f'Invalid string strategy: {strategy}. It must be one of ["finite_logp_point", "prior"]'
                 )
         else:
             value = pt.as_tensor(strategy, dtype=variable.dtype).astype(variable.dtype)

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -653,34 +653,34 @@ def check_selfconsistency_discrete_logcdf(
             )
 
 
-def assert_finite_logp_point_is_expected(model, expected, check_finite_logp=True):
+def assert_support_point_is_expected(model, expected, check_finite_logp=True):
     fn = make_initial_point_fn(
         model=model,
         return_transformed=False,
-        default_strategy="finite_logp_point",
+        default_strategy="support_point",
     )
-    finite_logp_point = fn(0)["x"]
+    support_point = fn(0)["x"]
     expected = np.asarray(expected)
     try:
         random_draw = model["x"].eval()
     except NotImplementedError:
-        random_draw = finite_logp_point
+        random_draw = support_point
 
-    assert finite_logp_point.shape == expected.shape
+    assert support_point.shape == expected.shape
     assert expected.shape == random_draw.shape
-    assert np.allclose(finite_logp_point, expected)
+    assert np.allclose(support_point, expected)
 
     if check_finite_logp:
-        logp_finite_logp_point = (
+        logp_support_point = (
             transformed_conditional_logp(
                 (model["x"],),
-                rvs_to_values={model["x"]: pt.constant(finite_logp_point)},
+                rvs_to_values={model["x"]: pt.constant(support_point)},
                 rvs_to_transforms={},
             )[0]
             .sum()
             .eval()
         )
-        assert np.isfinite(logp_finite_logp_point)
+        assert np.isfinite(logp_support_point)
 
 
 def continuous_random_tester(

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 import functools as ft
 import itertools as it
+import warnings
 
 from collections.abc import Sequence
 from typing import Any, Callable, Optional, Union
@@ -651,6 +652,14 @@ def check_selfconsistency_discrete_logcdf(
                 decimal=decimal,
                 err_msg=str(point),
             )
+
+
+def assert_moment_is_expected(model, expected, check_finite_logp=True):
+    warnings.warn(
+        "assert_moment_is_expected is deprecated. Use assert_support_point_is_expected instead.",
+        FutureWarning,
+    )
+    assert_support_point_is_expected(model, expected, check_finite_logp=check_finite_logp)
 
 
 def assert_support_point_is_expected(model, expected, check_finite_logp=True):

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -653,34 +653,34 @@ def check_selfconsistency_discrete_logcdf(
             )
 
 
-def assert_moment_is_expected(model, expected, check_finite_logp=True):
+def assert_finite_logp_point_is_expected(model, expected, check_finite_logp=True):
     fn = make_initial_point_fn(
         model=model,
         return_transformed=False,
-        default_strategy="moment",
+        default_strategy="finite_logp_point",
     )
-    moment = fn(0)["x"]
+    finite_logp_point = fn(0)["x"]
     expected = np.asarray(expected)
     try:
         random_draw = model["x"].eval()
     except NotImplementedError:
-        random_draw = moment
+        random_draw = finite_logp_point
 
-    assert moment.shape == expected.shape
+    assert finite_logp_point.shape == expected.shape
     assert expected.shape == random_draw.shape
-    assert np.allclose(moment, expected)
+    assert np.allclose(finite_logp_point, expected)
 
     if check_finite_logp:
-        logp_moment = (
+        logp_finite_logp_point = (
             transformed_conditional_logp(
                 (model["x"],),
-                rvs_to_values={model["x"]: pt.constant(moment)},
+                rvs_to_values={model["x"]: pt.constant(finite_logp_point)},
                 rvs_to_transforms={},
             )[0]
             .sum()
             .eval()
         )
-        assert np.isfinite(logp_moment)
+        assert np.isfinite(logp_finite_logp_point)
 
 
 def continuous_random_tester(

--- a/tests/distributions/test_censored.py
+++ b/tests/distributions/test_censored.py
@@ -44,9 +44,9 @@ class TestCensored:
                 "mu",
                 mu=((high - low) / 2) + low,
                 sigma=(high - low) / 2.0,
-                initval="finite_logp_point",
+                initval="support_point",
             )
-            sigma = pm.HalfNormal("sigma", sigma=(high - low) / 2.0, initval="finite_logp_point")
+            sigma = pm.HalfNormal("sigma", sigma=(high - low) / 2.0, initval="support_point")
             observed = pm.Censored(
                 "observed",
                 pm.Normal.dist(mu=mu, sigma=sigma),

--- a/tests/distributions/test_censored.py
+++ b/tests/distributions/test_censored.py
@@ -44,9 +44,9 @@ class TestCensored:
                 "mu",
                 mu=((high - low) / 2) + low,
                 sigma=(high - low) / 2.0,
-                initval="moment",
+                initval="finite_logp_point",
             )
-            sigma = pm.HalfNormal("sigma", sigma=(high - low) / 2.0, initval="moment")
+            sigma = pm.HalfNormal("sigma", sigma=(high - low) / 2.0, initval="finite_logp_point")
             observed = pm.Censored(
                 "observed",
                 pm.Normal.dist(mu=mu, sigma=sigma),

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -42,7 +42,7 @@ from pymc.testing import (
     Rplusunif,
     Runif,
     Unit,
-    assert_moment_is_expected,
+    assert_finite_logp_point_is_expected,
     check_icdf,
     check_logcdf,
     check_logp,
@@ -1058,10 +1058,10 @@ class TestMoments:
             ((2, 5), np.zeros((2, 5))),
         ],
     )
-    def test_flat_moment(self, size, expected):
+    def test_flat_finite_logp_point(self, size, expected):
         with pm.Model() as model:
             pm.Flat("x", size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "size, expected",
@@ -1071,10 +1071,10 @@ class TestMoments:
             ((2, 5), np.ones((2, 5))),
         ],
     )
-    def test_halfflat_moment(self, size, expected):
+    def test_halfflat_finite_logp_point(self, size, expected):
         with pm.Model() as model:
             pm.HalfFlat("x", size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "lower, upper, size, expected",
@@ -1085,10 +1085,10 @@ class TestMoments:
             (0, np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(1, 6) / 2)),
         ],
     )
-    def test_uniform_moment(self, lower, upper, size, expected):
+    def test_uniform_finite_logp_point(self, lower, upper, size, expected):
         with pm.Model() as model:
             pm.Uniform("x", lower=lower, upper=upper, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, sigma, size, expected",
@@ -1099,10 +1099,10 @@ class TestMoments:
             (np.arange(5), np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(5))),
         ],
     )
-    def test_normal_moment(self, mu, sigma, size, expected):
+    def test_normal_finite_logp_point(self, mu, sigma, size, expected):
         with pm.Model() as model:
             pm.Normal("x", mu=mu, sigma=sigma, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "sigma, size, expected",
@@ -1113,10 +1113,10 @@ class TestMoments:
             (np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(1, 6))),
         ],
     )
-    def test_halfnormal_moment(self, sigma, size, expected):
+    def test_halfnormal_finite_logp_point(self, sigma, size, expected):
         with pm.Model() as model:
             pm.HalfNormal("x", sigma=sigma, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "nu, sigma, size, expected",
@@ -1127,10 +1127,10 @@ class TestMoments:
             (np.arange(1, 6), 1, None, np.full(5, 1)),
         ],
     )
-    def test_halfstudentt_moment(self, nu, sigma, size, expected):
+    def test_halfstudentt_finite_logp_point(self, nu, sigma, size, expected):
         with pm.Model() as model:
             pm.HalfStudentT("x", nu=nu, sigma=sigma, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, sigma, lower, upper, size, expected",
@@ -1141,10 +1141,10 @@ class TestMoments:
             (1, 1, [-np.inf, -np.inf, -np.inf], 10, None, np.full(3, 9)),
         ],
     )
-    def test_truncatednormal_moment(self, mu, sigma, lower, upper, size, expected):
+    def test_truncatednormal_finite_logp_point(self, mu, sigma, lower, upper, size, expected):
         with pm.Model() as model:
             pm.TruncatedNormal("x", mu=mu, sigma=sigma, lower=lower, upper=upper, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, beta, size, expected",
@@ -1155,10 +1155,10 @@ class TestMoments:
             (1, np.arange(1, 6), (2, 5), np.full((2, 5), 1 / np.arange(2, 7))),
         ],
     )
-    def test_beta_moment(self, alpha, beta, size, expected):
+    def test_beta_finite_logp_point(self, alpha, beta, size, expected):
         with pm.Model() as model:
             pm.Beta("x", alpha=alpha, beta=beta, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "lam, size, expected",
@@ -1169,10 +1169,10 @@ class TestMoments:
             (np.arange(1, 5), (2, 4), np.full((2, 4), 1 / np.arange(1, 5))),
         ],
     )
-    def test_exponential_moment(self, lam, size, expected):
+    def test_exponential_finite_logp_point(self, lam, size, expected):
         with pm.Model() as model:
             pm.Exponential("x", lam=lam, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, b, size, expected",
@@ -1183,10 +1183,10 @@ class TestMoments:
             (np.arange(5), np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(5))),
         ],
     )
-    def test_laplace_moment(self, mu, b, size, expected):
+    def test_laplace_finite_logp_point(self, mu, b, size, expected):
         with pm.Model() as model:
             pm.Laplace("x", mu=mu, b=b, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, nu, sigma, size, expected",
@@ -1203,10 +1203,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_studentt_moment(self, mu, nu, sigma, size, expected):
+    def test_studentt_finite_logp_point(self, mu, nu, sigma, size, expected):
         with pm.Model() as model:
             pm.StudentT("x", mu=mu, nu=nu, sigma=sigma, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, beta, size, expected",
@@ -1217,10 +1217,10 @@ class TestMoments:
             (np.arange(5), np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(5))),
         ],
     )
-    def test_cauchy_moment(self, alpha, beta, size, expected):
+    def test_cauchy_finite_logp_point(self, alpha, beta, size, expected):
         with pm.Model() as model:
             pm.Cauchy("x", alpha=alpha, beta=beta, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "a, b, size, expected",
@@ -1232,10 +1232,10 @@ class TestMoments:
             (1, np.arange(1, 6), (2, 5), np.full((2, 5), 1 / np.arange(2, 7))),
         ],
     )
-    def test_kumaraswamy_moment(self, a, b, size, expected):
+    def test_kumaraswamy_finite_logp_point(self, a, b, size, expected):
         with pm.Model() as model:
             pm.Kumaraswamy("x", a=a, b=b, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, sigma, size, expected",
@@ -1251,10 +1251,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_lognormal_moment(self, mu, sigma, size, expected):
+    def test_lognormal_finite_logp_point(self, mu, sigma, size, expected):
         with pm.Model() as model:
             pm.LogNormal("x", mu=mu, sigma=sigma, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "beta, size, expected",
@@ -1269,10 +1269,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_halfcauchy_moment(self, beta, size, expected):
+    def test_halfcauchy_finite_logp_point(self, beta, size, expected):
         with pm.Model() as model:
             pm.HalfCauchy("x", beta=beta, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, beta, size, expected",
@@ -1288,10 +1288,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_gamma_moment(self, alpha, beta, size, expected):
+    def test_gamma_finite_logp_point(self, alpha, beta, size, expected):
         with pm.Model() as model:
             pm.Gamma("x", alpha=alpha, beta=beta, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, beta, size, expected",
@@ -1302,10 +1302,10 @@ class TestMoments:
             (np.arange(1, 6), 1, None, np.array([0.5, 1, 1 / 2, 1 / 3, 1 / 4])),
         ],
     )
-    def test_inverse_gamma_moment(self, alpha, beta, size, expected):
+    def test_inverse_gamma_finite_logp_point(self, alpha, beta, size, expected):
         with pm.Model() as model:
             pm.InverseGamma("x", alpha=alpha, beta=beta, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, m, size, expected",
@@ -1321,10 +1321,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_pareto_moment(self, alpha, m, size, expected):
+    def test_pareto_finite_logp_point(self, alpha, m, size, expected):
         with pm.Model() as model:
             pm.Pareto("x", alpha=alpha, m=m, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, kappa, size, expected",
@@ -1335,10 +1335,10 @@ class TestMoments:
             (np.arange(4), np.arange(1, 5), (2, 4), np.full((2, 4), np.arange(4))),
         ],
     )
-    def test_vonmises_moment(self, mu, kappa, size, expected):
+    def test_vonmises_finite_logp_point(self, mu, kappa, size, expected):
         with pm.Model() as model:
             pm.VonMises("x", mu=mu, kappa=kappa, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, lam, phi, size, expected",
@@ -1350,10 +1350,10 @@ class TestMoments:
             (np.arange(1, 6), None, np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(1, 6))),
         ],
     )
-    def test_wald_moment(self, mu, lam, phi, size, expected):
+    def test_wald_finite_logp_point(self, mu, lam, phi, size, expected):
         with pm.Model() as model:
             pm.Wald("x", mu=mu, lam=lam, phi=phi, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, beta, size, expected",
@@ -1372,10 +1372,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_weibull_moment(self, alpha, beta, size, expected):
+    def test_weibull_finite_logp_point(self, alpha, beta, size, expected):
         with pm.Model() as model:
             pm.Weibull("x", alpha=alpha, beta=beta, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, s, size, expected",
@@ -1391,10 +1391,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_logistic_moment(self, mu, s, size, expected):
+    def test_logistic_finite_logp_point(self, mu, s, size, expected):
         with pm.Model() as model:
             pm.Logistic("x", mu=mu, s=s, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, nu, sigma, size, expected",
@@ -1406,10 +1406,10 @@ class TestMoments:
             (1, np.arange(1, 6), 1, (2, 5), np.full((2, 5), np.arange(2, 7))),
         ],
     )
-    def test_exgaussian_moment(self, mu, nu, sigma, size, expected):
+    def test_exgaussian_finite_logp_point(self, mu, nu, sigma, size, expected):
         with pm.Model() as model:
             pm.ExGaussian("x", mu=mu, sigma=sigma, nu=nu, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, beta, size, expected",
@@ -1426,10 +1426,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_gumbel_moment(self, mu, beta, size, expected):
+    def test_gumbel_finite_logp_point(self, mu, beta, size, expected):
         with pm.Model() as model:
             pm.Gumbel("x", mu=mu, beta=beta, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "c, lower, upper, size, expected",
@@ -1447,10 +1447,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_triangular_moment(self, c, lower, upper, size, expected):
+    def test_triangular_finite_logp_point(self, c, lower, upper, size, expected):
         with pm.Model() as model:
             pm.Triangular("x", c=c, lower=lower, upper=upper, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, sigma, size, expected",
@@ -1462,10 +1462,10 @@ class TestMoments:
             (np.arange(4), np.arange(1, 5), (2, 4), np.full((2, 4), sp.expit(np.arange(4)))),
         ],
     )
-    def test_logitnormal_moment(self, mu, sigma, size, expected):
+    def test_logitnormal_finite_logp_point(self, mu, sigma, size, expected):
         with pm.Model() as model:
             pm.LogitNormal("x", mu=mu, sigma=sigma, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "x_points, pdf_points, size, expected",
@@ -1504,10 +1504,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_interpolated_moment(self, x_points, pdf_points, size, expected):
+    def test_interpolated_finite_logp_point(self, x_points, pdf_points, size, expected):
         with pm.Model() as model:
             pm.Interpolated("x", x_points=x_points, pdf_points=pdf_points, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, sigma, size, expected",
@@ -1518,10 +1518,10 @@ class TestMoments:
             (np.arange(5), np.ones(5), (2, 5), np.full((2, 5), np.arange(5) + 1.2703628454614782)),
         ],
     )
-    def test_moyal_moment(self, mu, sigma, size, expected):
+    def test_moyal_finite_logp_point(self, mu, sigma, size, expected):
         with pm.Model() as model:
             pm.Moyal("x", mu=mu, sigma=sigma, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, mu, sigma, size, expected",
@@ -1545,10 +1545,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_skewnormal_moment(self, alpha, mu, sigma, size, expected):
+    def test_skewnormal_finite_logp_point(self, alpha, mu, sigma, size, expected):
         with pm.Model() as model:
             pm.SkewNormal("x", alpha=alpha, mu=mu, sigma=sigma, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "b, kappa, mu, size, expected",
@@ -1572,10 +1572,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_asymmetriclaplace_moment(self, b, kappa, mu, size, expected):
+    def test_asymmetriclaplace_finite_logp_point(self, b, kappa, mu, size, expected):
         with pm.Model() as model:
             pm.AsymmetricLaplace("x", b=b, kappa=kappa, mu=mu, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "nu, sigma, size, expected",
@@ -1611,7 +1611,7 @@ class TestMoments:
             ),
         ],
     )
-    def test_rice_moment(self, nu, sigma, size, expected):
+    def test_rice_finite_logp_point(self, nu, sigma, size, expected):
         with pm.Model() as model:
             pm.Rice("x", nu=nu, sigma=sigma, size=size)
 
@@ -1664,10 +1664,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_polyagamma_moment(self, h, z, size, expected):
+    def test_polyagamma_finite_logp_point(self, h, z, size, expected):
         with pm.Model() as model:
             pm.PolyaGamma("x", h=h, z=z, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
 
 class TestFlat(BaseTestDistributionRandom):

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -42,7 +42,7 @@ from pymc.testing import (
     Rplusunif,
     Runif,
     Unit,
-    assert_finite_logp_point_is_expected,
+    assert_support_point_is_expected,
     check_icdf,
     check_logcdf,
     check_logp,
@@ -1058,10 +1058,10 @@ class TestMoments:
             ((2, 5), np.zeros((2, 5))),
         ],
     )
-    def test_flat_finite_logp_point(self, size, expected):
+    def test_flat_support_point(self, size, expected):
         with pm.Model() as model:
             pm.Flat("x", size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "size, expected",
@@ -1071,10 +1071,10 @@ class TestMoments:
             ((2, 5), np.ones((2, 5))),
         ],
     )
-    def test_halfflat_finite_logp_point(self, size, expected):
+    def test_halfflat_support_point(self, size, expected):
         with pm.Model() as model:
             pm.HalfFlat("x", size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "lower, upper, size, expected",
@@ -1085,10 +1085,10 @@ class TestMoments:
             (0, np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(1, 6) / 2)),
         ],
     )
-    def test_uniform_finite_logp_point(self, lower, upper, size, expected):
+    def test_uniform_support_point(self, lower, upper, size, expected):
         with pm.Model() as model:
             pm.Uniform("x", lower=lower, upper=upper, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, sigma, size, expected",
@@ -1099,10 +1099,10 @@ class TestMoments:
             (np.arange(5), np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(5))),
         ],
     )
-    def test_normal_finite_logp_point(self, mu, sigma, size, expected):
+    def test_normal_support_point(self, mu, sigma, size, expected):
         with pm.Model() as model:
             pm.Normal("x", mu=mu, sigma=sigma, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "sigma, size, expected",
@@ -1113,10 +1113,10 @@ class TestMoments:
             (np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(1, 6))),
         ],
     )
-    def test_halfnormal_finite_logp_point(self, sigma, size, expected):
+    def test_halfnormal_support_point(self, sigma, size, expected):
         with pm.Model() as model:
             pm.HalfNormal("x", sigma=sigma, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "nu, sigma, size, expected",
@@ -1127,10 +1127,10 @@ class TestMoments:
             (np.arange(1, 6), 1, None, np.full(5, 1)),
         ],
     )
-    def test_halfstudentt_finite_logp_point(self, nu, sigma, size, expected):
+    def test_halfstudentt_support_point(self, nu, sigma, size, expected):
         with pm.Model() as model:
             pm.HalfStudentT("x", nu=nu, sigma=sigma, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, sigma, lower, upper, size, expected",
@@ -1141,10 +1141,10 @@ class TestMoments:
             (1, 1, [-np.inf, -np.inf, -np.inf], 10, None, np.full(3, 9)),
         ],
     )
-    def test_truncatednormal_finite_logp_point(self, mu, sigma, lower, upper, size, expected):
+    def test_truncatednormal_support_point(self, mu, sigma, lower, upper, size, expected):
         with pm.Model() as model:
             pm.TruncatedNormal("x", mu=mu, sigma=sigma, lower=lower, upper=upper, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, beta, size, expected",
@@ -1155,10 +1155,10 @@ class TestMoments:
             (1, np.arange(1, 6), (2, 5), np.full((2, 5), 1 / np.arange(2, 7))),
         ],
     )
-    def test_beta_finite_logp_point(self, alpha, beta, size, expected):
+    def test_beta_support_point(self, alpha, beta, size, expected):
         with pm.Model() as model:
             pm.Beta("x", alpha=alpha, beta=beta, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "lam, size, expected",
@@ -1169,10 +1169,10 @@ class TestMoments:
             (np.arange(1, 5), (2, 4), np.full((2, 4), 1 / np.arange(1, 5))),
         ],
     )
-    def test_exponential_finite_logp_point(self, lam, size, expected):
+    def test_exponential_support_point(self, lam, size, expected):
         with pm.Model() as model:
             pm.Exponential("x", lam=lam, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, b, size, expected",
@@ -1183,10 +1183,10 @@ class TestMoments:
             (np.arange(5), np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(5))),
         ],
     )
-    def test_laplace_finite_logp_point(self, mu, b, size, expected):
+    def test_laplace_support_point(self, mu, b, size, expected):
         with pm.Model() as model:
             pm.Laplace("x", mu=mu, b=b, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, nu, sigma, size, expected",
@@ -1203,10 +1203,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_studentt_finite_logp_point(self, mu, nu, sigma, size, expected):
+    def test_studentt_support_point(self, mu, nu, sigma, size, expected):
         with pm.Model() as model:
             pm.StudentT("x", mu=mu, nu=nu, sigma=sigma, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, beta, size, expected",
@@ -1217,10 +1217,10 @@ class TestMoments:
             (np.arange(5), np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(5))),
         ],
     )
-    def test_cauchy_finite_logp_point(self, alpha, beta, size, expected):
+    def test_cauchy_support_point(self, alpha, beta, size, expected):
         with pm.Model() as model:
             pm.Cauchy("x", alpha=alpha, beta=beta, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "a, b, size, expected",
@@ -1232,10 +1232,10 @@ class TestMoments:
             (1, np.arange(1, 6), (2, 5), np.full((2, 5), 1 / np.arange(2, 7))),
         ],
     )
-    def test_kumaraswamy_finite_logp_point(self, a, b, size, expected):
+    def test_kumaraswamy_support_point(self, a, b, size, expected):
         with pm.Model() as model:
             pm.Kumaraswamy("x", a=a, b=b, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, sigma, size, expected",
@@ -1251,10 +1251,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_lognormal_finite_logp_point(self, mu, sigma, size, expected):
+    def test_lognormal_support_point(self, mu, sigma, size, expected):
         with pm.Model() as model:
             pm.LogNormal("x", mu=mu, sigma=sigma, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "beta, size, expected",
@@ -1269,10 +1269,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_halfcauchy_finite_logp_point(self, beta, size, expected):
+    def test_halfcauchy_support_point(self, beta, size, expected):
         with pm.Model() as model:
             pm.HalfCauchy("x", beta=beta, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, beta, size, expected",
@@ -1288,10 +1288,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_gamma_finite_logp_point(self, alpha, beta, size, expected):
+    def test_gamma_support_point(self, alpha, beta, size, expected):
         with pm.Model() as model:
             pm.Gamma("x", alpha=alpha, beta=beta, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, beta, size, expected",
@@ -1302,10 +1302,10 @@ class TestMoments:
             (np.arange(1, 6), 1, None, np.array([0.5, 1, 1 / 2, 1 / 3, 1 / 4])),
         ],
     )
-    def test_inverse_gamma_finite_logp_point(self, alpha, beta, size, expected):
+    def test_inverse_gamma_support_point(self, alpha, beta, size, expected):
         with pm.Model() as model:
             pm.InverseGamma("x", alpha=alpha, beta=beta, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, m, size, expected",
@@ -1321,10 +1321,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_pareto_finite_logp_point(self, alpha, m, size, expected):
+    def test_pareto_support_point(self, alpha, m, size, expected):
         with pm.Model() as model:
             pm.Pareto("x", alpha=alpha, m=m, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, kappa, size, expected",
@@ -1335,10 +1335,10 @@ class TestMoments:
             (np.arange(4), np.arange(1, 5), (2, 4), np.full((2, 4), np.arange(4))),
         ],
     )
-    def test_vonmises_finite_logp_point(self, mu, kappa, size, expected):
+    def test_vonmises_support_point(self, mu, kappa, size, expected):
         with pm.Model() as model:
             pm.VonMises("x", mu=mu, kappa=kappa, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, lam, phi, size, expected",
@@ -1350,10 +1350,10 @@ class TestMoments:
             (np.arange(1, 6), None, np.arange(1, 6), (2, 5), np.full((2, 5), np.arange(1, 6))),
         ],
     )
-    def test_wald_finite_logp_point(self, mu, lam, phi, size, expected):
+    def test_wald_support_point(self, mu, lam, phi, size, expected):
         with pm.Model() as model:
             pm.Wald("x", mu=mu, lam=lam, phi=phi, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, beta, size, expected",
@@ -1372,10 +1372,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_weibull_finite_logp_point(self, alpha, beta, size, expected):
+    def test_weibull_support_point(self, alpha, beta, size, expected):
         with pm.Model() as model:
             pm.Weibull("x", alpha=alpha, beta=beta, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, s, size, expected",
@@ -1391,10 +1391,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_logistic_finite_logp_point(self, mu, s, size, expected):
+    def test_logistic_support_point(self, mu, s, size, expected):
         with pm.Model() as model:
             pm.Logistic("x", mu=mu, s=s, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, nu, sigma, size, expected",
@@ -1406,10 +1406,10 @@ class TestMoments:
             (1, np.arange(1, 6), 1, (2, 5), np.full((2, 5), np.arange(2, 7))),
         ],
     )
-    def test_exgaussian_finite_logp_point(self, mu, nu, sigma, size, expected):
+    def test_exgaussian_support_point(self, mu, nu, sigma, size, expected):
         with pm.Model() as model:
             pm.ExGaussian("x", mu=mu, sigma=sigma, nu=nu, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, beta, size, expected",
@@ -1426,10 +1426,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_gumbel_finite_logp_point(self, mu, beta, size, expected):
+    def test_gumbel_support_point(self, mu, beta, size, expected):
         with pm.Model() as model:
             pm.Gumbel("x", mu=mu, beta=beta, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "c, lower, upper, size, expected",
@@ -1447,10 +1447,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_triangular_finite_logp_point(self, c, lower, upper, size, expected):
+    def test_triangular_support_point(self, c, lower, upper, size, expected):
         with pm.Model() as model:
             pm.Triangular("x", c=c, lower=lower, upper=upper, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, sigma, size, expected",
@@ -1462,10 +1462,10 @@ class TestMoments:
             (np.arange(4), np.arange(1, 5), (2, 4), np.full((2, 4), sp.expit(np.arange(4)))),
         ],
     )
-    def test_logitnormal_finite_logp_point(self, mu, sigma, size, expected):
+    def test_logitnormal_support_point(self, mu, sigma, size, expected):
         with pm.Model() as model:
             pm.LogitNormal("x", mu=mu, sigma=sigma, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "x_points, pdf_points, size, expected",
@@ -1504,10 +1504,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_interpolated_finite_logp_point(self, x_points, pdf_points, size, expected):
+    def test_interpolated_support_point(self, x_points, pdf_points, size, expected):
         with pm.Model() as model:
             pm.Interpolated("x", x_points=x_points, pdf_points=pdf_points, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, sigma, size, expected",
@@ -1518,10 +1518,10 @@ class TestMoments:
             (np.arange(5), np.ones(5), (2, 5), np.full((2, 5), np.arange(5) + 1.2703628454614782)),
         ],
     )
-    def test_moyal_finite_logp_point(self, mu, sigma, size, expected):
+    def test_moyal_support_point(self, mu, sigma, size, expected):
         with pm.Model() as model:
             pm.Moyal("x", mu=mu, sigma=sigma, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "alpha, mu, sigma, size, expected",
@@ -1545,10 +1545,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_skewnormal_finite_logp_point(self, alpha, mu, sigma, size, expected):
+    def test_skewnormal_support_point(self, alpha, mu, sigma, size, expected):
         with pm.Model() as model:
             pm.SkewNormal("x", alpha=alpha, mu=mu, sigma=sigma, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "b, kappa, mu, size, expected",
@@ -1572,10 +1572,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_asymmetriclaplace_finite_logp_point(self, b, kappa, mu, size, expected):
+    def test_asymmetriclaplace_support_point(self, b, kappa, mu, size, expected):
         with pm.Model() as model:
             pm.AsymmetricLaplace("x", b=b, kappa=kappa, mu=mu, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "nu, sigma, size, expected",
@@ -1611,7 +1611,7 @@ class TestMoments:
             ),
         ],
     )
-    def test_rice_finite_logp_point(self, nu, sigma, size, expected):
+    def test_rice_support_point(self, nu, sigma, size, expected):
         with pm.Model() as model:
             pm.Rice("x", nu=nu, sigma=sigma, size=size)
 
@@ -1664,10 +1664,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_polyagamma_finite_logp_point(self, h, z, size, expected):
+    def test_polyagamma_support_point(self, h, z, size, expected):
         with pm.Model() as model:
             pm.PolyaGamma("x", h=h, z=z, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
 
 class TestFlat(BaseTestDistributionRandom):

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -47,7 +47,7 @@ from pymc.testing import (
     Unit,
     UnitSortedVector,
     Vector,
-    assert_finite_logp_point_is_expected,
+    assert_support_point_is_expected,
     check_icdf,
     check_logcdf,
     check_logp,
@@ -510,10 +510,10 @@ class TestMoments:
             (np.linspace(0, 1, 4), (2, 4), np.full((2, 4), [0, 0, 1, 1])),
         ],
     )
-    def test_bernoulli_finite_logp_point(self, p, size, expected):
+    def test_bernoulli_support_point(self, p, size, expected):
         with pm.Model() as model:
             pm.Bernoulli("x", p=p, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "n, alpha, beta, size, expected",
@@ -524,10 +524,10 @@ class TestMoments:
             (10, 1, np.arange(1, 6), (2, 5), np.full((2, 5), np.round(10 / np.arange(2, 7)))),
         ],
     )
-    def test_beta_binomial_finite_logp_point(self, alpha, beta, n, size, expected):
+    def test_beta_binomial_support_point(self, alpha, beta, n, size, expected):
         with pm.Model() as model:
             pm.BetaBinomial("x", alpha=alpha, beta=beta, n=n, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "n, p, size, expected",
@@ -538,10 +538,10 @@ class TestMoments:
             (10, np.arange(1, 6) / 10, (2, 5), np.full((2, 5), np.arange(1, 6))),
         ],
     )
-    def test_binomial_finite_logp_point(self, n, p, size, expected):
+    def test_binomial_support_point(self, n, p, size, expected):
         with pm.Model() as model:
             pm.Binomial("x", n=n, p=p, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, size, expected",
@@ -552,10 +552,10 @@ class TestMoments:
             (np.arange(1, 5), (2, 4), np.full((2, 4), np.arange(1, 5))),
         ],
     )
-    def test_poisson_finite_logp_point(self, mu, size, expected):
+    def test_poisson_support_point(self, mu, size, expected):
         with pm.Model() as model:
             pm.Poisson("x", mu=mu, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "n, p, size, expected",
@@ -571,10 +571,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_negative_binomial_finite_logp_point(self, n, p, size, expected):
+    def test_negative_binomial_support_point(self, n, p, size, expected):
         with pm.Model() as model:
             pm.NegativeBinomial("x", n=n, p=p, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "p, size, expected",
@@ -585,10 +585,10 @@ class TestMoments:
             (np.linspace(0.25, 1, 4), (2, 4), np.full((2, 4), [4, 2, 1, 1])),
         ],
     )
-    def test_geometric_finite_logp_point(self, p, size, expected):
+    def test_geometric_support_point(self, p, size, expected):
         with pm.Model() as model:
             pm.Geometric("x", p=p, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "N, k, n, size, expected",
@@ -605,10 +605,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_hyper_geometric_finite_logp_point(self, N, k, n, size, expected):
+    def test_hyper_geometric_support_point(self, N, k, n, size, expected):
         with pm.Model() as model:
             pm.HyperGeometric("x", N=N, k=k, n=n, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "lower, upper, size, expected",
@@ -624,10 +624,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_discrete_uniform_finite_logp_point(self, lower, upper, size, expected):
+    def test_discrete_uniform_support_point(self, lower, upper, size, expected):
         with pm.Model() as model:
             pm.DiscreteUniform("x", lower=lower, upper=upper, size=size)
-            assert_finite_logp_point_is_expected(model, expected)
+            assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "q, beta, size, expected",
@@ -643,10 +643,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_discrete_weibull_finite_logp_point(self, q, beta, size, expected):
+    def test_discrete_weibull_support_point(self, q, beta, size, expected):
         with pm.Model() as model:
             pm.DiscreteWeibull("x", q=q, beta=beta, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "p, size, expected",
@@ -661,10 +661,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_categorical_finite_logp_point(self, p, size, expected):
+    def test_categorical_support_point(self, p, size, expected):
         with pm.Model() as model:
             pm.Categorical("x", p=p, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
 
 class TestDiscreteWeibull(BaseTestDistributionRandom):

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -47,7 +47,7 @@ from pymc.testing import (
     Unit,
     UnitSortedVector,
     Vector,
-    assert_moment_is_expected,
+    assert_finite_logp_point_is_expected,
     check_icdf,
     check_logcdf,
     check_logp,
@@ -510,10 +510,10 @@ class TestMoments:
             (np.linspace(0, 1, 4), (2, 4), np.full((2, 4), [0, 0, 1, 1])),
         ],
     )
-    def test_bernoulli_moment(self, p, size, expected):
+    def test_bernoulli_finite_logp_point(self, p, size, expected):
         with pm.Model() as model:
             pm.Bernoulli("x", p=p, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "n, alpha, beta, size, expected",
@@ -524,10 +524,10 @@ class TestMoments:
             (10, 1, np.arange(1, 6), (2, 5), np.full((2, 5), np.round(10 / np.arange(2, 7)))),
         ],
     )
-    def test_beta_binomial_moment(self, alpha, beta, n, size, expected):
+    def test_beta_binomial_finite_logp_point(self, alpha, beta, n, size, expected):
         with pm.Model() as model:
             pm.BetaBinomial("x", alpha=alpha, beta=beta, n=n, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "n, p, size, expected",
@@ -538,10 +538,10 @@ class TestMoments:
             (10, np.arange(1, 6) / 10, (2, 5), np.full((2, 5), np.arange(1, 6))),
         ],
     )
-    def test_binomial_moment(self, n, p, size, expected):
+    def test_binomial_finite_logp_point(self, n, p, size, expected):
         with pm.Model() as model:
             pm.Binomial("x", n=n, p=p, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, size, expected",
@@ -552,10 +552,10 @@ class TestMoments:
             (np.arange(1, 5), (2, 4), np.full((2, 4), np.arange(1, 5))),
         ],
     )
-    def test_poisson_moment(self, mu, size, expected):
+    def test_poisson_finite_logp_point(self, mu, size, expected):
         with pm.Model() as model:
             pm.Poisson("x", mu=mu, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "n, p, size, expected",
@@ -571,10 +571,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_negative_binomial_moment(self, n, p, size, expected):
+    def test_negative_binomial_finite_logp_point(self, n, p, size, expected):
         with pm.Model() as model:
             pm.NegativeBinomial("x", n=n, p=p, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "p, size, expected",
@@ -585,10 +585,10 @@ class TestMoments:
             (np.linspace(0.25, 1, 4), (2, 4), np.full((2, 4), [4, 2, 1, 1])),
         ],
     )
-    def test_geometric_moment(self, p, size, expected):
+    def test_geometric_finite_logp_point(self, p, size, expected):
         with pm.Model() as model:
             pm.Geometric("x", p=p, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "N, k, n, size, expected",
@@ -605,10 +605,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_hyper_geometric_moment(self, N, k, n, size, expected):
+    def test_hyper_geometric_finite_logp_point(self, N, k, n, size, expected):
         with pm.Model() as model:
             pm.HyperGeometric("x", N=N, k=k, n=n, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "lower, upper, size, expected",
@@ -624,10 +624,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_discrete_uniform_moment(self, lower, upper, size, expected):
+    def test_discrete_uniform_finite_logp_point(self, lower, upper, size, expected):
         with pm.Model() as model:
             pm.DiscreteUniform("x", lower=lower, upper=upper, size=size)
-            assert_moment_is_expected(model, expected)
+            assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "q, beta, size, expected",
@@ -643,10 +643,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_discrete_weibull_moment(self, q, beta, size, expected):
+    def test_discrete_weibull_finite_logp_point(self, q, beta, size, expected):
         with pm.Model() as model:
             pm.DiscreteWeibull("x", q=q, beta=beta, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "p, size, expected",
@@ -661,10 +661,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_categorical_moment(self, p, size, expected):
+    def test_categorical_finite_logp_point(self, p, size, expected):
         with pm.Model() as model:
             pm.Categorical("x", p=p, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
 
 class TestDiscreteWeibull(BaseTestDistributionRandom):

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -43,9 +43,9 @@ from pymc.distributions.distribution import (
     CustomSymbolicDistRV,
     PartialObservedRV,
     SymbolicRandomVariable,
-    _finite_logp_point,
+    _support_point,
     create_partial_observed_rv,
-    finite_logp_point,
+    support_point,
 )
 from pymc.distributions.shape_utils import change_dist_size, rv_size_is_none, to_tuple
 from pymc.distributions.transforms import log
@@ -57,7 +57,7 @@ from pymc.sampling import draw, sample
 from pymc.testing import (
     BaseTestDistributionRandom,
     I,
-    assert_finite_logp_point_is_expected,
+    assert_support_point_is_expected,
     check_logcdf,
     check_logp,
 )
@@ -119,19 +119,19 @@ def test_logp_gives_migration_instructions(method, newcode):
     pass
 
 
-def test_all_distributions_have_finite_logp_points():
+def test_all_distributions_have_support_points():
     import pymc.distributions as dist_module
 
     from pymc.distributions.distribution import DistributionMeta
 
     dists = (getattr(dist_module, dist) for dist in dist_module.__all__)
     dists = (dist for dist in dists if isinstance(dist, DistributionMeta))
-    missing_finite_logp_points = {
-        dist for dist in dists if getattr(dist, "rv_type", None) not in _finite_logp_point.registry
+    missing_support_points = {
+        dist for dist in dists if getattr(dist, "rv_type", None) not in _support_point.registry
     }
 
     # Ignore super classes
-    missing_finite_logp_points -= {
+    missing_support_points -= {
         dist_module.Distribution,
         dist_module.Discrete,
         dist_module.Continuous,
@@ -144,23 +144,23 @@ def test_all_distributions_have_finite_logp_points():
         dist_module.timeseries.EulerMaruyama,
     }
 
-    # Distributions that have been refactored but don't yet have finite_logp_points
+    # Distributions that have been refactored but don't yet have support_points
     not_implemented |= {
         dist_module.multivariate.Wishart,
     }
 
-    unexpected_implemented = not_implemented - missing_finite_logp_points
+    unexpected_implemented = not_implemented - missing_support_points
     if unexpected_implemented:
         raise Exception(
-            f"Distributions {unexpected_implemented} have a `finite_logp_point` implemented. "
+            f"Distributions {unexpected_implemented} have a `support_point` implemented. "
             "This test must be updated to expect this."
         )
 
-    unexpected_not_implemented = missing_finite_logp_points - not_implemented
+    unexpected_not_implemented = missing_support_points - not_implemented
     if unexpected_not_implemented:
         raise NotImplementedError(
             f"Unexpected by this test, distributions {unexpected_not_implemented} do "
-            "not have a `finite_logp_point` implementation. Either add a finite_logp_point or filter "
+            "not have a `support_point` implementation. Either add a support_point or filter "
             "these distributions in this test."
         )
 
@@ -291,45 +291,43 @@ class TestCustomDist:
         assert log_densityf({"a": a_test_value, "mu": mu_test_value})[0].shape == to_tuple(size)
 
     @pytest.mark.parametrize(
-        "finite_logp_point, size, expected",
+        "support_point, size, expected",
         [
             (None, None, 0.0),
             (None, 5, np.zeros(5)),
-            ("custom_finite_logp_point", None, 5),
-            ("custom_finite_logp_point", (2, 5), np.full((2, 5), 5)),
+            ("custom_support_point", None, 5),
+            ("custom_support_point", (2, 5), np.full((2, 5), 5)),
         ],
     )
-    def test_custom_dist_default_finite_logp_point_univariate(
-        self, finite_logp_point, size, expected
-    ):
-        if finite_logp_point == "custom_finite_logp_point":
-            finite_logp_point = lambda rv, size, *rv_inputs: 5 * pt.ones(size, dtype=rv.dtype)  # noqa E731
+    def test_custom_dist_default_support_point_univariate(self, support_point, size, expected):
+        if support_point == "custom_support_point":
+            support_point = lambda rv, size, *rv_inputs: 5 * pt.ones(size, dtype=rv.dtype)  # noqa E731
         with pm.Model() as model:
-            x = CustomDist("x", finite_logp_point=finite_logp_point, size=size)
+            x = CustomDist("x", support_point=support_point, size=size)
         assert isinstance(x.owner.op, CustomDistRV)
-        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=False)
+        assert_support_point_is_expected(model, expected, check_finite_logp=False)
 
     @pytest.mark.parametrize("size", [(), (2,), (3, 2)], ids=str)
-    def test_custom_dist_custom_finite_logp_point_univariate(self, size):
-        def density_finite_logp_point(rv, size, mu):
+    def test_custom_dist_custom_support_point_univariate(self, size):
+        def density_support_point(rv, size, mu):
             return (pt.ones(size) * mu).astype(rv.dtype)
 
         mu_val = np.array(np.random.normal(loc=2, scale=1)).astype(pytensor.config.floatX)
         with Model():
             mu = Normal("mu")
-            a = CustomDist("a", mu, finite_logp_point=density_finite_logp_point, size=size)
+            a = CustomDist("a", mu, support_point=density_support_point, size=size)
         assert isinstance(a.owner.op, CustomDistRV)
-        evaled_finite_logp_point = finite_logp_point(a).eval({mu: mu_val})
-        assert evaled_finite_logp_point.shape == to_tuple(size)
-        assert np.all(evaled_finite_logp_point == mu_val)
+        evaled_support_point = support_point(a).eval({mu: mu_val})
+        assert evaled_support_point.shape == to_tuple(size)
+        assert np.all(evaled_support_point == mu_val)
 
     @pytest.mark.xfail(
         NotImplementedError,
         reason="Support shape of multivariate CustomDist cannot be inferred. See https://github.com/pymc-devs/pytensor/pull/388",
     )
     @pytest.mark.parametrize("size", [(), (2,), (3, 2)], ids=str)
-    def test_custom_dist_custom_finite_logp_point_multivariate(self, size):
-        def density_finite_logp_point(rv, size, mu):
+    def test_custom_dist_custom_support_point_multivariate(self, size):
+        def density_support_point(rv, size, mu):
             return (pt.ones(size)[..., None] * mu).astype(rv.dtype)
 
         mu_val = np.random.normal(loc=2, scale=1, size=5).astype(pytensor.config.floatX)
@@ -338,15 +336,15 @@ class TestCustomDist:
             a = CustomDist(
                 "a",
                 mu,
-                finite_logp_point=density_finite_logp_point,
+                support_point=density_support_point,
                 ndims_params=[1],
                 ndim_supp=1,
                 size=size,
             )
         assert isinstance(a.owner.op, CustomDistRV)
-        evaled_finite_logp_point = finite_logp_point(a).eval({mu: mu_val})
-        assert evaled_finite_logp_point.shape == (*to_tuple(size), 5)
-        assert np.all(evaled_finite_logp_point == mu_val)
+        evaled_support_point = support_point(a).eval({mu: mu_val})
+        assert evaled_support_point.shape == (*to_tuple(size), 5)
+        assert np.all(evaled_support_point == mu_val)
 
     @pytest.mark.xfail(
         NotImplementedError,
@@ -362,7 +360,7 @@ class TestCustomDist:
             (False, (2,)),
         ],
     )
-    def test_custom_dist_default_finite_logp_point_multivariate(self, with_random, size):
+    def test_custom_dist_default_support_point_multivariate(self, with_random, size):
         def _random(mu, rng=None, size=None):
             return rng.normal(mu, scale=1, size=to_tuple(size) + mu.shape)
 
@@ -377,15 +375,15 @@ class TestCustomDist:
             a = CustomDist("a", mu, random=random, ndims_params=[1], ndim_supp=1, size=size)
         assert isinstance(a.owner.op, CustomDistRV)
         if with_random:
-            evaled_finite_logp_point = finite_logp_point(a).eval({mu: mu_val})
-            assert evaled_finite_logp_point.shape == (*to_tuple(size), 5)
-            assert np.all(evaled_finite_logp_point == 0)
+            evaled_support_point = support_point(a).eval({mu: mu_val})
+            assert evaled_support_point.shape == (*to_tuple(size), 5)
+            assert np.all(evaled_support_point == 0)
         else:
             with pytest.raises(
                 TypeError,
-                match="Cannot safely infer the size of a multivariate random variable's finite_logp_point.",
+                match="Cannot safely infer the size of a multivariate random variable's support_point.",
             ):
-                evaled_finite_logp_point = finite_logp_point(a).eval({mu: mu_val})
+                evaled_support_point = support_point(a).eval({mu: mu_val})
 
     def test_dist(self):
         mu = 1
@@ -475,12 +473,12 @@ class TestCustomSymbolicDist:
             ),
         ],
     )
-    def test_custom_dist_default_finite_logp_point(self, dist_params, size, expected, dist_fn):
+    def test_custom_dist_default_support_point(self, dist_params, size, expected, dist_fn):
         with Model() as model:
             CustomDist("x", *dist_params, dist=dist_fn, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
-    def test_custom_dist_default_finite_logp_point_scan(self):
+    def test_custom_dist_default_support_point_scan(self):
         def scan_step(left, right):
             x = pm.Uniform.dist(left, right)
             x_update = collect_default_updates([x])
@@ -499,9 +497,9 @@ class TestCustomSymbolicDist:
 
         with Model() as model:
             CustomDist("x", dist=dist)
-        assert_finite_logp_point_is_expected(model, np.array([-3, -2]))
+        assert_support_point_is_expected(model, np.array([-3, -2]))
 
-    def test_custom_dist_default_finite_logp_point_scan_recurring(self):
+    def test_custom_dist_default_support_point_scan_recurring(self):
         def scan_step(xtm1):
             x = pm.Normal.dist(xtm1 + 1)
             x_update = collect_default_updates([x])
@@ -518,7 +516,7 @@ class TestCustomSymbolicDist:
 
         with Model() as model:
             CustomDist("x", dist=dist)
-        assert_finite_logp_point_is_expected(model, np.array([[1], [2], [3]]))
+        assert_support_point_is_expected(model, np.array([[1], [2], [3]]))
 
     @pytest.mark.parametrize(
         "left, right, size, expected",
@@ -528,13 +526,13 @@ class TestCustomSymbolicDist:
             (-3, 1, (3,), np.array([-1 + 5, -1 + 5, -1 + 5])),
         ],
     )
-    def test_custom_dist_default_finite_logp_point_nested(self, left, right, size, expected):
+    def test_custom_dist_default_support_point_nested(self, left, right, size, expected):
         def dist_fn(left, right, size):
             return pm.Truncated.dist(pm.Normal.dist(0, 1), left, right, size=size) + 5
 
         with Model() as model:
             CustomDist("x", left, right, size=size, dist=dist_fn)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     def test_logcdf_inference(self):
         def custom_dist(mu, sigma, size):
@@ -581,7 +579,7 @@ class TestCustomSymbolicDist:
                 return mu
             return pt.full(size, mu)
 
-        def custom_finite_logp_point(rv, size, mu):
+        def custom_support_point(rv, size, mu):
             return pt.full_like(rv, mu + 1)
 
         def custom_logp(value, mu):
@@ -593,7 +591,7 @@ class TestCustomSymbolicDist:
         customdist = CustomDist.dist(
             [np.e, np.e],
             dist=custom_dist,
-            finite_logp_point=custom_finite_logp_point,
+            support_point=custom_support_point,
             logp=custom_logp,
             logcdf=custom_logcdf,
         )
@@ -601,7 +599,7 @@ class TestCustomSymbolicDist:
         assert isinstance(customdist.owner.op, CustomSymbolicDistRV)
 
         np.testing.assert_allclose(draw(customdist), [np.e, np.e])
-        np.testing.assert_allclose(finite_logp_point(customdist).eval(), [np.e + 1, np.e + 1])
+        np.testing.assert_allclose(support_point(customdist).eval(), [np.e + 1, np.e + 1])
         np.testing.assert_allclose(logp(customdist, [0, 0]).eval(), [np.e + 2, np.e + 2])
         np.testing.assert_allclose(logcdf(customdist, [0, 0]).eval(), [np.e + 3, np.e + 3])
 
@@ -815,10 +813,10 @@ class TestDiracDelta:
                 (np.arange(1, 6), None, np.arange(1, 6)),
             ],
         )
-        def test_finite_logp_point(self, c, size, expected):
+        def test_support_point(self, c, size, expected):
             with pm.Model() as model:
                 pm.DiracDelta("x", c=c, size=size)
-            assert_finite_logp_point_is_expected(model, expected)
+            assert_support_point_is_expected(model, expected)
 
     class TestDiracDelta(BaseTestDistributionRandom):
         def diracdelta_rng_fn(self, size, c):
@@ -1048,18 +1046,18 @@ class TestPartialObservedRV:
         np.testing.assert_almost_equal(obs_logp, new_expected_logp)
         np.testing.assert_array_equal(unobs_logp, [])
 
-    def test_finite_logp_point(self):
+    def test_support_point(self):
         x = pm.GaussianRandomWalk.dist(init_dist=pm.Normal.dist(-5), mu=1, steps=9)
-        ref_finite_logp_point = finite_logp_point(x).eval()
+        ref_support_point = support_point(x).eval()
         assert not np.allclose(
-            ref_finite_logp_point[::2], ref_finite_logp_point[1::2]
+            ref_support_point[::2], ref_support_point[1::2]
         )  # Otherwise test is weak
 
         (obs_x, _), (unobs_x, _), _ = create_partial_observed_rv(
             x, mask=np.array([False, True] * 5)
         )
-        np.testing.assert_allclose(finite_logp_point(obs_x).eval(), ref_finite_logp_point[::2])
-        np.testing.assert_allclose(finite_logp_point(unobs_x).eval(), ref_finite_logp_point[1::2])
+        np.testing.assert_allclose(support_point(obs_x).eval(), ref_support_point[::2])
+        np.testing.assert_allclose(support_point(unobs_x).eval(), ref_support_point[1::2])
 
     def test_wrong_mask(self):
         rv = pm.Normal.dist(shape=(5,))

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -307,6 +307,15 @@ class TestCustomDist:
         assert isinstance(x.owner.op, CustomDistRV)
         assert_support_point_is_expected(model, expected, check_finite_logp=False)
 
+    def test_custom_dist_moment_future_warning(self):
+        moment = lambda rv, size, *rv_inputs: 5 * pt.ones(size, dtype=rv.dtype)  # noqa E731
+        with pm.Model() as model:
+            with pytest.warns(
+                FutureWarning, match="`moment` argument is deprecated. Use `support_point` instead."
+            ):
+                x = CustomDist("x", moment=moment)
+        assert_support_point_is_expected(model, 5, check_finite_logp=False)
+
     @pytest.mark.parametrize("size", [(), (2,), (3, 2)], ids=str)
     def test_custom_dist_custom_support_point_univariate(self, size):
         def density_support_point(rv, size, mu):

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -79,7 +79,7 @@ from pymc.testing import (
     Rplusbig,
     Simplex,
     Unit,
-    assert_finite_logp_point_is_expected,
+    assert_support_point_is_expected,
     check_logcdf,
     check_logp,
     check_selfconsistency_discrete_logcdf,
@@ -1146,7 +1146,7 @@ class TestMixtureMoments:
     def test_single_univariate_component(self, weights, comp_dists, size, expected):
         with Model() as model:
             Mixture("x", weights, comp_dists, size=size)
-        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=False)
+        assert_support_point_is_expected(model, expected, check_finite_logp=False)
 
     @pytest.mark.parametrize(
         "weights, comp_dists, size, expected",
@@ -1199,7 +1199,7 @@ class TestMixtureMoments:
     def test_list_univariate_components(self, weights, comp_dists, size, expected):
         with Model() as model:
             Mixture("x", weights, comp_dists, size=size)
-        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=False)
+        assert_support_point_is_expected(model, expected, check_finite_logp=False)
 
     @pytest.mark.parametrize(
         "weights, comp_dists, size, expected",
@@ -1235,7 +1235,7 @@ class TestMixtureMoments:
     def test_single_multivariate_component(self, weights, comp_dists, size, expected):
         with Model() as model:
             Mixture("x", weights, comp_dists, size=size)
-        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=False)
+        assert_support_point_is_expected(model, expected, check_finite_logp=False)
 
     @pytest.mark.parametrize(
         "weights, comp_dists, size, expected",
@@ -1281,7 +1281,7 @@ class TestMixtureMoments:
     def test_list_multivariate_components(self, weights, comp_dists, size, expected):
         with Model() as model:
             Mixture("x", weights, comp_dists, size=size)
-        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=False)
+        assert_support_point_is_expected(model, expected, check_finite_logp=False)
 
 
 class TestMixtureDefaultTransforms:
@@ -1323,7 +1323,7 @@ class TestMixtureDefaultTransforms:
             mix2 = Mixture("mix2", [0.3, 0.7][::-1], comp_dists[::-1])
 
         ip = model.initial_point()
-        # We want an informative finite_logp_point, other than zero
+        # We want an informative support_point, other than zero
         assert ip["mix1_interval__"] != 0
 
         expected_mix_ip = (
@@ -1495,10 +1495,10 @@ class TestZeroInflatedMixture:
             (0.2, np.arange(1, 5) * 5, (2, 4), np.full((2, 4), np.arange(1, 5))),
         ],
     )
-    def test_zero_inflated_poisson_finite_logp_point(self, psi, mu, size, expected):
+    def test_zero_inflated_poisson_support_point(self, psi, mu, size, expected):
         with Model() as model:
             ZeroInflatedPoisson("x", psi=psi, mu=mu, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "psi, n, p, size, expected",
@@ -1515,10 +1515,10 @@ class TestZeroInflatedMixture:
             ),
         ],
     )
-    def test_zero_inflated_binomial_finite_logp_point(self, psi, n, p, size, expected):
+    def test_zero_inflated_binomial_support_point(self, psi, n, p, size, expected):
         with Model() as model:
             ZeroInflatedBinomial("x", psi=psi, n=n, p=p, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "psi, mu, alpha, size, expected",
@@ -1541,12 +1541,10 @@ class TestZeroInflatedMixture:
             ),
         ],
     )
-    def test_zero_inflated_negative_binomial_finite_logp_point(
-        self, psi, mu, alpha, size, expected
-    ):
+    def test_zero_inflated_negative_binomial_support_point(self, psi, mu, alpha, size, expected):
         with Model() as model:
             ZeroInflatedNegativeBinomial("x", psi=psi, mu=mu, alpha=alpha, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "dist, non_psi_args",

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -79,7 +79,7 @@ from pymc.testing import (
     Rplusbig,
     Simplex,
     Unit,
-    assert_moment_is_expected,
+    assert_finite_logp_point_is_expected,
     check_logcdf,
     check_logp,
     check_selfconsistency_discrete_logcdf,
@@ -1146,7 +1146,7 @@ class TestMixtureMoments:
     def test_single_univariate_component(self, weights, comp_dists, size, expected):
         with Model() as model:
             Mixture("x", weights, comp_dists, size=size)
-        assert_moment_is_expected(model, expected, check_finite_logp=False)
+        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=False)
 
     @pytest.mark.parametrize(
         "weights, comp_dists, size, expected",
@@ -1199,7 +1199,7 @@ class TestMixtureMoments:
     def test_list_univariate_components(self, weights, comp_dists, size, expected):
         with Model() as model:
             Mixture("x", weights, comp_dists, size=size)
-        assert_moment_is_expected(model, expected, check_finite_logp=False)
+        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=False)
 
     @pytest.mark.parametrize(
         "weights, comp_dists, size, expected",
@@ -1235,7 +1235,7 @@ class TestMixtureMoments:
     def test_single_multivariate_component(self, weights, comp_dists, size, expected):
         with Model() as model:
             Mixture("x", weights, comp_dists, size=size)
-        assert_moment_is_expected(model, expected, check_finite_logp=False)
+        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=False)
 
     @pytest.mark.parametrize(
         "weights, comp_dists, size, expected",
@@ -1281,7 +1281,7 @@ class TestMixtureMoments:
     def test_list_multivariate_components(self, weights, comp_dists, size, expected):
         with Model() as model:
             Mixture("x", weights, comp_dists, size=size)
-        assert_moment_is_expected(model, expected, check_finite_logp=False)
+        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=False)
 
 
 class TestMixtureDefaultTransforms:
@@ -1323,7 +1323,7 @@ class TestMixtureDefaultTransforms:
             mix2 = Mixture("mix2", [0.3, 0.7][::-1], comp_dists[::-1])
 
         ip = model.initial_point()
-        # We want an informative moment, other than zero
+        # We want an informative finite_logp_point, other than zero
         assert ip["mix1_interval__"] != 0
 
         expected_mix_ip = (
@@ -1495,10 +1495,10 @@ class TestZeroInflatedMixture:
             (0.2, np.arange(1, 5) * 5, (2, 4), np.full((2, 4), np.arange(1, 5))),
         ],
     )
-    def test_zero_inflated_poisson_moment(self, psi, mu, size, expected):
+    def test_zero_inflated_poisson_finite_logp_point(self, psi, mu, size, expected):
         with Model() as model:
             ZeroInflatedPoisson("x", psi=psi, mu=mu, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "psi, n, p, size, expected",
@@ -1515,10 +1515,10 @@ class TestZeroInflatedMixture:
             ),
         ],
     )
-    def test_zero_inflated_binomial_moment(self, psi, n, p, size, expected):
+    def test_zero_inflated_binomial_finite_logp_point(self, psi, n, p, size, expected):
         with Model() as model:
             ZeroInflatedBinomial("x", psi=psi, n=n, p=p, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "psi, mu, alpha, size, expected",
@@ -1541,10 +1541,12 @@ class TestZeroInflatedMixture:
             ),
         ],
     )
-    def test_zero_inflated_negative_binomial_moment(self, psi, mu, alpha, size, expected):
+    def test_zero_inflated_negative_binomial_finite_logp_point(
+        self, psi, mu, alpha, size, expected
+    ):
         with Model() as model:
             ZeroInflatedNegativeBinomial("x", psi=psi, mu=mu, alpha=alpha, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "dist, non_psi_args",

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -55,7 +55,7 @@ from pymc.testing import (
     Rplus,
     Simplex,
     Vector,
-    assert_finite_logp_point_is_expected,
+    assert_support_point_is_expected,
     check_logp,
     continuous_random_tester,
     seeded_numpy_distribution_builder,
@@ -1003,7 +1003,7 @@ class TestLKJCholeskCov:
         assert draw_x3.shape == (3, 10, 3, 6)
 
 
-# Used for MvStudentT finite_logp_point test
+# Used for MvStudentT support_point test
 rand1d = np.random.rand(2)
 rand2d = np.random.rand(2, 3)
 
@@ -1056,10 +1056,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_multinomial_finite_logp_point(self, p, n, size, expected):
+    def test_multinomial_support_point(self, p, n, size, expected):
         with pm.Model() as model:
             pm.Multinomial("x", n=n, p=p, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "a, size, expected",
@@ -1090,10 +1090,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_dirichlet_finite_logp_point(self, a, size, expected):
+    def test_dirichlet_support_point(self, a, size, expected):
         with pm.Model() as model:
             pm.Dirichlet("x", a=a, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, cov, size, expected",
@@ -1123,11 +1123,11 @@ class TestMoments:
             ),
         ],
     )
-    def test_mv_normal_finite_logp_point(self, mu, cov, size, expected):
+    def test_mv_normal_support_point(self, mu, cov, size, expected):
         with pm.Model() as model:
             x = pm.MvNormal("x", mu=mu, cov=cov, size=size)
 
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "shape, n_zerosum_axes, expected",
@@ -1137,10 +1137,10 @@ class TestMoments:
             ((2, 5, 6), 3, np.zeros((2, 5, 6))),
         ],
     )
-    def test_zerosum_normal_finite_logp_point(self, shape, n_zerosum_axes, expected):
+    def test_zerosum_normal_support_point(self, shape, n_zerosum_axes, expected):
         with pm.Model() as model:
             pm.ZeroSumNormal("x", shape=shape, n_zerosum_axes=n_zerosum_axes)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, size, expected",
@@ -1159,7 +1159,7 @@ class TestMoments:
             ),
         ],
     )
-    def test_car_finite_logp_point(self, mu, size, expected):
+    def test_car_support_point(self, mu, size, expected):
         W = np.array(
             [[0.0, 1.0, 1.0, 0.0], [1.0, 0.0, 0.0, 1.0], [1.0, 0.0, 0.0, 1.0], [0.0, 1.0, 1.0, 0.0]]
         )
@@ -1167,7 +1167,7 @@ class TestMoments:
         alpha = 0.5
         with pm.Model() as model:
             pm.CAR("x", mu=mu, W=W, alpha=alpha, tau=tau, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "W, expected",
@@ -1176,10 +1176,10 @@ class TestMoments:
             (np.array([[0, 1], [1, 0]]), np.array([0, 0])),
         ],
     )
-    def test_icar_finite_logp_point(self, W, expected):
+    def test_icar_support_point(self, W, expected):
         with pm.Model() as model:
             RV = pm.ICAR("x", W=W)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "nu, mu, cov, size, expected",
@@ -1194,11 +1194,11 @@ class TestMoments:
             ([2, 4], 0, np.eye(3), None, np.zeros((2, 3))),
         ],
     )
-    def test_mvstudentt_finite_logp_point(self, nu, mu, cov, size, expected):
+    def test_mvstudentt_support_point(self, nu, mu, cov, size, expected):
         with pm.Model() as model:
             x = pm.MvStudentT("x", nu=nu, mu=mu, scale=cov, size=size)
 
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, rowchol, colchol, size, expected",
@@ -1210,13 +1210,13 @@ class TestMoments:
             (rand2d, np.eye(2), np.eye(3), (2, 5), np.full((2, 5, 2, 3), rand2d)),
         ],
     )
-    def test_matrixnormal_finite_logp_point(self, mu, rowchol, colchol, size, expected):
+    def test_matrixnormal_support_point(self, mu, rowchol, colchol, size, expected):
         with pm.Model() as model:
             x = pm.MatrixNormal("x", mu=mu, rowchol=rowchol, colchol=colchol, size=size)
 
         # MatrixNormal logp is only implemented for 2d values
         check_logp = x.ndim == 2
-        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=check_logp)
+        assert_support_point_is_expected(model, expected, check_finite_logp=check_logp)
 
     @pytest.mark.parametrize(
         "alpha, K, size, expected",
@@ -1269,10 +1269,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_stickbreakingweights_finite_logp_point(self, alpha, K, size, expected):
+    def test_stickbreakingweights_support_point(self, alpha, K, size, expected):
         with pm.Model() as model:
             pm.StickBreakingWeights("x", alpha=alpha, K=K, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, covs, size, expected",
@@ -1297,10 +1297,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_kronecker_normal_finite_logp_point(self, mu, covs, size, expected):
+    def test_kronecker_normal_support_point(self, mu, covs, size, expected):
         with pm.Model() as model:
             pm.KroneckerNormal("x", mu=mu, covs=covs, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "n, eta, size, expected",
@@ -1329,10 +1329,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_lkjcorr_finite_logp_point(self, n, eta, size, expected):
+    def test_lkjcorr_support_point(self, n, eta, size, expected):
         with pm.Model() as model:
             pm.LKJCorr("x", n=n, eta=eta, size=size, return_matrix=False)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "n, eta, size, expected",
@@ -1348,11 +1348,11 @@ class TestMoments:
             ),
         ],
     )
-    def test_lkjcholeskycov_finite_logp_point(self, n, eta, size, expected):
+    def test_lkjcholeskycov_support_point(self, n, eta, size, expected):
         with pm.Model() as model:
             sd_dist = pm.Exponential.dist(1, size=(*to_tuple(size), n))
             pm.LKJCholeskyCov("x", n=n, eta=eta, sd_dist=sd_dist, size=size, compute_corr=False)
-        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=size is None)
+        assert_support_point_is_expected(model, expected, check_finite_logp=size is None)
 
     @pytest.mark.parametrize(
         "a, n, size, expected",
@@ -1383,10 +1383,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_dirichlet_multinomial_finite_logp_point(self, a, n, size, expected):
+    def test_dirichlet_multinomial_support_point(self, a, n, size, expected):
         with pm.Model() as model:
             pm.DirichletMultinomial("x", n=n, a=a, size=size)
-        assert_finite_logp_point_is_expected(model, expected)
+        assert_support_point_is_expected(model, expected)
 
 
 class TestMvNormalCov(BaseTestDistributionRandom):

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -55,7 +55,7 @@ from pymc.testing import (
     Rplus,
     Simplex,
     Vector,
-    assert_moment_is_expected,
+    assert_finite_logp_point_is_expected,
     check_logp,
     continuous_random_tester,
     seeded_numpy_distribution_builder,
@@ -1003,7 +1003,7 @@ class TestLKJCholeskCov:
         assert draw_x3.shape == (3, 10, 3, 6)
 
 
-# Used for MvStudentT moment test
+# Used for MvStudentT finite_logp_point test
 rand1d = np.random.rand(2)
 rand2d = np.random.rand(2, 3)
 
@@ -1056,10 +1056,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_multinomial_moment(self, p, n, size, expected):
+    def test_multinomial_finite_logp_point(self, p, n, size, expected):
         with pm.Model() as model:
             pm.Multinomial("x", n=n, p=p, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "a, size, expected",
@@ -1090,10 +1090,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_dirichlet_moment(self, a, size, expected):
+    def test_dirichlet_finite_logp_point(self, a, size, expected):
         with pm.Model() as model:
             pm.Dirichlet("x", a=a, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, cov, size, expected",
@@ -1123,11 +1123,11 @@ class TestMoments:
             ),
         ],
     )
-    def test_mv_normal_moment(self, mu, cov, size, expected):
+    def test_mv_normal_finite_logp_point(self, mu, cov, size, expected):
         with pm.Model() as model:
             x = pm.MvNormal("x", mu=mu, cov=cov, size=size)
 
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "shape, n_zerosum_axes, expected",
@@ -1137,10 +1137,10 @@ class TestMoments:
             ((2, 5, 6), 3, np.zeros((2, 5, 6))),
         ],
     )
-    def test_zerosum_normal_moment(self, shape, n_zerosum_axes, expected):
+    def test_zerosum_normal_finite_logp_point(self, shape, n_zerosum_axes, expected):
         with pm.Model() as model:
             pm.ZeroSumNormal("x", shape=shape, n_zerosum_axes=n_zerosum_axes)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, size, expected",
@@ -1159,7 +1159,7 @@ class TestMoments:
             ),
         ],
     )
-    def test_car_moment(self, mu, size, expected):
+    def test_car_finite_logp_point(self, mu, size, expected):
         W = np.array(
             [[0.0, 1.0, 1.0, 0.0], [1.0, 0.0, 0.0, 1.0], [1.0, 0.0, 0.0, 1.0], [0.0, 1.0, 1.0, 0.0]]
         )
@@ -1167,7 +1167,7 @@ class TestMoments:
         alpha = 0.5
         with pm.Model() as model:
             pm.CAR("x", mu=mu, W=W, alpha=alpha, tau=tau, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "W, expected",
@@ -1176,10 +1176,10 @@ class TestMoments:
             (np.array([[0, 1], [1, 0]]), np.array([0, 0])),
         ],
     )
-    def test_icar_moment(self, W, expected):
+    def test_icar_finite_logp_point(self, W, expected):
         with pm.Model() as model:
             RV = pm.ICAR("x", W=W)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "nu, mu, cov, size, expected",
@@ -1194,11 +1194,11 @@ class TestMoments:
             ([2, 4], 0, np.eye(3), None, np.zeros((2, 3))),
         ],
     )
-    def test_mvstudentt_moment(self, nu, mu, cov, size, expected):
+    def test_mvstudentt_finite_logp_point(self, nu, mu, cov, size, expected):
         with pm.Model() as model:
             x = pm.MvStudentT("x", nu=nu, mu=mu, scale=cov, size=size)
 
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, rowchol, colchol, size, expected",
@@ -1210,13 +1210,13 @@ class TestMoments:
             (rand2d, np.eye(2), np.eye(3), (2, 5), np.full((2, 5, 2, 3), rand2d)),
         ],
     )
-    def test_matrixnormal_moment(self, mu, rowchol, colchol, size, expected):
+    def test_matrixnormal_finite_logp_point(self, mu, rowchol, colchol, size, expected):
         with pm.Model() as model:
             x = pm.MatrixNormal("x", mu=mu, rowchol=rowchol, colchol=colchol, size=size)
 
         # MatrixNormal logp is only implemented for 2d values
         check_logp = x.ndim == 2
-        assert_moment_is_expected(model, expected, check_finite_logp=check_logp)
+        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=check_logp)
 
     @pytest.mark.parametrize(
         "alpha, K, size, expected",
@@ -1269,10 +1269,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_stickbreakingweights_moment(self, alpha, K, size, expected):
+    def test_stickbreakingweights_finite_logp_point(self, alpha, K, size, expected):
         with pm.Model() as model:
             pm.StickBreakingWeights("x", alpha=alpha, K=K, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "mu, covs, size, expected",
@@ -1297,10 +1297,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_kronecker_normal_moment(self, mu, covs, size, expected):
+    def test_kronecker_normal_finite_logp_point(self, mu, covs, size, expected):
         with pm.Model() as model:
             pm.KroneckerNormal("x", mu=mu, covs=covs, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "n, eta, size, expected",
@@ -1329,10 +1329,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_lkjcorr_moment(self, n, eta, size, expected):
+    def test_lkjcorr_finite_logp_point(self, n, eta, size, expected):
         with pm.Model() as model:
             pm.LKJCorr("x", n=n, eta=eta, size=size, return_matrix=False)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
         "n, eta, size, expected",
@@ -1348,11 +1348,11 @@ class TestMoments:
             ),
         ],
     )
-    def test_lkjcholeskycov_moment(self, n, eta, size, expected):
+    def test_lkjcholeskycov_finite_logp_point(self, n, eta, size, expected):
         with pm.Model() as model:
             sd_dist = pm.Exponential.dist(1, size=(*to_tuple(size), n))
             pm.LKJCholeskyCov("x", n=n, eta=eta, sd_dist=sd_dist, size=size, compute_corr=False)
-        assert_moment_is_expected(model, expected, check_finite_logp=size is None)
+        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=size is None)
 
     @pytest.mark.parametrize(
         "a, n, size, expected",
@@ -1383,10 +1383,10 @@ class TestMoments:
             ),
         ],
     )
-    def test_dirichlet_multinomial_moment(self, a, n, size, expected):
+    def test_dirichlet_multinomial_finite_logp_point(self, a, n, size, expected):
         with pm.Model() as model:
             pm.DirichletMultinomial("x", n=n, a=a, size=size)
-        assert_moment_is_expected(model, expected)
+        assert_finite_logp_point_is_expected(model, expected)
 
 
 class TestMvNormalCov(BaseTestDistributionRandom):

--- a/tests/distributions/test_simulator.py
+++ b/tests/distributions/test_simulator.py
@@ -321,7 +321,7 @@ class TestSimulator:
     @pytest.mark.parametrize("mu", [0, np.arange(3)], ids=str)
     @pytest.mark.parametrize("sigma", [1, np.array([1, 2, 5])], ids=str)
     @pytest.mark.parametrize("size", [None, 3, (5, 3)], ids=str)
-    def test_simulator_finite_logp_point(self, seeded_test, mu, sigma, size):
+    def test_simulator_support_point(self, seeded_test, mu, sigma, size):
         def normal_sim(rng, mu, sigma, size):
             return rng.normal(mu, sigma, size=size)
 
@@ -331,15 +331,15 @@ class TestSimulator:
         fn = make_initial_point_fn(
             model=model,
             return_transformed=False,
-            default_strategy="finite_logp_point",
+            default_strategy="support_point",
         )
 
         random_draw = model["x"].eval()
         result = fn(0)["x"]
         assert result.shape == random_draw.shape
 
-        # We perform a z-test between the finite_logp_point and expected mean from a sample of 10 draws
-        # This test fails if the number of samples averaged in finite_logp_point(Simulator)
+        # We perform a z-test between the support_point and expected mean from a sample of 10 draws
+        # This test fails if the number of samples averaged in support_point(Simulator)
         # is much smaller than 10, but would not catch the case where the number of samples
         # is higher than the expected 10
 

--- a/tests/distributions/test_simulator.py
+++ b/tests/distributions/test_simulator.py
@@ -321,7 +321,7 @@ class TestSimulator:
     @pytest.mark.parametrize("mu", [0, np.arange(3)], ids=str)
     @pytest.mark.parametrize("sigma", [1, np.array([1, 2, 5])], ids=str)
     @pytest.mark.parametrize("size", [None, 3, (5, 3)], ids=str)
-    def test_simulator_moment(self, seeded_test, mu, sigma, size):
+    def test_simulator_finite_logp_point(self, seeded_test, mu, sigma, size):
         def normal_sim(rng, mu, sigma, size):
             return rng.normal(mu, sigma, size=size)
 
@@ -331,15 +331,15 @@ class TestSimulator:
         fn = make_initial_point_fn(
             model=model,
             return_transformed=False,
-            default_strategy="moment",
+            default_strategy="finite_logp_point",
         )
 
         random_draw = model["x"].eval()
         result = fn(0)["x"]
         assert result.shape == random_draw.shape
 
-        # We perform a z-test between the moment and expected mean from a sample of 10 draws
-        # This test fails if the number of samples averaged in moment(Simulator)
+        # We perform a z-test between the finite_logp_point and expected mean from a sample of 10 draws
+        # This test fails if the number of samples averaged in finite_logp_point(Simulator)
         # is much smaller than 10, but would not catch the case where the number of samples
         # is higher than the expected 10
 

--- a/tests/distributions/test_timeseries.py
+++ b/tests/distributions/test_timeseries.py
@@ -44,7 +44,7 @@ from pymc.model import Model
 from pymc.pytensorf import floatX
 from pymc.sampling.forward import draw, sample_posterior_predictive
 from pymc.sampling.mcmc import sample
-from pymc.testing import assert_finite_logp_point_is_expected, select_by_precision
+from pymc.testing import assert_support_point_is_expected, select_by_precision
 
 # Turn all warnings into errors for this module
 # Ignoring NumPy deprecation warning tracked in https://github.com/pymc-devs/pytensor/issues/146
@@ -378,14 +378,14 @@ class TestRandomWalk:
             ),
         ],
     )
-    def test_finite_logp_point(
+    def test_support_point(
         self, init_dist, innovation_dist, steps, size, expected, check_finite_logp
     ):
         with Model() as model:
             RandomWalk(
                 "x", init_dist=init_dist, innovation_dist=innovation_dist, steps=steps, size=size
             )
-        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=check_finite_logp)
+        assert_support_point_is_expected(model, expected, check_finite_logp=check_finite_logp)
 
 
 class TestPredefinedRandomWalk:
@@ -700,11 +700,11 @@ class TestAR:
             ((5, 2), np.full((5, 2, 7), [[2.0], [4.0]])),
         ],
     )
-    def test_finite_logp_point(self, size, expected):
+    def test_support_point(self, size, expected):
         with Model() as model:
             init_dist = DiracDelta.dist([[1.0, 2.0], [3.0, 4.0]])
             AR("x", rho=[0, 0], init_dist=init_dist, steps=5, size=size)
-        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=False)
+        assert_support_point_is_expected(model, expected, check_finite_logp=False)
 
     def test_init_deprecated_arg(self):
         with pytest.warns(FutureWarning, match="init parameter is now called init_dist"):
@@ -820,7 +820,7 @@ class TestGARCH11:
             ((5, 2), np.zeros((5, 2, 8))),
         ],
     )
-    def test_finite_logp_point(self, size, expected):
+    def test_support_point(self, size, expected):
         with Model() as model:
             GARCH11(
                 "x",
@@ -831,7 +831,7 @@ class TestGARCH11:
                 steps=7,
                 size=size,
             )
-        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=True)
+        assert_support_point_is_expected(model, expected, check_finite_logp=True)
 
     def test_change_dist_size(self):
         base_dist = GARCH11.dist(

--- a/tests/distributions/test_timeseries.py
+++ b/tests/distributions/test_timeseries.py
@@ -44,7 +44,7 @@ from pymc.model import Model
 from pymc.pytensorf import floatX
 from pymc.sampling.forward import draw, sample_posterior_predictive
 from pymc.sampling.mcmc import sample
-from pymc.testing import assert_moment_is_expected, select_by_precision
+from pymc.testing import assert_finite_logp_point_is_expected, select_by_precision
 
 # Turn all warnings into errors for this module
 # Ignoring NumPy deprecation warning tracked in https://github.com/pymc-devs/pytensor/issues/146
@@ -378,12 +378,14 @@ class TestRandomWalk:
             ),
         ],
     )
-    def test_moment(self, init_dist, innovation_dist, steps, size, expected, check_finite_logp):
+    def test_finite_logp_point(
+        self, init_dist, innovation_dist, steps, size, expected, check_finite_logp
+    ):
         with Model() as model:
             RandomWalk(
                 "x", init_dist=init_dist, innovation_dist=innovation_dist, steps=steps, size=size
             )
-        assert_moment_is_expected(model, expected, check_finite_logp=check_finite_logp)
+        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=check_finite_logp)
 
 
 class TestPredefinedRandomWalk:
@@ -698,11 +700,11 @@ class TestAR:
             ((5, 2), np.full((5, 2, 7), [[2.0], [4.0]])),
         ],
     )
-    def test_moment(self, size, expected):
+    def test_finite_logp_point(self, size, expected):
         with Model() as model:
             init_dist = DiracDelta.dist([[1.0, 2.0], [3.0, 4.0]])
             AR("x", rho=[0, 0], init_dist=init_dist, steps=5, size=size)
-        assert_moment_is_expected(model, expected, check_finite_logp=False)
+        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=False)
 
     def test_init_deprecated_arg(self):
         with pytest.warns(FutureWarning, match="init parameter is now called init_dist"):
@@ -818,7 +820,7 @@ class TestGARCH11:
             ((5, 2), np.zeros((5, 2, 8))),
         ],
     )
-    def test_moment(self, size, expected):
+    def test_finite_logp_point(self, size, expected):
         with Model() as model:
             GARCH11(
                 "x",
@@ -829,7 +831,7 @@ class TestGARCH11:
                 steps=7,
                 size=size,
             )
-        assert_moment_is_expected(model, expected, check_finite_logp=True)
+        assert_finite_logp_point_is_expected(model, expected, check_finite_logp=True)
 
     def test_change_dist_size(self):
         base_dist = GARCH11.dist(

--- a/tests/distributions/test_truncated.py
+++ b/tests/distributions/test_truncated.py
@@ -34,7 +34,7 @@ from pymc.logprob.abstract import _icdf
 from pymc.logprob.basic import logcdf, logp
 from pymc.logprob.transforms import IntervalTransform
 from pymc.logprob.utils import ParameterValueError
-from pymc.testing import assert_finite_logp_point_is_expected
+from pymc.testing import assert_support_point_is_expected
 
 
 class IcdfNormalRV(NormalRV):
@@ -53,7 +53,7 @@ class RejectionGeometricRV(GeometricRV):
     """Geometric RV that has neither icdf nor truncated dispatching."""
 
 
-icdf_normal = no_finite_logp_point_normal = IcdfNormalRV()
+icdf_normal = no_support_point_normal = IcdfNormalRV()
 rejection_normal = RejectionNormalRV()
 icdf_geometric = IcdfGeometricRV()
 rejection_geometric = RejectionGeometricRV()
@@ -369,10 +369,10 @@ def test_truncated_transform_logp():
         (icdf_normal([0, 3, 3], 1), None, [2, 2, 4], (4, 3), np.full((4, 3), [0, 1, 3])),
     ],
 )
-def test_truncated_finite_logp_point(truncated_dist, lower, upper, shape, expected):
+def test_truncated_support_point(truncated_dist, lower, upper, shape, expected):
     with Model() as model:
         Truncated("x", dist=truncated_dist, lower=lower, upper=upper, shape=shape)
-    assert_finite_logp_point_is_expected(model, expected)
+    assert_support_point_is_expected(model, expected)
 
 
 def test_truncated_inference():

--- a/tests/distributions/test_truncated.py
+++ b/tests/distributions/test_truncated.py
@@ -34,7 +34,7 @@ from pymc.logprob.abstract import _icdf
 from pymc.logprob.basic import logcdf, logp
 from pymc.logprob.transforms import IntervalTransform
 from pymc.logprob.utils import ParameterValueError
-from pymc.testing import assert_moment_is_expected
+from pymc.testing import assert_finite_logp_point_is_expected
 
 
 class IcdfNormalRV(NormalRV):
@@ -53,7 +53,7 @@ class RejectionGeometricRV(GeometricRV):
     """Geometric RV that has neither icdf nor truncated dispatching."""
 
 
-icdf_normal = no_moment_normal = IcdfNormalRV()
+icdf_normal = no_finite_logp_point_normal = IcdfNormalRV()
 rejection_normal = RejectionNormalRV()
 icdf_geometric = IcdfGeometricRV()
 rejection_geometric = RejectionGeometricRV()
@@ -369,10 +369,10 @@ def test_truncated_transform_logp():
         (icdf_normal([0, 3, 3], 1), None, [2, 2, 4], (4, 3), np.full((4, 3), [0, 1, 3])),
     ],
 )
-def test_truncated_moment(truncated_dist, lower, upper, shape, expected):
+def test_truncated_finite_logp_point(truncated_dist, lower, upper, shape, expected):
     with Model() as model:
         Truncated("x", dist=truncated_dist, lower=lower, upper=upper, shape=shape)
-    assert_moment_is_expected(model, expected)
+    assert_finite_logp_point_is_expected(model, expected)
 
 
 def test_truncated_inference():

--- a/tests/test_initial_point.py
+++ b/tests/test_initial_point.py
@@ -217,7 +217,7 @@ class TestInitvalEvaluation:
         assert iv["C_log__"] == 0
 
 
-class TestMoment:
+class TestSupportPoint:
     def test_basic(self):
         # Standard distributions
         rv = pm.Normal.dist(mu=2.3)
@@ -283,6 +283,15 @@ class TestMoment:
             res = m.initial_point()
 
         assert np.isclose(res["x"], np.pi)
+
+    def test_future_warning_moment(self):
+        with pm.Model() as m:
+            pm.Normal("x", initval="moment")
+            with pytest.warns(
+                FutureWarning,
+                match="The 'moment' strategy is deprecated. Use 'support_point' instead.",
+            ):
+                ip = m.initial_point(random_seed=42)
 
 
 def test_pickling_issue_5090():

--- a/tests/test_initial_point.py
+++ b/tests/test_initial_point.py
@@ -22,7 +22,7 @@ from pytensor.tensor.random.op import RandomVariable
 
 import pymc as pm
 
-from pymc.distributions.distribution import moment
+from pymc.distributions.distribution import finite_logp_point
 from pymc.initial_point import make_initial_point_fn, make_initial_point_fns_per_chain
 
 
@@ -66,7 +66,7 @@ class TestInitvalEvaluation:
     def test_make_initial_point_fns_per_chain_checks_kwargs(self):
         with pm.Model() as pmodel:
             A = pm.Uniform("A", 0, 1, initval=0.5)
-            B = pm.Uniform("B", lower=A, upper=1.5, transform=None, initval="moment")
+            B = pm.Uniform("B", lower=A, upper=1.5, transform=None, initval="finite_logp_point")
         with pytest.raises(ValueError, match="Number of initval dicts"):
             make_initial_point_fns_per_chain(
                 model=pmodel,
@@ -136,7 +136,7 @@ class TestInitvalEvaluation:
         with pm.Model() as pmodel:
             pm.Normal("A", initval="prior")
             pm.Uniform("B", initval="prior")
-            pm.Normal("C", initval="moment")
+            pm.Normal("C", initval="finite_logp_point")
             ip1 = pmodel.initial_point(random_seed=42)
             ip2 = pmodel.initial_point(random_seed=42)
             ip3 = pmodel.initial_point(random_seed=15)
@@ -146,8 +146,8 @@ class TestInitvalEvaluation:
 
     def test_untransformed_initial_point(self):
         with pm.Model() as pmodel:
-            pm.Flat("A", initval="moment")
-            pm.HalfFlat("B", initval="moment")
+            pm.Flat("A", initval="finite_logp_point")
+            pm.HalfFlat("B", initval="finite_logp_point")
         fn = make_initial_point_fn(model=pmodel, jitter_rvs={}, return_transformed=False)
         iv = fn(0)
         assert iv["A"] == 0
@@ -156,9 +156,9 @@ class TestInitvalEvaluation:
 
     def test_adds_jitter(self):
         with pm.Model() as pmodel:
-            A = pm.Flat("A", initval="moment")
-            B = pm.HalfFlat("B", initval="moment")
-            C = pm.Normal("C", mu=A + B, initval="moment")
+            A = pm.Flat("A", initval="finite_logp_point")
+            B = pm.HalfFlat("B", initval="finite_logp_point")
+            C = pm.Normal("C", mu=A + B, initval="finite_logp_point")
         fn = make_initial_point_fn(model=pmodel, jitter_rvs={B}, return_transformed=True)
         iv = fn(0)
         # Moment of the Flat is 0
@@ -177,9 +177,9 @@ class TestInitvalEvaluation:
 
     def test_respects_overrides(self):
         with pm.Model() as pmodel:
-            A = pm.Flat("A", initval="moment")
+            A = pm.Flat("A", initval="finite_logp_point")
             B = pm.HalfFlat("B", initval=4)
-            C = pm.Normal("C", mu=A + B, initval="moment")
+            C = pm.Normal("C", mu=A + B, initval="finite_logp_point")
         fn = make_initial_point_fn(
             model=pmodel,
             jitter_rvs={},
@@ -221,34 +221,34 @@ class TestMoment:
     def test_basic(self):
         # Standard distributions
         rv = pm.Normal.dist(mu=2.3)
-        np.testing.assert_allclose(moment(rv).eval(), 2.3)
+        np.testing.assert_allclose(finite_logp_point(rv).eval(), 2.3)
 
         # Special distributions
         rv = pm.Flat.dist()
-        assert moment(rv).eval() == np.zeros(())
+        assert finite_logp_point(rv).eval() == np.zeros(())
         rv = pm.HalfFlat.dist()
-        assert moment(rv).eval() == np.ones(())
+        assert finite_logp_point(rv).eval() == np.ones(())
         rv = pm.Flat.dist(size=(2, 4))
-        assert np.all(moment(rv).eval() == np.zeros((2, 4)))
+        assert np.all(finite_logp_point(rv).eval() == np.zeros((2, 4)))
         rv = pm.HalfFlat.dist(size=(2, 4))
-        assert np.all(moment(rv).eval() == np.ones((2, 4)))
+        assert np.all(finite_logp_point(rv).eval() == np.ones((2, 4)))
 
     @pytest.mark.parametrize("rv_cls", [pm.Flat, pm.HalfFlat])
-    def test_numeric_moment_shape(self, rv_cls):
+    def test_numeric_finite_logp_point_shape(self, rv_cls):
         rv = rv_cls.dist(shape=(2,))
         assert not hasattr(rv.tag, "test_value")
-        assert tuple(moment(rv).shape.eval()) == (2,)
+        assert tuple(finite_logp_point(rv).shape.eval()) == (2,)
 
     @pytest.mark.parametrize("rv_cls", [pm.Flat, pm.HalfFlat])
-    def test_symbolic_moment_shape(self, rv_cls):
+    def test_symbolic_finite_logp_point_shape(self, rv_cls):
         s = pt.scalar(dtype="int64")
         rv = rv_cls.dist(shape=(s,))
         assert not hasattr(rv.tag, "test_value")
-        assert tuple(moment(rv).shape.eval({s: 4})) == (4,)
+        assert tuple(finite_logp_point(rv).shape.eval({s: 4})) == (4,)
         pass
 
     @pytest.mark.parametrize("rv_cls", [pm.Flat, pm.HalfFlat])
-    def test_moment_from_dims(self, rv_cls):
+    def test_finite_logp_point_from_dims(self, rv_cls):
         with pm.Model(
             coords={
                 "year": [2019, 2020, 2021, 2022],
@@ -257,10 +257,10 @@ class TestMoment:
         ):
             rv = rv_cls("rv", dims=("year", "city"))
             assert not hasattr(rv.tag, "test_value")
-            assert tuple(moment(rv).shape.eval()) == (4, 3)
+            assert tuple(finite_logp_point(rv).shape.eval()) == (4, 3)
         pass
 
-    def test_moment_not_implemented_fallback(self):
+    def test_finite_logp_point_not_implemented_fallback(self):
         class MyNormalRV(RandomVariable):
             name = "my_normal"
             ndim_supp = 0
@@ -275,7 +275,7 @@ class TestMoment:
             rv_op = MyNormalRV()
 
         with pm.Model() as m:
-            x = MyNormalDistribution("x", 0, 1, initval="moment")
+            x = MyNormalDistribution("x", 0, 1, initval="finite_logp_point")
 
         with pytest.warns(
             UserWarning, match="Moment not defined for variable x of type MyNormalRV"


### PR DESCRIPTION
## Description
Rename `moment` method to avoid confusion with distribution mean. 

## Related Issue
- [x] Closes #6974 

## Checklist
- [x] Rename `moment` method in code (and other related variable names)
- [X] Update documentation


## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7166.org.readthedocs.build/en/7166/

<!-- readthedocs-preview pymc end -->