### PR TITLE
HSGP improvements

### DIFF
--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -108,9 +108,9 @@ def approx_hsgp_hyperparams(
 
     Parameters
     ----------
-    x_range : List[float]
-        The range of the input variable on which the GP is going to be evaluated.
-        Should be a list with two elements [x_min, x_max].
+    x : np.ndarray
+        The input variable on which the GP is going to be evaluated.
+        Careful: should be the X values you want to predict over, not *only* the training X.
     lengthscale_range : List[float]
         The range of the lengthscales. Should be a list with two elements [lengthscale_min, lengthscale_max].
     cov_func : str

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -354,17 +354,16 @@ class HSGP(Base):
                 # Pass X to the GP
                 phi, sqrt_psd = gp.prior_linearized(Xs=X)
 
-                # Specify standard normal prior in the coefficients.  The number of which
-                # is given by the number of basis vectors, which is also saved in the GP object
-                # as m_star.
-                beta = pm.Normal("beta", size=gp._m_star)
+                # Specify standard normal prior in the coefficients, the number of which
+                # is given by the number of basis vectors, saved in `n_basis_vectors`.
+                beta = pm.Normal("beta", size=gp.n_basis_vectors)
 
                 # The (non-centered) GP approximation is given by:
                 f = pm.Deterministic("f", phi @ (beta * sqrt_psd))
 
                 # The centered approximation can be more efficient when
                 # the GP is stronger than the noise
-                # beta = pm.Normal("beta", sigma=sqrt_psd, size=gp._m_star)
+                # beta = pm.Normal("beta", sigma=sqrt_psd, size=gp.n_basis_vectors)
                 # f = pm.Deterministic("f", phi @ beta)
 
                 ...

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -218,7 +218,7 @@ class HSGP(Base):
 
         self._drop_first = drop_first
         self._m = m
-        self._m_star = int(np.prod(self._m))
+        self._m_star = self.n_basis_vectors = int(np.prod(self._m))
         self._L: pt.TensorVariable | None = None
         if L is not None:
             self._L = pt.as_tensor(L).eval()  # make sure L cannot be changed

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -409,6 +409,8 @@ class HSGP(Base):
         X: TensorLike,
         hsgp_coeffs_dims: str | None = None,
         gp_dims: str | None = None,
+        *args,
+        **kwargs,
     ):  # type: ignore
         R"""
         Returns the (approximate) GP prior distribution evaluated over the input locations `X`.
@@ -425,7 +427,6 @@ class HSGP(Base):
         gp_dims: str, default None
             Dimension name for the GP random variable.
         """
-        # self._X_mean = pt.mean(X, axis=0)
         phi, sqrt_psd = self.prior_linearized(X)
 
         if self._parametrization == "noncentered":

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -108,12 +108,12 @@ class _BaseFixtures:
 class TestHSGP(_BaseFixtures):
     def test_set_boundaries_1d(self, X1):
         X1s = X1 - np.mean(X1, axis=0)
-        L = pm.gp.hsgp_approx.set_boundary(X1s, c=2).eval()
+        L = pm.gp.hsgp_approx.set_boundary(X1s, c=2)
         assert np.all(L == 10)
 
     def test_set_boundaries_3d(self, X2):
         X2s = X2 - np.mean(X2, axis=0)
-        L = pm.gp.hsgp_approx.set_boundary(X2s, c=2).eval()
+        L = pm.gp.hsgp_approx.set_boundary(X2s, c=2)
         assert np.all(L == 10)
 
     def test_parametrization(self):
@@ -141,10 +141,11 @@ class TestHSGP(_BaseFixtures):
             pm.gp.HSGP(m=[500], L=[12, 12], cov_func=cov_func)
 
         with pytest.raises(
-            ValueError, match="`parameterization` must be either 'centered' or 'noncentered'."
+            ValueError,
+            match="`parametrization` must be either 'centered' or 'noncentered'.",
         ):
             cov_func = pm.gp.cov.ExpQuad(2, ls=[1, 2])
-            pm.gp.HSGP(m=[50, 50], L=[12, 12], parameterization="wrong", cov_func=cov_func)
+            pm.gp.HSGP(m=[50, 50], L=[12, 12], parametrization="wrong", cov_func=cov_func)
 
         # pass without error, cov_func has 2 active dimensions, c given as scalar
         cov_func = pm.gp.cov.ExpQuad(3, ls=[1, 2], active_dims=[0, 2])
