### PR TITLE
Allow accessing wrapped function attributes in PointFunc

### DIFF
--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -600,6 +600,12 @@ class PointFunc:
     def __call__(self, state):
         return self.f(**state)
 
+    def __getattr__(self, item):
+        """Allow access to the original function attributes."""
+        if item == "f":
+            return self.f
+        return getattr(self.f, item)
+
 
 class CallableTensor:
     """Turns a symbolic variable with one input into a function that returns symbolic arguments with the one variable replaced with the input."""


### PR DESCRIPTION
Makes debugging it less painful

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7823.org.readthedocs.build/en/7823/

<!-- readthedocs-preview pymc end -->