### PR TITLE
Fix bug with pickling PointFunc

### DIFF
--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -567,10 +567,8 @@ class PointFunc:
     def __call__(self, state):
         return self.f(**state)
 
-    def __getattr__(self, item):
-        """Allow access to the original function attributes."""
-        # This is only reached if `__getattribute__` fails.
-        return getattr(self.f, item)
+    def dprint(self, **kwrags):
+        return self.f.dprint(**kwrags)
 
 
 class CallableTensor:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Fixes a bug when unpickling certain step samplers (BinaryMetropolis, BinaryGibbsMetropolis, and CategoricalGibbsMetropolis) when mp_ctx is spawn or forkserver

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #7857 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
