### PR TITLE
Use more numerically stable function in TruncatedNormal area computation

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -706,11 +706,7 @@ class TruncatedNormal(BoundedContinuous):
         is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value)))
 
         if is_lower_bounded and is_upper_bounded:
-            lcdf_a = normal_lcdf(mu, sigma, lower)
-            lcdf_b = normal_lcdf(mu, sigma, upper)
-            lsf_a = normal_lccdf(mu, sigma, lower)
-            lsf_b = normal_lccdf(mu, sigma, upper)
-            norm = pt.switch(lower > 0, logdiffexp(lsf_a, lsf_b), logdiffexp(lcdf_b, lcdf_a))
+            norm = log_diff_normal_cdf(mu, sigma, upper, lower)
         elif is_lower_bounded:
             norm = normal_lccdf(mu, sigma, lower)
         elif is_upper_bounded:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
Replace the complex logic for area computation in TruncateNormal with a single, more numerically stable function meant for exactly that computation. 

## Related Issue
This is mainly code cleanup, although I did run into a few cases where it actually improves convergence.

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [X] Maintenance
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7305.org.readthedocs.build/en/7305/

<!-- readthedocs-preview pymc end -->