### PR TITLE
Foward `compile_kwargs` to ADVI when `init = "advi+..."`

### DIFF
--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -22,7 +22,6 @@ import pytensor
 import pytensor.tensor as pt
 import scipy.sparse as sps
 
-from pytensor import scalar
 from pytensor.compile import Function, Mode, get_mode
 from pytensor.compile.builders import OpFromGraph
 from pytensor.gradient import grad
@@ -413,31 +412,6 @@ def hessian_diag(f, vars=None, negate_output=True):
         return res
     else:
         return empty_gradient
-
-
-class IdentityOp(scalar.UnaryScalarOp):
-    @staticmethod
-    def st_impl(x):
-        return x
-
-    def impl(self, x):
-        return x
-
-    def grad(self, inp, grads):
-        return grads
-
-    def c_code(self, node, name, inp, out, sub):
-        return f"{out[0]} = {inp[0]};"
-
-    def __eq__(self, other):
-        return isinstance(self, type(other))
-
-    def __hash__(self):
-        return hash(type(self))
-
-
-scalar_identity = IdentityOp(scalar.upgrade_to_float, name="scalar_identity")
-identity = Elemwise(scalar_identity, name="identity")
 
 
 def make_shared_replacements(point, vars, model):

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1553,6 +1553,7 @@ def init_nuts(
             callbacks=cb,
             progressbar=progressbar,
             obj_optimizer=pm.adagrad_window,
+            compile_kwargs=compile_kwargs,
         )
         approx_sample = approx.sample(
             draws=chains, random_seed=random_seed_list[0], return_inferencedata=False
@@ -1566,6 +1567,7 @@ def init_nuts(
         potential = quadpotential.QuadPotentialDiagAdapt(
             n, mean, cov, weight, rng=random_seed_list[0]
         )
+
     elif init == "advi":
         approx = pm.fit(
             random_seed=random_seed_list[0],
@@ -1575,6 +1577,7 @@ def init_nuts(
             callbacks=cb,
             progressbar=progressbar,
             obj_optimizer=pm.adagrad_window,
+            compile_kwargs=compile_kwargs,
         )
         approx_sample = approx.sample(
             draws=chains, random_seed=random_seed_list[0], return_inferencedata=False
@@ -1592,6 +1595,7 @@ def init_nuts(
             callbacks=cb,
             progressbar=progressbar,
             obj_optimizer=pm.adagrad_window,
+            compile_kwargs=compile_kwargs,
         )
         approx_sample = approx.sample(
             draws=chains, random_seed=random_seed_list[0], return_inferencedata=False

--- a/pymc/variational/inference.py
+++ b/pymc/variational/inference.py
@@ -82,7 +82,14 @@ class Inference:
 
     def run_profiling(self, n=1000, score=None, **kwargs):
         score = self._maybe_score(score)
-        compile_kwargs = kwargs.pop("compile_kwargs", {})
+        if "fn_kwargs" in kwargs:
+            warnings.warn(
+                DeprecationWarning, "fn_kwargs is deprecated, please use compile_kwargs instead"
+            )
+            compile_kwargs = kwargs.pop("fn_kwargs")
+        else:
+            compile_kwargs = kwargs.pop("compile_kwargs", {})
+
         compile_kwargs["profile"] = True
         step_func = self.objective.step_function(
             score=score, compile_kwargs=compile_kwargs, **kwargs

--- a/pymc/variational/inference.py
+++ b/pymc/variational/inference.py
@@ -82,9 +82,11 @@ class Inference:
 
     def run_profiling(self, n=1000, score=None, **kwargs):
         score = self._maybe_score(score)
-        fn_kwargs = kwargs.pop("fn_kwargs", {})
-        fn_kwargs["profile"] = True
-        step_func = self.objective.step_function(score=score, fn_kwargs=fn_kwargs, **kwargs)
+        compile_kwargs = kwargs.pop("compile_kwargs", {})
+        compile_kwargs["profile"] = True
+        step_func = self.objective.step_function(
+            score=score, compile_kwargs=compile_kwargs, **kwargs
+        )
         try:
             for _ in track(range(n)):
                 step_func()
@@ -134,7 +136,7 @@ class Inference:
             Add custom updates to resulting updates
         total_grad_norm_constraint: `float`
             Bounds gradient norm, prevents exploding gradient problem
-        fn_kwargs: `dict`
+        compile_kwargs: `dict`
             Add kwargs to pytensor.function (e.g. `{'profile': True}`)
         more_replacements: `dict`
             Apply custom replacements before calculating gradients
@@ -729,7 +731,7 @@ def fit(
         Add custom updates to resulting updates
     total_grad_norm_constraint: `float`
         Bounds gradient norm, prevents exploding gradient problem
-    fn_kwargs: `dict`
+    compile_kwargs: `dict`
         Add kwargs to pytensor.function (e.g. `{'profile': True}`)
     more_replacements: `dict`
         Apply custom replacements before calculating gradients

--- a/pymc/variational/inference.py
+++ b/pymc/variational/inference.py
@@ -84,7 +84,7 @@ class Inference:
         score = self._maybe_score(score)
         if "fn_kwargs" in kwargs:
             warnings.warn(
-                DeprecationWarning, "fn_kwargs is deprecated, please use compile_kwargs instead"
+                "fn_kwargs is deprecated, please use compile_kwargs instead", DeprecationWarning
             )
             compile_kwargs = kwargs.pop("fn_kwargs")
         else:

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -61,6 +61,8 @@ import xarray
 
 from pytensor.graph.basic import Variable
 from pytensor.graph.replace import graph_replace
+from pytensor.scalar.basic import identity as scalar_identity
+from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.shape import unbroadcast
 
 import pymc as pm
@@ -74,7 +76,6 @@ from pymc.pytensorf import (
     SeedSequenceSeed,
     compile,
     find_rng_nodes,
-    identity,
     reseed_rngs,
 )
 from pymc.util import (
@@ -469,7 +470,7 @@ class Operator:
     require_logq = True
     objective_class = ObjectiveFunction
     supports_aevb = property(lambda self: not self.approx.any_histograms)
-    T = identity
+    T = Elemwise(scalar_identity)
 
     def __init__(self, approx):
         self.approx = approx

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -333,6 +333,7 @@ class ObjectiveFunction:
         total_grad_norm_constraint=None,
         score=False,
         compile_kwargs=None,
+        fn_kwargs=None,
     ):
         R"""Step function that should be called on each optimization step.
 
@@ -364,6 +365,11 @@ class ObjectiveFunction:
             calculate loss on each step? Defaults to False for speed
         compile_kwargs: `dict`
             Add kwargs to pytensor.function (e.g. `{'profile': True}`)
+        fn_kwargs: dict
+            arbitrary kwargs passed to `pytensor.function`
+
+            .. warning:: `fn_kwargs` is deprecated and will be removed in future versions
+
         more_replacements: `dict`
             Apply custom replacements before calculating gradients
 
@@ -371,6 +377,10 @@ class ObjectiveFunction:
         -------
         `pytensor.function`
         """
+        if fn_kwargs is not None:
+            warnings.warn("`fn_kwargs` is deprecated and will be removed in future versions")
+            compile_kwargs = fn_kwargs
+
         if compile_kwargs is None:
             compile_kwargs = {}
         if score and not self.op.returns_loss:
@@ -395,7 +405,7 @@ class ObjectiveFunction:
 
     @pytensor.config.change_flags(compute_test_value="off")
     def score_function(
-        self, sc_n_mc=None, more_replacements=None, compile_kwargs=None
+        self, sc_n_mc=None, more_replacements=None, compile_kwargs=None, fn_kwargs=None
     ):  # pragma: no cover
         R"""Compile scoring function that operates which takes no inputs and returns Loss.
 
@@ -407,11 +417,19 @@ class ObjectiveFunction:
             Apply custom replacements before compiling a function
         compile_kwargs: `dict`
             arbitrary kwargs passed to `pytensor.function`
+        fn_kwargs: `dict`
+            arbitrary kwargs passed to `pytensor.function`
+
+            .. warning:: `fn_kwargs` is deprecated and will be removed in future versions
 
         Returns
         -------
         pytensor.function
         """
+        if fn_kwargs is not None:
+            warnings.warn("`fn_kwargs` is deprecated and will be removed in future versions")
+            compile_kwargs = fn_kwargs
+
         if compile_kwargs is None:
             compile_kwargs = {}
         if not self.op.returns_loss:

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -379,7 +379,11 @@ class ObjectiveFunction:
         `pytensor.function`
         """
         if fn_kwargs is not None:
-            warnings.warn("`fn_kwargs` is deprecated and will be removed in future versions")
+            warnings.warn(
+                "`fn_kwargs` is deprecated and will be removed in future versions. Use "
+                "`compile_kwargs` instead.",
+                DeprecationWarning,
+            )
             compile_kwargs = fn_kwargs
 
         if compile_kwargs is None:
@@ -428,7 +432,11 @@ class ObjectiveFunction:
         pytensor.function
         """
         if fn_kwargs is not None:
-            warnings.warn("`fn_kwargs` is deprecated and will be removed in future versions")
+            warnings.warn(
+                "`fn_kwargs` is deprecated and will be removed in future versions. Use "
+                "`compile_kwargs` instead",
+                DeprecationWarning,
+            )
             compile_kwargs = fn_kwargs
 
         if compile_kwargs is None:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
See title. Now that we are allowed to pass `compile_kwargs` to pm.sample, it would be nice if these kwargs were also passed to any subroutines that are called before/after sampling. An obvious example is the call to `pm.fit` when the user sets `init = "advi+something"`. This PR forwards the `compile_kwargs` to ADVI.

It also renames `fn_kwargs` to `compile_kwargs` in the variational sub-module. This harmonizes the naming convention across the library. A depreciation warning is added when `fn_kwargs` is used for backwards compatibility.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #7638 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7640.org.readthedocs.build/en/7640/

<!-- readthedocs-preview pymc end -->