### PR TITLE
add _moment function for bacward backward compatibility

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -535,6 +535,14 @@ def support_point(rv: TensorVariable) -> TensorVariable:
     return _support_point(rv.owner.op, rv, *rv.owner.inputs).astype(rv.dtype)
 
 
+def _moment(op, rv, *rv_inputs) -> TensorVariable:
+    warnings.warn(
+        "The moment() method is deprecated. Use support_point() instead.",
+        DeprecationWarning,
+    )
+    return _support_point(op, rv, *rv_inputs)
+
+
 def moment(rv: TensorVariable) -> TensorVariable:
     warnings.warn(
         "The moment() method is deprecated. Use support_point() instead.",


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Add `_moment` function with deprecation warning to fix import error in pymc-experimental 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to https://github.com/pymc-devs/pymc-experimental/issues/317


## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7216.org.readthedocs.build/en/7216/

<!-- readthedocs-preview pymc end -->