### PR TITLE
Add refresh call to progress bar in apply_function_over_dataset

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -660,6 +660,7 @@ def apply_function_over_dataset(
                 out_dict.insert(var_name, val, idx)
 
             progress.advance(task)
+        progress.update(task, refresh=True, completed=n_pts)
 
     out_trace = out_dict.trace_dict
     for key, val in out_trace.items():


### PR DESCRIPTION
## Description
`compute_log_likelihood` typically runs so quickly that the progress bar does not update and sits at 0% at the end of the calculation. This adds a `refresh` call to the progress bar after iteration so that it finishes at 100%.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7343.org.readthedocs.build/en/7343/

<!-- readthedocs-preview pymc end -->