### PR TITLE
Allow more distributions to be truncated

### DIFF
--- a/pymc/distributions/censored.py
+++ b/pymc/distributions/censored.py
@@ -112,7 +112,7 @@ class Censored(Distribution):
     rv_op = CensoredRV.rv_op
 
     @classmethod
-    def dist(cls, dist, lower, upper, **kwargs):
+    def dist(cls, dist, lower=-np.inf, upper=np.inf, **kwargs):
         if not isinstance(dist, TensorVariable) or not isinstance(
             dist.owner.op, RandomVariable | SymbolicRandomVariable
         ):

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2941,8 +2941,8 @@ class ExGaussian(Continuous):
     rv_op = ExGaussianRV.rv_op
 
     @classmethod
-    def dist(cls, mu=0.0, sigma=None, nu=None, *args, **kwargs):
-        return super().dist([mu, sigma, nu], *args, **kwargs)
+    def dist(cls, mu=0.0, sigma=1.0, *, nu, **kwargs):
+        return super().dist([mu, sigma, nu], **kwargs)
 
     def support_point(rv, size, mu, sigma, nu):
         mu, nu, _ = pt.broadcast_arrays(mu, nu, sigma)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
AS reported in https://discourse.pymc.io/t/custom-distribution-for-truncated-gamma/11006/7?u=ricardov94 SymbolicRandomVariable distributions like ExGaussian couldn't be Truncated. The reason why this restriction was inplace are technical, and have to do with not all SymbolicRandomVariables being completely encapsulated in the inner graph. For distributions like Mixture this would be quite some work (which we may still want to do). 

However many SymbolicRandomVariables are fine, specially those introduced in https://github.com/pymc-devs/pymc/pull/7239.

This PR allow truncation of those that are fine.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7476.org.readthedocs.build/en/7476/

<!-- readthedocs-preview pymc end -->