### PR TITLE
Formatted docker file to have standardized spacing in arguments following CMD.

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -27,4 +27,4 @@ RUN echo "conda activate pymc-dev" >> ~/.bashrc && \
 
 # For running from jupyter notebook
 EXPOSE 8888
-CMD ["conda", "run", "--no-capture-output", "-n", "pymc-dev", "jupyter","notebook","--ip=0.0.0.0","--port=8888","--no-browser"]
+CMD ["conda", "run", "--no-capture-output", "-n", "pymc-dev", "jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser"]


### PR DESCRIPTION
Standardized spacing of elements following CMD.

This is a minor formatting change. Every element in the list following `CDM` is now separated by a comma followed by a single space. Git diff should be self-explanatory.


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7582.org.readthedocs.build/en/7582/

<!-- readthedocs-preview pymc end -->