### PR TITLE
Fix typo in the docstring of the Beta distribution

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -1118,7 +1118,7 @@ class Beta(UnitContinuous):
 
        \text{where } \kappa = \frac{\mu(1-\mu)}{\sigma^2} - 1
 
-       \alpha = \mu * \nu
+       \alpha = \mu * \nu \\
        \beta = (1 - \mu) * \nu
 
     Parameters

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -1118,8 +1118,8 @@ class Beta(UnitContinuous):
 
        \text{where } \kappa = \frac{\mu(1-\mu)}{\sigma^2} - 1
 
-       \alpha = \mu * \nu \\
-       \beta = (1 - \mu) * \nu
+       \alpha &= \mu * \nu \\
+       \beta &= (1 - \mu) * \nu
 
     Parameters
     ----------


### PR DESCRIPTION
## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7469.org.readthedocs.build/en/7469/

<!-- readthedocs-preview pymc end -->