### PR TITLE
Add blas_cores argument to pm.sample

### DIFF
--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -18,6 +18,7 @@ dependencies:
 - networkx
 - scipy>=1.4.1
 - typing-extensions>=3.7.4
+- threadpoolctl>=3.1.0
 # Extra dependencies for dev, testing and docs build
 - ipython>=7.16
 - jax

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -16,6 +16,7 @@ dependencies:
 - rich>=13.7.1
 - scipy>=1.4.1
 - typing-extensions>=3.7.4
+- threadpoolctl>=3.1.0
 # Extra dependencies for docs build
 - ipython>=7.16
 - jax

--- a/conda-envs/environment-jax.yml
+++ b/conda-envs/environment-jax.yml
@@ -24,6 +24,7 @@ dependencies:
 - python-graphviz
 - networkx
 - rich>=13.7.1
+- threadpoolctl>=3.1.0
 # JAX is only compatible with Scipy 1.13.0 from >=0.4.26, but the respective version of
 # JAXlib is still not on conda: https://github.com/conda-forge/jaxlib-feedstock/pull/243
 - scipy>=1.4.1,<1.13.0

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -22,6 +22,7 @@ dependencies:
 - rich>=13.7.1
 - scipy>=1.4.1
 - typing-extensions>=3.7.4
+- threadpoolctl>=3.1.0
 # Extra dependencies for testing
 - ipython>=7.16
 - pre-commit>=2.8.0

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -19,6 +19,7 @@ dependencies:
 - rich>=13.7.1
 - scipy>=1.4.1
 - typing-extensions>=3.7.4
+- threadpoolctl>=3.1.0
 # Extra dependencies for dev, testing and docs build
 - ipython>=7.16
 - myst-nb

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -22,6 +22,7 @@ dependencies:
 - rich>=13.7.1
 - scipy>=1.4.1
 - typing-extensions>=3.7.4
+- threadpoolctl>=3.1.0
 # Extra dependencies for testing
 - ipython>=7.16
 - pre-commit>=2.8.0

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -505,12 +505,12 @@ def sample(
         This requires the chosen sampler to be installed.
         All samplers, except "pymc", require the full model to be continuous.
     blas_cores: int or "auto" or None, default = "auto"
-        The total number of threads blas and openmp functions should use during sampling. If set to None,
-        this will keep the default behavior of whatever blas implementation is used at runtime.
-        Setting it to "auto" will set it so that the total number of active blas threads is the
+        The total number of threads blas and openmp functions should use during sampling.
+        Setting it to "auto" will ensure that the total number of active blas threads is the
         same as the `cores` argument. If set to an integer, the sampler will try to use that total
         number of blas threads. If `blas_cores` is not divisible by `cores`, it might get rounded
-        down.
+        down. If set to None, this will keep the default behavior of whatever blas implementation
+        is used at runtime.
     initvals : optional, dict, array of dict
         Dict or list of dicts with initial value strategies to use instead of the defaults from
         `Model.initial_values`. The keys should be names of transformed random variables.
@@ -660,15 +660,6 @@ def sample(
         blas_cores = cores
 
     cores = min(cores, chains)
-
-    if cores < 1:
-        raise ValueError("`cores` must be larger or equal to one")
-
-    if chains < 1:
-        raise ValueError("`chains` must be larger or equal to one")
-
-    if blas_cores is not None and blas_cores < 1:
-        raise ValueError("`blas_cores` must be larger or equal to one")
 
     num_blas_cores_per_chain: int | None
     joined_blas_limiter: Callable[[], Any]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,6 +28,7 @@ sphinx-notfound-page
 sphinx-remove-toctrees
 sphinx>=1.5
 sphinxext-rediraffe
+threadpoolctl>=3.1.0
 types-cachetools
 typing-extensions>=3.7.4
 watermark

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ pandas>=0.24.0
 pytensor>=2.20,<2.21
 rich>=13.7.1
 scipy>=1.4.1
+threadpoolctl>=3.1.0,<4.0.0
 typing-extensions>=3.7.4

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -507,6 +507,14 @@ def test_empty_model():
         error.match("any free variables")
 
 
+def test_blas_cores():
+    with pm.Model():
+        pm.Normal("a")
+        pm.sample(blas_cores="auto", tune=10, cores=2, draws=10)
+        pm.sample(blas_cores=None, tune=10, cores=2, draws=10)
+        pm.sample(blas_cores=2, tune=10, cores=2, draws=10)
+
+
 def test_partial_trace_with_trace_unsupported():
     with pm.Model() as model:
         a = pm.Normal("a", mu=0, sigma=1)

--- a/tests/sampling/test_parallel.py
+++ b/tests/sampling/test_parallel.py
@@ -161,6 +161,7 @@ def test_explicit_sample(mp_start_method):
         mp_ctx=ctx,
         start={"a": floatX(np.array([1.0])), "b_log__": floatX(np.array(2.0))},
         step_method_pickled=step_method_pickled,
+        blas_cores=None,
     )
     proc.start()
     while True:
@@ -193,6 +194,7 @@ def test_iterator():
         start_points=[start] * 3,
         step_method=step,
         progressbar=False,
+        blas_cores=None,
     )
     with sampler:
         for draw in sampler:


### PR DESCRIPTION
## Description

We currently do not configure blas in any way. This can lead to very bad behavior if we sample in several threads:
Many blas implementations default to using one worker thread per hardware thread in the machine. But if we sample in parallel with multiprocessing, each chain will use an independent thread pool, so we end up starting `chains*hardware_chains` worker threads. Combined with some spinnlocking that some blas implementations seem to do, this can lead to terrible performance.

This PR adds a `blas_cores` argument to `pm.sample()`, and then uses `threadpoolctl` to control how many worker threads we start.

If it is set to `None`, we don't do anything, and keep the current behavior of just using whatever the blas implementation uses as default. If set to `auto` (the default) use the cores argument to guess a decent number of blas worker threads. If it is set to an integer, we use that number of total blas worker.

See for instance [here](https://discourse.pymc.io/t/slow-sampling-speed-with-newer-versions-of-pymc/14421/18?u=aseyboldt) for a model that shows bad behavior without this PR.

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7318.org.readthedocs.build/en/7318/

<!-- readthedocs-preview pymc end -->