### PR TITLE
implement invgamma icdf + test

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -29,7 +29,7 @@ from pytensor.tensor import gamma as gammafn
 from pytensor.tensor import gammaln, get_underlying_scalar_constant_value
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.extra_ops import broadcast_shape
-from pytensor.tensor.math import betaincinv, gammaincinv, gammainccinv, tanh
+from pytensor.tensor.math import betaincinv, gammainccinv, gammaincinv, tanh
 from pytensor.tensor.random.basic import (
     BetaRV,
     _gamma,

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -29,7 +29,7 @@ from pytensor.tensor import gamma as gammafn
 from pytensor.tensor import gammaln, get_underlying_scalar_constant_value
 from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.extra_ops import broadcast_shape
-from pytensor.tensor.math import betaincinv, gammaincinv, tanh
+from pytensor.tensor.math import betaincinv, gammaincinv, gammainccinv, tanh
 from pytensor.tensor.random.basic import (
     BetaRV,
     _gamma,
@@ -2535,6 +2535,16 @@ class InverseGamma(PositiveContinuous):
         )
 
         return check_parameters(
+            res,
+            alpha > 0,
+            beta > 0,
+            msg="alpha > 0, beta > 0",
+        )
+
+    def icdf(value, alpha, beta):
+        res = beta / gammainccinv(alpha, value)
+        res = check_icdf_value(res, value)
+        return check_icdf_parameters(
             res,
             alpha > 0,
             beta > 0,

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -675,6 +675,13 @@ class TestMatchesScipy:
             lambda value, alpha, beta: st.invgamma.logpdf(value, alpha, scale=beta),
         )
 
+    def test_inverse_gamma_icdf(self):
+        check_icdf(
+            pm.InverseGamma,
+            {"alpha": Rplusbig, "beta": Rplusbig},
+            lambda q, alpha, beta: st.invgamma.ppf(q, alpha, scale=beta),
+        )
+
     @pytest.mark.skipif(
         condition=(pytensor.config.floatX == "float32"),
         reason="Fails on float32 due to numerical issues",


### PR DESCRIPTION
## Description
Implements the ICDF of the InverseGamma distribution, for #6612, with a test comparing it to the scipy implementation.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7619.org.readthedocs.build/en/7619/

<!-- readthedocs-preview pymc end -->