### PR TITLE
Speedup `sample` and allow specifying `compile_kwargs` (several major changes related to step samplers)

### DIFF
--- a/pymc/backends/__init__.py
+++ b/pymc/backends/__init__.py
@@ -72,6 +72,7 @@ from pytensor.tensor.variable import TensorVariable
 from pymc.backends.arviz import predictions_to_inference_data, to_inference_data
 from pymc.backends.base import BaseTrace, IBaseTrace
 from pymc.backends.ndarray import NDArray
+from pymc.blocking import PointType
 from pymc.model import Model
 from pymc.step_methods.compound import BlockedStep, CompoundStep
 
@@ -100,11 +101,12 @@ def _init_trace(
     trace: BaseTrace | None,
     model: Model,
     trace_vars: list[TensorVariable] | None = None,
+    initial_point: PointType | None = None,
 ) -> BaseTrace:
     """Initialize a trace backend for a chain."""
     strace: BaseTrace
     if trace is None:
-        strace = NDArray(model=model, vars=trace_vars)
+        strace = NDArray(model=model, vars=trace_vars, test_point=initial_point)
     elif isinstance(trace, BaseTrace):
         if len(trace) > 0:
             raise ValueError("Continuation of traces is no longer supported.")
@@ -122,7 +124,7 @@ def init_traces(
     chains: int,
     expected_length: int,
     step: BlockedStep | CompoundStep,
-    initial_point: Mapping[str, np.ndarray],
+    initial_point: PointType,
     model: Model,
     trace_vars: list[TensorVariable] | None = None,
 ) -> tuple[RunType | None, Sequence[IBaseTrace]]:
@@ -145,6 +147,7 @@ def init_traces(
             trace=backend,
             model=model,
             trace_vars=trace_vars,
+            initial_point=initial_point,
         )
         for chain_number in range(chains)
     ]

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -40,8 +40,8 @@ class NDArray(base.BaseTrace):
         `model.unobserved_RVs` is used.
     """
 
-    def __init__(self, name=None, model=None, vars=None, test_point=None):
-        super().__init__(name, model, vars, test_point)
+    def __init__(self, name=None, model=None, vars=None, test_point=None, **kwargs):
+        super().__init__(name, model, vars, test_point, **kwargs)
         self.draw_idx = 0
         self.draws = None
         self.samples = {}
@@ -166,7 +166,13 @@ class NDArray(base.BaseTrace):
         # Only the first `draw_idx` value are valid because of preallocation
         idx = slice(*idx.indices(len(self)))
 
-        sliced = NDArray(model=self.model, vars=self.vars)
+        sliced = type(self)(
+            model=self.model,
+            vars=self.vars,
+            fn=self.fn,
+            var_shapes=self.var_shapes,
+            var_dtypes=self.var_dtypes,
+        )
         sliced.chain = self.chain
         sliced.samples = {varname: values[idx] for varname, values in self.samples.items()}
         sliced.sampler_vars = self.sampler_vars

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -76,7 +76,7 @@ class NDArray(base.BaseTrace):
         else:  # Otherwise, make array of zeros for each variable.
             self.draws = draws
             for varname, shape in self.var_shapes.items():
-                self.samples[varname] = np.zeros((draws, *shape), dtype=self.var_dtypes[varname])
+                self.samples[varname] = np.empty((draws, *shape), dtype=self.var_dtypes[varname])
 
         if sampler_vars is None:
             return
@@ -105,7 +105,7 @@ class NDArray(base.BaseTrace):
         point: dict
             Values mapped to variable names
         """
-        for varname, value in zip(self.varnames, self.fn(point)):
+        for varname, value in zip(self.varnames, self.fn(*point.values())):
             self.samples[varname][self.draw_idx] = value
 
         if self._stats is not None and sampler_stats is None:

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -105,17 +105,18 @@ class NDArray(base.BaseTrace):
         point: dict
             Values mapped to variable names
         """
+        samples = self.samples
+        draw_idx = self.draw_idx
         for varname, value in zip(self.varnames, self.fn(*point.values())):
-            self.samples[varname][self.draw_idx] = value
+            samples[varname][draw_idx] = value
 
-        if self._stats is not None and sampler_stats is None:
-            raise ValueError("Expected sampler_stats")
-        if self._stats is None and sampler_stats is not None:
-            raise ValueError("Unknown sampler_stats")
         if sampler_stats is not None:
             for data, vars in zip(self._stats, sampler_stats):
                 for key, val in vars.items():
-                    data[key][self.draw_idx] = val
+                    data[key][draw_idx] = val
+        elif self._stats is not None:
+            raise ValueError("Expected sampler_stats")
+
         self.draw_idx += 1
 
     def _get_sampler_stats(

--- a/pymc/blocking.py
+++ b/pymc/blocking.py
@@ -39,11 +39,11 @@ StatDtype: TypeAlias = type | np.dtype
 StatShape: TypeAlias = Sequence[int | None] | None
 
 
-# `point_map_info` is a tuple of tuples containing `(name, shape, dtype)` for
+# `point_map_info` is a tuple of tuples containing `(name, shape, size, dtype)` for
 # each of the raveled variables.
 class RaveledVars(NamedTuple):
     data: np.ndarray
-    point_map_info: tuple[tuple[str, tuple[int, ...], np.dtype], ...]
+    point_map_info: tuple[tuple[str, tuple[int, ...], int, np.dtype], ...]
 
 
 class Compose(Generic[T]):
@@ -67,10 +67,9 @@ class DictToArrayBijection:
     @staticmethod
     def map(var_dict: PointType) -> RaveledVars:
         """Map a dictionary of names and variables to a concatenated 1D array space."""
-        vars_info = tuple((v, k, v.shape, v.dtype) for k, v in var_dict.items())
-        raveled_vars = [v[0].ravel() for v in vars_info]
-        if raveled_vars:
-            result = np.concatenate(raveled_vars)
+        vars_info = tuple((v, k, v.shape, v.size, v.dtype) for k, v in var_dict.items())
+        if vars_info:
+            result = np.concatenate(tuple(v[0].ravel() for v in vars_info))
         else:
             result = np.array([])
         return RaveledVars(result, tuple(v[1:] for v in vars_info))
@@ -91,19 +90,15 @@ class DictToArrayBijection:
 
         """
         if start_point:
-            result = dict(start_point)
+            result = start_point.copy()
         else:
             result = {}
 
-        if not isinstance(array, RaveledVars):
-            raise TypeError("`array` must be a `RaveledVars` type")
-
         last_idx = 0
-        for name, shape, dtype in array.point_map_info:
-            arr_len = np.prod(shape, dtype=int)
-            var = array.data[last_idx : last_idx + arr_len].reshape(shape).astype(dtype)
-            result[name] = var
-            last_idx += arr_len
+        for name, shape, size, dtype in array.point_map_info:
+            end = last_idx + size
+            result[name] = array.data[last_idx:end].reshape(shape).astype(dtype)
+            last_idx = end
 
         return result
 

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -48,7 +48,7 @@ from pymc.exceptions import (
     ShapeError,
     ShapeWarning,
 )
