### PR TITLE
fix: deep copy nuts_sampler_kwarg to prevent `.pop` side effects

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -309,7 +309,6 @@ def _sample_external_nuts(
     nuts_sampler_kwargs: dict | None,
     **kwargs,
 ):
-    nuts_sampler_kwargs = nuts_sampler_kwargs.copy()
     if nuts_sampler_kwargs is None:
         nuts_sampler_kwargs = {}
 
@@ -339,6 +338,7 @@ def _sample_external_nuts(
                 UserWarning,
             )
         compile_kwargs = {}
+        nuts_sampler_kwargs = nuts_sampler_kwargs.copy()
         for kwarg in ("backend", "gradient_backend"):
             if kwarg in nuts_sampler_kwargs:
                 compile_kwargs[kwarg] = nuts_sampler_kwargs.pop(kwarg)
@@ -687,7 +687,6 @@ def sample(
             mean     sd  hdi_3%  hdi_97%
         p  0.609  0.047   0.528    0.699
     """
-    nuts_sampler_kwargs = nuts_sampler_kwargs.copy()
     if "start" in kwargs:
         if initvals is not None:
             raise ValueError("Passing both `start` and `initvals` is not supported.")

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -309,11 +309,9 @@ def _sample_external_nuts(
     nuts_sampler_kwargs: dict | None,
     **kwargs,
 ):
-    import copy
-
-    nuts_sampler_kwargs_copy = copy.deepcopy(nuts_sampler_kwargs)
-    if nuts_sampler_kwargs_copy is None:
-        nuts_sampler_kwargs_copy = {}
+    nuts_sampler_kwargs = nuts_sampler_kwargs.copy()
+    if nuts_sampler_kwargs is None:
+        nuts_sampler_kwargs = {}
 
     if sampler == "nutpie":
         try:
@@ -342,8 +340,8 @@ def _sample_external_nuts(
             )
         compile_kwargs = {}
         for kwarg in ("backend", "gradient_backend"):
-            if kwarg in nuts_sampler_kwargs_copy:
-                compile_kwargs[kwarg] = nuts_sampler_kwargs_copy.pop(kwarg)
+            if kwarg in nuts_sampler_kwargs:
+                compile_kwargs[kwarg] = nuts_sampler_kwargs.pop(kwarg)
         compiled_model = nutpie.compile_pymc_model(
             model,
             **compile_kwargs,
@@ -357,7 +355,7 @@ def _sample_external_nuts(
             target_accept=target_accept,
             seed=_get_seeds_per_chain(random_seed, 1)[0],
             progress_bar=progressbar,
-            **nuts_sampler_kwargs_copy,
+            **nuts_sampler_kwargs,
         )
         t_sample = time.time() - t_start
         # Temporary work-around. Revert once https://github.com/pymc-devs/nutpie/issues/74 is fixed
@@ -409,7 +407,7 @@ def _sample_external_nuts(
             nuts_sampler=sampler,
             idata_kwargs=idata_kwargs,
             compute_convergence_checks=compute_convergence_checks,
-            **nuts_sampler_kwargs_copy,
+            **nuts_sampler_kwargs,
         )
         return idata
 
@@ -689,9 +687,7 @@ def sample(
             mean     sd  hdi_3%  hdi_97%
         p  0.609  0.047   0.528    0.699
     """
-    import copy
-
-    nuts_sampler_kwargs_copy = copy.deepcopy(nuts_sampler_kwargs)
+    nuts_sampler_kwargs = nuts_sampler_kwargs.copy()
     if "start" in kwargs:
         if initvals is not None:
             raise ValueError("Passing both `start` and `initvals` is not supported.")
@@ -701,8 +697,8 @@ def sample(
             stacklevel=2,
         )
         initvals = kwargs.pop("start")
-    if nuts_sampler_kwargs_copy is None:
-        nuts_sampler_kwargs_copy = {}
+    if nuts_sampler_kwargs is None:
+        nuts_sampler_kwargs = {}
     if "target_accept" in kwargs:
         if "nuts" in kwargs and "target_accept" in kwargs["nuts"]:
             raise ValueError(
@@ -814,7 +810,7 @@ def sample(
                 progressbar=progressbar,
                 idata_kwargs=idata_kwargs,
                 compute_convergence_checks=compute_convergence_checks,
-                nuts_sampler_kwargs=nuts_sampler_kwargs_copy,
+                nuts_sampler_kwargs=nuts_sampler_kwargs,
                 **kwargs,
             )
 

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -309,8 +309,11 @@ def _sample_external_nuts(
     nuts_sampler_kwargs: dict | None,
     **kwargs,
 ):
-    if nuts_sampler_kwargs is None:
-        nuts_sampler_kwargs = {}
+    import copy
+
+    nuts_sampler_kwargs_copy = copy.deepcopy(nuts_sampler_kwargs)
+    if nuts_sampler_kwargs_copy is None:
+        nuts_sampler_kwargs_copy = {}
 
     if sampler == "nutpie":
         try:
@@ -339,8 +342,8 @@ def _sample_external_nuts(
             )
         compile_kwargs = {}
         for kwarg in ("backend", "gradient_backend"):
-            if kwarg in nuts_sampler_kwargs:
-                compile_kwargs[kwarg] = nuts_sampler_kwargs.pop(kwarg)
+            if kwarg in nuts_sampler_kwargs_copy:
+                compile_kwargs[kwarg] = nuts_sampler_kwargs_copy.pop(kwarg)
         compiled_model = nutpie.compile_pymc_model(
             model,
             **compile_kwargs,
@@ -354,7 +357,7 @@ def _sample_external_nuts(
             target_accept=target_accept,
             seed=_get_seeds_per_chain(random_seed, 1)[0],
             progress_bar=progressbar,
-            **nuts_sampler_kwargs,
+            **nuts_sampler_kwargs_copy,
         )
         t_sample = time.time() - t_start
         # Temporary work-around. Revert once https://github.com/pymc-devs/nutpie/issues/74 is fixed
@@ -406,7 +409,7 @@ def _sample_external_nuts(
             nuts_sampler=sampler,
             idata_kwargs=idata_kwargs,
             compute_convergence_checks=compute_convergence_checks,
-            **nuts_sampler_kwargs,
+            **nuts_sampler_kwargs_copy,
         )
         return idata
 
@@ -686,6 +689,9 @@ def sample(
             mean     sd  hdi_3%  hdi_97%
         p  0.609  0.047   0.528    0.699
     """
+    import copy
+
+    nuts_sampler_kwargs_copy = copy.deepcopy(nuts_sampler_kwargs)
     if "start" in kwargs:
         if initvals is not None:
             raise ValueError("Passing both `start` and `initvals` is not supported.")
@@ -695,8 +701,8 @@ def sample(
             stacklevel=2,
         )
         initvals = kwargs.pop("start")
-    if nuts_sampler_kwargs is None:
-        nuts_sampler_kwargs = {}
+    if nuts_sampler_kwargs_copy is None:
+        nuts_sampler_kwargs_copy = {}
     if "target_accept" in kwargs:
         if "nuts" in kwargs and "target_accept" in kwargs["nuts"]:
             raise ValueError(
@@ -808,7 +814,7 @@ def sample(
                 progressbar=progressbar,
                 idata_kwargs=idata_kwargs,
                 compute_convergence_checks=compute_convergence_checks,
-                nuts_sampler_kwargs=nuts_sampler_kwargs,
+                nuts_sampler_kwargs=nuts_sampler_kwargs_copy,
                 **kwargs,
             )
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Deep copy the `nuts_sampler_kwargs` to prevent the function (`.pop` method) mutating the original passed dictonary.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7632 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7652.org.readthedocs.build/en/7652/

<!-- readthedocs-preview pymc end -->