### PR TITLE
Refactor model graph and allow suppressing dim lengths

### DIFF
--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -43,17 +43,17 @@ __all__ = (
 @dataclass
 class DimInfo:
     names: tuple[str | None]
-    sizes: tuple[int]
+    lengths: tuple[int]
 
     def __post_init__(self) -> None:
-        if len(self.names) != len(self.sizes):
-            raise ValueError("The number of names and sizes must be equal.")
+        if len(self.names) != len(self.lengths):
+            raise ValueError("The number of names and lengths must be equal.")
 
     def __hash__(self):
-        return hash((self.names, self.sizes))
+        return hash((self.names, self.lengths))
 
     def __bool__(self) -> bool:
-        return len(self.sizes) > 0 or len(self.names) > 0
+        return len(self.lengths) > 0 or len(self.names) > 0
 
 
 def create_plate_label(
@@ -72,7 +72,7 @@ def create_plate_label(
 
         return label
 
-    values = enumerate(zip(dim_info.names, dim_info.sizes))
+    values = enumerate(zip(dim_info.names, dim_info.lengths))
     return " x ".join(create_label(d, dname, dlen) for d, (dname, dlen) in values)
 
 
@@ -365,21 +365,21 @@ class ModelGraph:
             if var_name in self.model.named_vars_to_dims:
                 # The RV is associated with `dims` information.
                 names = []
-                sizes = []
+                lengths = []
                 for d, dname in enumerate(self.model.named_vars_to_dims[var_name]):
                     names.append(dname)
-                    sizes.append(dim_lengths.get(dname, shape[d]))
+                    lengths.append(dim_lengths.get(dname, shape[d]))
 
                 dim_info = DimInfo(
                     names=tuple(names),
-                    sizes=tuple(sizes),
+                    lengths=tuple(lengths),
                 )
             else:
                 # The RV has no `dims` information.
                 dim_size = len(shape)
                 dim_info = DimInfo(
                     names=tuple([None] * dim_size),
-                    sizes=tuple(shape),
+                    lengths=tuple(shape),
                 )
 
             v = self.model[var_name]

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -105,6 +105,12 @@ class Plate:
     dim_info: DimInfo
     variables: list[NodeInfo]
 
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Plate):
+            return False
+
+        return self.dim_info == other.dim_info and set(self.variables) == set(other.variables)
+
 
 GraphvizNodeKwargs = dict[str, Any]
 NodeFormatter = Callable[[TensorVariable], GraphvizNodeKwargs]

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -17,7 +17,6 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import Enum
-from itertools import zip_longest
 from os import path
 from typing import Any
 
@@ -46,6 +45,10 @@ class DimInfo:
     names: tuple[str | None]
     sizes: tuple[int]
 
+    def __post_init__(self) -> None:
+        if len(self.names) != len(self.sizes):
+            raise ValueError("The number of names and sizes must be equal.")
+
     def __hash__(self):
         return hash((self.names, self.sizes))
 
@@ -69,9 +72,7 @@ def create_plate_label(
 
         return label
 
-    values = enumerate(
-        zip_longest(dim_info.names, dim_info.sizes, fillvalue=None),
-    )
+    values = enumerate(zip(dim_info.names, dim_info.sizes))
     return " x ".join(create_label(d, dname, dlen) for d, (dname, dlen) in values)
 
 
@@ -388,7 +389,7 @@ class ModelGraph:
 
         return [
             Plate(
-                dim_info=dim_info if dim_info else None,
+                dim_info=dim_info,
                 variables=list(variables),
             )
             for dim_info, variables in plates.items()

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -18,7 +18,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import Enum
 from os import path
-from typing import Any, Protocol, cast
+from typing import Any, cast
 
 from pytensor import function
 from pytensor.graph import Apply
@@ -215,8 +215,7 @@ def update_node_formatters(node_formatters: NodeTypeFormatterMapping) -> NodeTyp
     return node_formatters
 
 
-class AddNode(Protocol):
-    def __call__(self, arg1: str, **kwargs: Any) -> None: ...
+AddNode = Callable[[str, GraphvizNodeKwargs], None]
 
 
 def _make_node(
@@ -235,7 +234,7 @@ def _make_node(
         kwargs["cluster"] = cluster
 
     var_name: str = cast(str, node.var.name)
-    add_node(var_name.replace(":", "&"), **kwargs)
+    add_node(var_name.replace(":", "&"), **kwargs)  # type: ignore
 
 
 class ModelGraph:

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -439,7 +439,7 @@ class ModelGraph:
         for plate in self.get_plates(var_names):
             plate_meta = plate.meta
             all_vars = plate.variables
-            if plate_meta:
+            if plate_meta.names or plate_meta.sizes:
                 # must be preceded by 'cluster' to get a box around it
                 plate_label = create_plate_label(
                     all_vars[0].var.name, plate_meta, include_size=include_shape_size
@@ -509,7 +509,7 @@ class ModelGraph:
         for plate in self.get_plates(var_names):
             plate_meta = plate.meta
             all_vars = plate.variables
-            if plate_meta:
+            if plate_meta.names or plate_meta.sizes:
                 # # must be preceded by 'cluster' to get a box around it
 
                 plate_label = create_plate_label(

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -62,22 +62,18 @@ PlateLabelFunc = Callable[[DimInfo], str]
 def create_plate_label_without_dim_length(
     dim_info: DimInfo,
 ) -> str:
-    def create_label(dname: str | None, dlen: int):
-        return f"{dname}" if dname else f"{dlen}"
-
     return " x ".join(
-        create_label(dname, dlen) for (dname, dlen) in zip(dim_info.names, dim_info.lengths)
+        f"{dname}" if dname else f"{dlen}"
+        for (dname, dlen) in zip(dim_info.names, dim_info.lengths)
     )
 
 
 def create_plate_label_with_dim_length(
     dim_info: DimInfo,
 ) -> str:
-    def create_label(dname: str | None, dlen: int):
-        return f"{dname} ({dlen})" if dname else f"{dlen}"
-
     return " x ".join(
-        create_label(dname, dlen) for (dname, dlen) in zip(dim_info.names, dim_info.lengths)
+        f"{dname} ({dlen})" if dname else f"{dlen}"
+        for (dname, dlen) in zip(dim_info.names, dim_info.lengths)
     )
 
 

--- a/tests/test_model_graph.py
+++ b/tests/test_model_graph.py
@@ -518,3 +518,19 @@ def test_shape_without_dims() -> None:
         ),
     ]
     assert graph.edges() == []
+
+
+def test_scalars_have_no_dim_info() -> None:
+    with pm.Model() as model:
+        pm.Normal("x")
+
+    graph = ModelGraph(model)
+
+    assert graph.get_plates() == [
+        Plate(
+            dim_info=None,
+            variables=[NodeInfo(var=model["x"], node_type=NodeType.FREE_RV)],
+        )
+    ]
+
+    assert graph.edges() == []

--- a/tests/test_model_graph.py
+++ b/tests/test_model_graph.py
@@ -499,11 +499,11 @@ def test_none_dim_in_plate() -> None:
 
     assert graph.get_plates() == [
         Plate(
-            dim_info=DimInfo(names=("obs", None), sizes=(5, 5)),
+            dim_info=DimInfo(names=("obs", None), lengths=(5, 5)),
             variables=[NodeInfo(var=model["C"], node_type=NodeType.DETERMINISTIC)],
         ),
         Plate(
-            dim_info=DimInfo(names=(None, "obs"), sizes=(5, 5)),
+            dim_info=DimInfo(names=(None, "obs"), lengths=(5, 5)),
             variables=[NodeInfo(var=model["D"], node_type=NodeType.DETERMINISTIC)],
         ),
     ]
@@ -518,7 +518,7 @@ def test_shape_without_dims() -> None:
 
     assert graph.get_plates() == [
         Plate(
-            dim_info=DimInfo(names=(None,), sizes=(5,)),
+            dim_info=DimInfo(names=(None,), lengths=(5,)),
             variables=[NodeInfo(var=model["mu"], node_type=NodeType.FREE_RV)],
         ),
     ]
@@ -533,7 +533,7 @@ def test_scalars_dim_info() -> None:
 
     assert graph.get_plates() == [
         Plate(
-            dim_info=DimInfo(names=(), sizes=()),
+            dim_info=DimInfo(names=(), lengths=()),
             variables=[NodeInfo(var=model["x"], node_type=NodeType.FREE_RV)],
         )
     ]

--- a/tests/test_model_graph.py
+++ b/tests/test_model_graph.py
@@ -489,17 +489,22 @@ def test_none_dim_in_plate() -> None:
     }
     with pm.Model(coords=coords) as model:
         data = pt.as_tensor_variable(
-            np.ones((5, 3)),
+            np.ones((5, 5)),
             name="data",
         )
         pm.Deterministic("C", data, dims=("obs", None))
+        pm.Deterministic("D", data.T, dims=(None, "obs"))
 
     graph = ModelGraph(model)
 
     assert graph.get_plates() == [
         Plate(
-            dim_info=DimInfo(names=("obs", None), sizes=(5, 3)),
+            dim_info=DimInfo(names=("obs", None), sizes=(5, 5)),
             variables=[NodeInfo(var=model["C"], node_type=NodeType.DETERMINISTIC)],
+        ),
+        Plate(
+            dim_info=DimInfo(names=(None, "obs"), sizes=(5, 5)),
+            variables=[NodeInfo(var=model["D"], node_type=NodeType.DETERMINISTIC)],
         ),
     ]
     assert graph.edges() == []
@@ -520,7 +525,7 @@ def test_shape_without_dims() -> None:
     assert graph.edges() == []
 
 
-def test_scalars_have_no_dim_info() -> None:
+def test_scalars_dim_info() -> None:
     with pm.Model() as model:
         pm.Normal("x")
 
@@ -528,7 +533,7 @@ def test_scalars_have_no_dim_info() -> None:
 
     assert graph.get_plates() == [
         Plate(
-            dim_info=None,
+            dim_info=DimInfo(names=(), sizes=()),
             variables=[NodeInfo(var=model["x"], node_type=NodeType.FREE_RV)],
         )
     ]


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

Pulled any graph related information into two methods: 

1. `get_plates`: Get plate meta information and the nodes that are associated with each plate
2. `edges`: Edges between nodes as a list[tuple[VarName, VarName]]

The `get_plates` methods returns a list of `Plate` objects which store all the variable information. That data include:

1. `DimInfo` with stores the dim names and lengths
1. `NodeInfo` which stores the model variable and it's NodeType in the graph (introduced in #7302)
1. `Plate` which is a collection of the `DimInfo` and `list[NodeInfo]`

With `list[tuple[VarName, VarName]]` and `list[Plate]`, a user can now make use of the exposed `make_graph` and `make_networkx` functions to create customized graphviz or networkx graphs.

The previous behavior of `model_to_graphviz` and `model_to_networkx` is still maintained. However, there is a new `include_dim_lengths` parameter that can be used to include the dim lengths in the plate labels.

The previous issue #6335 behavior has changed to now include all the variables on a plate with dlen instead of var_name_dim{d}. (See examples below)

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7319
- [ ] Related to 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7392.org.readthedocs.build/en/7392/

<!-- readthedocs-preview pymc end -->