### PR TITLE
Check for observed variables in the trace

### DIFF
--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -820,7 +820,7 @@ def sample_posterior_predictive(
     else:
         vars_ = model.observed_RVs + observed_dependent_deterministics(model)
         if observed_data is not None:
-            vars_ += [model[x] for x in observed_data if x in model]
+            vars_ += [model[x] for x in observed_data if x in model and x not in vars_]
 
     vars_to_sample = list(get_default_varnames(vars_, include_transformed=False))
 

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -775,7 +775,7 @@ def sample_posterior_predictive(
             trace_coords.update({str(k): v.data for k, v in _constant_data.coords.items()})
             constant_data.update({str(k): v.data for k, v in _constant_data.items()})
         idata = trace
-        observed_data = trace["observed_data"]
+        observed_data = trace.get("observed_data", None)
         trace = trace["posterior"]
     if isinstance(trace, xarray.Dataset):
         trace_coords.update({str(k): v.data for k, v in trace.coords.items()})

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -821,10 +821,12 @@ def sample_posterior_predictive(
     if var_names is not None:
         vars_ = [model[x] for x in var_names]
     else:
-        vars_ = model.observed_RVs + observed_dependent_deterministics(model)
+        observed_vars = model.observed_RVs
         if observed_data is not None:
-            vars_ += [model[x] for x in observed_data if x in model and x not in vars_]
-            vars_ += observed_dependent_deterministics(model, vars_)
+            observed_vars += [
+                model[x] for x in observed_data if x in model and x not in observed_vars
+            ]
+        vars_ = observed_vars + observed_dependent_deterministics(model, observed_vars)
 
     vars_to_sample = list(get_default_varnames(vars_, include_transformed=False))
 

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -767,6 +767,7 @@ def sample_posterior_predictive(
     if "coords" not in idata_kwargs:
         idata_kwargs["coords"] = {}
     idata: InferenceData | None = None
+    observed_data = None
     stacked_dims = None
     if isinstance(trace, InferenceData):
         _constant_data = getattr(trace, "constant_data", None)
@@ -774,6 +775,7 @@ def sample_posterior_predictive(
             trace_coords.update({str(k): v.data for k, v in _constant_data.coords.items()})
             constant_data.update({str(k): v.data for k, v in _constant_data.items()})
         idata = trace
+        observed_data = trace["observed_data"]
         trace = trace["posterior"]
     if isinstance(trace, xarray.Dataset):
         trace_coords.update({str(k): v.data for k, v in trace.coords.items()})
@@ -817,6 +819,8 @@ def sample_posterior_predictive(
         vars_ = [model[x] for x in var_names]
     else:
         vars_ = model.observed_RVs + observed_dependent_deterministics(model)
+        if observed_data is not None:
+            vars_ += [model[x] for x in observed_data if x in model]
 
     vars_to_sample = list(get_default_varnames(vars_, include_transformed=False))
 

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -345,10 +345,13 @@ def draw(
     return [np.stack(v) for v in drawn_values]
 
 
-def observed_dependent_deterministics(model: Model):
+def observed_dependent_deterministics(model: Model, extra_observeds=None):
     """Find deterministics that depend directly on observed variables."""
+    if extra_observeds is None:
+        extra_observeds = []
+
     deterministics = model.deterministics
-    observed_rvs = set(model.observed_RVs)
+    observed_rvs = set(model.observed_RVs + extra_observeds)
     blockers = model.basic_RVs
     return [
         deterministic
@@ -821,6 +824,7 @@ def sample_posterior_predictive(
         vars_ = model.observed_RVs + observed_dependent_deterministics(model)
         if observed_data is not None:
             vars_ += [model[x] for x in observed_data if x in model and x not in vars_]
+            vars_ += observed_dependent_deterministics(model, vars_)
 
     vars_to_sample = list(get_default_varnames(vars_, include_transformed=False))
 

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -481,16 +481,6 @@ class TestSamplePPC:
                 chains=nchains,
             )
 
-        # test that trace is used in ppc
-        with pm.Model() as model_ppc:
-            mu = pm.Normal("mu", 0.0, 1.0)
-            a = pm.Normal("a", mu=mu, sigma=1)
-
-        ppc = pm.sample_posterior_predictive(
-            trace=trace, model=model_ppc, return_inferencedata=False
-        )
-        assert "a" in ppc
-
         with model:
             # test list input
             ppc0 = pm.sample_posterior_predictive(
@@ -549,6 +539,51 @@ class TestSamplePPC:
 
             ppc = pm.sample_posterior_predictive(idata, return_inferencedata=False)
             assert ppc["a"].shape == (nchains, ndraws)
+
+    def test_external_trace(self):
+        nchains = 2
+        ndraws = 500
+        with pm.Model() as model:
+            mu = pm.Normal("mu", 0.0, 1.0)
+            a = pm.Normal("a", mu=mu, sigma=1, observed=0.0)
+            trace = pm.sample(
+                draws=ndraws,
+                chains=nchains,
+            )
+
+        # test that trace is used in ppc
+        with pm.Model() as model_ppc:
+            mu = pm.Normal("mu", 0.0, 1.0)
+            a = pm.Normal("a", mu=mu, sigma=1)
+
+        ppc = pm.sample_posterior_predictive(
+            trace=trace, model=model_ppc, return_inferencedata=False
+        )
+        assert list(ppc.keys()) == ["a"]
+
+    @pytest.mark.xfail(reason="Auto-imputation of variables not supported in this setting")
+    def test_external_trace_det(self):
+        nchains = 2
+        ndraws = 500
+        with pm.Model() as model:
+            mu = pm.Normal("mu", 0.0, 1.0)
+            a = pm.Normal("a", mu=mu, sigma=1, observed=0.0)
+            b = pm.Deterministic("b", a + 1)
+            trace = pm.sample(
+                draws=ndraws,
+                chains=nchains,
+            )
+
+        # test that trace is used in ppc
+        with pm.Model() as model_ppc:
+            mu = pm.Normal("mu", 0.0, 1.0)
+            a = pm.Normal("a", mu=mu, sigma=1)
+            b = pm.Deterministic("b", a + 1)
+
+        ppc = pm.sample_posterior_predictive(
+            trace=trace, model=model_ppc, return_inferencedata=False
+        )
+        assert list(ppc.keys()) == ["a", "b"]
 
     def test_normal_vector(self):
         with pm.Model() as model:

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -540,38 +540,12 @@ class TestSamplePPC:
             ppc = pm.sample_posterior_predictive(idata, return_inferencedata=False)
             assert ppc["a"].shape == (nchains, ndraws)
 
-    def test_external_trace(self):
-        nchains = 2
-        ndraws = 500
-        with pm.Model() as model:
-            mu = pm.Normal("mu", 0.0, 1.0)
-            a = pm.Normal("a", mu=mu, sigma=1, observed=0.0)
-            trace = pm.sample(
-                draws=ndraws,
-                chains=nchains,
-            )
-
-        # test that trace is used in ppc
-        with pm.Model() as model_ppc:
-            mu = pm.Normal("mu", 0.0, 1.0)
-            a = pm.Normal("a", mu=mu, sigma=1)
-
-        ppc = pm.sample_posterior_predictive(
-            trace=trace, model=model_ppc, return_inferencedata=False
-        )
-        assert list(ppc.keys()) == ["a"]
-
     def test_external_trace_det(self):
-        nchains = 2
-        ndraws = 500
         with pm.Model() as model:
             mu = pm.Normal("mu", 0.0, 1.0)
             a = pm.Normal("a", mu=mu, sigma=1, observed=0.0)
             b = pm.Deterministic("b", a + 1)
-            trace = pm.sample(
-                draws=ndraws,
-                chains=nchains,
-            )
+            trace = pm.sample(tune=50, draws=50, chains=1, compute_convergence_checks=False)
 
         # test that trace is used in ppc
         with pm.Model() as model_ppc:

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -481,6 +481,16 @@ class TestSamplePPC:
                 chains=nchains,
             )
 
+        # test that trace is used in ppc
+        with pm.Model() as model_ppc:
+            mu = pm.Normal("mu", 0.0, 1.0)
+            a = pm.Normal("a", mu=mu, sigma=1)
+
+        ppc = pm.sample_posterior_predictive(
+            trace=trace, model=model_ppc, return_inferencedata=False
+        )
+        assert "a" in ppc
+
         with model:
             # test list input
             ppc0 = pm.sample_posterior_predictive(

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -561,7 +561,6 @@ class TestSamplePPC:
         )
         assert list(ppc.keys()) == ["a"]
 
-    @pytest.mark.xfail(reason="Auto-imputation of variables not supported in this setting")
     def test_external_trace_det(self):
         nchains = 2
         ndraws = 500
@@ -578,12 +577,12 @@ class TestSamplePPC:
         with pm.Model() as model_ppc:
             mu = pm.Normal("mu", 0.0, 1.0)
             a = pm.Normal("a", mu=mu, sigma=1)
-            b = pm.Deterministic("b", a + 1)
+            c = pm.Deterministic("c", a + 1)
 
         ppc = pm.sample_posterior_predictive(
             trace=trace, model=model_ppc, return_inferencedata=False
         )
-        assert list(ppc.keys()) == ["a", "b"]
+        assert list(ppc.keys()) == ["a", "c"]
 
     def test_normal_vector(self):
         with pm.Model() as model:


### PR DESCRIPTION
## Description
This introduces the enhancement discussed in https://github.com/pymc-devs/pymc/discussions/7225

This makes it easier to use `sample_posterior_predictive` in model factory workflows

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7641.org.readthedocs.build/en/7641/

<!-- readthedocs-preview pymc end -->