### PR TITLE
Add test to compare draws when `var_names` is used in `pm.sample()`

### DIFF
--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -712,7 +712,7 @@ def test_sample_var_names_draws():
     x = rng.normal(size=100)
     y = rng.normal(size=100)
 
-    group_values, group_idx  = np.unique(group, return_inverse=True)
+    group_values, group_idx = np.unique(group, return_inverse=True)
 
     coords = {"group": group_values}
 
@@ -721,7 +721,7 @@ def test_sample_var_names_draws():
         b_group = pm.Normal("b_group", dims="group")
         b_x = pm.Normal("b_x")
         mu = pm.Deterministic("mu", b_group[group_idx] + b_x * x)
-        sigma = pm.HalfNormal("sigma")    
+        sigma = pm.HalfNormal("sigma")
         pm.Normal("y", mu=mu, sigma=sigma, observed=y)
 
     # Sample with and without var_names, but always with the same seed

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -695,15 +695,6 @@ def test_no_init_nuts_compound(caplog):
 
 
 def test_sample_var_names():
-    with pm.Model() as model:
-        a = pm.Normal("a")
-        b = pm.Deterministic("b", a**2)
-        idata = pm.sample(10, tune=10, var_names=["a"])
-        assert "a" in idata.posterior
-        assert "b" not in idata.posterior
-
-
-def test_sample_var_names_draws():
     # Generate data
     seed = 1234
     rng = np.random.default_rng(seed)


### PR DESCRIPTION
This PR adds a test that complements the bug fix in #7284

It finally closes #7258 

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7287.org.readthedocs.build/en/7287/

<!-- readthedocs-preview pymc end -->