### PR TITLE
Assert ndim and number of dims match

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1185,13 +1185,6 @@ class Categorical(Discrete):
         )
 
 
-class _OrderedLogistic(Categorical):
-    r"""
-    Underlying class for ordered logistic distributions.
-    See docs for the OrderedLogistic wrapper class for more details on how to use it in models.
-    """
-
-
 class OrderedLogistic:
     R"""Ordered Logistic distribution.
 
@@ -1263,7 +1256,7 @@ class OrderedLogistic:
     def __new__(cls, name, eta, cutpoints, compute_p=True, **kwargs):
         p = cls.compute_p(eta, cutpoints)
         if compute_p:
-            p = pm.Deterministic(f"{name}_probs", p, dims=kwargs.get("dims"))
+            p = pm.Deterministic(f"{name}_probs", p)
         out_rv = Categorical(name, p=p, **kwargs)
         return out_rv
 
@@ -1367,7 +1360,7 @@ class OrderedProbit:
     def __new__(cls, name, eta, cutpoints, sigma=1, compute_p=True, **kwargs):
         p = cls.compute_p(eta, cutpoints, sigma)
         if compute_p:
-            p = pm.Deterministic(f"{name}_probs", p, dims=kwargs.get("dims"))
+            p = pm.Deterministic(f"{name}_probs", p)
         out_rv = Categorical(name, p=p, **kwargs)
         return out_rv
 

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1532,6 +1532,11 @@ class Model(WithMemoization, metaclass=ContextMeta):
                     raise ValueError(f"Dimension {dim} is not specified in `coords`.")
             if any(var.name == dim for dim in dims if dim is not None):
                 raise ValueError(f"Variable `{var.name}` has the same name as its dimension label.")
+            # This check implicitly states that only vars with .ndim attribute can have dims
+            if var.ndim != len(dims):
+                raise ValueError(
+                    f"{var} has {var.ndim} dims but {len(dims)} dim labels were provided."
+                )
             self.named_vars_to_dims[var.name] = dims
 
         self.named_vars[var.name] = var

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -897,19 +897,25 @@ class TestOrderedLogistic:
         assert p_shape == expected
 
     def test_compute_p(self):
-        with pm.Model() as m:
-            pm.OrderedLogistic("ol_p", cutpoints=np.array([-2, 0, 2]), eta=0)
-            pm.OrderedLogistic("ol_no_p", cutpoints=np.array([-2, 0, 2]), eta=0, compute_p=False)
+        with pm.Model(coords={"test_dim": [0]}) as m:
+            pm.OrderedLogistic("ol_p", cutpoints=np.array([-2, 0, 2]), eta=0, dims="test_dim")
+            pm.OrderedLogistic(
+                "ol_no_p", cutpoints=np.array([-2, 0, 2]), eta=0, compute_p=False, dims="test_dim"
+            )
         assert len(m.deterministics) == 1
 
         x = pm.OrderedLogistic.dist(cutpoints=np.array([-2, 0, 2]), eta=0)
         assert isinstance(x, TensorVariable)
 
         # Test it works with auto-imputation
-        with pm.Model() as m:
+        with pm.Model(coords={"test_dim": [0, 1, 2]}) as m:
             with pytest.warns(ImputationWarning):
                 pm.OrderedLogistic(
-                    "ol", cutpoints=np.array([-2, 0, 2]), eta=0, observed=[0, np.nan, 1]
+                    "ol",
+                    cutpoints=np.array([[-2, 0, 2]]),
+                    eta=0,
+                    observed=[0, np.nan, 1],
+                    dims=["test_dim"],
                 )
         assert len(m.deterministics) == 2  # One from the auto-imputation, the other from compute_p
 

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -899,12 +899,14 @@ class TestSetUpdateCoords:
         # TODO: Either allow dims without coords everywhere or nowhere
         with pm.Model() as m:
             m.add_coord(name="a", values=None, length=3)
-            m.add_coord(name="b", values=range(5))
-            x = pm.Normal("x", dims=("a", "b"))
+            m.add_coord(name="b", values=range(-5, 0))
+            m.add_coord(name="c", values=None, length=7)
+            x = pm.Normal("x", dims=("a", "b", "c"))
             prior = pm.sample_prior_predictive(draws=2).prior
-        assert prior["x"].shape == (1, 2, 3, 5)
+        assert prior["x"].shape == (1, 2, 3, 5, 7)
         assert list(prior.coords["a"].values) == list(range(3))
-        assert list(prior.coords["b"].values) == list(range(5))
+        assert list(prior.coords["b"].values) == list(range(-5, 0))
+        assert list(prior.coords["c"].values) == list(range(7))
 
     def test_set_data_indirect_resize_without_coords(self):
         with pm.Model() as pmodel:


### PR DESCRIPTION
Fixes bug where invalid number of dims was given to Deterministic introduced by OrderedLogistic/Probit

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7390.org.readthedocs.build/en/7390/

<!-- readthedocs-preview pymc end -->