### PR TITLE
Add HSGPPeriodic to Docs

### DIFF
--- a/docs/source/api/gp/implementations.rst
+++ b/docs/source/api/gp/implementations.rst
@@ -7,6 +7,7 @@ Implementations
    :toctree: generated
 
    HSGP
+   HSGPPeriodic
    Latent
    LatentKron
    Marginal


### PR DESCRIPTION
This should make the `HSGPPeriodic` visible in the docs.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7230.org.readthedocs.build/en/7230/

<!-- readthedocs-preview pymc end -->