### PR TITLE
Remove redundant pre-commit job

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,4 +1,4 @@
-name: pre-commit
+name: mypy
 
 on:
   pull_request:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,16 +6,6 @@ on:
     branches: [main]
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    env:
-      SKIP: no-commit-to-branch
-    steps:
-    - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"  # Run pre-commit on oldest supported Python version
-    - uses: pre-commit/action@v3.0.1
   mypy:
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
As we have the pre-commit-ci (https://pre-commit.ci/), we do not to have a pre-commit GitHub action right?

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7285.org.readthedocs.build/en/7285/

<!-- readthedocs-preview pymc end -->