### PR TITLE
Fix `numpy` deprecation warning when running tests in `test_metropolis.py`

### DIFF
--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -1091,7 +1091,7 @@ class DEMetropolisZ(ArrayStepShared):
         "accept": (np.float64, []),
         "accepted": (bool, []),
         "tune": (bool, []),
-        "scaling": (np.float64, []),
+        "scaling": (np.float64, [None]),
         "lambda": (np.float64, []),
     }
 
@@ -1214,7 +1214,7 @@ class DEMetropolisZ(ArrayStepShared):
 
         stats = {
             "tune": self.tune,
-            "scaling": self.scaling,
+            "scaling": np.mean(self.scaling),
             "lambda": self.lamb,
             "accept": np.exp(accept),
             "accepted": accepted,

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -1091,7 +1091,7 @@ class DEMetropolisZ(ArrayStepShared):
         "accept": (np.float64, []),
         "accepted": (bool, []),
         "tune": (bool, []),
-        "scaling": (np.float64, [None]),
+        "scaling": (np.float64, []),
         "lambda": (np.float64, []),
     }
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
This PR is an attempt to address the `numpy` deprecation warning (#7369). Previous attempts to make the fix (ex., #7514) focussed on checking for scalars in `pymc/backends/ndarray.py`. Following this [hint](https://github.com/pymc-devs/pymc/pull/7514#issuecomment-2382409866), the present PR instead checks which offending stat variable is not respecting the scalar requirement and modifies that.

After the fix, we can see that no warnings are seen:
```sh
(pymc-dev) jovyan@75886b6f8645:~/work$ python -m pytest tests/step_methods/test_metropolis.py 
=== test session starts ===
 ...

tests/step_methods/test_metropolis.py .............................................                                               [100%]

==== 45 passed in 259.02s (0:04:19) ===
```

## Related Issue
- [ ] Closes #7369 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7871.org.readthedocs.build/en/7871/

<!-- readthedocs-preview pymc end -->