### PR TITLE
Fix some type hinting to help with migrating `Distribution`

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -55,10 +55,10 @@ from pytensor.tensor.random.basic import (
 )
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.utils import normalize_size_param
-from pytensor.tensor.variable import TensorConstant
+from pytensor.tensor.variable import TensorConstant, TensorVariable
 
 from pymc.logprob.abstract import _logprob_helper
-from pymc.logprob.basic import icdf
+from pymc.logprob.basic import TensorLike, icdf
 from pymc.pytensorf import normalize_rng_param
 
 try:
@@ -214,7 +214,9 @@ def assert_negative_support(var, label, distname, value=-1e-6):
     return Assert(msg)(var, pt.all(pt.ge(var, 0.0)))
 
 
-def get_tau_sigma(tau=None, sigma=None):
+def get_tau_sigma(
+    tau: TensorLike | None = None, sigma: TensorLike | None = None
+) -> tuple[TensorVariable, TensorVariable]:
     r"""
     Find precision and standard deviation. The link between the two
     parameterizations is given by the inverse relationship:
@@ -241,13 +243,14 @@ def get_tau_sigma(tau=None, sigma=None):
         sigma = pt.as_tensor_variable(1.0)
         tau = pt.as_tensor_variable(1.0)
     elif tau is None:
+        assert sigma is not None  # Just for type checker
         sigma = pt.as_tensor_variable(sigma)
         # Keep tau negative, if sigma was negative, so that it will
         # fail when used
         tau = (sigma**-2.0) * pt.sign(sigma)
     else:
         tau = pt.as_tensor_variable(tau)
-        # Keep tau negative, if sigma was negative, so that it will
+        # Keep sigma negative, if tau was negative, so that it will
         # fail when used
         sigma = pt.abs(tau) ** -0.5 * pt.sign(tau)
 

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -152,7 +152,7 @@ class BoundedContinuous(Continuous):
     """Base class for bounded continuous distributions"""
 
     # Indices of the arguments that define the lower and upper bounds of the distribution
-    bound_args_indices: list[int] | None = None
+    bound_args_indices: tuple[int, int] | None = None
 
 
 @_default_transform.register(PositiveContinuous)

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -152,7 +152,7 @@ class BoundedContinuous(Continuous):
     """Base class for bounded continuous distributions"""
 
     # Indices of the arguments that define the lower and upper bounds of the distribution
-    bound_args_indices: tuple[int, int] | None = None
+    bound_args_indices: tuple[int | None, int | None] | None = None
 
 
 @_default_transform.register(PositiveContinuous)

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -423,7 +423,7 @@ def change_symbolic_rv_size(op: SymbolicRandomVariable, rv, new_size, expand) ->
 class Distribution(metaclass=DistributionMeta):
     """Statistical distribution"""
 
-    rv_op: [RandomVariable, SymbolicRandomVariable] = None
+    rv_op: RandomVariable | SymbolicRandomVariable = None
     rv_type: MetaType = None
 
     def __new__(

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -21,7 +21,7 @@ import warnings
 from abc import ABCMeta
 from collections.abc import Callable, Sequence
 from functools import singledispatch
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 import numpy as np
 
@@ -122,6 +122,8 @@ class DistributionMeta(ABCMeta):
                     )
 
             class_change_dist_size = clsdict.get("change_dist_size")
+            if class_change_dist_size is not None:
+                raise ValueError("HAHAHA")
             if class_change_dist_size:
 
                 @_change_dist_size.register(rv_type)
@@ -423,8 +425,12 @@ def change_symbolic_rv_size(op: SymbolicRandomVariable, rv, new_size, expand) ->
 class Distribution(metaclass=DistributionMeta):
     """Statistical distribution"""
 
-    rv_op: Callable[..., TensorVariable]
-    rv_type: MetaType
+    # rv_op and _type are set to None via the DistributionMeta.__new__
+    # if not specified as class attributes in subclasses of Distribution.
+    # rv_op can either be a class (see the Normal class) or a method
+    # (see the Censored class), both callable to return a TensorVariable.
+    rv_op: Any = None
+    rv_type: MetaType | None = None
 
     def __new__(
         cls,

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -122,8 +122,6 @@ class DistributionMeta(ABCMeta):
                     )
 
             class_change_dist_size = clsdict.get("change_dist_size")
-            if class_change_dist_size is not None:
-                raise ValueError("HAHAHA")
             if class_change_dist_size:
 
                 @_change_dist_size.register(rv_type)

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -423,8 +423,8 @@ def change_symbolic_rv_size(op: SymbolicRandomVariable, rv, new_size, expand) ->
 class Distribution(metaclass=DistributionMeta):
     """Statistical distribution"""
 
-    rv_op: Callable[..., TensorVariable] | None = None
-    rv_type: MetaType | None = None
+    rv_op: Callable[..., TensorVariable]
+    rv_type: MetaType
 
     def __new__(
         cls,

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -423,8 +423,8 @@ def change_symbolic_rv_size(op: SymbolicRandomVariable, rv, new_size, expand) ->
 class Distribution(metaclass=DistributionMeta):
     """Statistical distribution"""
 
-    rv_op: RandomVariable | SymbolicRandomVariable = None
-    rv_type: MetaType = None
+    rv_op: Callable[..., TensorVariable] | None = None
+    rv_type: MetaType | None = None
 
     def __new__(
         cls,


### PR DESCRIPTION
## Description
This is a small PR. I've added and fixed type hinting to a few lines of code. The idea is to make it easier to migrate the `Distribution` class to a function-based approach as discussed in the related issue.

## Related Issue
- [x] Related to #6083

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7484.org.readthedocs.build/en/7484/

<!-- readthedocs-preview pymc end -->