### PR TITLE
Allow copy and deepcopy of PYMC models

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1579,8 +1579,9 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
     def copy(self):
         """
-        Clone a pymc model by overiding the python copy method using the clone_model method from fgraph.
-        Constants are not cloned and if guassian process variables are detected then a warning will be triggered.
+        Clone the model
+
+        To access variables in the cloned model use `cloned_model["var_name"]`.
 
         Examples
         --------

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1570,6 +1570,22 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
     def __contains__(self, key):
         return key in self.named_vars or self.name_for(key) in self.named_vars
+    
+    def __copy__(self):
+        from pymc.model.fgraph import clone_model
+        check_for_gp_vars = [k for x in ['_rotated_', '_hsgp_coeffs_'] for k in self.named_vars.keys() if x in k]
+        if len(check_for_gp_vars) > 0:
+            raise Exception("Unable to clone Gaussian Process Variables")
+    
+        return clone_model(self)
+    
+    def __deepcopy__(self, _):
+        from pymc.model.fgraph import clone_model
+        check_for_gp_vars = [k for x in ['_rotated_', '_hsgp_coeffs_'] for k in self.named_vars.keys() if x in k]
+        if len(check_for_gp_vars) > 0:
+            raise Exception("Unable to clone Gaussian Process Variables")
+        
+        return clone_model(self)
 
     def replace_rvs_by_values(
         self,

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1570,21 +1570,35 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
     def __contains__(self, key):
         return key in self.named_vars or self.name_for(key) in self.named_vars
-    
+
     def __copy__(self):
+        """
+        Clone a pymc model by overiding the python copy method using the clone_model method from fgraph.
+        if guassian process variables are detected then an exception will be raised.
+        """
         from pymc.model.fgraph import clone_model
-        check_for_gp_vars = [k for x in ['_rotated_', '_hsgp_coeffs_'] for k in self.named_vars.keys() if x in k]
+
+        check_for_gp_vars = [
+            k for x in ["_rotated_", "_hsgp_coeffs_"] for k in self.named_vars.keys() if x in k
+        ]
         if len(check_for_gp_vars) > 0:
             raise Exception("Unable to clone Gaussian Process Variables")
-    
+
         return clone_model(self)
-    
+
     def __deepcopy__(self, _):
+        """
+        Clone a pymc model by overiding the python copy method using the clone_model method from fgraph.
+        if guassian process variables are detected then an exception will be raised.
+        """
         from pymc.model.fgraph import clone_model
-        check_for_gp_vars = [k for x in ['_rotated_', '_hsgp_coeffs_'] for k in self.named_vars.keys() if x in k]
+
+        check_for_gp_vars = [
+            k for x in ["_rotated_", "_hsgp_coeffs_"] for k in self.named_vars.keys() if x in k
+        ]
         if len(check_for_gp_vars) > 0:
             raise Exception("Unable to clone Gaussian Process Variables")
-        
+
         return clone_model(self)
 
     def replace_rvs_by_values(

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1574,30 +1574,56 @@ class Model(WithMemoization, metaclass=ContextMeta):
     def __copy__(self):
         """
         Clone a pymc model by overiding the python copy method using the clone_model method from fgraph.
-        if guassian process variables are detected then an exception will be raised.
+        Constants are not cloned and if guassian process variables are detected then a warning will be triggered.
+
+        Examples
+        --------
+        .. code-block:: python
+
+            import pymc as pm
+            import copy
+
+            with pm.Model() as m:
+                p = pm.Beta("p", 1, 1)
+                x = pm.Bernoulli("x", p=p, shape=(3,))
+
+            clone_m = copy.copy(m)
+
+            # Access cloned variables by name
+            clone_x = clone_m["x"]
+
+            # z will be part of clone_m but not m
+            z = pm.Deterministic("z", clone_x + 1)
         """
         from pymc.model.fgraph import clone_model
-
-        check_for_gp_vars = [
-            k for x in ["_rotated_", "_hsgp_coeffs_"] for k in self.named_vars.keys() if x in k
-        ]
-        if len(check_for_gp_vars) > 0:
-            raise Exception("Unable to clone Gaussian Process Variables")
 
         return clone_model(self)
 
     def __deepcopy__(self, _):
         """
         Clone a pymc model by overiding the python copy method using the clone_model method from fgraph.