@@ -171,19 +172,19 @@ class TestHSGP(_BaseFixtures):
                 assert n_coeffs == n_basis, "one was dropped when it shouldn't have been"
 
     @pytest.mark.parametrize(
-        "cov_func,parameterization",
+        "cov_func,parametrization",
         [
             (pm.gp.cov.ExpQuad(1, ls=1), "centered"),
             (pm.gp.cov.ExpQuad(1, ls=1), "noncentered"),
         ],
     )
-    def test_prior(self, model, cov_func, X1, parameterization, rng):
+    def test_prior(self, model, cov_func, X1, parametrization, rng):
         """Compare HSGP prior to unapproximated GP prior, pm.gp.Latent.  Draw samples from the
         prior and compare them using MMD two sample test.  Tests both centered and non-centered
-        parameterizations.
+        parametrization.
         """
         with model:
-            hsgp = pm.gp.HSGP(m=[200], c=2.0, parameterization=parameterization, cov_func=cov_func)
+            hsgp = pm.gp.HSGP(m=[200], c=2.0, parametrization=parametrization, cov_func=cov_func)
             f1 = hsgp.prior("f1", X=X1)
 
             gp = pm.gp.Latent(cov_func=cov_func)
@@ -200,19 +201,19 @@ class TestHSGP(_BaseFixtures):
         assert not reject, "H0 was rejected, even though HSGP and GP priors should match."
 
     @pytest.mark.parametrize(
-        "cov_func,parameterization",
+        "cov_func,parametrization",
         [
             (pm.gp.cov.ExpQuad(1, ls=1), "centered"),
             (pm.gp.cov.ExpQuad(1, ls=1), "noncentered"),
         ],
     )
-    def test_conditional(self, model, cov_func, X1, parameterization):
+    def test_conditional(self, model, cov_func, X1, parametrization):
         """Compare HSGP conditional to unapproximated GP prior, pm.gp.Latent.  Draw samples from the
         prior and compare them using MMD two sample test.  Tests both centered and non-centered
-        parameterizations.  The conditional should match the prior when no data is observed.
+        parametrization.  The conditional should match the prior when no data is observed.
         """
         with model:
-            hsgp = pm.gp.HSGP(m=[100], c=2.0, parameterization=parameterization, cov_func=cov_func)
+            hsgp = pm.gp.HSGP(m=[100], c=2.0, parametrization=parametrization, cov_func=cov_func)
             f = hsgp.prior("f", X=X1)
             fc = hsgp.conditional("fc", Xnew=X1)
 

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -123,7 +123,7 @@ class TestHSGP(_BaseFixtures):
 
     def test_mean_invariance(self):
         X = np.linspace(0, 10, 100)[:, None]
-        original_mean = np.mean(X, axis=0)
+        original_center = (np.max(X, axis=0) - np.min(X, axis=0)) / 2
 
         with pm.Model() as model:
             _ = pm.Data("X", X)
@@ -136,8 +136,8 @@ class TestHSGP(_BaseFixtures):
             pm.set_data({"X": x_new})
 
         assert np.allclose(
-            gp._X_mean, original_mean
-        ), "gp._X_mean should not change after updating data for out-of-sample predictions."
+            gp._X_center, original_center
+        ), "gp._X_center should not change after updating data for out-of-sample predictions."
 
     def test_parametrization(self):
         err_msg = (


### PR DESCRIPTION
Closes #7240 

Working on this in concert with @bwengals for [this example](https://github.com/pymc-devs/pymc-examples/pull/647)

- [x] Fix the [bug in the computation](https://github.com/pymc-devs/pymc/issues/7240) of `L`
- [x] Do mean-centering of `X` values under the hood, instead of requiring it from users
- [x] Enable setting `prior_linearized` with `m` and `c` instead of only `m` and `L`
- [x] `parametrization` is not documented
- [x] Add option to pass in nicely named `coords` to HSGP for the `beta` coefficients
- [x] Make `._m_star` more accessible / user friendly (make a property with no leading underscore so existing code doesn't break), document it, and fix example in `prior_linearized` docstring.
- [x] Get rid of numpy option, `tl=np`.  It's subtly wrong when calculating the eigen stuff and its not used anywhere.
- [x] Add the `approx_params` function to `hsgp_approx` file

## Type of change
- New feature / enhancement
- Bug fix

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7335.org.readthedocs.build/en/7335/

<!-- readthedocs-preview pymc end -->