### PR TITLE
Convert random variables to value variables so `pm.sample(var_names)` works correctly

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -742,6 +742,7 @@ def sample(
 
     if var_names is not None:
         trace_vars = [v for v in model.unobserved_RVs if v.name in var_names]
+        trace_vars = model.replace_rvs_by_values(trace_vars)
         assert len(trace_vars) == len(var_names), "Not all var_names were found in the model"
     else:
         trace_vars = None


### PR DESCRIPTION
## Description

This PR converts the random variables to value variables when `var_names` is not `None` in `pm.sample()`. Before this PR, using `var_names` resulted in sampling from the prior. The problem is better explained in the linked issue.

## Related Issue

Closes #7258

## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7284.org.readthedocs.build/en/7284/

<!-- readthedocs-preview pymc end -->