### PR TITLE
Fix error in docstring example for MatrixNormal

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -1827,8 +1827,7 @@ class MatrixNormal(Continuous):
         with pm.Model() as model:
             # Setup right cholesky matrix
             sd_dist = pm.HalfCauchy.dist(beta=2.5, shape=3)
-            colchol_packed = pm.LKJCholeskyCov('colcholpacked', n=3, eta=2,compute_corr=False,
-                                            sd_dist=sd_dist)
+            colchol_packed, _, _ = pm.LKJCholeskyCov('colcholpacked', n=3, eta=2, sd_dist=sd_dist)
             colchol = pm.expand_packed_triangular(3, colchol_packed)
 
             # Setup left covariance matrix

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -1791,14 +1791,21 @@ class MatrixNormal(Continuous):
     Examples
     --------
     Define a matrixvariate normal variable for given row and column covariance
-    matrices::
-    with pm.Model() as model:
-        colcov = np.array([[1.0, 0.5], [0.5, 2]])
-        rowcov = np.array([[1, 0, 0], [0, 4, 0], [0, 0, 16]])
-        m = rowcov.shape[0]
-        n = colcov.shape[0]
-        mu = np.zeros((m, n))
-        vals = pm.MatrixNormal("vals", mu=mu, colcov=colcov, rowcov=rowcov)
+    matrices.
+
+    .. code:: python
+
+        import pymc as pm
+        import numpy as np
+        import pytensor.tensor as pt
+
+        with pm.Model() as model:
+            colcov = np.array([[1.0, 0.5], [0.5, 2]])
+            rowcov = np.array([[1, 0, 0], [0, 4, 0], [0, 0, 16]])
+            m = rowcov.shape[0]
+            n = colcov.shape[0]
+            mu = np.zeros((m, n))
+            vals = pm.MatrixNormal("vals", mu=mu, colcov=colcov, rowcov=rowcov)
 
     Above, the ith row in vals has a variance that is scaled by 4^i.
     Alternatively, row or column cholesky matrices could be substituted for

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -1792,7 +1792,7 @@ class MatrixNormal(Continuous):
     --------
     Define a matrixvariate normal variable for given row and column covariance
     matrices::
-
+    with pm.Model() as model:
         colcov = np.array([[1.0, 0.5], [0.5, 2]])
         rowcov = np.array([[1, 0, 0], [0, 4, 0], [0, 0, 16]])
         m = rowcov.shape[0]
@@ -1811,29 +1811,29 @@ class MatrixNormal(Continuous):
 
     .. code:: python
 
-            # Setup data
-            true_colcov = np.array([[1.0, 0.5, 0.1],
-                                    [0.5, 1.0, 0.2],
-                                    [0.1, 0.2, 1.0]])
-            m = 3
-            n = true_colcov.shape[0]
-            true_scale = 3
-            true_rowcov = np.diag([true_scale**(2*i) for i in range(m)])
-            mu = np.zeros((m, n))
-            true_kron = np.kron(true_rowcov, true_colcov)
-            data = np.random.multivariate_normal(mu.flatten(), true_kron)
-            data = data.reshape(m, n)
+        # Setup data
+        true_colcov = np.array([[1.0, 0.5, 0.1],
+                                [0.5, 1.0, 0.2],
+                                [0.1, 0.2, 1.0]])
+        m = 3
+        n = true_colcov.shape[0]
+        true_scale = 3
+        true_rowcov = np.diag([true_scale**(2*i) for i in range(m)])
+        mu = np.zeros((m, n))
+        true_kron = np.kron(true_rowcov, true_colcov)
+        data = np.random.multivariate_normal(mu.flatten(), true_kron)
+        data = data.reshape(m, n)
 
-            with pm.Model() as model:
-                # Setup right cholesky matrix
-                sd_dist = pm.HalfCauchy.dist(beta=2.5, shape=3)
-                colchol,_,_ = pm.LKJCholeskyCov('colchol', n=3, eta=2,sd_dist=sd_dist)
-                # Setup left covariance matrix
-                scale = pm.LogNormal('scale', mu=np.log(true_scale), sigma=0.5)
-                rowcov = pt.diag([scale**(2*i) for i in range(m)])
+        with pm.Model() as model:
+            # Setup right cholesky matrix
+            sd_dist = pm.HalfCauchy.dist(beta=2.5, shape=3)
+            colchol,_,_ = pm.LKJCholeskyCov('colchol', n=3, eta=2,sd_dist=sd_dist)
+            # Setup left covariance matrix
+            scale = pm.LogNormal('scale', mu=np.log(true_scale), sigma=0.5)
+            rowcov = pt.diag([scale**(2*i) for i in range(m)])
 
