### PR TITLE
Print OP name for unnamed RVs instead of raising AssertionErrors

### DIFF
--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -232,6 +232,12 @@ def _str_for_expression(var: Variable, formatting: str) -> str:
         if x.owner and isinstance(x.owner.op, RandomVariable | SymbolicRandomVariable):
             parents.append(x)
             xname = x.name
+            if xname is None:
+                # If the variable is unnamed, we show the op's name as we do
+                # with constants
+                opname = x.owner.op.name
+                if opname is not None:
+                    xname = rf"<{opname}>"
             assert xname is not None
             names.append(xname)
 

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -125,8 +125,11 @@ class TestMonolith(BaseTestStrAndLatexRepr):
             # add a potential as well
             pot = Potential("pot", mu**2)
 
+            # add a deterministic that depends on an unnamed random variable
+            pred = Deterministic("pred", Normal.dist(0, 1))
+
         self.distributions = [alpha, sigma, mu, b, Z, nb2, zip, w, nested_mix, Y_obs, pot]
-        self.deterministics_or_potentials = [mu, pot]
+        self.deterministics_or_potentials = [mu, pot, pred]
         # tuples of (formatting, include_params)
         self.formats = [("plain", True), ("plain", False), ("latex", True), ("latex", False)]
         self.expected = {
@@ -146,6 +149,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 ),
                 r"Y_obs ~ Normal(mu, sigma)",
                 r"pot ~ Potential(f(beta, alpha))",
+                r"pred ~ Deterministic(f(<normal>))",
             ],
             ("plain", False): [
                 r"alpha ~ Normal",
@@ -159,6 +163,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"nested_mix ~ MarginalMixture",
                 r"Y_obs ~ Normal",
                 r"pot ~ Potential",
+                r"pred ~ Deterministic",
             ],
             ("latex", True): [
                 r"$\text{alpha} \sim \operatorname{Normal}(0,~10)$",
@@ -176,6 +181,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 ),
                 r"$\text{Y_obs} \sim \operatorname{Normal}(\text{mu},~\text{sigma})$",
                 r"$\text{pot} \sim \operatorname{Potential}(f(\text{beta},~\text{alpha}))$",
+                r"$\text{pred} \sim \operatorname{Deterministic}(f(\text{<normal>}))",
             ],
             ("latex", False): [
                 r"$\text{alpha} \sim \operatorname{Normal}$",
@@ -189,6 +195,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"$\text{nested_mix} \sim \operatorname{MarginalMixture}$",
                 r"$\text{Y_obs} \sim \operatorname{Normal}$",
                 r"$\text{pot} \sim \operatorname{Potential}$",
+                r"$\text{pred} \sim \operatorname{Deterministic}",
             ],
         }
 


### PR DESCRIPTION
## Description
When trying to get the string representation of a model that has raw pytensor random variable OP's in it, instead of raising an `AssertionError`, try to print the OP's name between arrow brackets <>, just like what is already done for constant data.

The string representation doesn't have much of a docstring so I didn't add anything to it. I'm not sure if it's showcased anywhere either, so I didn't touch anythin doc related.

## Related Issue
- [X] Closes #7427 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [X] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [X] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [X] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
