### PR TITLE
Allow debug evaling IR logp graphs

### DIFF
--- a/pymc/logprob/abstract.py
+++ b/pymc/logprob/abstract.py
@@ -236,13 +236,16 @@ class ValuedRV(Op):
     and breaking the dependency of `b` on `a`. The new nodes isolate the graphs between conditioning points.
     """
 
+    view_map = {0: [0]}
+
     def make_node(self, rv, value):
         assert isinstance(rv, Variable)
         assert isinstance(value, Variable)
         return Apply(self, [rv, value], [rv.type(name=rv.name)])
 
     def perform(self, node, inputs, out):
-        raise NotImplementedError("ValuedVar should not be present in the final graph!")
+        warnings.warn("ValuedVar should not be present in the final graph!")
+        out[0][0] = inputs[0]
 
     def infer_shape(self, fgraph, node, input_shapes):
         return [input_shapes[0]]

--- a/pymc/logprob/transform_value.py
+++ b/pymc/logprob/transform_value.py
@@ -11,6 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import warnings
 
 from collections.abc import Sequence
 
@@ -40,7 +41,8 @@ class TransformedValue(Op):
         return Apply(self, [tran_value, value], [tran_value.type()])
 
     def perform(self, node, inputs, outputs):
-        raise NotImplementedError("These `Op`s should be removed from graphs used for computation.")
+        warnings.warn("TransformedValue should not be present in the final graph!")
+        outputs[0][0] = inputs[0]
 
     def infer_shape(self, fgraph, node, input_shapes):
         return [input_shapes[0]]


### PR DESCRIPTION
A user on discourse recently raised the question of why we can't eval logp graphs during their construction. We have some tagging Ops that raise on the perform method, that prevent this. 

https://discourse.pymc.io/t/how-to-implement-bivariate-poisson-logbp/16400/7?u=ricardov94

This PR allows evaluating them, but issues a warning. I've felt the need to get values in interactive debug many times.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7666.org.readthedocs.build/en/7666/

<!-- readthedocs-preview pymc end -->