### PR TITLE
Use `narwhals` as dataframe-agnostic backend 

### DIFF
--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -17,6 +17,7 @@ dependencies:
 - jaxlib>=0.4.28
 - libblas=*=*mkl
 - mkl-service
+- narwhals>=2.11.0
 - numpy>=1.25.0
 - numpyro>=0.8.0
 - pandas>=0.24.0

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -9,6 +9,7 @@ dependencies:
 - blas
 - cachetools>=4.2.1,<7
 - cloudpickle
+- narwhals>=2.11.0
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -8,6 +8,7 @@ dependencies:
 - arviz>=1.0.0,<2.0
 - cachetools>=4.2.1,<7
 - cloudpickle
+- narwhals>=2.11.0
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -10,6 +10,7 @@ dependencies:
 - cachetools>=4.2.1,<7
 - cloudpickle
 - jax
+- narwhals>=2.11.0
 - numpy>=1.25.0
 - netcdf4
 - pandas>=0.24.0

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -9,6 +9,7 @@ dependencies:
 - blas
 - cachetools>=4.2.1,<7
 - cloudpickle
+- narwhals>=2.11.0
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -11,6 +11,7 @@ dependencies:
 - cloudpickle
 - libpython
 - mkl-service>=2.3.0
+- narwhals>=2.11.0
 - netcdf4
 - numpy>=1.25.0
 - pandas>=0.24.0

--- a/pymc/data.py
+++ b/pymc/data.py
@@ -18,20 +18,17 @@ import urllib.request
 
 from collections.abc import Sequence
 from copy import copy
-from typing import Union, cast
 
 import numpy as np
-import pandas as pd
 import pytensor
 import pytensor.tensor as pt
-import xarray as xr
 
 from pytensor.compile.builders import OpFromGraph
 from pytensor.compile.sharedvalue import SharedVariable
 from pytensor.graph.basic import Variable
 from pytensor.raise_op import Assert
 from pytensor.tensor.random.basic import IntegersRV
-from pytensor.tensor.variable import TensorConstant, TensorVariable
+from pytensor.tensor.variable import TensorVariable
 
 from pymc.exceptions import ShapeError
 from pymc.pytensorf import convert_data, rvs_in_graph
