### PR TITLE
Update starting.py. Clarified find_MAP doc regarding start parameter

### DIFF
--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -70,8 +70,8 @@ def find_MAP(
     Parameters
     ----------
     start: `dict` of parameter values (Defaults to `model.initial_point`)
-        These values will be fixed and used for any free RandomVariables that are
-        not being optimized.
+        Starting point for the maximization.
+        Any free RandomVariables that are not being optimized, will be fixed to the start values.
     vars: list of TensorVariable
         List of free RandomVariables to optimize the posterior with respect to.
         Defaults to all continuous RVs in a model. The respective value variables


### PR DESCRIPTION
Clarified find_MAP doc regarding start parameter

Also see https://discourse.pymc.io/t/start-parameter-in-find-map/11774

Documentation only.


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7673.org.readthedocs.build/en/7673/

<!-- readthedocs-preview pymc end -->