### PR TITLE
Implement several RandomVariables as SymbolicRandomVariables

### DIFF
--- a/pymc/distributions/censored.py
+++ b/pymc/distributions/censored.py
@@ -16,13 +16,19 @@ import pytensor.tensor as pt
 
 from pytensor.tensor import TensorVariable
 from pytensor.tensor.random.op import RandomVariable
+from pytensor.tensor.random.utils import normalize_size_param
 
 from pymc.distributions.distribution import (
     Distribution,
     SymbolicRandomVariable,
     _support_point,
 )
-from pymc.distributions.shape_utils import _change_dist_size, change_dist_size
+from pymc.distributions.shape_utils import (
+    _change_dist_size,
+    change_dist_size,
+    implicit_size_from_params,
+    rv_size_is_none,
+)
 from pymc.util import check_dist_not_registered
 
 
@@ -31,8 +37,26 @@ class CensoredRV(SymbolicRandomVariable):
 
     inline_logprob = True
     signature = "(),(),()->()"
-    ndim_supp = 0
     _print_name = ("Censored", "\\operatorname{Censored}")
+
+    @classmethod
+    def rv_op(cls, dist, lower, upper, *, size=None):
+        # We don't allow passing `rng` because we don't fully control the rng of the components!
+        lower = pt.constant(-np.inf) if lower is None else pt.as_tensor(lower)
+        upper = pt.constant(np.inf) if upper is None else pt.as_tensor(upper)
+        size = normalize_size_param(size)
+
+        if rv_size_is_none(size):
+            size = implicit_size_from_params(dist, lower, upper, ndims_params=cls.ndims_params)
+
+        # Censoring is achieved by clipping the base distribution between lower and upper
+        dist = change_dist_size(dist, size)
+        censored_rv = pt.clip(dist, lower, upper)
+
+        return CensoredRV(
+            inputs=[dist, lower, upper],
+            outputs=[censored_rv],
+        )(dist, lower, upper)
 
 
 class Censored(Distribution):
@@ -85,6 +109,7 @@ class Censored(Distribution):
     """
 
     rv_type = CensoredRV
+    rv_op = CensoredRV.rv_op
 
     @classmethod
     def dist(cls, dist, lower, upper, **kwargs):
@@ -100,24 +125,6 @@ class Censored(Distribution):
             )
         check_dist_not_registered(dist)
         return super().dist([dist, lower, upper], **kwargs)
-
-    @classmethod
-    def rv_op(cls, dist, lower=None, upper=None, size=None):
-        lower = pt.constant(-np.inf) if lower is None else pt.as_tensor_variable(lower)
-        upper = pt.constant(np.inf) if upper is None else pt.as_tensor_variable(upper)
-
-        # When size is not specified, dist may have to be broadcasted according to lower/upper
-        dist_shape = size if size is not None else pt.broadcast_shape(dist, lower, upper)
-        dist = change_dist_size(dist, dist_shape)
-
-        # Censoring is achieved by clipping the base distribution between lower and upper
-        dist_, lower_, upper_ = dist.type(), lower.type(), upper.type()
-        censored_rv_ = pt.clip(dist_, lower_, upper_)
-
-        return CensoredRV(
-            inputs=[dist_, lower_, upper_],
-            outputs=[censored_rv_],
-        )(dist, lower, upper)
 
 
 @_change_dist_size.register(CensoredRV)

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 import contextvars
 import functools
+import re
 import sys
 import types
 import warnings
@@ -186,13 +187,29 @@ class DistributionMeta(ABCMeta):
         if rv_type is not None:
             # Create dispatch functions
 
+            signature = getattr(rv_type, "signature", None)
+            size_idx: int | None = None
+            params_idxs: tuple[int] | None = None
+            if signature is not None:
+                _, size_idx, params_idxs = SymbolicRandomVariable.get_idxs(signature)
+
+            class_change_dist_size = clsdict.get("change_dist_size")
+            if class_change_dist_size:
+
+                @_change_dist_size.register(rv_type)
+                def change_dist_size(op, rv, new_size, expand):
+                    return class_change_dist_size(rv, new_size, expand)
+
             class_logp = clsdict.get("logp")
             if class_logp:
 
                 @_logprob.register(rv_type)
                 def logp(op, values, *dist_params, **kwargs):
-                    dist_params = dist_params[3:]
-                    (value,) = values
+                    if isinstance(op, RandomVariable):
+                        rng, size, dtype, *dist_params = dist_params
+                    elif params_idxs:
+                        dist_params = [dist_params[i] for i in params_idxs]
+                    [value] = values
                     return class_logp(value, *dist_params)
 
             class_logcdf = clsdict.get("logcdf")
@@ -200,7 +217,10 @@ class DistributionMeta(ABCMeta):
 
                 @_logcdf.register(rv_type)
                 def logcdf(op, value, *dist_params, **kwargs):
-                    dist_params = dist_params[3:]
+                    if isinstance(op, RandomVariable):
+                        rng, size, dtype, *dist_params = dist_params
+                    elif params_idxs:
+                        dist_params = [dist_params[i] for i in params_idxs]
                     return class_logcdf(value, *dist_params)
 
             class_icdf = clsdict.get("icdf")
@@ -208,7 +228,10 @@ class DistributionMeta(ABCMeta):
 
                 @_icdf.register(rv_type)
                 def icdf(op, value, *dist_params, **kwargs):
-                    dist_params = dist_params[3:]
+                    if isinstance(op, RandomVariable):
+                        rng, size, dtype, *dist_params = dist_params
+                    elif params_idxs:
+                        dist_params = [dist_params[i] for i in params_idxs]
                     return class_icdf(value, *dist_params)
 
             class_moment = clsdict.get("moment")
@@ -218,20 +241,25 @@ class DistributionMeta(ABCMeta):
                     DeprecationWarning,
                 )
 
-                @_support_point.register(rv_type)
-                def support_point(op, rv, rng, size, dtype, *dist_params):
-                    return class_moment(rv, size, *dist_params)
+                clsdict["support_point"] = class_moment
 
             class_support_point = clsdict.get("support_point")
 
             if class_support_point:
 
                 @_support_point.register(rv_type)
-                def support_point(op, rv, rng, size, dtype, *dist_params):
-                    return class_support_point(rv, size, *dist_params)
+                def support_point(op, rv, *dist_params):
+                    if isinstance(op, RandomVariable):
+                        rng, size, dtype, *dist_params = dist_params
+                        return class_support_point(rv, size, *dist_params)
+                    elif params_idxs and size_idx is not None:
+                        size = dist_params[size_idx]
+                        dist_params = [dist_params[i] for i in params_idxs]
+                        return class_support_point(rv, size, *dist_params)
+                    else:
+                        return class_support_point(rv, *dist_params)
 
-            # Register the PyTensor rv_type as a subclass of this
-            # PyMC Distribution type.
+            # Register the PyTensor rv_type as a subclass of this PyMC Distribution type.
             new_cls.register(rv_type)
 
         return new_cls
@@ -242,6 +270,21 @@ def _make_nice_attr_error(oldcode: str, newcode: str):
         raise AttributeError(f"The `{oldcode}` method was removed. Instead use `{newcode}`.`")
 
     return fn
+
+
+class _class_or_instancemethod(classmethod):
+    """Allow a method to be called both as a classmethod and an instancemethod,
+    giving priority to the instancemethod.
+
+    This is used to allow extracting information from the signature of a SymbolicRandomVariable
+    which may be provided either as a class attribute or as an instance attribute.
+
+    Adapted from https://stackoverflow.com/a/28238047
+    """
+
+    def __get__(self, instance, type_):
+        descr_get = super().__get__ if instance is None else self.__func__.__get__
+        return descr_get(instance, type_)
 
 
 class SymbolicRandomVariable(OpFromGraph):
@@ -258,16 +301,14 @@ class SymbolicRandomVariable(OpFromGraph):
     classmethod `cls.rv_op`, taking care to clone and resize random inputs, if needed.
     """
 
