### PR TITLE
Fix test failures due to old change_flags API

### DIFF
--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -846,7 +846,7 @@ class TestAssignStepMethods:
 class TestType:
     samplers = (Metropolis, Slice, HamiltonianMC, NUTS)
 
-    @pytensor.config.change_flags({"floatX": "float64", "warn_float64": "ignore"})
+    @pytensor.config.change_flags(floatX="float64", warn_float64="ignore")
     def test_float64(self):
         with pm.Model() as model:
             x = pm.Normal("x", initval=np.array(1.0, dtype="float64"))
@@ -861,7 +861,7 @@ class TestType:
                     warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
                     pm.sample(draws=10, tune=10, chains=1, step=sampler())
 
-    @pytensor.config.change_flags({"floatX": "float32", "warn_float64": "warn"})
+    @pytensor.config.change_flags(floatX="float32", warn_float64="warn")
     def test_float32(self):
         with pm.Model() as model:
             x = pm.Normal("x", initval=np.array(1.0, dtype="float32"))


### PR DESCRIPTION
Breakage was caused by this:
<https://github.com/pymc-devs/pytensor/commit/936554c14b05d4ff8ecf116ab205c2d18a8b067e> Fix is to unpack the dict into kwargs.

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7475.org.readthedocs.build/en/7475/

<!-- readthedocs-preview pymc end -->