### PR TITLE
Increase tolerance in TestGARCH11::test_batched_size to reduce flakiness

### DIFF
--- a/tests/distributions/test_timeseries.py
+++ b/tests/distributions/test_timeseries.py
@@ -818,6 +818,8 @@ class TestGARCH11:
         np.testing.assert_allclose(
             t0.compile_logp()(t0.initial_point()),
             t1.compile_logp()(t1.initial_point()),
+            atol=1e-3,
+            rtol=1e-2,
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- !! Thank you for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Increased the absolute (`atol=1e-3`) and relative (`rtol=1e-2`) tolerances in `np.testing.assert_allclose` within `TestGARCH11::test_batched_size`.  
This should help reduce test flakiness caused by minor numerical variations.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7674

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works (ran `pytest tests/distributions/test_timeseries.py`)
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):

<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7684.org.readthedocs.build/en/7684/

<!-- readthedocs-preview pymc end -->