### PR TITLE
Allow for passing of backend and gradient_backend to nutpie

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -305,10 +305,13 @@ def _sample_external_nuts(
                 "`var_names` are currently ignored by the nutpie sampler",
                 UserWarning,
             )
+        compile_kwargs = {}
+        for kwarg in ("backend", "gradient_backend"):
+            if kwarg in nuts_sampler_kwargs:
+                compile_kwargs[kwarg] = nuts_sampler_kwargs.pop(kwarg)
         compiled_model = nutpie.compile_pymc_model(
             model,
-            backend=nuts_sampler_kwargs.pop("backend", None),
-            gradient_backend=nuts_sampler_kwargs.pop("gradient_backend", None),
+            **compile_kwargs,
         )
         t_start = time.time()
         idata = nutpie.sample(

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -305,7 +305,11 @@ def _sample_external_nuts(
                 "`var_names` are currently ignored by the nutpie sampler",
                 UserWarning,
             )
-        compiled_model = nutpie.compile_pymc_model(model)
+        compiled_model = nutpie.compile_pymc_model(
+            model,
+            backend=nuts_sampler_kwargs.pop("backend", None),
+            gradient_backend=nuts_sampler_kwargs.pop("gradient_backend", None),
+        )
         t_start = time.time()
         idata = nutpie.sample(
             compiled_model,


### PR DESCRIPTION
## Description

There is no means for passing `backend` and `gradient_backend` to `compile_pymc_model` from `sample`, so that JAX can be used as a backend. This just looks for these arguments in `nuts_sampler_kwargs` and passes them if they exist.

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7535.org.readthedocs.build/en/7535/

<!-- readthedocs-preview pymc end -->