### PR TITLE
Compute Metropolis average accept probability with `logsumexp`

### DIFF
--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -308,13 +308,12 @@ class Metropolis(ArrayStepShared):
         else:
             accept_rate = self.delta_logp(q, q0d)
             q, accepted = metrop_select(accept_rate, q, q0d, rng=self.rng)
-            self.accept_rate_iter = accept_rate
+            self.accept_rate_iter[:] = accept_rate
             self.accepted_iter[0] = accepted
             self.accepted_sum += accepted
 
         self.steps_until_tune -= 1
 
-        self.accept_rate_iter = np.atleast_1d(self.accept_rate_iter)
         log_N = np.log(self.accept_rate_iter.shape[0])
 
         stats = {

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -314,10 +314,13 @@ class Metropolis(ArrayStepShared):
 
         self.steps_until_tune -= 1
 
+        self.accept_rate_iter = np.atleast_1d(self.accept_rate_iter)
+        log_N = np.log(self.accept_rate_iter.shape[0])
+
         stats = {
             "tune": self.tune,
             "scaling": np.mean(self.scaling),
-            "accept": np.mean(np.exp(self.accept_rate_iter)),
+            "accept": np.exp(scipy.special.logsumexp(self.accept_rate_iter) - log_N),
             "accepted": np.mean(self.accepted_iter),
         }
 

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -308,7 +308,7 @@ class Metropolis(ArrayStepShared):
         else:
             accept_rate = self.delta_logp(q, q0d)
             q, accepted = metrop_select(accept_rate, q, q0d, rng=self.rng)
-            self.accept_rate_iter[:] = accept_rate
+            self.accept_rate_iter[0] = accept_rate
             self.accepted_iter[0] = accepted
             self.accepted_sum += accepted
 


### PR DESCRIPTION
In the Metropolis step stats that we report on the progressbar, we have a probability of acceptance. This is currently computed in a very direct way, just `np.mean(np.exp(log_accept_prob))`. We can do better with `np.exp(logsumexp(log_accept_prob) - log(len(log_accept_prob)))`.

In really gnarly models, I've encountered overflows in this step. This might also be because there's a max(delta_logp, 1) missing from the acceptance probabilities. But even if we add that, the computation method in this PR is more numerically stable and accurate.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7783.org.readthedocs.build/en/7783/

<!-- readthedocs-preview pymc end -->