### PR TITLE
Allow Minibatch of derived RVs and deprecate generators as data

### DIFF
--- a/pymc/logprob/basic.py
+++ b/pymc/logprob/basic.py
@@ -308,7 +308,7 @@ def logcdf(rv: TensorVariable, value: TensorLike, warn_rvs=None, **kwargs) -> Te
         return _logcdf_helper(rv, value, **kwargs)
     except NotImplementedError:
         # Try to rewrite rv
-        fgraph, rv_values, _ = construct_ir_fgraph({rv: value})
+        fgraph, _, _ = construct_ir_fgraph({rv: value})
         [ir_rv] = fgraph.outputs
         expr = _logcdf_helper(ir_rv, value, **kwargs)
         cleanup_ir([expr])
@@ -390,7 +390,7 @@ def icdf(rv: TensorVariable, value: TensorLike, warn_rvs=None, **kwargs) -> Tens
         return _icdf_helper(rv, value, **kwargs)
     except NotImplementedError:
         # Try to rewrite rv
-        fgraph, rv_values, _ = construct_ir_fgraph({rv: value})
+        fgraph, _, _ = construct_ir_fgraph({rv: value})
         [ir_rv] = fgraph.outputs
         expr = _icdf_helper(ir_rv, value, **kwargs)
         cleanup_ir([expr])

--- a/pymc/logprob/rewriting.py
+++ b/pymc/logprob/rewriting.py
@@ -41,9 +41,7 @@ from collections.abc import Collection, Sequence
 from pytensor import config
 from pytensor.compile.mode import optdb
 from pytensor.graph.basic import (
-    Constant,
     Variable,
-    ancestors,
     io_toposort,
     truncated_graph_inputs,
 )
