### PR TITLE
Censor & Truncate Docstrings

### DIFF
--- a/pymc/distributions/censored.py
+++ b/pymc/distributions/censored.py
@@ -101,14 +101,20 @@ class Censored(Distribution):
 
     Examples
     --------
+    Censoring with upper & lower points set to +/-1
     .. code-block:: python
 
         with pm.Model():
             normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
             censored_normal = pm.Censored("censored_normal", normal_dist, lower=-1, upper=1)
+    
+    Partial censoring of normal distributions achienved by passing +/-inf censor points. 
+    Examples of 4 censor conditions: uncensored (-inf, inf), upper censored (-inf, 1),
+    lower censored (-1, inf), and both censored (-1, 1)
+    .. code-block:: python
         with pm.Model():
             normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
-            partially_censored_normal = pm.Censored("partially_censored_normal", normal_dist, lower=-1, upper=np.inf)
+            partially_censored_normals = pm.Censored("partially_censored_normals", normal_dist, lower=[-np.inf, -np.inf, -1, -1], upper=[np.inf, 1, np.inf, 1], shape=(4,))
     """
 
     rv_type = CensoredRV

--- a/pymc/distributions/censored.py
+++ b/pymc/distributions/censored.py
@@ -107,8 +107,8 @@ class Censored(Distribution):
         with pm.Model():
             normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
             censored_normal = pm.Censored("censored_normal", normal_dist, lower=-1, upper=1)
-    
-    Partial censoring of normal distributions achienved by passing +/-inf censor points. 
+
+    Partial censoring of normal distributions achienved by passing +/-inf censor points.
     Examples of 4 censor conditions: uncensored (-inf, inf), upper censored (-inf, 1),
     lower censored (-1, inf), and both censored (-1, 1)
     .. code-block:: python

--- a/pymc/distributions/censored.py
+++ b/pymc/distributions/censored.py
@@ -106,6 +106,9 @@ class Censored(Distribution):
         with pm.Model():
             normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
             censored_normal = pm.Censored("censored_normal", normal_dist, lower=-1, upper=1)
+        with pm.Model():
+            normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
+            partially_censored_normal = pm.Censored("partially_censored_normal", normal_dist, lower=-1, upper=np.inf)
     """
 
     rv_type = CensoredRV

--- a/pymc/distributions/censored.py
+++ b/pymc/distributions/censored.py
@@ -84,9 +84,9 @@ class Censored(Distribution):
 
         .. warning:: dist will be cloned, rendering it independent of the one passed as input.
 
-    lower : float or None
+    lower : float, int, array-like or None
         Lower (left) censoring point. If `None` the distribution will not be left censored
-    upper : float or None
+    upper : float, int, array-like or None
         Upper (right) censoring point. If `None`, the distribution will not be right censored.
 
     Warnings

--- a/pymc/distributions/truncated.py
+++ b/pymc/distributions/truncated.py
@@ -291,8 +291,8 @@ class Truncated(Distribution):
         with pm.Model():
             normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
             truncated_normal = pm.Truncated("truncated_normal", normal_dist, lower=-1, upper=1)
-    
-    Partial truncatin of normal distributions achieved by passing +/-inf truncation points. 
+
+    Partial truncatin of normal distributions achieved by passing +/-inf truncation points.
     Examples of 4 truncation conditions: untruncated (-inf, inf), upper truncated (-inf, 1),
     lower truncated (-1, inf), and both truncated (-1, 1)
     .. code-block:: python

--- a/pymc/distributions/truncated.py
+++ b/pymc/distributions/truncated.py
@@ -285,14 +285,20 @@ class Truncated(Distribution):
 
     Examples
     --------
+    Truncation with upper & lower points set to +/-1
     .. code-block:: python
 
         with pm.Model():
             normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
             truncated_normal = pm.Truncated("truncated_normal", normal_dist, lower=-1, upper=1)
+    
+    Partial truncatin of normal distributions achieved by passing +/-inf truncation points. 
+    Examples of 4 truncation conditions: untruncated (-inf, inf), upper truncated (-inf, 1),
+    lower truncated (-1, inf), and both truncated (-1, 1)
+    .. code-block:: python
         with pm.Model():
             normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
-            partially_truncated_normal = pm.Truncated("partially_truncated_normal", normal_dist, lower=-np.inf, upper=1)
+            partially_truncated_normal = pm.Truncated("partially_truncated_normal", normal_dist, lower=[-np.inf, -np.inf, -1, -1], upper=[np.inf, 1, np.inf, 1], shape=(4,))
     """
 
     rv_type = TruncatedRV

--- a/pymc/distributions/truncated.py
+++ b/pymc/distributions/truncated.py
@@ -266,9 +266,9 @@ class Truncated(Distribution):
 
         .. warning:: dist will be cloned, rendering it independent of the one passed as input.
 
-    lower: tensor_like of float or None
+    lower: tensor_like of float, int, or None
         Lower (left) truncation point. If `None` the distribution will not be left truncated.
-    upper: tensor_like of float or None
+    upper: tensor_like of float, int, or None
         Upper (right) truncation point. If `None`, the distribution will not be right truncated.
     max_n_steps: int, defaults 10_000
         Maximum number of resamples that are attempted when performing rejection sampling.
@@ -290,7 +290,6 @@ class Truncated(Distribution):
         with pm.Model():
             normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
             truncated_normal = pm.Truncated("truncated_normal", normal_dist, lower=-1, upper=1)
-
     """
 
     rv_type = TruncatedRV

--- a/pymc/distributions/truncated.py
+++ b/pymc/distributions/truncated.py
@@ -290,6 +290,9 @@ class Truncated(Distribution):
         with pm.Model():
             normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
             truncated_normal = pm.Truncated("truncated_normal", normal_dist, lower=-1, upper=1)
+        with pm.Model():
+            normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
+            partially_truncated_normal = pm.Truncated("partially_truncated_normal", normal_dist, lower=-np.inf, upper=1)
     """
 
     rv_type = TruncatedRV


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Provides updated type listing for lower and upper censor & truncate points to include `int` and `array-like`.
Additionally, provides an example using -/+inf for partial censor or truncation.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #7581

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7590.org.readthedocs.build/en/7590/

<!-- readthedocs-preview pymc end -->