### PR TITLE
Fix: Prevent name collision between coords and data variables

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -948,6 +948,11 @@ class Model(WithMemoization, metaclass=ContextMeta):
                 FutureWarning,
             )
 
+        if name in self.named_vars:
+            raise ValueError(
+                f"Name '{name}' already exists as a variable name in the model. Please choose a different name for the coordinate."
+            )
+
         if name in {"draw", "chain", "__sample__"}:
             raise ValueError(
                 "Dimensions can not be named `draw`, `chain` or `__sample__`, "
@@ -1463,6 +1468,10 @@ class Model(WithMemoization, metaclass=ContextMeta):
         """
         if var.name is None:
             raise ValueError("Variable is unnamed.")
+        if var.name in self.coords:
+            raise ValueError(
+                f"Name '{var.name}' already exists as a coordinate name in the model. Please choose a different name for the variable."
+            )
         if self.named_vars.tree_contains(var.name):
             raise ValueError(f"Variable name {var.name} already exists.")
 

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -950,7 +950,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         if name in self.named_vars:
             raise ValueError(
-                f"Name '{name}' already exists as a variable name in the model. Please choose a different name for the coordinate."
+                f"Name '{name}' already exists as a variable name in the model. Please choose a different name for the dimension."
             )
 
         if name in {"draw", "chain", "__sample__"}:

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -99,6 +99,16 @@ class TestBaseModel:
                 assert len(submodel.value_vars) == 2
             assert len(model.value_vars) == 3
 
+    def test_name_conflict_variable_and_coord(self):
+        with pm.Model(coords={"test_name": [1, 2, 3]}) as model1:
+            with pytest.raises(ValueError, match="already exists as a coordinate name"):
+                pm.Data("test_name", [4, 5, 6])
+
+        with pm.Model() as model2:
+            pm.Data("another_name", [7, 8, 9])
+            with pytest.raises(ValueError, match="already exists as a variable name"):
+                model2.add_coord("another_name", [10, 11, 12])
+
     def test_context_passes_vars_to_parent_model(self):
         with pm.Model() as model:
             assert pm.model.modelcontext(None) == model


### PR DESCRIPTION
Fix: Prevent name collision between coords and data variables

Adds checks to prevent you from defining a coordinate with the same name as a data variable, or vice-versa.

This addresses issue #7788, where such name collisions could lead to downstream errors, particularly with `sample_posterior_predictive` returning prior predictive samples instead of posterior predictive samples.

The following changes were made:
- Modified `Model.add_named_variable` to check if the proposed variable name already exists as a coordinate name.
- Modified `Model.add_coord` to check if the proposed coordinate name already exists as a variable name.
- Added a test case to `tests/model/test_core.py` to verify these checks.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7794.org.readthedocs.build/en/7794/

<!-- readthedocs-preview pymc end -->