### PR TITLE
Bump PyTensor dependency

### DIFF
--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -22,7 +22,7 @@ dependencies:
 - numpyro>=0.8.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.30.2,<2.31
+- pytensor>=2.31.2,<2.32
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.30.2,<2.31
+- pytensor>=2.31.2,<2.32
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -11,7 +11,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.30.2,<2.31
+- pytensor>=2.31.2,<2.32
 - python-graphviz
 - rich>=13.7.1
 - scipy>=1.4.1

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -14,7 +14,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=2.30.2,<2.31
+- pytensor>=2.31.2,<2.32
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.30.2,<2.31
+- pytensor>=2.31.2,<2.32
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -15,7 +15,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=2.30.2,<2.31
+- pytensor>=2.31.2,<2.32
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ numpydoc
 pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
-pytensor>=2.30.2,<2.31
+pytensor>=2.31.2,<2.32
 pytest-cov>=2.5
 pytest>=3.0
 rich>=13.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cachetools>=4.2.1
 cloudpickle
 numpy>=1.25.0
 pandas>=0.24.0
-pytensor>=2.30.2,<2.31
+pytensor>=2.31.2,<2.32
 rich>=13.7.1
 scipy>=1.4.1
 threadpoolctl>=3.1.0,<4.0.0

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -44,6 +44,7 @@ pymc/model/fgraph.py
 pymc/model/transform/conditioning.py
 pymc/pytensorf.py
 pymc/sampling/jax.py
+pymc/sampling/mcmc.py
 """
 
 

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -526,7 +526,6 @@ def test_partial_trace_with_trace_unsupported():
             pm.sample(trace=[a])
 
 
-@pytest.mark.xfail(condition=(pytensor.config.floatX == "float32"), reason="Fails on float32")
 class TestNamedSampling:
     def test_shared_named(self):
         G_var = shared(value=np.atleast_2d(1.0), shape=(1, None), name="G")
@@ -537,7 +536,6 @@ class TestNamedSampling:
                 mu=np.atleast_2d(0),
                 tau=np.atleast_2d(1e20),
                 size=(1, 1),
-                initval=np.atleast_2d(0),
             )
             theta = pm.Normal(
                 "theta", mu=pt.dot(G_var, theta0), tau=np.atleast_2d(1e20), size=(1, 1)
@@ -553,7 +551,6 @@ class TestNamedSampling:
                 mu=np.atleast_2d(0),
                 tau=np.atleast_2d(1e20),
                 size=(1, 1),
-                initval=np.atleast_2d(0),
             )
             theta = pm.Normal(
                 "theta", mu=pt.dot(G_var, theta0), tau=np.atleast_2d(1e20), size=(1, 1)
@@ -569,7 +566,6 @@ class TestNamedSampling:
                 mu=np.atleast_2d(0),
                 tau=np.atleast_2d(1e20),
                 size=(1, 1),
-                initval=np.atleast_2d(0),
             )
             theta = pm.Normal(
                 "theta", mu=pt.dot(G_var, theta0), tau=np.atleast_2d(1e20), size=(1, 1)


### PR DESCRIPTION
New PyTensor release includes a check for runtime broadcasting in AdvancedIncSubtensor1 that did not exist before.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7792.org.readthedocs.build/en/7792/

<!-- readthedocs-preview pymc end -->