### PR TITLE
Fixes & improvements on HSGP

### DIFF
--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -34,8 +34,8 @@ def set_boundary(Xs: TensorLike, c: numbers.Real | TensorLike) -> TensorLike:
     """Set the boundary using the mean-subtracted `Xs` and `c`.  `c` is usually a scalar
     multiplyer greater than 1.0, but it may be one value per dimension or column of `Xs`.
     """
-    S = pt.max(pt.abs(Xs), axis=0)
-    L = c * S
+    S = pt.max(Xs, axis=0)
+    L = (c * S).eval()  # to make sure L is not updated with out-of-sample preds
     return L
 
 


### PR DESCRIPTION
Closes #7240 

Working on this in concert with @bwengals for [this example](https://github.com/pymc-devs/pymc-examples/pull/

- [x] Fix the [bug in the computation](https://github.com/pymc-devs/pymc/issues/7240) of `L`
- [x] Do mean-centering of `X` values under the hood, instead of requiring it from users
- [x] Enable setting `prior_linearized` with `m` and `c` instead of only `m` and `L`
- [x] `parametrization` is not documented
- [x] Add option to pass in nicely named `coords` to HSGP for the `beta` coefficients
- [x] Make `._m_star` more accessible / user friendly (make a property with no leading underscore so existing code doesn't break), document it, and fix example in `prior_linearized` docstring.
- [x] Get rid of numpy option, `tl=np`.  It's subtly wrong when calculating the eigen stuff and its not used anywhere.
- [x] Add the `approx_params` function to `hsgp_approx` file

## Type of change
- New feature / enhancement
- Bug fix


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7298.org.readthedocs.build/en/7298/

<!-- readthedocs-preview pymc end -->