### PR TITLE
Fix spurious inputs failure when building Truncated variables

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -930,6 +930,8 @@ class _CustomSymbolicDist(Distribution):
         ):
             dummy_rv = dist(*dummy_dist_params, dummy_size_param)
         dummy_params = [dummy_size_param, *dummy_dist_params]
+        # RNGs are not passed as explicit inputs (because we usually don't know how many are needed)
+        # We retrieve them here. This will also raise if the user forgot to specify some update in a Scan Op
         dummy_updates_dict = collect_default_updates(inputs=dummy_params, outputs=(dummy_rv,))
 
         rv_type = type(
@@ -1001,12 +1003,7 @@ class _CustomSymbolicDist(Distribution):
 
             return new_rv
 
-        # RNGs are not passed as explicit inputs (because we usually don't know how many are needed)
-        # We retrieve them here
-        updates_dict = collect_default_updates(inputs=dummy_params, outputs=(dummy_rv,))
-        rngs = updates_dict.keys()
-        rngs_updates = updates_dict.values()
-
+        rngs, rngs_updates = zip(*dummy_updates_dict.items())
         inputs = [*dummy_params, *rngs]
         outputs = [dummy_rv, *rngs_updates]
         signature = cls._infer_final_signature(

--- a/tests/distributions/test_truncated.py
+++ b/tests/distributions/test_truncated.py
@@ -585,3 +585,17 @@ def test_truncated_identity_input(dist_op):
 
     rv_out = Truncated.dist(dist=dist_op(mu_identity, 5), lower=0, upper=1)
     assert np.ptp(draw(rv_out, draws=500)) < 1
+
+
+@pytest.mark.parametrize("rv_op", [icdf_normal, rejection_normal])
+def test_truncated_custom_dist_indexed_argument(rv_op):
+    # Regression test for https://github.com/pymc-devs/pymc/issues/7312
+
+    def dist(scale, size):
+        return pt.exp(rv_op(scale=scale, size=size))
+
+    scale = Exponential.dist(scale=[1, 2, 3])
+    latent = CustomDist.dist(scale[[0, 0, 1, 1, 2, 2]], dist=dist)
+    rv_out = Truncated.dist(latent, upper=7)
+
+    assert np.ptp(draw(rv_out, draws=100)) < 7


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Reintroduce dummy intermediate variables in implementation of TruncatedRV

Partially reverts 9d4a3d7d371eda91be99c9bffc519d680d2cf290 and 3888d53575dfc2bf8527e4d69a7621645df5cbf6

The logprob derivation(s) in the icdf implementation of `Truncated` can duplicate nodes and cause spurious input variables to be marked as missing. We revert back to the old approach of replacing these by dummies so the graph above any inputs is hidden, and variables cannot be accidentally cloned/modified during logprob inference.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7312 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7328.org.readthedocs.build/en/7328/

<!-- readthedocs-preview pymc end -->