### PR TITLE
Fix draws of Weibull when alpha and beta implicitly define size

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2499,6 +2499,8 @@ class WeibullBetaRV(RandomVariable):
 
     @classmethod
     def rng_fn(cls, rng, alpha, beta, size) -> np.ndarray:
+        if size is None:
+            size = np.broadcast_shapes(alpha.shape, beta.shape)
         return np.asarray(beta * rng.weibull(alpha, size=size))
 
 

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -2369,24 +2369,13 @@ class TestWeibull(BaseTestDistributionRandom):
         "check_rv_size",
     ]
 
-    # See issue #7220
     def test_rng_different_shapes(self):
+        # See issue #7220
         rng = np.random.default_rng(123)
-
-        # Simulate mean from an only-intercept model. 2 chains, 100 draws, 5 observations.
-        # So 'mu' is the same for all the observations (because it's intercept-only)
-        mu_draws = np.abs(150 + np.dstack([rng.normal(size=(2, 100, 1))] * 5))
-
-        # Simulate some alpha values
-        alpha_draws = np.abs(rng.normal(size=(2, 100, 1)))
-
-        # With 'mu' and 'alpha' get 'beta', which is what pm.Weibull needs
-        beta_draws = mu_draws / sp.gamma(1 + 1 / alpha_draws)
-
-        # See the draws, for a given chain and draw, they look all the same!
-        weibull_draws = pm.draw(pm.Weibull.dist(alpha=alpha_draws, beta=beta_draws))
-
-        assert not (weibull_draws == weibull_draws[:, :, 0][..., None]).all()
+        alpha = np.abs(rng.normal(size=5))
+        beta = np.abs(rng.normal(size=(3, 1)))
+        draws = pm.draw(pm.Weibull.dist(alpha, beta), random_seed=rng)
+        assert len(np.unique(draws)) == draws.size
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Description

This PR incorporates the broadcasting of the shapes of `alpha` and `beta` in the random value generation method from the Weibull distribution to provide a fix to the problem shown in #7220 

## Related Issue

Closes #7220

## Type of change

- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7288.org.readthedocs.build/en/7288/

<!-- readthedocs-preview pymc end -->