### PR TITLE
Use the resized welcome-bot banners 910x483

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,6 +1,6 @@
 # Comment to be posted to on first time issues
 newIssueWelcomeComment: >
-  ![Welcome Banner](https://raw.githubusercontent.com/pymc-devs/brand/main/welcome-bot/BannerWelcome.jpg)]
+  ![Welcome Banner](https://raw.githubusercontent.com/pymc-devs/brand/main/welcome-bot/BannerWelcome_910x483_resized.jpg)]
 
   :tada: Welcome to _PyMC_! :tada:
   We're really excited to have your input into the project! :sparkling_heart:
@@ -10,7 +10,7 @@ newIssueWelcomeComment: >
 
 # Comment to be posted to on PRs from first time contributors in your repository
 newPRWelcomeComment: >
-  ![Thank You Banner](https://raw.githubusercontent.com/pymc-devs/brand/main/welcome-bot/BannerThanks.jpg)]
+  ![Thank You Banner](https://raw.githubusercontent.com/pymc-devs/brand/main/welcome-bot/BannerThanks_910x483_resized.jpg)]
 
   :sparkling_heart: Thanks for opening this pull request! :sparkling_heart:
   The _PyMC_ community really appreciates your time and effort to contribute to the project.
@@ -19,7 +19,7 @@ newPRWelcomeComment: >
 
 # Comment to be posted to on pull requests merged by a first time user
 firstPRMergeComment: >
-  ![Congratulations Banner](https://raw.githubusercontent.com/pymc-devs/brand/main/welcome-bot/BannerCongratulations.jpg)]
+  ![Congratulations Banner](https://raw.githubusercontent.com/pymc-devs/brand/main/welcome-bot/BannerCongratulations_910x483_resized.jpg)]
 
   Congrats on merging your first pull request! :tada:
   We here at _PyMC_ are proud of you! :sparkling_heart:


### PR DESCRIPTION
## Description
With this PR the welcome-bot configuration is changed to use the smaller (lower resolution) versions of the Congratulations/Welcome/Thanks banners.

See https://github.com/pymc-devs/brand/pull/29 where the new banners are added.

## Related Issue
- [X] Closes https://github.com/pymc-devs/pymc/issues/7323
- [ ] Related to #

## Checklist
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [X] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [X] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7394.org.readthedocs.build/en/7394/

<!-- readthedocs-preview pymc end -->