### PR TITLE
Split convert observed data

### DIFF
--- a/docs/source/api/pytensorf.rst
+++ b/docs/source/api/pytensorf.rst
@@ -16,6 +16,7 @@ PyTensor utils
    floatX
    intX
    smartfloatX
+   smarttypeX
    constant_fold
    CallableTensor
    join_nonshared_inputs

--- a/docs/source/api/pytensorf.rst
+++ b/docs/source/api/pytensorf.rst
@@ -15,8 +15,6 @@ PyTensor utils
    cont_inputs
    floatX
    intX
-   smartfloatX
-   smarttypeX
    constant_fold
    CallableTensor
    join_nonshared_inputs

--- a/docs/source/api/pytensorf.rst
+++ b/docs/source/api/pytensorf.rst
@@ -22,4 +22,5 @@ PyTensor utils
    join_nonshared_inputs
    make_shared_replacements
    generator
-   convert_observed_data
+   convert_generator_data
+   convert_data

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -37,7 +37,8 @@ from pytensor.tensor.variable import TensorConstant, TensorVariable
 
 import pymc as pm
 
-from pymc.pytensorf import convert_observed_data
+from pymc.pytensorf import convert_data
+from pymc.vartypes import isgenerator
 
 __all__ = [
     "get_data",
@@ -98,7 +99,7 @@ class GeneratorAdapter:
     def __init__(self, generator):
         if not pm.vartypes.isgenerator(generator):
             raise TypeError("Object should be generator like")
-        self.test_value = pm.smartfloatX(copy(next(generator)))
+        self.test_value = pm.smarttypeX(copy(next(generator)))
         # make pickling potentially possible
         self._yielded_test_value = False
         self.gen = generator
@@ -110,7 +111,7 @@ class GeneratorAdapter:
             self._yielded_test_value = True
             return self.test_value
         else:
-            return pm.smartfloatX(copy(next(self.gen)))
+            return pm.smarttypeX(copy(next(self.gen)))
 
     # python2 generator
     next = __next__
@@ -403,9 +404,15 @@ def Data(
         )
     name = model.name_for(name)
 
-    # `convert_observed_data` takes care of parameter `value` and
-    # transforms it to something digestible for PyTensor.
-    arr = convert_observed_data(value)
+    # Transform `value` it to something digestible for PyTensor.
+    if isgenerator(value):
+        raise NotImplementedError(
+            "Generator type data is no longer supported with pm.Data.",
+            # It messes up InferenceData and can't be the input to a SharedVariable.
+        )
+    else:
+        arr = convert_data(value)
+
     if isinstance(arr, np.ma.MaskedArray):
         raise NotImplementedError(
             "Masked arrays or arrays with `nan` entries are not supported. "

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -37,7 +37,7 @@ from pytensor.tensor.variable import TensorConstant, TensorVariable
 
 import pymc as pm
 
-from pymc.pytensorf import convert_data
+from pymc.pytensorf import convert_data, smarttypeX
 from pymc.vartypes import isgenerator
 
 __all__ = [
@@ -99,7 +99,7 @@ class GeneratorAdapter:
     def __init__(self, generator):
         if not pm.vartypes.isgenerator(generator):
             raise TypeError("Object should be generator like")
-        self.test_value = pm.smarttypeX(copy(next(generator)))
+        self.test_value = smarttypeX(copy(next(generator)))
         # make pickling potentially possible
         self._yielded_test_value = False
         self.gen = generator
@@ -111,7 +111,7 @@ class GeneratorAdapter:
             self._yielded_test_value = True
             return self.test_value
         else:
-            return pm.smarttypeX(copy(next(self.gen)))
+            return smarttypeX(copy(next(self.gen)))
 
     # python2 generator
     next = __next__

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -68,6 +68,7 @@ __all__ = [
     "floatX",
     "intX",
     "smartfloatX",
+    "smarttypeX",
     "jacobian",
     "CallableTensor",
     "join_nonshared_inputs",
@@ -294,6 +295,14 @@ def smartfloatX(x):
     """
     if str(x.dtype).startswith("float"):
         x = floatX(x)
+    return x
+
+
+def smarttypeX(x):
+    if str(x.dtype).startswith("float"):
+        x = floatX(x)
+    elif str(x.dtype).startswith("int"):
+        x = intX(x)
     return x
 
 

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -89,6 +89,12 @@ def convert_observed_data(data) -> np.ndarray | Variable:
 
 
 def convert_generator_data(data) -> TensorVariable:
+    warnings.warn(
+        "Generator data is deprecated and we intend to remove it."
+        " If you disagree and need this, please get in touch via https://github.com/pymc-devs/pymc/issues.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return generator(data)
 
 

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -67,8 +67,6 @@ __all__ = [
     "cont_inputs",
     "floatX",
     "intX",
-    "smartfloatX",
-    "smarttypeX",
     "jacobian",
     "CallableTensor",
     "join_nonshared_inputs",

--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -262,7 +262,8 @@ def test_convert_generator_data(input_dtype):
 
     # Output is NOT wrapped with `pm.floatX`/`intX`,
     # but produced from calling a special Op.
-    result = convert_generator_data(square_generator)
+    with pytest.warns(DeprecationWarning, match="get in touch"):
+        result = convert_generator_data(square_generator)
     apply = result.owner
     op = apply.op
     # Make sure the returned object is an PyTensor TensorVariable

--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -50,6 +50,7 @@ from pymc.pytensorf import (
     replace_rng_nodes,
     replace_vars_in_graphs,
     reseed_rngs,
+    smarttypeX,
     walk_model,
 )
 from pymc.vartypes import int_types
@@ -275,7 +276,7 @@ def test_convert_generator_data(input_dtype):
     # Evaluation results should have the correct* dtype!
     # (*intX/floatX will be enforced!)
     evaled = result.eval()
-    expected_dtype = pm.smarttypeX(np.array(1, dtype=input_dtype)).dtype
+    expected_dtype = smarttypeX(np.array(1, dtype=input_dtype)).dtype
     assert result.type.dtype == expected_dtype
     assert evaled.dtype == np.dtype(expected_dtype)
 


### PR DESCRIPTION
## Description
`convert_observed_data` is a messy do-it-all conversion function that was recently refactored in #7299.

This PR takes the next step and splits it such that generator data is treated separately.

## Related Issue
- Makes it easier to work on #7277.

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [x] Maintenance
- [x] Other (please specify):
  - Generator data is no longer supported with `pm.Data`.
  - Generator data of integer type is no longer converted to floatX, but only to intX.


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7334.org.readthedocs.build/en/7334/

<!-- readthedocs-preview pymc end -->