### PR TITLE
Minibatch warning fix

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1241,7 +1241,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             self.add_named_variable(rv_var, dims)
             self.set_initval(rv_var, initval)
         else:
-            if total_size is None and isinstance(node, TensorVariable):
+            if total_size is None and isinstance(observed, TensorVariable):
                 for node in ancestors([observed]):
                     if node.owner is not None and isinstance(node.owner.op, MinibatchOp):
                         warnings.warn(


### PR DESCRIPTION
## Description
This fixes a small oversight in #7742 where it didn't check all ancestors to an observed value if it contains a `MinibatchOp`

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7749.org.readthedocs.build/en/7749/

<!-- readthedocs-preview pymc end -->