### PR TITLE
Make default STEP_METHODS a list that can be modified

### DIFF
--- a/pymc/step_methods/__init__.py
+++ b/pymc/step_methods/__init__.py
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from pymc.step_methods.compound import CompoundStep
+from pymc.step_methods.compound import BlockedStep, CompoundStep
 from pymc.step_methods.hmc import NUTS, HamiltonianMC
 from pymc.step_methods.metropolis import (
     BinaryGibbsMetropolis,
@@ -30,7 +30,8 @@ from pymc.step_methods.metropolis import (
 )
 from pymc.step_methods.slicer import Slice
 
-STEP_METHODS = (
+# Other step methods can be added by appending to this list
+STEP_METHODS: list[type[BlockedStep]] = [
     NUTS,
     HamiltonianMC,
     Metropolis,
@@ -38,4 +39,4 @@ STEP_METHODS = (
     BinaryGibbsMetropolis,
     Slice,
     CategoricalGibbsMetropolis,
-)
+]

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -762,12 +762,18 @@ class TestAssignStepMethods:
                 steps = assign_step_methods(model, [])
         assert isinstance(steps, Slice)
 
-    def test_modify_step_methods(self):
+    @pytest.fixture
+    def step_methods(self):
+        """Make sure we reset the STEP_METHODS after the test is done."""
+        methods_copy = pm.STEP_METHODS.copy()
+        yield pm.STEP_METHODS
+        pm.STEP_METHODS.clear()
+        for method in methods_copy:
+            pm.STEP_METHODS.append(method)
+
+    def test_modify_step_methods(self, step_methods):
         """Test step methods can be changed"""
-        # remove nuts from step_methods
-        step_methods = list(pm.STEP_METHODS)
         step_methods.remove(NUTS)
-        pm.STEP_METHODS = step_methods
 
         with pm.Model() as model:
             pm.Normal("x", 0, 1)
@@ -776,7 +782,7 @@ class TestAssignStepMethods:
         assert not isinstance(steps, NUTS)
 
         # add back nuts
-        pm.STEP_METHODS = [*step_methods, NUTS]
+        step_methods.append(NUTS)
 
         with pm.Model() as model:
             pm.Normal("x", 0, 1)

--- a/tests/step_methods/test_compound.py
+++ b/tests/step_methods/test_compound.py
@@ -26,7 +26,6 @@ from pymc.step_methods import (
     Slice,
 )
 from pymc.step_methods.compound import (
-    BlockedStep,
     StatsBijection,
     flatten_steps,
     get_stats_dtypes_shapes_from_steps,
@@ -38,10 +37,7 @@ from tests.models import simple_2model_continuous
 
 
 def test_all_stepmethods_emit_tune_stat():
-    attrs = [getattr(pm.step_methods, n) for n in dir(pm.step_methods)]
-    step_types = [
-        attr for attr in attrs if isinstance(attr, type) and issubclass(attr, BlockedStep)
-    ]
+    step_types = pm.step_methods.STEP_METHODS
     assert len(step_types) > 5
     for cls in step_types:
         assert "tune" in cls.stats_dtypes_shapes


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Having as a tuple is a bit cumbersome and makes it seem like it should not be modified. However, until we have a more proper system (disptach based probably), this is the API for other packages (including BART, pymc-experimental) to define default samplers.

This PR makes it a list (and over-engineers a fixture for the test :D, happy to remove if you think it's silly)

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
