### PR TITLE
Fix `release_notes_to_discourse` script

### DIFF
--- a/scripts/publish_release_notes_to_discourse.py
+++ b/scripts/publish_release_notes_to_discourse.py
@@ -64,7 +64,7 @@ def format_release_content(config: dict[str, str]) -> tuple[str, str]:
 
 - **Version:** `{config["RELEASE_TAG"]}`
 - **Repository:** [{config["REPO_NAME"]}](https://github.com/{config["REPO_NAME"]})
-- **Release Page:** [View on GitHub]({config["RELEASE_URL"]})
+- **Release Page:** {config["RELEASE_URL"]}
 - Note: It may take some time for the release to appear on PyPI and conda-forge.
 
 ## 📋 Release Notes
@@ -105,7 +105,7 @@ def publish_release_to_discourse(config: dict[str, str]) -> bool:
     url = f"{config['DISCOURSE_URL']}/posts.json"
 
     try:
-        response = requests.post(url, headers=headers, data=topic_data)
+        response = requests.post(url, headers=headers, json=topic_data)
         response.raise_for_status()
 
         data = response.json()


### PR DESCRIPTION
Failed here: https://github.com/pymc-devs/pymc/actions/runs/16454405920/job/46507668592

Now that I could recreate the inputs passed by github I could reproduce locally, and confirm the change to `json` fixes it: https://discourse.pymc.io/t/release-v5-25-0/17206

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7862.org.readthedocs.build/en/7862/

<!-- readthedocs-preview pymc end -->