### PR TITLE
Allow constant branches in logprob of switch/join/make_vector

### DIFF
--- a/pymc/logprob/tensor.py
+++ b/pymc/logprob/tensor.py
@@ -160,8 +160,10 @@ def find_measurable_stacks(fgraph, node) -> list[TensorVariable] | None:
 
     if is_join:
         axis, *base_vars = node.inputs
+        axis = typing.cast(TensorVariable, axis)
+        base_vars = typing.cast(list[TensorVariable], base_vars)
     else:
-        base_vars = node.inputs
+        base_vars = typing.cast(list[TensorVariable], node.inputs)
 
     # Allow mixing potentially measurable inputs with deterministic ones.
     new_base_vars: list[TensorVariable] = []
@@ -171,7 +173,7 @@ def find_measurable_stacks(fgraph, node) -> list[TensorVariable] | None:
             has_measurable = True
             new_base_vars.append(base_var)
         else:
-            new_base_vars.append(dirac_delta(base_var))
+            new_base_vars.append(typing.cast(TensorVariable, dirac_delta(base_var)))
     if not has_measurable:
         return None
     base_vars = new_base_vars
@@ -185,7 +187,7 @@ def find_measurable_stacks(fgraph, node) -> list[TensorVariable] | None:
     replacements = [(base_var, promised_valued_rv(base_var)) for base_var in base_vars]
     temp_fgraph = FunctionGraph(outputs=base_vars, clone=False)
     toposort_replace(temp_fgraph, replacements)  # type: ignore[arg-type]
-    new_base_vars = temp_fgraph.outputs
+    new_base_vars = typing.cast(list[TensorVariable], temp_fgraph.outputs)
 
     if is_join:
         measurable_stack = MeasurableJoin()(axis, *new_base_vars)

--- a/tests/logprob/test_mixture.py
+++ b/tests/logprob/test_mixture.py
@@ -980,13 +980,20 @@ def test_switch_mixture_constant_branch_broadcast_ok():
     cat_fixed_dirac = pt.where(t > 5, cat, pm.DiracDelta.dist(-1, shape=cat.shape))
     vv_const = cat_fixed_const.clone()
     vv_dirac = cat_fixed_dirac.clone()
-    logp_const = logp(cat_fixed_const, vv_const, warn_rvs=False)
-    logp_dirac = logp(cat_fixed_dirac, vv_dirac, warn_rvs=False)
+    logp_const = logp(cat_fixed_const, vv_const)
+    logp_dirac = logp(cat_fixed_dirac, vv_dirac)
     test_value = np.where(np.arange(10) > 5, 0, -1).astype(vv_const.dtype)
     np.testing.assert_allclose(
         logp_const.eval({vv_const: test_value}),
         logp_dirac.eval({vv_dirac: test_value.astype(vv_dirac.dtype)}),
     )
+
+    bad_value = test_value.copy()
+    bad_value[0] = 0  # violates the deterministic branch requirement (-1)
+    bad_const = logp_const.eval({vv_const: bad_value})
+    bad_dirac = logp_dirac.eval({vv_dirac: bad_value.astype(vv_dirac.dtype)})
+    assert np.isneginf(bad_const[0])
+    assert np.isneginf(bad_dirac[0])
 
 
 def test_ifelse_mixture_one_component():

--- a/tests/logprob/test_tensor.py
+++ b/tests/logprob/test_tensor.py
@@ -101,6 +101,30 @@ def test_measurable_make_vector():
     assert np.isclose(make_vector_logp_eval.sum(), ref_logp_eval_eval)
 
 
+def test_measurable_make_vector_with_constant_input():
+    base1_rv = pt.random.normal(name="base1")
+    base2_rv = pt.random.halfnormal(name="base2")
+    y_rv = pt.stack((base1_rv, pt.constant(0.0), base2_rv))
+    y_rv.name = "y"
+    base1_vv = base1_rv.clone()
+    base2_vv = base2_rv.clone()
+    y_vv = y_rv.clone()
+    ref_logp = conditional_logp({base1_rv: base1_vv, base2_rv: base2_vv})
+    ref_logp_combined = pt.sum([pt.sum(factor) for factor in ref_logp.values()])
+    y_logp = logp(y_rv, y_vv)
+    base1_testval = base1_rv.eval()
+    base2_testval = base2_rv.eval()
+    y_testval = np.stack((base1_testval, 0.0, base2_testval)).astype(y_vv.dtype)
+    ref_logp_eval = ref_logp_combined.eval({base1_vv: base1_testval, base2_vv: base2_testval})
+    y_logp_eval = y_logp.eval({y_vv: y_testval})
+    assert y_logp_eval.shape == y_testval.shape
+    assert np.isclose(y_logp_eval.sum(), ref_logp_eval)
+    y_testval_bad = y_testval.copy()
+    y_testval_bad[1] = 1.0
+    y_logp_eval_bad = y_logp.eval({y_vv: y_testval_bad})
+    assert y_logp_eval_bad[1] == -np.inf
+
+
 @pytest.mark.parametrize("reverse", (False, True))
 def test_measurable_make_vector_interdependent(reverse):
     """Test that we can obtain a proper graph when stacked RVs depend on each other"""
