### PR TITLE
Adds shape/rate info to Gamma docs

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2311,6 +2311,8 @@ class Gamma(PositiveContinuous):
        f(x \mid \alpha, \beta) =
            \frac{\beta^{\alpha}x^{\alpha-1}e^{-\beta x}}{\Gamma(\alpha)}
 
+    Here, the gamma distribution is parameterized by shape (alpha) and rate (beta).
+
     .. plot::
         :context: close-figs
 


### PR DESCRIPTION

## Description

I've had to keep going back and forth to the Wiki entry for the Gamma distribution to remind myself how the gamma is parameterized.  This PR adds a line to let readers know this is the shape and rate parameterization.

This is what the change looks like

<img width="783" alt="image" src="https://github.com/user-attachments/assets/6a78962d-a092-4065-a64b-5cae37db8dc9" />
)

## Related Issue

NA

## Checklist

- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change]

## Type of change

- [ ] New feature / enhancement
- [ ] Bug fix
- [ x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):



<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7625.org.readthedocs.build/en/7625/

<!-- readthedocs-preview pymc end -->