### PR TITLE
Avoid internal deprecation warnings in tests

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1159,9 +1159,8 @@ class Model(WithMemoization, metaclass=ContextMeta):
                     raise ShapeError(
                         f"Resizing dimension '{dname}' is impossible, because "
                         "a `TensorConstant` stores its length. To be able "
-                        "to change the dimension length, pass `mutable=True` when "
-                        "registering the dimension via `model.add_coord`, "
-                        "or define it via a `pm.MutableData` variable."
+                        "to change the dimension length, create data with "
+                        "pm.Data() instead."
                     )
                 elif length_tensor.owner is not None:
                     # The dimension was created from another variable:

--- a/pymc/model/transform/conditioning.py
+++ b/pymc/model/transform/conditioning.py
@@ -249,7 +249,7 @@ def change_value_transforms(
         from pymc.model.transform.conditioning import change_value_transforms
 
         with pm.Model() as base_m:
-            p = pm.Uniform("p", 0, 1, transform=None)
+            p = pm.Uniform("p", 0, 1, default_transform=None)
             w = pm.Binomial("w", n=9, p=p, observed=6)
 
         with change_value_transforms(base_m, {"p": logodds}) as transformed_p:

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -242,7 +242,7 @@ def build_model(distfam, valuedomain, vardomains, extra_args=None):
         distfam(
             "value",
             **param_vars,
-            transform=None,
+            default_transform=None,
         )
     return m, param_vars
 

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -370,7 +370,7 @@ class TestMatchesScipy:
         # See e.g., doi: 10.1111/j.1467-9876.2005.00510.x, or
         # http://www.gamlss.org/.
         with pm.Model() as model:
-            pm.Wald("wald", mu=mu, lam=lam, phi=phi, alpha=alpha, transform=None)
+            pm.Wald("wald", mu=mu, lam=lam, phi=phi, alpha=alpha, default_transform=None)
         point = {"wald": value}
         decimals = select_by_precision(float64=6, float32=1)
         npt.assert_almost_equal(

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -83,7 +83,7 @@ class TestBugfixes:
         # Test for bug in Uniform and DiscreteUniform logp when setting check_bounds = False
         # https://github.com/pymc-devs/pymc/issues/4499
         with pm.Model(check_bounds=False) as m:
-            x = pm.Uniform("x", 0, 2, size=10, transform=None)
+            x = pm.Uniform("x", 0, 2, size=10, default_transform=None)
         npt.assert_almost_equal(m.compile_logp()({"x": np.ones(10)}), -np.log(2) * 10)
 
         with pm.Model(check_bounds=False) as m:

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -433,7 +433,7 @@ class TestMixture:
         cov2 = np.diag([2.5, 3.5])
         obs = np.asarray([[0.5, 0.5], mu1, mu2])
         with Model() as model:
-            w = Dirichlet("w", floatX(np.ones(2)), transform=None, shape=(2,))
+            w = Dirichlet("w", floatX(np.ones(2)), default_transform=None, shape=(2,))
             mvncomp1 = MvNormal.dist(mu=mu1, cov=cov1)
             mvncomp2 = MvNormal.dist(mu=mu2, cov=cov2)
             y = Mixture("x_obs", w, [mvncomp1, mvncomp2], observed=obs)
@@ -630,19 +630,27 @@ class TestMixture:
         with Model() as model:
             # mixtures components
             g_comp = Normal.dist(
-                mu=Exponential("mu_g", lam=1.0, shape=nbr, transform=None), sigma=1, shape=nbr
+                mu=Exponential("mu_g", lam=1.0, shape=nbr, default_transform=None),
+                sigma=1,
+                shape=nbr,
             )
             l_comp = LogNormal.dist(
-                mu=Exponential("mu_l", lam=1.0, shape=nbr, transform=None), sigma=1, shape=nbr
+                mu=Exponential("mu_l", lam=1.0, shape=nbr, default_transform=None),
+                sigma=1,
+                shape=nbr,
             )
             # weight vector for the mixtures
-            g_w = Dirichlet("g_w", a=floatX(np.ones(nbr) * 0.0000001), transform=None, shape=(nbr,))
-            l_w = Dirichlet("l_w", a=floatX(np.ones(nbr) * 0.0000001), transform=None, shape=(nbr,))
+            g_w = Dirichlet(
+                "g_w", a=floatX(np.ones(nbr) * 0.0000001), default_transform=None, shape=(nbr,)
+            )
+            l_w = Dirichlet(
+                "l_w", a=floatX(np.ones(nbr) * 0.0000001), default_transform=None, shape=(nbr,)
+            )
             # mixture components
             g_mix = Mixture.dist(w=g_w, comp_dists=g_comp)
             l_mix = Mixture.dist(w=l_w, comp_dists=l_comp)
             # mixture of mixtures
-            mix_w = Dirichlet("mix_w", a=floatX(np.ones(2)), transform=None, shape=(2,))
+            mix_w = Dirichlet("mix_w", a=floatX(np.ones(2)), default_transform=None, shape=(2,))
             mix = Mixture("mix", w=mix_w, comp_dists=[g_mix, l_mix], observed=np.exp(norm_x))
 
         test_point = model.initial_point()
@@ -1306,9 +1314,9 @@ class TestMixtureDefaultTransforms:
         with Model() as model:
             lower = Normal("lower", 0.5)
             upper = Uniform("upper", 0, 1)
-            uniform = Uniform("uniform", -pt.abs(lower), pt.abs(upper), transform=None)
+            uniform = Uniform("uniform", -pt.abs(lower), pt.abs(upper), default_transform=None)
             triangular = Triangular(
-                "triangular", -pt.abs(lower), pt.abs(upper), c=0.25, transform=None
+                "triangular", -pt.abs(lower), pt.abs(upper), c=0.25, default_transform=None
             )
             comp_dists = [
                 Uniform.dist(-pt.abs(lower), pt.abs(upper)),
@@ -1334,7 +1342,7 @@ class TestMixtureDefaultTransforms:
             halfnorm = HalfNormal("halfnorm")
             comp_dists = [HalfNormal.dist(), HalfNormal.dist()]
             mix_transf = Mixture("mix_transf", w=[0.5, 0.5], comp_dists=comp_dists)
-            mix = Mixture("mix", w=[0.5, 0.5], comp_dists=comp_dists, transform=None)
+            mix = Mixture("mix", w=[0.5, 0.5], comp_dists=comp_dists, default_transform=None)
 
         logp_fn = m.compile_logp(vars=[halfnorm, mix_transf, mix], sum=False)
         test_point = {"halfnorm_log__": 1, "mix_transf_log__": 1, "mix": np.exp(1)}

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -559,7 +559,7 @@ class TestMatchesScipy:
     @pytest.mark.parametrize("x,eta,n,lp", LKJ_CASES)
     def test_lkjcorr(self, x, eta, n, lp):
         with pm.Model() as model:
-            pm.LKJCorr("lkj", eta=eta, n=n, transform=None, return_matrix=False)
+            pm.LKJCorr("lkj", eta=eta, n=n, default_transform=None, return_matrix=False)
 
         point = {"lkj": x}
         decimals = select_by_precision(float64=6, float32=4)
@@ -790,7 +790,7 @@ class TestMatchesScipy:
     )
     def test_stickbreakingweights_logp(self, value, alpha, K, logp):
         with pm.Model() as model:
-            sbw = pm.StickBreakingWeights("sbw", alpha=alpha, K=K, transform=None)
+            sbw = pm.StickBreakingWeights("sbw", alpha=alpha, K=K, default_transform=None)
         point = {"sbw": value}
         npt.assert_almost_equal(
             pm.logp(sbw, value).eval(),
@@ -817,7 +817,7 @@ class TestMatchesScipy:
     def test_stickbreakingweights_vectorized(self, alpha, K, stickbreakingweights_logpdf):
         value = pm.StickBreakingWeights.dist(alpha, K).eval()
         with pm.Model():
-            sbw = pm.StickBreakingWeights("sbw", alpha=alpha, K=K, transform=None)
+            sbw = pm.StickBreakingWeights("sbw", alpha=alpha, K=K, default_transform=None)
         point = {"sbw": value}
         npt.assert_almost_equal(
             pm.logp(sbw, value).eval(),

--- a/tests/distributions/test_truncated.py
+++ b/tests/distributions/test_truncated.py
@@ -386,7 +386,7 @@ def test_truncated_default_transform():
 def test_truncated_transform_logp():
     with Model() as m:
         base_dist = rejection_normal(0, 1)
-        x = Truncated("x", base_dist, lower=0, upper=None, transform=None)
+        x = Truncated("x", base_dist, lower=0, upper=None, default_transform=None)
         y = Truncated("y", base_dist, lower=0, upper=None)
         logp_eval = m.compile_logp(sum=False)({"x": -1, "y_interval__": -1})
     assert logp_eval[0] == -np.inf

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -900,7 +900,7 @@ class TestSetUpdateCoords:
 
     def test_set_data_indirect_resize_with_coords(self):
         with pm.Model() as pmodel:
-            pmodel.add_coord("mdim", ["A", "B"], mutable=True, length=2)
+            pmodel.add_coord("mdim", ["A", "B"], length=2)
             pm.Data("mdata", [1, 2], dims="mdim")
 
         assert pmodel.coords["mdim"] == ("A", "B")

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -1648,7 +1648,7 @@ class TestModelDebug:
     def test_invalid_value(self, capfd):
         with pm.Model() as m:
             x = pm.Normal("x", [1, -1, 1])
-            y = pm.HalfNormal("y", tau=pm.math.abs(x), initval=[-1, 1, -1], transform=None)
+            y = pm.HalfNormal("y", tau=pm.math.abs(x), initval=[-1, 1, -1], default_transform=None)
         m.debug()
 
         out, _ = capfd.readouterr()

--- a/tests/model/transform/test_conditioning.py
+++ b/tests/model/transform/test_conditioning.py
@@ -255,7 +255,7 @@ def test_do_self_reference():
 
 def test_change_value_transforms():
     with pm.Model() as base_m:
-        p = pm.Uniform("p", 0, 1, transform=None)
+        p = pm.Uniform("p", 0, 1, default_transform=None)
         w = pm.Binomial("w", n=9, p=p, observed=6)
         assert base_m.rvs_to_transforms[p] is None
         assert base_m.rvs_to_values[p].name == "p"

--- a/tests/models.py
+++ b/tests/models.py
@@ -161,13 +161,13 @@ def mv_simple_discrete():
 
 def non_normal(n=2):
     with pm.Model() as model:
-        pm.Beta("x", 3, 3, size=n, transform=None)
+        pm.Beta("x", 3, 3, size=n, default_transform=None)
     return model.initial_point(), model, (np.tile([0.5], n), None)
 
 
 def beta_bernoulli(n=2):
     with pm.Model() as model:
-        pm.Beta("x", 3, 1, size=n, transform=None)
+        pm.Beta("x", 3, 1, size=n, default_transform=None)
         pm.Bernoulli("y", 0.5)
     return model.initial_point(), model, None
 

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -342,8 +342,8 @@ class TestCompileForwardSampler:
         rng = np.random.default_rng(seed=42)
         data = rng.normal(loc=1, scale=0.2, size=(10, 3))
         with pm.Model() as model:
-            model.add_coord("name", ["A", "B", "C"], mutable=True)
-            model.add_coord("obs", list(range(10, 20)), mutable=True)
+            model.add_coord("name", ["A", "B", "C"])
+            model.add_coord("obs", list(range(10, 20)))
             offsets = pm.Data("offsets", rng.normal(0, 1, size=(10,)))
             a = pm.Normal("a", mu=0, sigma=1, dims=["name"])
             b = pm.Normal("b", mu=offsets, sigma=1)
@@ -873,8 +873,8 @@ class TestSamplePPC:
         rng = np.random.default_rng(seed=42)
         data = rng.normal(loc=1, scale=0.2, size=(10, 3))
         with pm.Model() as model:
-            model.add_coord("name", ["A", "B", "C"], mutable=True)
-            model.add_coord("obs", list(range(10, 20)), mutable=True)
+            model.add_coord("name", ["A", "B", "C"])
+            model.add_coord("obs", list(range(10, 20)))
             offsets = pm.Data("offsets", rng.normal(0, 1, size=(10,)))
             a = pm.Normal("a", mu=0, sigma=1, dims=["name"])
             b = pm.Normal("b", mu=offsets, sigma=1)

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -504,7 +504,7 @@ def test_sample_var_names():
 def test_convergence_warnings(caplog, nuts_sampler):
     with pm.Model() as m:
         # Model that should diverge
-        sigma = pm.Normal("sigma", initval=3, transform=None)
+        sigma = pm.Normal("sigma", initval=3, default_transform=None)
         pm.Normal("obs", mu=0, sigma=sigma, observed=[0.99, 1.0, 1.01])
 
         with caplog.at_level(logging.WARNING, logger="pymc"):

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -627,7 +627,7 @@ def test_exec_nuts_init(method):
 )
 def test_init_jitter(initval, jitter_max_retries, expectation):
     with pm.Model() as m:
-        pm.HalfNormal("x", transform=None, initval=initval)
+        pm.HalfNormal("x", default_transform=None, initval=initval)
 
     with expectation:
         # Starting value is negative (invalid) when np.random.rand returns 0 (jitter = -1)

--- a/tests/step_methods/hmc/test_nuts.py
+++ b/tests/step_methods/hmc/test_nuts.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 
 import logging
-import sys
 import warnings
 
 import numpy as np
@@ -114,7 +113,6 @@ class TestNutsCheckTrace:
                 pm.sample(chains=1, random_seed=1)
             error.match("Initial evaluation")
 
-    @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
     def test_bad_init_parallel(self):
         with pm.Model():
             pm.HalfNormal("a", sigma=1, initval=-1, transform=None)

--- a/tests/step_methods/hmc/test_nuts.py
+++ b/tests/step_methods/hmc/test_nuts.py
@@ -108,14 +108,14 @@ class TestNutsCheckTrace:
 
     def test_bad_init_nonparallel(self):
         with pm.Model():
-            pm.HalfNormal("a", sigma=1, initval=-1, transform=None)
+            pm.HalfNormal("a", sigma=1, initval=-1, default_transform=None)
             with pytest.raises(SamplingError) as error:
                 pm.sample(chains=1, random_seed=1)
             error.match("Initial evaluation")
 
     def test_bad_init_parallel(self):
         with pm.Model():
-            pm.HalfNormal("a", sigma=1, initval=-1, transform=None)
+            pm.HalfNormal("a", sigma=1, initval=-1, default_transform=None)
             with pytest.raises(SamplingError) as error:
                 pm.sample(cores=2, random_seed=1)
             error.match("Initial evaluation")

--- a/tests/test_initial_point.py
+++ b/tests/test_initial_point.py
@@ -66,7 +66,7 @@ class TestInitvalEvaluation:
     def test_make_initial_point_fns_per_chain_checks_kwargs(self):
         with pm.Model() as pmodel:
             A = pm.Uniform("A", 0, 1, initval=0.5)
-            B = pm.Uniform("B", lower=A, upper=1.5, transform=None, initval="support_point")
+            B = pm.Uniform("B", lower=A, upper=1.5, default_transform=None, initval="support_point")
         with pytest.raises(ValueError, match="Number of initval dicts"):
             make_initial_point_fns_per_chain(
                 model=pmodel,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

Remove the stale mutable=True which just causes unwanted warnings

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #7367 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7368.org.readthedocs.build/en/7368/

<!-- readthedocs-preview pymc end -->