-        if guassian process variables are detected then an exception will be raised.
+        Constants are not cloned and if guassian process variables are detected then a warning will be triggered.
+
+        Examples
+        --------
+        .. code-block:: python
+
+            import pymc as pm
+            import copy
+
+            with pm.Model() as m:
+                p = pm.Beta("p", 1, 1)
+                x = pm.Bernoulli("x", p=p, shape=(3,))
+
+            clone_m = copy.deepcopy(m)
+
+            # Access cloned variables by name
+            clone_x = clone_m["x"]
+
+            # z will be part of clone_m but not m
+            z = pm.Deterministic("z", clone_x + 1)
         """
         from pymc.model.fgraph import clone_model
-
-        check_for_gp_vars = [
-            k for x in ["_rotated_", "_hsgp_coeffs_"] for k in self.named_vars.keys() if x in k
-        ]
-        if len(check_for_gp_vars) > 0:
-            raise Exception("Unable to clone Gaussian Process Variables")
 
         return clone_model(self)
 

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1572,6 +1572,12 @@ class Model(WithMemoization, metaclass=ContextMeta):
         return key in self.named_vars or self.name_for(key) in self.named_vars
 
     def __copy__(self):
+        return self.copy()
+
+    def __deepcopy__(self, _):
+        return self.copy()
+
+    def copy(self):
         """
         Clone a pymc model by overiding the python copy method using the clone_model method from fgraph.
         Constants are not cloned and if guassian process variables are detected then a warning will be triggered.
@@ -1588,34 +1594,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
                 x = pm.Bernoulli("x", p=p, shape=(3,))
 
             clone_m = copy.copy(m)
-
-            # Access cloned variables by name
-            clone_x = clone_m["x"]
-
-            # z will be part of clone_m but not m
-            z = pm.Deterministic("z", clone_x + 1)
-        """
-        from pymc.model.fgraph import clone_model
-
-        return clone_model(self)
-
-    def __deepcopy__(self, _):
-        """
-        Clone a pymc model by overiding the python copy method using the clone_model method from fgraph.
-        Constants are not cloned and if guassian process variables are detected then a warning will be triggered.
-
-        Examples
-        --------
-        .. code-block:: python
-
-            import pymc as pm
-            import copy
-
-            with pm.Model() as m:
-                p = pm.Beta("p", 1, 1)
-                x = pm.Bernoulli("x", p=p, shape=(3,))
-
-            clone_m = copy.deepcopy(m)
 
             # Access cloned variables by name
             clone_x = clone_m["x"]

--- a/pymc/model/fgraph.py
+++ b/pymc/model/fgraph.py
@@ -160,6 +160,12 @@ def fgraph_from_model(
             "Nested sub-models cannot be converted to fgraph. Convert the parent model instead"
         )
 
+    check_for_gp_vars = [
+        k for x in ["_rotated_", "_hsgp_coeffs_"] for k in model.named_vars.keys() if x in k
+    ]
+    if len(check_for_gp_vars) > 0:
+        warnings.warn("Unable to clone Gaussian Process Variables", UserWarning)
+
     # Collect PyTensor variables
     rvs_to_values = model.rvs_to_values
     rvs = list(rvs_to_values.keys())
@@ -393,11 +399,6 @@ def clone_model(model: Model) -> Model:
             z = pm.Deterministic("z", clone_x + 1)
 
     """
-    check_for_gp_vars = [
-        k for x in ["_rotated_", "_hsgp_coeffs_"] for k in model.named_vars.keys() if x in k
-    ]
-    if len(check_for_gp_vars) > 0:
-        warnings.warn("Unable to clone Gaussian Process Variables", UserWarning)
     return model_from_fgraph(fgraph_from_model(model)[0], mutate_fgraph=True)
 
 

--- a/pymc/model/fgraph.py
+++ b/pymc/model/fgraph.py
@@ -160,11 +160,13 @@ def fgraph_from_model(
             "Nested sub-models cannot be converted to fgraph. Convert the parent model instead"
         )
 
-    check_for_gp_vars = [
-        k for x in ["_rotated_", "_hsgp_coeffs_"] for k in model.named_vars.keys() if x in k
-    ]
-    if len(check_for_gp_vars) > 0:
-        warnings.warn("Unable to clone Gaussian Process Variables", UserWarning)
+    if any(
+        ("_rotated_" in var_name or "_hsgp_coeffs_" in var_name) for var_name in model.named_vars
+    ):
+        warnings.warn(
+            "Detected variables likely created by GP objects. Further use of these old GP objects should be avoided as it may reintroduce variables from the old model. See issue: https://github.com/pymc-devs/pymc/issues/6883",
+            UserWarning,
+        )
 
     # Collect PyTensor variables
     rvs_to_values = model.rvs_to_values
@@ -377,7 +379,7 @@ def clone_model(model: Model) -> Model:
 
     Recreates a PyMC model with clones of the original variables.
     Shared variables will point to the same container but be otherwise different objects.
-    Constants are not cloned and if guassian process variables are detected then a warning will be triggered.
+    Constants are not cloned.
 
 
     Examples

--- a/pymc/model/fgraph.py
+++ b/pymc/model/fgraph.py
@@ -11,6 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import warnings
+
 from copy import copy, deepcopy
 
 import pytensor
@@ -369,7 +371,7 @@ def clone_model(model: Model) -> Model:
 
     Recreates a PyMC model with clones of the original variables.
     Shared variables will point to the same container but be otherwise different objects.
-    Constants are not cloned.
+    Constants are not cloned and if guassian process variables are detected then a warning will be triggered.
 
 
     Examples
@@ -391,6 +393,11 @@ def clone_model(model: Model) -> Model:
             z = pm.Deterministic("z", clone_x + 1)
 
     """
