### PR TITLE
Add time remaining column to progress bars

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -659,7 +659,7 @@ def apply_function_over_dataset(
     out_dict = _DefaultTrace(n_pts)
     indices = range(n_pts)
 
-    with Progress(console=Console(theme=progressbar_theme)) as progress:
+    with Progress(console=Console(theme=progressbar_theme), disable=not progressbar) as progress:
         task = progress.add_task("Computinng ...", total=n_pts, visible=progressbar)
         for idx in indices:
             out = fn(posterior_pts[idx])

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -660,7 +660,7 @@ def apply_function_over_dataset(
     indices = range(n_pts)
 
     with Progress(console=Console(theme=progressbar_theme), disable=not progressbar) as progress:
-        task = progress.add_task("Computinng ...", total=n_pts, visible=progressbar)
+        task = progress.add_task("Computing ...", total=n_pts, visible=progressbar)
         for idx in indices:
             out = fn(posterior_pts[idx])
             fn.f.trust_input = True  # If we arrive here the dtypes are valid

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -829,7 +829,7 @@ def sample_posterior_predictive(
     _log.info(f"Sampling: {list(sorted(volatile_basic_rvs, key=lambda var: var.name))}")  # type: ignore
     ppc_trace_t = _DefaultTrace(samples)
     try:
-        with Progress(console=Console(theme=progressbar_theme)) as progress:
+        with Progress(console=Console(theme=progressbar_theme), disable=not progressbar) as progress:
             task = progress.add_task("Sampling ...", total=samples, visible=progressbar)
             for idx in np.arange(samples):
                 if nchain > 1:

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -829,7 +829,9 @@ def sample_posterior_predictive(
     _log.info(f"Sampling: {list(sorted(volatile_basic_rvs, key=lambda var: var.name))}")  # type: ignore
     ppc_trace_t = _DefaultTrace(samples)
     try:
-        with Progress(console=Console(theme=progressbar_theme), disable=not progressbar) as progress:
+        with Progress(
+            console=Console(theme=progressbar_theme), disable=not progressbar
+        ) as progress:
             task = progress.add_task("Sampling ...", total=samples, visible=progressbar)
             for idx in np.arange(samples):
                 if nchain > 1:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1041,8 +1041,8 @@ def _sample(
             for it, diverging in enumerate(sampling_gen):
                 if it >= skip_first and diverging:
                     _pbar_data["divergences"] += 1
-                progress.update(task, advance=1)
-            progress.update(task, advance=1, completed=True)
+                progress.update(task, refresh=True, advance=1)
+            progress.update(task, refresh=True, advance=1, completed=True)
         except KeyboardInterrupt:
             pass
 

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -27,7 +27,7 @@ import cloudpickle
 import numpy as np
 
 from rich.console import Console
-from rich.progress import BarColumn, Progress, TimeRemainingColumn
+from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn, TimeElapsedColumn
 from rich.theme import Theme
 
 from pymc.blocking import DictToArrayBijection
@@ -428,6 +428,8 @@ class ParallelSampler:
             BarColumn(),
             "[progress.percentage]{task.percentage:>3.0f}%",
             TimeRemainingColumn(),
+            TextColumn("/"),
+            TimeElapsedColumn()
             console=Console(theme=progressbar_theme),
         )
         self._show_progress = progressbar

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -27,7 +27,7 @@ import cloudpickle
 import numpy as np
 
 from rich.console import Console
-from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn, TimeElapsedColumn
+from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 from rich.theme import Theme
 
 from pymc.blocking import DictToArrayBijection

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -431,6 +431,7 @@ class ParallelSampler:
             TextColumn("/"),
             TimeElapsedColumn(),
             console=Console(theme=progressbar_theme),
+            disable=not progressbar,
         )
         self._show_progress = progressbar
         self._divergences = 0

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -429,7 +429,7 @@ class ParallelSampler:
             "[progress.percentage]{task.percentage:>3.0f}%",
             TimeRemainingColumn(),
             TextColumn("/"),
-            TimeElapsedColumn()
+            TimeElapsedColumn(),
             console=Console(theme=progressbar_theme),
         )
         self._show_progress = progressbar

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -468,6 +468,7 @@ class ParallelSampler:
                     self._divergences += 1
                 progress.update(
                     task,
+                    refresh=True,
                     completed=self._completed_draws,
                     total=self._total_draws,
                     description=self._desc.format(self),

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -24,7 +24,7 @@ from typing import TypeAlias
 import cloudpickle
 import numpy as np
 
-from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn, TimeElaspedColumn
+from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn, TimeElapsedColumn
 
 from pymc.backends.base import BaseTrace
 from pymc.initial_point import PointType
@@ -181,7 +181,7 @@ class PopulationStepper:
                     "[progress.percentage]{task.percentage:>3.0f}%",
                     TimeRemainingColumn(),
                     TextColumn("/"),
-                    TimeElaspedColumn(),
+                    TimeElapsedColumn(),
                 ) as self._progress:
                     for c, stepper in enumerate(steppers):
                         #     enumerate(progress_bar(steppers)) if progressbar else enumerate(steppers)

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -24,7 +24,7 @@ from typing import TypeAlias
 import cloudpickle
 import numpy as np
 
-from rich.progress import BarColumn, Progress, TimeRemainingColumn
+from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn, TimeElaspedColumn
 
 from pymc.backends.base import BaseTrace
 from pymc.initial_point import PointType
@@ -180,6 +180,8 @@ class PopulationStepper:
                     BarColumn(),
                     "[progress.percentage]{task.percentage:>3.0f}%",
                     TimeRemainingColumn(),
+                    TextColumn("/"),
+                    TimeElaspedColumn(),
                 ) as self._progress:
                     for c, stepper in enumerate(steppers):
                         #     enumerate(progress_bar(steppers)) if progressbar else enumerate(steppers)

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -24,7 +24,7 @@ from typing import TypeAlias
 import cloudpickle
 import numpy as np
 
-from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn, TimeElapsedColumn
+from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 
 from pymc.backends.base import BaseTrace
 from pymc.initial_point import PointType

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -104,7 +104,7 @@ def _sample_population(
         task = progress.add_task("[red]Sampling...", total=draws, visible=progressbar)
 
         for _ in sampling:
-            progress.update(task, advance=1)
+            progress.update(task, advance=1, refresh=True)
 
     return
 

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -25,7 +25,7 @@ import cloudpickle
 import numpy as np
 
 from arviz import InferenceData
-from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 
 import pymc
 
@@ -367,6 +367,8 @@ def run_chains(chains, progressbar, params, random_seed, kernel_kwargs, cores):
         TextColumn("{task.description}"),
         SpinnerColumn(),
         TimeElapsedColumn(),
+        TextColumn("/"),
+        TimeRemainingColumn(),
         TextColumn("{task.fields[status]}"),
     ) as progress:
         futures = []  # keep track of the jobs

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -25,7 +25,13 @@ import cloudpickle
 import numpy as np
 
 from arviz import InferenceData
-from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
 
 import pymc
 

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -366,9 +366,9 @@ def run_chains(chains, progressbar, params, random_seed, kernel_kwargs, cores):
     with Progress(
         TextColumn("{task.description}"),
         SpinnerColumn(),
-        TimeElapsedColumn(),
-        TextColumn("/"),
         TimeRemainingColumn(),
+        TextColumn("/"),
+        TimeElapsedColumn(),
         TextColumn("{task.fields[status]}"),
     ) as progress:
         futures = []  # keep track of the jobs

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -411,6 +411,8 @@ def run_chains(chains, progressbar, params, random_seed, kernel_kwargs, cores):
                         stage = update_data["stage"]
                         beta = update_data["beta"]
                         # update the progress bar for this task:
-                        progress.update(status=f"Stage: {stage} Beta: {beta:.3f}", task_id=task_id)
+                        progress.update(
+                            status=f"Stage: {stage} Beta: {beta:.3f}", task_id=task_id, refresh=True
+                        )
 
         return tuple(cloudpickle.loads(r.result()) for r in futures)

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -223,6 +223,7 @@ class CostFuncWrapper:
             *Progress.get_default_columns(),
             TextColumn("{task.fields[loss]}"),
             console=Console(theme=progressbar_theme),
+            disable=not progressbar,
         )
         self.task = self.progress.add_task("MAP", total=maxeval, visible=progressbar, loss="")
 

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -178,7 +178,7 @@ def find_MAP(
             if isinstance(e, StopIteration):
                 pm._log.info(e)
         finally:
-            cost_func.progress.update(cost_func.task, completed=cost_func.n_eval)
+            cost_func.progress.update(cost_func.task, completed=cost_func.n_eval, refresh=True)
             print(file=sys.stdout)
 
     mx0 = RaveledVars(mx0, x0.point_map_info)

--- a/pymc/variational/inference.py
+++ b/pymc/variational/inference.py
@@ -166,7 +166,9 @@ class Inference:
     def _iterate_without_loss(self, s, n, step_func, progressbar, progressbar_theme, callbacks):
         i = 0
         try:
-            with Progress(console=Console(theme=progressbar_theme)) as progress:
+            with Progress(
+                console=Console(theme=progressbar_theme), disable=not progressbar
+            ) as progress:
                 task = progress.add_task("Fitting", total=n, visible=progressbar)
                 for i in range(n):
                     step_func()


### PR DESCRIPTION
## Description

Adds `TimeRemainingColumn` to progress bar where appropriate, also properly hides progressbar during `sample_posterior_predictive`

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7269 
- [x] Closes #7264  
- [x]  Closes #7278 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7273.org.readthedocs.build/en/7273/

<!-- readthedocs-preview pymc end -->