### PR TITLE
seed flaky test GARCH11::test_batched_size

### DIFF
--- a/tests/distributions/test_timeseries.py
+++ b/tests/distributions/test_timeseries.py
@@ -803,7 +803,7 @@ class TestGARCH11:
         with Model() as t0:
             y = GARCH11("y", **kwargs0)
 
-        y_eval = draw(y, draws=2, random_seed=random_seed)
+        y_eval = draw(y, draws=2, random_seed=rng)
         assert y_eval[0].shape == (batch_size, steps)
         assert not np.any(np.isclose(y_eval[0], y_eval[1]))
 

--- a/tests/distributions/test_timeseries.py
+++ b/tests/distributions/test_timeseries.py
@@ -785,7 +785,9 @@ class TestGARCH11:
     @pytest.mark.parametrize("explicit_shape", (True, False))
     def test_batched_size(self, explicit_shape, batched_param):
         steps, batch_size = 100, 5
-        param_val = np.square(np.random.randn(batch_size))
+        random_seed = 800
+        rng = np.random.default_rng(random_seed)
+        param_val = np.square(rng.random(batch_size))
         init_kwargs = {
             "omega": 1.25,
             "alpha_1": 0.5,
@@ -801,7 +803,7 @@ class TestGARCH11:
         with Model() as t0:
             y = GARCH11("y", **kwargs0)
 
-        y_eval = draw(y, draws=2, random_seed=800)
+        y_eval = draw(y, draws=2, random_seed=random_seed)
         assert y_eval[0].shape == (batch_size, steps)
         assert not np.any(np.isclose(y_eval[0], y_eval[1]))
 


### PR DESCRIPTION
seed flaky test GARCH11::test_batched_size

## Description
`TestGARCH11::test_batched_size` is flaky in CI, seeded previously non-deterministic rng function.

## Related Issue
- [x] Closes #7674
- [x] Related to #7684 (alternative solution, should credit the author of that PR also)

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change

## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7708.org.readthedocs.build/en/7708/

<!-- readthedocs-preview pymc end -->