### PR TITLE
Fix typing in multiple places

### DIFF
--- a/pymc/backends/__init__.py
+++ b/pymc/backends/__init__.py
@@ -81,7 +81,7 @@ try:
 
     from pymc.backends.mcbackend import init_chain_adapters
 
-    TraceOrBackend = BaseTrace | Backend
+    TraceOrBackend: TypeAlias = BaseTrace | Backend
     RunType: TypeAlias = Run
     HAS_MCB = True
 except ImportError:

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -28,7 +28,7 @@ import numpy as np
 from pytensor import tensor as pt
 from pytensor.compile.builders import OpFromGraph
 from pytensor.graph import FunctionGraph, clone_replace, node_rewriter
-from pytensor.graph.basic import Node, Variable, io_toposort
+from pytensor.graph.basic import Apply, Variable, io_toposort
 from pytensor.graph.features import ReplaceValidate
 from pytensor.graph.rewriting.basic import GraphRewriter, in2out
 from pytensor.graph.utils import MetaType
@@ -421,7 +421,7 @@ class SymbolicRandomVariable(OpFromGraph):
         kwargs.setdefault("strict", True)
         super().__init__(*args, **kwargs)
 
-    def update(self, node: Node) -> dict[Variable, Variable]:
+    def update(self, node: Apply) -> dict[Variable, Variable]:
         """Symbolic update expression for input random state variables
 
         Returns a dictionary with the symbolic expressions required for correct updating
@@ -430,7 +430,7 @@ class SymbolicRandomVariable(OpFromGraph):
         """
         return collect_default_updates_inner_fgraph(node)
 
-    def batch_ndim(self, node: Node) -> int:
+    def batch_ndim(self, node: Apply) -> int:
         """Number of dimensions of the distribution's batch shape."""
         out_ndim = max(getattr(out.type, "ndim", 0) for out in node.outputs)
         return out_ndim - self.ndim_supp

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
-from pytensor.graph.basic import Node, equal_computations
+from pytensor.graph.basic import Apply, equal_computations
 from pytensor.tensor import TensorVariable
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.utils import normalize_size_param
@@ -156,7 +156,7 @@ class MarginalMixtureRV(SymbolicRandomVariable):
 
         return [change_dist_size(component, size) for component in components]
 
-    def update(self, node: Node):
+    def update(self, node: Apply):
         # Update for the internal mix_indexes RV
         return {node.inputs[0]: node.outputs[0]}
 

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -13,6 +13,8 @@
 #   limitations under the License.
 
 
+from functools import partial
+
 from pytensor.compile import SharedVariable
 from pytensor.graph.basic import Constant, walk
 from pytensor.tensor.basic import TensorVariable, Variable
