### PR TITLE
Implement specialized Hurdle distribution

### DIFF
--- a/pymc/distributions/moments/means.py
+++ b/pymc/distributions/moments/means.py
@@ -70,7 +70,7 @@ from pymc.distributions.continuous import (
 )
 from pymc.distributions.discrete import DiscreteUniformRV
 from pymc.distributions.distribution import DiracDeltaRV
-from pymc.distributions.mixture import MarginalMixtureRV
+from pymc.distributions.mixture import MixtureRV
 from pymc.distributions.multivariate import (
     CARRV,
     DirichletMultinomialRV,
@@ -300,7 +300,7 @@ def lognormal_mean(op, rv, rng, size, mu, sigma):
     return maybe_resize(pt.exp(mu + 0.5 * sigma**2), size)
 
 
-@_mean.register(MarginalMixtureRV)
+@_mean.register(MixtureRV)
 def marginal_mixture_mean(op, rv, rng, weights, *components):
     ndim_supp = components[0].owner.op.ndim_supp
     weights = pt.shape_padright(weights, ndim_supp)

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -92,8 +92,14 @@ def test_all_distributions_have_support_points():
 
     dists = (getattr(dist_module, dist) for dist in dist_module.__all__)
     dists = (dist for dist in dists if isinstance(dist, DistributionMeta))
+    generic_func = _support_point.dispatch(object)
     missing_support_points = {
-        dist for dist in dists if getattr(dist, "rv_type", None) not in _support_point.registry
+        dist
+        for dist in dists
+        if (
+            getattr(dist, "rv_type", None) is not None
+            and _support_point.dispatch(dist.rv_type) is generic_func
+        )
     }
 
     # Ignore super classes

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -141,11 +141,11 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"beta ~ Normal(0, 10)",
                 r"Z ~ MultivariateNormal(f(), f())",
                 r"nb_with_p_n ~ NegativeBinomial(10, nbp)",
-                r"zip ~ MarginalMixture(f(), DiracDelta(0), Poisson(5))",
+                r"zip ~ Mixture(f(), DiracDelta(0), Poisson(5))",
                 r"w ~ Dirichlet(<constant>)",
                 (
-                    r"nested_mix ~ MarginalMixture(w, "
-                    r"MarginalMixture(f(), DiracDelta(0), Poisson(5)), "
+                    r"nested_mix ~ Mixture(w, "
+                    r"Mixture(f(), DiracDelta(0), Poisson(5)), "
                     r"Censored(Bernoulli(0.5), -1, 1))"
                 ),
                 r"Y_obs ~ Normal(mu, sigma)",
@@ -159,9 +159,9 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"beta ~ Normal",
                 r"Z ~ MultivariateNormal",
                 r"nb_with_p_n ~ NegativeBinomial",
-                r"zip ~ MarginalMixture",
+                r"zip ~ Mixture",
                 r"w ~ Dirichlet",
-                r"nested_mix ~ MarginalMixture",
+                r"nested_mix ~ Mixture",
                 r"Y_obs ~ Normal",
                 r"pot ~ Potential",
                 r"pred ~ Deterministic",
@@ -173,11 +173,11 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"$\text{beta} \sim \operatorname{Normal}(0,~10)$",
                 r"$\text{Z} \sim \operatorname{MultivariateNormal}(f(),~f())$",
                 r"$\text{nb\_with\_p\_n} \sim \operatorname{NegativeBinomial}(10,~\text{nbp})$",
-                r"$\text{zip} \sim \operatorname{MarginalMixture}(f(),~\operatorname{DiracDelta}(0),~\operatorname{Poisson}(5))$",
+                r"$\text{zip} \sim \operatorname{Mixture}(f(),~\operatorname{DiracDelta}(0),~\operatorname{Poisson}(5))$",
                 r"$\text{w} \sim \operatorname{Dirichlet}(\text{<constant>})$",
                 (
-                    r"$\text{nested\_mix} \sim \operatorname{MarginalMixture}(\text{w},"
-                    r"~\operatorname{MarginalMixture}(f(),~\operatorname{DiracDelta}(0),~\operatorname{Poisson}(5)),"
+                    r"$\text{nested\_mix} \sim \operatorname{Mixture}(\text{w},"
+                    r"~\operatorname{Mixture}(f(),~\operatorname{DiracDelta}(0),~\operatorname{Poisson}(5)),"
                     r"~\operatorname{Censored}(\operatorname{Bernoulli}(0.5),~-1,~1))$"
                 ),
                 r"$\text{Y\_obs} \sim \operatorname{Normal}(\text{mu},~\text{sigma})$",
@@ -191,9 +191,9 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"$\text{beta} \sim \operatorname{Normal}$",
                 r"$\text{Z} \sim \operatorname{MultivariateNormal}$",
                 r"$\text{nb\_with\_p\_n} \sim \operatorname{NegativeBinomial}$",
-                r"$\text{zip} \sim \operatorname{MarginalMixture}$",
+                r"$\text{zip} \sim \operatorname{Mixture}$",
                 r"$\text{w} \sim \operatorname{Dirichlet}$",
-                r"$\text{nested\_mix} \sim \operatorname{MarginalMixture}$",
+                r"$\text{nested\_mix} \sim \operatorname{Mixture}$",
                 r"$\text{Y\_obs} \sim \operatorname{Normal}$",
                 r"$\text{pot} \sim \operatorname{Potential}$",
                 r"$\text{pred} \sim \operatorname{Deterministic}",
@@ -276,7 +276,7 @@ def test_model_latex_repr_mixture_model():
         "\\begin{array}{rcl}",
         "\\text{w} &\\sim & "
         "\\operatorname{Dirichlet}(\\text{<constant>})\\\\\\text{mix} &\\sim & "
-        "\\operatorname{MarginalMixture}(\\text{w},~\\operatorname{Normal}(0,~5),~\\operatorname{StudentT}(7,~0,~1))",
+        "\\operatorname{Mixture}(\\text{w},~\\operatorname{Normal}(0,~5),~\\operatorname{StudentT}(7,~0,~1))",
         "\\end{array}",
         "$$",
     ]


### PR DESCRIPTION
It indirectly addresses the issue reported in in https://github.com/pymc-devs/nutpie/issues/163

The new objects have a logp that handles the discrete + continuous process correctly, without requiring the arbitrary truncation of the latter at epsilon. This provides a cheaper and more stable logp / logcdf.
For discrete variables we keep using a truncation

~~Also added special logic to truncate a Hurdle distribution which solves https://github.com/bambinos/bambi/issues/768~~, this is not the desired behavior, reverted it

CC @zwelitunyiswa

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7810.org.readthedocs.build/en/7810/

<!-- readthedocs-preview pymc end -->