### PR TITLE
Implement specialized MvNormal density based on precision matrix

### DIFF
--- a/pymc/logprob/rewriting.py
+++ b/pymc/logprob/rewriting.py
@@ -60,6 +60,7 @@ from pytensor.graph.rewriting.basic import (
     out2in,
 )
 from pytensor.graph.rewriting.db import (
+    EquilibriumDB,
     LocalGroupDB,
     RewriteDatabase,
     RewriteDatabaseQuery,
@@ -378,6 +379,14 @@ logprob_rewrites_db.register("measurable_ir_rewrites", measurable_ir_rewrites_db
 # "up" through the random/measurable variables and into their inputs.
 measurable_ir_rewrites_db.register("subtensor_lift", local_subtensor_rv_lift, "basic")
 measurable_ir_rewrites_db.register("incsubtensor_lift", incsubtensor_rv_replace, "basic")
+
+# These rewrites are used to introduce specalized operations with better logprob graphs
+specialization_ir_rewrites_db = EquilibriumDB()
+specialization_ir_rewrites_db.name = "specialization_ir_rewrites_db"
+logprob_rewrites_db.register(
+    "specialization_ir_rewrites_db", specialization_ir_rewrites_db, "basic"
+)
+
 
 logprob_rewrites_db.register("post-canonicalize", optdb.query("+canonicalize"), "basic")
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
This PR is exploring a specialized logp for a MvNormal (and possible MvStudentT) parametrized directly in terms of tau. According to  common model implementation looks like:

```python
import pymc as pm
import numpy as np

A = np.array([
    [0, 1, 1],
    [1, 0, 1], 
    [1, 1, 0]
])
D = A.sum(axis=-1)
np.testing.assert_allclose(A, A.T), "should be symmetric"

with pm.Model() as m:
    tau = pm.InverseGamma("tau", 1, 1)
    alpha = pm.Beta("alpha", 10, 10)
    Q = tau * (D - alpha * A)
    y = pm.MvNormal("y", mu=np.zeros(3), tau=Q)
```

## TODO (some are optional for this PR)
- [x] Benchmark to confirm it's more performant than old form where there's a matrix inverse and a cholesky decomposition (now we have a slogdet that does LU factorization under the hood)
- [x] Benchmark gradients as well
- [x] Check whether CAR is redundant with this?
- [x] Add tests
- [ ] Consider extending to MvStudentT
- [x] Explore whether something based on Cholesky decomposition still makes (more) sense here. CC @aseyboldt 
- [x] ~~Sparse implementation? May need some ideas like: https://stackoverflow.com/questions/19107617/how-to-compute-scipy-sparse-matrix-determinant-without-turning-it-to-dense~~ Investigate in a follow up PR


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Related to https://github.com/pymc-devs/pymc-experimental/issues/340

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

CC @theorashid @elizavetasemenova

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7345.org.readthedocs.build/en/7345/

<!-- readthedocs-preview pymc end -->