### PR TITLE
Fix doctring log-likelihood to distribution, Fix for issue #7563

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -194,7 +194,7 @@ def quaddist_chol(value, mu, cov):
 
 class MvNormal(Continuous):
     r"""
-    Multivariate normal log-likelihood.
+    Multivariate normal distribution.
 
     .. math::
 
@@ -394,7 +394,7 @@ mv_studentt = MvStudentTRV()
 
 class MvStudentT(Continuous):
     r"""
-    Multivariate Student-T log-likelihood.
+    Multivariate Student-T distribution.
 
     .. math::
         f(\mathbf{x}| \nu,\mu,\Sigma) =
@@ -491,7 +491,7 @@ class MvStudentT(Continuous):
 
 class Dirichlet(SimplexContinuous):
     r"""
-    Dirichlet log-likelihood.
+    Dirichlet distribution.
 
     .. math::
 
@@ -563,7 +563,7 @@ class Dirichlet(SimplexContinuous):
 
 class Multinomial(Discrete):
     r"""
-    Multinomial log-likelihood.
+    Multinomial distribution.
 
     Generalizes binomial distribution, but instead of each trial resulting
     in "success" or "failure", each one results in exactly one of some
@@ -691,7 +691,7 @@ class DirichletMultinomialRV(SymbolicRandomVariable):
 
 
 class DirichletMultinomial(Discrete):
-    r"""Dirichlet Multinomial log-likelihood.
+    r"""Dirichlet Multinomial distribution.
 
     Dirichlet mixture of Multinomials distribution, with a marginalized PMF.
 
@@ -950,7 +950,7 @@ wishart = WishartRV()
 
 class Wishart(Continuous):
     r"""
-    Wishart log-likelihood.
+    Wishart distribution.
 
     The Wishart distribution is the probability distribution of the
     maximum-likelihood estimator (MLE) of the precision matrix of a
@@ -1648,7 +1648,7 @@ def lkjcorr_default_transform(op, rv):
 
 class LKJCorr:
     r"""
-    The LKJ (Lewandowski, Kurowicka and Joe) log-likelihood.
+    The LKJ (Lewandowski, Kurowicka and Joe) distribution.
 
     The LKJ distribution is a prior distribution for correlation matrices.
     If eta = 1 this corresponds to the uniform distribution over correlation
@@ -1753,7 +1753,7 @@ matrixnormal = MatrixNormalRV()
 
 class MatrixNormal(Continuous):
     r"""
-    Matrix-valued normal log-likelihood.
+    Matrix-valued normal distribution.
 
     .. math::
        f(x \mid \mu, U, V) =
@@ -1961,7 +1961,7 @@ class KroneckerNormalRV(SymbolicRandomVariable):
 
 class KroneckerNormal(Continuous):
     r"""
-    Multivariate normal log-likelihood with Kronecker-structured covariance.
+    Multivariate normal distribution with Kronecker-structured covariance.
 
     .. math::
 


### PR DESCRIPTION
Replaced all the "log-likelihood" with "distribution" in multivariate.py file

## Description
Updated the docstrings for better clarity. Replaced "log-likelihood" with "distribution" to accurately describe the functionality, as the class provides more than just log-likelihood, including cdf, mean, and random methods.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7563 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7576.org.readthedocs.build/en/7576/

<!-- readthedocs-preview pymc end -->