### PR TITLE
Do not monkey-patch Ipython pretty representation on model variables

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -12,10 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import contextvars
-import functools
 import re
 import sys
-import types
 import warnings
 
 from abc import ABCMeta
@@ -53,7 +51,6 @@ from pymc.distributions.shape_utils import (
 from pymc.logprob.abstract import MeasurableOp, _icdf, _logcdf, _logprob
 from pymc.logprob.basic import logp
 from pymc.logprob.rewriting import logprob_rewrites_db
-from pymc.printing import str_for_dist
 from pymc.pytensorf import (
     collect_default_updates_inner_fgraph,
     constant_fold,
@@ -513,12 +510,6 @@ class Distribution(metaclass=DistributionMeta):
             transform=transform,
             default_transform=default_transform,
             initval=initval,
-        )
-
-        # add in pretty-printing support
-        rv_out.str_repr = types.MethodType(str_for_dist, rv_out)
-        rv_out._repr_latex_ = types.MethodType(
-            functools.partial(str_for_dist, formatting="latex"), rv_out
         )
         return rv_out
 


### PR DESCRIPTION
Only model objects will have a default Ipython/Jupyter representation.

This simplifies the codebase and saves half a second of import time.

Before:
```python
import pymc as pm

with pm.Model() as m:
    x = pm.Normal("x")
    a = pm.Deterministic("a", x + 1)
    y = pm.Normal("y", a)

# Before this would print x ~ Nomal(0, 1)
# Now it just prints x (the name)
x
# x
```

```python
# Still prints the same as before
m
# x ~ Normal(0, 1)
# y ~ Normal(f(x), 1)
# a ~ Deterministic(f(x))
```

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7712.org.readthedocs.build/en/7712/

<!-- readthedocs-preview pymc end -->