### PR TITLE
Add support for sample_stats group in `pymc.testing.mock_sample`

### DIFF
--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -1024,16 +1024,16 @@ def mock_sample(
         from functools import partial
 
         import numpy as np
-        import numpy.typing as npt
+        from numpy.typing import NDArray
 
         from pymc.testing import mock_sample
 
 
-        def mock_diverging(size: tuple[int, int]) -> npt.NDArray:
+        def mock_diverging(size: tuple[int, int]) -> NDArray:
             return np.zeros(size)
 
 
-        def mock_tree_depth(size: tuple[int, int]) -> npt.NDArray:
+        def mock_tree_depth(size: tuple[int, int]) -> NDArray:
             return np.random.choice(range(2, 10), size=size)
 
 

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -978,7 +978,7 @@ def assert_no_rvs(vars: Sequence[Variable]) -> None:
         raise AssertionError(f"RV found in graph: {rvs}")
 
 
-SampleStatsCreator = Callable[[tuple[str, ...]], NDArray]
+SampleStatsCreator = Callable[[tuple[int, int]], NDArray]
 
 
 def mock_sample(

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -1029,11 +1029,11 @@ def mock_sample(
         from pymc.testing import mock_sample
 
 
-        def mock_diverging(size: tuple[str, ...]) -> npt.NDArray:
+        def mock_diverging(size: tuple[int, int]) -> npt.NDArray:
             return np.zeros(size)
 
 
-        def mock_tree_depth(size: tuple[str, ...]) -> npt.NDArray:
+        def mock_tree_depth(size: tuple[int, int]) -> npt.NDArray:
             return np.random.choice(range(2, 10), size=size)
 
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

This allows users to create sample_stats group in the mock sample helper

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7887.org.readthedocs.build/en/7887/

<!-- readthedocs-preview pymc end -->