### PR TITLE
Improve HSGP and ZeroInflated / Hurdle distributions docs

### DIFF
--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -629,7 +629,7 @@ class ZeroInflatedPoisson:
     Parameters
     ----------
     psi : tensor_like of float
-        Expected proportion of Poisson variates (0 < psi < 1)
+        Expected proportion of Poisson draws (0 < psi < 1)
     mu : tensor_like of float
         Expected number of occurrences during the given interval
         (mu >= 0).
@@ -692,7 +692,7 @@ class ZeroInflatedBinomial:
     Parameters
     ----------
     psi : tensor_like of float
-        Expected proportion of Binomial variates (0 < psi < 1)
+        Expected proportion of Binomial draws (0 < psi < 1)
     n : tensor_like of int
         Number of Bernoulli trials (n >= 0).
     p : tensor_like of float
@@ -779,7 +779,7 @@ class ZeroInflatedNegativeBinomial:
     Parameters
     ----------
     psi : tensor_like of float
-        Expected proportion of NegativeBinomial variates (0 < psi < 1)
+        Expected proportion of NegativeBinomial draws (0 < psi < 1)
     mu : tensor_like of float
         Poisson distribution parameter (mu > 0).
     alpha : tensor_like of float
@@ -867,7 +867,7 @@ class HurdlePoisson:
     Parameters
     ----------
     psi : tensor_like of float
-        Expected proportion of Poisson variates (0 < psi < 1)
+        Expected proportion of Poisson draws (0 < psi < 1)
     mu : tensor_like of float
         Expected number of occurrences (mu >= 0).
     """
@@ -911,7 +911,7 @@ class HurdleNegativeBinomial:
     Parameters
     ----------
     psi : tensor_like of float
-        Expected proportion of Negative Binomial variates (0 < psi < 1)
+        Expected proportion of Negative Binomial draws (0 < psi < 1)
     alpha : tensor_like of float
         Gamma distribution shape parameter (alpha > 0).
     mu : tensor_like of float
@@ -963,7 +963,7 @@ class HurdleGamma:
     Parameters
     ----------
     psi : tensor_like of float
-        Expected proportion of Gamma variates (0 < psi < 1)
+        Expected proportion of Gamma draws (0 < psi < 1)
     alpha : tensor_like of float, optional
         Shape parameter (alpha > 0).
     beta : tensor_like of float, optional
@@ -1015,7 +1015,7 @@ class HurdleLogNormal:
     Parameters
     ----------
     psi : tensor_like of float
-        Expected proportion of LogNormal variates (0 < psi < 1)
+        Expected proportion of LogNormal draws (0 < psi < 1)
     mu : tensor_like of float, default 0
         Location parameter.
     sigma : tensor_like of float, optional


### PR DESCRIPTION
## Description
Just a small PR to improve and fix some typos in the doc pages of:
- HSGP (base method and `prior_linearized` method)
- `ZeroInflated` distributions (switched from "variates" to "draws", which is more common and much clearer when teaching)
- `Hurdle` distributions (same change as previous point)

Ready for review and merge

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify)


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7189.org.readthedocs.build/en/7189/

<!-- readthedocs-preview pymc end -->