### PR TITLE
Adding Dirichlet and SimplexTransform to pymc.dims

### DIFF
--- a/tests/distributions/test_censored.py
+++ b/tests/distributions/test_censored.py
@@ -137,15 +137,13 @@ class TestCensored:
 
         # No censoring
         censored_norm = pm.Censored.dist(norm, lower=None, upper=None)
-        with pytest.warns(RuntimeWarning, match=match_str):
-            censored_eval = logcdf(censored_norm, eval_points).eval()
+        censored_eval = logcdf(censored_norm, eval_points).eval()
         np.testing.assert_allclose(censored_eval, expected_logcdf_uncensored)
 
         # Left censoring
         censored_norm = pm.Censored.dist(norm, lower=-1, upper=None)
         expected_left = np.where(eval_points < -1, -np.inf, expected_logcdf_uncensored)
-        with pytest.warns(RuntimeWarning, match=match_str):
-            censored_eval = logcdf(censored_norm, eval_points).eval()
+        censored_eval = logcdf(censored_norm, eval_points).eval()
         np.testing.assert_allclose(
             censored_eval,
             expected_left,
@@ -155,8 +153,7 @@ class TestCensored:
         # Right censoring
         censored_norm = pm.Censored.dist(norm, lower=None, upper=1)
         expected_right = np.where(eval_points >= 1, 0.0, expected_logcdf_uncensored)
-        with pytest.warns(RuntimeWarning, match=match_str):
-            censored_eval = logcdf(censored_norm, eval_points).eval()
+        censored_eval = logcdf(censored_norm, eval_points).eval()
         np.testing.assert_allclose(
             censored_eval,
             expected_right,
@@ -167,8 +164,7 @@ class TestCensored:
         censored_norm = pm.Censored.dist(norm, lower=-1, upper=1)
         expected_interval = np.where(eval_points < -1, -np.inf, expected_logcdf_uncensored)
         expected_interval = np.where(eval_points >= 1, 0.0, expected_interval)
-        with pytest.warns(RuntimeWarning, match=match_str):
-            censored_eval = logcdf(censored_norm, eval_points).eval()
+        censored_eval = logcdf(censored_norm, eval_points).eval()
         np.testing.assert_allclose(
             censored_eval,
             expected_interval,


### PR DESCRIPTION
## Description
Adds support for the Dirichlet distributions in `pymc.dims`

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
This depends on https://github.com/pymc-devs/pytensor/pull/1629 to get merged

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7921.org.readthedocs.build/en/7921/

<!-- readthedocs-preview pymc end -->