-                vals = pm.MatrixNormal('vals', mu=mu, colchol=colchol, rowcov=rowcov,
-                                    observed=data)
+            vals = pm.MatrixNormal('vals', mu=mu, colchol=colchol, rowcov=rowcov,
+                                observed=data)
     """
 
     rv_op = matrixnormal

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -1811,31 +1811,29 @@ class MatrixNormal(Continuous):
 
     .. code:: python
 
-        # Setup data
-        true_colcov = np.array([[1.0, 0.5, 0.1],
-                                [0.5, 1.0, 0.2],
-                                [0.1, 0.2, 1.0]])
-        m = 3
-        n = true_colcov.shape[0]
-        true_scale = 3
-        true_rowcov = np.diag([true_scale**(2*i) for i in range(m)])
-        mu = np.zeros((m, n))
-        true_kron = np.kron(true_rowcov, true_colcov)
-        data = np.random.multivariate_normal(mu.flatten(), true_kron)
-        data = data.reshape(m, n)
+            # Setup data
+            true_colcov = np.array([[1.0, 0.5, 0.1],
+                                    [0.5, 1.0, 0.2],
+                                    [0.1, 0.2, 1.0]])
+            m = 3
+            n = true_colcov.shape[0]
+            true_scale = 3
+            true_rowcov = np.diag([true_scale**(2*i) for i in range(m)])
+            mu = np.zeros((m, n))
+            true_kron = np.kron(true_rowcov, true_colcov)
+            data = np.random.multivariate_normal(mu.flatten(), true_kron)
+            data = data.reshape(m, n)
 
-        with pm.Model() as model:
-            # Setup right cholesky matrix
-            sd_dist = pm.HalfCauchy.dist(beta=2.5, shape=3)
-            colchol_packed, _, _ = pm.LKJCholeskyCov('colcholpacked', n=3, eta=2, sd_dist=sd_dist)
-            colchol = pm.expand_packed_triangular(3, colchol_packed)
+            with pm.Model() as model:
+                # Setup right cholesky matrix
+                sd_dist = pm.HalfCauchy.dist(beta=2.5, shape=3)
+                colchol,_,_ = pm.LKJCholeskyCov('colchol', n=3, eta=2,sd_dist=sd_dist)
+                # Setup left covariance matrix
+                scale = pm.LogNormal('scale', mu=np.log(true_scale), sigma=0.5)
+                rowcov = pt.diag([scale**(2*i) for i in range(m)])
 
-            # Setup left covariance matrix
-            scale = pm.LogNormal('scale', mu=np.log(true_scale), sigma=0.5)
-            rowcov = pt.diag([scale**(2*i) for i in range(m)])
-
-            vals = pm.MatrixNormal('vals', mu=mu, colchol=colchol, rowcov=rowcov,
-                                observed=data)
+                vals = pm.MatrixNormal('vals', mu=mu, colchol=colchol, rowcov=rowcov,
+                                    observed=data)
     """
 
     rv_op = matrixnormal

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -1827,8 +1827,8 @@ class MatrixNormal(Continuous):
         with pm.Model() as model:
             # Setup right cholesky matrix
             sd_dist = pm.HalfCauchy.dist(beta=2.5, shape=3)
-            colchol_packed = pm.LKJCholeskyCov('colcholpacked', n=3, eta=2,
-                                               sd_dist=sd_dist)
+            colchol_packed = pm.LKJCholeskyCov('colcholpacked', n=3, eta=2,compute_corr=False,
+                                            sd_dist=sd_dist)
             colchol = pm.expand_packed_triangular(3, colchol_packed)
 
             # Setup left covariance matrix
@@ -1836,7 +1836,7 @@ class MatrixNormal(Continuous):
             rowcov = pt.diag([scale**(2*i) for i in range(m)])
 
             vals = pm.MatrixNormal('vals', mu=mu, colchol=colchol, rowcov=rowcov,
-                                   observed=data)
+                                observed=data)
     """
 
     rv_op = matrixnormal


### PR DESCRIPTION
…rrent version

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
The compute_corr parameter in pm.LKJCholeskyCov is set to True by default, which causes the issue in latest pymc versions.
Also discussed here: https://discourse.pymc.io/t/matrixnormal-example-in-documentation-throws-an-error/16171

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #7598

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->




<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7599.org.readthedocs.build/en/7599/

<!-- readthedocs-preview pymc end -->