### PR TITLE
Mention xtensorvariable methods in dims module

### DIFF
--- a/docs/source/api/dims/math.rst
+++ b/docs/source/api/dims/math.rst
@@ -1,9 +1,44 @@
 ***************************************
-Mathematical operations with dimensions
+Mathematical operations
 ***************************************
 
 This module wraps all the mathematical operations defined in :ref:`pytensor.xtensor.math <pytensor:libdoc_xtensor_math>`.
 
 It includes a ``linalg`` submodule that wraps all the operations defined in :ref:`pytensor.xtensor.linalg <pytensor:libdoc_xtensor_linalg>`.
 
-Operations defined at the module level in :ref:`pytensor.xtensor <pytensor:libdoc_xtensor_module_function>` are available at the ``pymc.dims`` module level.
+Operations defined at the module level in :ref:`pytensor.xtensor <pytensor:libdoc_xtensor_module_function>` are available at the :mod:`pymc.dims` module level.
+
+Method-based API on XTensorVariable
+===================================
+
+Many operations are also available as methods on :class:`~pytensor.xtensor.type.XTensorVariable` instances, providing a more intuitive interface when working with named dimensions:
+
+**Key methods include:**
+
+- :meth:`~pytensor.xtensor.type.XTensorVariable.isel` - Select data by dimension names
+- :meth:`~pytensor.xtensor.type.XTensorVariable.dot` - Perform dot products
+- :meth:`~pytensor.xtensor.type.XTensorVariable.sum`, :meth:`~pytensor.xtensor.type.XTensorVariable.mean`, :meth:`~pytensor.xtensor.type.XTensorVariable.prod` - Aggregation operations
+- :meth:`~pytensor.xtensor.type.XTensorVariable.transpose` - Reorder dimensions by name
+- :meth:`~pytensor.xtensor.type.XTensorVariable.expand_dims`, :meth:`~pytensor.xtensor.type.XTensorVariable.squeeze` - Dimension manipulation
+
+Example
+-------
+
+.. code-block:: python
+
+    import numpy as np
+    import pymc as pm
+    
+    coords = {"time": np.arange(10), "feature": ["a", "b", "c"]}
+    with pm.Model(coords=coords):
+        x = pm.Normal("x", mu=0, sigma=1, dims=("time", "feature"))
+        
+        # Method-based selection and operations
+        x_subset = x.isel(time=slice(0, 5))  # First 5 timesteps
+        x_mean = x_subset.mean(dim="feature")  # Average across features
+        
+        # Dot product using method syntax
+        y = pm.Normal("y", mu=0, sigma=1, dims="feature")
+        dot_result = x.dot(y, dim="feature")  # Shape: (time,)
+
+For a complete list of available methods, see the :class:`~pytensor.xtensor.type.XTensorVariable` API documentation.

--- a/docs/source/api/dims/math.rst
+++ b/docs/source/api/dims/math.rst
@@ -28,17 +28,17 @@ Example
 
     import numpy as np
     import pymc as pm
-    
+
     coords = {"time": np.arange(10), "feature": ["a", "b", "c"]}
     with pm.Model(coords=coords):
         x = pm.Normal("x", mu=0, sigma=1, dims=("time", "feature"))
-        
+
         # Method-based selection and operations
-        x_subset = x.isel(time=slice(0, 5))  # First 5 timesteps
-        x_mean = x_subset.mean(dim="feature")  # Average across features
-        
+        x_subset = x.isel(time=slice(0, 5))
+        x_mean = x_subset.mean(dim="feature")
+
         # Dot product using method syntax
         y = pm.Normal("y", mu=0, sigma=1, dims="feature")
-        dot_result = x.dot(y, dim="feature")  # Shape: (time,)
+        dot_result = x.dot(y, dim="feature")
 
 For a complete list of available methods, see the :class:`~pytensor.xtensor.type.XTensorVariable` API documentation.


### PR DESCRIPTION
## Description
This PR enhances the dims math documentation by adding information about the method-based API available on XTensorVariable instances. Previously, the documentation only mentioned where PyTensor operations were wrapped, but didn't inform users that many operations are also available as convenient methods directly on variables.

The addition includes:
- A new section explaining the method-based API on XTensorVariable
- Direct links to key methods like `.isel()` and `.dot()` as specifically requested
- Additional commonly used methods grouped by category (aggregation, shape operations)
- A practical example showing how to use these methods with named dimensions

## Related Issue
- [x] Closes #7863 

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Added necessary documentation (docstrings and/or example notebooks)

## Type of change
- [x] Documentation


## Notes
Documentation was tested locally. It did generate some folders that I had to delete for the pre-commit to pass. 
Maybe we should add it to contribution to documentation.
