### PR TITLE
Allow passing graph level attributes to graphviz

### DIFF
--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -463,10 +463,7 @@ def make_graph(
     node_formatters = node_formatters or {}
     node_formatters = update_node_formatters(node_formatters)
 
-    graph = graphviz.Digraph(name)
-    if graph_attrs is not None:
-        graph.attr(**graph_attrs)
-
+    graph = graphviz.Digraph(name, graph_attr=graph_attrs)
     for plate in plates:
         if plate.dim_info:
             # must be preceded by 'cluster' to get a box around it

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -430,9 +430,6 @@ class ModelGraph:
         ]
 
 
-GraphAttrMapping = dict[Any, Any]
-
-
 def make_graph(
     name: str,
     plates: list[Plate],
@@ -442,7 +439,7 @@ def make_graph(
     figsize=None,
     dpi=300,
     node_formatters: NodeTypeFormatterMapping | None = None,
-    graph_attrs: GraphAttrMapping | None = None,
+    graph_attr: dict[str, Any] | None = None,
     create_plate_label: PlateLabelFunc = create_plate_label_with_dim_length,
 ):
     """Make graphviz Digraph of PyMC model.
@@ -463,7 +460,7 @@ def make_graph(
     node_formatters = node_formatters or {}
     node_formatters = update_node_formatters(node_formatters)
 
-    graph = graphviz.Digraph(name, graph_attr=graph_attrs)
+    graph = graphviz.Digraph(name, graph_attr=graph_attr)
     for plate in plates:
         if plate.dim_info:
             # must be preceded by 'cluster' to get a box around it
@@ -680,7 +677,7 @@ def model_to_graphviz(
     figsize: tuple[int, int] | None = None,
     dpi: int = 300,
     node_formatters: NodeTypeFormatterMapping | None = None,
-    graph_attrs: GraphAttrMapping | None = None,
+    graph_attr: dict[str, Any] | None = None,
     include_dim_lengths: bool = True,
 ):
     """Produce a graphviz Digraph from a PyMC model.
@@ -709,7 +706,7 @@ def model_to_graphviz(
         the size of the saved figure.
     dpi : int, optional
         Dots per inch. It only affects the resolution of the saved figure. The default is 300.
-    graph_attrs : dict, optional
+    graph_attr : dict, optional
         A dictionary of top-level layout attributes for graphviz
         Check out graphviz documentation for more information on available attributes
         https://graphviz.org/doc/info/attrs.html
@@ -782,7 +779,7 @@ def model_to_graphviz(
         save=save,
         figsize=figsize,
         dpi=dpi,
-        graph_attrs=graph_attrs,
+        graph_attr=graph_attr,
         node_formatters=node_formatters,
         create_plate_label=create_plate_label_with_dim_length
         if include_dim_lengths

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -430,6 +430,9 @@ class ModelGraph:
         ]
 
 
+GraphAttrMapping = dict[Any, Any]
+
+
 def make_graph(
     name: str,
     plates: list[Plate],
@@ -439,6 +442,7 @@ def make_graph(
     figsize=None,
     dpi=300,
     node_formatters: NodeTypeFormatterMapping | None = None,
+    graph_attrs: GraphAttrMapping | None = None,
     create_plate_label: PlateLabelFunc = create_plate_label_with_dim_length,
 ):
     """Make graphviz Digraph of PyMC model.
@@ -460,6 +464,9 @@ def make_graph(
     node_formatters = update_node_formatters(node_formatters)
 
     graph = graphviz.Digraph(name)
+    if graph_attrs is not None:
+        graph.attr(**graph_attrs)
+
     for plate in plates:
         if plate.dim_info:
             # must be preceded by 'cluster' to get a box around it
@@ -676,6 +683,7 @@ def model_to_graphviz(
     figsize: tuple[int, int] | None = None,
     dpi: int = 300,
     node_formatters: NodeTypeFormatterMapping | None = None,
+    graph_attrs: GraphAttrMapping | None = None,
     include_dim_lengths: bool = True,
 ):
     """Produce a graphviz Digraph from a PyMC model.
@@ -704,6 +712,10 @@ def model_to_graphviz(
         the size of the saved figure.
     dpi : int, optional
         Dots per inch. It only affects the resolution of the saved figure. The default is 300.
+    graph_attrs : dict, optional
+        A dictionary of top-level layout attributes for graphviz
+        Check out graphviz documentation for more information on available attributes
+        https://graphviz.org/doc/info/attrs.html
     node_formatters : dict, optional
         A dictionary mapping node types to functions that return a dictionary of node attributes.
         Check out graphviz documentation for more information on available
@@ -773,6 +785,7 @@ def model_to_graphviz(
         save=save,
         figsize=figsize,
         dpi=dpi,
+        graph_attrs=graph_attrs,
         node_formatters=node_formatters,
         create_plate_label=create_plate_label_with_dim_length
         if include_dim_lengths


### PR DESCRIPTION
This add the ability to pass in graph level attributes to the `model_to_graphviz` function. This makes it easier to tweak the layout of the graph.

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7741.org.readthedocs.build/en/7741/

<!-- readthedocs-preview pymc end -->