### PR TITLE
Fix domain specification in OrderedLogistic and OrderedProbit documentation

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1189,7 +1189,7 @@ class OrderedLogistic:
     R"""Ordered Logistic distribution.
 
     Useful for regression on ordinal data values whose values range
-    from 1 to K as a function of some predictor, :math:`\eta`. The
+    from 0 to K-1 as a function of some predictor, :math:`\eta`
     cutpoints, :math:`c`, separate which ranges of :math:`\eta` are
     mapped to which of the K observed dependent variables. The number
     of cutpoints is K - 1. It is recommended that the cutpoints are


### PR DESCRIPTION
This PR corrects the domain specification in the documentation of the OrderedLogistic and OrderedProbit distributions. It ensures that the indexing is clearly mentioned as 0-based to avoid errors.


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7732.org.readthedocs.build/en/7732/

<!-- readthedocs-preview pymc end -->