### PR TITLE
fix flaky test, remove high tolerance

### DIFF
--- a/tests/gp/test_gp.py
+++ b/tests/gp/test_gp.py
@@ -409,9 +409,9 @@ class TestMarginalVsLatent:
             == numpy_rv_logp.shape.eval()
         )
 
-        npt.assert_allclose(latent_rv_logp.eval({"f": y}), marginal_rv_logp.eval())
-        npt.assert_allclose(latent_rv_logp.eval({"f": y}), numpy_rv_logp.eval())
-        npt.assert_allclose(marginal_rv_logp.eval(), numpy_rv_logp.eval())
+        npt.assert_allclose(latent_rv_logp.eval({"f": y}), marginal_rv_logp.eval(), rtol=1e-4)
+        npt.assert_allclose(latent_rv_logp.eval({"f": y}), numpy_rv_logp.eval(), rtol=1e-4)
+        npt.assert_allclose(marginal_rv_logp.eval(), numpy_rv_logp.eval(), rtol=1e-4)
 
 
 class TestTP:

--- a/tests/gp/test_gp.py
+++ b/tests/gp/test_gp.py
@@ -409,9 +409,9 @@ class TestMarginalVsLatent:
             == numpy_rv_logp.shape.eval()
         )
 
-        npt.assert_allclose(latent_rv_logp.eval(), marginal_rv_logp.eval(), atol=5)
-        npt.assert_allclose(latent_rv_logp.eval(), numpy_rv_logp.eval(), atol=5)
-        npt.assert_allclose(marginal_rv_logp.eval(), numpy_rv_logp.eval(), atol=5)
+        npt.assert_allclose(latent_rv_logp.eval({"f": y}), marginal_rv_logp.eval())
+        npt.assert_allclose(latent_rv_logp.eval({"f": y}), numpy_rv_logp.eval())
+        npt.assert_allclose(marginal_rv_logp.eval(), numpy_rv_logp.eval())
 
 
 class TestTP:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
The multi-output GP test was flaky.  Turns out that it was lucky that it was passing occasionally.  It was testing whether two GP implementations were correct when they were subtly different.  `pm.gp.Latent.conditional` was conditioning on the original gp `f`, and `pm.gp.Marginal.conditional` was conditioning on the observed data `y`.   The fix is to condition `pm.gp.Latent.conditional` on `y` also in the test.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7531 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7567.org.readthedocs.build/en/7567/

<!-- readthedocs-preview pymc end -->