### PR TITLE
Add Truncated normal dispatches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,7 @@ jobs:
             tests/distributions/test_shape_utils.py
             tests/distributions/test_mixture.py
             tests/test_testing.py
+            tests/dispatch/test_jax.py
 
           - |
             tests/distributions/test_continuous.py

--- a/pymc/dispatch/dispatch_jax.py
+++ b/pymc/dispatch/dispatch_jax.py
@@ -1,0 +1,28 @@
+#   Copyright 2024 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import jax
+
+from pytensor.link.jax.dispatch import jax_funcify
+
+from pymc.distributions.continous import TruncatedNormalRV
+
+
+@jax_funcify.register(TruncatedNormalRV)
+def jax_funcify_TruncatedNormalRV(op, **kwargs):
+    def trunc_normal_fn(key, size, mu, sigma, lower, upper):
+        return None, jax.random.truncated_normal(
+            key["jax_state"], lower=lower, upper=upper, shape=size
+        )
+
+    return trunc_normal_fn

--- a/tests/dispatch/test_jax.py
+++ b/tests/dispatch/test_jax.py
@@ -13,11 +13,12 @@
 #   limitations under the License.
 import numpy as np
 import pytest
-from pymc.dispatch import dispatch_jax
+
 from pytensor import function
+
 import pymc as pm
 
-
+from pymc.dispatch import dispatch_jax  # noqa: F401
 
 jax = pytest.importorskip("jax")
 

--- a/tests/dispatch/test_jax.py
+++ b/tests/dispatch/test_jax.py
@@ -1,0 +1,36 @@
+#   Copyright 2024 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import numpy as np
+import pytest
+
+from pytensor import function
+
+import pymc as pm
+
+jax = pytest.importorskip("jax", reason="JAX is not installed")
+
+
+def test_jax_TruncatedNormal():
+    with pm.Model() as m:
+        f_jax = function(
+            [],
+            [pm.TruncatedNormal("a", 0, 1, lower=-1, upper=2, rng=np.random.default_rng(seed=123))],
+            mode="JAX",
+        )
+        f_py = function(
+            [],
+            [pm.TruncatedNormal("b", 0, 1, lower=-1, upper=2, rng=np.random.default_rng(seed=123))],
+        )
+
+    assert jax.numpy.array_equal(a1=f_py(), a2=f_jax())

--- a/tests/dispatch/test_jax.py
+++ b/tests/dispatch/test_jax.py
@@ -13,12 +13,13 @@
 #   limitations under the License.
 import numpy as np
 import pytest
-
+from pymc.dispatch import dispatch_jax
 from pytensor import function
-
 import pymc as pm
 
-jax = pytest.importorskip("jax", reason="JAX is not installed")
+
+
+jax = pytest.importorskip("jax")
 
 
 def test_jax_TruncatedNormal():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
Add jax dispatch for truncated normal distribution

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7489


## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works


## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7506.org.readthedocs.build/en/7506/

<!-- readthedocs-preview pymc end -->