### PR TITLE
Infer logp and logcdf of abs of discrete variables

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1052,11 +1052,11 @@ class DiscreteUniform(Discrete):
 
     def logcdf(value, lower, upper):
         res = pt.switch(
-            pt.le(value, lower),
+            pt.lt(value, lower),
             -np.inf,
             pt.switch(
                 pt.lt(value, upper),
-                pt.log(pt.minimum(pt.floor(value), upper) - lower + 1) - pt.log(upper - lower + 1),
+                pt.log(pt.floor(value) - lower + 1) - pt.log(upper - lower + 1),
                 0,
             ),
         )

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -123,6 +123,7 @@ from pymc.logprob.utils import (
     filter_measurable_variables,
     find_negated_var,
 )
+from pymc.math import logdiffexp
 
 
 class Transform(abc.ABC):
@@ -267,7 +268,7 @@ def measurable_transform_logcdf(op: MeasurableTransform, value, *inputs, **kwarg
             logcdf_zero = _logcdf_helper(measurable_input, 0)
             logcdf = pt.switch(
                 pt.lt(backward_value, 0),
-                pt.log(pt.exp(logcdf_zero) - pt.exp(logcdf)),
+                logdiffexp(logcdf_zero, logcdf),
                 pt.logaddexp(logccdf, logcdf_zero),
             )
     else:

--- a/pymc/math.py
+++ b/pymc/math.py
@@ -282,7 +282,14 @@ def kron_diag(*diags):
 
 def logdiffexp(a, b):
     """Return log(exp(a) - exp(b))."""
-    return a + pt.log1mexp(b - a)
+    return pt.where(
+        # Handle special case where b is -inf
+        # If a == b == -inf, this will return the correct result of -inf
+        # whereas the default else branch would get a nan due to -inf - (-inf)
+        pt.isneginf(b),
+        a,
+        a + pt.log1mexp(b - a),
+    )
 
 
 invlogit = sigmoid

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -41,9 +41,7 @@ from pymc.testing import (
     Nat,
     NatSmall,
     R,
-    Rdunif,
     Rplus,
-    Rplusdunif,
     Runif,
     Simplex,
     Unit,
@@ -95,32 +93,36 @@ def orderedprobit_logpdf(value, eta, cutpoints):
 
 
 class TestMatchesScipy:
-    def test_discrete_unif(self):
+    def test_discrete_uniform(self):
+        # Choose domain/paramdomain so we test edge cases as well
+        test_domain = Domain([-np.inf, -10, -1, 0, 1, 10, np.inf], dtype="int64")
+        test_paramdomain = Domain([-np.inf, 0, 10, np.inf], dtype="int64")
         check_logp(
             pm.DiscreteUniform,
-            Rdunif,
-            {"lower": -Rplusdunif, "upper": Rplusdunif},
+            test_domain,
+            {"lower": -test_paramdomain, "upper": test_paramdomain},
             lambda value, lower, upper: st.randint.logpmf(value, lower, upper + 1),
             skip_paramdomain_outside_edge_test=True,
         )
         check_logcdf(
             pm.DiscreteUniform,
-            Rdunif,
-            {"lower": -Rplusdunif, "upper": Rplusdunif},
+            test_domain,
+            {"lower": -test_paramdomain, "upper": test_paramdomain},
             lambda value, lower, upper: st.randint.logcdf(value, lower, upper + 1),
             skip_paramdomain_outside_edge_test=True,
         )
         check_selfconsistency_discrete_logcdf(
             pm.DiscreteUniform,
             Domain([-10, 0, 10], "int64"),
-            {"lower": -Rplusdunif, "upper": Rplusdunif},
+            {"lower": -test_paramdomain, "upper": test_paramdomain},
         )
         check_icdf(
             pm.DiscreteUniform,
-            {"lower": -Rplusdunif, "upper": Rplusdunif},
+            {"lower": -test_paramdomain, "upper": test_paramdomain},
             lambda q, lower, upper: st.randint.ppf(q=q, low=lower, high=upper + 1),
             skip_paramdomain_outside_edge_test=True,
         )
+
         # Custom logp / logcdf check for invalid parameters
         invalid_dist = pm.DiscreteUniform.dist(lower=1, upper=0)
         with pytensor.config.change_flags(mode=Mode("py")):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -144,9 +144,13 @@ def test_log1mexp_deprecation_warnings():
 def test_logdiffexp():
     a = np.log([1, 2, 3, 4])
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "divide by zero encountered in log", RuntimeWarning)
         b = np.log([0, 1, 2, 3])
-    assert np.allclose(logdiffexp(a, b).eval(), 0)
+    np.testing.assert_allclose(logdiffexp(a, b).eval(), 0, atol=1e-15)
+
+    np.testing.assert_allclose(
+        logdiffexp(-np.inf, -np.inf).eval(),
+        -np.inf,
+    )
 
 
 class TestLogDet:


### PR DESCRIPTION
I was going to work on general icdf(abs(x)) which requires an optimization routine, but found some small crumbs along the way.

* Allow logp(abs(x)) and logcdf(abs(x)) for discrete x. 
* Fix logcdf of DiscreteUniform for x == lower
* Handle special case in logdiffexp(-inf, -inf) so it can be safely used in more contexts