### PR TITLE
Add return type overload for `sample_posterior_predictive`

### DIFF
--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -493,6 +493,36 @@ def sample_prior_predictive(
     return pm.to_inference_data(prior=prior, **ikwargs)
 
 
+@overload
+def sample_posterior_predictive(
+    trace,
+    model: Model | None = None,
+    var_names: list[str] | None = None,
+    sample_dims: list[str] | None = None,
+    random_seed: RandomState = None,
+    progressbar: bool = True,
+    progressbar_theme: Theme | None = default_progress_theme,
+    return_inferencedata: Literal[True] = True,
+    extend_inferencedata: bool = False,
+    predictions: bool = False,
+    idata_kwargs: dict | None = None,
+    compile_kwargs: dict | None = None,
+) -> InferenceData: ...
+@overload
+def sample_posterior_predictive(
+    trace,
+    model: Model | None = None,
+    var_names: list[str] | None = None,
+    sample_dims: list[str] | None = None,
+    random_seed: RandomState = None,
+    progressbar: bool = True,
+    progressbar_theme: Theme | None = default_progress_theme,
+    return_inferencedata: Literal[False] = False,
+    extend_inferencedata: bool = False,
+    predictions: bool = False,
+    idata_kwargs: dict | None = None,
+    compile_kwargs: dict | None = None,
+) -> dict[str, np.ndarray]: ...
 def sample_posterior_predictive(
     trace,
     model: Model | None = None,


### PR DESCRIPTION
add return type overload for sample_posterior_predictive

## Description
Added overloads to `sample_prior_predictive` to signal to type checkers the return type of the function, based on the `return_inferencedata` boolean parameter.

## Related Issue
- [ ] Closes #
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change]

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [x] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7710.org.readthedocs.build/en/7710/

<!-- readthedocs-preview pymc end -->