### PR TITLE
feat #7713: implement ICARRV/CARRV as SymbolicRVs

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2133,6 +2133,7 @@ class KroneckerNormal(Continuous):
         return a
 
 
+# TODO: change this code
 class CARRV(RandomVariable):
     name = "car"
     signature = "(m),(m,m),(),(),()->(m)"
@@ -2344,21 +2345,56 @@ class CAR(Continuous):
         )
 
 
-class ICARRV(RandomVariable):
+class ICARRV(SymbolicMVNormalUsedInternally):
+    r"""A SymbolicRandomVariable representing an Intrinsic Conditional Autoregressive (ICAR) distribution.
+
+    This class contains the symbolic logic for the ICAR distribution, which is used by the
+    user-facing `pm.ICAR` class to generate random samples and compute log-probabilities.
+    """
+
     name = "icar"
-    signature = "(m,m),(),()->(m)"
-    dtype = "floatX"
+    extended_signature = "[rng],[size],(n,n),(),()->[rng],(n)"
     _print_name = ("ICAR", "\\operatorname{ICAR}")
 
-    def __call__(self, W, sigma, zero_sum_stdev, size=None, **kwargs):
-        return super().__call__(W, sigma, zero_sum_stdev, size=size, **kwargs)
-
     @classmethod
-    def rng_fn(cls, rng, size, W, sigma, zero_sum_stdev):
-        raise NotImplementedError("Cannot sample from ICAR prior")
+    def rv_op(cls, W, sigma, zero_sum_stdev, method="eigh", rng=None, size=None):
+        W = pt.as_tensor(W)
+        sigma = pt.as_tensor(sigma)
+        zero_sum_stdev = pt.as_tensor(zero_sum_stdev)
+        rng = normalize_rng_param(rng)
+        size = normalize_size_param(size)
 
+        if rv_size_is_none(size):
+            size = implicit_size_from_params(
+                W, sigma, zero_sum_stdev, ndims_params=cls.ndims_params
+            )
 
-icar = ICARRV()
+        N = W.shape[0]
+
+        # Construct the precision matrix (graph Laplacian)
+        D = pt.diag(W.sum(axis=1))
+        Q = (D - W) / (sigma * sigma)
+
+        # Add regularization for the zero eigenvalue based on zero_sum_stdev
+        zero_sum_precision = 1.0 / (zero_sum_stdev * zero_sum_stdev)
+        Q_reg = Q + zero_sum_precision * pt.ones((N, N)) / N
+
+        # Convert precision to covariance matrix
+        cov = pt.linalg.inv(Q_reg)  # TODO: Should this be matrix_inverse(Q_reg)
+
+        next_rng, mv_draws = multivariate_normal(
+            mean=pt.zeros(N),
+            cov=cov,
+            size=size,
+            rng=rng,
+            method=method,
+        ).owner.outputs
+
+        return cls(
+            inputs=[rng, size, W, sigma, zero_sum_stdev],
+            outputs=[next_rng, mv_draws],
+            method=method,
+        )(rng, size, W, sigma, zero_sum_stdev)
 
 
 class ICAR(Continuous):
@@ -2449,7 +2485,8 @@ class ICAR(Continuous):
 
     """
 
-    rv_op = icar
+    rv_type = ICARRV
+    rv_op = ICARRV.rv_op
 
     @classmethod
     def dist(cls, W, sigma=1, zero_sum_stdev=0.001, **kwargs):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
We will implement `ICARRV` and `CARRV` as `SymbolicRV`s by subclassing `SymbolicMVNormalUsedInternally`. This will eliminate the need for `rng_fn`.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7713 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7879.org.readthedocs.build/en/7879/

<!-- readthedocs-preview pymc end -->