### PR TITLE
Handle NaNs in the logp in SMC

### DIFF
--- a/pymc/smc/kernels.py
+++ b/pymc/smc/kernels.py
@@ -269,6 +269,7 @@ class SMC_KERNEL(ABC):
         while up_beta - low_beta > 1e-6:
             new_beta = (low_beta + up_beta) / 2.0
             log_weights_un = (new_beta - old_beta) * self.likelihood_logp
+            log_weights_un = np.where(np.isnan(log_weights_un), -np.inf, log_weights_un)
             log_weights = log_weights_un - logsumexp(log_weights_un)
             ESS = int(np.exp(-logsumexp(log_weights * 2)))
             if ESS == rN:
@@ -280,6 +281,7 @@ class SMC_KERNEL(ABC):
         if new_beta >= 1:
             new_beta = 1
             log_weights_un = (new_beta - old_beta) * self.likelihood_logp
+            log_weights_un = np.where(np.isnan(log_weights_un), -np.inf, log_weights_un)
             log_weights = log_weights_un - logsumexp(log_weights_un)
 
         self.beta = new_beta


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
The changes deal with the case that the logp is NaN in the SMC sampler.
With the changes, samples with a NaN-logp will be simply discarded during the resampling step by assigning them a logp of -inf.

I know that this is not an ideal solution to the problem, but rather a pragmatic workaround. Maybe it would be wise to add a warning that there were NaN values?

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7292
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7293.org.readthedocs.build/en/7293/

<!-- readthedocs-preview pymc end -->