### PR TITLE
Updated pymc.step_methods.slicer.Slice docstring

### DIFF
--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -43,7 +43,7 @@ class Slice(ArrayStepShared):
         Initial width of slice.
     tune : bool, default True
         Flag for tuning.
-    model : PyMC Model, optional
+    model : Model, optional
         Optional model for sampling step. It will be taken from the context if not provided.
     iter_limit : int, default np.inf
         Maximum number of iterations for the slice sampler.

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -37,14 +37,16 @@ class Slice(ArrayStepShared):
 
     Parameters
     ----------
-    vars: list
+    vars : list, optional
         List of value variables for sampler.
-    w: float
-        Initial width of slice (Defaults to 1).
-    tune: bool
-        Flag for tuning (Defaults to True).
-    model: PyMC Model
-        Optional model for sampling step. Defaults to None (taken from context).
+    w : float, default 1.0
+        Initial width of slice.
+    tune : bool, default True
+        Flag for tuning.
+    model : PyMC Model, optional
+        Optional model for sampling step. It will be taken from the context if not provided.
+    iter_limit : int, default np.inf
+        Maximum number of iterations for the slice sampler.
 
     """
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
First time contributor to open-source and the project for me.
I updated the docstring of  `pymc.step_methods.slicer.Slice` to follow numpydoc format. 
To be specific, I added spaces preceding colons, and indicated optional or default value.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #5459 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7322.org.readthedocs.build/en/7322/

<!-- readthedocs-preview pymc end -->