### PR TITLE
Add `compute_deterministics` helper

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,7 @@ jobs:
           - |
             tests/distributions/test_censored.py
             tests/distributions/test_simulator.py
+            tests/sampling/test_deterministic.py
             tests/sampling/test_forward.py
             tests/sampling/test_population.py
             tests/stats/test_convergence.py

--- a/docs/source/api/samplers.rst
+++ b/docs/source/api/samplers.rst
@@ -4,34 +4,19 @@ Samplers
 This submodule contains functions for MCMC and forward sampling.
 
 
-.. currentmodule:: pymc.sampling.forward
-
-.. autosummary::
-   :toctree: generated/
-
-   sample_prior_predictive
-   sample_posterior_predictive
-   draw
-
-.. currentmodule:: pymc.sampling.deterministic
-   compute_deterministics
-
-
-.. currentmodule:: pymc.sampling.mcmc
+.. currentmodule:: pymc
 
 .. autosummary::
    :toctree: generated/
 
    sample
+   sample_prior_predictive
+   sample_posterior_predictive
+   draw
+   compute_deterministics
    init_nuts
-
-.. currentmodule:: pymc.sampling.jax
-
-.. autosummary::
-   :toctree: generated/
-
-   sample_blackjax_nuts
-   sample_numpyro_nuts
+   sampling.jax.sample_blackjax_nuts
+   sampling.jax.sample_numpyro_nuts
 
 
 Step methods

--- a/docs/source/api/samplers.rst
+++ b/docs/source/api/samplers.rst
@@ -13,6 +13,9 @@ This submodule contains functions for MCMC and forward sampling.
    sample_posterior_predictive
    draw
 
+.. currentmodule:: pymc.sampling.deterministic
+   compute_deterministics
+
 
 .. currentmodule:: pymc.sampling.mcmc
 

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -18,7 +18,7 @@ import threading
 import types
 import warnings
 
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Iterable, Sequence
 from sys import modules
 from typing import (
     TYPE_CHECKING,
@@ -27,6 +27,7 @@ from typing import (
     Optional,
     TypeVar,
     cast,
+    overload,
 )
 
 import numpy as np
@@ -35,7 +36,7 @@ import pytensor.sparse as sparse
 import pytensor.tensor as pt
 import scipy.sparse as sps
 
-from pytensor.compile import DeepCopyOp, get_mode
+from pytensor.compile import DeepCopyOp, Function, get_mode
 from pytensor.compile.sharedvalue import SharedVariable
 from pytensor.graph.basic import Constant, Variable, graph_inputs
 from pytensor.scalar import Cast
@@ -1524,6 +1525,28 @@ class Model(WithMemoization, metaclass=ContextMeta):
             rvs_to_transforms=self.rvs_to_transforms,
         )
 
+    @overload
+    def compile_fn(
+        self,
+        outs: Variable | Sequence[Variable],
+        *,
+        inputs: Sequence[Variable] | None = None,
+        mode=None,
+        point_fn: Literal[True] = True,
+        **kwargs,
+    ) -> PointFunc: ...
+
+    @overload
+    def compile_fn(
+        self,
+        outs: Variable | Sequence[Variable],
+        *,
+        inputs: Sequence[Variable] | None = None,
+        mode=None,
+        point_fn: Literal[False],
+        **kwargs,
+    ) -> Function: ...
+
     def compile_fn(
         self,
         outs: Variable | Sequence[Variable],
@@ -1532,7 +1555,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         mode=None,
         point_fn: bool = True,
         **kwargs,
-    ) -> PointFunc | Callable[[Sequence[np.ndarray]], Sequence[np.ndarray]]:
+    ) -> PointFunc | Function:
         """Compiles an PyTensor function
 
         Parameters
@@ -2044,7 +2067,7 @@ def compile_fn(
     point_fn: bool = True,
     model: Model | None = None,
     **kwargs,
-) -> PointFunc | Callable[[Sequence[np.ndarray]], Sequence[np.ndarray]]:
+) -> PointFunc | Function:
     """Compiles an PyTensor function
 
     Parameters

--- a/pymc/sampling/__init__.py
+++ b/pymc/sampling/__init__.py
@@ -12,5 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from pymc.sampling.deterministic import compute_deterministics
 from pymc.sampling.forward import *
 from pymc.sampling.mcmc import *

