### PR TITLE
Remove deprecated Distribution kwargs

### DIFF
--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -84,31 +84,6 @@ class TestBugfixes:
         npt.assert_almost_equal(m.compile_logp()({"x": np.ones(10)}), 0 * 10)
 
 
-@pytest.mark.parametrize(
-    "method,newcode",
-    [
-        ("logp", r"pm.logp\(rv, x\)"),
-        ("logcdf", r"pm.logcdf\(rv, x\)"),
-        ("random", r"pm.draw\(rv\)"),
-    ],
-)
-def test_logp_gives_migration_instructions(method, newcode):
-    rv = pm.Normal.dist()
-    f = getattr(rv, method)
-    with pytest.raises(AttributeError, match=rf"use `{newcode}`"):
-        f()
-
-    # A dim-induced resize of the rv created by the `.dist()` API,
-    # happening in Distribution.__new__ would make us loose the monkeypatches.
-    # So this triggers it to test if the monkeypatch still works.
-    with pm.Model(coords={"year": [2019, 2021, 2022]}):
-        rv = pm.Normal("n", dims="year")
-        f = getattr(rv, method)
-        with pytest.raises(AttributeError, match=rf"use `{newcode}`"):
-            f()
-    pass
-
-
 def test_all_distributions_have_support_points():
     import pymc.distributions as dist_module
 

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -660,8 +660,8 @@ def test_initial_point():
 
     b_initval = np.array(0.3, dtype=pytensor.config.floatX)
 
-    with pytest.warns(FutureWarning), model:
-        b = pm.Uniform("b", testval=b_initval)
+    with model:
+        b = pm.Uniform("b", initval=b_initval)
 
     b_initval_trans = model.rvs_to_transforms[b].forward(b_initval, *b.owner.inputs).eval()
 

--- a/tests/test_initial_point.py
+++ b/tests/test_initial_point.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 import cloudpickle
 import numpy as np
-import numpy.testing as npt
 import pytensor
 import pytensor.tensor as pt
 import pytest
@@ -32,34 +31,6 @@ def transform_fwd(rv, expected_untransformed, model):
 
 def transform_back(rv, transformed, model) -> np.ndarray:
     return model.rvs_to_transforms[rv].backward(transformed, *rv.owner.inputs).eval()
-
-
-class TestInitvalAssignment:
-    def test_dist_warnings_and_errors(self):
-        with pytest.warns(FutureWarning, match="argument is deprecated and has no effect"):
-            rv = pm.Exponential.dist(lam=1, testval=0.5)
-        assert not hasattr(rv.tag, "test_value")
-
-        with pytest.raises(TypeError, match="Unexpected keyword argument `initval`."):
-            pm.Normal.dist(1, 2, initval=None)
-        pass
-
-    def test_new_warnings(self):
-        with pm.Model() as pmodel:
-            with pytest.warns(FutureWarning, match="`testval` argument is deprecated"):
-                rv = pm.Uniform("u", 0, 1, testval=0.75)
-                initial_point = pmodel.initial_point(random_seed=0)
-                npt.assert_allclose(
-                    initial_point["u_interval__"], transform_fwd(rv, 0.75, model=pmodel)
-                )
-                assert not hasattr(rv.tag, "test_value")
-        pass
-
-    def test_valid_string_strategy(self):
-        with pm.Model() as pmodel:
-            pm.Uniform("x", 0, 1, size=2, initval="unknown")
-            with pytest.raises(ValueError, match="Invalid string strategy: unknown"):
-                pmodel.initial_point(random_seed=0)
 
 
 class TestInitvalEvaluation:


### PR DESCRIPTION
## Description
Removing these to reduce cognitive load for an eventual migration to a function-based distribution.

These were deprecated in #4500 and #5109, in 2021, as part of pymc 4 being released. We're on 5.x so these should be safe to remove now.

I found about six more deprecated instances of code that were deprecated before the 5.0 release. I don't want to overload maintainers with more work, so will only make a PR with those if it is desired.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #6083

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7488.org.readthedocs.build/en/7488/

<!-- readthedocs-preview pymc end -->