+    check_for_gp_vars = [
+        k for x in ["_rotated_", "_hsgp_coeffs_"] for k in model.named_vars.keys() if x in k
+    ]
+    if len(check_for_gp_vars) > 0:
+        warnings.warn("Unable to clone Gaussian Process Variables", UserWarning)
     return model_from_fgraph(fgraph_from_model(model)[0], mutate_fgraph=True)
 
 

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -1782,12 +1782,10 @@ class TestModelCopy:
                 samples=1, random_seed=42
             )
 
-        simple_model_prior_predictive_val = simple_model_prior_predictive["prior"]["y"].values
-        copy_simple_model_prior_predictive_val = copy_simple_model_prior_predictive["prior"][
-            "y"
-        ].values
-
-        assert simple_model_prior_predictive_val == copy_simple_model_prior_predictive_val
+        assert (
+            simple_model_prior_predictive["prior"]["y"].values
+            == copy_simple_model_prior_predictive["prior"]["y"].values
+        )
 
         with copy_simple_model:
             z = pm.Deterministic("z", copy_simple_model["alpha"] + 1)

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -1764,7 +1764,7 @@ class TestModelGraphs:
             )
 
 
-class TestModelCopy(unittest.TestCase):
+class TestModelCopy:
     @staticmethod
     def simple_model() -> pm.Model:
         with pm.Model() as simple_model:
@@ -1772,7 +1772,7 @@ class TestModelCopy(unittest.TestCase):
             alpha = pm.Normal("alpha", 0, 1)
             pm.Normal("y", alpha, error)
         return simple_model
-    
+
     @staticmethod
     def gp_model() -> pm.Model:
         with pm.Model() as gp_model:
@@ -1782,7 +1782,7 @@ class TestModelCopy(unittest.TestCase):
             f = gp.prior("f", X=np.arange(10)[:, None])
             pm.Normal("y", f * 2)
         return gp_model
-    
+
     def test_copy_model(self) -> None:
         simple_model = self.simple_model()
         copy_simple_model = copy.copy(simple_model)
@@ -1797,17 +1797,27 @@ class TestModelCopy(unittest.TestCase):
         with deepcopy_simple_model:
             deepcopy_simple_model_prior_predictive = pm.sample_prior_predictive(random_seed=42)
 
-        simple_model_prior_predictive_mean = simple_model_prior_predictive['prior']['y'].mean(('chain', 'draw'))
-        copy_simple_model_prior_predictive_mean = copy_simple_model_prior_predictive['prior']['y'].mean(('chain', 'draw'))
-        deepcopy_simple_model_prior_predictive_mean = deepcopy_simple_model_prior_predictive['prior']['y'].mean(('chain', 'draw'))
+        simple_model_prior_predictive_mean = simple_model_prior_predictive["prior"]["y"].mean(
+            ("chain", "draw")
+        )
+        copy_simple_model_prior_predictive_mean = copy_simple_model_prior_predictive["prior"][
+            "y"
+        ].mean(("chain", "draw"))
+        deepcopy_simple_model_prior_predictive_mean = deepcopy_simple_model_prior_predictive[
+            "prior"
+        ]["y"].mean(("chain", "draw"))
 
-        assert np.isclose(simple_model_prior_predictive_mean, copy_simple_model_prior_predictive_mean)
-        assert np.isclose(simple_model_prior_predictive_mean, deepcopy_simple_model_prior_predictive_mean)
+        assert np.isclose(
+            simple_model_prior_predictive_mean, copy_simple_model_prior_predictive_mean
+        )
+        assert np.isclose(
+            simple_model_prior_predictive_mean, deepcopy_simple_model_prior_predictive_mean
+        )
 
     def test_guassian_process_copy_failure(self) -> None:
         gaussian_process_model = self.gp_model()
-        with pytest.raises(Exception) as e:
+        with pytest.warns(UserWarning):
             copy.copy(gaussian_process_model)
-        
-        with pytest.raises(Exception) as e:
+
+        with pytest.warns(UserWarning):
             copy.deepcopy(gaussian_process_model)


### PR DESCRIPTION
## Description
I added  `__copy__` and `__deepcopy__` methods to the Model class. Both will use the `clone_model()` method from `pymc.model.fgraph` and if any guassian process variables are detected in the model an exception is raised. I also created 2 unit tests to test both that the methods work and that the exception is raised upon detecting a gaussian process variable

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #6985 
- [x] Related to #6883 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7492.org.readthedocs.build/en/7492/

<!-- readthedocs-preview pymc end -->