--- a/pymc/sampling/deterministic.py
+++ b/pymc/sampling/deterministic.py
@@ -1,0 +1,114 @@
+#   Copyright 2024 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from collections.abc import Sequence
+
+import xarray
+
+from xarray import Dataset
+
+from pymc.backends.arviz import apply_function_over_dataset, coords_and_dims_for_inferencedata
+from pymc.model.core import Model, modelcontext
+
+
+def compute_deterministics(
+    dataset: Dataset,
+    *,
+    var_names: Sequence[str] | None = None,
+    model: Model | None = None,
+    sample_dims: Sequence[str] = ("chain", "draw"),
+    merge_dataset: bool = False,
+    progressbar: bool = True,
+    compile_kwargs: dict | None = None,
+) -> Dataset:
+    """Compute model deterministics given a dataset with values for model variables.
+
+    Parameters
+    ----------
+    dataset : Dataset
+        Dataset with values for model variables. Commonly InferenceData["posterior"].
+    var_names : sequence of str, optional
+        List of names of deterministic variable to compute.
+        If None, compute all deterministics in the model.
+    model : Model, optional
+        Model to use. If None, use context model.
+    sample_dims : sequence of str, default ("chain", "draw")
+        Sample (batch) dimensions of the dataset over which to compute the deterministics.
+    merge_dataset : bool, default False
+        Whether to extend the original dataset or return a new one.
+    progressbar : bool, default True
+        Whether to display a progress bar in the command line.
+    progressbar_theme : Theme, optional
+        Custom theme for the progress bar.
+    compile_kwargs: dict, optional
+        Additional arguments passed to `model.compile_fn`.
+
+    Returns
+    -------
+    Dataset
+        Dataset with values for the deterministics.
+
+
+    Examples
+    --------
+    .. code:: python
+
+        import pymc as pm
+
+        with pm.Model(coords={"group": (0, 2, 4)}) as m:
+            mu_raw = pm.Normal("mu_raw", 0, 1, dims="group")
+            mu = pm.Deterministic("mu", mu_raw.cumsum(), dims="group")
+
+            trace = pm.sample(var_names=["mu_raw"], chains=2, tune=5 draws=5)
+
+        assert "mu" not in trace.posterior
+
+        with m:
+            trace.posterior = pm.compute_deterministics(trace.posterior, merge_dataset=True)
+
+        assert "mu" in trace.posterior
+
+
+    """
+    model = modelcontext(model)
+
+    if var_names is None:
+        deterministics = model.deterministics
+    else:
+        deterministics = [model[var_name] for var_name in var_names]
+        if not set(deterministics).issubset(set(model.deterministics)):
+            raise ValueError("Not all var_names corresponded to model deterministics")
+
+    fn = model.compile_fn(
+        inputs=model.free_RVs,
+        outs=deterministics,
+        on_unused_input="ignore",
+        **(compile_kwargs or {}),
+    )
+
+    coords, dims = coords_and_dims_for_inferencedata(model)
+
+    new_dataset = apply_function_over_dataset(
+        fn,
+        dataset[[rv.name for rv in model.free_RVs]],
+        output_var_names=[det.name for det in model.deterministics],
+        dims=dims,
+        coords=coords,
+        sample_dims=sample_dims,
+        progressbar=progressbar,
+    )
+
+    if merge_dataset:
+        new_dataset = xarray.merge([dataset, new_dataset], compat="override")
+
+    return new_dataset

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -49,7 +49,7 @@ from rich.theme import Theme
 
 import pymc as pm
 
-from pymc.backends.arviz import _DefaultTrace
+from pymc.backends.arviz import _DefaultTrace, dataset_to_point_list
 from pymc.backends.base import MultiTrace
 from pymc.blocking import PointType
 from pymc.model import Model, modelcontext
@@ -57,7 +57,6 @@ from pymc.pytensorf import compile_pymc
 from pymc.util import (
     RandomState,
     _get_seeds_per_chain,
-    dataset_to_point_list,
     default_progress_theme,
     get_default_varnames,
     point_wrapper,

--- a/pymc/stats/log_density.py
+++ b/pymc/stats/log_density.py
@@ -12,22 +12,16 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 from collections.abc import Sequence
-from typing import cast
+from typing import Literal
 
-from arviz import InferenceData, dict_to_dataset
-from rich.console import Console
-from rich.progress import Progress
-
-import pymc
+from arviz import InferenceData
+from xarray import Dataset
 
 from pymc.backends.arviz import (
-    _DefaultTrace,
+    apply_function_over_dataset,
     coords_and_dims_for_inferencedata,
-    dataset_to_point_list,
 )
 from pymc.model import Model, modelcontext
-from pymc.pytensorf import PointFunc
-from pymc.util import default_progress_theme
 
 __all__ = ("compute_log_likelihood", "compute_log_prior")
 
@@ -117,10 +111,10 @@ def compute_log_density(
     var_names: Sequence[str] | None = None,
     extend_inferencedata: bool = True,
     model: Model | None = None,
-    kind="likelihood",
+    kind: Literal["likelihood", "prior"] = "likelihood",
     sample_dims: Sequence[str] = ("chain", "draw"),
     progressbar=True,
-):
+) -> InferenceData | Dataset:
     """
     Compute elemwise log_likelihood or log_prior of model given InferenceData with posterior group
     """
