### PR TITLE
Fix bug in `implicit_size_from_params`

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -1626,7 +1626,7 @@ class AsymmetricLaplace(Continuous):
     def logp(value, b, kappa, mu):
         value = value - mu
         res = pt.log(b / (kappa + (kappa**-1))) + (
-            -value * b * pt.sgn(value) * (kappa ** pt.sgn(value))
+            -value * b * pt.sign(value) * (kappa ** pt.sign(value))
         )
 
         return check_parameters(

--- a/pymc/distributions/moments/means.py
+++ b/pymc/distributions/moments/means.py
@@ -50,7 +50,7 @@ from pytensor.tensor.random.basic import (
     UniformRV,
     VonMisesRV,
 )
-from pytensor.tensor.var import TensorVariable
+from pytensor.tensor.variable import TensorVariable
 
 from pymc.distributions.continuous import (
     AsymmetricLaplaceRV,

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -461,7 +461,7 @@ def implicit_size_from_params(
     for param, ndim in zip(params, ndims_params):
         batch_shape = list(param.shape[:-ndim] if ndim > 0 else param.shape)
         # Overwrite broadcastable dims
-        for i, broadcastable in enumerate(param.type.broadcastable):
+        for i, broadcastable in enumerate(param.type.broadcastable[: len(batch_shape)]):
             if broadcastable:
                 batch_shape[i] = 1
         batch_shapes.append(batch_shape)

--- a/tests/distributions/test_shape_utils.py
+++ b/tests/distributions/test_shape_utils.py
@@ -35,9 +35,11 @@ from pymc.distributions.shape_utils import (
     convert_size,
     get_support_shape,
     get_support_shape_1d,
+    implicit_size_from_params,
     rv_size_is_none,
 )
 from pymc.model import Model
+from pymc.pytensorf import constant_fold
 
 test_shapes = [
     ((), (1,), (4,), (5, 4)),
@@ -630,3 +632,10 @@ def test_get_support_shape(
             assert (f() == expected_support_shape).all()
             with pytest.raises(AssertionError, match="support_shape does not match"):
                 inferred_support_shape.eval()
+
+
+def test_implicit_size_from_params():
+    x = pt.tensor(shape=(5, 1))
+    y = pt.tensor(shape=(3, 3))
+    res = implicit_size_from_params(x, y, ndims_params=[1, 2])
+    assert constant_fold([res]) == (5,)


### PR DESCRIPTION
Also avoids some deprecation warnings in a separate commit

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7564.org.readthedocs.build/en/7564/

<!-- readthedocs-preview pymc end -->