-    ndim_supp: int = None
-    """Number of support dimensions as in RandomVariables
-    (0 for scalar, 1 for vector, ...)
-     """
-
-    ndims_params: Sequence[int] | None = None
-    """Number of core dimensions of the distribution's parameters."""
-
     signature: str = None
-    """Numpy-like vectorized signature of the distribution."""
+    """Numpy-like vectorized signature of the distribution.
+
+    It allows tokens [rng], [size] to identify the special inputs.
+
+    The signature of a Normal RV with mu and scale scalar params looks like
+    `"[rng],[size],(),()->[rng],()"`
+    """
 
     inline_logprob: bool = False
     """Specifies whether the logprob function is derived automatically by introspection
@@ -279,24 +320,102 @@ class SymbolicRandomVariable(OpFromGraph):
     _print_name: tuple[str, str] = ("Unknown", "\\operatorname{Unknown}")
     """Tuple of (name, latex name) used for for pretty-printing variables of this type"""
 
+    @staticmethod
+    def _parse_signature(signature: str) -> tuple[str, str]:
+        """Parse signature as if special tokens were vector elements"""
+        # Regex to split across commas not inside parenthesis
+        # Copied from https://stackoverflow.com/a/26634150
+        fake_signature = signature.replace("[rng]", "(rng)").replace("[size]", "(size)")
+        return _parse_gufunc_signature(fake_signature)
+
+    @staticmethod
+    def _parse_params_signature(signature):
+        """Parse the signature of the distribution's parameters, ignoring rng and size tokens."""
+        special_tokens = r"|".join((r"\[rng\],?", r"\[size\],?"))
+        params_signature = re.sub(special_tokens, "", signature)
+        # Remove dandling commas
+        params_signature = re.sub(r",(?=[->])|,$", "", params_signature)
+
+        # Numpy gufunc signature doesn't accept empty inputs
+        if params_signature.startswith("->"):
+            # Pretent there was at least one scalar input and then discard that
+            return [], _parse_gufunc_signature("()" + params_signature)[1]
+        else:
+            return _parse_gufunc_signature(params_signature)
+
+    @_class_or_instancemethod
+    @property
+    def ndims_params(cls_or_self) -> Sequence[int] | None:
+        """Number of core dimensions of the distribution's parameters."""
+        signature = cls_or_self.signature
+        if signature is None:
+            return None
+        inputs_signature, _ = cls_or_self._parse_params_signature(signature)
+        return [len(sig) for sig in inputs_signature]
+
+    @_class_or_instancemethod
+    @property
+    def ndim_supp(cls_or_self) -> int | None:
+        """Number of support dimensions of the RandomVariable
+
+        (0 for scalar, 1 for vector, ...)
+        """
+        signature = cls_or_self.signature
+        if signature is None:
+            return None
+        _, outputs_params_signature = cls_or_self._parse_params_signature(signature)
+        return max(len(out_sig) for out_sig in outputs_params_signature)
+
+    @_class_or_instancemethod
+    @property
+    def default_output(cls_or_self) -> int | None:
+        signature = cls_or_self.signature
+        if signature is None:
+            return None
+
+        _, outputs_signature = cls_or_self._parse_signature(signature)
+
+        # If there is a single non `[rng]` outputs, that is the default one!
+        candidate_default_output = [
+            i for i, out_sig in enumerate(outputs_signature) if out_sig != ("rng",)
+        ]
+        if len(candidate_default_output) == 1:
+            return candidate_default_output[0]
+        else:
+            return None
+
+    @staticmethod
+    def get_idxs(signature: str) -> tuple[tuple[int], int | None, tuple[int]]:
+        """Parse signature and return indexes for *[rng], [size] and parameters"""
+        inputs_signature, outputs_signature = SymbolicRandomVariable._parse_signature(signature)
+        rng_idxs = []
+        size_idx = None
+        params_idxs = []
+        for i, inp_sig in enumerate(inputs_signature):
+            if inp_sig == ("size",):
+                size_idx = i
+            elif inp_sig == ("rng",):
+                rng_idxs.append(i)
+            else:
+                params_idxs.append(i)
+        return tuple(rng_idxs), size_idx, tuple(params_idxs)
+
     def __init__(
         self,
         *args,
         **kwargs,
     ):
         """Initialize a SymbolicRandomVariable class."""
-        if self.signature is None:
-            self.signature = kwargs.get("signature", None)
+        if "signature" in kwargs:
+            self.signature = kwargs.pop("signature")
 
