### PR TITLE
DOC: fix mobile menu

### DIFF
--- a/docs/source/_static/css/mobile-menu-fix.css
+++ b/docs/source/_static/css/mobile-menu-fix.css
@@ -11,7 +11,15 @@
   pointer-events: auto !important;
 }
 
-/* Ensure the modal overlay allows pointer events to reach menu links */
+/* 
+ * Ensure the modal overlay allows pointer events to reach menu links.
+ * Both `pointer-events: auto` and a high `z-index` are necessary because:
+ * - Some themes/modal implementations use overlays that block pointer events or stack above menu links,
+ *   making them unclickable (especially on iOS).
+ * - This rule ensures that the backdrop does not block interaction with menu links,
+ *   and that the stacking order is correct so links remain accessible.
+ * If the theme/modal implementation changes, review whether this workaround is still needed.
+ */
 .pst-modal-backdrop {
   pointer-events: auto !important;
 }

--- a/docs/source/_static/css/mobile-menu-fix.css
+++ b/docs/source/_static/css/mobile-menu-fix.css
@@ -1,0 +1,17 @@
+/* Mobile menu fix: ensure overlay is clickable on iOS */
+
+/* Raise the stacked navigation elements above possible overlays */
+.primary-toggle,
+.secondary-toggle,
+.navbar,
+.navbar-collapse,
+#pst-primary-sidebar-modal,
+#pst-secondary-sidebar-modal {
+  z-index: 10000 !important;
+  pointer-events: auto !important;
+}
+
+/* Ensure the modal overlay allows pointer events to reach menu links */
+.pst-modal-backdrop {
+  pointer-events: auto !important;
+}

--- a/docs/source/_static/css/mobile-menu-fix.css
+++ b/docs/source/_static/css/mobile-menu-fix.css
@@ -3,8 +3,8 @@
 /* Raise the stacked navigation elements above possible overlays */
 .primary-toggle,
 .secondary-toggle,
-.navbar,
-.navbar-collapse,
+.mobile-menu-container .navbar,
+.mobile-menu-container .navbar-collapse,
 #pst-primary-sidebar-modal,
 #pst-secondary-sidebar-modal {
   z-index: 10000 !important;

--- a/docs/source/_static/css/mobile-menu-fix.css
+++ b/docs/source/_static/css/mobile-menu-fix.css
@@ -7,7 +7,7 @@
 .mobile-menu-container .navbar-collapse,
 #pst-primary-sidebar-modal,
 #pst-secondary-sidebar-modal {
-  z-index: 10000 !important;
+  z-index: 1500;
   pointer-events: auto !important;
 }
 

--- a/docs/source/_static/js/mobile-menu-fix.js
+++ b/docs/source/_static/js/mobile-menu-fix.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', function () {
       '.primary-toggle',
       '.secondary-toggle',
       '[data-toggle="collapse"]',
-      '[aria-controls][aria-expanded]'
+      '.navbar [aria-controls][aria-expanded]'
     ].join(',');
     const controls = Array.from(document.querySelectorAll(selectors));
     controls.forEach(el => {

--- a/docs/source/_static/js/mobile-menu-fix.js
+++ b/docs/source/_static/js/mobile-menu-fix.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', function () {
         // elements or elements in certain stacking contexts. Best-effort
         // bridge: prevent default then dispatch a MouseEvent click.
         try {
-          e.preventDefault();
+          // e.preventDefault(); // Removed to allow scrolling on touch devices
           this.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
         } catch (err) {
           // ignore errors

--- a/docs/source/_static/js/mobile-menu-fix.js
+++ b/docs/source/_static/js/mobile-menu-fix.js
@@ -1,0 +1,30 @@
+// Mobile menu fix: make touch interactions on mobile (iOS/Safari) reliably trigger
+// the mobile navigation toggle. Minimal, defensive enhancement.
+document.addEventListener('DOMContentLoaded', function () {
+  try {
+    const selectors = [
+      '.primary-toggle',
+      '.secondary-toggle',
+      '[data-toggle="collapse"]',
+      '[aria-controls][aria-expanded]'
+    ].join(',');
+    const controls = Array.from(document.querySelectorAll(selectors));
+    controls.forEach(el => {
+      if (el.__pymc_touchbound) return;
+      el.__pymc_touchbound = true;
+      el.addEventListener('touchstart', function (e) {
+        // iOS sometimes doesn't synthesize click events for transformed
+        // elements or elements in certain stacking contexts. Best-effort
+        // bridge: prevent default then dispatch a MouseEvent click.
+        try {
+          e.preventDefault();
+          this.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        } catch (err) {
+          // ignore errors
+        }
+      }, { passive: false });
+    });
+  } catch (err) {
+    // swallow errors to avoid breaking docs
+  }
+});

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -390,7 +390,16 @@ html_favicon = "../logos/PyMC.ico"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["../logos"]
+html_static_path = [
+    "../logos",
+    "_static",
+]
+html_css_files = [
+    "css/mobile-menu-fix.css",
+]
+html_js_files = [
+    "js/mobile-menu-fix.js",
+]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
This PR adds a small documentation-only fix to make the site navigation responsive on mobile (especially iOS/Safari).

What I changed
- Added `docs/source/_static/js/mobile-menu-fix.js` -- a small touchstart --> click bridge for mobile menu toggles.
- Added `docs/source/_static/css/mobile-menu-fix.css` -- z-index and pointer-events overrides to ensure the nav overlay and toggles are clickable on iOS.
- Updated `docs/source/conf.py` to include the CSS and JS via `html_static_path`, `html_css_files`, and `html_js_files`.

Why
- Users reported the hamburger menu and main header being non-responsive on mobile Safari (issue #7936). The changes are minimal and non-invasive; they override behavior via docs static assets rather than editing installed theme packages.

well ,I have check it it seems fine, (Sry for pr issue i am not good at writing pr had to use some tools but no use, peace !!) 
hope this pr will be fine, !!