### PR TITLE
Updated pymc.model.transform.conditioning.do docstring

### DIFF
--- a/pymc/model/transform/conditioning.py
+++ b/pymc/model/transform/conditioning.py
@@ -139,14 +139,14 @@ def do(
 
     Parameters
     ----------
-    model: PyMC Model
-    vars_to_interventions: Dict of variable or name to TensorLike
+    model : PyMC Model
+    vars_to_interventions : Dict of variable or name to TensorLike
         Dictionary that maps model variables (or names) to intervention expressions.
         Intervention expressions must have a shape and data type that is compatible
         with the original model variable.
-    make_interventions_shared: bool, defaults to True,
+    make_interventions_shared : bool, defaults to True,
         Whether to make constant interventions shared variables.
-    prune_vars: bool, defaults to False
+    prune_vars : bool, defaults to False
         Whether to prune model variables that are not connected to any observed variables,
         after the interventions.
 


### PR DESCRIPTION
## Description
Added spaces between argument's name and its colon.

## Related Issue
- [x] Closes #
- [x ] Related to #5459 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7782.org.readthedocs.build/en/7782/

<!-- readthedocs-preview pymc end -->