### PR TITLE
Install pymc-sphinx-theme from pypi

### DIFF
--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -40,6 +40,6 @@ dependencies:
 - mypy=1.15.0
 - types-cachetools
 - pip:
-  - git+https://github.com/pymc-devs/pymc-sphinx-theme
+  - pymc-sphinx-theme>=0.16.0
   - numdifftools>=0.9.40
   - mcbackend>=0.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@
 arviz>=0.13.0
 cachetools>=4.2.1
 cloudpickle
-pymc-sphinx-theme>=0.16.0
 ipython>=7.16
 jupyter-sphinx
 mcbackend>=0.4.0
@@ -16,6 +15,7 @@ numpydoc
 pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
+pymc-sphinx-theme>=0.16.0
 pytensor>=2.31.2,<2.32
 pytest-cov>=2.5
 pytest>=3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 arviz>=0.13.0
 cachetools>=4.2.1
 cloudpickle
-git+https://github.com/pymc-devs/pymc-sphinx-theme
+pymc-sphinx-theme>=0.16.0
 ipython>=7.16
 jupyter-sphinx
 mcbackend>=0.4.0

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -5,9 +5,6 @@ LABEL description="Environment for PyMC version 4"
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
-USER root
-RUN apt-get update && apt-get install -y git
-
 # Switch to jovyan to avoid container runs as root
 USER $NB_UID
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -5,6 +5,9 @@ LABEL description="Environment for PyMC version 4"
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
+USER root
+RUN apt-get update && apt-get install -y git
+
 # Switch to jovyan to avoid container runs as root
 USER $NB_UID
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Change installation source for pymc-sphinx-theme from git to pypi, so git will not required during docker image build. Now missing git cause docker build failure.
~~Git is required to install git dependencies, so this PR add git installation step into Dockerfile to fix issue related with missed git~~.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [X] Closes #7839 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7840.org.readthedocs.build/en/7840/

<!-- readthedocs-preview pymc end -->