### PR TITLE
Memoize model methods

### DIFF
--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -30,11 +30,9 @@ from typing import (
 )
 
 import numpy as np
-import pytensor
 
 from pymc.backends.report import SamplerReport
 from pymc.model import modelcontext
-from pymc.pytensorf import compile
 from pymc.util import get_var_name
 
 logger = logging.getLogger(__name__)
@@ -171,10 +169,14 @@ class BaseTrace(IBaseTrace):
 
         if fn is None:
             # borrow=True avoids deepcopy when inputs=output which is the case for untransformed value variables
-            fn = compile(
-                inputs=[pytensor.In(v, borrow=True) for v in model.value_vars],
-                outputs=[pytensor.Out(v, borrow=True) for v in vars],
+            fn = model.compile_fn(
+                inputs=model.value_vars,
+                outputs=vars,
                 on_unused_input="ignore",
+                random_seed=False,
+                borrow_inputs=True,
+                borrow_outputs=True,
+                wrap_point_fn=False,
             )
             fn.trust_input = True
 

--- a/pymc/step_methods/arraystep.py
+++ b/pymc/step_methods/arraystep.py
@@ -179,26 +179,22 @@ class GradientSharedStep(ArrayStepShared):
         model=None,
         blocked: bool = True,
         dtype=None,
-        logp_dlogp_func=None,
         rng: RandomGenerator = None,
-        initial_point: PointType | None = None,
         compile_kwargs: dict | None = None,
         **pytensor_kwargs,
     ):
         model = modelcontext(model)
 
-        if logp_dlogp_func is None:
-            if compile_kwargs is None:
-                compile_kwargs = {}
-            logp_dlogp_func = model.logp_dlogp_function(
-                vars,
-                dtype=dtype,
-                ravel_inputs=True,
-                initial_point=initial_point,
-                **compile_kwargs,
-                **pytensor_kwargs,
-            )
-            logp_dlogp_func.trust_input = True
+        if compile_kwargs is None:
+            compile_kwargs = {}
+        logp_dlogp_func = model.logp_dlogp_function(
+            vars,
+            dtype=dtype,
+            ravel_inputs=True,
+            trust_input=True,
+            **compile_kwargs,
+            **pytensor_kwargs,
+        )
 
         self._logp_dlogp_func = logp_dlogp_func
 

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -22,7 +22,7 @@ from typing import Any, NamedTuple
 
 import numpy as np
 
-from pymc.blocking import DictToArrayBijection, PointType, RaveledVars, StatsType
+from pymc.blocking import DictToArrayBijection, RaveledVars, StatsType
 from pymc.exceptions import SamplingError
 from pymc.model import Point, modelcontext
 from pymc.pytensorf import floatX
@@ -98,7 +98,6 @@ class BaseHMC(GradientSharedStep):
         adapt_step_size=True,
         step_rand=None,
         rng=None,
-        initial_point: PointType | None = None,
         **pytensor_kwargs,
     ):
         """Set up Hamiltonian samplers with common structures.
@@ -144,7 +143,6 @@ class BaseHMC(GradientSharedStep):
             model=self._model,
             dtype=dtype,
             rng=rng,
-            initial_point=initial_point,
             **pytensor_kwargs,
         )
 
@@ -152,9 +150,7 @@ class BaseHMC(GradientSharedStep):
         self.Emax = Emax
         self.iter_count = 0
 
-        if initial_point is None:
-            initial_point = self._model.initial_point()
-
+        initial_point = self._model.initial_point()
         nuts_vars = [initial_point[v.name] for v in vars]
         size = sum(v.size for v in nuts_vars)
 

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -30,7 +30,6 @@ from rich.table import Column
 import pymc as pm
 
 from pymc.blocking import DictToArrayBijection, RaveledVars
-from pymc.initial_point import PointType
 from pymc.pytensorf import (
     CallableTensor,
     compile,
@@ -163,7 +162,6 @@ class Metropolis(ArrayStepShared):
         model=None,
         mode=None,
         rng=None,
-        initial_point: PointType | None = None,
         compile_kwargs: dict | None = None,
         blocked: bool = False,
     ):
@@ -194,8 +192,7 @@ class Metropolis(ArrayStepShared):
             :py:func:`pymc.util.get_random_generator` for more information.
         """
         model = pm.modelcontext(model)
-        if initial_point is None:
-            initial_point = model.initial_point()
+        initial_point = model.initial_point()
 
         if vars is None:
             vars = model.value_vars
@@ -466,7 +463,6 @@ class BinaryMetropolis(ArrayStep):
         tune_interval=100,
         model=None,
         rng=None,
