### PR TITLE
Fix type-hint typo in CustomDist docs

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -1098,12 +1098,12 @@ class CustomDist:
        from pytensor.tensor import TensorVariable
 
         def pert(
-            low: Tensorvariable,
-            peak: Tensorvariable,
-            high: Tensorvariable,
-            lmbda: Tensorvariable,
-            size: Tensorvariable,
-        ) -> Tensorvariable:
+            low: TensorVariable,
+            peak: TensorVariable,
+            high: TensorVariable,
+            lmbda: TensorVariable,
+            size: TensorVariable,
+        ) -> TensorVariable:
             range = (high - low)
             s_alpha = 1 + lmbda * (peak - low) / range
             s_beta = 1 + lmbda * (high - peak) / range


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Replace `Tensorvariable` with `TensorVariable` in pymc.CustomDist documentation https://www.pymc.io/projects/docs/en/stable/api/distributions/generated/pymc.CustomDist.html

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
<!--- - [ ] Closes # -->
- [x] Closes #7223

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7243.org.readthedocs.build/en/7243/

<!-- readthedocs-preview pymc end -->