### PR TITLE
Fix setting initvals on ZeroSumTransform rv

### DIFF
--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -300,7 +300,7 @@ class ZeroSumTransform(Transform):
 
     @staticmethod
     def extend_axis(array, axis):
-        n = (array.shape[axis] + 1).astype("floatX")
+        n = pt.cast(array.shape[axis] + 1, "floatX")
         sum_vals = array.sum(axis, keepdims=True)
         norm = sum_vals / (pt.sqrt(n) + n)
         fill_val = norm - sum_vals / pt.sqrt(n)
@@ -312,7 +312,7 @@ class ZeroSumTransform(Transform):
     def extend_axis_rev(array, axis):
         normalized_axis = normalize_axis_tuple(axis, array.ndim)[0]
 
-        n = array.shape[normalized_axis].astype("floatX")
+        n = pt.cast(array.shape[normalized_axis], "floatX")
         last = pt.take(array, [-1], axis=normalized_axis)
 
         sum_vals = -last * pt.sqrt(n)

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -170,6 +170,17 @@ def test_sum_to_1():
     )
 
 
+def test_zerosumtransform():
+    zst = tr.ZeroSumTransform([0])
+
+    # Check numpy input works, as it is not always converted to pytensor before
+    # Case where it failed was when setting initvals in model
+    val = np.array([1, 2, 3, 4])
+    zval = zst.backward(val)
+    assert np.allclose(zval.eval().sum(), 0.0)
+    assert np.allclose(zst.forward(zval).eval(), val)
+
+
 def test_log():
     check_transform(tr.log, Rplusbig)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
Fix setting initvals on ZeroSumTransform'ed rv

## Related Issue
- [X] Closes #7772

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [X] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [X] Bug fix
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7773.org.readthedocs.build/en/7773/

<!-- readthedocs-preview pymc end -->