### PR TITLE
Allow draws from `Weibull`, `MvStudentT`, `LKJCorr` and `LKJCholeskyCovRV` in alternative backends 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -281,16 +281,20 @@ jobs:
           name: ${{ matrix.os }} ${{ matrix.floatx }}
           fail_ci_if_error: false
 
-  external_samplers:
+  alternative_backends:
     needs: changes
     if: ${{ needs.changes.outputs.changes == 'true' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
         floatx: [float64]
-        python-version: ["3.13"]
+        python-version: ["3.12"]
         test-subset:
-          - tests/sampling/test_jax.py tests/sampling/test_mcmc_external.py
+          - |
+            tests/distributions/test_random_alternative_backends.py
+            tests/sampling/test_jax.py
+            tests/sampling/test_mcmc_external.py
+
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
@@ -305,7 +309,7 @@ jobs:
           persist-credentials: false
       - uses: mamba-org/setup-micromamba@v2
         with:
-          environment-file: conda-envs/environment-jax.yml
+          environment-file: conda-envs/environment-alternative-backends.yml
           create-args: >-
             python=${{matrix.python-version}}
           environment-name: pymc-test
@@ -324,7 +328,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
           env_vars: TEST_SUBSET
-          name: JAX tests - ${{ matrix.os }} ${{ matrix.floatx }}
+          name: Alternative backend tests - ${{ matrix.os }} ${{ matrix.floatx }}
           fail_ci_if_error: false
 
   float32:
@@ -378,13 +382,13 @@ jobs:
   all_tests:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [ changes, ubuntu, windows, macos, external_samplers, float32 ]
+    needs: [ changes, ubuntu, windows, macos, alternative_backends, float32 ]
     steps:
       - name: Check build matrix status
         if: ${{ needs.changes.outputs.changes == 'true' &&
                 ( needs.ubuntu.result != 'success' ||
                   needs.windows.result != 'success' ||
                   needs.macos.result != 'success' ||
-                  needs.external_samplers.result != 'success' ||
+                  needs.alternative_backends.result != 'success' ||
                   needs.float32.result != 'success' ) }}
         run: exit 1

--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -10,6 +10,8 @@ dependencies:
 - cachetools>=4.2.1
 - cloudpickle
 - zarr>=2.5.0,<3
+- numba
+- nutpie >= 0.13.4
 # Jaxlib version must not be greater than jax version!
 - blackjax>=1.2.2
 - jax>=0.4.28

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.28.1,<2.29
+- pytensor>=2.28.3,<2.29
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -11,7 +11,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.28.1,<2.29
+- pytensor>=2.28.3,<2.29
 - python-graphviz
 - rich>=13.7.1
 - scipy>=1.4.1

--- a/conda-envs/environment-jax.yml
+++ b/conda-envs/environment-jax.yml
@@ -20,7 +20,7 @@ dependencies:
 - numpyro>=0.8.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.28.1,<2.29
+- pytensor>=2.28.3,<2.29
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -14,7 +14,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=2.28.1,<2.29
+- pytensor>=2.28.3,<2.29
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.28.1,<2.29
+- pytensor>=2.28.3,<2.29
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -15,7 +15,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=2.28.1,<2.29
+- pytensor>=2.28.3,<2.29
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -383,6 +383,14 @@ class SymbolicRandomVariable(MeasurableOp, OpFromGraph):
         out_ndim = max(getattr(out.type, "ndim", 0) for out in node.outputs)
         return out_ndim - self.ndim_supp
 
+    def rebuild_rv(self, *args, **kwargs):
+        """Rebuild the RandomVariable with new inputs."""
+        if not hasattr(self, "rv_op"):
+            raise NotImplementedError(
+                f"SymbolicRandomVariable {self} without `rv_op` method cannot be rebuilt automatically."
+            )
+        return self.rv_op(*args, **kwargs)
+
 
 @_change_dist_size.register(SymbolicRandomVariable)
 def change_symbolic_rv_size(op: SymbolicRandomVariable, rv, new_size, expand) -> TensorVariable:
@@ -403,7 +411,7 @@ def change_symbolic_rv_size(op: SymbolicRandomVariable, rv, new_size, expand) ->
     if expand and not rv_size_is_none(size):
         new_size = tuple(new_size) + tuple(size)
 
-    return op.rv_op(*params, size=new_size)
+    return op.rebuild_rv(*params, size=new_size)
 
 
 class Distribution(metaclass=DistributionMeta):

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -400,7 +400,7 @@ def change_symbolic_rv_size(op: SymbolicRandomVariable, rv, new_size, expand) ->
 
     params = op.dist_params(rv.owner)
 
-    if expand:
+    if expand and not rv_size_is_none(size):
         new_size = tuple(new_size) + tuple(size)
 
     return op.rv_op(*params, size=new_size)

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -468,5 +468,6 @@ def implicit_size_from_params(
         pt.broadcast_shape(
             *batch_shapes,
             arrays_are_shapes=True,
-        )
+        ),
+        dtype="int64",  # In case it's empty, as_tensor will default to floatX
     )

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -18,11 +18,8 @@ from functools import singledispatch
 import numpy as np
 import pytensor.tensor as pt
 
-
-# ignore mypy error because it somehow considers that
-# "numpy.core.numeric has no attribute normalize_axis_tuple"
-from numpy.core.numeric import normalize_axis_tuple  # type: ignore[attr-defined]
 from pytensor.graph import Op
+from pytensor.npy_2_compat import normalize_axis_tuple
 from pytensor.tensor import TensorVariable
 
 from pymc.logprob.transforms import (

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ numpydoc
 pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
-pytensor>=2.28.1,<2.29
+pytensor>=2.28.3,<2.29
 pytest-cov>=2.5
 pytest>=3.0
 rich>=13.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cachetools>=4.2.1
 cloudpickle
 numpy>=1.25.0
 pandas>=0.24.0
-pytensor>=2.28.1,<2.29
+pytensor>=2.28.2,<2.29
 rich>=13.7.1
 scipy>=1.4.1
 threadpoolctl>=3.1.0,<4.0.0

--- a/tests/distributions/test_random_alternative_backends.py
+++ b/tests/distributions/test_random_alternative_backends.py
@@ -1,0 +1,70 @@
+#   Copyright 2025 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from contextlib import nullcontext
+
+import numpy as np
+import pytest
+
+import pymc as pm
+
+from pymc import DirichletMultinomial, MvStudentT
+from pymc.model.transform.optimization import freeze_dims_and_data
+
+
+@pytest.fixture(params=["FAST_RUN", "JAX", "NUMBA"])
+def mode(request):
+    mode_param = request.param
+    if mode_param != "FAST_RUN":
+        pytest.importorskip(mode_param.lower())
+    return mode_param
+
+
+def test_dirichlet_multinomial(mode):
+    """Test we can draw from a DM in the JAX backend if the shape is constant."""
+    dm = DirichletMultinomial.dist(n=5, a=np.eye(3) * 1e6 + 0.01)
+    dm_draws = pm.draw(dm, mode=mode)
+    np.testing.assert_equal(dm_draws, np.eye(3) * 5)
+
+
+def test_dirichlet_multinomial_dims(mode):
+    """Test we can draw from a DM with a shape defined by dims in the JAX backend,
+    after freezing those dims.
+    """
+    with pm.Model(coords={"trial": range(3), "item": range(3)}) as m:
+        dm = DirichletMultinomial("dm", n=5, a=np.eye(3) * 1e6 + 0.01, dims=("trial", "item"))
+
+    # JAX does not allow us to JIT a function with dynamic shape
+    expected_ctxt = pytest.raises(TypeError) if mode == "JAX" else nullcontext()
+    with expected_ctxt:
+        pm.draw(dm, mode=mode)
+
+    # Should be fine after freezing the dims that specify the shape
+    frozen_dm = freeze_dims_and_data(m)["dm"]
+    dm_draws = pm.draw(frozen_dm, mode=mode)
+    np.testing.assert_equal(dm_draws, np.eye(3) * 5)
+
+
+def test_mvstudentt(mode):
+    mvt = MvStudentT.dist(nu=100, mu=[1, 2, 3], scale=np.eye(3) * [0.01, 1, 100], shape=(10_000, 3))
+    draws = pm.draw(mvt, mode=mode)
+    np.testing.assert_allclose(draws.mean(0), [1, 2, 3], rtol=0.1)
+    np.testing.assert_allclose(draws.std(0), np.sqrt([0.01, 1, 100]), rtol=0.1)
+
+
+def test_repeated_arguments(mode):
+    # Regression test for a failure in Numba mode when a RV had repeated arguments
+    v = 0.5 * 1e5
+    x = pm.Beta.dist(v, v)
+    x_draw = pm.draw(x, mode=mode)
+    np.testing.assert_allclose(x_draw, 0.5, rtol=0.01)

--- a/tests/distributions/test_shape_utils.py
+++ b/tests/distributions/test_shape_utils.py
@@ -427,6 +427,17 @@ def test_change_rv_size():
     assert tuple(rv_newer.shape.eval()) == (2,)
 
 
+def test_change_rv_size_expand_none_size():
+    x = pt.random.normal()
+    size = x.owner.op.size_param(x.owner)
+    assert rv_size_is_none(size)
+    new_x = change_dist_size(x, new_size=(2,), expand=True)
+    new_size = new_x.owner.op.size_param(new_x.owner)
+    assert not rv_size_is_none(new_size)
+    assert new_size.data == [2]
+    assert new_x.type.shape == (2,)
+
+
 def test_change_rv_size_default_update():
     rng = pytensor.shared(np.random.default_rng(0))
     x = normal(rng=rng)

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -34,8 +34,7 @@ from pytensor.graph import graph_inputs
 import pymc as pm
 
 from pymc import ImputationWarning
-from pymc.distributions.multivariate import DirichletMultinomial, PosDefMatrix
-from pymc.model.transform.optimization import freeze_dims_and_data
+from pymc.distributions.multivariate import PosDefMatrix
 from pymc.sampling.jax import (
     _get_batched_jittered_initial_points,
     _get_log_likelihood,
@@ -505,27 +504,3 @@ def test_convergence_warnings(caplog, nuts_sampler):
 
     [record] = caplog.records
     assert re.match(r"There were \d+ divergences after tuning", record.message)
-
-
-def test_dirichlet_multinomial():
-    """Test we can draw from a DM in the JAX backend if the shape is constant."""
-    dm = DirichletMultinomial.dist(n=5, a=np.eye(3) * 1e6 + 0.01)
-    dm_draws = pm.draw(dm, mode="JAX")
-    np.testing.assert_equal(dm_draws, np.eye(3) * 5)
-
-
-def test_dirichlet_multinomial_dims():
-    """Test we can draw from a DM with a shape defined by dims in the JAX backend,
-    after freezing those dims.
-    """
-    with pm.Model(coords={"trial": range(3), "item": range(3)}) as m:
-        dm = DirichletMultinomial("dm", n=5, a=np.eye(3) * 1e6 + 0.01, dims=("trial", "item"))
-
-    # JAX does not allow us to JIT a function with dynamic shape
-    with pytest.raises(TypeError):
-        pm.draw(dm, mode="JAX")
-
-    # Should be fine after freezing the dims that specify the shape
-    frozen_dm = freeze_dims_and_data(m)["dm"]
-    dm_draws = pm.draw(frozen_dm, mode="JAX")
-    np.testing.assert_equal(dm_draws, np.eye(3) * 5)

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -81,7 +81,8 @@ def test_step_args():
             nuts_sampler="numpyro",
             target_accept=0.5,
             nuts={"max_treedepth": 10},
-            random_seed=1410,
+            random_seed=1411,
+            progressbar=False,
         )
 
     npt.assert_almost_equal(idata.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)


### PR DESCRIPTION
This PR converts more RandomVariable Ops to SymbolicRandomVariable (built on top of other RV Ops), which makes them automatically compatible with alternative backends.

Depends on: 
https://github.com/pymc-devs/pytensor/pull/1222
https://github.com/pymc-devs/pytensor/pull/1223

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7685.org.readthedocs.build/en/7685/

<!-- readthedocs-preview pymc end -->