### PR TITLE
Publish release notes to News category

### DIFF
--- a/.github/workflows/publish-release-notes-to-discourse.yml
+++ b/.github/workflows/publish-release-notes-to-discourse.yml
@@ -28,7 +28,7 @@ jobs:
           DISCOURSE_API_KEY: ${{ secrets.DISCOURSE_API_KEY }}
           DISCOURSE_USERNAME: "pymc-bot"
           DISCOURSE_URL: "https://discourse.pymc.io"
-          DISCOURSE_CATEGORY: "Development"
+          DISCOURSE_CATEGORY: "News"
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_BODY: ${{ github.event.release.body }}
           RELEASE_URL: ${{ github.event.release.html_url }}


### PR DESCRIPTION
From the discourse description it seems better suited than Development?

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7873.org.readthedocs.build/en/7873/

<!-- readthedocs-preview pymc end -->