### PR TITLE
Allow opting out of model nesting by setting `model=None`

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -25,6 +25,7 @@ from typing import (
     Literal,
     Optional,
     TypeVar,
+    Union,
     cast,
     overload,
 )
@@ -441,7 +442,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         coords = {
             "feature", ["A", "B", "C"],
-             "trial", [1, 2, 3, 4, 5],
+            "trial", [1, 2, 3, 4, 5],
         }
 
         with pm.Model(coords=coords) as model:
@@ -476,6 +477,11 @@ class Model(WithMemoization, metaclass=ContextMeta):
                 # Variable will belong to root and second
                 z = pm.Normal("z", mu=y)  # Variable wil be named "root::second::z"
 
+            # Set None for standalone model
+            with pm.Model(name="third", model=None) as third:
+                # Variable will belong to third only
+                w = pm.Normal("w")  # Variable wil be named "third::w"
+
 
     Set `check_bounds` to False for models with only continuous variables and default transformers
     PyMC will remove the bounds check from the model logp which can speed up sampling
@@ -497,13 +503,13 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         def __exit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None: ...
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, model: Union[Literal[UNSET], None, "Model"] = UNSET, **kwargs):
         # resolves the parent instance
         instance = super().__new__(cls)
-        if kwargs.get("model") is not None:
-            instance._parent = kwargs.get("model")
-        else:
+        if model is UNSET:
             instance._parent = cls.get_context(error_if_none=False)
+        else:
+            instance._parent = model
         return instance
 
     @staticmethod
@@ -519,9 +525,9 @@ class Model(WithMemoization, metaclass=ContextMeta):
         check_bounds=True,
         *,
         coords_mutable=None,
-        model=None,
+        model: Union[Literal[UNSET], None, "Model"] = UNSET,
     ):
-        del model  # used in __new__
+        del model  # used in __new__ to define the parent of this model
         self.name = self._validate_name(name)
         self.check_bounds = check_bounds
 

--- a/pymc/model/fgraph.py
+++ b/pymc/model/fgraph.py
@@ -299,9 +299,7 @@ def model_from_fgraph(fgraph: FunctionGraph, mutate_fgraph: bool = False) -> Mod
         else:
             return var
 
-    model = Model()
-    if model.parent is not None:
-        raise RuntimeError("model_to_fgraph cannot be called inside a PyMC model context")
+    model = Model(model=None)  # Do not inherit from any model in the context manager
 
     _coords = getattr(fgraph, "_coords", {})
     _dim_lengths = getattr(fgraph, "_dim_lengths", {})

--- a/pymc/model/transform/basic.py
+++ b/pymc/model/transform/basic.py
@@ -16,7 +16,7 @@ from collections.abc import Sequence
 from pytensor import Variable
 from pytensor.graph import ancestors
 
-from pymc import Model
+from pymc.model.core import Model
 from pymc.model.fgraph import (
     ModelObservedRV,
     ModelVar,

--- a/pymc/model/transform/conditioning.py
+++ b/pymc/model/transform/conditioning.py
@@ -19,9 +19,9 @@ from typing import Any, Union
 from pytensor.graph import ancestors
 from pytensor.tensor import TensorVariable
 
-from pymc import Model
 from pymc.logprob.transforms import Transform
 from pymc.logprob.utils import rvs_in_graph
+from pymc.model.core import Model
 from pymc.model.fgraph import (
     ModelDeterministic,
     ModelFreeRV,

--- a/pymc/sampling/deterministic.py
+++ b/pymc/sampling/deterministic.py
@@ -83,7 +83,7 @@ def compute_deterministics(
     model = modelcontext(model)
 
     if var_names is None:
-        deterministics = model.deterministics
+        deterministics = list(model.deterministics)
         var_names = [det.name for det in deterministics]
     else:
         deterministics = [model[var_name] for var_name in var_names]

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -143,13 +143,20 @@ class TestBaseModel:
                 # Variable will belong to root and second
                 z = pm.Normal("z", mu=y)  # Variable wil be named "root::second::z"
 
+            # Set None for standalone model
+            with pm.Model(name="third", model=None) as third:
+                # Variable will belong to third only
+                w = pm.Normal("w")  # Variable wil be named "third::w"
+
         assert x.name == "root::x"
         assert y.name == "root::first::y"
         assert z.name == "root::second::z"
+        assert w.name == "third::w"
 
         assert set(root.basic_RVs) == {x, y, z}
         assert set(first.basic_RVs) == {y}
         assert set(second.basic_RVs) == {z}
+        assert set(third.basic_RVs) == {w}
 
 
 class TestNested:
@@ -1106,11 +1113,17 @@ def test_model_parent_set_programmatically():
         y = pm.Normal("y")
 
     with model:
+        # Default inherits from model
+        with pm.Model():
+            z_in = pm.Normal("z_in")
+
+        # Explict None opts out of model context
         with pm.Model(model=None):
-            z = pm.Normal("z")
+            z_out = pm.Normal("z_out")
 
     assert "y" in model.named_vars
-    assert "z" in model.named_vars
+    assert "z_in" in model.named_vars
+    assert "z_out" not in model.named_vars
 
 
 class TestModelContext:

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -1077,22 +1077,6 @@ def test_compile_fn():
     np.testing.assert_allclose(result_compute, result_expect)
 
 
-def test_model_pytensor_config():
-    assert pytensor.config.mode != "JAX"
-    with pytest.warns(FutureWarning, match="pytensor_config is deprecated"):
-        m = pm.Model(pytensor_config=dict(mode="JAX"))
-    with m:
-        assert pytensor.config.mode == "JAX"
-    assert pytensor.config.mode != "JAX"
-
-
-def test_deprecated_model_property():
-    m = pm.Model()
-    with pytest.warns(FutureWarning, match="Model.model property is deprecated"):
-        m_property = m.model
-    assert m is m_property
-
-
 def test_model_parent_set_programmatically():
     with pm.Model() as model:
         x = pm.Normal("x")

--- a/tests/model/test_fgraph.py
+++ b/tests/model/test_fgraph.py
@@ -267,10 +267,15 @@ def test_context_error():
     with pm.Model() as m:
         x = pm.Normal("x")
 
-        fg = fgraph_from_model(m)
+        fg, _ = fgraph_from_model(m)
 
-        with pytest.raises(RuntimeError, match="cannot be called inside a PyMC model context"):
-            model_from_fgraph(fg)
+        new_m = model_from_fgraph(fg)
+        new_x = new_m["x"]
+
+    assert new_m.parent is None
+    assert x != new_x
+    assert m.named_vars == {"x": x}
+    assert new_m.named_vars == {"x": new_x}
 
 
 def test_sub_model_error():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
This PR allows setting `model=None` to explicitly disable model nesting. This is needed for model transformations `do, observe, clone, remove_value_transforms, freeze_rv_and_dims` to be possible under a model context without side-effects on the original model.

I still think model nesting is an overkill, but a lot of code out there depends on it so I am not touching it.

I also updated the docstrings with more relevant (imo) examples. The previous example was broken as per #6715 and I am not sure we really want to incentivize people to subclass PyMC models. That certainly shouldn't be the focus of the docstrings?

Finally, removed deprecated functionality.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #6715 
- [x] Related to #7268 
- [x] Related to https://github.com/pymc-devs/pymc-experimental/pull/345#discussion_r1627311093
- [x] Related to #7348

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7352.org.readthedocs.build/en/7352/

<!-- readthedocs-preview pymc end -->