### PR TITLE
Fix link to API quick start. Closes #7266.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Getting started
 If you already know about Bayesian statistics:
 ----------------------------------------------
 
--  `API quickstart guide <https://www.pymc.io/projects/examples/en/latest/howto/api_quickstart.html>`__
+-  `API quickstart guide <https://www.pymc.io/projects/examples/en/latest/introductory/api_quickstart.html>`__
 -  The `PyMC tutorial <https://docs.pymc.io/en/latest/learn/core_notebooks/pymc_overview.html>`__
 -  `PyMC examples <https://www.pymc.io/projects/examples/en/latest/gallery.html>`__ and the `API reference <https://docs.pymc.io/en/stable/api.html>`__
 


### PR DESCRIPTION
Closes #7266

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7275.org.readthedocs.build/en/7275/

<!-- readthedocs-preview pymc end -->