-        if self.signature is not None:
-            inputs_sig, outputs_sig = _parse_gufunc_signature(self.signature)
-            self.ndims_params = [len(sig) for sig in inputs_sig]
-            self.ndim_supp = max(len(out_sig) for out_sig in outputs_sig)
+        if "ndim_supp" in kwargs:
+            # For backwards compatibility we allow passing ndim_supp without signature
+            # This is the only variable that PyMC absolutely needs to work with SymbolicRandomVariables
+            self.ndim_supp = kwargs.pop("ndim_supp")
 
         if self.ndim_supp is None:
-            self.ndim_supp = kwargs.get("ndim_supp", None)
-            if self.ndim_supp is None:
-                raise ValueError("ndim_supp or gufunc_signature must be provided")
+            raise ValueError("ndim_supp or signature must be provided")
 
         kwargs.setdefault("inline", True)
         kwargs.setdefault("strict", True)
@@ -315,6 +434,29 @@ class SymbolicRandomVariable(OpFromGraph):
         """Number of dimensions of the distribution's batch shape."""
         out_ndim = max(getattr(out.type, "ndim", 0) for out in node.outputs)
         return out_ndim - self.ndim_supp
+
+
+@_change_dist_size.register(SymbolicRandomVariable)
+def change_symbolic_rv_size(op, rv, new_size, expand) -> TensorVariable:
+    if op.signature is None:
+        raise NotImplementedError(
+            f"SymbolicRandomVariable {op} without signature requires custom `_change_dist_size` implementation."
+        )
+    inputs_signature = op.signature.split("->")[0].split(",")
+    if "[size]" not in inputs_signature:
+        raise NotImplementedError(
+            f"SymbolicRandomVariable {op} without [size] in signature requires custom `_change_dist_size` implementation."
+        )
+    size_arg_idx = inputs_signature.index("[size]")
+    size = rv.owner.inputs[size_arg_idx]
+
+    if expand:
+        new_size = tuple(new_size) + tuple(size)
+
+    numerical_inputs = [
+        inp for inp, sig in zip(rv.owner.inputs, inputs_signature) if sig not in ("[size]", "[rng]")
+    ]
+    return op.rv_op(*numerical_inputs, size=new_size)
 
 
 class Distribution(metaclass=DistributionMeta):
@@ -483,8 +625,8 @@ class Distribution(metaclass=DistributionMeta):
         shape = convert_shape(shape)
         size = convert_size(size)
 
-        # SymbolicRVs don't have `ndim_supp` until they are created
-        ndim_supp = getattr(cls.rv_op, "ndim_supp", None)
+        # SymbolicRVs don't always have `ndim_supp` until they are created
+        ndim_supp = getattr(cls.rv_type, "ndim_supp", None)
         if ndim_supp is None:
             ndim_supp = cls.rv_op(*dist_params, **kwargs).owner.op.ndim_supp
         create_size = find_size(shape=shape, size=size, ndim_supp=ndim_supp)
@@ -684,11 +826,11 @@ class _CustomDist(Distribution):
             return logp(values[0], *dist_params)
 
         @_logcdf.register(rv_type)
-        def density_dist_logcdf(op, value, rng, size, dtype, *dist_params, **kwargs):
+        def custom_dist_logcdf(op, value, rng, size, dtype, *dist_params, **kwargs):
             return logcdf(value, *dist_params, **kwargs)
 
         @_support_point.register(rv_type)
-        def density_dist_get_support_point(op, rv, rng, size, dtype, *dist_params):
+        def custom_dist_support_point(op, rv, rng, size, dtype, *dist_params):
             return support_point(rv, size, *dist_params)
 
         rv_op = rv_type()
@@ -788,10 +930,6 @@ class _CustomSymbolicDist(Distribution):
         dummy_params = [dummy_size_param, *dummy_dist_params]
         dummy_updates_dict = collect_default_updates(inputs=dummy_params, outputs=(dummy_rv,))
 
