### PR TITLE
Add icdf functions for Inverse Gamma distribution

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2530,6 +2530,16 @@ class InverseGamma(PositiveContinuous):
             beta > 0,
             msg="alpha > 0, beta > 0",
         )
+    
+    def icdf(value, alpha, beta):
+        res = 1 / Gamma.icdf(value=1-value, alpha=alpha, scale=1 / beta)
+        res = check_icdf_value(res, value)
+        return check_icdf_parameters(
+            res,
+            alpha > 0,
+            beta > 0,
+            msg="alpha > 0, beta > 0",
+        )
 
 
 class ChiSquared:

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2530,9 +2530,9 @@ class InverseGamma(PositiveContinuous):
             beta > 0,
             msg="alpha > 0, beta > 0",
         )
-    
+
     def icdf(value, alpha, beta):
-        res = 1 / Gamma.icdf(value=1-value, alpha=alpha, scale=1 / beta)
+        res = 1 / Gamma.icdf(value=1 - value, alpha=alpha, scale=1 / beta)
         res = check_icdf_value(res, value)
         return check_icdf_parameters(
             res,

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -705,6 +705,13 @@ class TestMatchesScipy:
             decimal=select_by_precision(float64=4, float32=3),
         )
 
+    def test_inverse_gamma_icdf(self):
+        check_icdf(
+            pm.InverseGamma,
+            {"alpha": Rplusbig, "beta": Rplusbig},
+            lambda q, alpha, beta: st.invgamma.ppf(q, alpha, scale=beta),
+        )
+
     def test_pareto(self):
         check_logp(
             pm.Pareto,


### PR DESCRIPTION
Adds ICDF functions to Inverse Gamma distribution

## Description
The quantile function depends on the quantile function of Gamma distribution: https://github.com/pymc-devs/pymc/pull/6845

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to https://github.com/pymc-devs/pymc/issues/6612

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change]

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7917.org.readthedocs.build/en/7917/

<!-- readthedocs-preview pymc end -->