### PR TITLE
Fix link and typo in developer_guide.md

### DIFF
--- a/docs/source/contributing/developer_guide.md
+++ b/docs/source/contributing/developer_guide.md
@@ -543,7 +543,7 @@ The base class for most MCMC sampler (except SMC) is in [ArrayStep](https://gith
 You can see that the ``step.step()`` is mapping the ``point`` into an array, and call ``self.astep()``, which is an array in, array out function.
 A PyMC model compiles a conditional logp/dlogp function that replace the input RVs with a shared 1D tensor (flatten and stack view of the original RVs).
 And the transition kernel (i.e., ``.astep()``) takes an array as input and outputs an array.
-See for example in the [MH sampler](https://github.com/pymc-devs/pymc/blob/89f6fcf751774fb50016561dc448a87fba7ed3aa/pymc/step_methods/metropolis.py#L235-L289).
+For example, see the [MH sampler](https://github.com/pymc-devs/pymc/blob/89f6fcf751774fb50016561dc448a87fba7ed3aa/pymc/step_methods/metropolis.py#L235-L289).
 
 This is of course very different compared to the transition kernel in e.g. TFP, which is a tenor in tensor out function.
 Moreover, transition kernels in TFP do not flatten the tensors, see eg docstring of [tensorflow\_probability/python/mcmc/random\_walk\_metropolis.py](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/mcmc/random_walk_metropolis.py):

--- a/docs/source/contributing/developer_guide.md
+++ b/docs/source/contributing/developer_guide.md
@@ -542,10 +542,10 @@ There are some example in the ``CompoundStep`` doc:
 The base class for most MCMC sampler (except SMC) is in [ArrayStep](https://github.com/pymc-devs/pymc/blob/main/pymc/step_methods/arraystep.py).
 You can see that the ``step.step()`` is mapping the ``point`` into an array, and call ``self.astep()``, which is an array in, array out function.
 A PyMC model compiles a conditional logp/dlogp function that replace the input RVs with a shared 1D tensor (flatten and stack view of the original RVs).
-And the transition kernel (i.e., ``.astep()``) takes an array as input and output an array.
-See for example in the [MH sampler](https://github.com/pymc-devs/pymc/blob/6d07591962a6c135640a3c31903eba66b34e71d8/pymc/step_methods/metropolis.py#L139-L173).
+And the transition kernel (i.e., ``.astep()``) takes an array as input and outputs an array.
+See for example in the [MH sampler](https://github.com/pymc-devs/pymc/blob/89f6fcf751774fb50016561dc448a87fba7ed3aa/pymc/step_methods/metropolis.py#L235-L289).
 
-This is of course very different compare to the transition kernel in e.g. TFP, which is a tenor in tensor out function.
+This is of course very different compared to the transition kernel in e.g. TFP, which is a tenor in tensor out function.
 Moreover, transition kernels in TFP do not flatten the tensors, see eg docstring of [tensorflow\_probability/python/mcmc/random\_walk\_metropolis.py](https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/mcmc/random_walk_metropolis.py):
 
 ```python


### PR DESCRIPTION
## Description

Fix the link to `MH-sampler`'s `astep()` method in `developer_guide.md`. The previous link is not valid and returns 404.

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7219.org.readthedocs.build/en/7219/

<!-- readthedocs-preview pymc end -->