### PR TITLE
Add background sampling handle to pm.sample

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,7 @@ jobs:
             tests/sampling/test_deterministic.py
             tests/sampling/test_forward.py
             tests/sampling/test_population.py
+            tests/sampling/test_background_sampling.py
             tests/stats/test_convergence.py
             tests/stats/test_log_density.py
             tests/distributions/test_distribution.py
@@ -190,7 +191,7 @@ jobs:
         python-version: ["3.11"]
         test-subset:
           - tests/variational/test_approximations.py tests/variational/test_callbacks.py tests/variational/test_inference.py tests/variational/test_opvi.py tests/test_initial_point.py
-          - tests/model/test_core.py tests/sampling/test_mcmc.py
+          - tests/model/test_core.py tests/sampling/test_mcmc.py tests/sampling/test_background_sampling.py
           - tests/gp/test_cov.py tests/gp/test_gp.py tests/gp/test_mean.py tests/gp/test_util.py tests/ode/test_ode.py tests/ode/test_utils.py tests/smc/test_smc.py tests/sampling/test_parallel.py
           - tests/step_methods/test_metropolis.py tests/step_methods/test_slicer.py tests/step_methods/hmc/test_nuts.py tests/step_methods/test_compound.py tests/step_methods/hmc/test_hmc.py tests/step_methods/test_state.py
 
@@ -247,6 +248,7 @@ jobs:
 
           - |
             tests/sampling/test_mcmc.py
+            tests/sampling/test_background_sampling.py
 
           - |
             tests/backends/test_arviz.py
@@ -347,7 +349,7 @@ jobs:
         floatx: [float32]
         python-version: ["3.13"]
         test-subset:
-        - tests/sampling/test_mcmc.py tests/ode/test_ode.py tests/ode/test_utils.py tests/distributions/test_transform.py
+        - tests/sampling/test_mcmc.py tests/ode/test_ode.py tests/ode/test_utils.py tests/distributions/test_transform.py tests/sampling/test_background_sampling.py
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -18,9 +18,9 @@ import contextlib
 import logging
 import pickle
 import sys
+import threading
 import time
 import warnings
-import threading
 
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import (
@@ -103,7 +103,7 @@ class BackgroundSampleHandle:
         def runner():
             try:
                 self._result = target(*args, **kwargs)
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 self._exception = exc
             finally:
                 self._done.set()

--- a/tests/sampling/test_background_sampling.py
+++ b/tests/sampling/test_background_sampling.py
@@ -1,0 +1,33 @@
+import pymc as pm
+import pytest
+
+
+def test_background_sampling_happy_path():
+    with pm.Model():
+        pm.Normal("x", 0, 1)
+        handle = pm.sample(
+            draws=20,
+            tune=10,
+            chains=1,
+            cores=1,
+            background=True,
+            progressbar=False,
+        )
+    idata = handle.result()
+    assert hasattr(idata, "posterior")
+    assert idata.posterior.sizes["chain"] >= 1
+
+
+def test_background_sampling_raises():
+    with pm.Model():
+        pm.Normal("x", 0, sigma=-1)
+        handle = pm.sample(
+            draws=10,
+            tune=5,
+            chains=1,
+            cores=1,
+            background=True,
+            progressbar=False,
+        )
+    with pytest.raises(Exception):
+        handle.result()

--- a/tests/sampling/test_background_sampling.py
+++ b/tests/sampling/test_background_sampling.py
@@ -1,5 +1,19 @@
-import pymc as pm
+#   Copyright 2025 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 import pytest
+
+import pymc as pm
 
 
 def test_background_sampling_happy_path():


### PR DESCRIPTION
## Description

This adds an opt-in background mode to `pm.sample` so users can start sampling and continue working while it runs in a background thread. When `background=True`, `pm.sample` returns a handle with `done()`, `result()`, and `exception()` helpers, and the progress bar is suppressed to keep output clean. Background mode is currently limited to the built-in `nuts_sampler="pymc"`; other samplers raise `NotImplementedError` to make the scope clear. The model is resolved eagerly so the background thread always has a valid context.

Docstring notes describe how to use `background=True` and the current limitations. Tests cover both a successful background run and error propagation (`tests/sampling/test_background_sampling.py`).

Summary of changes:
- Add `background` flag to `pm.sample` and return a `BackgroundSampleHandle` when enabled.
- Suppress progress bars in background mode.
- Resolve the model before launching the background thread.
- Document background mode in the `pm.sample` docstring.
- Add tests for background sampling (happy path and error propagation).

## Related Issue
- [x] Closes #7929

## Checklist
- [ ] Checked that pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a relevant logical change

## Type of change
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance