### PR TITLE
Implement CustomProgress that does not output empty divs when disabled

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -32,7 +32,7 @@ from arviz import InferenceData, concat, rcParams
 from arviz.data.base import CoordSpec, DimSpec, dict_to_dataset, requires
 from pytensor.graph import ancestors
 from pytensor.tensor.sharedvar import SharedVariable
-from rich.progress import Console, Progress
+from rich.progress import Console
 from rich.theme import Theme
 from xarray import Dataset
 
@@ -40,7 +40,7 @@ import pymc
 
 from pymc.model import Model, modelcontext
 from pymc.pytensorf import PointFunc, extract_obs_data
-from pymc.util import default_progress_theme, get_default_varnames
+from pymc.util import CustomProgress, default_progress_theme, get_default_varnames
 
 if TYPE_CHECKING:
     from pymc.backends.base import MultiTrace
@@ -649,8 +649,10 @@ def apply_function_over_dataset(
     out_dict = _DefaultTrace(n_pts)
     indices = range(n_pts)
 
-    with Progress(console=Console(theme=progressbar_theme), disable=not progressbar) as progress:
-        task = progress.add_task("Computing ...", total=n_pts, visible=progressbar)
+    with CustomProgress(
+        console=Console(theme=progressbar_theme), disable=not progressbar
+    ) as progress:
+        task = progress.add_task("Computing ...", total=n_pts)
         for idx in indices:
             out = fn(posterior_pts[idx])
             fn.f.trust_input = True  # If we arrive here the dtypes are valid

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -44,6 +44,7 @@ from pytensor.tensor.random.var import (
 )
 from pytensor.tensor.sharedvar import SharedVariable
 from rich.console import Console
+from rich.progress import BarColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 from rich.theme import Theme
 
 import pymc as pm
@@ -828,11 +829,21 @@ def sample_posterior_predictive(
     # All model variables have a name, but mypy does not know this
     _log.info(f"Sampling: {list(sorted(volatile_basic_rvs, key=lambda var: var.name))}")  # type: ignore
     ppc_trace_t = _DefaultTrace(samples)
+
+    progress = CustomProgress(
+        "[progress.description]{task.description}",
+        BarColumn(),
+        "[progress.percentage]{task.percentage:>3.0f}%",
+        TimeRemainingColumn(),
+        TextColumn("/"),
+        TimeElapsedColumn(),
+        console=Console(theme=progressbar_theme),
+        disable=not progressbar,
+    )
+
     try:
-        with CustomProgress(
-            console=Console(theme=progressbar_theme), disable=not progressbar
-        ) as progress:
-            task = progress.add_task("Sampling ...", total=samples)
+        with progress:
+            task = progress.add_task("Sampling ...", completed=0, total=samples)
             for idx in np.arange(samples):
                 if nchain > 1:
                     # the trace object will either be a MultiTrace (and have _straces)...
@@ -854,6 +865,7 @@ def sample_posterior_predictive(
                     ppc_trace_t.insert(k.name, v, idx)
 
                 progress.advance(task)
+            progress.update(task, refresh=True, completed=samples)
 
     except KeyboardInterrupt:
         pass

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -44,7 +44,6 @@ from pytensor.tensor.random.var import (
 )
 from pytensor.tensor.sharedvar import SharedVariable
 from rich.console import Console
-from rich.progress import Progress
 from rich.theme import Theme
 
 import pymc as pm
@@ -55,6 +54,7 @@ from pymc.blocking import PointType
 from pymc.model import Model, modelcontext
 from pymc.pytensorf import compile_pymc
 from pymc.util import (
+    CustomProgress,
     RandomState,
     _get_seeds_per_chain,
     default_progress_theme,
@@ -829,10 +829,10 @@ def sample_posterior_predictive(
     _log.info(f"Sampling: {list(sorted(volatile_basic_rvs, key=lambda var: var.name))}")  # type: ignore
     ppc_trace_t = _DefaultTrace(samples)
     try:
-        with Progress(
+        with CustomProgress(
             console=Console(theme=progressbar_theme), disable=not progressbar
         ) as progress:
-            task = progress.add_task("Sampling ...", total=samples, visible=progressbar)
+            task = progress.add_task("Sampling ...", total=samples)
             for idx in np.arange(samples):
                 if nchain > 1:
                     # the trace object will either be a MultiTrace (and have _straces)...

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1083,7 +1083,7 @@ def _sample(
             for it, diverging in enumerate(sampling_gen):
                 if it >= skip_first and diverging:
                     _pbar_data["divergences"] += 1
-                progress.update(task, refresh=True, advance=1)
+                progress.update(task)
             progress.update(task, refresh=True, advance=1, completed=True)
         except KeyboardInterrupt:
             pass

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -36,7 +36,6 @@ from arviz import InferenceData, dict_to_dataset
 from arviz.data.base import make_attrs
 from pytensor.graph.basic import Variable
 from rich.console import Console
-from rich.progress import Progress
 from rich.theme import Theme
 from threadpoolctl import threadpool_limits
 from typing_extensions import Protocol

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -36,6 +36,7 @@ from arviz import InferenceData, dict_to_dataset
 from arviz.data.base import make_attrs
 from pytensor.graph.basic import Variable
 from rich.console import Console
+from rich.progress import BarColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 from rich.theme import Theme
 from threadpoolctl import threadpool_limits
 from typing_extensions import Protocol
@@ -1075,16 +1076,28 @@ def _sample(
     )
     _pbar_data = {"chain": chain, "divergences": 0}
     _desc = "Sampling chain {chain:d}, {divergences:,d} divergences"
-    with CustomProgress(
-        console=Console(theme=progressbar_theme), disable=not progressbar
-    ) as progress:
+
+    progress = CustomProgress(
+        "[progress.description]{task.description}",
+        BarColumn(),
+        "[progress.percentage]{task.percentage:>3.0f}%",
+        TimeRemainingColumn(),
+        TextColumn("/"),
+        TimeElapsedColumn(),
+        console=Console(theme=progressbar_theme),
+        disable=not progressbar,
+    )
+
+    with progress:
         try:
-            task = progress.add_task(_desc.format(**_pbar_data), total=draws)
+            task = progress.add_task(_desc.format(**_pbar_data), completed=0, total=draws)
             for it, diverging in enumerate(sampling_gen):
                 if it >= skip_first and diverging:
                     _pbar_data["divergences"] += 1
-                progress.update(task)
-            progress.update(task, refresh=True, advance=1, completed=True)
+                progress.update(task, description=_desc.format(**_pbar_data), completed=it)
+            progress.update(
+                task, description=_desc.format(**_pbar_data), completed=draws, refresh=True
+            )
         except KeyboardInterrupt:
             pass
 

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -65,6 +65,7 @@ from pymc.step_methods import NUTS, CompoundStep
 from pymc.step_methods.arraystep import BlockedStep, PopulationArrayStepShared
 from pymc.step_methods.hmc import quadpotential
 from pymc.util import (
+    CustomProgress,
     RandomSeed,
     RandomState,
     _get_seeds_per_chain,
@@ -1075,9 +1076,11 @@ def _sample(
     )
     _pbar_data = {"chain": chain, "divergences": 0}
     _desc = "Sampling chain {chain:d}, {divergences:,d} divergences"
-    with Progress(console=Console(theme=progressbar_theme)) as progress:
+    with CustomProgress(
+        console=Console(theme=progressbar_theme), disable=not progressbar
+    ) as progress:
         try:
-            task = progress.add_task(_desc.format(**_pbar_data), total=draws, visible=progressbar)
+            task = progress.add_task(_desc.format(**_pbar_data), total=draws)
             for it, diverging in enumerate(sampling_gen):
                 if it >= skip_first and diverging:
                     _pbar_data["divergences"] += 1

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -473,7 +473,6 @@ class ParallelSampler:
                 self._completed_draws += 1
                 if not tuning and stats and stats[0].get("diverging"):
                     self._divergences += 1
-
                 progress.update(
                     task,
                     completed=self._completed_draws,

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -487,9 +487,7 @@ class ParallelSampler:
                     self._active.remove(proc)
                     self._finished.append(proc)
                     self._make_active()
-
-                    if self._progress.is_enabled:
-                        progress.update(task, description=self._desc.format(self), refresh=True)
+                    progress.update(task, description=self._desc.format(self), refresh=True)
 
                 # We could also yield proc.shared_point_view directly,
                 # and only call proc.write_next() after the yield returns.

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -487,7 +487,9 @@ class ParallelSampler:
                     self._active.remove(proc)
                     self._finished.append(proc)
                     self._make_active()
-                    progress.update(task, description=self._desc.format(self), refresh=True)
+
+                    if self._progress.is_enabled:
+                        progress.update(task, description=self._desc.format(self), refresh=True)
 
                 # We could also yield proc.shared_point_view directly,
                 # and only call proc.write_next() after the yield returns.

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -474,23 +474,20 @@ class ParallelSampler:
                 if not tuning and stats and stats[0].get("diverging"):
                     self._divergences += 1
 
-                if self._progress.is_enabled:
-                    progress.update(
-                        task,
-                        refresh=True,
-                        completed=self._completed_draws,
-                        total=self._total_draws,
-                        description=self._desc.format(self),
-                    )
+                progress.update(
+                    task,
+                    refresh=True,
+                    completed=self._completed_draws,
+                    total=self._total_draws,
+                    description=self._desc.format(self),
+                )
 
                 if is_last:
                     proc.join()
                     self._active.remove(proc)
                     self._finished.append(proc)
                     self._make_active()
-
-                    if self._progress.is_enabled:
-                        progress.update(task, description=self._desc.format(self), refresh=True)
+                    progress.update(task, description=self._desc.format(self), refresh=True)
 
                 # We could also yield proc.shared_point_view directly,
                 # and only call proc.write_next() after the yield returns.

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -476,7 +476,6 @@ class ParallelSampler:
 
                 progress.update(
                     task,
-                    refresh=True,
                     completed=self._completed_draws,
                     total=self._total_draws,
                     description=self._desc.format(self),

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -104,7 +104,7 @@ def _sample_population(
         task = progress.add_task("[red]Sampling...", total=draws)
 
         for _ in sampling:
-            progress.update(task, advance=1, refresh=True)
+            progress.update(task)
 
     return
 

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -102,7 +102,6 @@ def _sample_population(
 
     with CustomProgress(disable=not progressbar) as progress:
         task = progress.add_task("[red]Sampling...", total=draws)
-
         for _ in sampling:
             progress.update(task)
 

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -24,7 +24,7 @@ from typing import TypeAlias
 import cloudpickle
 import numpy as np
 
-from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, TimeRemainingColumn
+from rich.progress import BarColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 
 from pymc.backends.base import BaseTrace
 from pymc.initial_point import PointType
@@ -37,7 +37,7 @@ from pymc.step_methods.arraystep import (
     StatsType,
 )
 from pymc.step_methods.metropolis import DEMetropolis
-from pymc.util import RandomSeed
+from pymc.util import CustomProgress, RandomSeed
 
 __all__ = ()
 
@@ -100,8 +100,8 @@ def _sample_population(
         progressbar=progressbar,
     )
 
-    with Progress() as progress:
-        task = progress.add_task("[red]Sampling...", total=draws, visible=progressbar)
+    with CustomProgress(disable=not progressbar) as progress:
+        task = progress.add_task("[red]Sampling...", total=draws)
 
         for _ in sampling:
             progress.update(task, advance=1, refresh=True)
@@ -175,20 +175,19 @@ class PopulationStepper:
                 )
                 import multiprocessing
 
-                with Progress(
+                with CustomProgress(
                     "[progress.description]{task.description}",
                     BarColumn(),
                     "[progress.percentage]{task.percentage:>3.0f}%",
                     TimeRemainingColumn(),
                     TextColumn("/"),
                     TimeElapsedColumn(),
+                    disable=not progressbar,
                 ) as self._progress:
                     for c, stepper in enumerate(steppers):
                         #     enumerate(progress_bar(steppers)) if progressbar else enumerate(steppers)
                         # ):
-                        task = self._progress.add_task(
-                            description=f"Chain {c}", visible=progressbar
-                        )
+                        task = self._progress.add_task(description=f"Chain {c}")
                         secondary_end, primary_end = multiprocessing.Pipe()
                         stepper_dumps = cloudpickle.dumps(stepper, protocol=4)
                         process = multiprocessing.Process(

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -37,7 +37,12 @@ import pymc as pm
 from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.initial_point import make_initial_point_fn
 from pymc.model import modelcontext
-from pymc.util import default_progress_theme, get_default_varnames, get_value_vars_from_user_vars
+from pymc.util import (
+    CustomProgress,
+    default_progress_theme,
+    get_default_varnames,
+    get_value_vars_from_user_vars,
+)
 from pymc.vartypes import discrete_types, typefilter
 
 __all__ = ["find_MAP"]
@@ -219,13 +224,13 @@ class CostFuncWrapper:
             self.desc = "logp = {:,.5g}, ||grad|| = {:,.5g}"
         self.previous_x = None
         self.progressbar = progressbar
-        self.progress = Progress(
+        self.progress = CustomProgress(
             *Progress.get_default_columns(),
             TextColumn("{task.fields[loss]}"),
             console=Console(theme=progressbar_theme),
             disable=not progressbar,
         )
-        self.task = self.progress.add_task("MAP", total=maxeval, visible=progressbar, loss="")
+        self.task = self.progress.add_task("MAP", total=maxeval, loss="")
 
     def __call__(self, x):
         neg_value = np.float64(self.logp_func(pm.floatX(x)))

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -27,6 +27,7 @@ from cachetools import LRUCache, cachedmethod
 from pytensor import Variable
 from pytensor.compile import SharedVariable
 from pytensor.graph.utils import ValidatingScratchpad
+from rich.progress import Progress
 from rich.theme import Theme
 
 from pymc.exceptions import BlockModelAccessError
@@ -520,3 +521,36 @@ def makeiter(a):
         return a
     else:
         return [a]
+
+
+class CustomProgress(Progress):
+    """A child of Progress that allows to disable progress bars and its container
+
+    The implementation simply checks an `is_enabled` flag and generates the progress bar only if
+    it's `True`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.is_enabled = not kwargs.get("disable", None) is True
+        if self.is_enabled:
+            super().__init__(*args, **kwargs)
+
+    def __enter__(self):
+        if self.is_enabled:
+            self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.is_enabled:
+            super().__exit__(exc_type, exc_val, exc_tb)
+
+    def add_task(self, *args, **kwargs):
+        if self.is_enabled:
+            return super().add_task(*args, **kwargs)
+        return None
+
+    def advance(self, task_id, advance=1) -> None:
+        if self.is_enabled:
+            super().advance(task_id, advance)
+            self.refresh()
+        return None

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -531,7 +531,7 @@ class CustomProgress(Progress):
     """
 
     def __init__(self, *args, **kwargs):
-        self.is_enabled = not kwargs.get("disable", None) is True
+        self.is_enabled = kwargs.get("disable", None) is not True
         if self.is_enabled:
             super().__init__(*args, **kwargs)
 

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -531,7 +531,7 @@ class CustomProgress(Progress):
     """
 
     def __init__(self, *args, **kwargs):
-        self.is_enabled = kwargs.get("disable", None) is not True
+        self.is_enabled = not kwargs.get("disable", None) is True
         if self.is_enabled:
             super().__init__(*args, **kwargs)
 

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -531,7 +531,7 @@ class CustomProgress(Progress):
     """
 
     def __init__(self, *args, **kwargs):
-        self.is_enabled = not kwargs.get("disable", None) is True
+        self.is_enabled = kwargs.get("disable", None) is not True
         if self.is_enabled:
             super().__init__(*args, **kwargs)
 
@@ -552,5 +552,29 @@ class CustomProgress(Progress):
     def advance(self, task_id, advance=1) -> None:
         if self.is_enabled:
             super().advance(task_id, advance)
-            self.refresh()
+        return None
+
+    def update(
+        self,
+        task_id,
+        *,
+        total=None,
+        completed=None,
+        advance=None,
+        description=None,
+        visible=None,
+        refresh=False,
+        **fields,
+    ):
+        if self.is_enabled:
+            super().update(
+                task_id,
+                total=total,
+                completed=completed,
+                advance=advance,
+                description=description,
+                visible=visible,
+                refresh=refresh,
+                **fields,
+            )
         return None

--- a/pymc/variational/inference.py
+++ b/pymc/variational/inference.py
@@ -23,7 +23,7 @@ from rich.progress import Progress, TextColumn, track
 
 import pymc as pm
 
-from pymc.util import default_progress_theme
+from pymc.util import CustomProgress, default_progress_theme
 from pymc.variational import test_functions
 from pymc.variational.approximations import Empirical, FullRank, MeanField
 from pymc.variational.operators import KL, KSD
@@ -166,10 +166,10 @@ class Inference:
     def _iterate_without_loss(self, s, n, step_func, progressbar, progressbar_theme, callbacks):
         i = 0
         try:
-            with Progress(
+            with CustomProgress(
                 console=Console(theme=progressbar_theme), disable=not progressbar
             ) as progress:
-                task = progress.add_task("Fitting", total=n, visible=progressbar)
+                task = progress.add_task("Fitting", total=n)
                 for i in range(n):
                     step_func()
                     progress.update(task, advance=1)
@@ -217,12 +217,13 @@ class Inference:
         scores[:] = np.nan
         i = 0
         try:
-            with Progress(
+            with CustomProgress(
                 *Progress.get_default_columns(),
                 TextColumn("{task.fields[loss]}"),
                 console=Console(theme=progressbar_theme),
+                disable=not progressbar,
             ) as progress:
-                task = progress.add_task("Fitting:", total=n, visible=progressbar, loss="")
+                task = progress.add_task("Fitting:", total=n, loss="")
                 for i in range(n):
                     e = step_func()
                     progress.update(task, advance=1)


### PR DESCRIPTION
## Description

This PR adds a new class `CustomProgress` that inherits from `rich.progress.Progress`. I overloaded the necessary methods to make it not output anything when we disable the progress bar. **I feel it's a bit hacky** so I would like to know what others think about this modification.

This problem is noticeable especially in VS Code. It's not such a big issue in Jupyter Notebook. Some screenshots:

VS Code `progressbar=True` (before and after we get the same result, I cannot get rid of those empty spaces)

![capture1](https://github.com/pymc-devs/pymc/assets/25507629/41767ff5-d153-4aa4-bdee-d49ab9b35a01)


VS Code `progressbar=False` before the changes

![capture2](https://github.com/pymc-devs/pymc/assets/25507629/5952644f-9e32-4e72-8dd0-e19fb9fac27f)

VS Code `progressbar=False` after the changes

![image](https://github.com/pymc-devs/pymc/assets/25507629/a8ab0116-ea79-463c-9d1b-b6e062969c00)


Jupyter Notebook after the changes

![capture3](https://github.com/pymc-devs/pymc/assets/25507629/b15df76b-313b-4b59-b853-025cc5db1a95)


**Update**

In the terminal, after the change

![image](https://github.com/pymc-devs/pymc/assets/25507629/ef418e83-91f5-49e2-ac92-48dcfbf44b78)



## Related Issue

-  Closes #7264



<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7290.org.readthedocs.build/en/7290/

<!-- readthedocs-preview pymc end -->