-        initial_point: PointType | None = None,
         compile_kwargs: dict | None = None,
         blocked: bool = True,
     ):
@@ -591,7 +587,6 @@ class BinaryGibbsMetropolis(ArrayStep):
         transit_p=0.8,
         model=None,
         rng=None,
-        initial_point: PointType | None = None,
         compile_kwargs: dict | None = None,
         blocked: bool = True,
     ):
@@ -605,8 +600,7 @@ class BinaryGibbsMetropolis(ArrayStep):
 
         vars = get_value_vars_from_user_vars(vars, model)
 
-        if initial_point is None:
-            initial_point = model.initial_point()
+        initial_point = model.initial_point()
         self.dim = sum(initial_point[v.name].size for v in vars)
 
         if order == "random":
@@ -713,7 +707,6 @@ class CategoricalGibbsMetropolis(ArrayStep):
         order="random",
         model=None,
         rng: RandomGenerator = None,
-        initial_point: PointType | None = None,
         compile_kwargs: dict | None = None,
         blocked: bool = True,
     ):
@@ -721,8 +714,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
 
         vars = get_value_vars_from_user_vars(vars, model)
 
-        if initial_point is None:
-            initial_point = model.initial_point()
+        initial_point = model.initial_point()
 
         dimcats: list[tuple[int, int]] = []
         # The above variable is a list of pairs (aggregate dimension, number
@@ -948,13 +940,11 @@ class DEMetropolis(PopulationArrayStepShared):
         model=None,
         mode=None,
         rng=None,
-        initial_point: PointType | None = None,
         compile_kwargs: dict | None = None,
         blocked: bool = True,
     ):
         model = pm.modelcontext(model)
-        if initial_point is None:
-            initial_point = model.initial_point()
+        initial_point = model.initial_point()
         initial_values_size = sum(initial_point[n.name].size for n in model.value_vars)
 
         if vars is None:
@@ -1118,15 +1108,13 @@ class DEMetropolisZ(ArrayStepShared):
         tune_interval=100,
         tune_drop_fraction: float = 0.9,
         model=None,
-        initial_point: PointType | None = None,
         compile_kwargs: dict | None = None,
         mode=None,
         rng=None,
         blocked: bool = True,
     ):
         model = pm.modelcontext(model)
-        if initial_point is None:
-            initial_point = model.initial_point()
+        initial_point = model.initial_point()
         initial_values_size = sum(initial_point[n.name].size for n in model.value_vars)
 
         if vars is None:

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -21,7 +21,6 @@ from rich.progress import TextColumn
 from rich.table import Column
 
 from pymc.blocking import RaveledVars, StatsType
-from pymc.initial_point import PointType
 from pymc.model import modelcontext
 from pymc.pytensorf import compile, join_nonshared_inputs, make_shared_replacements
 from pymc.step_methods.arraystep import ArrayStepShared
@@ -88,7 +87,6 @@ class Slice(ArrayStepShared):
         model=None,
         iter_limit=np.inf,
         rng=None,
-        initial_point: PointType | None = None,
         compile_kwargs: dict | None = None,
         blocked: bool = False,  # Could be true since tuning is independent across dims?
     ):
@@ -103,8 +101,7 @@ class Slice(ArrayStepShared):
         else:
             vars = get_value_vars_from_user_vars(vars, model)
 
