### PR TITLE
Fix latex rendering of variables with underscore in name

### DIFF
--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -58,6 +58,7 @@ def str_for_dist(
     if "latex" in formatting:
         if print_name is not None:
             print_name = r"\text{" + _latex_escape(print_name.strip("$")) + "}"
+            print_name = _format_underscore(print_name)
 
         op_name = (
             dist.owner.op._print_name[1]
@@ -307,8 +308,15 @@ def _format_underscore(variable: str) -> str:
     """
     if "_" not in variable:
         return variable
+
     inds = [i for i, ltr in enumerate(variable) if ltr == "_"]
-    for i, ind in enumerate(inds):
-        ind = ind + i
-        variable = variable[:ind] + "\\" + variable[ind:]
+    var_len_original = len(variable)
+    var_len = None
+    for ind in inds:
+        if var_len:
+            if var_len != var_len_original:
+                ind = ind + (var_len - var_len_original)
+        if variable[ind - 1 : ind] != "\\":
+            variable = variable[:ind] + "\\" + variable[ind:]
+            var_len = len(variable)
     return variable

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -114,6 +114,7 @@ def str_for_model(model: Model, formatting: str = "plain", include_params: bool 
     if not var_reprs:
         return ""
     if "latex" in formatting:
+        var_reprs = [_format_underscore(x) for x in var_reprs]
         var_reprs = [
             var_repr.replace(r"\sim", r"&\sim &").strip("$")
             for var_repr in var_reprs
@@ -295,3 +296,19 @@ try:
 except (ModuleNotFoundError, AttributeError):
     # no ipython shell
     pass
+
+
+def _format_underscore(variable: str) -> str:
+    """
+    formats variables with underscores in its name by prefixing underscores by '\\'
+    ---
+    Params:
+        variable: The string representation of the variable in the model
+    """
+    if "_" not in variable:
+        return variable
+    inds = [i for i, ltr in enumerate(variable) if ltr == "_"]
+    for i, ind in enumerate(inds):
+        ind = ind + i
+        variable = variable[:ind] + "\\" + variable[ind:]
+    return variable

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -13,6 +13,8 @@
 #   limitations under the License.
 
 
+import re
+
 from functools import partial
 
 from pytensor.compile import SharedVariable
@@ -301,22 +303,6 @@ except (ModuleNotFoundError, AttributeError):
 
 def _format_underscore(variable: str) -> str:
     """
-    formats variables with underscores in its name by prefixing underscores by '\\'
-    ---
-    Params:
-        variable: The string representation of the variable in the model
+    Escapes all unescaped underscores in the variable name for LaTeX representation.
     """
-    if "_" not in variable:
-        return variable
-
-    inds = [i for i, ltr in enumerate(variable) if ltr == "_"]
-    var_len_original = len(variable)
-    var_len = None
-    for ind in inds:
-        if var_len:
-            if var_len != var_len_original:
-                ind = ind + (var_len - var_len_original)
-        if variable[ind - 1 : ind] != "\\":
-            variable = variable[:ind] + "\\" + variable[ind:]
-            var_len = len(variable)
-    return variable
+    return re.sub(r"(?<!\\)_", r"\\_", variable)

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -173,15 +173,15 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"$\text{mu} \sim \operatorname{Deterministic}(f(\text{beta},~\text{alpha}))$",
                 r"$\text{beta} \sim \operatorname{Normal}(0,~10)$",
                 r"$\text{Z} \sim \operatorname{MultivariateNormal}(f(),~f())$",
-                r"$\text{nb_with_p_n} \sim \operatorname{NegativeBinomial}(10,~\text{nbp})$",
+                r"$\text{nb\_with\_p\_n} \sim \operatorname{NegativeBinomial}(10,~\text{nbp})$",
                 r"$\text{zip} \sim \operatorname{MarginalMixture}(f(),~\operatorname{DiracDelta}(0),~\operatorname{Poisson}(5))$",
                 r"$\text{w} \sim \operatorname{Dirichlet}(\text{<constant>})$",
                 (
-                    r"$\text{nested_mix} \sim \operatorname{MarginalMixture}(\text{w},"
+                    r"$\text{nested\_mix} \sim \operatorname{MarginalMixture}(\text{w},"
                     r"~\operatorname{MarginalMixture}(f(),~\operatorname{DiracDelta}(0),~\operatorname{Poisson}(5)),"
                     r"~\operatorname{Censored}(\operatorname{Bernoulli}(0.5),~-1,~1))$"
                 ),
-                r"$\text{Y_obs} \sim \operatorname{Normal}(\text{mu},~\text{sigma})$",
+                r"$\text{Y\_obs} \sim \operatorname{Normal}(\text{mu},~\text{sigma})$",
                 r"$\text{pot} \sim \operatorname{Potential}(f(\text{beta},~\text{alpha}))$",
                 r"$\text{pred} \sim \operatorname{Deterministic}(f(\text{<normal>}))",
             ],
@@ -191,11 +191,11 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"$\text{mu} \sim \operatorname{Deterministic}$",
                 r"$\text{beta} \sim \operatorname{Normal}$",
                 r"$\text{Z} \sim \operatorname{MultivariateNormal}$",
-                r"$\text{nb_with_p_n} \sim \operatorname{NegativeBinomial}$",
+                r"$\text{nb\_with\_p\_n} \sim \operatorname{NegativeBinomial}$",
                 r"$\text{zip} \sim \operatorname{MarginalMixture}$",
                 r"$\text{w} \sim \operatorname{Dirichlet}$",
-                r"$\text{nested_mix} \sim \operatorname{MarginalMixture}$",
-                r"$\text{Y_obs} \sim \operatorname{Normal}$",
+                r"$\text{nested\_mix} \sim \operatorname{MarginalMixture}$",
+                r"$\text{Y\_obs} \sim \operatorname{Normal}$",
                 r"$\text{pot} \sim \operatorname{Potential}$",
                 r"$\text{pred} \sim \operatorname{Deterministic}",
             ],
@@ -258,7 +258,7 @@ def test_model_latex_repr_three_levels_model():
         "$$",
         "\\begin{array}{rcl}",
         "\\text{mu} &\\sim & \\operatorname{Normal}(0,~5)\\\\\\text{sigma} &\\sim & "
-        "\\operatorname{HalfCauchy}(0,~2.5)\\\\\\text{censored_normal} &\\sim & "
+        "\\operatorname{HalfCauchy}(0,~2.5)\\\\\\text{censored\\_normal} &\\sim & "
         "\\operatorname{Censored}(\\operatorname{Normal}(\\text{mu},~\\text{sigma}),~-2,~2)",
         "\\end{array}",
         "$$",

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -11,7 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import re
 
 import numpy as np
 
@@ -335,8 +334,5 @@ class TestLatexRepr:
         """
         model = self.simple_model()
         model_str = model.str_repr(formatting="latex")
-        underscores = re.finditer(r"_", model_str)
-        for match in underscores:
-            if match:
-                start = match.span(0)[0] - 1
-                assert model_str[start : start + 1] == "\\"
+        assert "\\_" in model_str
+        assert "_" not in model_str.replace("\\_", "")

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -325,8 +325,8 @@ class TestLatexRepr:
     def simple_model() -> Model:
         with Model() as simple_model:
             error = HalfNormal("error", 0.5)
-            alpha = Normal("alpha", 0, 1)
-            Normal("y", alpha, error)
+            alpha_a = Normal("alpha_a", 0, 1)
+            Normal("y", alpha_a, error)
         return simple_model
 
     def test_latex_escaped_underscore(self):


### PR DESCRIPTION
## Description
I added a simple fix to LaTeX Repr that escapes variables that have underscores in them and I created a unit test to test the fix.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #6508 
- [ ] Related to #7495 and #6533

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change]

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7501.org.readthedocs.build/en/7501/

<!-- readthedocs-preview pymc end -->