### PR TITLE
Fix error in warn_treedepth when using multiple NUTS samplers

### DIFF
--- a/pymc/stats/convergence.py
+++ b/pymc/stats/convergence.py
@@ -164,7 +164,7 @@ def warn_treedepth(idata: arviz.InferenceData) -> list[SamplerWarning]:
 
     warnings = []
     for c in rmtd.chain:
-        if sum(rmtd.sel(chain=c)) / rmtd.sizes["draw"] > 0.05:
+        if (rmtd.sel(chain=c).mean("draw") > 0.05).any():
             warnings.append(
                 SamplerWarning(
                     WarningType.TREEDEPTH,

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -198,7 +198,7 @@ class NUTS(BaseHMC):
 
             if divergence_info or turning:
                 break
-        else:
+        else:  # no-break
             reached_max_treedepth = not self.tune
 
         stats = tree.stats()

--- a/tests/stats/test_convergence.py
+++ b/tests/stats/test_convergence.py
@@ -42,6 +42,22 @@ def test_warn_treedepth():
     assert "Chain 1 reached the maximum tree depth" in warns[0].message
 
 
+def test_warn_treedepth_multiple_samplers():
+    """Check we handle cases when sampling with multiple NUTS samplers, each of which reports max_treedepth."""
+    max_treedepth = np.zeros((3, 2, 2), dtype=bool)
+    max_treedepth[0, 0, 0] = True
+    max_treedepth[2, 1, 1] = True
+    idata = arviz.from_dict(
+        sample_stats={
+            "reached_max_treedepth": max_treedepth,
+        }
+    )
+    warns = convergence.warn_treedepth(idata)
+    assert len(warns) == 2
+    assert "Chain 0 reached the maximum tree depth" in warns[0].message
+    assert "Chain 2 reached the maximum tree depth" in warns[1].message
+
+
 def test_log_warning_stats(caplog):
     s1 = dict(warning="Temperature too low!")
     s2 = dict(warning="Temperature too high!")


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Fix issue reported in https://discourse.pymc.io/t/valueerror-the-truth-value-of-an-array-with-more-than-one-element-is-ambiguous-given-at-the-end-of-sampling/13875/3

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7182.org.readthedocs.build/en/7182/

<!-- readthedocs-preview pymc end -->