### PR TITLE
Add docstring to pymc.sampling.jax.sample_jax_nuts

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -521,6 +521,72 @@ def sample_jax_nuts(
     compute_convergence_checks: bool = True,
     nuts_sampler: Literal["numpyro", "blackjax"],
 ) -> az.InferenceData:
+    """
+    Draw samples from the posterior using a jax NUTS method.
+
+    Parameters
+    ----------
+    draws : int, default 1000
+        The number of samples to draw. The number of tuned samples are discarded by
+        default.
+    tune : int, default 1000
+        Number of iterations to tune. Samplers adjust the step sizes, scalings or
+        similar during tuning. Tuning samples will be drawn in addition to the number
+        specified in the ``draws`` argument.
+    chains : int, default 4
+        The number of chains to sample.
+    target_accept : float in [0, 1].
+        The step size is tuned such that we approximate this acceptance rate. Higher
+        values like 0.9 or 0.95 often work better for problematic posteriors.
+    random_seed : int, RandomState or Generator, optional
+        Random seed used by the sampling steps.
+    initvals: StartDict or Sequence[Optional[StartDict]], optional
+        Initial values for random variables provided as a dictionary (or sequence of
+        dictionaries) mapping the random variable (by name or reference) to desired
+        starting values.
+    jitter: bool, default True
+        If True, add jitter to initial points.
+    model : Model, optional
+        Model to sample from. The model needs to have free random variables. When inside
+        a ``with`` model context, it defaults to that model, otherwise the model must be
+        passed explicitly.
+    var_names : sequence of str, optional
+        Names of variables for which to compute the posterior samples. Defaults to all
+        variables in the posterior.
+    nuts_kwargs : dict, optional
+        Keyword arguments for underlying nuts sampler
+    progressbar: bool, default True
+        If True, display progressbar while sampling
+    keep_untransformed : bool, default False
+        Include untransformed variables in the posterior samples. Defaults to False.
+    chain_method : str, default "parallel"
+        Specify how samples should be drawn. The choices include "parallel", and
+        "vectorized".
+    postprocessing_backend : Optional[Literal["cpu", "gpu"]], default None,
+        Specify how postprocessing should be computed. gpu or cpu
+    postprocessing_vectorize : Literal["vmap", "scan"], default "scan"
+        How to vectorize the postprocessing: vmap or sequential scan
+    postprocessing_chunks : None
+        This argument is deprecated
+    idata_kwargs : dict, optional
+        Keyword arguments for :func:`arviz.from_dict`. It also accepts a boolean as
+        value for the ``log_likelihood`` key to indicate that the pointwise log
+        likelihood should not be included in the returned object. Values for
+        ``observed_data``, ``constant_data``, ``coords``, and ``dims`` are inferred from
+        the ``model`` argument if not provided in ``idata_kwargs``. If ``coords`` and
+        ``dims`` are provided, they are used to update the inferred dictionaries.
+    compute_convergence_checks: bool, default True
+        Compute ess and rhat values and warn if they indicate potential sampling issues.
+    nuts_sampler : Literal["numpyro", "blackjax"]
+        Nuts sampler library to use
+
+    Returns
+    -------
+    InferenceData
+        ArviZ ``InferenceData`` object that contains the posterior samples, together
+        with their respective sample stats and pointwise log likeihood values (unless
+        skipped with ``idata_kwargs``).
+    """
     if postprocessing_chunks is not None:
         import warnings
 

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -532,7 +532,7 @@ def sample_jax_nuts(
     tune : int, default 1000
         Number of iterations to tune. Samplers adjust the step sizes, scalings or
         similar during tuning. Tuning samples will be drawn in addition to the number
-        specified in the ``draws`` argument.
+        specified in the ``draws`` argument.  Tuned samples are discarded.
     chains : int, default 4
         The number of chains to sample.
     target_accept : float in [0, 1].
@@ -554,11 +554,11 @@ def sample_jax_nuts(
         Names of variables for which to compute the posterior samples. Defaults to all
         variables in the posterior.
     nuts_kwargs : dict, optional
-        Keyword arguments for underlying nuts sampler
-    progressbar: bool, default True
-        If True, display progressbar while sampling
+        Keyword arguments for the underlying nuts sampler
+    progressbar : bool, default True
+        If True, display a progressbar while sampling
     keep_untransformed : bool, default False
-        Include untransformed variables in the posterior samples. Defaults to False.
+        Include untransformed variables in the posterior samples.
     chain_method : str, default "parallel"
         Specify how samples should be drawn. The choices include "parallel", and
         "vectorized".
@@ -575,10 +575,11 @@ def sample_jax_nuts(
         ``observed_data``, ``constant_data``, ``coords``, and ``dims`` are inferred from
         the ``model`` argument if not provided in ``idata_kwargs``. If ``coords`` and
         ``dims`` are provided, they are used to update the inferred dictionaries.
-    compute_convergence_checks: bool, default True
-        Compute ess and rhat values and warn if they indicate potential sampling issues.
+    compute_convergence_checks : bool, default True
+        If True, compute ess and rhat values and warn if they indicate potential sampling issues.
     nuts_sampler : Literal["numpyro", "blackjax"]
-        Nuts sampler library to use
+        Nuts sampler library to use - do not change - use sample_numpyro_nuts or
+        sample_blackjax_nuts as appropriate
 
     Returns
     -------


### PR DESCRIPTION
Add docstring to pymc.sampling.jax.sample_jax_nuts

## Description
As above - mostly just copied from _sample_blackjax_nuts.  Fixes empty documentation here https://www.pymc.io/projects/docs/en/stable/api/generated/pymc.sampling.jax.sample_blackjax_nuts.html#pymc.sampling.jax.sample_blackjax_nuts and here https://www.pymc.io/projects/docs/en/stable/api/generated/pymc.sampling.jax.sample_numpyro_nuts.html#pymc.sampling.jax.sample_numpyro_nuts

## Related Issue
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7313.org.readthedocs.build/en/7313/

<!-- readthedocs-preview pymc end -->