### PR TITLE
premshaw04/#7581/Fix Censored doc type hints and add example for partially censored array inputs

### DIFF
--- a/pymc/distributions/censored.py
+++ b/pymc/distributions/censored.py
@@ -87,9 +87,9 @@ class Censored(Distribution):
 
         .. warning:: dist will be cloned, rendering it independent of the one passed as input.
 
-    lower : float or None
+    lower : float | int | array-like | None
         Lower (left) censoring point. If `None` the distribution will not be left censored
-    upper : float or None
+    upper : float | int | array-like | None
         Upper (right) censoring point. If `None`, the distribution will not be right censored.
 
     Warnings
@@ -109,6 +109,13 @@ class Censored(Distribution):
         with pm.Model():
             normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
             censored_normal = pm.Censored("censored_normal", normal_dist, lower=-1, upper=1)
+    
+    Partially censored vector using +/- inf masking:
+
+    >>> y = np.array([3.2, 10.5, 1.1, 14.4])
+    >>> lower = np.array([-np.inf, 9.0, -np.inf, 12.0])
+    >>> upper = np.array([ 4.0,  np.inf, 2.5,   np.inf])
+    >>> Censored("y_obs", pm.Normal.dist(mu=5, sigma=3), lower=lower, upper=upper, observed=y)
     """
 
     rv_type = CensoredRV


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- #7581/Fix Censored doc type hints and add example for partially censored array inputs-->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- issue-#7581
         Current docs say lower/upper accept float | None, but the implementation allows float | int | array. This PR corrects the docstring type hints accordingly and adds an explicit usage example with a vector of bounds including ±inf to illustrate partially censored data.

No code behavior change, docs only.-->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [*] Closes #7581 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [*] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [*] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7954.org.readthedocs.build/en/7954/

<!-- readthedocs-preview pymc end -->