@@ -188,6 +212,31 @@ def test_measurable_join_interdependent(reverse):
             }
         ),
     )
+
+
+def test_measurable_join_with_constant_input():
+    base1_rv = pt.random.normal(size=(2,), name="base1")
+    base2_rv = pt.random.exponential(size=(3,), name="base2")
+    const = pt.constant(np.array([0.0, 0.0, 0.0]))
+    y_rv = pt.join(0, base1_rv, const, base2_rv)
+    y_rv.name = "y"
+    base1_vv = base1_rv.clone()
+    base2_vv = base2_rv.clone()
+    y_vv = y_rv.clone()
+    ref_logp = conditional_logp({base1_rv: base1_vv, base2_rv: base2_vv})
+    ref_logp_combined = pt.sum([pt.sum(factor) for factor in ref_logp.values()])
+    y_logp = logp(y_rv, y_vv)
+    base1_testval = base1_rv.eval()
+    base2_testval = base2_rv.eval()
+    y_testval = np.concatenate([base1_testval, np.zeros(3), base2_testval]).astype(y_vv.dtype)
+    ref_logp_eval = ref_logp_combined.eval({base1_vv: base1_testval, base2_vv: base2_testval})
+    y_logp_eval = y_logp.eval({y_vv: y_testval})
+    assert y_logp_eval.shape == y_testval.shape
+    assert np.isclose(y_logp_eval.sum(), ref_logp_eval)
+    y_testval_bad = y_testval.copy()
+    y_testval_bad[2] = 1.0
+    y_logp_eval_bad = y_logp.eval({y_vv: y_testval_bad})
+    assert y_logp_eval_bad[2] == -np.inf
 
 
 @pytest.mark.parametrize(

--- a/tests/logprob/test_tensor.py
+++ b/tests/logprob/test_tensor.py
@@ -106,19 +106,25 @@ def test_measurable_make_vector_with_constant_input():
     base2_rv = pt.random.halfnormal(name="base2")
     y_rv = pt.stack((base1_rv, pt.constant(0.0), base2_rv))
     y_rv.name = "y"
+
     base1_vv = base1_rv.clone()
     base2_vv = base2_rv.clone()
     y_vv = y_rv.clone()
+
     ref_logp = conditional_logp({base1_rv: base1_vv, base2_rv: base2_vv})
     ref_logp_combined = pt.sum([pt.sum(factor) for factor in ref_logp.values()])
     y_logp = logp(y_rv, y_vv)
+
     base1_testval = base1_rv.eval()
     base2_testval = base2_rv.eval()
     y_testval = np.stack((base1_testval, 0.0, base2_testval)).astype(y_vv.dtype)
+
     ref_logp_eval = ref_logp_combined.eval({base1_vv: base1_testval, base2_vv: base2_testval})
     y_logp_eval = y_logp.eval({y_vv: y_testval})
+
     assert y_logp_eval.shape == y_testval.shape
     assert np.isclose(y_logp_eval.sum(), ref_logp_eval)
+
     y_testval_bad = y_testval.copy()
     y_testval_bad[1] = 1.0
     y_logp_eval_bad = y_logp.eval({y_vv: y_testval_bad})
@@ -220,19 +226,25 @@ def test_measurable_join_with_constant_input():
     const = pt.constant(np.array([0.0, 0.0, 0.0]))
     y_rv = pt.join(0, base1_rv, const, base2_rv)
     y_rv.name = "y"
+
     base1_vv = base1_rv.clone()
     base2_vv = base2_rv.clone()
     y_vv = y_rv.clone()
+
     ref_logp = conditional_logp({base1_rv: base1_vv, base2_rv: base2_vv})
     ref_logp_combined = pt.sum([pt.sum(factor) for factor in ref_logp.values()])
     y_logp = logp(y_rv, y_vv)
+
     base1_testval = base1_rv.eval()
     base2_testval = base2_rv.eval()
     y_testval = np.concatenate([base1_testval, np.zeros(3), base2_testval]).astype(y_vv.dtype)
+
     ref_logp_eval = ref_logp_combined.eval({base1_vv: base1_testval, base2_vv: base2_testval})
     y_logp_eval = y_logp.eval({y_vv: y_testval})
+
     assert y_logp_eval.shape == y_testval.shape
     assert np.isclose(y_logp_eval.sum(), ref_logp_eval)
+
     y_testval_bad = y_testval.copy()
     y_testval_bad[2] = 1.0
     y_logp_eval_bad = y_logp.eval({y_vv: y_testval_bad})


### PR DESCRIPTION
## Description
i relaxed the logp derivation restrictions for mixing measurable variables with compile time constants in branching/stacking ops. expressions like `pt.where(cond, rv, -1)` now produce a logp without requiring users to manually wrap constants in `pm.DiracDelta`.

### notes
- only compile time constants are accepted
- only constant branches are allowed to broadcast.


## Related Issue
- Closes [#7711](https://github.com/pymc-devs/pymc/issues/7711) 

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
