### PR TITLE
Allow compile_kwargs in sample_smc

### DIFF
--- a/pymc/smc/kernels.py
+++ b/pymc/smc/kernels.py
@@ -175,8 +175,8 @@ class SMC_KERNEL(ABC):
         self.model = modelcontext(model)
         self.variables = self.model.value_vars
 
-        self.var_info = {}
-        self.tempered_posterior = None
+        self.var_info: dict[str, tuple] = {}
+        self.tempered_posterior: np.ndarray
         self.prior_logp = None
         self.likelihood_logp = None
         self.tempered_posterior_logp = None

--- a/pymc/smc/kernels.py
+++ b/pymc/smc/kernels.py
@@ -134,6 +134,7 @@ class SMC_KERNEL(ABC):
         model=None,
         random_seed=None,
         threshold=0.5,
+        compile_kwargs: dict | None = None,
     ):
         """
         Initialize the SMC_kernel class.
@@ -154,6 +155,8 @@ class SMC_KERNEL(ABC):
             Determines the change of beta from stage to stage, i.e.indirectly the number of stages,
             the higher the value of `threshold` the higher the number of stages. Defaults to 0.5.
             It should be between 0 and 1.
+        compile_kwargs: dict, optional
+            Keyword arguments passed to pytensor.function
 
         Attributes
         ----------
@@ -184,6 +187,7 @@ class SMC_KERNEL(ABC):
         self.iteration = 0
         self.resampling_indexes = None
         self.weights = np.ones(self.draws) / self.draws
+        self.compile_kwargs = compile_kwargs if compile_kwargs is not None else {}
 
     def initialize_population(self) -> dict[str, np.ndarray]:
         """Create an initial population from the prior distribution."""
@@ -239,10 +243,10 @@ class SMC_KERNEL(ABC):
         shared = make_shared_replacements(initial_point, self.variables, self.model)
 
         self.prior_logp_func = _logp_forw(
-            initial_point, [self.model.varlogp], self.variables, shared
+            initial_point, [self.model.varlogp], self.variables, shared, self.compile_kwargs
         )
         self.likelihood_logp_func = _logp_forw(
-            initial_point, [self.model.datalogp], self.variables, shared
+            initial_point, [self.model.datalogp], self.variables, shared, self.compile_kwargs
         )
 
         priors = [self.prior_logp_func(sample) for sample in self.tempered_posterior]
@@ -606,7 +610,7 @@ def systematic_resampling(weights, rng):
     return new_indices
 
 
-def _logp_forw(point, out_vars, in_vars, shared):
+def _logp_forw(point, out_vars, in_vars, shared, compile_kwargs=None):
     """Compile PyTensor function of the model and the input and output variables.
 
     Parameters
@@ -617,7 +621,12 @@ def _logp_forw(point, out_vars, in_vars, shared):
         Containing Distribution for the input variables
     shared : list
         Containing TensorVariable for depended shared data
+    compile_kwargs: dict, optional
+        Additional keyword arguments passed to pytensor.function
     """
+    if compile_kwargs is None:
+        compile_kwargs = {}
+
     # Replace integer inputs with rounded float inputs
     if any(var.dtype in discrete_types for var in in_vars):
         replace_int_input = {}
@@ -636,6 +645,6 @@ def _logp_forw(point, out_vars, in_vars, shared):
     out_list, inarray0 = join_nonshared_inputs(
         point=point, outputs=out_vars, inputs=in_vars, shared_inputs=shared
     )
-    f = compile([inarray0], out_list[0])
+    f = compile([inarray0], out_list[0], **compile_kwargs)
     f.trust_input = True
     return f

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -58,6 +58,7 @@ def sample_smc(
     return_inferencedata=True,
     idata_kwargs=None,
     progressbar=True,
+    compile_kwargs: dict | None = None,
     **kernel_kwargs,
 ) -> InferenceData | MultiTrace:
     r"""
@@ -95,6 +96,9 @@ def sample_smc(
         Keyword arguments for :func:`pymc.to_inference_data`.
     progressbar : bool, optional, default True
         Whether or not to display a progress bar in the command line.
+    compile_kwargs: dict, optional
+        Keyword arguments to pass to pytensor.function
+
     **kernel_kwargs : dict, optional
         Keyword arguments passed to the SMC_kernel. The default IMH kernel takes the following keywords:
 
@@ -102,10 +106,11 @@ def sample_smc(
           Determines the change of beta from stage to stage, i.e. indirectly the number of stages,
           the higher the value of `threshold` the higher the number of stages. Defaults to 0.5.
           It should be between 0 and 1.
-            correlation_threshold : float, default 0.01
-                The lower the value the higher the number of MCMC steps computed automatically.
-                Defaults to 0.01. It should be between 0 and 1.
-        Keyword arguments for other kernels should be checked in the respective docstrings.
+        correlation_threshold : float, default 0.01
+            The lower the value the higher the number of MCMC steps computed automatically.
+            Defaults to 0.01. It should be between 0 and 1.
+
+        Additional keyword arguments for other kernels should be checked in the respective docstrings.
 
     Notes
     -----
@@ -159,6 +164,11 @@ def sample_smc(
         chains = max(2, cores)
     else:
         cores = min(chains, cores)
+
+    if compile_kwargs is None:
+        compile_kwargs = {}
+
+    kernel_kwargs["compile_kwargs"] = compile_kwargs
 
     random_seed = _get_seeds_per_chain(random_state=random_seed, chains=chains)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Allow `compile_kwargs` to be included among `kernel_kwargs`, so users can compile logp functions to numba/jax/torch. e.g. `pm.sample_smc(..., compile_kwargs={'mode':'NUMBA'})`

Necessary because the multiprocessors don't respect `pytensor.config.change_flags` context. But also we allow this everywhere else, so why not here too?

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7702.org.readthedocs.build/en/7702/

<!-- readthedocs-preview pymc end -->