### PR TITLE
Reuse jaxified logp when sampling via jax

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -669,6 +669,7 @@ def sample_jax_nuts(
         random_seed=random_seed,
         initial_points=initial_points,
         nuts_kwargs=nuts_kwargs,
+        logp_fn=logp_fn,
     )
     tic2 = datetime.now()
 


### PR DESCRIPTION
reuse jaxified logp when sampling via jax

## Description

#7610 added logic to handle passing a pre-jaxified logp function into the blackjax/numpyro samplers, but missed actually passing the jaxified logp that is computed in `sample_jax_nuts`

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change]

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7681.org.readthedocs.build/en/7681/

<!-- readthedocs-preview pymc end -->