### PR TITLE
Isolate discourse Github environment

### DIFF
--- a/.github/workflows/publish-release-notes-to-discourse.yml
+++ b/.github/workflows/publish-release-notes-to-discourse.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish-to-discourse:
+    environment: discourse
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Follow-up to https://github.com/pymc-devs/pymc/pull/7860#issuecomment-3112324307

I'll delete the repo level API key next.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7869.org.readthedocs.build/en/7869/

<!-- readthedocs-preview pymc end -->