### PR TITLE
Suggest `var_names` when using deprecated API for partial traces

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -630,7 +630,7 @@ def sample(
         else:
             kwargs["nuts"] = {"target_accept": kwargs.pop("target_accept")}
     if isinstance(trace, list):
-        raise DeprecationWarning("Please use `var_names` keyword argument for partial traces.")
+        raise ValueError("Please use `var_names` keyword argument for partial traces.")
 
     model = modelcontext(model)
     if not model.free_RVs:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -630,10 +630,7 @@ def sample(
         else:
             kwargs["nuts"] = {"target_accept": kwargs.pop("target_accept")}
     if isinstance(trace, list):
-        raise DeprecationWarning(
-            "We have removed support for partial traces because it simplified things."
-            " Please open an issue if & why this is a problem for you."
-        )
+        raise DeprecationWarning("Please use `var_names` keyword argument for partial traces.")
 
     model = modelcontext(model)
     if not model.free_RVs:

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -507,11 +507,11 @@ def test_empty_model():
         error.match("any free variables")
 
 
-def test_partial_trace_unsupported():
+def test_partial_trace_with_trace_unsupported():
     with pm.Model() as model:
         a = pm.Normal("a", mu=0, sigma=1)
         b = pm.Normal("b", mu=0, sigma=1)
-        with pytest.raises(DeprecationWarning, match="removed support"):
+        with pytest.raises(ValueError, match="var_names"):
             pm.sample(trace=[a])
 
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

Sampling a partial trace was first done in #271, with the `trace` kwarg.
Then, it subsequently removed in  #6269 raising `DeprecationWarning` error.
Partial trace was added back with the `var_names` kwarg in #7206.

This PR updates the error message to reference the new `var_names` kwarg instead, as `trace` may still be suggested by coding LLMs.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #271 #6269 #7206

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7289.org.readthedocs.build/en/7289/

<!-- readthedocs-preview pymc end -->