### PR TITLE
Fix typo of Data containers in model graph

### DIFF
--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -177,7 +177,7 @@ class ModelGraph:
         else:
             shape = "box"
             style = "rounded, filled"
-            label = f"{var_name}\n~\nCData"
+            label = f"{var_name}\n~\nData"
 
         kwargs = {
             "shape": shape,


### PR DESCRIPTION
Here you have a massive PR where I simply delete one character! 

This was introduced in https://github.com/pymc-devs/pymc/commit/1ffbc2c98b6801c6f7cf3741747917fd7b536502 when coords were made always mutable.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7250.org.readthedocs.build/en/7250/

<!-- readthedocs-preview pymc end -->