### PR TITLE
Show more digits of step size in progress_bar

### DIFF
--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -236,7 +236,7 @@ class NUTS(BaseHMC):
     def _progressbar_config(n_chains=1):
         columns = [
             TextColumn("{task.fields[divergences]}", table_column=Column("Divergences", ratio=1)),
-            TextColumn("{task.fields[step_size]:0.2f}", table_column=Column("Step size", ratio=1)),
+            TextColumn("{task.fields[step_size]:0.3f}", table_column=Column("Step size", ratio=1)),
             TextColumn("{task.fields[tree_size]}", table_column=Column("Grad evals", ratio=1)),
         ]
 


### PR DESCRIPTION
The two digits was copied from nutpie according to @jessegrabowski. I noticed that we always have a 0.0x, so it's not very useful. @aseyboldt explained that something something pymc nuts considers small eigenvalues of the matrix, while nutpie ignores it, which means our step-sizes tend to be smaller. 

This PR adds one extra digit for me to look at.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7870.org.readthedocs.build/en/7870/

<!-- readthedocs-preview pymc end -->