### PR TITLE
Automatically label PRs based on *closing* issues

### DIFF
--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -12,29 +12,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Sync labels with closing issues
-      run: |
-        owner="pymc-devs"
-        name="pymc"
-        pr_number=${{ github.event.pull_request.number }}
-
-        labels=$(gh api graphql --paginate -F number=$pr_number -F owner=$owner -F name=$name -f query='
-          query($endCursor: String, $owner: String!, $name: String!, $number: Int!) {
-            repository(owner: $owner, name: $name) {
-              pullRequest(number: $number) {
-                closingIssuesReferences(first: 10, after: $endCursor) {
-                  nodes {
-                    labels(first: 10) {
-                      nodes {
-                        name
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-          ' --jq '.data.repository.pullRequest.closingIssuesReferences.nodes | map(.labels.nodes | map(.name)) | flatten | unique | join(",")')
-
-        gh pr edit $pr_number --add-label "$labels"
+      uses: wd60622/closing-labels@v0.0.3
+      with:
+        exclude: ""
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,40 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  sync:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Sync labels with closing issues
+      run: |
+        owner="pymc-devs"
+        name="pymc"
+        pr_number=${{ github.event.pull_request.number }}
+
+        labels=$(gh api graphql --paginate -F number=$pr_number -F owner=$owner -F name=$name -f query='
+          query($endCursor: String, $owner: String!, $name: String!, $number: Int!) {
+            repository(owner: $owner, name: $name) {
+              pullRequest(number: $number) {
+                closingIssuesReferences(first: 10, after: $endCursor) {
+                  nodes {
+                    labels(first: 10) {
+                      nodes {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          ' --jq '.data.repository.pullRequest.closingIssuesReferences.nodes | map(.labels.nodes | map(.name)) | flatten | unique | join(",")')
+
+        gh pr edit $pr_number --add-label "$labels"
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -14,6 +14,6 @@ jobs:
     - name: Sync labels with closing issues
       uses: wd60622/closing-labels@v0.0.3
       with:
-        exclude: ""
+        exclude: "help wanted,needs info"
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

Automation added to pymc-marketing. Adds all of the labels that are in the closing issues of a PR

Should pair well with the issue templates having labels

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7547.org.readthedocs.build/en/7547/

<!-- readthedocs-preview pymc end -->