### PR TITLE
Add introduction section to Transformations API page to document role of Transforms

### DIFF
--- a/docs/source/api/distributions/transforms.rst
+++ b/docs/source/api/distributions/transforms.rst
@@ -4,6 +4,36 @@ Transformations
 
 .. currentmodule:: pymc.distributions.transforms
 
+While many distributions are defined on constrained spaces (e.g. intervals), MCMC samplers typically perform best when sampling on the unconstrained real line; this is especially true of HMC samplers. PyMC balances this through the use of transforms. A transform instance can be passed to the constructor of a random variable to tell the sampler how to move between the underlying unconstrained space where the samples are actually drawn and the transformed space constituting the support of the random variable. Transforms are not currently implemented for discrete random variables.
+
+All transforms have three core methods:
+
+* ``forward``: The map from a constrained space to the unconstrained space.
+* ``backward``: The inverse map from the unconstrained space to a constrained space.
+* ``log_jac_det``: The log of the determinant of the Jacobian of the ``backward`` map. This is used to account for the transformed random variable correctly in the posterior log-probability.
+
+.. note::
+   Transforms are principally intended for internal use and in most cases users do not need to change them. In particular, all continuous distributions on a constrained domain that are implemented in PyMC have a ``default_transform`` that will automatically transform the random variables as required without needing any extra work from the user.
+
+The main use-cases for setting custom transforms include the following:
+
+#. The ``default_transform`` may need to be replaced with an alternative transform on the same constained space. For example, the ``default_transform`` for positive-valued random variables is the :class:`log` transform but in some cases it may be advantageous to use the :class:`log_exp_m1` transform instead.
+#. The ``default_transform`` may be removed entirely in some cases when using non-HMC samplers.
+#. Exceptionally, transforms can be used to add constraints to the model specification. However this should not be viewed as a default use-case and, in practice, this is mostly limited to using :class:`ordered` in mixture models.
+
+   * NB: :class:`ordered` is not guaranteed to work correctly when used in combination with other transforms, such as :class:`simplex` and :class:`ZeroSumTransform`.
+
+.. warning::
+   Transforms are **only** applied when sampling *unobserved* random variables with :func:`pymc.sample`. In particular:
+
+   * Transforms are not applied during forward sampling, i.e. :func:`pymc.draw`, :func:`pymc.sample_prior_predictive` and :func:`pymc.sample_posterior_predictive`
+   * Transforms are not applied when sampling *observed* random variables with :func:`pymc.sample`
+
+Since transforms are not applied during :func:`pymc.sample_prior_predictive`, a workaround to carry out prior predictive checks is to remove observations from the likelihood and use :func:`pymc.sample` instead.
+
+Transforms are not usually the correct tool to represent transformations that are part of the *generative* specification of the model. Such transformations should be included explicitly in the model, typically via :class:`pymc.Deterministic`. Doing so allows such transformed random variables to be sampled by forward samplers.
+
+
 Transform Instances
 ~~~~~~~~~~~~~~~~~~~
 
@@ -17,22 +47,27 @@ Transform instances are the entities that should be used in the
     log
     log_exp_m1
     logodds
-    simplex
-    sum_to_1
     ordered
+    simplex
 
 
 Specific Transform Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+An instance of these classes needs to be created before being used
+in the ``transform`` parameter to a random variable constructor.
+
 .. autosummary::
    :toctree: generated
 
     CholeskyCovPacked
+    CircularTransform
     Interval
     LogExpM1
+    LogOddsTransform
+    LogTransform
     Ordered
-    SumTo1
+    SimplexTransform
     ZeroSumTransform
 
 

--- a/docs/source/api/distributions/transforms.rst
+++ b/docs/source/api/distributions/transforms.rst
@@ -19,7 +19,7 @@ The main use-cases for setting custom transforms include the following:
 
 #. The ``default_transform`` may need to be replaced with an alternative transform on the same constained space. For example, the ``default_transform`` for positive-valued random variables is the :class:`log` transform but in some cases it may be advantageous to use the :class:`log_exp_m1` transform instead.
 #. The ``default_transform`` may be removed entirely in some cases when using non-HMC samplers.
-#. Exceptionally, transforms can be used to add constraints to the model specification. However this should not be viewed as a default use-case and, in practice, this is mostly limited to using :class:`ordered` in mixture models.
+#. Exceptionally, transforms can be used to *add* constraints to the model specification without modifying the ``default_transform``. This can be done by specifying the additional transform via the ``transform`` parameter. However this should not be viewed as a default use-case and, in practice, this is mostly limited to using :class:`ordered` in mixture models.
 
    * NB: :class:`ordered` is not guaranteed to work correctly when used in combination with other transforms, such as :class:`simplex` and :class:`ZeroSumTransform`.
 
@@ -38,7 +38,8 @@ Transform Instances
 ~~~~~~~~~~~~~~~~~~~
 
 Transform instances are the entities that should be used in the
-``transform`` parameter to a random variable constructor.
+``default_transform`` or ``transform`` parameters to a random variable
+constructor.
 
 .. autosummary::
    :toctree: generated
@@ -55,7 +56,8 @@ Specific Transform Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 An instance of these classes needs to be created before being used
-in the ``transform`` parameter to a random variable constructor.
+in the ``default_transform`` or ``transform`` parameters to a random variable
+constructor.
 
 .. autosummary::
    :toctree: generated
@@ -73,6 +75,14 @@ in the ``transform`` parameter to a random variable constructor.
 
 Transform Composition Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An instance of this class needs to be created from a list of transforms before
+being used in the ``transform`` parameter to a random variable constructor.
+
+If a random variable has a ``default_transform`` and an additional transform
+is provided through the ``transform`` parameter, PyMC will automatically
+create an instance of the :class:`Chain` transform that applies the
+user-provided transform on top of the default one.
 
 .. autosummary::
    :toctree: generated

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -322,7 +322,6 @@ log_exp_m1.__doc__ = """
 Instantiation of :class:`pymc.distributions.transforms.LogExpM1`
 for use in the ``transform`` argument of a random variable."""
 
-# Deprecated
 ordered = Ordered()
 ordered.__doc__ = """
 Instantiation of :class:`pymc.distributions.transforms.Ordered`


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
This PR adds an introduction section to the Transformations API page to:
- explain the principal purpose of transforms
- warn that most users don't need to play with these and that most attempts to do so don't do what users tend to think
- provide some guidance on when tweaking transforms may be appropriate and what other options user have when wanting to deal with transformed random variables

In addition this PR:
- removes a seemingly incorrect deprecation comment next to the `ordered` transform (I think it was accidentally left over from when `univariate_ordered` was deprecated)
- removes mention of `SumsTo1`, which is being deprecated
- organises instance and class names in the autosummary to 
  1. alphebtize them, and
  2. add missing class names for the included instances

This PR assumes that the issue #5674 is closed (via PR #7207) to avoid extensive (and somewhat non-intuitive to casual user) guidance that will shortly be outdated


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7040
- [x] Related to #6975, #5674, #7009

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7232.org.readthedocs.build/en/7232/

<!-- readthedocs-preview pymc end -->