### PR TITLE
Update Twitter Link to X

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,7 +222,7 @@ You can also follow us on these social media platforms for updates and other ann
 
 - `LinkedIn @pymc <https://www.linkedin.com/company/pymc/>`__
 - `YouTube @PyMCDevelopers <https://www.youtube.com/c/PyMCDevelopers>`__
-- `Twitter @pymc_devs <https://twitter.com/pymc_devs>`__
+- `X @pymc_devs <https://x.com/pymc_devs>`__
 - `Mastodon @pymc@bayes.club <https://bayes.club/@pymc>`__
 
 To report an issue with PyMC please use the `issue tracker <https://github.com/pymc-devs/pymc/issues>`__.

--- a/docs/source/contributing/developer_guide.md
+++ b/docs/source/contributing/developer_guide.md
@@ -173,7 +173,7 @@ self.logp_nojac_unscaledt = distribution.logp_nojac(data)
 
 ### Model context and Random Variable
 
-I like to think that the ``with pm.Model() ...`` is a key syntax feature and *the* signature of PyMC model language, and in general a great out-of-the-box thinking/usage of the context manager in Python (with [some critics](https://twitter.com/_szhang/status/890793373740617729), of course).
+I like to think that the ``with pm.Model() ...`` is a key syntax feature and *the* signature of PyMC model language, and in general a great out-of-the-box thinking/usage of the context manager in Python (with some critics, of course).
 
 Essentially [what a context manager does](https://www.python.org/dev/peps/pep-0343/) is:
 


### PR DESCRIPTION
### Fixes #7450 

### Summary

This Pull Request removes the non-working Twitter link in `docs/source/contributing/developer_guide.md` and updates the Twitter link to X in `README.rst`.

### Changes Made

- Removed the outdated Twitter link from `developer_guide.md`.
- Updated the Twitter link to reflect the rebranding to X in `README.rst`.

### Motivation

The old Twitter link was non-functional, and the Twitter brand has changed to X. These changes ensure the documentation is up-to-date and accurate.

### Checklist

- [x] Removed the outdated Twitter link.
- [x] Updated the Twitter link to X.
- [x] Tested the changes to ensure no broken links.
- [x] Ready for review and merging.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7451.org.readthedocs.build/en/7451/

<!-- readthedocs-preview pymc end -->