-        if initial_point is None:
-            initial_point = model.initial_point()
+        initial_point = model.initial_point()
 
         shared = make_shared_replacements(initial_point, vars, model)
         [logp], raveled_inp = join_nonshared_inputs(

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -399,7 +399,7 @@ class WithMemoization:
         self.__dict__.update(state)
 
 
-def locally_cachedmethod(f):
+def memoize(f):
     from collections import defaultdict
 
     def self_cache_fn(f_name):
@@ -409,6 +409,16 @@ def locally_cachedmethod(f):
         return cf
 
     return cachedmethod(self_cache_fn(f.__name__), key=hash_key)(f)
+
+
+def invalidates_memoize(f):
+    @functools.wraps(f)
+    def wrapper_fn(self, *args, **kwargs):
+        if cache := getattr(self, "_cache", None):
+            cache.clear()
+        return f(self, *args, **kwargs)
+
+    return wrapper_fn
 
 
 def check_dist_not_registered(dist, model=None):

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -82,8 +82,8 @@ from pymc.util import (
     RandomState,
     WithMemoization,
     _get_seeds_per_chain,
-    locally_cachedmethod,
     makeiter,
+    memoize,
 )
 from pymc.variational.minibatch_rv import MinibatchRandomVariable, get_scaling
 from pymc.variational.updates import adagrad_window
@@ -150,12 +150,12 @@ def node_property(f):
         def wrapper(fn):
             ff = append_name(f)(fn)
             f_ = pytensor.config.change_flags(compute_test_value="off")(ff)
-            return property(locally_cachedmethod(f_))
+            return property(memoize(f_))
 
         return wrapper
     else:
         f_ = pytensor.config.change_flags(compute_test_value="off")(f)
-        return property(locally_cachedmethod(f_))
+        return property(memoize(f_))
 
 
 @pytensor.config.change_flags(compute_test_value="ignore")

--- a/pymc/variational/stein.py
+++ b/pymc/variational/stein.py
@@ -17,7 +17,7 @@ import pytensor.tensor as pt
 from pytensor.graph.replace import graph_replace
 
 from pymc.pytensorf import floatX
-from pymc.util import WithMemoization, locally_cachedmethod
+from pymc.util import WithMemoization, memoize
 from pymc.variational.opvi import node_property
 from pymc.variational.test_functions import rbf
 
@@ -93,6 +93,6 @@ class Stein(WithMemoization):
             )
         return sized_symbolic_logp / self.approx.symbolic_normalizing_constant
 
-    @locally_cachedmethod
+    @memoize
     def _kernel(self):
         return self._kernel_f(self.input_joint_matrix)

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -1855,3 +1855,21 @@ class TestModelCopy:
             match="Detected variables likely created by GP objects. Further use of these old GP objects should be avoided as it may reintroduce variables from the old model. See issue: https://github.com/pymc-devs/pymc/issues/6883",
         ):
             copy_method(gaussian_process_model)
+
+
+@pytest.mark.parametrize()
+def test_memoization():
+    with pm.Model() as m:
+        x = pm.Normal("x")
+        y = pm.Normal("y")
+
+    res1 = m.logp()
+    res2 = m.logp()
+    res3 = m.logp(sum=False)
+
+    res4 = m.logp()
+    assert res1 is res2
+    assert res1 is not res3
+    assert res1 is res4
+
+    m.invalidate_cache()

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -212,22 +212,6 @@ class TestSample:
             assert step.potential._n_samples == tune
             assert step.step_adapt._count == tune + 1
 
-    @pytest.mark.parametrize(
-        "start, error",
-        [
-            ({"x": 1}, ValueError),
-            ({"x": [1, 2, 3]}, ValueError),
-            ({"x": np.array([[1, 1], [1, 1]])}, ValueError),
-        ],
-    )
-    def test_sample_start_bad_shape(self, start, error):
-        with pytest.raises(error):
-            pm.sampling.mcmc._check_start_shape(self.model, start)
-
-    @pytest.mark.parametrize("start", [{"x": np.array([1, 1])}, {"x": [10, 10]}, {"x": [-10, -10]}])
-    def test_sample_start_good_shape(self, start):
-        pm.sampling.mcmc._check_start_shape(self.model, start)
-
     def test_sample_callback(self):
         callback = mock.Mock()
         test_cores = [1, 2]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -30,7 +30,7 @@ from pymc.util import (
     get_value_vars_from_user_vars,
     hash_key,
     hashable,
-    locally_cachedmethod,
+    memoize,
 )
 
 
@@ -138,7 +138,7 @@ def test_hash_key():
     assert some_func(b1) != some_func(b2)
 
     class TestClass:
-        @locally_cachedmethod
+        @memoize
         def some_method(self, x):
             return x
 


### PR DESCRIPTION
This PR caches the expensive model methods (logp extraction, and function compilation).

It introduces a decorator for methods that can invalidate the cache of a model (such as registering a new variable or changing the initval strategy). When those methods are called the old cache is reset.

Closes https://github.com/pymc-devs/pymc/issues/7815

One important aspect to be able to cache compiled functions is to reproduce the `random_seed` behavior from `pytensorf.compile`. In hindsight this was a poor mixing of concerns, compiling the function and setting the RNG variables should not be mixed. This behavior is now disabled by setting `random_seed=False` and use the new `seed_compiled_function` helper instead. This allows us to cache the compiled functions but still respect the behavior of `random_seed` that may be passed to these functions.

I decided to put the cache at the Model level so it's easier for the user to control. That means some parts of the codebase will contort themselves to use `model.compile_fn` in order to benefit from the cache.

It's also important that they avoid creating new expressions (such as model.logp().sum())` as this will be a new variable and invalidate the cache.


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7816.org.readthedocs.build/en/7816/

<!-- readthedocs-preview pymc end -->