### PR TITLE
Reenable some compiler errors

### DIFF
--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -29,14 +29,13 @@ def __set_compiler_flags():
     import pytensor
 
     current = pytensor.config.gcc__cxxflags
-    augmented = f"{current} -Wno-c++11-narrowing"
 
     # Work around compiler bug in GCC < 8.4 related to structured exception
     # handling registers on Windows.
     # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782 for details.
     # First disable C++ exception handling altogether since it's not needed
     # for the C extensions that we generate.
-    augmented = f"{augmented} -fno-exceptions"
+    augmented = f"{current} -fno-exceptions"
     # Now disable the generation of stack unwinding tables.
     augmented = f"{augmented} -fno-unwind-tables -fno-asynchronous-unwind-tables"
 


### PR DESCRIPTION
Ideally we fix issues instead of suppressing them

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

I'm hoping that https://github.com/pymc-devs/pytensor/pull/725 will make this flag unnecessary. Looking forward to seeing what happens.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7270.org.readthedocs.build/en/7270/

<!-- readthedocs-preview pymc end -->