### PR TITLE
Fix bug in Truncated with Deterministic inputs

### DIFF
--- a/pymc/distributions/truncated.py
+++ b/pymc/distributions/truncated.py
@@ -121,7 +121,9 @@ class TruncatedRV(SymbolicRandomVariable):
                 rng=uniform_rng,
                 size=rv.shape,
             ).owner.outputs
-            truncated_rv = icdf(rv, uniform, warn_rvs=False)
+            # So icdf does not see the random graph of uniform
+            uniform_type = uniform.type()
+            truncated_rv = graph_replace(icdf(rv, uniform_type), {uniform_type: uniform})
             return TruncatedRV(
                 base_rv_op=dist.owner.op,
                 inputs=graph_inputs,


### PR DESCRIPTION
When using `Deterministic`, variables get wrapped in an `identity` operation. When attempting to define an `icdf`, the logp graph rewrites would remove this useless operation from the graph of the underlying RV and cause a mismatch between explict and implicit inputs of the inner graph of TruncatedRV

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7312 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7315.org.readthedocs.build/en/7315/

<!-- readthedocs-preview pymc end -->