### PR TITLE
Fix bug in `compute_deterministics`

### DIFF
--- a/pymc/sampling/deterministic.py
+++ b/pymc/sampling/deterministic.py
@@ -84,6 +84,7 @@ def compute_deterministics(
 
     if var_names is None:
         deterministics = model.deterministics
+        var_names = [det.name for det in deterministics]
     else:
         deterministics = [model[var_name] for var_name in var_names]
         if not set(deterministics).issubset(set(model.deterministics)):
@@ -101,7 +102,7 @@ def compute_deterministics(
     new_dataset = apply_function_over_dataset(
         fn,
         dataset[[rv.name for rv in model.free_RVs]],
-        output_var_names=[det.name for det in model.deterministics],
+        output_var_names=var_names,
         dims=dims,
         coords=coords,
         sample_dims=sample_dims,

--- a/tests/sampling/test_deterministic.py
+++ b/tests/sampling/test_deterministic.py
@@ -59,6 +59,11 @@ def test_compute_deterministics():
     assert extended_with_mu["mu"].dims == ("chain", "draw", "group")
     assert_allclose(extended_with_mu["mu"], dataset["mu_raw"].cumsum("group"))
 
+    only_sigma = compute_deterministics(dataset, var_names=["sigma"], model=m, progressbar=False)
+    assert set(only_sigma.data_vars.variables) == {"sigma"}
+    assert only_sigma["sigma"].dims == ("chain", "draw")
+    assert_allclose(only_sigma["sigma"], np.exp(dataset["sigma_raw"]))
+
 
 def test_docstring_example():
     import pymc as pm


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
We were passing the wrong `output_var_names`

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7249.org.readthedocs.build/en/7249/

<!-- readthedocs-preview pymc end -->