### PR TITLE
Fix `compute_log_prior` in models with `Deterministics`

### DIFF
--- a/pymc/stats/log_density.py
+++ b/pymc/stats/log_density.py
@@ -131,7 +131,7 @@ def compute_log_density(
         target_rvs = model.observed_RVs
         target_str = "observed_RVs"
     else:
-        target_rvs = model.unobserved_RVs
+        target_rvs = model.free_RVs
         target_str = "free_RVs"
 
     if var_names is None:

--- a/tests/stats/test_log_density.py
+++ b/tests/stats/test_log_density.py
@@ -19,7 +19,7 @@ from arviz import InferenceData, dict_to_dataset, from_dict
 
 from pymc.distributions import Dirichlet, Normal
 from pymc.distributions.transforms import log
-from pymc.model import Model, Deterministic
+from pymc.model import Deterministic, Model
 from pymc.stats.log_density import compute_log_likelihood, compute_log_prior
 from tests.distributions.test_multivariate import dirichlet_logpdf
 
@@ -156,11 +156,10 @@ class TestComputeLogLikelihood:
             st.norm(0, 1).logpdf(idata.posterior["x"].values),
         )
 
-
     def test_deterministic_log_prior(self):
         with Model() as m:
             x = Normal("x")
-            Deterministic("d", 2*x)
+            Deterministic("d", 2 * x)
             Normal("y", x, observed=[0, 1, 2])
 
             idata = InferenceData(posterior=dict_to_dataset({"x": np.arange(100).reshape(4, 25)}))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
The default for `var_names` in `compute_log_likelihood` was `unobserved_RVs` which
includes also deterministics. This changes the default to `free_RVs`.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7168.org.readthedocs.build/en/7168/

<!-- readthedocs-preview pymc end -->