### PR TITLE
Rename `samples` argument to `draws` in `sample_prior_predictive`

### DIFF
--- a/docs/source/learn/core_notebooks/posterior_predictive.ipynb
+++ b/docs/source/learn/core_notebooks/posterior_predictive.ipynb
@@ -156,7 +156,7 @@
     "    sigma = pm.Exponential(\"sigma\", 1.0)\n",
     "\n",
     "    pm.Normal(\"obs\", mu=mu, sigma=sigma, observed=outcome_scaled)\n",
-    "    idata = pm.sample_prior_predictive(samples=50, random_seed=rng)"
+    "    idata = pm.sample_prior_predictive(draws=50, random_seed=rng)"
    ]
   },
   {
@@ -225,7 +225,7 @@
     "    sigma = pm.Exponential(\"sigma\", 1.0)\n",
     "\n",
     "    pm.Normal(\"obs\", mu=mu, sigma=sigma, observed=outcome_scaled)\n",
-    "    idata = pm.sample_prior_predictive(samples=50, random_seed=rng)"
+    "    idata = pm.sample_prior_predictive(draws=50, random_seed=rng)"
    ]
   },
   {

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -380,7 +380,7 @@ def sample_prior_predictive(
         warnings.warn(
             f"The samples argument has been deprecated in favor of draws. Use draws={samples} going forward.",
             DeprecationWarning,
-            stacklevel=2,
+            stacklevel=1,
         )
 
         draws = samples

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -561,7 +561,7 @@ class TestMixture:
 
         n_samples = 30
         with model:
-            prior = sample_prior_predictive(samples=n_samples, return_inferencedata=False)
+            prior = sample_prior_predictive(draws=n_samples, return_inferencedata=False)
             ppc = sample_posterior_predictive(
                 n_samples * [self.get_initial_point(model)], return_inferencedata=False
             )
@@ -607,7 +607,7 @@ class TestMixture:
 
         n_samples = 20
         with model:
-            prior = sample_prior_predictive(samples=n_samples, return_inferencedata=False)
+            prior = sample_prior_predictive(draws=n_samples, return_inferencedata=False)
             ppc = sample_posterior_predictive(
                 n_samples * [self.get_initial_point(model)], return_inferencedata=False
             )
@@ -1028,7 +1028,7 @@ class TestMixtureSameFamily:
                 comp_dists=comp_dists,
                 shape=(*batch_shape, 3),
             )
-            prior = sample_prior_predictive(samples=self.n_samples, return_inferencedata=False)
+            prior = sample_prior_predictive(draws=self.n_samples, return_inferencedata=False)
 
         assert prior["mixture"].shape == (self.n_samples, *batch_shape, 3)
         assert draw(mixture, draws=self.size).shape == (self.size, *batch_shape, 3)
@@ -1060,7 +1060,7 @@ class TestMixtureSameFamily:
         with Model() as model:
             comp_dists = MvNormal.dist(mu=mu, chol=chol, shape=(self.mixture_comps, 3))
             mixture = Mixture("mixture", w=w, comp_dists=comp_dists, shape=(3,))
-            prior = sample_prior_predictive(samples=self.n_samples, return_inferencedata=False)
+            prior = sample_prior_predictive(draws=self.n_samples, return_inferencedata=False)
 
         assert prior["mixture"].shape == (self.n_samples, 3)
         assert draw(mixture, draws=self.size).shape == (self.size, 3)
@@ -1084,7 +1084,7 @@ class TestMixtureSameFamily:
             mu = Gamma("mu", 1.0, 1.0, shape=2)
             comp_dists = Poisson.dist(mu, shape=2)
             mix = Mixture("mix", w=np.ones(2) / 2, comp_dists=comp_dists, shape=(1000,))
-            prior = sample_prior_predictive(samples=self.n_samples, return_inferencedata=False)
+            prior = sample_prior_predictive(draws=self.n_samples, return_inferencedata=False)
 
         assert prior["mix"].shape == (self.n_samples, 1000)
 

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -1448,7 +1448,7 @@ class TestMvNormalMisc:
                 "chol_cov", n=3, eta=2, sd_dist=sd_dist, compute_corr=True
             )
             mv = pm.MvNormal("mv", mu, chol=chol, size=4)
-            prior = pm.sample_prior_predictive(samples=10, return_inferencedata=False)
+            prior = pm.sample_prior_predictive(draws=10, return_inferencedata=False)
 
         assert prior["mv"].shape == (10, 4, 3)
 
