### PR TITLE
Set multiprocessing to spawn for Linux

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -17,6 +17,7 @@
 import contextlib
 import logging
 import pickle
+import platform
 import sys
 import time
 import warnings
@@ -77,6 +78,11 @@ from pymc.util import (
     is_transformed_name,
 )
 from pymc.vartypes import discrete_types
+
+if platform.system() == "linux":
+    import multiprocessing
+
+    multiprocessing.set_start_method("spawn", force=True)
 
 try:
     from zarr.storage import MemoryStore

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -17,7 +17,6 @@
 import contextlib
 import logging
 import pickle
-import platform
 import sys
 import time
 import warnings
@@ -78,12 +77,6 @@ from pymc.util import (
     is_transformed_name,
 )
 from pymc.vartypes import discrete_types
-
-if platform.system() == "linux":
-    # Threads are not fork-safe on Linux, so we need to use spawn
-    import multiprocessing
-
-    multiprocessing.set_start_method("spawn", force=True)
 
 try:
     from zarr.storage import MemoryStore

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -80,6 +80,7 @@ from pymc.util import (
 from pymc.vartypes import discrete_types
 
 if platform.system() == "linux":
+    # Threads are not fork-safe on Linux, so we need to use spawn
     import multiprocessing
 
     multiprocessing.set_start_method("spawn", force=True)

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -448,7 +448,7 @@ class ParallelSampler:
                     else:
                         mp_ctx = "forkserver"
                 elif platform.system() == "Linux":
-                    # Threads are not fork-safe on Linux when using libraries like OpenBLAS
+                    # Threads are not fork-safe on Linux
                     mp_ctx = "spawn"
                     logger.debug(
                         "mp_ctx is set to 'spawn' for Linux to ensure thread safety. "

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -437,15 +437,23 @@ class ParallelSampler:
         if mp_ctx is None or isinstance(mp_ctx, str):
             # Closes issue https://github.com/pymc-devs/pymc/issues/3849
             # Related issue https://github.com/pymc-devs/pymc/issues/5339
-            if mp_ctx is None and platform.system() == "Darwin":
-                if platform.processor() == "arm":
-                    mp_ctx = "fork"
+            if mp_ctx is None:
+                if platform.system() == "Darwin":
+                    if platform.processor() == "arm":
+                        mp_ctx = "fork"
+                        logger.debug(
+                            "mp_ctx is set to 'fork' for MacOS with ARM architecture. "
+                            + "This might cause unexpected behavior with JAX, which is inherently multithreaded."
+                        )
+                    else:
+                        mp_ctx = "forkserver"
+                elif platform.system() == "Linux":
+                    # Threads are not fork-safe on Linux when using libraries like OpenBLAS
+                    mp_ctx = "spawn"
                     logger.debug(
-                        "mp_ctx is set to 'fork' for MacOS with ARM architecture. "
-                        + "This might cause unexpected behavior with JAX, which is inherently multithreaded."
+                        "mp_ctx is set to 'spawn' for Linux to ensure thread safety. "
+                        + "This is required when using multithreaded numerical libraries."
                     )
-                else:
-                    mp_ctx = "forkserver"
 
             mp_ctx = multiprocessing.get_context(mp_ctx)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description

Multiprocess sampling often fails randomly on Linux due to the start method defaulting to "fork". This sets it to "spawn" when `mcmc` is imported.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7354
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7804.org.readthedocs.build/en/7804/

<!-- readthedocs-preview pymc end -->