### PR TITLE
Fix bug in mixture logprob inference with `None` indices

### DIFF
--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -62,7 +62,7 @@ from pytensor.tensor.subtensor import (
     is_basic_idx,
 )
 from pytensor.tensor.type import TensorType
-from pytensor.tensor.type_other import NoneConst, NoneTypeT, SliceConstant, SliceType
+from pytensor.tensor.type_other import NoneConst, NoneTypeT, SliceType
 from pytensor.tensor.variable import TensorVariable
 
 from pymc.logprob.abstract import (
@@ -289,9 +289,10 @@ def find_measurable_index_mixture(fgraph, node):
         # We don't support (non-scalar) integer array indexing as it can pick repeated values,
         # but the Mixture logprob assumes all mixture values are independent
         if any(
-            indices.dtype.startswith("int") and sum(1 - b for b in indices.type.broadcastable) > 0
+            hasattr(indices, "dtype")
+            and indices.dtype.startswith("int")
+            and sum(1 - b for b in indices.type.broadcastable) > 0
             for indices in mixing_indices
-            if not isinstance(indices, SliceConstant)
         ):
             return None
 

--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -289,7 +289,7 @@ def find_measurable_index_mixture(fgraph, node):
         # We don't support (non-scalar) integer array indexing as it can pick repeated values,
         # but the Mixture logprob assumes all mixture values are independent
         if any(
-            hasattr(indices, "dtype")
+            isinstance(indices, TensorVariable)
             and indices.dtype.startswith("int")
             and not all(indices.type.broadcastable)
             for indices in mixing_indices

--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -291,7 +291,7 @@ def find_measurable_index_mixture(fgraph, node):
         if any(
             hasattr(indices, "dtype")
             and indices.dtype.startswith("int")
-            and sum(1 - b for b in indices.type.broadcastable) > 0
+            and not all(indices.type.broadcastable)
             for indices in mixing_indices
         ):
             return None

--- a/tests/logprob/test_mixture.py
+++ b/tests/logprob/test_mixture.py
@@ -1178,5 +1178,8 @@ def test_advanced_subtensor_none_and_integer():
     a_val = a.type()
     a_val.name = "a_val"
 
-    with pytest.raises(RuntimeError, match="logprob terms of the following value variables could not be derived: {b_val}"):
+    with pytest.raises(
+        RuntimeError,
+        match="logprob terms of the following value variables could not be derived: {b_val}",
+    ):
         conditional_logp({b: b_val, a: a_val})

--- a/tests/logprob/test_mixture.py
+++ b/tests/logprob/test_mixture.py
@@ -1178,9 +1178,5 @@ def test_advanced_subtensor_none_and_integer():
     a_val = a.type()
     a_val.name = "a_val"
 
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(RuntimeError, match="logprob terms of the following value variables could not be derived: {b_val}"):
         conditional_logp({b: b_val, a: a_val})
-
-    # Assert that the error message does NOT contain "AttributeError",
-    # which would indicate the presence of the original bug.
-    assert "AttributeError" not in str(e.value)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description

Previously, calculating the log-probability (`logp`) of an `AdvancedSubTensor` that included a `None` index would cause the system to crash with an unhandled internal `AttributeError`.

This change resolves the bug by adding a guard within the `logp` rewriting logic in `mixture.py`. Instead of crashing, the system now correctly identifies the ambiguous operation and raises a controlled `RuntimeError`.

A new test, `test_advanced_subtensor_none_and_integer`, has been added to `test_mixture.py` to validate this fix and prevent regressions.

Reproducible example from the ticket now executes:

```python
>>> import numpy as np
... import pymc as pm
... 
... 
... obs = np.random.default_rng().normal(size=(7, 4))
... with pm.Model():
...    inds = np.arange(obs.shape[1])
...    a = pm.Normal("a", shape=10)
...    b = pm.Deterministic("b", a[None, inds])
...    c = pm.Normal("c", mu=b, sigma=1, observed=obs)
...    pm.sample()
...    
Initializing NUTS using jitter+adapt_diag...
Multiprocess sampling (3 chains in 3 jobs)
NUTS: [a]
                                                                                                                                  
  Progress                                   Draws   Divergences   Step size   Grad evals   Sampling Speed   Elapsed   Remaining  
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   2000    0             0.871       3            792.47 draws/s   0:00:02   0:00:00    
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   2000    0             0.819       3            807.38 draws/s   0:00:02   0:00:00    
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   2000    0             0.951       3            783.45 draws/s   0:00:02   0:00:00    
                                                                                                                                  
Sampling 3 chains for 1_000 tune and 1_000 draw iterations (3_000 + 3_000 draws total) took 3 seconds.
We recommend running at least 4 chains for robust computation of convergence diagnostics
Inference data with groups:
	> posterior
	> sample_stats
	> observed_data
``` 


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7762 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7877.org.readthedocs.build/en/7877/

<!-- readthedocs-preview pymc end -->