### PR TITLE
Allow `var_names` to be propagated to nutpie sampler

### DIFF
--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -11,7 +11,7 @@ dependencies:
 - cloudpickle
 - zarr>=2.5.0,<3
 - numba
-- nutpie >= 0.13.4
+- nutpie >= 0.15.1
 # Jaxlib version must not be greater than jax version!
 - blackjax>=1.2.2
 - jax>=0.4.28

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -31,7 +31,6 @@ from typing import (
 )
 
 import numpy as np
-import pytensor
 import pytensor.gradient as tg
 
 from arviz import InferenceData, dict_to_dataset
@@ -78,8 +77,6 @@ from pymc.util import (
     is_transformed_name,
 )
 from pymc.vartypes import discrete_types
-
-pytensor.config.cxx = "/usr/bin/clang++"
 
 try:
     from zarr.storage import MemoryStore

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -31,6 +31,7 @@ from typing import (
 )
 
 import numpy as np
+import pytensor
 import pytensor.gradient as tg
 
 from arviz import InferenceData, dict_to_dataset
@@ -78,8 +79,7 @@ from pymc.util import (
 )
 from pymc.vartypes import discrete_types
 
-import pytensor
-pytensor.config.cxx = '/usr/bin/clang++'
+pytensor.config.cxx = "/usr/bin/clang++"
 
 try:
     from zarr.storage import MemoryStore
@@ -334,7 +334,7 @@ def _sample_external_nuts(
                 "`idata_kwargs` are currently ignored by the nutpie sampler",
                 UserWarning,
             )
-        
+
         compile_kwargs = {}
         nuts_sampler_kwargs = nuts_sampler_kwargs.copy()
         for kwarg in ("backend", "gradient_backend"):

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -78,6 +78,9 @@ from pymc.util import (
 )
 from pymc.vartypes import discrete_types
 
+import pytensor
+pytensor.config.cxx = '/usr/bin/clang++'
+
 try:
     from zarr.storage import MemoryStore
 except ImportError:
@@ -331,11 +334,7 @@ def _sample_external_nuts(
                 "`idata_kwargs` are currently ignored by the nutpie sampler",
                 UserWarning,
             )
-        if var_names is not None:
-            warnings.warn(
-                "`var_names` are currently ignored by the nutpie sampler",
-                UserWarning,
-            )
+        
         compile_kwargs = {}
         nuts_sampler_kwargs = nuts_sampler_kwargs.copy()
         for kwarg in ("backend", "gradient_backend"):
