### PR TITLE
Blackjax sampler fix for breaking change / enable progress bar under parallel chain_method

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -365,14 +365,6 @@ def _sample_blackjax_nuts(
     # Adapted from numpyro
     if chain_method == "parallel":
         map_fn = jax.pmap
-        if progressbar:
-            import warnings
-
-            warnings.warn(
-                "BlackJax currently only display progress bar correctly under "
-                "`chain_method == 'vectorized'`. Setting `progressbar=False`."
-            )
-            progressbar = False
     elif chain_method == "vectorized":
         map_fn = jax.vmap
     else:

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -278,15 +278,10 @@ def _blackjax_inference_loop(
         return state, (position, stats)
 
     progress_bar = adaptation_kwargs.pop("progress_bar", False)
-    if progress_bar:
-        from blackjax.progress_bar import progress_bar_scan
-
-        one_step = jax.jit(progress_bar_scan(draws)(_one_step))
-    else:
-        one_step = jax.jit(_one_step)
 
     keys = jax.random.split(seed, draws)
-    _, (samples, stats) = jax.lax.scan(one_step, last_state, (jnp.arange(draws), keys))
+    scan_fn = blackjax.progress_bar.gen_scan_fn(draws, progress_bar, label='sampling chain: ')
+    _, (samples, stats) = scan_fn(_one_step, last_state, (jnp.arange(draws), keys))
 
     return samples, stats
 

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -280,7 +280,7 @@ def _blackjax_inference_loop(
     progress_bar = adaptation_kwargs.pop("progress_bar", False)
 
     keys = jax.random.split(seed, draws)
-    scan_fn = blackjax.progress_bar.gen_scan_fn(draws, progress_bar, label='sampling chain: ')
+    scan_fn = blackjax.progress_bar.gen_scan_fn(draws, progress_bar)
     _, (samples, stats) = scan_fn(_one_step, last_state, (jnp.arange(draws), keys))
 
     return samples, stats


### PR DESCRIPTION
https://github.com/blackjax-devs/blackjax/pull/712 changes the expected jax.lax.scan carry in `progress_bar_scan`.  Since pymc's external blackjax sampler directly uses `progress_bar_scan` it will break when `progressbar=True`.  This change switches to use a new wrapper to hide the progress bar details.  In addition it enables the use of progress bars under `chain_method="parallel"`.

I think any breaking issues can be handled by restricting blackjax version numbers.  However, I'm not sure how to properly do that?

And of course for now tests are expected to fail until the changes show in a blackjax release.

PRs that are dependencies:
https://github.com/blackjax-devs/blackjax/pull/712
https://github.com/blackjax-devs/blackjax/pull/716


## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7453.org.readthedocs.build/en/7453/

<!-- readthedocs-preview pymc end -->