@@ -163,76 +160,17 @@ def Minibatch(variable: TensorVariable, *variables: TensorVariable, batch_size: 
     return mb_tensors if len(variables) else mb_tensors[0]
 
 
-def determine_coords(
-    model,
-    value: pd.DataFrame | pd.Series | xr.DataArray,
-    dims: Sequence[str] | None = None,
-    coords: dict[str, Sequence | np.ndarray] | None = None,
-) -> tuple[dict[str, Sequence | np.ndarray], Sequence[str] | Sequence[None]]:
-    """Determine coordinate values from data or the model (via ``dims``)."""
-    if coords is None:
-        coords = {}
-
-    dim_name = None
-    # If value is a df or a series, we interpret the index as coords:
-    if hasattr(value, "index"):
-        if dims is not None:
-            dim_name = dims[0]
-        if dim_name is None and value.index.name is not None:
-            dim_name = value.index.name
-        if dim_name is not None:
-            coords[dim_name] = value.index
-
-    # If value is a df, we also interpret the columns as coords:
-    if hasattr(value, "columns"):
-        if dims is not None:
-            dim_name = dims[1]
-        if dim_name is None and value.columns.name is not None:
-            dim_name = value.columns.name
-        if dim_name is not None:
-            coords[dim_name] = value.columns
-
-    if isinstance(value, xr.DataArray):
-        if dims is not None:
-            for dim in dims:
-                dim_name = dim
-                # str is applied because dim entries may be None
-                coords[str(dim_name)] = cast(xr.DataArray, value[dim]).to_numpy()
-
-    if isinstance(value, np.ndarray) and dims is not None:
-        if len(dims) != value.ndim:
-            raise ShapeError(
-                "Invalid data shape. The rank of the dataset must match the length of `dims`.",
-                actual=value.shape,
-                expected=value.ndim,
-            )
-        for size, dim in zip(value.shape, dims):
-            coord = model.coords.get(dim, None)
-            if coord is None and dim is not None:
-                coords[dim] = range(size)
-
-    if dims is None:
-        # TODO: Also determine dim names from the index
-        new_dims: Sequence[str] | Sequence[None] = [None] * np.ndim(value)
-    else:
-        new_dims = dims
-    return coords, new_dims
-
-
 def Data(
     name: str,
     value,
     *,
     dims: Sequence[str] | None = None,
-    coords: dict[str, Sequence | np.ndarray] | None = None,
-    infer_dims_and_coords=False,
-    model: Union["Model", None] = None,
+    model: "Model | None" = None,
     **kwargs,
-) -> SharedVariable | TensorConstant:
+) -> SharedVariable:
     """Create a data container that registers a data variable with the model.
 
-    Depending on the ``mutable`` setting (default: True), the variable
-    is registered as a :class:`~pytensor.compile.sharedvalue.SharedVariable`,
+    The variable is registered as a :class:`~pytensor.compile.sharedvalue.SharedVariable`,
     enabling it to be altered in value and shape, but NOT in dimensionality using
     :func:`pymc.set_data`.
 
@@ -250,23 +188,19 @@ def Data(
     ----------
     name : str
         The name for this variable.
-    value : array_like or pandas.Series, pandas.Dataframe
-        A value to associate with this variable.
-    dims : str, tuple of str or tuple of None, optional
-        Dimension names of the random variables (as opposed to the shapes of these
-        random variables). Use this when ``value`` is a pandas Series or DataFrame. The
-        ``dims`` will then be the name of the Series / DataFrame's columns. See ArviZ
-        documentation for more information about dimensions and coordinates:
-        :ref:`arviz:quickstart`.
-        If this parameter is not specified, the random variables will not have dimension
-        names.
-    coords : dict, optional
-        Coordinate values to set for new dimensions introduced by this ``Data`` variable.
-    export_index_as_coords : bool
-        Deprecated, previous version of "infer_dims_and_coords"
-    infer_dims_and_coords : bool, default=False
-        If True, the ``Data`` container will try to infer what the coordinates
-        and dimension names should be if there is an index in ``value``.
+    value : array-like, DataFrame, or Series
+        A value to associate with this variable. Accepts numpy arrays, lists,
+        scipy sparse matrices, xarray DataArrays, and any DataFrame or Series
+        supported by `narwhals <https://narwhals-dev.github.io/narwhals/>`_
+        (pandas, polars, dask, pyarrow, modin, cudf, ibis, ...). The value is
+        converted to a numpy array.
+    dims : str or tuple of str, optional
+        Dimension names of the data variable. See ArviZ documentation for more
+        information about dimensions and coordinates: :ref:`arviz:quickstart`.
+        If not specified, the data variable will not have dimension names.
+    model : pymc.Model, optional
+        Model to which to add the data variable. If not specified, the data
+        variable will be added to the model on the context stack.
     **kwargs : dict, optional
         Extra arguments passed to :func:`pytensor.shared`.
 
@@ -293,13 +227,6 @@ def Data(
     """
     from pymc.model.core import modelcontext
 
-    if coords is None:
-        coords = {}
-
-    if isinstance(value, list):
-        value = np.array(value)
-
-    # Add data container to the named variables of the model.
     try:
         model = modelcontext(model)
     except TypeError:
@@ -309,14 +236,18 @@ def Data(
         )
     name = model.name_for(name)
 
-    # Transform `value` it to something digestible for PyTensor.
     if isgenerator(value):
         raise NotImplementedError(
             "Generator type data is no longer supported with pm.Data.",
             # It messes up InferenceData and can't be the input to a SharedVariable.
         )