-        signature = cls._infer_final_signature(
-            signature, len(dummy_params), len(dummy_updates_dict)
-        )
-
         rv_type = type(
             class_name,
             (CustomSymbolicDistRV,),
@@ -821,7 +959,7 @@ class _CustomSymbolicDist(Distribution):
         if support_point is not None:
 
             @_support_point.register(rv_type)
-            def custom_dist_get_support_point(op, rv, size, *params):
+            def custom_dist_support_point(op, rv, size, *params):
                 return support_point(
                     rv,
                     size,
@@ -833,14 +971,14 @@ class _CustomSymbolicDist(Distribution):
                 )
 
         @_change_dist_size.register(rv_type)
-        def change_custom_symbolic_dist_size(op, rv, new_size, expand):
+        def change_custom_dist_size(op, rv, new_size, expand):
             node = rv.owner
 
             if expand:
                 shape = tuple(rv.shape)
                 old_size = shape[: len(shape) - node.op.ndim_supp]
                 new_size = tuple(new_size) + tuple(old_size)
-            new_size = pt.as_tensor(new_size, ndim=1, dtype="int64")
+            new_size = pt.as_tensor(new_size, dtype="int64", ndim=1)
 
             old_size, *old_dist_params = node.inputs[: len(dist_params) + 1]
 
@@ -866,30 +1004,47 @@ class _CustomSymbolicDist(Distribution):
         updates_dict = collect_default_updates(inputs=dummy_params, outputs=(dummy_rv,))
         rngs = updates_dict.keys()
         rngs_updates = updates_dict.values()
+
+        inputs = [*dummy_params, *rngs]
+        outputs = [dummy_rv, *rngs_updates]
+        signature = cls._infer_final_signature(
+            signature, n_inputs=len(inputs), n_outputs=len(outputs), n_rngs=len(rngs)
+        )
         rv_op = rv_type(
-            inputs=[*dummy_params, *rngs],
-            outputs=[dummy_rv, *rngs_updates],
+            inputs=inputs,
+            outputs=outputs,
             signature=signature,
         )
         return rv_op(size, *dist_params, *rngs)
 
     @staticmethod
-    def _infer_final_signature(signature: str, n_inputs, n_updates) -> str:
+    def _infer_final_signature(signature: str, n_inputs, n_outputs, n_rngs) -> str:
         """Add size and updates to user provided gufunc signature if they are missing."""
+
+        # Regex to split across outer commas
+        # Copied from https://stackoverflow.com/a/26634150
+        outer_commas = re.compile(r",\s*(?![^()]*\))")
+
         input_sig, output_sig = signature.split("->")
-        # Numpy parser does not accept (constant) functions without inputs like "->()"
-        # We work around as this makes sense for distributions like Flat that have no inputs
-        if input_sig.strip() == "":
-            inputs = ()
-            _, outputs = _parse_gufunc_signature("()" + signature)
-        else:
-            inputs, outputs = _parse_gufunc_signature(signature)
-        if len(inputs) == n_inputs - 1:
-            # Assume size is missing
-            input_sig = ("()," if input_sig else "()") + input_sig
-        if len(outputs) == 1:
+        # It's valid to have a signature without params inputs, as in a Flat RV
+        n_inputs_sig = len(outer_commas.split(input_sig)) if input_sig.strip() else 0
+        n_outputs_sig = len(outer_commas.split(output_sig))
+
+        if n_inputs_sig == n_inputs and n_outputs_sig == n_outputs:
+            # User provided a signature with no missing parts
+            return signature
+
+        size_sig = "[size]"
+        rngs_sig = ("[rng]",) * n_rngs
+        if n_inputs_sig == (n_inputs - n_rngs - 1):
+            # Assume size and rngs are missing
+            if input_sig.strip():
+                input_sig = ",".join((size_sig, input_sig, *rngs_sig))
+            else:
+                input_sig = ",".join((size_sig, *rngs_sig))
+        if n_outputs_sig == (n_outputs - n_rngs):
             # Assume updates are missing
-            output_sig = "()," * n_updates + output_sig
+            output_sig = ",".join((output_sig, *rngs_sig))
         signature = "->".join((input_sig, output_sig))
         return signature
 

--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -25,6 +25,7 @@ from pytensor.graph.basic import Node, ancestors
 from pytensor.graph.replace import clone_replace
 from pytensor.tensor import TensorVariable
 from pytensor.tensor.random.op import RandomVariable
+from pytensor.tensor.random.utils import normalize_size_param
 
 from pymc.distributions.continuous import Normal, get_tau_sigma
 from pymc.distributions.distribution import (
@@ -39,6 +40,7 @@ from pymc.distributions.shape_utils import (
     change_dist_size,
     get_support_shape,
     get_support_shape_1d,
+    rv_size_is_none,
 )
 from pymc.exceptions import NotConstantValueError
 from pymc.logprob.abstract import _logprob
@@ -60,8 +62,60 @@ __all__ = [
 class RandomWalkRV(SymbolicRandomVariable):
     """RandomWalk Variable"""
 
-    default_output = 0
     _print_name = ("RandomWalk", "\\operatorname{RandomWalk}")
+
+    @classmethod
+    def rv_op(cls, init_dist, innovation_dist, steps, size=None):
+        # We don't allow passing `rng` because we don't fully control the rng of the components!
+        steps = pt.as_tensor(steps, dtype=int, ndim=0)
+
+        dist_ndim_supp = init_dist.owner.op.ndim_supp
+        init_dist_shape = tuple(init_dist.shape)
+        init_dist_batch_shape = init_dist_shape[: len(init_dist_shape) - dist_ndim_supp]
+        innovation_dist_shape = tuple(innovation_dist.shape)
+        innovation_batch_shape = innovation_dist_shape[
+            : len(innovation_dist_shape) - dist_ndim_supp
+        ]
+        ndim_supp = dist_ndim_supp + 1
+
+        size = normalize_size_param(size)
+
+        # If not explicit, size is determined by the shapes of the input distributions
+        if rv_size_is_none(size):
+            size = pt.broadcast_shape(
+                init_dist_batch_shape, innovation_batch_shape, arrays_are_shapes=True
+            )
+
+        # Resize input distributions. We will size them to (T, B, S) in order
+        # to safely take random draws. We later swap the steps dimension so
+        # that the final distribution will follow (B, T, S)
+        # init_dist must have shape (1, B, S)
+        init_dist = change_dist_size(init_dist, (1, *size))
+        # innovation_dist must have shape (T-1, B, S)
+        innovation_dist = change_dist_size(innovation_dist, (steps, *size))
+
+        # We can only infer the logp of a dimshuffled variables, if the dimshuffle is
+        # done directly on top of a RandomVariable. Because of this we dimshuffle the
+        # distributions and only then concatenate them, instead of the other way around.
+        # shape = (B, 1, S)
+        init_dist_dimswapped = pt.moveaxis(init_dist, 0, -ndim_supp)
+        # shape = (B, T-1, S)
+        innovation_dist_dimswapped = pt.moveaxis(innovation_dist, 0, -ndim_supp)
+        # shape = (B, T, S)
+        grw = pt.concatenate([init_dist_dimswapped, innovation_dist_dimswapped], axis=-ndim_supp)
+        grw = pt.cumsum(grw, axis=-ndim_supp)
+
+        innov_supp_dims = [f"d{i}" for i in range(dist_ndim_supp)]
+        innov_supp_str = ",".join(innov_supp_dims)
+        out_supp_str = ",".join(["t", *innov_supp_dims])
+        signature = f"({innov_supp_str}),({innov_supp_str}),(s),[rng]->({out_supp_str}),[rng]"
+        return RandomWalkRV(
+            [init_dist, innovation_dist, steps],
+            # We pass steps_ through just so we can keep a reference to it, even though
+            # it's no longer needed at this point
+            [grw],
+            signature=signature,
+        )(init_dist, innovation_dist, steps)
 
 
 class RandomWalk(Distribution):
@@ -71,6 +125,7 @@ class RandomWalk(Distribution):
     """
 
     rv_type = RandomWalkRV
+    rv_op = RandomWalkRV.rv_op
 
     def __new__(cls, *args, innovation_dist, steps=None, **kwargs):
         steps = cls.get_steps(
@@ -149,64 +204,6 @@ class RandomWalk(Distribution):
         if support_shape is not None:
             steps = support_shape[-dist_ndim_supp - 1]
         return steps
-
-    @classmethod
-    def rv_op(cls, init_dist, innovation_dist, steps, size=None):
-        if not steps.ndim == 0 or not steps.dtype.startswith("int"):
-            raise ValueError("steps must be an integer scalar (ndim=0).")
-
-        dist_ndim_supp = init_dist.owner.op.ndim_supp
-        init_dist_shape = tuple(init_dist.shape)
-        init_dist_batch_shape = init_dist_shape[: len(init_dist_shape) - dist_ndim_supp]
-        innovation_dist_shape = tuple(innovation_dist.shape)
-        innovation_batch_shape = innovation_dist_shape[
-            : len(innovation_dist_shape) - dist_ndim_supp
-        ]
-
-        ndim_supp = dist_ndim_supp + 1
-
-        # If not explicit, size is determined by the shapes of the input distributions
-        if size is None:
-            size = pt.broadcast_shape(
-                init_dist_batch_shape, innovation_batch_shape, arrays_are_shapes=True
-            )
-
-        # Resize input distributions. We will size them to (T, B, S) in order
-        # to safely take random draws. We later swap the steps dimension so
-        # that the final distribution will follow (B, T, S)
-        # init_dist must have shape (1, B, S)
-        init_dist = change_dist_size(init_dist, (1, *size))
-        # innovation_dist must have shape (T-1, B, S)
-        innovation_dist = change_dist_size(innovation_dist, (steps, *size))
-
-        # Create SymbolicRV
-        init_dist_, innovation_dist_, steps_ = (
-            init_dist.type(),
-            innovation_dist.type(),
-            steps.type(),
-        )
-        # We can only infer the logp of a dimshuffled variables, if the dimshuffle is
-        # done directly on top of a RandomVariable. Because of this we dimshuffle the
-        # distributions and only then concatenate them, instead of the other way around.
-        # shape = (B, 1, S)
-        init_dist_dimswapped_ = pt.moveaxis(init_dist_, 0, -ndim_supp)
-        # shape = (B, T-1, S)
-        innovation_dist_dimswapped_ = pt.moveaxis(innovation_dist_, 0, -ndim_supp)
-        # shape = (B, T, S)
-        grw_ = pt.concatenate([init_dist_dimswapped_, innovation_dist_dimswapped_], axis=-ndim_supp)
-        grw_ = pt.cumsum(grw_, axis=-ndim_supp)
-
-        innov_supp_dims = [f"d{i}" for i in range(dist_ndim_supp)]
-        innov_supp_str = ",".join(innov_supp_dims)
-        out_supp_str = ",".join(["t", *innov_supp_dims])
-        signature = f"({innov_supp_str}),({innov_supp_str}),(s)->({out_supp_str})"
-        return RandomWalkRV(
-            [init_dist_, innovation_dist_, steps_],
-            # We pass steps_ through just so we can keep a reference to it, even though
-            # it's no longer needed at this point
-            [grw_],
-            signature=signature,
-        )(init_dist, innovation_dist, steps)
 
 
 @_change_dist_size.register(RandomWalkRV)
@@ -422,9 +419,7 @@ class MvStudentTRandomWalk(PredefinedRandomWalk):
 class AutoRegressiveRV(SymbolicRandomVariable):
     """A placeholder used to specify a log-likelihood for an AR sub-graph."""
 
-    signature = "(o),(),(o),(s)->(),(t)"
-    ndim_supp = 1
-    default_output = 1
+    signature = "(o),(),(o),(s),[rng]->[rng],(t)"
     ar_order: int
     constant_term: bool
     _print_name = ("AR", "\\operatorname{AR}")
@@ -433,6 +428,65 @@ class AutoRegressiveRV(SymbolicRandomVariable):
         self.ar_order = ar_order
         self.constant_term = constant_term
         super().__init__(*args, **kwargs)
+
+    @classmethod
+    def rv_op(cls, rhos, sigma, init_dist, steps, ar_order, constant_term, size=None):
+        # We don't allow passing `rng` because we don't fully control the rng of the components!
+        noise_rng = pytensor.shared(np.random.default_rng())
+        size = normalize_size_param(size)
+
+        # Init dist should have shape (*size, ar_order)
+        if rv_size_is_none(size):
+            # In this case the size of the init_dist depends on the parameters shape
+            # The last dimension of rho and init_dist does not matter
+            batch_size = pt.broadcast_shape(
+                tuple(sigma.shape),
+                tuple(rhos.shape)[:-1],
+                tuple(pt.atleast_1d(init_dist).shape)[:-1],
+                arrays_are_shapes=True,
+            )
+        else:
+            batch_size = size
+
+        if init_dist.owner.op.ndim_supp == 0:
+            init_dist_size = (*batch_size, ar_order)
+        else:
+            # In this case the support dimension must cover for ar_order
+            init_dist_size = batch_size
+        init_dist = change_dist_size(init_dist, init_dist_size)
+
+        rhos_bcast_shape = init_dist.shape
+        if constant_term:
+            # In this case init shape is one unit smaller than rhos in the last dimension
+            rhos_bcast_shape = (*rhos_bcast_shape[:-1], rhos_bcast_shape[-1] + 1)
+        rhos_bcast = pt.broadcast_to(rhos, rhos_bcast_shape)
+
+        def step(*args):
+            *prev_xs, reversed_rhos, sigma, rng = args
+            if constant_term:
+                mu = reversed_rhos[-1] + pt.sum(prev_xs * reversed_rhos[:-1], axis=0)
+            else:
+                mu = pt.sum(prev_xs * reversed_rhos, axis=0)
+            next_rng, new_x = Normal.dist(mu=mu, sigma=sigma, rng=rng).owner.outputs
+            return new_x, {rng: next_rng}
+
+        # We transpose inputs as scan iterates over first dimension
+        innov, innov_updates = pytensor.scan(
+            fn=step,
+            outputs_info=[{"initial": init_dist.T, "taps": range(-ar_order, 0)}],
+            non_sequences=[rhos_bcast.T[::-1], sigma.T, noise_rng],
+            n_steps=steps,
+            strict=True,
+        )
+        (noise_next_rng,) = tuple(innov_updates.values())
+        ar = pt.concatenate([init_dist, innov.T], axis=-1)
+
+        return AutoRegressiveRV(
+            inputs=[rhos, sigma, init_dist, steps, noise_rng],
+            outputs=[noise_next_rng, ar],
+            ar_order=ar_order,
+            constant_term=constant_term,
+        )(rhos, sigma, init_dist, steps, noise_rng)
 
     def update(self, node: Node):
         """Return the update mapping for the noise RV."""
@@ -499,6 +553,7 @@ class AR(Distribution):
     """
 
     rv_type = AutoRegressiveRV
+    rv_op = AutoRegressiveRV.rv_op
 
     def __new__(cls, name, rho, *args, steps=None, constant=False, ar_order=None, **kwargs):
         rhos = pt.atleast_1d(pt.as_tensor_variable(rho))
@@ -601,71 +656,6 @@ class AR(Distribution):
 
         return ar_order
 
-    @classmethod
-    def ndim_supp(cls, *args):
-        return 1
-
-    @classmethod
-    def rv_op(cls, rhos, sigma, init_dist, steps, ar_order, constant_term, size=None):
-        # Init dist should have shape (*size, ar_order)
-        if size is not None:
-            batch_size = size
-        else:
-            # In this case the size of the init_dist depends on the parameters shape
-            # The last dimension of rho and init_dist does not matter
-            batch_size = pt.broadcast_shape(sigma, rhos[..., 0], pt.atleast_1d(init_dist)[..., 0])
-        if init_dist.owner.op.ndim_supp == 0:
-            init_dist_size = (*batch_size, ar_order)
-        else:
-            # In this case the support dimension must cover for ar_order
-            init_dist_size = batch_size
-        init_dist = change_dist_size(init_dist, init_dist_size)
-
-        # Create OpFromGraph representing random draws from AR process
-        # Variables with underscore suffix are dummy inputs into the OpFromGraph
-        init_ = init_dist.type()
-        rhos_ = rhos.type()
-        sigma_ = sigma.type()
-        steps_ = steps.type()
-
-        rhos_bcast_shape_ = init_.shape
-        if constant_term:
-            # In this case init shape is one unit smaller than rhos in the last dimension
-            rhos_bcast_shape_ = (*rhos_bcast_shape_[:-1], rhos_bcast_shape_[-1] + 1)
-        rhos_bcast_ = pt.broadcast_to(rhos_, rhos_bcast_shape_)
-
-        noise_rng = pytensor.shared(np.random.default_rng())
-
-        def step(*args):
-            *prev_xs, reversed_rhos, sigma, rng = args
-            if constant_term:
-                mu = reversed_rhos[-1] + pt.sum(prev_xs * reversed_rhos[:-1], axis=0)
-            else:
-                mu = pt.sum(prev_xs * reversed_rhos, axis=0)
-            next_rng, new_x = Normal.dist(mu=mu, sigma=sigma, rng=rng).owner.outputs
-            return new_x, {rng: next_rng}
-
-        # We transpose inputs as scan iterates over first dimension
-        innov_, innov_updates_ = pytensor.scan(
-            fn=step,
-            outputs_info=[{"initial": init_.T, "taps": range(-ar_order, 0)}],
-            non_sequences=[rhos_bcast_.T[::-1], sigma_.T, noise_rng],
-            n_steps=steps_,
-            strict=True,
-        )
-        (noise_next_rng,) = tuple(innov_updates_.values())
-        ar_ = pt.concatenate([init_, innov_.T], axis=-1)
-
-        ar_op = AutoRegressiveRV(
-            inputs=[rhos_, sigma_, init_, steps_, noise_rng],
-            outputs=[noise_next_rng, ar_],
-            ar_order=ar_order,
-            constant_term=constant_term,
-        )
-
-        ar = ar_op(rhos, sigma, init_dist, steps, noise_rng)
-        return ar
-
 
 @_change_dist_size.register(AutoRegressiveRV)
 def change_ar_size(op, dist, new_size, expand=False):
@@ -723,10 +713,57 @@ def ar_support_point(op, rv, rhos, sigma, init_dist, steps, noise_rng):
 class GARCH11RV(SymbolicRandomVariable):
     """A placeholder used to specify a GARCH11 graph."""
 
-    default_output = 1
-    signature = "(),(),(),(),(),(s)->(),(t)"
-    ndim_supp = 1
+    signature = "(),(),(),(),(),(s),[rng]->[rng],(t)"
     _print_name = ("GARCH11", "\\operatorname{GARCH11}")
+
+    @classmethod
+    def rv_op(cls, omega, alpha_1, beta_1, initial_vol, init_dist, steps, size=None):
+        # We don't allow passing `rng` because we don't fully control the rng of the components!
+        steps = pt.as_tensor(steps, ndim=0)
+        omega = pt.as_tensor(omega)
+        alpha_1 = pt.as_tensor(alpha_1)
+        beta_1 = pt.as_tensor(beta_1)
+        initial_vol = pt.as_tensor(initial_vol)
+        noise_rng = pytensor.shared(np.random.default_rng())
+        size = normalize_size_param(size)
+
+        if rv_size_is_none(size):
+            # In this case the size of the init_dist depends on the parameters shape
+            batch_size = pt.broadcast_shape(omega, alpha_1, beta_1, initial_vol)
+        else:
+            batch_size = size
+
+        init_dist = change_dist_size(init_dist, batch_size)
+
+        # Create OpFromGraph representing random draws from GARCH11 process
+
+        def step(prev_y, prev_sigma, omega, alpha_1, beta_1, rng):
+            new_sigma = pt.sqrt(
+                omega + alpha_1 * pt.square(prev_y) + beta_1 * pt.square(prev_sigma)
+            )
+            next_rng, new_y = Normal.dist(mu=0, sigma=new_sigma, rng=rng).owner.outputs
+            return (new_y, new_sigma), {rng: next_rng}
+
+        (y_t, _), innov_updates = pytensor.scan(
+            fn=step,
+            outputs_info=[
+                init_dist,
+                pt.broadcast_to(initial_vol.astype("floatX"), init_dist.shape),
+            ],
+            non_sequences=[omega, alpha_1, beta_1, noise_rng],
+            n_steps=steps,
+            strict=True,
+        )
+        (noise_next_rng,) = tuple(innov_updates.values())
+
+        garch11 = pt.concatenate([init_dist[None, ...], y_t], axis=0).dimshuffle(
+            (*range(1, y_t.ndim), 0)
+        )
+
+        return GARCH11RV(
+            inputs=[omega, alpha_1, beta_1, initial_vol, init_dist, steps, noise_rng],
+            outputs=[noise_next_rng, garch11],
+        )(omega, alpha_1, beta_1, initial_vol, init_dist, steps, noise_rng)
 
     def update(self, node: Node):
         """Return the update mapping for the noise RV."""
@@ -758,6 +795,7 @@ class GARCH11(Distribution):
     """
 
     rv_type = GARCH11RV
+    rv_op = GARCH11RV.rv_op
 
     def __new__(cls, *args, steps=None, **kwargs):
         steps = get_support_shape_1d(
@@ -776,64 +814,9 @@ class GARCH11(Distribution):
         )
         if steps is None:
             raise ValueError("Must specify steps or shape parameter")
-        steps = pt.as_tensor_variable(intX(steps), ndim=0)
-
-        omega = pt.as_tensor_variable(omega)
-        alpha_1 = pt.as_tensor_variable(alpha_1)
-        beta_1 = pt.as_tensor_variable(beta_1)
-        initial_vol = pt.as_tensor_variable(initial_vol)
 
         init_dist = Normal.dist(0, initial_vol)
-
         return super().dist([omega, alpha_1, beta_1, initial_vol, init_dist, steps], **kwargs)
-
-    @classmethod
-    def rv_op(cls, omega, alpha_1, beta_1, initial_vol, init_dist, steps, size=None):
-        if size is not None:
-            batch_size = size
-        else:
-            # In this case the size of the init_dist depends on the parameters shape
-            batch_size = pt.broadcast_shape(omega, alpha_1, beta_1, initial_vol)
-        init_dist = change_dist_size(init_dist, batch_size)
-
-        # Create OpFromGraph representing random draws from GARCH11 process
-        # Variables with underscore suffix are dummy inputs into the OpFromGraph
-        init_ = init_dist.type()
-        initial_vol_ = initial_vol.type()
-        omega_ = omega.type()
-        alpha_1_ = alpha_1.type()
-        beta_1_ = beta_1.type()
-        steps_ = steps.type()
-
-        noise_rng = pytensor.shared(np.random.default_rng())
-
-        def step(prev_y, prev_sigma, omega, alpha_1, beta_1, rng):
-            new_sigma = pt.sqrt(
-                omega + alpha_1 * pt.square(prev_y) + beta_1 * pt.square(prev_sigma)
-            )
-            next_rng, new_y = Normal.dist(mu=0, sigma=new_sigma, rng=rng).owner.outputs
-            return (new_y, new_sigma), {rng: next_rng}
-
-        (y_t, _), innov_updates_ = pytensor.scan(
-            fn=step,
-            outputs_info=[init_, pt.broadcast_to(initial_vol_.astype("floatX"), init_.shape)],
-            non_sequences=[omega_, alpha_1_, beta_1_, noise_rng],
-            n_steps=steps_,
-            strict=True,
-        )
-        (noise_next_rng,) = tuple(innov_updates_.values())
-
-        garch11_ = pt.concatenate([init_[None, ...], y_t], axis=0).dimshuffle(
-            (*range(1, y_t.ndim), 0)
-        )
-
-        garch11_op = GARCH11RV(
-            inputs=[omega_, alpha_1_, beta_1_, initial_vol_, init_, steps_, noise_rng],
-            outputs=[noise_next_rng, garch11_],
-        )
-
-        garch11 = garch11_op(omega, alpha_1, beta_1, initial_vol, init_dist, steps, noise_rng)
-        return garch11
 
 
 @_change_dist_size.register(GARCH11RV)
@@ -882,16 +865,56 @@ def garch11_support_point(op, rv, omega, alpha_1, beta_1, initial_vol, init_dist
 class EulerMaruyamaRV(SymbolicRandomVariable):
     """A placeholder used to specify a log-likelihood for a EulerMaruyama sub-graph."""
 
-    default_output = 1
     dt: float
     sde_fn: Callable
-    ndim_supp = 1
     _print_name = ("EulerMaruyama", "\\operatorname{EulerMaruyama}")
 
     def __init__(self, *args, dt: float, sde_fn: Callable, **kwargs):
         self.dt = dt
         self.sde_fn = sde_fn
         super().__init__(*args, **kwargs)
+
+    @classmethod
+    def rv_op(cls, init_dist, steps, sde_pars, dt, sde_fn, size=None):
+        # We don't allow passing `rng` because we don't fully control the rng of the components!
+        noise_rng = pytensor.shared(np.random.default_rng())
+
+        # Init dist should have shape (*size,)
+        if size is not None:
+            batch_size = size
+        else:
+            batch_size = pt.broadcast_shape(*sde_pars, init_dist)
+        init_dist = change_dist_size(init_dist, batch_size)
+
+        # Create OpFromGraph representing random draws from SDE process
+        def step(*prev_args):
+            prev_y, *prev_sde_pars, rng = prev_args
+            f, g = sde_fn(prev_y, *prev_sde_pars)
+            mu = prev_y + dt * f
+            sigma = pt.sqrt(dt) * g
+            next_rng, next_y = Normal.dist(mu=mu, sigma=sigma, rng=rng).owner.outputs
+            return next_y, {rng: next_rng}
+
+        y_t, innov_updates = pytensor.scan(
+            fn=step,
+            outputs_info=[init_dist],
+            non_sequences=[*sde_pars, noise_rng],
+            n_steps=steps,
+            strict=True,
+        )
+        (noise_next_rng,) = tuple(innov_updates.values())
+
+        sde_out = pt.concatenate([init_dist[None, ...], y_t], axis=0).dimshuffle(
+            (*range(1, y_t.ndim), 0)
+        )
+
+        return EulerMaruyamaRV(
+            inputs=[init_dist, steps, *sde_pars, noise_rng],
+            outputs=[noise_next_rng, sde_out],
+            dt=dt,
+            sde_fn=sde_fn,
+            signature=f"(),(s),{','.join('()' for _ in sde_pars)},[rng]->[rng],(t)",
+        )(init_dist, steps, *sde_pars, noise_rng)
 
     def update(self, node: Node):
         """Return the update mapping for the noise RV."""
@@ -918,6 +941,7 @@ class EulerMaruyama(Distribution):
     """
 
     rv_type = EulerMaruyamaRV
+    rv_op = EulerMaruyamaRV.rv_op
 
     def __new__(cls, name, dt, sde_fn, *args, steps=None, **kwargs):
         dt = pt.as_tensor_variable(dt)
@@ -966,55 +990,6 @@ class EulerMaruyama(Distribution):
             init_dist = Normal.dist(0, 100, shape=sde_pars[0].shape)
 
         return super().dist([init_dist, steps, sde_pars, dt, sde_fn], **kwargs)
-
-    @classmethod
-    def rv_op(cls, init_dist, steps, sde_pars, dt, sde_fn, size=None):
-        # Init dist should have shape (*size,)
-        if size is not None:
-            batch_size = size
-        else:
-            batch_size = pt.broadcast_shape(*sde_pars, init_dist)
-        init_dist = change_dist_size(init_dist, batch_size)
-
-        # Create OpFromGraph representing random draws from SDE process
-        # Variables with underscore suffix are dummy inputs into the OpFromGraph
-        init_ = init_dist.type()
-        sde_pars_ = [x.type() for x in sde_pars]
-        steps_ = steps.type()
-
-        noise_rng = pytensor.shared(np.random.default_rng())
-
-        def step(*prev_args):
-            prev_y, *prev_sde_pars, rng = prev_args
-            f, g = sde_fn(prev_y, *prev_sde_pars)
-            mu = prev_y + dt * f
-            sigma = pt.sqrt(dt) * g
-            next_rng, next_y = Normal.dist(mu=mu, sigma=sigma, rng=rng).owner.outputs
-            return next_y, {rng: next_rng}
-
-        y_t, innov_updates_ = pytensor.scan(
-            fn=step,
-            outputs_info=[init_],
-            non_sequences=[*sde_pars_, noise_rng],
-            n_steps=steps_,
-            strict=True,
-        )
-        (noise_next_rng,) = tuple(innov_updates_.values())
-
-        sde_out_ = pt.concatenate([init_[None, ...], y_t], axis=0).dimshuffle(
-            (*range(1, y_t.ndim), 0)
-        )
-
-        eulermaruyama_op = EulerMaruyamaRV(
-            inputs=[init_, steps_, *sde_pars_, noise_rng],
-            outputs=[noise_next_rng, sde_out_],
-            dt=dt,
-            sde_fn=sde_fn,
-            signature=f"(),(s),{','.join('()' for _ in sde_pars_)}->(),(t)",
-        )
-
-        eulermaruyama = eulermaruyama_op(init_dist, steps, *sde_pars, noise_rng)
-        return eulermaruyama
 
 
 @_change_dist_size.register(EulerMaruyamaRV)

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -1089,3 +1089,14 @@ def toposort_replace(
         reverse=reverse,
     )
     fgraph.replace_all(sorted_replacements, import_missing=True)
+
+
+def normalize_rng_param(rng: None | Variable) -> Variable:
+    """Validate rng is a valid type or create a new one if None"""
+    if rng is None:
+        rng = pytensor.shared(np.random.default_rng())
+    elif not isinstance(rng.type, RandomType):
+        raise TypeError(
+            "The type of rng should be an instance of either RandomGeneratorType or RandomStateType"
+        )
+    return rng

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -928,7 +928,6 @@ class BaseTestDistributionRandom:
             params = {
                 k: p * np.ones(self.repeated_params_shape) for k, p in self.pymc_dist_params.items()
             }
-            self._instantiate_pymc_rv(params)
             sizes_to_check = [None, self.repeated_params_shape, (5, self.repeated_params_shape)]
             sizes_expected = [
                 (self.repeated_params_shape,),

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -749,27 +749,27 @@ class TestCustomSymbolicDist:
 
         out = CustomDist.dist([0.25, 0.75], dist=dist, signature="(p)->()")
         # Size and updates are added automatically to the signature
-        assert out.owner.op.signature == "(),(p)->(),()"
+        assert out.owner.op.signature == "[size],(p),[rng]->(),[rng]"
         assert out.owner.op.ndim_supp == 0
-        assert out.owner.op.ndims_params == [0, 1]
+        assert out.owner.op.ndims_params == [1]
 
         # When recreated internally, the whole signature may already be known
-        out = CustomDist.dist([0.25, 0.75], dist=dist, signature="(),(p)->(),()")
-        assert out.owner.op.signature == "(),(p)->(),()"
+        out = CustomDist.dist([0.25, 0.75], dist=dist, signature="[size],(p),[rng]->(),[rng]")
+        assert out.owner.op.signature == "[size],(p),[rng]->(),[rng]"
         assert out.owner.op.ndim_supp == 0
-        assert out.owner.op.ndims_params == [0, 1]
+        assert out.owner.op.ndims_params == [1]
 
         # A safe signature can be inferred from ndim_supp and ndims_params
-        out = CustomDist.dist([0.25, 0.75], dist=dist, ndim_supp=0, ndims_params=[0, 1])
-        assert out.owner.op.signature == "(),(i10)->(),()"
+        out = CustomDist.dist([0.25, 0.75], dist=dist, ndim_supp=0, ndims_params=[1])
+        assert out.owner.op.signature == "[size],(i00),[rng]->(),[rng]"
         assert out.owner.op.ndim_supp == 0
-        assert out.owner.op.ndims_params == [0, 1]
+        assert out.owner.op.ndims_params == [1]
 
         # Otherwise be default we assume everything is scalar, even though it's wrong in this case
         out = CustomDist.dist([0.25, 0.75], dist=dist)
-        assert out.owner.op.signature == "(),()->(),()"
+        assert out.owner.op.signature == "[size],(),[rng]->(),[rng]"
         assert out.owner.op.ndim_supp == 0
-        assert out.owner.op.ndims_params == [0, 0]
+        assert out.owner.op.ndims_params == [0]
 
 
 class TestSymbolicRandomVariable:

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -34,7 +34,7 @@ from pytensor.graph import graph_inputs
 import pymc as pm
 
 from pymc import ImputationWarning
-from pymc.distributions.multivariate import PosDefMatrix
+from pymc.distributions.multivariate import DirichletMultinomial, PosDefMatrix
 from pymc.sampling.jax import (
     _get_batched_jittered_initial_points,
     _get_log_likelihood,
@@ -511,3 +511,9 @@ def test_convergence_warnings(caplog, nuts_sampler):
 
     [record] = caplog.records
     assert re.match(r"There were \d+ divergences after tuning", record.message)
+
+
+def test_dirichlet_multinomial():
+    dm = DirichletMultinomial.dist(n=5, a=np.eye(3) * 1e6 + 0.01)
+    dm_draws = pm.draw(dm, mode="JAX")
+    np.testing.assert_equal(dm_draws, np.eye(3) * 5)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Implement several RandomVariables as SymbolicRandomVariables

This allows sampling from multiple backends without having to dispatch for each one

Also:
* Allow signature to handle rng and size arguments explicitly.
* Move rv_op method to the SymbolicRandomVariable class and get rid of dummy inputs logic (it was needed in previous versions of PyTensor)
* Allow dispatch methods without filtering of inputs for SymbolicRandomVariable distributions


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7239.org.readthedocs.build/en/7239/

<!-- readthedocs-preview pymc end -->