@@ -400,8 +398,8 @@ def construct_ir_fgraph(
     # the old nodes to the new ones; otherwise, we won't be able to use
     # `rv_values`.
     # We start the `dict` with mappings from the value variables to themselves,
-    # to prevent them from being cloned. This also includes ancestors
-    memo = {v: v for v in ancestors(rv_values.values()) if not isinstance(v, Constant)}
+    # to prevent them from being cloned.
+    memo = {v: v for v in rv_values.values()}
 
     # We add `ShapeFeature` because it will get rid of references to the old
     # `RandomVariable`s that have been lifted; otherwise, it will be difficult

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -672,6 +672,9 @@ class GeneratorOp(Op):
     __props__ = ("generator",)
 
     def __init__(self, gen, default=None):
+        warnings.warn(
+            "generator data is deprecated and will be removed in a future release", FutureWarning
+        )
         from pymc.data import GeneratorAdapter
 
         super().__init__()

--- a/pymc/variational/minibatch_rv.py
+++ b/pymc/variational/minibatch_rv.py
@@ -20,7 +20,8 @@ from pytensor import Variable, config
 from pytensor.graph import Apply, Op
 from pytensor.tensor import NoneConst, TensorVariable, as_tensor_variable
 
-from pymc.logprob.abstract import MeasurableOp, _logprob, _logprob_helper
+from pymc.logprob.abstract import MeasurableOp, _logprob
+from pymc.logprob.basic import logp
 
 
 class MinibatchRandomVariable(MeasurableOp, Op):
@@ -99,4 +100,4 @@ def get_scaling(total_size: Sequence[Variable], shape: TensorVariable) -> Tensor
 def minibatch_rv_logprob(op, values, *inputs, **kwargs):
     [value] = values
     rv, *total_size = inputs
-    return _logprob_helper(rv, value, **kwargs) * get_scaling(total_size, value.shape)
+    return logp(rv, value, **kwargs) * get_scaling(total_size, value.shape)

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -116,13 +116,13 @@ class GroupError(VariationalInferenceError, TypeError):
 
 def _known_scan_ignored_inputs(terms):
     # TODO: remove when scan issue with grads is fixed
-    from pymc.data import MinibatchIndexRV
+    from pymc.data import MinibatchOp
     from pymc.distributions.simulator import SimulatorRV
 
     return [
         n.owner.inputs[0]
         for n in pytensor.graph.ancestors(terms)
-        if n.owner is not None and isinstance(n.owner.op, MinibatchIndexRV | SimulatorRV)
+        if n.owner is not None and isinstance(n.owner.op, MinibatchOp | SimulatorRV)
     ]
 
 

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -14,9 +14,6 @@
 
 import io
 import operator
-import warnings
-
-from contextlib import nullcontext
 
 import cloudpickle
 import numpy as np
@@ -162,22 +159,7 @@ def fit_kwargs(inference, use_minibatch):
 
 
 def test_fit_oo(inference, fit_kwargs, simple_model_data):
-    # Minibatch data can't be extracted into the `observed_data` group in the final InferenceData
-    if getattr(simple_model_data["data"], "name", "").startswith("minibatch"):
-        warn_ctxt = pytest.warns(
-            UserWarning, match="Could not extract data from symbolic observation"
-        )
-    else:
-        warn_ctxt = nullcontext()
-
-    with warn_ctxt:
-        with warnings.catch_warnings():
-            # Related to https://github.com/arviz-devs/arviz/issues/2327
-            warnings.filterwarnings(
-                "ignore", message="datetime.datetime.utcnow()", category=DeprecationWarning
-            )
-
-            trace = inference.fit(**fit_kwargs).sample(10000)
+    trace = inference.fit(**fit_kwargs).sample(10000)
     mu_post = simple_model_data["mu_post"]
     d = simple_model_data["d"]
     np.testing.assert_allclose(np.mean(trace.posterior["mu"]), mu_post, rtol=0.05)
@@ -203,33 +185,10 @@ def test_fit_start(inference_spec, simple_model):
     with simple_model:
         inference = inference_spec(**kw)
 
-    # Minibatch data can't be extracted into the `observed_data` group in the final InferenceData
-    [observed_value] = [simple_model.rvs_to_values[obs] for obs in simple_model.observed_RVs]
-
-    # We can`t use pytest.warns here because after version 8.0 it`s still check for warning when
-    # exception raised and test failed instead being skipped
-    warning_raised = False
-    expected_warning = observed_value.name.startswith("minibatch")
-    with warnings.catch_warnings(record=True) as record:
-        warnings.simplefilter("always")
-        with warnings.catch_warnings():
-            # Related to https://github.com/arviz-devs/arviz/issues/2327
-            warnings.filterwarnings(
-                "ignore", message="datetime.datetime.utcnow()", category=DeprecationWarning
-            )
-
-            try:
-                trace = inference.fit(n=0).sample(10000)
-            except NotImplementedInference as e:
-                pytest.skip(str(e))
-
-    if expected_warning:
-        assert len(record) > 0
-        for item in record:
-            assert issubclass(item.category, UserWarning)
-            assert "Could not extract data from symbolic observation" in str(item.message)
-    if not expected_warning:
-        assert not record
+    try:
+        trace = inference.fit(n=0).sample(10000)
+    except NotImplementedInference as e:
+        pytest.skip(str(e))
 
     np.testing.assert_allclose(np.mean(trace.posterior["mu"]), mu_init, rtol=0.05)
     if has_start_sigma:

--- a/tests/variational/test_minibatch_rv.py
+++ b/tests/variational/test_minibatch_rv.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 import numpy as np
 import pytensor
+import pytensor.tensor as pt
 import pytest
 
 from scipy import stats as st
@@ -186,3 +187,12 @@ class TestMinibatchRandomVariable:
         with m:
             pm.set_data({"AD": rng.normal(size=1000)})
         assert logp_fn(ip) != logp_fn(ip)
+
+    def test_derived_rv(self):
+        """Test we can obtain a minibatch logp out of a derived RV."""
+        dist = pt.clip(pm.Normal.dist(0, 1, size=(1,)), -1, 1)
+        mb_dist = create_minibatch_rv(dist, total_size=(2,))
+        np.testing.assert_allclose(
+            pm.logp(mb_dist, -1).eval(),
+            pm.logp(dist, -1).eval() * 2,
+        )

--- a/tests/variational/test_minibatch_rv.py
+++ b/tests/variational/test_minibatch_rv.py
@@ -20,7 +20,7 @@ from scipy import stats as st
 import pymc as pm
 
 from pymc import Normal, draw
-from pymc.data import minibatch_index
+from pymc.data import Minibatch
 from pymc.testing import select_by_precision
 from pymc.variational.minibatch_rv import create_minibatch_rv
 from tests.test_data import gen1, gen2
@@ -165,10 +165,7 @@ class TestMinibatchRandomVariable:
         with pm.Model(check_bounds=False) as m:
             AD = pm.Data("AD", np.arange(total_size, dtype="float64"))
             TD = pm.Data("TD", np.arange(total_size, dtype="float64"))
-
-            minibatch_idx = minibatch_index(0, 10, size=(9,))
-            AD_mt = AD[minibatch_idx]
-            TD_mt = TD[minibatch_idx]
+            AD_mt, TD_mt = Minibatch(AD, TD, batch_size=9)
 
             pm.Normal(
                 "AD_predicted",


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
This PR fixes issues related to Minibatch indexing reported in https://discourse.pymc.io/t/warning-using-minibatch-and-censored-together-rng-variable-has-shared-clients/14943 and extends the MinibatchRV functionality for derived RVs.

Minibatch value variables are uniquely tricky because they are random graphs, that can share RNG with other variables in the forward / logp graph. As such we need to make sure they are not mutated for the default updates to work. We tried some tricks in the past but as revealed in the discourse issue that was not enough. This PR solves the problem by encapsulating the random graph in an OpFromGraph so that the inner graph will not be touched by PyMC logprob derivation routines. It will still be inlined in the final compiled functions to avoid overhead.

I also decided to deprecate Generators as data, which showed up in some of the refactoring. The GeneratorOp is not a true Op, which should not have any side-effects. It is also not compatible with non default backends like Numba and JAX that we are moving towards to. If needed, the logic should be handled by the sampler by consuming the generator and setting the values before subsequent function calls.