-    else:
-        arr = convert_data(value)
+
+    if isinstance(value, list | tuple):
+        # Promote here so the inferred dtype (e.g. int64 for an index list) survives
+        # `convert_data`, instead of being floatX'd by the "no dtype" fallback.
+        value = np.asarray(value)
+
+    arr = convert_data(value)
 
     if isinstance(arr, np.ma.MaskedArray):
         raise NotImplementedError(
@@ -335,25 +266,12 @@ def Data(
             expected=x.ndim,
         )
 
-    new_dims: Sequence[str] | Sequence[None] | None
-    if infer_dims_and_coords:
-        coords, new_dims = determine_coords(model, value, dims)
-    else:
-        new_dims = dims
-
-    if new_dims:
+    if dims:
         xshape = x.shape
-        # Register new dimension lengths
-        for d, dname in enumerate(new_dims):
+        for d, dname in enumerate(dims):
             if dname not in model.dim_lengths and dname is not None:
-                model.add_coord(
-                    name=dname,
-                    # Note: Coordinate values can't be taken from
-                    # the value, because it could be N-dimensional.
-                    values=coords.get(dname, None),
-                    length=xshape[d],
-                )
+                model.add_coord(name=dname, values=None, length=xshape[d])
 
-    model.register_data_var(x, dims=new_dims)
+    model.register_data_var(x, dims=dims)
 
     return x

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -16,8 +16,8 @@ import warnings
 from collections.abc import Iterable, Sequence
 from typing import cast
 
+import narwhals as nw
 import numpy as np
-import pandas as pd
 import pytensor
 import pytensor.tensor as pt
 import scipy.sparse as sps
@@ -82,44 +82,41 @@ def convert_observed_data(data) -> np.ndarray | Variable:
 
 
 def convert_data(data) -> np.ndarray | Variable:
+    """Convert user-provided data to a numpy array, masked array, sparse matrix, or pytensor Variable.
+
+    Anything that is not already an ndarray, sparse matrix, or pytensor Variable is routed
+    through narwhals, which transparently handles every supported DataFrame/Series backend
+    (pandas, polars, dask, pyarrow, modin, cudf, ibis, ...). NaN and null entries are folded
+    into a single mask.
+    """
     ret: np.ndarray | Variable
-    if hasattr(data, "to_numpy") and hasattr(data, "isnull"):
-        # typically, but not limited to pandas objects
-        vals = data.to_numpy()
-        null_data = data.isnull()
-        if hasattr(null_data, "to_numpy"):
-            # pandas Series
-            mask = null_data.to_numpy()
-        else:
-            # pandas Index
-            mask = null_data
-        if mask.any():
-            # there are missing values
-            ret = np.ma.MaskedArray(vals, mask)
-        else:
-            ret = vals
-    elif isinstance(data, np.ndarray):
-        if isinstance(data, np.ma.MaskedArray):
-            if not data.mask.any():
-                # empty mask
-                ret = data.filled()
-            else:
-                # already masked and rightly so
-                ret = data
-        else:
-            # already a ndarray, but not masked
-            mask = np.isnan(data)
-            if np.any(mask):
-                ret = np.ma.MaskedArray(data, mask)
-            else:
-                # no masking required
-                ret = data
-    elif isinstance(data, Variable):
+    if isinstance(data, Variable):
         ret = data
     elif sps.issparse(data):
         ret = data
-    else:
+    elif isinstance(data, np.ma.MaskedArray):
+        ret = data if data.mask.any() else data.filled()
+    elif isinstance(data, np.ndarray):
+        mask = np.isnan(data) if np.issubdtype(data.dtype, np.floating) else None
+        ret = np.ma.MaskedArray(data, mask) if mask is not None and mask.any() else data
+    elif isinstance(data, list | tuple):
         ret = np.asarray(data)
+    else:
+        # Try narwhals: this covers every DataFrame/Series backend it supports.
+        nw_data = nw.from_native(data, allow_series=True, pass_through=True)
+        if nw_data is not data:
+            if isinstance(nw_data, nw.LazyFrame):
+                nw_data = nw_data.collect()
+            # Some backends (e.g. polars) distinguish NaN from null; treat both as missing.
+            if isinstance(nw_data, nw.Series):
+                mask = nw_data.fill_nan(None).is_null().to_numpy()
+            else:
+                mask = nw_data.select(nw.all().fill_nan(None).is_null()).to_numpy()
+            vals = nw_data.to_numpy()
+            ret = np.ma.MaskedArray(vals, mask) if mask.any() else vals
+        else:
+            # Fallback for anything np.asarray can handle: xarray, numpy scalars, etc.
+            ret = np.asarray(data)
 
     # Data without dtype info is converted to float arrays by default.
     # This is the most common case for simple examples.
@@ -129,10 +126,23 @@ def convert_data(data) -> np.ndarray | Variable:
     return smarttypeX(ret)
 
 
-@_as_tensor_variable.register(pd.Series)
-@_as_tensor_variable.register(pd.DataFrame)
-def dataframe_to_tensor_variable(df: pd.DataFrame, *args, **kwargs) -> TensorVariable:
-    return pt.as_tensor_variable(df.to_numpy(), *args, **kwargs)
+@_as_tensor_variable.register(object)
+def _narwhals_to_tensor_variable(x, *args, **kwargs) -> TensorVariable:
+    """Catch-all final dispatch for ``pt.as_tensor_variable``.
+
+    This allows any narwhals-supported DataFrame/Series (pandas, polars, dask, pyarrow, modin, cudf, ibis, ...) to
+    be registered via pm.Data, without PyMC itself having to have any special logic for these packages.
+
+    Registered on ``object`` so it only fires as a least-specific fallback — concrete handlers (ndarray, Variable,
+    etc.) take priority. Unrecognized types re-raise the original ``NotImplementedError`` so pytensor's error surface
+    is preserved.
+    """
+    nw_x = nw.from_native(x, allow_series=True, pass_through=True)
+    if nw_x is x:
+        raise NotImplementedError(f"Cannot convert {x!r} to a tensor variable.")
+    if isinstance(nw_x, nw.LazyFrame):
+        nw_x = nw_x.collect()
+    return pt.as_tensor_variable(nw_x.to_numpy(), *args, **kwargs)
 
 
 _cheap_eval_mode = Mode(linker="py", optimizer="minimum_compile")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ jupyter-sphinx
 mcbackend>=0.4.0
 mypy==1.19.1
 myst-nb<=1.0.0
+narwhals>=2.11.0
 netCDF4
 numdifftools>=0.9.40
 numpy>=1.25.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 arviz>=1.0.0,<2.0
 cachetools>=4.2.1,<7
 cloudpickle
+narwhals>=2.11.0
 numpy>=1.25.0
-pandas>=0.24.0
 pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3
 rich>=13.7.1
 scipy>=1.4.1

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -23,6 +23,7 @@ import pytest
 
 from pytensor import shared
 from pytensor.tensor.variable import TensorVariable
+from scipy import stats
 
 import pymc as pm
 
@@ -336,20 +337,6 @@ class TestData:
         assert "columns" in pmodel.dim_lengths
         assert pmodel.dim_lengths["columns"].eval() == 7
 
-    def test_set_coords_through_pmdata(self):
-        with pm.Model() as pmodel:
-            pm.Data("population", [100, 200], dims="city", coords={"city": ["Tinyvil", "Minitown"]})
-            pm.Data(
-                "temperature",
-                [[15, 20, 22, 17], [18, 22, 21, 12]],
-                dims=("city", "season"),
-                coords={"season": ["winter", "spring", "summer", "fall"]},
-            )
-        assert "city" in pmodel.coords
-        assert "season" in pmodel.coords
-        assert pmodel.coords["city"] == ("Tinyvil", "Minitown")
-        assert pmodel.coords["season"] == ("winter", "spring", "summer", "fall")
-
     def test_symbolic_coords(self):
         """
         Since v4 dimensions can be created without passing coordinate values.
@@ -369,48 +356,63 @@ class TestData:
             assert pmodel.dim_lengths["row"].eval() == 4
             assert pmodel.dim_lengths["column"].eval() == 5
 
-    def test_implicit_coords_series(self, seeded_test):
-        pd = pytest.importorskip("pandas")
-        ser_sales = pd.Series(
-            data=np.random.randint(low=0, high=30, size=22),
-            index=pd.date_range(start="2020-05-01", periods=22, freq="24h", name="date"),
-            name="sales",
-        )
-        with pm.Model() as pmodel:
-            pm.Data("sales", ser_sales, dims="date", infer_dims_and_coords=True)
+    @pytest.mark.parametrize(
+        "input_type",
+        [
+            "ndarray",
+            "list",
+            "pandas_df",
+            "pandas_series",
+            "polars_df",
+            "polars_series",
+            "dask_df",
+            "pyarrow_df",
+            "xarray",
+        ],
+    )
+    def test_data_input_types(self, input_type):
+        """``pm.Data`` should accept any narwhals-supported DataFrame/Series, plus the usual array-likes."""
+        input_data = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        expected = stats.norm(loc=0, scale=1).logpdf(input_data)
 
-        assert "date" in pmodel.coords
-        assert len(pmodel.coords["date"]) == 22
-        assert pmodel.named_vars_to_dims == {"sales": ("date",)}
+        match input_type:
+            case "ndarray":
+                value = input_data.copy()
+            case "list":
+                value = input_data.tolist()
+            case "pandas_df":
+                pd = pytest.importorskip("pandas")
+                value = pd.DataFrame(input_data)
+            case "pandas_series":
+                pd = pytest.importorskip("pandas")
+                value = pd.Series(input_data[:, 0])
+                expected = expected[:, 0]
+            case "polars_df":
+                pl = pytest.importorskip("polars")
+                value = pl.DataFrame(input_data)
+            case "polars_series":
+                pl = pytest.importorskip("polars")
+                value = pl.Series(input_data[:, 0])
+                expected = expected[:, 0]
+            case "dask_df":
+                dd = pytest.importorskip("dask.dataframe")
+                pd = pytest.importorskip("pandas")
+                value = dd.from_pandas(pd.DataFrame(input_data), npartitions=1)
+            case "pyarrow_df":
+                pa = pytest.importorskip("pyarrow")
+                value = pa.table({f"c{i}": input_data[:, i] for i in range(input_data.shape[1])})
+            case "xarray":
+                xr = pytest.importorskip("xarray")
+                value = xr.DataArray(input_data, dims=["row", "col"])
+            case _:
+                raise ValueError(f"Unknown input_type: {input_type}")
 
-    def test_implicit_coords_dataframe(self, seeded_test):
-        pd = pytest.importorskip("pandas")
-        N_rows = 5
-        N_cols = 7
-        df_data = pd.DataFrame()
-        for c in range(N_cols):
-            df_data[f"Column {c + 1}"] = np.random.normal(size=(N_rows,))
-        df_data.index.name = "rows"
-        df_data.columns.name = "columns"
+        with pm.Model():
+            data = pm.Data("test_data", value)
+            x = pm.Normal("x", mu=0, sigma=1)
+            result = pm.logp(x, data).eval()
 
-        # infer coordinates from index and columns of the DataFrame
-        with pm.Model() as pmodel:
-            pm.Data("observations", df_data, dims=("rows", "columns"), infer_dims_and_coords=True)
-
-        assert "rows" in pmodel.coords
-        assert "columns" in pmodel.coords
-        assert pmodel.named_vars_to_dims == {"observations": ("rows", "columns")}
-
-    def test_implicit_coords_xarray(self):
-        xr = pytest.importorskip("xarray")
-        data = xr.DataArray([[1, 2, 3], [4, 5, 6]], dims=("y", "x"))
-        with pm.Model() as pmodel:
-            pm.Data("observations", data, dims=("x", "y"), infer_dims_and_coords=True)
-        assert "x" in pmodel.coords
-        assert "y" in pmodel.coords
-        assert pmodel.named_vars_to_dims == {"observations": ("x", "y")}
-        assert tuple(pmodel.coords["x"]) == tuple(data.coords["x"].to_numpy())
-        assert tuple(pmodel.coords["y"]) == tuple(data.coords["y"].to_numpy())
+        np.testing.assert_array_almost_equal(*np.broadcast_arrays(result, expected))
 
     def test_data_kwargs(self):
         strict_value = True

--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -58,29 +58,33 @@ from pymc.vartypes import int_types
         np.ones(shape=(10, 1)),
     ],
 )
-def test_pd_dataframe_as_tensor_variable(np_array: np.ndarray) -> None:
-    df = pd.DataFrame(np_array)
+@pytest.mark.parametrize("library", ["pandas", "polars", "dask.dataframe", "pyarrow"])
+def test_dataframe_as_tensor_variable(np_array: np.ndarray, library: str) -> None:
+    """``pt.as_tensor_variable`` should accept any narwhals-supported DataFrame."""
+    lib = pytest.importorskip(library)
+    col_names = [f"col_{i}" for i in range(np_array.shape[1])]
+    match library:
+        case "pandas":
+            df = lib.DataFrame(np_array, columns=col_names)
+        case "polars":
+            df = lib.DataFrame(np_array, schema=dict.fromkeys(col_names, float))
+        case "dask.dataframe":
+            df = lib.DataFrame.from_dict({col: np_array[:, i] for i, col in enumerate(col_names)})
+        case "pyarrow":
+            df = lib.table({col: np_array[:, i] for i, col in enumerate(col_names)})
     np.testing.assert_array_equal(pt.as_tensor_variable(df).eval(), np_array)
 
 
 @pytest.mark.parametrize(
     argnames="np_array",
-    argvalues=[np.array([1.0, 2.0, -1.0]), np.ones(shape=4), np.zeros(shape=10), [1, 2, 3, 4]],
+    argvalues=[np.array([1.0, 2.0, -1.0]), np.ones(shape=4), np.zeros(shape=10)],
 )
-def test_pd_series_as_tensor_variable(np_array: np.ndarray) -> None:
-    df = pd.Series(np_array)
-    np.testing.assert_array_equal(pt.as_tensor_variable(df).eval(), np_array)
-
-
-def test_pd_as_tensor_variable_multiindex() -> None:
-    tuples = [("L", "Q"), ("L", "I"), ("O", "L"), ("O", "I")]
-
-    index = pd.MultiIndex.from_tuples(tuples, names=["Id1", "Id2"])
-
-    df = pd.DataFrame({"A": [12.0, 80.0, 30.0, 20.0], "B": [120.0, 700.0, 30.0, 20.0]}, index=index)
-    np_array = np.array([[12.0, 80.0, 30.0, 20.0], [120.0, 700.0, 30.0, 20.0]]).T
-    assert isinstance(df.index, pd.MultiIndex)
-    np.testing.assert_array_equal(pt.as_tensor_variable(df).eval(), np_array)
+@pytest.mark.parametrize("library", ["pandas", "polars"])
+def test_series_as_tensor_variable(np_array: np.ndarray, library: str) -> None:
+    """``pt.as_tensor_variable`` should accept any narwhals-supported Series."""
+    lib = pytest.importorskip(library)
+    s = lib.Series(np_array)
+    np.testing.assert_array_equal(pt.as_tensor_variable(s).eval(), np_array)
 
 
 class TestBroadcasting:
@@ -273,13 +277,6 @@ def test_convert_data(input_dtype):
         assert pytensor_output.dtype == pytensor.config.floatX
     else:
         assert pytensor_output.dtype == intX
-
-
-def test_pandas_to_array_pandas_index():
-    data = pd.Index([1, 2, 3])
-    result = convert_data(data)
-    expected = np.array([1, 2, 3])
-    np.testing.assert_array_equal(result, expected)
 
 
 class TestCompile:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
Continues/completes [#7462](https://github.com/pymc-devs/pymc/pull/7918). I didn't have permission to push into that PR, so I'm opening this one. 

The purpose of this PR is to use narwhals as a one-stop shop dataframe backend. Currently, we use pandas in `data.py` and `pytensorf.py` to allow users to pass dataframe objects into `pm.Data` and `pt.as_tensor`, respectively. I add a narwhals compatibility layer between the input and the pymc model to allow the user to bring his data in any form that narwhals supports, provided we register the libraries. 

(If we could eliminate registration that would also be great, but I wasn't clever enough to figure out the multiple dispatch using only narwhals as a dependency. Maybe @MarcoGorelli could help 👉 👈 )

 Some notes:

1. Since generalized dataframes don't have a notion of an index, we don't look at the index to find the labels for the left-most dimension provided to `pm.Data`. Instead, we look for a column matching that dimension name. If it is found, it is used as labels, and excluded from the values. 
2. Narwhals has a lazy API via `nw.LazyFrame` and `nw.LazySeries`. I don't think we can do anything with those at the modeling level (maybe in the future with minibatching?). For now, I'm just calling `.collect()` on them to make them eager. 
3. As mentioned above, we don't get all of narwhals for free yet -- the PR as it currently stands forces us to register each backend library we want to support. I don't think this is so bad, because it forces us to write tests for say DuckDB if someone comes along and really wants that. But it's a bit ugly. I added a `dask.dataframe` backend as an example of how we could extend things.

As of this PR, `pandas` could be made an optional or dev-only dependency for us. I didn't do it right away because I wanted to take people's temperature on the idea.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #7462 Closes #7463
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
