### PR TITLE
Transform to remove Minibatch from model

### DIFF
--- a/pymc/model/transform/basic.py
+++ b/pymc/model/transform/basic.py
@@ -13,9 +13,9 @@
 #   limitations under the License.
 from collections.abc import Sequence
 
-from pytensor import Variable
-from pytensor.graph import ancestors, node_rewriter
-from pytensor.graph.rewriting.basic import out2in
+from pytensor import Variable, clone_replace
+from pytensor.graph import ancestors
+from pytensor.graph.fg import FunctionGraph
 
 from pymc.data import MinibatchOp
 from pymc.model.core import Model
@@ -62,14 +62,23 @@ def parse_vars(model: Model, vars: ModelVariable | Sequence[ModelVariable]) -> l
     return [model[var] if isinstance(var, str) else var for var in vars_seq]
 
 
-def remove_minibatched_nodes(model: Model):
+def remove_minibatched_nodes(model: Model) -> Model:
     """Remove all uses of pm.Minibatch in the Model."""
-
-    @node_rewriter([MinibatchOp])
-    def local_remove_minibatch(fgraph, node):
-        return node.inputs
-
-    remove_minibatch = out2in(local_remove_minibatch)
     fgraph, _ = fgraph_from_model(model)
-    remove_minibatch.apply(fgraph)
+
+    replacements = {}
+    for var in fgraph.apply_nodes:
+        if isinstance(var.op, MinibatchOp):
+            for inp, out in zip(var.inputs, var.outputs):
+                replacements[out] = inp
+
+    old_outs, old_coords, old_dim_lengths = fgraph.outputs, fgraph._coords, fgraph._dim_lengths  # type: ignore[attr-defined]
+    # Using `rebuild_strict=False` means all coords, names, and dim information is lost
+    # So we need to restore it from the old fgraph
+    new_outs = clone_replace(old_outs, replacements, rebuild_strict=False)  # type: ignore[arg-type]
+    for old_out, new_out in zip(old_outs, new_outs):
+        new_out.name = old_out.name
+    fgraph = FunctionGraph(outputs=new_outs, clone=False)
+    fgraph._coords = old_coords  # type: ignore[attr-defined]
+    fgraph._dim_lengths = old_dim_lengths  # type: ignore[attr-defined]
     return model_from_fgraph(fgraph, mutate_fgraph=True)

--- a/tests/model/transform/test_basic.py
+++ b/tests/model/transform/test_basic.py
@@ -38,11 +38,14 @@ def test_remove_minibatches():
     data_size = 100
     data = np.zeros((data_size,))
     batch_size = 10
-    with pm.Model() as m1:
+    with pm.Model(coords={"d": range(5)}) as m1:
         mb = pm.Minibatch(data, batch_size=batch_size)
+        mu = pm.Normal("mu", dims="d")
         x = pm.Normal("x")
         y = pm.Normal("y", x, observed=mb, total_size=100)
 
     m2 = remove_minibatched_nodes(m1)
     assert m1.y.shape[0].eval() == batch_size
     assert m2.y.shape[0].eval() == data_size
+    assert m1.coords == m2.coords
+    assert m1.dim_lengths["d"].eval() == m2.dim_lengths["d"].eval()


### PR DESCRIPTION
## Description
This is a model transform to remove Minibatched variables in a model and replace them with the full underlying data.

This is very handy for posterior predictive checks, prediction, and other out-of-sample uses of the fitted model

Closes #7521 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7746.org.readthedocs.build/en/7746/

<!-- readthedocs-preview pymc end -->