### PR TITLE
Add warning if a Minibatched variable is used without total_size

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -40,7 +40,7 @@ from pytensor.tensor.random.type import RandomType
 from pytensor.tensor.variable import TensorConstant, TensorVariable
 
 from pymc.blocking import DictToArrayBijection, RaveledVars
-from pymc.data import is_valid_observed
+from pymc.data import is_valid_observed, MinibatchOp
 from pymc.exceptions import (
     BlockModelAccessError,
     ImputationWarning,
@@ -1241,6 +1241,14 @@ class Model(WithMemoization, metaclass=ContextMeta):
             self.add_named_variable(rv_var, dims)
             self.set_initval(rv_var, initval)
         else:
+            if (
+                isinstance(observed, TensorVariable)
+                and isinstance(observed.owner.op, MinibatchOp)
+                and total_size is None
+            ):
+                warnings.warn(
+                    "total_size not provided for observed variable that uses pm.Minibatch"
+                )
             if not is_valid_observed(observed):
                 raise TypeError(
                     "Variables that depend on other nodes cannot be used for observed data."

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -40,7 +40,7 @@ from pytensor.tensor.random.type import RandomType
 from pytensor.tensor.variable import TensorConstant, TensorVariable
 
 from pymc.blocking import DictToArrayBijection, RaveledVars
-from pymc.data import is_valid_observed, MinibatchOp
+from pymc.data import MinibatchOp, is_valid_observed
 from pymc.exceptions import (
     BlockModelAccessError,
     ImputationWarning,

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1248,7 +1248,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
                 and total_size is None
             ):
                 warnings.warn(
-                    "total_size not provided for observed variable that uses pm.Minibatch"
+                    f"total_size not provided for observed variable `{name}` that uses pm.Minibatch"
                 )
             if not is_valid_observed(observed):
                 raise TypeError(

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1243,6 +1243,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         else:
             if (
                 isinstance(observed, TensorVariable)
+                and observed.owner is not None
                 and isinstance(observed.owner.op, MinibatchOp)
                 and total_size is None
             ):

--- a/tests/variational/test_minibatch_rv.py
+++ b/tests/variational/test_minibatch_rv.py
@@ -112,6 +112,13 @@ class TestMinibatchRandomVariable:
         assert mx is not x
         np.testing.assert_array_equal(draw(mx, random_seed=1), draw(x, random_seed=1))
 
+    def test_warning_on_missing_total_size(self):
+        total_size = 1000
+        with pytest.warns(match="total_size not provided"):
+            with pm.Model() as m:
+                MB = pm.Minibatch(np.arange(total_size, dtype="float64"), batch_size=100)
+                pm.Normal("n", observed=MB)
+
     @pytest.mark.filterwarnings("error")
     def test_minibatch_parameter_and_value(self):
         rng = np.random.default_rng(161)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This should help catch a well-known Minibatch footgun where a user forgets to include the `total_size` argument

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7742.org.readthedocs.build/en/7742/

<!-- readthedocs-preview pymc end -->