@@ -163,40 +157,20 @@ def compute_log_density(
             outs=model.logp(vars=vars, sum=False),
             on_unused_input="ignore",
         )
-        elemwise_logdens_fn = cast(PointFunc, elemwise_logdens_fn)
     finally:
         model.rvs_to_values = original_rvs_to_values
         model.rvs_to_transforms = original_rvs_to_transforms
 
-    # Ignore Deterministics
-    posterior_values = posterior[[rv.name for rv in model.free_RVs]]
-    posterior_pts, stacked_dims = dataset_to_point_list(posterior_values, sample_dims)
-
-    n_pts = len(posterior_pts)
-    logdens_dict = _DefaultTrace(n_pts)
-
-    with Progress(console=Console(theme=default_progress_theme)) as progress:
-        task = progress.add_task("Computing log density...", total=n_pts, visible=progressbar)
-        for idx in range(n_pts):
-            logdenss_pts = elemwise_logdens_fn(posterior_pts[idx])
-            for rv_name, rv_logdens in zip(var_names, logdenss_pts):
-                logdens_dict.insert(rv_name, rv_logdens, idx)
-            progress.update(task, advance=1)
-
-    logdens_trace = logdens_dict.trace_dict
-    for key, array in logdens_trace.items():
-        logdens_trace[key] = array.reshape(
-            (*[len(coord) for coord in stacked_dims.values()], *array.shape[1:])
-        )
-
     coords, dims = coords_and_dims_for_inferencedata(model)
