### PR TITLE
Return InferenceData when there are no variables sampled and extend=True

### DIFF
--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -825,7 +825,7 @@ def sample_posterior_predictive(
         if return_inferencedata and not extend_inferencedata:
             return InferenceData()
         elif return_inferencedata and extend_inferencedata:
-            return trace
+            return trace if idata is None else idata
         return {}
 
     vars_in_trace = get_vars_in_point_list(_trace, model)

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -492,6 +492,11 @@ class TestSamplePPC:
             ppc = pm.sample_posterior_predictive(trace, var_names=[], return_inferencedata=False)
             assert len(ppc) == 0
 
+            # test empty ppc with extend_inferencedata
+            assert isinstance(trace, InferenceData)
+            ppc = pm.sample_posterior_predictive(trace, var_names=[], extend_inferencedata=True)
+            assert ppc is trace
+
             # test keep_size parameter
             ppc = pm.sample_posterior_predictive(trace, return_inferencedata=False)
             assert ppc["a"].shape == (nchains, ndraws)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
When there are no variables to sample and `extend_inferencedata=True` the returned object
is `trace` _at that point in the code_ which in the common case of providing an InferenceData
to sample_posterior_predictive is only its posterior group. Consequently:

```python
with model:
    idata = pm.sample_posterior_predictive(idata, var_names=[], extend_inferencedata=True)
# now `idata` is the xarray Dataset corresponding to the posterior group
```

This PR changes the behaviour so `idata` above continues to be the provided `idata` and adds
a test for it.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
I considered it was easier to open the PR directly instead of first issue then PR.

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7509.org.readthedocs.build/en/7509/

<!-- readthedocs-preview pymc end -->