### PR TITLE
Bump numpy version due to use of `Generator.spawn` only available in `>=1.25`

### DIFF
--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
 - cachetools>=4.2.1
 - cloudpickle
 - h5py>=2.7
-- numpy>=1.15.0
+- numpy>=1.25.0
 - pandas>=0.24.0
 - pip
 - pytensor>=2.26.2,<2.27

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -8,7 +8,7 @@ dependencies:
 - arviz>=0.13.0
 - cachetools>=4.2.1
 - cloudpickle
-- numpy>=1.15.0
+- numpy>=1.25.0
 - pandas>=0.24.0
 - pip
 - pytensor>=2.26.2,<2.27

--- a/conda-envs/environment-jax.yml
+++ b/conda-envs/environment-jax.yml
@@ -16,7 +16,7 @@ dependencies:
 - jaxlib>=0.4.28
 - libblas=*=*mkl
 - mkl-service
-- numpy>=1.15.0
+- numpy>=1.25.0
 - numpyro>=0.8.0
 - pandas>=0.24.0
 - pip

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -11,7 +11,7 @@ dependencies:
 - cloudpickle
 - h5py>=2.7
 - jax
-- numpy>=1.15.0
+- numpy>=1.25.0
 - pandas>=0.24.0
 - pip
 - pytensor>=2.26.2,<2.27

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
 - cachetools>=4.2.1
 - cloudpickle
 - h5py>=2.7
-- numpy>=1.15.0
+- numpy>=1.25.0
 - pandas>=0.24.0
 - pip
 - pytensor>=2.26.2,<2.27

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -13,7 +13,7 @@ dependencies:
 - libpython
 - mkl-service>=2.3.0
 - m2w64-toolchain
-- numpy>=1.15.0
+- numpy>=1.25.0
 - pandas>=0.24.0
 - pip
 - pytensor>=2.26.2,<2.27

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -727,6 +727,10 @@ def sample(
         )
 
     if random_seed == -1:
+        warnings.warn(
+            "Setting random_seed = -1 is deprecated. Pass `None` to not specify a seed.",
+            FutureWarning,
+        )
         random_seed = None
     elif isinstance(random_seed, tuple | list):
         warnings.warn(

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -528,10 +528,8 @@ def sample(
     random_seed : int, array-like of int, or Generator, optional
         Random seed(s) used by the sampling steps. Each step will create its own
         :py:class:`~numpy.random.Generator` object to make its random draws in a way that is
-        indepedent from all other steppers and all other chains. If a list, tuple or array of ints
-        is passed, each entry will be used to seed the creation of ``Generator`` objects.
-        A ``ValueError`` will be raised if the length does not match the number of chains.
-        A ``TypeError`` will be raised if a :py:class:`~numpy.random.RandomState` object is passed.
+        indepedent from all other steppers and all other chains.
+        A ``TypeError`` will be raised if a legacy :py:class:`~numpy.random.RandomState` object is passed.
         We no longer support ``RandomState`` objects because their seeding mechanism does not allow
         easy spawning of new independent random streams that are needed by the step methods.
     progressbar : bool, optional default=True
@@ -730,6 +728,12 @@ def sample(
 
     if random_seed == -1:
         random_seed = None
+    elif isinstance(random_seed, tuple | list):
+        warnings.warn(
+            "A list or tuple of random_seed no longer specifies the specific random_seed of each chain. "
+            "Use a single seed instead.",
+            UserWarning,
+        )
     rngs = get_random_generator(random_seed).spawn(chains)
     random_seed_list = [rng.integers(2**30) for rng in rngs]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ mcbackend>=0.4.0
 mypy==1.5.1
 myst-nb<=1.0.0
 numdifftools>=0.9.40
-numpy>=1.15.0
+numpy>=1.25.0
 numpydoc
 pandas>=0.24.0
 polyagamma

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 arviz>=0.13.0
 cachetools>=4.2.1
 cloudpickle
-numpy>=1.15.0
+numpy>=1.25.0
 pandas>=0.24.0
 pytensor>=2.26.1,<2.27
 rich>=13.7.1

--- a/tests/distributions/test_custom.py
+++ b/tests/distributions/test_custom.py
@@ -287,7 +287,7 @@ class TestCustomDist:
         with pytest.raises(
             NotImplementedError, match="signature is not sufficient to infer the support shape"
         ):
-            CustomDist.dist(signature="(n)->(m)")
+            CustomDist.dist([0], signature="(n)->(m)")
 
 
 class TestCustomSymbolicDist:


### PR DESCRIPTION
Introduced in https://github.com/pymc-devs/pymc/pull/7508 (specifically https://github.com/pymc-devs/pymc/commit/4ea1406331923444838c7c8dfe9fc411934ed5a0)

Closes #7605 

Actually #7508 had a subtle breaking change, in that it used to be possible to seed each chain separately by passing a list of integers/rngs. Now there's no such control. Hopefully nobody needs that behavior these days...



<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7607.org.readthedocs.build/en/7607/

<!-- readthedocs-preview pymc end -->