### PR TITLE
Fix DOI visibility badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Please choose from the following:
 - |DOIzenodo| A DOI for all versions.
 - DOIs for specific versions are shown on Zenodo and under `Releases <https://github.com/pymc-devs/pymc/releases>`_
 
-.. |DOIpaper| image:: https://img.shields.io/badge/DOI-10.7717%2Fpeerj--cs.1516-blue
+.. |DOIpaper| image:: https://img.shields.io/badge/DOI-10.7717%2Fpeerj--cs.1516-blue.svg
      :target: https://doi.org/10.7717/peerj-cs.1516
 .. |DOIzenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4603970.svg
    :target: https://doi.org/10.5281/zenodo.4603970


### PR DESCRIPTION
In README file in `.rst` format, some badges from [Shields.io](https://shields.io/) on Github may require a `.svg` in the path

## Description
I add a `.svg` at the end of the path of a [Shields.io](https://shields.io/) badge.

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7245.org.readthedocs.build/en/7245/

<!-- readthedocs-preview pymc end -->