@@ -1462,7 +1462,7 @@ class TestMvNormalMisc:
                 "chol_cov", n=3, eta=2, sd_dist=sd_dist, compute_corr=True
             )
             mv = pm.MvNormal("mv", mu, cov=pm.math.dot(chol, chol.T), size=4)
-            prior = pm.sample_prior_predictive(samples=10, return_inferencedata=False)
+            prior = pm.sample_prior_predictive(draws=10, return_inferencedata=False)
 
         assert prior["mv"].shape == (10, 4, 3)
 
@@ -1473,7 +1473,7 @@ class TestMvNormalMisc:
             corr = pm.LKJCorr("corr", n=3, eta=2, return_matrix=True)
             pm.Deterministic("corr_mat", corr)
             mv = pm.MvNormal("mv", 0.0, cov=corr, size=4)
-            prior = pm.sample_prior_predictive(samples=10, return_inferencedata=False)
+            prior = pm.sample_prior_predictive(draws=10, return_inferencedata=False)
 
         assert prior["corr_mat"].shape == (10, 3, 3)  # square
         assert (prior["corr_mat"][:, [0, 1, 2], [0, 1, 2]] == 1.0).all()  # 1.0 on diagonal

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -213,7 +213,7 @@ class TestHSGP(_BaseFixtures):
             gp = pm.gp.Latent(cov_func=cov_func)
             f2 = gp.prior("f2", X=X1)
 
-            idata = pm.sample_prior_predictive(samples=1000, random_seed=rng)
+            idata = pm.sample_prior_predictive(draws=1000, random_seed=rng)
 
         samples1 = az.extract(idata.prior["f1"])["f1"].values.T
         samples2 = az.extract(idata.prior["f2"])["f2"].values.T
@@ -240,7 +240,7 @@ class TestHSGP(_BaseFixtures):
             f = hsgp.prior("f", X=X1)
             fc = hsgp.conditional("fc", Xnew=X1)
 
-            idata = pm.sample_prior_predictive(samples=1000)
+            idata = pm.sample_prior_predictive(draws=1000)
 
         samples1 = az.extract(idata.prior["f"])["f"].values.T
         samples2 = az.extract(idata.prior["fc"])["fc"].values.T
@@ -300,7 +300,7 @@ class TestHSGPPeriodic(_BaseFixtures):
             gp = pm.gp.Latent(cov_func=eta**2 * cov_func)
             f2 = gp.prior("f2", X=X1)
 
-            idata = pm.sample_prior_predictive(samples=1000, random_seed=rng)
+            idata = pm.sample_prior_predictive(draws=1000, random_seed=rng)
 
         samples1 = az.extract(idata.prior["f1"])["f1"].values.T
         samples2 = az.extract(idata.prior["f2"])["f2"].values.T
@@ -321,7 +321,7 @@ class TestHSGPPeriodic(_BaseFixtures):
             f = hsgp.prior("f", X=X1)
             fc = hsgp.conditional("fc", Xnew=X1)
 
-            idata = pm.sample_prior_predictive(samples=1000)
+            idata = pm.sample_prior_predictive(draws=1000)
 
         samples1 = az.extract(idata.prior["f"])["f"].values.T
         samples2 = az.extract(idata.prior["fc"])["fc"].values.T

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -873,7 +873,7 @@ class TestSetUpdateCoords:
             m.add_coord(name="a", values=None, length=3)
             m.add_coord(name="b", values=range(5))
             x = pm.Normal("x", dims=("a", "b"))
-            prior = pm.sample_prior_predictive(samples=2).prior
+            prior = pm.sample_prior_predictive(draws=2).prior
         assert prior["x"].shape == (1, 2, 3, 5)
         assert list(prior.coords["a"].values) == list(range(3))
         assert list(prior.coords["b"].values) == list(range(5))

--- a/tests/sampling/test_deterministic.py
+++ b/tests/sampling/test_deterministic.py
@@ -34,7 +34,7 @@ def test_compute_deterministics():
         sigma = Deterministic("sigma", sigma_raw.exp())
 
     dataset = sample_prior_predictive(
-        samples=5, model=m, var_names=["mu_raw", "sigma_raw"], random_seed=22
+        draws=5, model=m, var_names=["mu_raw", "sigma_raw"], random_seed=22
     ).prior
 
     # Test default


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

Consolidate with other sampling parameter names

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7173 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7366.org.readthedocs.build/en/7366/

<!-- readthedocs-preview pymc end -->