@@ -55,7 +57,7 @@ def str_for_dist(
 
     if "latex" in formatting:
         if print_name is not None:
-            print_name = r"\text{" + _latex_escape(dist.name.strip("$")) + "}"
+            print_name = r"\text{" + _latex_escape(print_name.strip("$")) + "}"
 
         op_name = (
             dist.owner.op._print_name[1]
@@ -96,17 +98,16 @@ def str_for_model(model: Model, formatting: str = "plain", include_params: bool 
     """Make a human-readable string representation of Model, listing all random variables
     and their distributions, optionally including parameter values."""
 
-    kwargs = dict(formatting=formatting, include_params=include_params)
-    free_rv_reprs = [str_for_dist(dist, **kwargs) for dist in model.free_RVs]
-    observed_rv_reprs = [str_for_dist(rv, **kwargs) for rv in model.observed_RVs]
-    det_reprs = [
-        str_for_potential_or_deterministic(dist, **kwargs, dist_name="Deterministic")
-        for dist in model.deterministics
-    ]
-    potential_reprs = [
-        str_for_potential_or_deterministic(pot, **kwargs, dist_name="Potential")
-        for pot in model.potentials
-    ]
+    # Wrap functions to avoid confusing typecheckers
+    sfd = partial(str_for_dist, formatting=formatting, include_params=include_params)
+    sfp = partial(
+        str_for_potential_or_deterministic, formatting=formatting, include_params=include_params
+    )
+
+    free_rv_reprs = [sfd(dist) for dist in model.free_RVs]
+    observed_rv_reprs = [sfd(rv) for rv in model.observed_RVs]
+    det_reprs = [sfp(dist, dist_name="Deterministic") for dist in model.deterministics]
+    potential_reprs = [sfp(pot, dist_name="Potential") for pot in model.potentials]
 
     var_reprs = free_rv_reprs + det_reprs + observed_rv_reprs + potential_reprs
 
@@ -162,6 +163,8 @@ def _str_for_input_var(var: Variable, formatting: str) -> str:
     from pymc.distributions.distribution import SymbolicRandomVariable
 
     def _is_potential_or_deterministic(var: Variable) -> bool:
+        if not hasattr(var, "str_repr"):
+            return False
         try:
             return var.str_repr.__func__.func is str_for_potential_or_deterministic
         except AttributeError:
@@ -175,6 +178,7 @@ def _str_for_input_var(var: Variable, formatting: str) -> str:
     ) or _is_potential_or_deterministic(var):
         # show the names for RandomVariables, Deterministics, and Potentials, rather
         # than the full expression
+        assert isinstance(var, TensorVariable)
         return _str_for_input_rv(var, formatting)
     elif isinstance(var.owner.op, DimShuffle):
         return _str_for_input_var(var.owner.inputs[0], formatting)
@@ -182,7 +186,7 @@ def _str_for_input_var(var: Variable, formatting: str) -> str:
         return _str_for_expression(var, formatting)
 
 
-def _str_for_input_rv(var: Variable, formatting: str) -> str:
+def _str_for_input_rv(var: TensorVariable, formatting: str) -> str:
     _str = (
         var.name
         if var.name is not None
@@ -221,12 +225,15 @@ def _str_for_expression(var: Variable, formatting: str) -> str:
         if x.owner and (not isinstance(x.owner.op, RandomVariable | SymbolicRandomVariable)):
             return reversed(x.owner.inputs)
 
-    parents = [
-        x
-        for x in walk(nodes=var.owner.inputs, expand=_expand)
-        if x.owner and isinstance(x.owner.op, RandomVariable | SymbolicRandomVariable)
-    ]
-    names = [x.name for x in parents]
+    parents = []
+    names = []
+    for x in walk(nodes=var.owner.inputs, expand=_expand):
+        assert isinstance(x, Variable)
+        if x.owner and isinstance(x.owner.op, RandomVariable | SymbolicRandomVariable):
+            parents.append(x)
+            xname = x.name
+            assert xname is not None
+            names.append(xname)
 
     if "latex" in formatting:
         return (
@@ -257,6 +264,8 @@ def _default_repr_pretty(obj: TensorVariable | Model, p, cycle):
     """Handy plug-in method to instruct IPython-like REPLs to use our str_repr above."""
     # we know that our str_repr does not recurse, so we can ignore cycle
     try:
+        if not hasattr(obj, "str_repr"):
+            raise AttributeError
         output = obj.str_repr()
         # Find newlines and replace them with p.break_()
         # (see IPython.lib.pretty._repr_pprint)

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -926,15 +926,15 @@ def collect_default_updates(
     if inputs is None:
         inputs = []
 
-    outputs = makeiter(outputs)
-    fg = FunctionGraph(outputs=outputs, clone=False)
+    outs = makeiter(outputs)
+    fg = FunctionGraph(outputs=outs, clone=False)
     clients = fg.clients
 
     rng_updates = {}
     # Iterate over input RNGs. Only consider shared RNGs if `must_be_shared==True`
     for input_rng in (
         inp
-        for inp in graph_inputs(outputs, blockers=inputs)
+        for inp in graph_inputs(outs, blockers=inputs)
         if (
             (not must_be_shared or isinstance(inp, SharedVariable))
             and isinstance(inp.type, RandomType)

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -225,7 +225,7 @@ def sample_smc(
     trace = MultiTrace(traces)
 
     _t_sampling = time.time() - t1
-    sample_stats, idata = _save_sample_stats(
+    _, idata = _save_sample_stats(
         sample_settings,
         sample_stats,
         chains,

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -44,7 +44,6 @@ pymc/logprob/utils.py
 pymc/model/core.py
 pymc/model/fgraph.py
 pymc/model/transform/conditioning.py
-pymc/printing.py
 pymc/pytensorf.py
 pymc/sampling/jax.py
 """

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -25,7 +25,6 @@ FAILING = """
 pymc/distributions/continuous.py
 pymc/distributions/dist_math.py
 pymc/distributions/distribution.py
-pymc/distributions/mixture.py
 pymc/distributions/multivariate.py
 pymc/distributions/timeseries.py
 pymc/distributions/truncated.py
@@ -34,7 +33,6 @@ pymc/logprob/binary.py
 pymc/logprob/censoring.py
 pymc/logprob/basic.py
 pymc/logprob/mixture.py
-pymc/logprob/order.py
 pymc/logprob/rewriting.py
 pymc/logprob/scan.py
 pymc/logprob/tensor.py


### PR DESCRIPTION
## Description
Fixes to type hints, mostly in `printing.py` and `logprob/order.py`.

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7333.org.readthedocs.build/en/7333/

<!-- readthedocs-preview pymc end -->