### PR TITLE
Graceful incompatible coords handling

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -58,10 +58,10 @@ RAISE_ON_INCOMPATIBLE_COORD_LENGTHS = False
 Var = Any
 
 
-def dict_to_dataset_drop_incompatible_coords(vars_dict, *args, dims, coords, **kwargs):
+def dict_to_dataset_drop_incompatible_coords(vars_dict, *args, dims=None, coords=None, **kwargs):
     safe_coords = coords
 
-    if dims and not RAISE_ON_INCOMPATIBLE_COORD_LENGTHS:
+    if dims and coords is not None and not RAISE_ON_INCOMPATIBLE_COORD_LENGTHS:
         coords_lengths = {k: len(v) for k, v in coords.items()}
         for var_name, var in vars_dict.items():
             # Iterate in reversed because of chain/draw batch dimensions

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -33,7 +33,7 @@ from typing import (
 import numpy as np
 import pytensor.gradient as tg
 
-from arviz import InferenceData, dict_to_dataset
+from arviz import InferenceData
 from arviz.data.base import make_attrs
 from pytensor.graph.basic import Variable
 from rich.theme import Theme
@@ -45,6 +45,7 @@ import pymc as pm
 from pymc.backends import RunType, TraceOrBackend, init_traces
 from pymc.backends.arviz import (
     coords_and_dims_for_inferencedata,
+    dict_to_dataset_drop_incompatible_coords,
     find_constants,
     find_observations,
 )
@@ -355,14 +356,14 @@ def _sample_external_nuts(
         # Temporary work-around. Revert once https://github.com/pymc-devs/nutpie/issues/74 is fixed
         # gather observed and constant data as nutpie.sample() has no access to the PyMC model
         coords, dims = coords_and_dims_for_inferencedata(model)
-        constant_data = dict_to_dataset(
+        constant_data = dict_to_dataset_drop_incompatible_coords(
             find_constants(model),
             library=pm,
             coords=coords,
             dims=dims,
             default_dims=[],
         )
-        observed_data = dict_to_dataset(
+        observed_data = dict_to_dataset_drop_incompatible_coords(
             find_observations(model),
             library=pm,
             coords=coords,

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -33,7 +33,7 @@ from rich.progress import (
 
 import pymc
 
-from pymc.backends.arviz import dict_to_dataset, to_inference_data
+from pymc.backends.arviz import dict_to_dataset_drop_incompatible_coords, to_inference_data
 from pymc.backends.base import MultiTrace
 from pymc.distributions.custom import CustomDistRV, CustomSymbolicDistRV
 from pymc.distributions.distribution import _support_point
@@ -264,7 +264,7 @@ def _save_sample_stats(
             else:
                 sample_stats_dict[stat] = np.array(value)
 
-        sample_stats = dict_to_dataset(
+        sample_stats = dict_to_dataset_drop_incompatible_coords(
             sample_stats_dict,
             attrs=sample_settings_dict,
             library=pymc,

--- a/tests/distributions/test_timeseries.py
+++ b/tests/distributions/test_timeseries.py
@@ -951,7 +951,8 @@ class TestEulerMaruyama:
         with model:
             trace = sample(chains=1, random_seed=numpy_rng)
 
-        ppc = sample_posterior_predictive(trace, model=model, random_seed=numpy_rng)
+        with pytest.warns(UserWarning, match="Incompatible coordinate length"):
+            ppc = sample_posterior_predictive(trace, model=model, random_seed=numpy_rng)
 
         p95 = [2.5, 97.5]
         lo, hi = np.percentile(trace.posterior["lamh"], p95, axis=[0, 1])

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -1134,8 +1134,10 @@ class TestSamplePPC:
 
         with m:
             pm.set_data({"x_data": new_x_data}, coords=new_coords)
+            pm.backends.arviz.RAISE_ON_INCOMPATIBLE_COORD_LENGTHS = True
             with pytest.raises(ValueError, match="conflicting sizes for dimension 'trial'"):
                 pm.sample_posterior_predictive(fake_idata, predictions=True, progressbar=False)
+            pm.backends.arviz.RAISE_ON_INCOMPATIBLE_COORD_LENGTHS = False
 
         new_y_data = np.random.normal(size=(2,))
         with m:


### PR DESCRIPTION
## Description
This PR updates the internal conversion logic to use `dict_to_dataset_drop_incompatible_coords` across all relevant backends. 

## Related Issue
- [x] Related to #7908
- [x] Closes #7891

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [x] Maintenance


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7912.org.readthedocs.build/en/7912/

<!-- readthedocs-preview pymc end -->