### PR TITLE
Remove release test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.7
-    # TODO: ideally, this pipeline should run parallelized tests in upstream jobs..
-    #- name: Install test tooling
-    #  run: |
-    #    pip install pytest pytest-cov nose nose-parameterized
-    #    pip install -r requirements.txt
-    #- name: Run tests
-    #  run: |
-    #    pytest --cov=./pymc --cov-report term-missing pymc/
     - name: Install release tooling
       run: |
         pip install build twine
@@ -40,16 +32,3 @@ jobs:
       run: |
         twine check dist/*
         twine upload --repository pypi --username __token__ --password ${PYPI_TOKEN} dist/*
-  test-install-job:
-    needs: release-job
-    runs-on: ubuntu-latest
-    steps:
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.7
-    - name: Give PyPI a chance to update the index
-      run: sleep 240
-    - name: Install from PyPI
-      run: |
-        pip install pymc==${GITHUB_REF:11}


### PR DESCRIPTION
Failed last time probably because of python3.7 (should we bump the build python as well).

Removed as @maresb thinks it's useless.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7523.org.readthedocs.build/en/7523/

<!-- readthedocs-preview pymc end -->