### PR TITLE
Remove default initval for Flat variables

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -373,10 +373,6 @@ class Flat(Continuous):
 
     rv_op = flat
 
-    def __new__(cls, *args, **kwargs):
-        kwargs.setdefault("initval", "support_point")
-        return super().__new__(cls, *args, **kwargs)
-
     @classmethod
     def dist(cls, **kwargs):
         res = super().dist([], **kwargs)
@@ -413,10 +409,6 @@ class HalfFlat(PositiveContinuous):
     """Improper flat prior over the positive reals."""
 
     rv_op = halfflat
-
-    def __new__(cls, *args, **kwargs):
-        kwargs.setdefault("initval", "support_point")
-        return super().__new__(cls, *args, **kwargs)
 
     @classmethod
     def dist(cls, **kwargs):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
This was brought up in #7348. I think this default was present before the `support_point` machinery was implemented and we used to take a random draw from the prior to decide on the initial point. That has long ceased to be the case.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #7348 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7379.org.readthedocs.build/en/7379/

<!-- readthedocs-preview pymc end -->