### PR TITLE
Advanced sub tensor with none and integers fix

### DIFF
--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -291,7 +291,9 @@ def find_measurable_index_mixture(fgraph, node):
         if any(
             indices.dtype.startswith("int") and sum(1 - b for b in indices.type.broadcastable) > 0
             for indices in mixing_indices
+            # this is the line with the bug
             if not isinstance(indices, SliceConstant)
+            if not isinstance(indices, type(NoneConst))
         ):
             return None
 

--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -291,7 +291,6 @@ def find_measurable_index_mixture(fgraph, node):
         if any(
             indices.dtype.startswith("int") and sum(1 - b for b in indices.type.broadcastable) > 0
             for indices in mixing_indices
-            # this is the line with the bug
             if not isinstance(indices, SliceConstant)
             if not isinstance(indices, type(NoneConst))
         ):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Fixed the AdvancedSubTensor with None and Integer values bug of having a logprob error instead of gracefully crashing through including a check for NoneConst types in mixture.py. None is returned if None values are found in a logprob. Added a test in test_mixture.py called test_advanced_subtensor_none_and_integer that validates the bug is fixed through checking there is a runtime error instead of an internal error when a logprob dictionary of integers and None values is attempted to be created.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7762
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7814.org.readthedocs.build/en/7814/

<!-- readthedocs-preview pymc end -->