### PR TITLE
Expand logging test cases for sample_prior_predictive and add return type overloads

### DIFF
--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -473,9 +473,7 @@ def sample_prior_predictive(
     )
 
     # All model variables have a name, but mypy does not know this
-    _log.info(
-        f"Sampling: {sorted(volatile_basic_rvs.intersection(vars_to_sample), key=lambda var: var.name)}"  # type: ignore[arg-type, return-value]
-    )
+    _log.info(f"Sampling: {sorted(volatile_basic_rvs, key=lambda var: var.name)}")  # type: ignore[arg-type, return-value]
     values = zip(*(sampler_fn() for i in range(draws)))
 
     data = {k: np.stack(v) for k, v in zip(names, values)}

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -22,6 +22,7 @@ from typing import (
     Any,
     TypeAlias,
     cast,
+    overload,
 )
 
 import numpy as np
@@ -360,6 +361,28 @@ def observed_dependent_deterministics(model: Model, extra_observeds=None):
     ]
 
 
+@overload
+def sample_prior_predictive(
+    draws: int = 500,
+    model: Model | None = None,
+    var_names: Iterable[str] | None = None,
+    random_seed: RandomState = None,
+    return_inferencedata: bool = True,
+    idata_kwargs: dict | None = None,
+    compile_kwargs: dict | None = None,
+    samples: int | None = None,
+) -> InferenceData: ...
+@overload
+def sample_prior_predictive(
+    draws: int = 500,
+    model: Model | None = None,
+    var_names: Iterable[str] | None = None,
+    random_seed: RandomState = None,
+    return_inferencedata: bool = False,
+    idata_kwargs: dict | None = None,
+    compile_kwargs: dict | None = None,
+    samples: int | None = None,
+) -> dict[str, np.ndarray]: ...
 def sample_prior_predictive(
     draws: int = 500,
     model: Model | None = None,
@@ -449,7 +472,7 @@ def sample_prior_predictive(
     )
 
     # All model variables have a name, but mypy does not know this
-    _log.info(f"Sampling: {sorted(volatile_basic_rvs, key=lambda var: var.name)}")  # type: ignore[arg-type, return-value]
+    _log.info(f"Sampling: {sorted(vars_to_sample, key=lambda var: var.name)}")  # type: ignore[arg-type, return-value]
     values = zip(*(sampler_fn() for i in range(draws)))
 
     data = {k: np.stack(v) for k, v in zip(names, values)}

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -473,7 +473,9 @@ def sample_prior_predictive(
     )
 
     # All model variables have a name, but mypy does not know this
-    _log.info(f"Sampling: {sorted(vars_to_sample, key=lambda var: var.name)}")  # type: ignore[arg-type, return-value]
+    _log.info(
+        f"Sampling: {sorted(volatile_basic_rvs.intersection(vars_to_sample), key=lambda var: var.name)}"  # type: ignore[arg-type, return-value]
+    )
     values = zip(*(sampler_fn() for i in range(draws)))
 
     data = {k: np.stack(v) for k, v in zip(names, values)}

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -20,6 +20,7 @@ import warnings
 from collections.abc import Callable, Iterable, Sequence
 from typing import (
     Any,
+    Literal,
     TypeAlias,
     cast,
     overload,
@@ -367,7 +368,7 @@ def sample_prior_predictive(
     model: Model | None = None,
     var_names: Iterable[str] | None = None,
     random_seed: RandomState = None,
-    return_inferencedata: bool = True,
+    return_inferencedata: Literal[True] = True,
     idata_kwargs: dict | None = None,
     compile_kwargs: dict | None = None,
     samples: int | None = None,
@@ -378,7 +379,7 @@ def sample_prior_predictive(
     model: Model | None = None,
     var_names: Iterable[str] | None = None,
     random_seed: RandomState = None,
-    return_inferencedata: bool = False,
+    return_inferencedata: Literal[False] = False,
     idata_kwargs: dict | None = None,
     compile_kwargs: dict | None = None,
     samples: int | None = None,

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -857,21 +857,22 @@ class TestSamplePPC:
             y = pm.Deterministic("y", x + 1)
             z = pm.Normal("z", y, observed=0)
 
+        # all volatile RVs in model
         with m:
             pm.sample_prior_predictive(draws=1)
         assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [x, z]")]
         caplog.clear()
 
-        # RV only
+        # `x` has no dependencies so will be sampled by itself
         with m:
             pm.sample_prior_predictive(draws=1, var_names=["x"])
         assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [x]")]
         caplog.clear()
 
-        # observed only
+        # `z` depends on `x`
         with m:
             pm.sample_prior_predictive(draws=1, var_names=["z"])
-        assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [z]")]
+        assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [x, z]")]
         caplog.clear()
 
     def test_logging_sampled_basic_rvs_posterior(self, caplog):

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -862,9 +862,16 @@ class TestSamplePPC:
         assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [x, z]")]
         caplog.clear()
 
+        # RV only
         with m:
             pm.sample_prior_predictive(draws=1, var_names=["x"])
         assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [x]")]
+        caplog.clear()
+
+        # observed only
+        with m:
+            pm.sample_prior_predictive(draws=1, var_names=["z"])
+        assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [z]")]
         caplog.clear()
 
     def test_logging_sampled_basic_rvs_posterior(self, caplog):


### PR DESCRIPTION
expand logging test cases for sample_prior_predictive & add return type overloads

## Description

Expanded logging test cases to clarify expected behaviour/purpose of logged message in `sample_prior_predictive`

Added return type overloads while I'm in there for useability (and to remove a bunch of instances of `assert isinstance(trace, az.InferenceData)` from my own code :joy:)

## Related Issue
- [x] Closes #7703 

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change]

## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7707.org.readthedocs.build/en/7707/

<!-- readthedocs-preview pymc end -->