### PR TITLE
Error in idata.posterior variable

### DIFF
--- a/docs/source/learn/core_notebooks/GLM_linear.ipynb
+++ b/docs/source/learn/core_notebooks/GLM_linear.ipynb
@@ -416,7 +416,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "idata.posterior[\"y_model\"] = idata.posterior[\"Intercept\"] + idata.posterior[\"x\"] * xr.DataArray(x)"
+    "idata.posterior[\"y_model\"] = idata.posterior[\"Intercept\"] + idata.posterior[\"slope\"] * xr.DataArray(x)"
    ]
   },
   {


### PR DESCRIPTION
Run the example in the line:
`idata.posterior["y_model"] = idata.posterior["Intercept"] + idata.posterior["x"] * xr.DataArray(x) `
show de error:

> KeyError: "No variable named 'x'. Variables on the dataset include ['chain', 'draw', 'Intercept', 'slope', 'sigma', 'y_model']"

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
change variable "x" by "slope"


## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7234.org.readthedocs.build/en/7234/

<!-- readthedocs-preview pymc end -->