### PR TITLE
update steering council members

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -205,11 +205,10 @@ In particular, the Council may:
 
 The current Steering Council membership comprises:
 
-- Chris Fonnesbeck (dev, docs)
-- Junpeng Lao (dev, community)
-- Oriol Abril-Pla (docs, community)
-- Ravin Kumar (dev, community, docs)
-- Thomas Wiecki (dev, community - PyMC Labs)
+- Ricardo Vieira (dev, community - PyMC Labs)
+- Colin Carroll (dev)
+- Osvaldo Martin (dev, docs)
+- Jesse Grabowski (community, dev - PyMC Labs)
 
 Note that as explained in the [community architecture section](#community-and-team-architecture)
 and as indicated again in the description of the Steering Council above,
@@ -483,9 +482,9 @@ The log of past election processes is kept on [Discourse](https://discourse.pymc
   the membership constraints were not met,
   candidates are ranked by interpreting yes=+1, abstain=0 and no=-1.
   * If too many candidates were confirmed,
-    the {max_range} number of candidates with higher rank are elected.
+    the max number of candidates (7) with higher rank are elected.
   * If not enough candidates were chosen,
-    the {min_range} number of candidates with higher rank are elected.
+    the min number of candidates (4) with higher rank are elected.
   * If membership constraints were not met, candidates are selected
     progressively by rank if they meet the membership requirements.
     If for example out of 7 candidates for the NumFOCUS subcommittee


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Update steering council members with the results from the election: https://discourse.pymc.io/t/steering-council-2024-election-results/16280

It would be nice to have reviews from the 4 new council members to make sure I wrote their names
correctly and in their preferred way. cc @ricardoV94, @colcarroll, @aloctavodia and @jessegrabowski


We also had a voter registration step in order to have the info needed for the numfocus mediator to
validate that votes came from core contributors. We should add it if we'd like to do that going
forward or think a bit more about vote validation while keeping votes secret to anyone within the
project. cc @fonnesbeck

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [x] Other (please specify): governance related
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7627.org.readthedocs.build/en/7627/

<!-- readthedocs-preview pymc end -->