### PR TITLE
Premshaw04/#7713/ICAR wrapper should return MvNormal.dist instead of constructing the RV directly

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -67,6 +67,7 @@ from pymc.distributions.distribution import (
 )
 from pymc.distributions.shape_utils import (
     _change_dist_size,
+    build_icar_covariance,
     change_dist_size,
     get_support_shape,
     implicit_size_from_params,
@@ -2452,6 +2453,15 @@ class ICAR(Continuous):
     rv_op = icar
 
     @classmethod
+    def ICAR(name, W, tau=1.0, mu=None, **kwargs):
+        W = pt.as_tensor_variable(W)
+        if mu is None:
+            mu = pt.zeros(W.shape[0])
+
+        cov = build_icar_covariance(W, tau)  # python helper that does eig pseudo inverse
+
+        return pm.MvNormal(name, mu=mu, cov=cov, method="eig", **kwargs)
+
     def dist(cls, W, sigma=1, zero_sum_stdev=0.001, **kwargs):
         # Note: These checks are forcing W to be non-symbolic
         if not W.ndim == 2:

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2452,15 +2452,16 @@ class ICAR(Continuous):
 
     rv_op = icar
 
-    @classmethod
-    def ICAR(name, W, tau=1.0, mu=None, **kwargs):
+    
+    def ICAR(name, W, tau=1.0, mu=None, method="eig", **kwargs):
         W = pt.as_tensor_variable(W)
+
         if mu is None:
             mu = pt.zeros(W.shape[0])
 
-        cov = build_icar_covariance(W, tau)  # python helper that does eig pseudo inverse
+        cov = build_icar_covariance(W, tau)   # private python helper that gets eig pseudo inverse
 
-        return pm.MvNormal(name, mu=mu, cov=cov, method="eig", **kwargs)
+        return pm.MvNormal.dist(mu=mu, cov=cov, method=method, name=name, **kwargs)
 
     def dist(cls, W, sigma=1, zero_sum_stdev=0.001, **kwargs):
         # Note: These checks are forcing W to be non-symbolic

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -46,6 +46,16 @@ from pymc.exceptions import ShapeError
 from pymc.pytensorf import PotentialShapeType
 
 
+def build_icar_covariance(W, tau):
+    D = np.diag(W.sum(axis=1))
+    Q = tau*(D-W)
+    vals, vecs = np.linalg.eigh(Q)
+    tol = np.max(vals)*1e-12
+    inv_vals = np.where(vals > tol, 1/vals, 0.0)
+    cov = (vecs*inv_vals) @ vecs.T
+    cov = 0.5*(cov+cov.T)
+    return cov
+
 def to_tuple(shape):
     """Convert ints, arrays, and Nones to tuples.
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!---#7713/ICAR wrapper should return MvNormal.dist instead of constructing the RV directly -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Right now the ICAR implementation is using the direct pm.MvNormal(name, ...) constructor.
For wrapper distributions in PyMC, the correct pattern is to return pm.MvNormal.dist(...) instead.
This keeps ICAR consistent with LKJ, LKJCholeskyCov, Dirichlet, etc. and matches how reviewers expect thin wrappers to behave.

This issue proposes refactoring the ICAR helper so that:

ICAR remains a simple function wrapper (not a class)

No @classmethod or custom .dist is created

ICAR returns pm.MvNormal.dist(mu=..., cov=..., method="eig")

This change improves API consistency and makes the implementation align with core PyMC distribution wrapper conventions.-->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [*] Closes #7713 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [*] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [*] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [*] New feature / enhancement
- [ ] Bug fix
- [] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7955.org.readthedocs.build/en/7955/

<!-- readthedocs-preview pymc end -->