@@ -343,6 +342,7 @@ def _sample_external_nuts(
                 compile_kwargs[kwarg] = nuts_sampler_kwargs.pop(kwarg)
         compiled_model = nutpie.compile_pymc_model(
             model,
+            var_names=var_names,
             **compile_kwargs,
         )
         t_start = time.time()

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -15,6 +15,7 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
+import xarray as xr
 
 from pymc import Data, Deterministic, HalfNormal, Model, Normal, sample
 
@@ -128,6 +129,6 @@ def test_sample_var_names(nuts_sampler):
     assert "mu" in idata_1.posterior
     assert "mu" not in idata_2.posterior
 
-    assert np.all(idata_1.posterior["b_group"] == idata_2.posterior["b_group"]).item()
-    assert np.all(idata_1.posterior["b_x"] == idata_2.posterior["b_x"]).item()
-    assert np.all(idata_1.posterior["sigma"] == idata_2.posterior["sigma"]).item()
+    xr.testing.assert_allclose(idata_1.posterior["b_group"], idata_2.posterior["b_group"])
+    xr.testing.assert_allclose(idata_1.posterior["b_x"], idata_2.posterior["b_x"])
+    xr.testing.assert_allclose(idata_1.posterior["sigma"], idata_2.posterior["sigma"])

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -131,8 +131,8 @@ def test_sample_var_names(nuts_sampler):
     assert "mu" in idata_1.posterior
     assert "mu" not in idata_2.posterior
 
-    assert free_RVs[-1].name in idata_1.posterior
-    assert free_RVs[-1].name not in idata_2.posterior
+    assert free_RVs[-1] in idata_1.posterior
+    assert free_RVs[-1] not in idata_2.posterior
 
     for var in free_RVs[:-1]:
         assert var in idata_1.posterior

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -93,7 +93,6 @@ def test_step_args():
 def test_sample_var_names(nuts_sampler):
     seed = 1234
     kwargs = {
-        "nuts_sampler": nuts_sampler,
         "chains": 1,
         "tune": 100,
         "draws": 100,
@@ -125,9 +124,9 @@ def test_sample_var_names(nuts_sampler):
 
     with model:
         # Sample with and without var_names, but always with the same seed
-        idata_1 = sample(**kwargs)
+        idata_1 = sample(nuts_sampler=nuts_sampler, **kwargs)
         # Remove the last free RV from the sampling
-        idata_2 = sample(var_names=free_RVs[:-1], **kwargs)
+        idata_2 = sample(nuts_sampler=nuts_sampler, var_names=free_RVs[:-1], **kwargs)
 
     assert "mu" in idata_1.posterior
     assert "mu" not in idata_2.posterior

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -87,6 +87,7 @@ def test_step_args():
 
     npt.assert_almost_equal(idata.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
 
+
 @pytest.mark.parametrize("nuts_sampler", ["pymc", "nutpie", "blackjax", "numpyro"])
 def test_sample_var_names(nuts_sampler):
     kwargs = {

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -90,13 +90,16 @@ def test_step_args():
 
 @pytest.mark.parametrize("nuts_sampler", ["pymc", "nutpie", "blackjax", "numpyro"])
 def test_sample_var_names(nuts_sampler):
+    seed = 1234
     kwargs = {
         "nuts_sampler": nuts_sampler,
         "chains": 1,
+        "tune": 100,
+        "draws": 100,
+        "random_seed": seed,
     }
 
     # Generate data
-    seed = 1234
     rng = np.random.default_rng(seed)
 
     group = rng.choice(list("ABCD"), size=100)
@@ -117,10 +120,8 @@ def test_sample_var_names(nuts_sampler):
 
     # Sample with and without var_names, but always with the same seed
     with model:
-        idata_1 = sample(tune=100, draws=100, random_seed=seed, **kwargs)
-        idata_2 = sample(
-            tune=100, draws=100, var_names=["b_group", "b_x", "sigma"], random_seed=seed, **kwargs
-        )
+        idata_1 = sample(**kwargs)
+        idata_2 = sample(var_names=["b_group", "b_x", "sigma"], **kwargs)
 
     assert "mu" in idata_1.posterior
     assert "mu" not in idata_2.posterior

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -97,6 +97,8 @@ def test_sample_var_names(nuts_sampler):
         "tune": 100,
         "draws": 100,
         "random_seed": seed,
+        "progressbar": False,
+        "compute_convergence_checks": False,
     }
 
     # Generate data

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -131,8 +131,8 @@ def test_sample_var_names(nuts_sampler):
     assert "mu" in idata_1.posterior
     assert "mu" not in idata_2.posterior
 
-    assert free_RVs[-1].name in idata1.posterior
-    assert free_RVs[-1].name not in idata2.posterior
+    assert free_RVs[-1].name in idata_1.posterior
+    assert free_RVs[-1].name not in idata_2.posterior
 
     for var in free_RVs[:-1]:
         assert var in idata_1.posterior

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -131,6 +131,9 @@ def test_sample_var_names(nuts_sampler):
     assert "mu" in idata_1.posterior
     assert "mu" not in idata_2.posterior
 
+    assert free_RVs[-1].name in idata1.posterior
+    assert free_RVs[-1].name not in idata2.posterior
+
     for var in free_RVs[:-1]:
         assert var in idata_1.posterior
         assert var in idata_2.posterior


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Passing `var_names` to `nutpie` sampler has been supported since [0.13.3](https://github.com/pymc-devs/nutpie/releases/tag/v0.13.3).

This PR just activates this option when using nutpie sampler from `pymc`


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #7206 
- [x] Related to https://github.com/pymc-devs/nutpie/pull/165
- [x] Related to https://github.com/pymc-labs/pymc-marketing/pull/1802

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7850.org.readthedocs.build/en/7850/

<!-- readthedocs-preview pymc end -->