### PR TITLE
Allow customizing truncation max_n_steps in Hurdle Mixtures

### DIFF
--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -798,7 +798,7 @@ class ZeroInflatedNegativeBinomial:
         )
 
 
-def _hurdle_mixture(*, name, nonzero_p, nonzero_dist, dtype, **kwargs):
+def _hurdle_mixture(*, name, nonzero_p, nonzero_dist, dtype, max_n_steps=None, **kwargs):
     """Helper function to create a hurdle mixtures
 
     If name is `None`, this function returns an unregistered variable
@@ -818,18 +818,15 @@ def _hurdle_mixture(*, name, nonzero_p, nonzero_dist, dtype, **kwargs):
     nonzero_p = pt.as_tensor_variable(nonzero_p)
     weights = pt.stack([1 - nonzero_p, nonzero_p], axis=-1)
 
-    truncated_kwargs = {k: v for k, v in kwargs.items() if k in {"lower", "upper", "max_n_steps"}}
-    mixture_kwargs = {k: v for k, v in kwargs.items() if k not in truncated_kwargs}
-
     comp_dists = [
         DiracDelta.dist(zero),
-        Truncated.dist(nonzero_dist, lower=lower, **truncated_kwargs),
+        Truncated.dist(nonzero_dist, lower=lower, max_n_steps=max_n_steps),
     ]
 
     if name is not None:
-        return Mixture(name, weights, comp_dists, **mixture_kwargs)
+        return Mixture(name, weights, comp_dists, **kwargs)
     else:
-        return Mixture.dist(weights, comp_dists, **mixture_kwargs)
+        return Mixture.dist(weights, comp_dists, **kwargs)
 
 
 class HurdlePoisson:

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -818,10 +818,11 @@ def _hurdle_mixture(*, name, nonzero_p, nonzero_dist, dtype, max_n_steps=None, *
     nonzero_p = pt.as_tensor_variable(nonzero_p)
     weights = pt.stack([1 - nonzero_p, nonzero_p], axis=-1)
 
-    comp_dists = [
-        DiracDelta.dist(zero),
-        Truncated.dist(nonzero_dist, lower=lower, max_n_steps=max_n_steps),
-    ]
+    if max_n_steps:
+        truncated_dist = Truncated.dist(nonzero_dist, lower=lower, max_n_steps=max_n_steps)
+    else:
+        truncated_dist = Truncated.dist(nonzero_dist, lower=lower)
+    comp_dists = [DiracDelta.dist(zero), truncated_dist]
 
     if name is not None:
         return Mixture(name, weights, comp_dists, **kwargs)

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -817,15 +817,19 @@ def _hurdle_mixture(*, name, nonzero_p, nonzero_dist, dtype, **kwargs):
 
     nonzero_p = pt.as_tensor_variable(nonzero_p)
     weights = pt.stack([1 - nonzero_p, nonzero_p], axis=-1)
+
+    truncated_kwargs = {k: v for k, v in kwargs.items() if k in {"lower", "upper", "max_n_steps"}}
+    mixture_kwargs = {key: val for key, val in kwargs.items() if key not in truncated_kwargs}
+
     comp_dists = [
         DiracDelta.dist(zero),
-        Truncated.dist(nonzero_dist, lower=lower),
+        Truncated.dist(nonzero_dist, lower=lower, **truncated_kwargs),
     ]
 
     if name is not None:
-        return Mixture(name, weights, comp_dists, **kwargs)
+        return Mixture(name, weights, comp_dists, **mixture_kwargs)
     else:
-        return Mixture.dist(weights, comp_dists, **kwargs)
+        return Mixture.dist(weights, comp_dists, **mixture_kwargs)
 
 
 class HurdlePoisson:

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -798,7 +798,7 @@ class ZeroInflatedNegativeBinomial:
         )
 
 
-def _hurdle_mixture(*, name, nonzero_p, nonzero_dist, dtype, max_n_steps: int = 10_000, **kwargs):
+def _hurdle_mixture(*, name, nonzero_p, nonzero_dist, dtype, max_n_steps=10_000, **kwargs):
     """Helper function to create a hurdle mixtures
 
     If name is `None`, this function returns an unregistered variable

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -798,7 +798,7 @@ class ZeroInflatedNegativeBinomial:
         )
 
 
-def _hurdle_mixture(*, name, nonzero_p, nonzero_dist, dtype, max_n_steps=None, **kwargs):
+def _hurdle_mixture(*, name, nonzero_p, nonzero_dist, dtype, max_n_steps: int = 10_000, **kwargs):
     """Helper function to create a hurdle mixtures
 
     If name is `None`, this function returns an unregistered variable
@@ -817,12 +817,10 @@ def _hurdle_mixture(*, name, nonzero_p, nonzero_dist, dtype, max_n_steps=None, *
 
     nonzero_p = pt.as_tensor_variable(nonzero_p)
     weights = pt.stack([1 - nonzero_p, nonzero_p], axis=-1)
-
-    if max_n_steps:
-        truncated_dist = Truncated.dist(nonzero_dist, lower=lower, max_n_steps=max_n_steps)
-    else:
-        truncated_dist = Truncated.dist(nonzero_dist, lower=lower)
-    comp_dists = [DiracDelta.dist(zero), truncated_dist]
+    comp_dists = [
+        DiracDelta.dist(zero),
+        Truncated.dist(nonzero_dist, lower=lower, max_n_steps=max_n_steps),
+    ]
 
     if name is not None:
         return Mixture(name, weights, comp_dists, **kwargs)

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -819,7 +819,7 @@ def _hurdle_mixture(*, name, nonzero_p, nonzero_dist, dtype, **kwargs):
     weights = pt.stack([1 - nonzero_p, nonzero_p], axis=-1)
 
     truncated_kwargs = {k: v for k, v in kwargs.items() if k in {"lower", "upper", "max_n_steps"}}
-    mixture_kwargs = {key: val for key, val in kwargs.items() if key not in truncated_kwargs}
+    mixture_kwargs = {k: v for k, v in kwargs.items() if k not in truncated_kwargs}
 
     comp_dists = [
         DiracDelta.dist(zero),


### PR DESCRIPTION
## Description
Separates kwargs going to `_hurdle_mixture` by name. Gathers any which should redirect to `Truncated` (`lower`, `upper`, and `max_n_steps`), and otherwise assumes they should go to `Mixture`.

## Related Issue
- [x] Closes #7307

Reproducing their MWE after changes:

```
import pymc as pm
import pytensor as pt
with pm.Model():
     ad_nb = pm.HurdleNegativeBinomial('ad_nb', psi=.1, n=4000, p=1 - 5.8 * 1e-5, max_n_steps=10000)
     prior = pm.sample_prior_predictive(samples=100)
print("Done!")
```

Gives:

```
WARNING (pytensor.tensor.blas): Using NumPy C-API based implementation for BLAS functions.
Sampling: [ad_nb]
Done!
```

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
No new tests, confirmed existing `tests/distributions/test_mixture.py` runs without errors (python 3.12)

- [ ] Added necessary documentation (docstrings and/or example notebooks)
Probably not warranted

- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7339.org.readthedocs.build/en/7339/

<!-- readthedocs-preview pymc end -->