### PR TITLE
Fix bug when reusing jax logp for initial point generation

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -240,7 +240,10 @@ def _get_batched_jittered_initial_points(
             Wraps jaxified logp function to accept a dict of
             {model_variable: np.array} key:value pairs.
             """
-            return logp_fn(point.values())
+            # Because logp_fn is not jitted, we need to convert inputs to jax arrays,
+            # or some methods that are only available for jax arrays will fail
+            # such as x.at[indices].set(y)
+            return logp_fn([jax.numpy.asarray(v) for v in point.values()])
 
     initial_points = _init_jitter(
         model,


### PR DESCRIPTION
Fixes issue described in https://discourse.pymc.io/t/attributeerror-numpy-ndarray-object-has-no-attribute-at-when-sampling-lkj-cholesky-covariance-priors-for-multivariate-normal-models-example-with-numpyro-or-blackjax/16598/3

Caused by #7681 
CC @nataziel 

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7695.org.readthedocs.build/en/7695/

<!-- readthedocs-preview pymc end -->