### PR TITLE
Do not include rvs in symbolic normalizing constant

### DIFF
--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -979,7 +979,7 @@ def constant_fold(
     """
     fg = FunctionGraph(outputs=xs, features=[ShapeFeature()], copy_inputs=False, clone=True)
 
-    # The default rewrite_graph includes a constand_folding that is not always applied.
+    # The default rewrite_graph includes a constant_folding that is not always applied.
     # We use an unconditional constant_folding as the last pass to ensure a thorough constant folding.
     rewrite_graph(fg)
     topo_unconditional_constant_folding.apply(fg)

--- a/pymc/variational/minibatch_rv.py
+++ b/pymc/variational/minibatch_rv.py
@@ -40,6 +40,9 @@ class MinibatchRandomVariable(MeasurableOp, Op):
         out = rv.type()
         return Apply(self, [rv, *total_size], [out])
 
+    def infer_shape(self, fgraph, node, shapes):
+        return [shapes[0]]
+
     def perform(self, node, inputs, output_storage):
         output_storage[0][0] = inputs[0]
 

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -74,6 +74,7 @@ from pymc.model import modelcontext
 from pymc.pytensorf import (
     SeedSequenceSeed,
     compile,
+    constant_fold,
     find_rng_nodes,
     reseed_rngs,
 )
@@ -1105,7 +1106,10 @@ class Group(WithMemoization):
         t = self.to_flat_input(
             pt.max(
                 [
-                    get_scaling(v.owner.inputs[1:], v.shape)
+                    get_scaling(
+                        v.owner.inputs[1:],
+                        constant_fold([v.owner.inputs[0].shape], raise_not_constant=False),
+                    )
                     for v in self.group
                     if isinstance(v.owner.op, MinibatchRandomVariable)
                 ]
@@ -1272,7 +1276,10 @@ class Approximation(WithMemoization):
         t = pt.max(
             self.collect("symbolic_normalizing_constant")
             + [
-                get_scaling(obs.owner.inputs[1:], obs.shape)
+                get_scaling(
+                    obs.owner.inputs[1:],
+                    constant_fold([obs.owner.inputs[0].shape], raise_not_constant=False),
+                )
                 for obs in self.model.observed_RVs
                 if isinstance(obs.owner.op, MinibatchRandomVariable)
             ]


### PR DESCRIPTION
This is a more proper fix for the problem highlighted in #7778 

The normalizing constant for MinibatchRVs included the graph of the shape of the RVs. 

Even though the shape of the MinibatchRV can be derived without evaluating the draws, passing any graph with RVs to `pytensorf.compile` will automatically integrate the updates which requires evaluating the RV anyway. This PR makes sure we don't include the RVs only to get the symbolic normalizing constant.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7787.org.readthedocs.build/en/7787/

<!-- readthedocs-preview pymc end -->