### PR TITLE
Use exponentially scaled modified Bessel function in periodic HSGPs

### DIFF
--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -810,7 +810,7 @@ class Periodic(Stationary):
         a = 1 / pt.square(self.ls)
         c = pt.where(J > 0, 2, 1)
 
-        q2 = c * pt.iv(J, a) / pt.exp(a)
+        q2 = c * pt.ive(J, a)
 
         return q2
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
This updates the scale factor in the periodic HSGP implementation to use the exponentially scaled modified Bessel function recently added to PyTensor. This should improve the numerical stability of the implementation, and simplify the gradient slightly. Note
```
ive(v, z) = iv(v, z) * exp(-abs(z.real))
```

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7228.org.readthedocs.build/en/7228/

<!-- readthedocs-preview pymc end -->