-from pymc.initial_point import make_initial_point_fn
+from pymc.initial_point import PointType, make_initial_point_fn
 from pymc.logprob.basic import transformed_conditional_logp
 from pymc.logprob.transforms import Transform
 from pymc.logprob.utils import ParameterValueError, replace_rvs_by_values
@@ -174,7 +174,7 @@ class ValueGradFunction:
         casting="no",
         compute_grads=True,
         model=None,
-        initial_point=None,
+        initial_point: PointType | None = None,
         ravel_inputs: bool | None = None,
         **kwargs,
     ):
@@ -533,7 +533,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         self,
         grad_vars=None,
         tempered=False,
-        initial_point=None,
+        initial_point: PointType | None = None,
         ravel_inputs: bool | None = None,
         **kwargs,
     ):

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -1024,7 +1024,12 @@ def compile_pymc(
     """
     # Create an update mapping of RandomVariable's RNG so that it is automatically
     # updated after every function call
-    rng_updates = collect_default_updates(inputs=inputs, outputs=outputs)
+    rng_updates = collect_default_updates(
+        inputs=[inp.variable if isinstance(inp, pytensor.In) else inp for inp in inputs],
+        outputs=[
+            out.variable if isinstance(out, pytensor.Out) else out for out in makeiter(outputs)
+        ],
+    )
 
     # We always reseed random variables as this provides RNGs with no chances of collision
     if rng_updates:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1277,14 +1277,11 @@ def _mp_sample(
                     strace = traces[draw.chain]
                     strace.record(draw.point, draw.stats)
                     log_warning_stats(draw.stats)
-                    if draw.is_last:
-                        strace.close()
 
                     if callback is not None:
                         callback(trace=strace, draw=draw)
 
         except ps.ParallelSamplingError as error:
-            strace = traces[error._chain]
             for strace in traces:
                 strace.close()
             raise

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -101,7 +101,9 @@ def instantiate_steppers(
     model: Model,
     steps: list[Step],
     selected_steps: Mapping[type[BlockedStep], list[Any]],
+    *,
     step_kwargs: dict[str, dict] | None = None,
+    initial_point: PointType | None = None,
 ) -> Step | list[Step]:
     """Instantiate steppers assigned to the model variables.
 
@@ -131,13 +133,22 @@ def instantiate_steppers(
         step_kwargs = {}
 
     used_keys = set()
-    for step_class, vars in selected_steps.items():
-        if vars:
-            name = getattr(step_class, "name")
-            args = step_kwargs.get(name, {})
-            used_keys.add(name)
-            step = step_class(vars=vars, model=model, **args)
-            steps.append(step)
+    if selected_steps:
+        if initial_point is None:
+            initial_point = model.initial_point()
+
+        for step_class, vars in selected_steps.items():
+            if vars:
+                name = getattr(step_class, "name")
+                kwargs = step_kwargs.get(name, {})
+                used_keys.add(name)
+                step = step_class(
+                    vars=vars,
+                    model=model,
+                    initial_point=initial_point,
+                    **kwargs,
+                )
+                steps.append(step)
 
     unused_args = set(step_kwargs).difference(used_keys)
     if unused_args:
@@ -161,17 +172,21 @@ def assign_step_methods(
     model: Model,
     step: Step | Sequence[Step] | None = None,
     methods: Sequence[type[BlockedStep]] | None = None,
-    step_kwargs: dict[str, Any] | None = None,
-) -> Step | list[Step]:
+) -> tuple[list[Step], dict[type[BlockedStep], list[Variable]]]:
     """Assign model variables to appropriate step methods.
 
-    Passing a specified model will auto-assign its constituent stochastic
-    variables to step methods based on the characteristics of the variables.
+    Passing a specified model will auto-assign its constituent value
+    variables to step methods based on the characteristics of the respective
+    random variables, and whether the logp can be differentiated with respect to it.
+
     This function is intended to be called automatically from ``sample()``, but
     may be called manually. Each step method passed should have a
     ``competence()`` method that returns an ordinal competence value
     corresponding to the variable passed to it. This value quantifies the
     appropriateness of the step method for sampling the variable.
+
+    The outputs of this function can then be passed to `instantiate_steppers()`
+    to initialize the assigned step samplers.
 
     Parameters
     ----------
@@ -183,24 +198,32 @@ def assign_step_methods(
     methods : iterable of step method classes, optional
         The set of step methods from which the function may choose. Defaults
         to the main step methods provided by PyMC.
-    step_kwargs : dict, optional
-        Parameters for the samplers. Keys are the lower case names of
-        the step method, values a dict of arguments.
 
     Returns
     -------
-    methods : list
-        List of step methods associated with the model's variables.
+    provided_steps: list of Step instances
+        List of user provided instantiated step(s)
+    assigned_steps: dict of Step class to Variable
+        Dictionary with automatically selected step classes as keys and associated value variables as values
     """
-    steps: list[Step] = []
+    provided_steps: list[Step] = []
     assigned_vars: set[Variable] = set()
 
     if step is not None:
         if isinstance(step, BlockedStep | CompoundStep):
-            steps.append(step)
+            provided_steps = [step]
+        elif isinstance(step, Sequence):
+            provided_steps = list(step)
         else:
-            steps.extend(step)
-        for step in steps:
+            raise ValueError(f"Step should be a Step or a sequence of Steps, got {step}")
+
+        for step in provided_steps:
+            if not isinstance(step, BlockedStep | CompoundStep):
+                if issubclass(step, BlockedStep | CompoundStep):
+                    raise ValueError(f"Provided {step} was not initialized")
+                else:
+                    raise ValueError(f"{step} is not a Step instance")
+
             for var in step.vars:
                 if var not in model.value_vars:
                     raise ValueError(
@@ -235,7 +258,7 @@ def assign_step_methods(
             )
             selected_steps.setdefault(selected, []).append(var)
 
-    return instantiate_steppers(model, steps, selected_steps, step_kwargs)
+    return provided_steps, selected_steps
 
 
 def _print_step_hierarchy(s: Step, level: int = 0) -> None:
@@ -719,22 +742,23 @@ def sample(
         msg = f"Only {draws} samples per chain. Reliable r-hat and ESS diagnostics require longer chains for accurate estimate."
         _log.warning(msg)
 
-    auto_nuts_init = True
-    if step is not None:
-        if isinstance(step, CompoundStep):
-            for method in step.methods:
-                if isinstance(method, NUTS):
-                    auto_nuts_init = False
-        elif isinstance(step, NUTS):
-            auto_nuts_init = False
-
-    initial_points = None
-    step = assign_step_methods(model, step, methods=pm.STEP_METHODS, step_kwargs=kwargs)
+    provided_steps, selected_steps = assign_step_methods(model, step, methods=pm.STEP_METHODS)
+    exclusive_nuts = (
+        # User provided an instantiated NUTS step, and nothing else is needed
+        (not selected_steps and len(provided_steps) == 1 and isinstance(provided_steps[0], NUTS))
+        or
+        # Only automatically selected NUTS step is needed
+        (
+            not provided_steps
+            and len(selected_steps) == 1
+            and issubclass(next(iter(selected_steps)), NUTS)
+        )
+    )
 
     if nuts_sampler != "pymc":
-        if not isinstance(step, NUTS):
+        if not exclusive_nuts:
             raise ValueError(
-                "Model can not be sampled with NUTS alone. Your model is probably not continuous."
+                "Model can not be sampled with NUTS alone. It either has discrete variables or a non-differentiable log-probability."
             )
 
         with joined_blas_limiter():
@@ -755,13 +779,11 @@ def sample(
                 **kwargs,
             )
 
-    if isinstance(step, list):
-        step = CompoundStep(step)
-    elif isinstance(step, NUTS) and auto_nuts_init:
+    if exclusive_nuts and not provided_steps:
+        # Special path for NUTS initialization
         if "nuts" in kwargs:
             nuts_kwargs = kwargs.pop("nuts")
             [kwargs.setdefault(k, v) for k, v in nuts_kwargs.items()]
-        _log.info("Auto-assigning NUTS sampler...")
         with joined_blas_limiter():
             initial_points, step = init_nuts(
                 init=init,
@@ -775,9 +797,8 @@ def sample(
                 initvals=initvals,
                 **kwargs,
             )
-
-    if initial_points is None:
-        # Time to draw/evaluate numeric start points for each chain.
+    else:
+        # Get initial points
         ipfns = make_initial_point_fns_per_chain(
             model=model,
             overrides=initvals,
@@ -786,11 +807,16 @@ def sample(
         )
         initial_points = [ipfn(seed) for ipfn, seed in zip(ipfns, random_seed_list)]
 
-    # One final check that shapes and logps at the starting points are okay.
-    ip: dict[str, np.ndarray]
-    for ip in initial_points:
-        model.check_start_vals(ip)
-        _check_start_shape(model, ip)
+        # Instantiate automatically selected steps
+        step = instantiate_steppers(
+            model,
+            steps=provided_steps,
+            selected_steps=selected_steps,
+            step_kwargs=kwargs,
+            initial_point=initial_points[0],
+        )
+        if isinstance(step, list):
+            step = CompoundStep(step)
 
     if var_names is not None:
         trace_vars = [v for v in model.unobserved_RVs if v.name in var_names]
@@ -806,7 +832,7 @@ def sample(
         expected_length=draws + tune,
         step=step,
         trace_vars=trace_vars,
-        initial_point=ip,
+        initial_point=initial_points[0],
         model=model,
     )
 
@@ -954,7 +980,6 @@ def _sample_return(
         f"took {t_sampling:.0f} seconds."
     )
 
-    idata = None
     if compute_convergence_checks or return_inferencedata:
         ikwargs: dict[str, Any] = {"model": model, "save_warmup": not discard_tuned_samples}
         ikwargs.update(idata_kwargs)
@@ -1159,7 +1184,6 @@ def _iter_sample(
     diverging : bool
         Indicates if the draw is divergent. Only available with some samplers.
     """
-    model = modelcontext(model)
     draws = int(draws)
 
     if draws < 1:
@@ -1174,8 +1198,6 @@ def _iter_sample(
         if hasattr(step, "reset_tuning"):
             step.reset_tuning()
         for i in range(draws):
-            diverging = False
-
             if i == 0 and hasattr(step, "iter_count"):
                 step.iter_count = 0
             if i == tune:
@@ -1298,6 +1320,7 @@ def _init_jitter(
     seeds: Sequence[int] | np.ndarray,
     jitter: bool,
     jitter_max_retries: int,
+    logp_dlogp_func=None,
 ) -> list[PointType]:
     """Apply a uniform jitter in [-1, 1] to the test value as starting point in each chain.
 
@@ -1328,19 +1351,30 @@ def _init_jitter(
     if not jitter:
         return [ipfn(seed) for ipfn, seed in zip(ipfns, seeds)]
 
+    model_logp_fn: Callable
+    if logp_dlogp_func is None:
+        model_logp_fn = model.compile_logp()
+    else:
+
+        def model_logp_fn(ip):
+            q, _ = DictToArrayBijection.map(ip)
+            return logp_dlogp_func([q], extra_vars={})[0]
+
     initial_points = []
     for ipfn, seed in zip(ipfns, seeds):
-        rng = np.random.RandomState(seed)
+        rng = np.random.default_rng(seed)
         for i in range(jitter_max_retries + 1):
             point = ipfn(seed)
-            if i < jitter_max_retries:
-                try:
+            point_logp = model_logp_fn(point)
+            if not np.isfinite(point_logp):
+                if i == jitter_max_retries:
+                    # Print informative message on last attempted point
                     model.check_start_vals(point)
-                except SamplingError:
-                    # Retry with a new seed
-                    seed = rng.randint(2**30, dtype=np.int64)
-                else:
-                    break
+                # Retry with a new seed
+                seed = rng.integers(2**30, dtype=np.int64)
+            else:
+                break
+
         initial_points.append(point)
     return initial_points
 
@@ -1436,10 +1470,12 @@ def init_nuts(
 
     _log.info(f"Initializing NUTS using {init}...")
 
-    cb = [
-        pm.callbacks.CheckParametersConvergence(tolerance=1e-2, diff="absolute"),
-        pm.callbacks.CheckParametersConvergence(tolerance=1e-2, diff="relative"),
-    ]
+    cb = []
+    if "advi" in init:
+        cb = [
+            pm.callbacks.CheckParametersConvergence(tolerance=1e-2, diff="absolute"),
+            pm.callbacks.CheckParametersConvergence(tolerance=1e-2, diff="relative"),
+        ]
 
     logp_dlogp_func = model.logp_dlogp_function(ravel_inputs=True)
     logp_dlogp_func.trust_input = True
@@ -1449,6 +1485,7 @@ def init_nuts(
         seeds=random_seed_list,
         jitter="jitter" in init,
         jitter_max_retries=jitter_max_retries,
+        logp_dlogp_func=logp_dlogp_func,
     )
 
     apoints = [DictToArrayBijection.map(point) for point in initial_points]
@@ -1562,7 +1599,14 @@ def init_nuts(
     else:
         raise ValueError(f"Unknown initializer: {init}.")
 
-    step = pm.NUTS(potential=potential, model=model, rng=random_seed_list[0], **kwargs)
+    step = pm.NUTS(
+        potential=potential,
+        model=model,
+        rng=random_seed_list[0],
+        initial_point=initial_points[0],
+        logp_dlogp_func=logp_dlogp_func,
+        **kwargs,
+    )
 
     # Filter deterministics from initial_points
     value_var_names = [var.name for var in model.value_vars]

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1441,6 +1441,8 @@ def init_nuts(
         pm.callbacks.CheckParametersConvergence(tolerance=1e-2, diff="relative"),
     ]
 
+    logp_dlogp_func = model.logp_dlogp_function(ravel_inputs=True)
+    logp_dlogp_func.trust_input = True
     initial_points = _init_jitter(
         model,
         initvals,

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -228,15 +228,12 @@ class ProcessAdapter:
         self._shared_point = {}
         self._point = {}
 
-        for name, shape, dtype in DictToArrayBijection.map(start).point_map_info:
-            size = 1
-            for dim in shape:
-                size *= int(dim)
-            size *= dtype.itemsize
-            if size != ctypes.c_size_t(size).value:
+        for name, shape, size, dtype in DictToArrayBijection.map(start).point_map_info:
+            byte_size = size * dtype.itemsize
+            if byte_size != ctypes.c_size_t(byte_size).value:
                 raise ValueError(f"Variable {name} is too large")
 
-            array = mp_ctx.RawArray("c", size)
+            array = mp_ctx.RawArray("c", byte_size)
             self._shared_point[name] = (array, shape, dtype)
             array_np = np.frombuffer(array, dtype).reshape(shape)
             array_np[...] = start[name]

--- a/pymc/step_methods/arraystep.py
+++ b/pymc/step_methods/arraystep.py
@@ -181,6 +181,7 @@ class GradientSharedStep(ArrayStepShared):
         dtype=None,
         logp_dlogp_func=None,
         rng: RandomGenerator = None,
+        initial_point: PointType | None = None,
         **pytensor_kwargs,
     ):
         model = modelcontext(model)
@@ -190,6 +191,7 @@ class GradientSharedStep(ArrayStepShared):
                 vars,
                 dtype=dtype,
                 ravel_inputs=True,
+                initial_point=initial_point,
                 **pytensor_kwargs,
             )
             logp_dlogp_func.trust_input = True

--- a/pymc/step_methods/arraystep.py
+++ b/pymc/step_methods/arraystep.py
@@ -174,8 +174,9 @@ class GradientSharedStep(ArrayStepShared):
     def __init__(
         self,
         vars,
+        *,
         model=None,
-        blocked=True,
+        blocked: bool = True,
         dtype=None,
         logp_dlogp_func=None,
         rng: RandomGenerator = None,

--- a/pymc/step_methods/arraystep.py
+++ b/pymc/step_methods/arraystep.py
@@ -185,17 +185,17 @@ class GradientSharedStep(ArrayStepShared):
         model = modelcontext(model)
 
         if logp_dlogp_func is None:
-            func = model.logp_dlogp_function(vars, dtype=dtype, **pytensor_kwargs)
-        else:
-            func = logp_dlogp_func
+            logp_dlogp_func = model.logp_dlogp_function(
+                vars,
+                dtype=dtype,
+                ravel_inputs=True,
+                **pytensor_kwargs,
+            )
+            logp_dlogp_func.trust_input = True
 
-        self._logp_dlogp_func = func
+        self._logp_dlogp_func = logp_dlogp_func
 
-        super().__init__(vars, func._extra_vars_shared, blocked, rng=rng)
-
-    def step(self, point) -> tuple[PointType, StatsType]:
-        self._logp_dlogp_func._extra_are_set = True
-        return super().step(point)
+        super().__init__(vars, logp_dlogp_func._extra_vars_shared, blocked, rng=rng)
 
 
 def metrop_select(

--- a/pymc/step_methods/arraystep.py
+++ b/pymc/step_methods/arraystep.py
@@ -182,16 +182,20 @@ class GradientSharedStep(ArrayStepShared):
         logp_dlogp_func=None,
         rng: RandomGenerator = None,
         initial_point: PointType | None = None,
+        compile_kwargs: dict | None = None,
         **pytensor_kwargs,
     ):
         model = modelcontext(model)
 
         if logp_dlogp_func is None:
+            if compile_kwargs is None:
+                compile_kwargs = {}
             logp_dlogp_func = model.logp_dlogp_function(
                 vars,
                 dtype=dtype,
                 ravel_inputs=True,
                 initial_point=initial_point,
+                **compile_kwargs,
                 **pytensor_kwargs,
             )
             logp_dlogp_func.trust_input = True

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -22,7 +22,7 @@ from typing import Any, NamedTuple
 
 import numpy as np
 
-from pymc.blocking import DictToArrayBijection, RaveledVars, StatsType
+from pymc.blocking import DictToArrayBijection, PointType, RaveledVars, StatsType
 from pymc.exceptions import SamplingError
 from pymc.model import Point, modelcontext
 from pymc.pytensorf import floatX
@@ -98,6 +98,7 @@ class BaseHMC(GradientSharedStep):
         adapt_step_size=True,
         step_rand=None,
         rng=None,
+        initial_point: PointType | None = None,
         **pytensor_kwargs,
     ):
         """Set up Hamiltonian samplers with common structures.
@@ -138,20 +139,23 @@ class BaseHMC(GradientSharedStep):
         else:
             vars = get_value_vars_from_user_vars(vars, self._model)
         super().__init__(
-            vars, blocked=blocked, model=self._model, dtype=dtype, rng=rng, **pytensor_kwargs
+            vars,
+            blocked=blocked,
+            model=self._model,
+            dtype=dtype,
+            rng=rng,
+            initial_point=initial_point,
+            **pytensor_kwargs,
         )
 
         self.adapt_step_size = adapt_step_size
         self.Emax = Emax
         self.iter_count = 0
 
-        # We're using the initial/test point to determine the (initial) step
-        # size.
-        # XXX: If the dimensions of these terms change, the step size
-        # dimension-scaling should change as well, no?
-        test_point = self._model.initial_point()
+        if initial_point is None:
+            initial_point = self._model.initial_point()
 
-        nuts_vars = [test_point[v.name] for v in vars]
+        nuts_vars = [initial_point[v.name] for v in vars]
         size = sum(v.size for v in nuts_vars)
 
         self.step_size = step_scale / (size**0.25)
@@ -207,7 +211,8 @@ class BaseHMC(GradientSharedStep):
             self.potential.raise_ok(q0.point_map_info)
             message_energy = (
                 "Bad initial energy, check any log probabilities that "
-                f"are inf or -inf, nan or very small:\n{error_logp}"
+                f"are inf or -inf, nan or very small:\n{error_logp}\n."
+                f"Try model.debug() to identify parametrization problems."
             )
             warning = SamplerWarning(
                 WarningType.BAD_ENERGY,

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -194,8 +194,6 @@ class BaseHMC(GradientSharedStep):
         process_start = time.process_time()
 
         p0 = self.potential.random()
-        p0 = RaveledVars(p0, q0.point_map_info)
-
         start = self.integrator.compute_state(q0, p0)
 
         warning: SamplerWarning | None = None
@@ -226,13 +224,13 @@ class BaseHMC(GradientSharedStep):
         if self._step_rand is not None:
             step_size = self._step_rand(step_size, rng=self.rng)
 
-        hmc_step = self._hamiltonian_step(start, p0.data, step_size)
+        hmc_step = self._hamiltonian_step(start, p0, step_size)
 
         perf_end = time.perf_counter()
         process_end = time.process_time()
 
         self.step_adapt.update(hmc_step.accept_stat, adapt_step)
-        self.potential.update(hmc_step.end.q, hmc_step.end.q_grad, self.tune)
+        self.potential.update(hmc_step.end.q.data, hmc_step.end.q_grad, self.tune)
         if hmc_step.divergence_info:
             info = hmc_step.divergence_info
             point = None

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -82,11 +82,12 @@ class BaseHMC(GradientSharedStep):
     def __init__(
         self,
         vars=None,
+        *,
         scaling=None,
         step_scale=0.25,
         is_cov=False,
         model=None,
-        blocked=True,
+        blocked: bool = True,
         potential=None,
         dtype=None,
         Emax=1000,

--- a/pymc/step_methods/hmc/integration.py
+++ b/pymc/step_methods/hmc/integration.py
@@ -18,13 +18,13 @@ import numpy as np
 
 from scipy import linalg
 
-from pymc.blocking import RaveledVars
+from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.step_methods.hmc.quadpotential import QuadPotential
 
 
 class State(NamedTuple):
     q: RaveledVars
-    p: RaveledVars
+    p: np.ndarray
     v: np.ndarray
     q_grad: np.ndarray
     energy: float
@@ -40,23 +40,35 @@ class CpuLeapfrogIntegrator:
     def __init__(self, potential: QuadPotential, logp_dlogp_func):
         """Leapfrog integrator using CPU."""
         self._potential = potential
-        self._logp_dlogp_func = logp_dlogp_func
-        self._dtype = self._logp_dlogp_func.dtype
+        # Sidestep logp_dlogp_function.__call__
+        pytensor_function = logp_dlogp_func._pytensor_function
+        # Create some wrappers for backwards compatibility during transition
+        # When raveled_inputs=False is forbidden, func = pytensor_function
+        if logp_dlogp_func._raveled_inputs:
+
+            def func(q, _):
+                return pytensor_function(q)
+
+        else:
+
+            def func(q, point_map_info):
+                unraveled_q = DictToArrayBijection.rmap(RaveledVars(q, point_map_info)).values()
+                return pytensor_function(*unraveled_q)
+
+        self._logp_dlogp_func = func
+        self._dtype = logp_dlogp_func.dtype
         if self._potential.dtype != self._dtype:
             raise ValueError(
                 f"dtypes of potential ({self._potential.dtype}) and logp function ({self._dtype})"
                 "don't match."
             )
 
-    def compute_state(self, q: RaveledVars, p: RaveledVars):
+    def compute_state(self, q: RaveledVars, p: np.ndarray):
         """Compute Hamiltonian functions using a position and momentum."""
-        if q.data.dtype != self._dtype or p.data.dtype != self._dtype:
-            raise ValueError(f"Invalid dtype. Must be {self._dtype}")
+        logp, dlogp = self._logp_dlogp_func(q.data, q.point_map_info)
 
-        logp, dlogp = self._logp_dlogp_func(q)
-
-        v = self._potential.velocity(p.data, out=None)
-        kinetic = self._potential.energy(p.data, velocity=v)
+        v = self._potential.velocity(p, out=None)
+        kinetic = self._potential.energy(p, velocity=v)
         energy = kinetic - logp
         return State(q, p, v, dlogp, energy, logp, 0)
 
@@ -96,10 +108,10 @@ class CpuLeapfrogIntegrator:
         axpy = linalg.blas.get_blas_funcs("axpy", dtype=self._dtype)
         pot = self._potential
 
-        q_new = state.q.data.copy()
-        p_new = state.p.data.copy()
+        q = state.q
+        q_new = q.data.copy()
+        p_new = state.p.copy()
         v_new = np.empty_like(q_new)
-        q_new_grad = np.empty_like(q_new)
 
         dt = 0.5 * epsilon
 
@@ -112,19 +124,16 @@ class CpuLeapfrogIntegrator:
         # q_new = q + epsilon * v_new
         axpy(v_new, q_new, a=epsilon)
 
-        p_new = RaveledVars(p_new, state.p.point_map_info)
-        q_new = RaveledVars(q_new, state.q.point_map_info)
-
-        logp = self._logp_dlogp_func(q_new, grad_out=q_new_grad)
+        logp, q_new_grad = self._logp_dlogp_func(q_new, q.point_map_info)
 
         # p_new = p_new + dt * q_new_grad
-        axpy(q_new_grad, p_new.data, a=dt)
+        axpy(q_new_grad, p_new, a=dt)
 
-        kinetic = pot.velocity_energy(p_new.data, v_new)
+        kinetic = pot.velocity_energy(p_new, v_new)
         energy = kinetic - logp
 
         return State(
-            q_new,
+            RaveledVars(q_new, state.q.point_map_info),
             p_new,
             v_new,
             q_new_grad,

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -279,7 +279,7 @@ class _Tree:
         self.log_accept_sum = -np.inf
         self.mean_tree_accept = 0.0
         self.n_proposals = 0
-        self.p_sum = start.p.data.copy()
+        self.p_sum = start.p.copy()
         self.max_energy_change = 0.0
 
     def extend(self, direction):
@@ -330,9 +330,9 @@ class _Tree:
             left, right = self.left, self.right
             p_sum = self.p_sum
             turning = (p_sum.dot(left.v) <= 0) or (p_sum.dot(right.v) <= 0)
-            p_sum1 = leftmost_p_sum + rightmost_begin.p.data
+            p_sum1 = leftmost_p_sum + rightmost_begin.p
             turning1 = (p_sum1.dot(leftmost_begin.v) <= 0) or (p_sum1.dot(rightmost_begin.v) <= 0)
-            p_sum2 = leftmost_end.p.data + rightmost_p_sum
+            p_sum2 = leftmost_end.p + rightmost_p_sum
             turning2 = (p_sum2.dot(leftmost_end.v) <= 0) or (p_sum2.dot(rightmost_end.v) <= 0)
             turning = turning | turning1 | turning2
 
@@ -372,7 +372,7 @@ class _Tree:
                     right.model_logp,
                     right.index_in_trajectory,
                 )
-                tree = Subtree(right, right, right.p.data, proposal, log_size)
+                tree = Subtree(right, right, right.p, proposal, log_size)
                 return tree, None, False
             else:
                 error_msg = f"Energy change in leapfrog step is too large: {energy_change}."
@@ -400,9 +400,9 @@ class _Tree:
             turning = (p_sum.dot(left.v) <= 0) or (p_sum.dot(right.v) <= 0)
             # Additional U turn check only when depth > 1 to avoid redundant work.
             if depth - 1 > 0:
-                p_sum1 = tree1.p_sum + tree2.left.p.data
+                p_sum1 = tree1.p_sum + tree2.left.p
                 turning1 = (p_sum1.dot(tree1.left.v) <= 0) or (p_sum1.dot(tree2.left.v) <= 0)
-                p_sum2 = tree1.right.p.data + tree2.p_sum
+                p_sum2 = tree1.right.p + tree2.p_sum
                 turning2 = (p_sum2.dot(tree1.right.v) <= 0) or (p_sum2.dot(tree2.right.v) <= 0)
                 turning = turning | turning1 | turning2
 

--- a/pymc/step_methods/hmc/quadpotential.py
+++ b/pymc/step_methods/hmc/quadpotential.py
@@ -363,11 +363,11 @@ class QuadPotentialDiagAdapt(QuadPotential):
         if np.any(self._stds == 0):
             errmsg = ["Mass matrix contains zeros on the diagonal. "]
             last_idx = 0
-            for name, shape, dtype in map_info:
-                arr_len = np.prod(shape, dtype=int)
-                index = np.where(self._stds[last_idx : last_idx + arr_len] == 0)[0]
+            for name, shape, size, dtype in map_info:
+                end = last_idx + size
+                index = np.where(self._stds[last_idx:end] == 0)[0]
                 errmsg.append(f"The derivative of RV `{name}`.ravel()[{index}] is zero.")
-                last_idx += arr_len
+                last_idx += end
 
             raise ValueError("\n".join(errmsg))
 
@@ -375,11 +375,11 @@ class QuadPotentialDiagAdapt(QuadPotential):
             errmsg = ["Mass matrix contains non-finite values on the diagonal. "]
 
             last_idx = 0
-            for name, shape, dtype in map_info:
-                arr_len = np.prod(shape, dtype=int)
-                index = np.where(~np.isfinite(self._stds[last_idx : last_idx + arr_len]))[0]
+            for name, shape, size, dtype in map_info:
+                end = last_idx + size
+                index = np.where(~np.isfinite(self._stds[last_idx:end]))[0]
                 errmsg.append(f"The derivative of RV `{name}`.ravel()[{index}] is non-finite.")
-                last_idx += arr_len
+                last_idx = end
             raise ValueError("\n".join(errmsg))
 
 

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -151,6 +151,7 @@ class Metropolis(ArrayStepShared):
     def __init__(
         self,
         vars=None,
+        *,
         S=None,
         proposal_dist=None,
         scaling=1.0,
@@ -159,7 +160,7 @@ class Metropolis(ArrayStepShared):
         model=None,
         mode=None,
         rng=None,
-        **kwargs,
+        blocked: bool = False,
     ):
         """Create an instance of a Metropolis stepper.
 
@@ -251,7 +252,7 @@ class Metropolis(ArrayStepShared):
 
         shared = pm.make_shared_replacements(initial_values, vars, model)
         self.delta_logp = delta_logp(initial_values, model.logp(), vars, shared)
-        super().__init__(vars, shared, rng=rng)
+        super().__init__(vars, shared, blocked=blocked, rng=rng)
 
     def reset_tuning(self):
         """Reset the tuned sampler parameters to their initial values."""
@@ -418,7 +419,17 @@ class BinaryMetropolis(ArrayStep):
 
     _state_class = BinaryMetropolisState
 
-    def __init__(self, vars, scaling=1.0, tune=True, tune_interval=100, model=None, rng=None):
+    def __init__(
+        self,
+        vars,
+        *,
+        scaling=1.0,
+        tune=True,
+        tune_interval=100,
+        model=None,
+        rng=None,
+        blocked: bool = True,
+    ):
         model = pm.modelcontext(model)
 
         self.scaling = scaling
@@ -432,7 +443,7 @@ class BinaryMetropolis(ArrayStep):
         if not all(v.dtype in pm.discrete_types for v in vars):
             raise ValueError("All variables must be Bernoulli for BinaryMetropolis")
 
-        super().__init__(vars, [model.compile_logp()], rng=rng)
+        super().__init__(vars, [model.compile_logp()], blocked=blocked, rng=rng)
 
     def astep(self, apoint: RaveledVars, *args) -> tuple[RaveledVars, StatsType]:
         logp = args[0]
@@ -530,7 +541,16 @@ class BinaryGibbsMetropolis(ArrayStep):
 
     _state_class = BinaryGibbsMetropolisState
 
-    def __init__(self, vars, order="random", transit_p=0.8, model=None, rng=None):
+    def __init__(
+        self,
+        vars,
+        *,
+        order="random",
+        transit_p=0.8,
+        model=None,
+        rng=None,
+        blocked: bool = True,
+    ):
         model = pm.modelcontext(model)
 
         # Doesn't actually tune, but it's required to emit a sampler stat
@@ -556,7 +576,7 @@ class BinaryGibbsMetropolis(ArrayStep):
         if not all(v.dtype in pm.discrete_types for v in vars):
             raise ValueError("All variables must be binary for BinaryGibbsMetropolis")
 
-        super().__init__(vars, [model.compile_logp()], rng=rng)
+        super().__init__(vars, [model.compile_logp()], blocked=blocked, rng=rng)
 
     def reset_tuning(self):
         # There are no tuning parameters in this step method.
@@ -638,7 +658,14 @@ class CategoricalGibbsMetropolis(ArrayStep):
     _state_class = CategoricalGibbsMetropolisState
 
     def __init__(
-        self, vars, proposal="uniform", order="random", model=None, rng: RandomGenerator = None
+        self,
+        vars,
+        *,
+        proposal="uniform",
+        order="random",
+        model=None,
+        rng: RandomGenerator = None,
+        blocked: bool = True,
     ):
         model = pm.modelcontext(model)
 
@@ -693,7 +720,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
         # that indicates whether a draw was done in a tuning phase.
         self.tune = True
 
-        super().__init__(vars, [model.compile_logp()], rng=rng)
+        super().__init__(vars, [model.compile_logp()], blocked=blocked, rng=rng)
 
     def reset_tuning(self):
         # There are no tuning parameters in this step method.
@@ -858,6 +885,7 @@ class DEMetropolis(PopulationArrayStepShared):
     def __init__(
         self,
         vars=None,
+        *,
         S=None,
         proposal_dist=None,
         lamb=None,
@@ -867,7 +895,7 @@ class DEMetropolis(PopulationArrayStepShared):
         model=None,
         mode=None,
         rng=None,
-        **kwargs,
+        blocked: bool = True,
     ):
         model = pm.modelcontext(model)
         initial_values = model.initial_point()
@@ -902,7 +930,7 @@ class DEMetropolis(PopulationArrayStepShared):
 
         shared = pm.make_shared_replacements(initial_values, vars, model)
         self.delta_logp = delta_logp(initial_values, model.logp(), vars, shared)
-        super().__init__(vars, shared, rng=rng)
+        super().__init__(vars, shared, blocked=blocked, rng=rng)
 
     def astep(self, q0: RaveledVars) -> tuple[RaveledVars, StatsType]:
         point_map_info = q0.point_map_info
@@ -1025,6 +1053,7 @@ class DEMetropolisZ(ArrayStepShared):
     def __init__(
         self,
         vars=None,
+        *,
         S=None,
         proposal_dist=None,
         lamb=None,
@@ -1035,7 +1064,7 @@ class DEMetropolisZ(ArrayStepShared):
         model=None,
         mode=None,
         rng=None,
-        **kwargs,
+        blocked: bool = True,
     ):
         model = pm.modelcontext(model)
         initial_values = model.initial_point()
@@ -1082,7 +1111,7 @@ class DEMetropolisZ(ArrayStepShared):
 
         shared = pm.make_shared_replacements(initial_values, vars, model)
         self.delta_logp = delta_logp(initial_values, model.logp(), vars, shared)
-        super().__init__(vars, shared, rng=rng)
+        super().__init__(vars, shared, blocked=blocked, rng=rng)
 
     def reset_tuning(self):
         """Reset the tuned sampler parameters and history to their initial values."""

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -76,7 +76,15 @@ class Slice(ArrayStepShared):
     _state_class = SliceState
 
     def __init__(
-        self, vars=None, w=1.0, tune=True, model=None, iter_limit=np.inf, rng=None, **kwargs
+        self,
+        vars=None,
+        *,
+        w=1.0,
+        tune=True,
+        model=None,
+        iter_limit=np.inf,
+        rng=None,
+        blocked: bool = False,  # Could be true since tuning is independent across dims?
     ):
         model = modelcontext(model)
         self.w = np.asarray(w).copy()
@@ -97,7 +105,7 @@ class Slice(ArrayStepShared):
         self.logp = compile_pymc([raveled_inp], logp)
         self.logp.trust_input = True
 
-        super().__init__(vars, shared, rng=rng)
+        super().__init__(vars, shared, blocked=blocked, rng=rng)
 
     def astep(self, apoint: RaveledVars) -> tuple[RaveledVars, StatsType]:
         # The arguments are determined by the list passed via `super().__init__(..., fs, ...)`

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -86,6 +86,7 @@ class Slice(ArrayStepShared):
         iter_limit=np.inf,
         rng=None,
         initial_point: PointType | None = None,
+        compile_kwargs: dict | None = None,
         blocked: bool = False,  # Could be true since tuning is independent across dims?
     ):
         model = modelcontext(model)
@@ -106,7 +107,9 @@ class Slice(ArrayStepShared):
         [logp], raveled_inp = join_nonshared_inputs(
             point=initial_point, outputs=[model.logp()], inputs=vars, shared_inputs=shared
         )
-        self.logp = compile_pymc([raveled_inp], logp)
+        if compile_kwargs is None:
+            compile_kwargs = {}
+        self.logp = compile_pymc([raveled_inp], logp, **compile_kwargs)
         self.logp.trust_input = True
 
         super().__init__(vars, shared, blocked=blocked, rng=rng)

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -143,7 +143,7 @@ def find_MAP(
     compiled_logp_func = DictToArrayBijection.mapf(model.compile_logp(jacobian=False), start)
     logp_func = lambda x: compiled_logp_func(RaveledVars(x, x0.point_map_info))  # noqa: E731
 
-    rvs = [model.values_to_rvs[vars_dict[name]] for name, _, _ in x0.point_map_info]
+    rvs = [model.values_to_rvs[vars_dict[name]] for name, _, _, _ in x0.point_map_info]
     try:
         # This might be needed for calls to `dlogp_func`
         # start_map_info = tuple((v.name, v.shape, v.dtype) for v in vars)

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1554,7 +1554,10 @@ class Approximation(WithMemoization):
         if random_seed is not None:
             (random_seed,) = _get_seeds_per_chain(random_seed, 1)
         samples: dict = self.sample_dict_fn(draws, random_seed=random_seed)
-        points = ({name: records[i] for name, records in samples.items()} for i in range(draws))
+        points = (
+            {name: np.asarray(records[i]) for name, records in samples.items()}
+            for i in range(draws)
+        )
 
         trace = NDArray(
             model=self.model,

--- a/tests/backends/fixtures.py
+++ b/tests/backends/fixtures.py
@@ -238,7 +238,10 @@ class SamplingTestCase(ModelBackendSetupTestCase):
     """
 
     def record_point(self, val):
-        point = {varname: np.tile(val, value.shape) for varname, value in self.test_point.items()}
+        point = {
+            varname: np.tile(val, value.shape).astype(value.dtype)
+            for varname, value in self.test_point.items()
+        }
         if self.sampler_vars is not None:
             stats = [{key: dtype(val) for key, dtype in vars.items()} for vars in self.sampler_vars]
             self.strace.record(point=point, sampler_stats=stats)

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -2395,7 +2395,7 @@ def test_mvnormal_no_cholesky_in_model_logp():
     d2logp = m.compile_d2logp()
     assert not contains_cholesky_op(d2logp.f.maker.fgraph)
 
-    logp_dlogp = m.logp_dlogp_function()
+    logp_dlogp = m.logp_dlogp_function(ravel_inputs=True)
     assert not contains_cholesky_op(logp_dlogp._pytensor_function.maker.fgraph)
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -26,6 +26,7 @@ import numpy.random as nr
 import pytensor
 
 from numpy.testing import assert_array_less
+from pytensor.compile.mode import Mode
 from pytensor.gradient import verify_grad as at_verify_grad
 
 import pymc as pm
@@ -198,10 +199,11 @@ class RVsAssignmentStepsTester:
             c1 = pm.HalfNormal("c1")
             c2 = pm.HalfNormal("c2")
 
-            # Test methods can handle initial_point
+            # Test methods can handle initial_point and compile_kwargs
             step_kwargs.setdefault(
                 "initial_point", {"c1_log__": np.array(0.5), "c2_log__": np.array(0.9)}
             )
+            step_kwargs.setdefault("compile_kwargs", {"mode": Mode(linker="py", optimizer=None)})
             with pytensor.config.change_flags(mode=fast_unstable_sampling_mode):
                 assert [m.rvs_to_values[c1]] == step([c1], **step_kwargs).vars
                 assert {m.rvs_to_values[c1], m.rvs_to_values[c2]} == set(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -198,11 +198,15 @@ class RVsAssignmentStepsTester:
             c1 = pm.HalfNormal("c1")
             c2 = pm.HalfNormal("c2")
 
+            # Test methods can handle initial_point
+            step_kwargs.setdefault(
+                "initial_point", {"c1_log__": np.array(0.5), "c2_log__": np.array(0.9)}
+            )
             with pytensor.config.change_flags(mode=fast_unstable_sampling_mode):
                 assert [m.rvs_to_values[c1]] == step([c1], **step_kwargs).vars
-            assert {m.rvs_to_values[c1], m.rvs_to_values[c2]} == set(
-                step([c1, c2], **step_kwargs).vars
-            )
+                assert {m.rvs_to_values[c1], m.rvs_to_values[c2]} == set(
+                    step([c1, c2], **step_kwargs).vars
+                )
 
 
 def equal_sampling_states(this, other):

--- a/tests/models.py
+++ b/tests/models.py
@@ -78,7 +78,7 @@ def simple_arbitrary_det():
 
 def simple_init():
     start, model, moments = simple_model()
-    step = Metropolis(model.value_vars, np.diag([1.0]), model=model)
+    step = Metropolis(model.value_vars, S=np.diag([1.0]), model=model)
     return model, start, step, moments
 
 

--- a/tests/step_methods/hmc/test_hmc.py
+++ b/tests/step_methods/hmc/test_hmc.py
@@ -59,10 +59,9 @@ def test_leapfrog_reversible():
 
     step = HMC(vars=model.value_vars, model=model, scaling=scaling)
 
-    step.integrator._logp_dlogp_func.set_extra_values({})
     astart = DictToArrayBijection.map(start)
     p = RaveledVars(floatX(step.potential.random()), astart.point_map_info)
-    q = RaveledVars(floatX(np.random.randn(size)), astart.point_map_info)
+    q = floatX(np.random.randn(size))
     start = step.integrator.compute_state(p, q)
     for epsilon in [0.01, 0.1]:
         for n_steps in [1, 2, 3, 4, 20]:

--- a/tests/step_methods/test_metropolis.py
+++ b/tests/step_methods/test_metropolis.py
@@ -22,6 +22,8 @@ import numpy.testing as npt
 import pytensor
 import pytest
 
+from pytensor.compile.mode import Mode
+
 import pymc as pm
 
 from pymc.step_methods.metropolis import (
@@ -368,18 +370,16 @@ class TestRVsAssignmentMetropolis(RVsAssignmentStepsTester):
             d1 = pm.Bernoulli("d1", p=0.5)
             d2 = pm.Bernoulli("d2", p=0.5)
 
-            # Test it can take initial_point as a kwarg
+            # Test it can take initial_point, and compile_kwargs as a kwarg
             step_kwargs = {
                 "initial_point": {
                     "d1": np.array(0, dtype="int64"),
                     "d2": np.array(1, dtype="int64"),
                 },
+                "compile_kwargs": {"mode": Mode(linker="py", optimizer=None)},
             }
-            with pytensor.config.change_flags(mode=fast_unstable_sampling_mode):
-                assert [m.rvs_to_values[d1]] == step([d1]).vars
-                assert {m.rvs_to_values[d1], m.rvs_to_values[d2]} == set(
-                    step([d1, d2]).vars
-                )
+            assert [m.rvs_to_values[d1]] == step([d1]).vars
+            assert {m.rvs_to_values[d1], m.rvs_to_values[d2]} == set(step([d1, d2]).vars)
 
     @pytest.mark.parametrize(
         "step, step_kwargs", [(Metropolis, {}), (DEMetropolis, {}), (DEMetropolisZ, {})]

--- a/tests/step_methods/test_metropolis.py
+++ b/tests/step_methods/test_metropolis.py
@@ -368,9 +368,18 @@ class TestRVsAssignmentMetropolis(RVsAssignmentStepsTester):
             d1 = pm.Bernoulli("d1", p=0.5)
             d2 = pm.Bernoulli("d2", p=0.5)
 
+            # Test it can take initial_point as a kwarg
+            step_kwargs = {
+                "initial_point": {
+                    "d1": np.array(0, dtype="int64"),
+                    "d2": np.array(1, dtype="int64"),
+                },
+            }
             with pytensor.config.change_flags(mode=fast_unstable_sampling_mode):
                 assert [m.rvs_to_values[d1]] == step([d1]).vars
-                assert {m.rvs_to_values[d1], m.rvs_to_values[d2]} == set(step([d1, d2]).vars)
+                assert {m.rvs_to_values[d1], m.rvs_to_values[d2]} == set(
+                    step([d1, d2]).vars
+                )
 
     @pytest.mark.parametrize(
         "step, step_kwargs", [(Metropolis, {}), (DEMetropolis, {}), (DEMetropolisZ, {})]


### PR DESCRIPTION
## Major changes
1. internal uses of logp_dlogp_function now work with raveled inputs. External use will issue a warning unless `ravel_inputs` is specified explicitly. Eventually it will only be possible to use `ravel_inputs=True`.
1. Step samplers arguments besides vars must be passed by keyword
1. RaveledVars point_map_info is now a 4-n tuple, with size introduced.
1. `assign_step_method` does not call `instantiate_steppers`, but returns arguments needed for the latter.
1. Allow passing `compile_kwargs` to `pm.sample` which is then forwarded to the step samplers functions

## Enhancement
This PR speedups `NUTS` (and other step samplers), by:
  1. Avoiding many variable unravel and copies, by doing it inside PyTensor
  3. Avoiding copies when setting shared variables (borrow=True)
  6. Setting `trust_input=True` which can have a large overhead.
  7. Disabling GC collection for the C-backend function (related to #7539)
  8. Using slots for faster attribute access in the Tree class (and smaller footprint)
  9. Inlining some functions and being more lazy when possible

This PR speedups sample by:
 1. Avoiding way too many pytensor function compilations (model.initial_point() and very silly trace.fn after slicing at the end. It's also silly to compile the same function for every trace. We should just copy it.
 3. Avoid initializing NUTS step sampler just for most of the times then immediately discard it and using the one inside `init_nuts`. This will also reduce the path towards external samplers with nutpie/numpyro as it avoids the costly and useless compilation of the logp_dlogp_function
 4. Using `trust_input` and avoiding deepcopies in the trace function by using `pytensor.In(borrow=True)` and `pytensor.Out(borrow=True)`.

Further speedups should come for free from https://github.com/pymc-devs/pymc/issues/7539, specially for the Numba backend.

## Benchmark 

In the example below, sampling time is now only 7x slower than nutpie (5s vs 0.7s), compared to 13.5x slower (9.45s vs 0.7s) before. This assuming the same number of logp evals, in fact nutpie tuning allows us to get out with half the evals! We can hopefully bring it over.

Full time until from `pm.sample` to getting a trace is roughly halved as well (7.5s vs 14.4s), although this gain is not proportional to the number of draws.

With `compile_kwargs=(mode="NUMBA")`, sampling time is only  3x slower (2.3s).

```python
import time
import pymc as pm
import numpy as np
import nutpie
import pandas as pd

# Load the radon dataset
data = pd.read_csv(pm.get_data("radon.csv"))
data["log_radon"] = data["log_radon"].astype(np.float64)
county_idx, counties = pd.factorize(data.county)
coords = {"county": counties, "obs_id": np.arange(len(county_idx))}

# Create a simple hierarchical model for the radon dataset
with pm.Model(coords=coords, check_bounds=False) as model:
    intercept = pm.Normal("intercept", sigma=10)

    # County effects
    raw = pm.ZeroSumNormal("county_raw", dims="county")
    sd = pm.HalfNormal("county_sd")
    county_effect = pm.Deterministic("county_effect", raw * sd, dims="county")

    # Global floor effect
    floor_effect = pm.Normal("floor_effect", sigma=2)

    # County:floor interaction
    raw = pm.ZeroSumNormal("county_floor_raw", dims="county")
    sd = pm.HalfNormal("county_floor_sd")
    county_floor_effect = pm.Deterministic(
        "county_floor_effect", raw * sd, dims="county"
    )

    mu = (
        intercept
        + county_effect[county_idx]
        + floor_effect * data.floor.values
        + county_floor_effect[county_idx] * data.floor.values
    )

    sigma = pm.HalfNormal("sigma", sigma=1.5)
    pm.Normal(
        "log_radon", mu=mu, sigma=sigma, observed=data.log_radon.values, dims="obs_id"
    )

from pymc.model.transform.optimization import freeze_dims_and_data
model = freeze_dims_and_data(model)
```
```python
compiled_model = nutpie.compile_pymc_model(model)

start = time.perf_counter()
# More draws to make up for the fact that nutpie tunes better
trace_pymc = nutpie.sample(compiled_model, chains=1, tune=500, draws=1500, progress_bar=False)
end = time.perf_counter()
print(end - start)
```
```python
idata = pm.sample(
    model=model, 
    chains=1,
    tune=500, 
    draws=500, 
    progressbar=False, 
    compute_convergence_checks=False, 
    return_inferencedata=False,
    # compile_kwargs=dict(mode="NUMBA")
)
print(idata._report.t_sampling)
```

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7578.org.readthedocs.build/en/7578/

<!-- readthedocs-preview pymc end -->