-    logdens_dataset = dict_to_dataset(
-        logdens_trace,
-        library=pymc,
+
+    logdens_dataset = apply_function_over_dataset(
+        elemwise_logdens_fn,
+        posterior[[rv.name for rv in model.free_RVs]],
+        output_var_names=var_names,
+        sample_dims=sample_dims,
         dims=dims,
         coords=coords,
-        default_dims=list(sample_dims),
-        skip_event_dims=True,
+        progressbar=progressbar,
     )
 
     if extend_inferencedata:

--- a/pymc/stats/log_density.py
+++ b/pymc/stats/log_density.py
@@ -20,10 +20,14 @@ from rich.progress import Progress
 
 import pymc
 
-from pymc.backends.arviz import _DefaultTrace, coords_and_dims_for_inferencedata
+from pymc.backends.arviz import (
+    _DefaultTrace,
+    coords_and_dims_for_inferencedata,
+    dataset_to_point_list,
+)
 from pymc.model import Model, modelcontext
 from pymc.pytensorf import PointFunc
-from pymc.util import dataset_to_point_list, default_progress_theme
+from pymc.util import default_progress_theme
 
 __all__ = ("compute_log_likelihood", "compute_log_prior")
 

--- a/tests/sampling/test_deterministic.py
+++ b/tests/sampling/test_deterministic.py
@@ -1,0 +1,77 @@
+#   Copyright 2024 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import numpy as np
+import pytest
+
+from numpy.testing import assert_allclose
+
+from pymc.distributions import Normal
+from pymc.model.core import Deterministic, Model
+from pymc.sampling.deterministic import compute_deterministics
+from pymc.sampling.forward import sample_prior_predictive
+
+# Turn all warnings into errors for this module
+pytestmark = pytest.mark.filterwarnings("error")
+
+
+def test_compute_deterministics():
+    with Model(coords={"group": (0, 2, 4)}) as m:
+        mu_raw = Normal("mu_raw", 0, 1, dims="group")
+        mu = Deterministic("mu", mu_raw.cumsum(), dims="group")
+
+        sigma_raw = Normal("sigma_raw", 0, 1)
+        sigma = Deterministic("sigma", sigma_raw.exp())
+
+    dataset = sample_prior_predictive(
+        samples=5, model=m, var_names=["mu_raw", "sigma_raw"], random_seed=22
+    ).prior
+
+    # Test default
+    with m:
+        all_dets = compute_deterministics(dataset)
+    assert set(all_dets.data_vars.variables) == {"mu", "sigma"}
+    assert all_dets["mu"].dims == ("chain", "draw", "group")
+    assert all_dets["sigma"].dims == ("chain", "draw")
+    assert_allclose(all_dets["mu"], dataset["mu_raw"].cumsum("group"))
+    assert_allclose(all_dets["sigma"], np.exp(dataset["sigma_raw"]))
+
+    # Test custom arguments
+    extended_with_mu = compute_deterministics(
+        dataset,
+        var_names=["mu"],
+        merge_dataset=True,
+        model=m,
+        compile_kwargs={"mode": "FAST_COMPILE"},
+        progressbar=False,
+    )
+    assert set(extended_with_mu.data_vars.variables) == {"mu_raw", "sigma_raw", "mu"}
+    assert extended_with_mu["mu"].dims == ("chain", "draw", "group")
+    assert_allclose(extended_with_mu["mu"], dataset["mu_raw"].cumsum("group"))
+
+
+def test_docstring_example():
+    import pymc as pm
+
+    with pm.Model(coords={"group": (0, 2, 4)}) as m:
+        mu_raw = pm.Normal("mu_raw", 0, 1, dims="group")
+        mu = pm.Deterministic("mu", mu_raw.cumsum(), dims="group")
+
+        trace = pm.sample(var_names=["mu_raw"], chains=2, tune=5, draws=5)
+
+    assert "mu" not in trace.posterior
+
+    with m:
+        trace.posterior = pm.compute_deterministics(trace.posterior, merge_dataset=True)
+
+    assert "mu" in trace.posterior

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -26,7 +26,6 @@ from pymc.distributions.transforms import Transform
 from pymc.util import (
     UNSET,
     _get_seeds_per_chain,
-    dataset_to_point_list,
     drop_warning_stat,
     get_value_vars_from_user_vars,
     hash_key,
@@ -154,38 +153,6 @@ def test_unset_repr(capsys):
     help(fn)
     captured = capsys.readouterr()
     assert "a=UNSET" in captured.out
-
-
-@pytest.mark.parametrize("input_type", ("dict", "Dataset"))
-def test_dataset_to_point_list(input_type):
-    if input_type == "dict":
-        ds = {}
-    elif input_type == "Dataset":
-        ds = xarray.Dataset()
-    ds["A"] = xarray.DataArray([[1, 2, 3]] * 2, dims=("chain", "draw"))
-    pl, _ = dataset_to_point_list(ds, sample_dims=["chain", "draw"])
-    assert isinstance(pl, list)
-    assert len(pl) == 6
-    assert isinstance(pl[0], dict)
-    assert isinstance(pl[0]["A"], np.ndarray)
-
-
-def test_transposed_dataset_to_point_list():
-    ds = xarray.Dataset()
-    ds["A"] = xarray.DataArray([[[1, 2, 3], [2, 3, 4]]] * 5, dims=("team", "draw", "chain"))
-    pl, _ = dataset_to_point_list(ds, sample_dims=["chain", "draw"])
-    assert isinstance(pl, list)
-    assert len(pl) == 6
-    assert isinstance(pl[0], dict)
-    assert isinstance(pl[0]["A"], np.ndarray)
-
-
-def test_dataset_to_point_list_str_key():
-    # Check that non-str keys are caught
-    ds = xarray.Dataset()
-    ds[3] = xarray.DataArray([1, 2, 3])
-    with pytest.raises(ValueError, match="must be str"):
-        dataset_to_point_list(ds, sample_dims=["chain", "draw"])
 
 
 def test_drop_warning_stat():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
After #7206 this utility becomes more relevant.

```python
import pymc as pm

with pm.Model(coords={"group": (0, 2, 4)}) as m:
    mu_raw = pm.Normal("mu_raw", 0, 1, dims="group")
    mu = pm.Deterministic("mu", mu_raw.cumsum(), dims="group")

    trace = pm.sample(var_names=["mu_raw"], chains=2, tune=5 draws=5)

assert "mu" not in trace.posterior

with m:
    trace.posterior = pm.compute_deterministics(trace.posterior, merge_dataset=True)

assert "mu" in trace.posterior
```

Also refactored the base logic to apply a Dataset to a PointFunc which was needed in a couple of places (here and in pymc-experimental).

This function could plausible be used by `sample_prior_predictive` and `sample_posterior_predictive`, but it seems that for backward compatibility these return and accept more diverse kinds of inputs. Let me know if I am wrong.

**I am not so sure where to place the `compute_deterministics`. I put it in the `sampling` module which is a bit odd perhaps.** 



## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7221 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7238.org.readthedocs.build/en/7238/

<!-- readthedocs-preview pymc end -->