### PR TITLE
Remove `tune` stat from steps and fix non-discarding of tuning draws from trace

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -333,7 +333,7 @@ class InferenceDataConverter:
         data_warmup = {}
         for stat in self.trace.stat_names:
             name = rename_key.get(stat, stat)
-            if name == "tune":
+            if name in {"tune", "in_warmup"}:
                 continue
             if self.warmup_trace:
                 data_warmup[name] = np.array(

--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -17,14 +17,12 @@
 See the docstring for pymc.backends for more information
 """
 
-import inspect
 import itertools as itl
 import logging
 import warnings
 
 from abc import ABC
 from collections.abc import Mapping, Sequence, Sized
-from functools import cache
 from typing import (
     Any,
     TypeVar,
@@ -40,58 +38,6 @@ from pymc.pytensorf import compile
 from pymc.util import get_var_name
 
 logger = logging.getLogger(__name__)
-
-
-@cache
-def _record_supports_in_warmup(trace_type: type) -> str:
-    """Return how to call `trace.record` for this backend type.
-
-    Returns
-    -------
-    mode : {"kw", "no", "try"}
-        - "kw": safe to pass `in_warmup=` (parameter present or **kwargs supported)
-        - "no": do not pass `in_warmup=`
-        - "try": signature introspection failed; try `in_warmup=` and fallback on
-          unexpected-keyword errors.
-    """
-    try:
-        sig = inspect.signature(trace_type.record)
-    except (TypeError, ValueError):
-        return "try"
-
-    parameters = sig.parameters
-    if "in_warmup" in parameters:
-        return "kw"
-    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in parameters.values()):
-        return "kw"
-    return "no"
-
-
-def _record_with_in_warmup(
-    trace: "IBaseTrace",
-    draw: Mapping[str, np.ndarray],
-    stats: Sequence[Mapping[str, Any]],
-    *,
-    in_warmup: bool,
-):
-    """Record a draw, passing `in_warmup` when the backend supports it.
-
-    this will keep compatibility with custom traces that predate the `in_warmup` kwarg.
-    """
-    mode = _record_supports_in_warmup(type(trace))
-    if mode == "kw":
-        return trace.record(draw, stats, in_warmup=in_warmup)
-    if mode == "no":
-        return trace.record(draw, stats)
-
-    # fallback for backends we can't introspect reliably.
-    try:
-        return trace.record(draw, stats, in_warmup=in_warmup)
-    except TypeError as err:
-        message = str(err)
-        if "unexpected keyword argument" in message and "in_warmup" in message:
-            return trace.record(draw, stats)
-        raise
 
 
 class BackendError(Exception):

--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -113,7 +113,13 @@ class IBaseTrace(ABC, Sized):
         """
         raise NotImplementedError()
 
-    def record(self, draw: Mapping[str, np.ndarray], stats: Sequence[Mapping[str, Any]]):
+    def record(
+        self,
+        draw: Mapping[str, np.ndarray],
+        stats: Sequence[Mapping[str, Any]],
+        *,
+        tune: bool | None = None,
+    ):
         """Record results of a sampling iteration.
 
         Parameters
@@ -122,6 +128,9 @@ class IBaseTrace(ABC, Sized):
             Values mapped to variable names
         stats: list of dicts
             The diagnostic values for each sampler
+        tune: bool | None
+            Whether this draw belongs to the tuning/warmup phase. This is a driver-owned
+            concept and is intended for storage/backends to persist warmup information.
         """
         raise NotImplementedError()
 

--- a/pymc/backends/mcbackend.py
+++ b/pymc/backends/mcbackend.py
@@ -34,7 +34,6 @@ from pymc.step_methods.compound import (
     BlockedStep,
     CompoundStep,
     StatsBijection,
-    check_step_emits_tune,
     flat_statname,
     flatten_steps,
 )
@@ -209,8 +208,6 @@ def make_runmeta_and_point_fn(
     model: Model,
 ) -> tuple[mcb.RunMeta, PointFunc]:
     variables, point_fn = get_variables_and_point_fn(model, initial_point)
-
-    check_step_emits_tune(step)
 
     # In PyMC the sampler stats are grouped by the sampler.
     sample_stats = []

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -97,7 +97,7 @@ class NDArray(base.BaseTrace):
                     new = np.zeros(draws, dtype=dtype)
                     data[varname] = np.concatenate([old, new])
 
-    def record(self, point, sampler_stats=None) -> None:
+    def record(self, point, sampler_stats=None, *, tune: bool | None = None) -> None:
         """Record results of a sampling iteration.
 
         Parameters

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -97,7 +97,7 @@ class NDArray(base.BaseTrace):
                     new = np.zeros(draws, dtype=dtype)
                     data[varname] = np.concatenate([old, new])
 
-    def record(self, point, sampler_stats=None, *, tune: bool | None = None) -> None:
+    def record(self, point, sampler_stats=None, *, in_warmup: bool) -> None:
         """Record results of a sampling iteration.
 
         Parameters

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -238,5 +238,5 @@ def point_list_to_multitrace(
 
         chain.fn = point_fun
         for point in point_list:
-            chain.record(point)
+            chain.record(point, in_warmup=False)
     return MultiTrace([chain])

--- a/pymc/backends/zarr.py
+++ b/pymc/backends/zarr.py
@@ -163,7 +163,7 @@ class ZarrChain(BaseTrace):
         draw: Mapping[str, np.ndarray],
         stats: Sequence[Mapping[str, Any]],
         *,
-        tune: bool | None = None,
+        in_warmup: bool,
     ) -> bool | None:
         """Record the step method's returned draw and stats.
 
@@ -189,7 +189,7 @@ class ZarrChain(BaseTrace):
                 self.buffer(group="posterior", var_name=var_name, value=var_value)
         for var_name, var_value in self.stats_bijection.map(stats).items():
             self.buffer(group="sample_stats", var_name=var_name, value=var_value)
-        self.buffer(group="sample_stats", var_name="tune", value=bool(tune))
+        self.buffer(group="sample_stats", var_name="in_warmup", value=bool(in_warmup))
         self._buffered_draws += 1
         if self._buffered_draws == self.draws_until_flush:
             self.flush()
@@ -530,7 +530,7 @@ class ZarrTrace:
         stats_dtypes_shapes = get_stats_dtypes_shapes_from_steps(
             [step] if isinstance(step, BlockedStep) else step.methods
         )
-        stats_dtypes_shapes = {"tune": (bool, [])} | stats_dtypes_shapes
+        stats_dtypes_shapes = {"in_warmup": (bool, [])} | stats_dtypes_shapes
         self.init_group_with_empty(
             group=self.root.create_group(name="sample_stats", overwrite=True),
             var_dtype_and_shape=stats_dtypes_shapes,

--- a/pymc/backends/zarr.py
+++ b/pymc/backends/zarr.py
@@ -159,7 +159,11 @@ class ZarrChain(BaseTrace):
         buffer[var_name].append(value)
 
     def record(
-        self, draw: Mapping[str, np.ndarray], stats: Sequence[Mapping[str, Any]]
+        self,
+        draw: Mapping[str, np.ndarray],
+        stats: Sequence[Mapping[str, Any]],
+        *,
+        tune: bool | None = None,
     ) -> bool | None:
         """Record the step method's returned draw and stats.
 
@@ -185,6 +189,7 @@ class ZarrChain(BaseTrace):
                 self.buffer(group="posterior", var_name=var_name, value=var_value)
         for var_name, var_value in self.stats_bijection.map(stats).items():
             self.buffer(group="sample_stats", var_name=var_name, value=var_value)
+        self.buffer(group="sample_stats", var_name="tune", value=bool(tune))
         self._buffered_draws += 1
         if self._buffered_draws == self.draws_until_flush:
             self.flush()
@@ -525,6 +530,7 @@ class ZarrTrace:
         stats_dtypes_shapes = get_stats_dtypes_shapes_from_steps(
             [step] if isinstance(step, BlockedStep) else step.methods
         )
+        stats_dtypes_shapes = {"tune": (bool, [])} | stats_dtypes_shapes
         self.init_group_with_empty(
             group=self.root.create_group(name="sample_stats", overwrite=True),
             var_dtype_and_shape=stats_dtypes_shapes,

--- a/pymc/backends/zarr.py
+++ b/pymc/backends/zarr.py
@@ -689,6 +689,7 @@ class ZarrTrace:
                 for i, shape_i in enumerate(shape):
                     dim = f"{name}_dim_{i}"
                     dims.append(dim)
+                    assert shape_i is not None, f"{dim} shape is None"
                     group_coords[dim] = np.arange(shape_i, dtype="int")
             dims = ("chain", "draw", *dims)
             attrs = extra_var_attrs[name] if extra_var_attrs is not None else {}

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -47,7 +47,7 @@ from pymc.backends.arviz import (
     find_constants,
     find_observations,
 )
-from pymc.backends.base import IBaseTrace, MultiTrace, _choose_chains, _record_with_in_warmup
+from pymc.backends.base import IBaseTrace, MultiTrace, _choose_chains
 from pymc.backends.zarr import ZarrChain, ZarrTrace
 from pymc.blocking import DictToArrayBijection
 from pymc.exceptions import SamplingError
@@ -1367,7 +1367,7 @@ def _iter_sample(
                 step.stop_tuning()
 
             point, stats = step.step(point)
-            _record_with_in_warmup(trace, point, stats, in_warmup=i < tune)
+            trace.record(point, stats, in_warmup=i < tune)
             log_warning_stats(stats)
 
             if callback is not None:
@@ -1480,9 +1480,7 @@ def _mp_sample(
                     strace = traces[draw.chain]
                     if not zarr_recording:
                         # Zarr recording happens in each process
-                        _record_with_in_warmup(
-                            strace, draw.point, draw.stats, in_warmup=draw.tuning
-                        )
+                        strace.record(draw.point, draw.stats, in_warmup=draw.tuning)
                     log_warning_stats(draw.stats)
 
                     if callback is not None:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -47,7 +47,7 @@ from pymc.backends.arviz import (
     find_constants,
     find_observations,
 )
-from pymc.backends.base import IBaseTrace, MultiTrace, _choose_chains
+from pymc.backends.base import IBaseTrace, MultiTrace, _choose_chains, _record_with_in_warmup
 from pymc.backends.zarr import ZarrChain, ZarrTrace
 from pymc.blocking import DictToArrayBijection
 from pymc.exceptions import SamplingError
@@ -1367,7 +1367,7 @@ def _iter_sample(
                 step.stop_tuning()
 
             point, stats = step.step(point)
-            trace.record(point, stats, tune=i < tune)
+            _record_with_in_warmup(trace, point, stats, in_warmup=i < tune)
             log_warning_stats(stats)
 
             if callback is not None:
@@ -1480,7 +1480,9 @@ def _mp_sample(
                     strace = traces[draw.chain]
                     if not zarr_recording:
                         # Zarr recording happens in each process
-                        strace.record(draw.point, draw.stats, tune=draw.tuning)
+                        _record_with_in_warmup(
+                            strace, draw.point, draw.stats, in_warmup=draw.tuning
+                        )
                     log_warning_stats(draw.stats)
 
                     if callback is not None:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1124,18 +1124,10 @@ def _sample_return(
     else:
         traces, length = _choose_chains(traces, 0)
     mtrace = MultiTrace(traces)[:length]
-    # count the number of tune/draw iterations that happened
-    # ideally via the "tune" statistic, but not all samplers record it!
-    if "tune" in mtrace.stat_names:
-        # Get the tune stat directly from chain 0, sampler 0
-        stat = mtrace._straces[0].get_sampler_stats("tune", sampler_idx=0)
-        stat = tuple(stat)
-        n_tune = stat.count(True)
-        n_draws = stat.count(False)
-    else:
-        # these may be wrong when KeyboardInterrupt happened, but they're better than nothing
-        n_tune = min(tune, len(mtrace))
-        n_draws = max(0, len(mtrace) - n_tune)
+    # Count the number of tune/draw iterations that happened.
+    # The warmup/draw boundary is owned by the sampling driver.
+    n_tune = min(tune, len(mtrace))
+    n_draws = max(0, len(mtrace) - n_tune)
 
     if discard_tuned_samples:
         mtrace = mtrace[n_tune:]

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1296,7 +1296,7 @@ def _sample(
     try:
         for it, stats in enumerate(sampling_gen):
             progress_manager.update(
-                chain_idx=chain, is_last=False, draw=it, stats=stats, tuning=it > tune
+                chain_idx=chain, is_last=False, draw=it, stats=stats, tuning=it < tune
             )
 
         if not progress_manager.combined_progress or chain == progress_manager.chains - 1:
@@ -1367,7 +1367,7 @@ def _iter_sample(
                 step.stop_tuning()
 
             point, stats = step.step(point)
-            trace.record(point, stats)
+            trace.record(point, stats, tune=i < tune)
             log_warning_stats(stats)
 
             if callback is not None:
@@ -1480,7 +1480,7 @@ def _mp_sample(
                     strace = traces[draw.chain]
                     if not zarr_recording:
                         # Zarr recording happens in each process
-                        strace.record(draw.point, draw.stats)
+                        strace.record(draw.point, draw.stats, tune=draw.tuning)
                     log_warning_stats(draw.stats)
 
                     if callback is not None:

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -249,7 +249,7 @@ class _Process:
                 raise KeyboardInterrupt()
             elif msg[0] == "write_next":
                 if zarr_recording:
-                    self._zarr_chain.record(point, stats)
+                    self._zarr_chain.record(point, stats, tune=tuning)
                 self._write_point(point)
                 is_last = draw + 1 == self._draws + self._tune
                 self._msg_pipe.send(("writing_done", is_last, draw, tuning, stats))

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -249,7 +249,7 @@ class _Process:
                 raise KeyboardInterrupt()
             elif msg[0] == "write_next":
                 if zarr_recording:
-                    self._zarr_chain.record(point, stats, tune=tuning)
+                    self._zarr_chain.record(point, stats, in_warmup=tuning)
                 self._write_point(point)
                 is_last = draw + 1 == self._draws + self._tune
                 self._msg_pipe.send(("writing_done", is_last, draw, tuning, stats))

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -26,7 +26,7 @@ import numpy as np
 
 from rich.progress import BarColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 
-from pymc.backends.base import BaseTrace, _record_with_in_warmup
+from pymc.backends.base import BaseTrace
 from pymc.backends.zarr import ZarrChain
 from pymc.initial_point import PointType
 from pymc.model import Model, modelcontext
@@ -458,7 +458,7 @@ def _iter_population(
                 # apply the update to the points and record to the traces
                 for c, strace in enumerate(traces):
                     points[c], stats = updates[c]
-                    flushed = _record_with_in_warmup(strace, points[c], stats, in_warmup=i < tune)
+                    flushed = strace.record(points[c], stats, in_warmup=i < tune)
                     log_warning_stats(stats)
                     if flushed and isinstance(strace, ZarrChain):
                         sampling_state = popstep.request_sampling_state(c)

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -458,7 +458,7 @@ def _iter_population(
                 # apply the update to the points and record to the traces
                 for c, strace in enumerate(traces):
                     points[c], stats = updates[c]
-                    flushed = strace.record(points[c], stats)
+                    flushed = strace.record(points[c], stats, tune=i < tune)
                     log_warning_stats(stats)
                     if flushed and isinstance(strace, ZarrChain):
                         sampling_state = popstep.request_sampling_state(c)

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -26,7 +26,7 @@ import numpy as np
 
 from rich.progress import BarColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 
-from pymc.backends.base import BaseTrace
+from pymc.backends.base import BaseTrace, _record_with_in_warmup
 from pymc.backends.zarr import ZarrChain
 from pymc.initial_point import PointType
 from pymc.model import Model, modelcontext
@@ -458,7 +458,7 @@ def _iter_population(
                 # apply the update to the points and record to the traces
                 for c, strace in enumerate(traces):
                     points[c], stats = updates[c]
-                    flushed = strace.record(points[c], stats, tune=i < tune)
+                    flushed = _record_with_in_warmup(strace, points[c], stats, in_warmup=i < tune)
                     log_warning_stats(stats)
                     if flushed and isinstance(strace, ZarrChain):
                         sampling_state = popstep.request_sampling_state(c)

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -414,7 +414,7 @@ def _build_trace_from_kernel_state(
                 var_samples = np.round(var_samples).astype(var.dtype)
             value.append(var_samples.reshape(shape))
             size += new_size
-        strace.record(point=dict(zip(varnames, value)))
+        strace.record(point=dict(zip(varnames, value)), in_warmup=False)
 
     return strace
 

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -355,10 +355,6 @@ def flatten_steps(step: BlockedStep | CompoundStep) -> list[BlockedStep]:
     return steps
 
 
-def check_step_emits_tune(step: CompoundStep | BlockedStep):
-    return
-
-
 class StatsBijection:
     """Map between a `list` of stats to `dict` of stats."""
 

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -92,6 +92,10 @@ def infer_warn_stats_info(
                 sds[sname] = (dtype, None)
     elif sds:
         stats_dtypes.append({sname: dtype for sname, (dtype, _) in sds.items()})
+
+    # Even when a step method does not emit any stats, downstream components still assume one stats "slot" per step method. represent that with a single empty dict.
+    if not stats_dtypes:
+        stats_dtypes.append({})
     return stats_dtypes, sds
 
 
@@ -352,12 +356,6 @@ def flatten_steps(step: BlockedStep | CompoundStep) -> list[BlockedStep]:
 
 
 def check_step_emits_tune(step: CompoundStep | BlockedStep):
-    if isinstance(step, BlockedStep) and "tune" not in step.stats_dtypes_shapes:
-        raise TypeError(f"{type(step)} does not emit the required 'tune' stat.")
-    elif isinstance(step, CompoundStep):
-        for sstep in step.methods:
-            if "tune" not in sstep.stats_dtypes_shapes:
-                raise TypeError(f"{type(sstep)} does not emit the required 'tune' stat.")
     return
 
 

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -273,7 +273,6 @@ class BaseHMC(GradientSharedStep):
         self.iter_count += 1
 
         stats: dict[str, Any] = {
-            "tune": self.tune,
             "diverging": diverging,
             "divergences": self.divergences,
             "perf_counter_diff": perf_end - perf_start,

--- a/pymc/step_methods/hmc/hmc.py
+++ b/pymc/step_methods/hmc/hmc.py
@@ -53,7 +53,6 @@ class HamiltonianMC(BaseHMC):
     stats_dtypes_shapes = {
         "step_size": (np.float64, []),
         "n_steps": (np.int64, []),
-        "tune": (bool, []),
         "step_size_bar": (np.float64, []),
         "accept": (np.float64, []),
         "diverging": (bool, []),

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -110,7 +110,6 @@ class NUTS(BaseHMC):
     stats_dtypes_shapes = {
         "depth": (np.int64, []),
         "step_size": (np.float64, []),
-        "tune": (bool, []),
         "mean_tree_accept": (np.float64, []),
         "step_size_bar": (np.float64, []),
         "tree_size": (np.float64, []),

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -531,7 +531,6 @@ class BinaryMetropolis(ArrayStep):
 
 @dataclass_state
 class BinaryGibbsMetropolisState(StepMethodState):
-    tune: bool
     transit_p: int
     shuffle_dims: bool
     order: list
@@ -586,7 +585,6 @@ class BinaryGibbsMetropolis(ArrayStep):
     ):
         model = pm.modelcontext(model)
 
-        self.tune = True
         # transition probabilities
         self.transit_p = transit_p
 

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -146,7 +146,6 @@ class Metropolis(ArrayStepShared):
     stats_dtypes_shapes = {
         "accept": (np.float64, []),
         "accepted": (np.float64, []),
-        "tune": (bool, []),
         "scaling": (np.float64, []),
     }
 
@@ -316,7 +315,6 @@ class Metropolis(ArrayStepShared):
         self.steps_until_tune -= 1
 
         stats = {
-            "tune": self.tune,
             "scaling": np.mean(self.scaling),
             "accept": np.mean(np.exp(self.accept_rate_iter)),
             "accepted": np.mean(self.accepted_iter),
@@ -331,7 +329,6 @@ class Metropolis(ArrayStepShared):
     @staticmethod
     def _progressbar_config(n_chains=1):
         columns = [
-            TextColumn("{task.fields[tune]}", table_column=Column("Tuning", ratio=1)),
             TextColumn("{task.fields[scaling]:0.2f}", table_column=Column("Scaling", ratio=1)),
             TextColumn(
                 "{task.fields[accept_rate]:0.2f}", table_column=Column("Accept Rate", ratio=1)
@@ -339,7 +336,6 @@ class Metropolis(ArrayStepShared):
         ]
 
         stats = {
-            "tune": [True] * n_chains,
             "scaling": [0] * n_chains,
             "accept_rate": [0.0] * n_chains,
         }
@@ -351,7 +347,7 @@ class Metropolis(ArrayStepShared):
         def update_stats(step_stats):
             return {
                 "accept_rate" if key == "accept" else key: step_stats[key]
-                for key in ("tune", "accept", "scaling")
+                for key in ("accept", "scaling")
             }
 
         return (update_stats,)
@@ -448,7 +444,6 @@ class BinaryMetropolis(ArrayStep):
 
     stats_dtypes_shapes = {
         "accept": (np.float64, []),
-        "tune": (bool, []),
         "p_jump": (np.float64, []),
     }
 
@@ -505,7 +500,6 @@ class BinaryMetropolis(ArrayStep):
         self.accepted += accepted
 
         stats = {
-            "tune": self.tune,
             "accept": np.exp(accept),
             "p_jump": p_jump,
         }
@@ -574,9 +568,7 @@ class BinaryGibbsMetropolis(ArrayStep):
 
     name = "binary_gibbs_metropolis"
 
-    stats_dtypes_shapes = {
-        "tune": (bool, []),
-    }
+    stats_dtypes_shapes = {}
 
     _state_class = BinaryGibbsMetropolisState
 
@@ -594,8 +586,6 @@ class BinaryGibbsMetropolis(ArrayStep):
     ):
         model = pm.modelcontext(model)
 
-        # Doesn't actually tune, but it's required to emit a sampler stat
-        # that indicates whether a draw was done in a tuning phase.
         self.tune = True
         # transition probabilities
         self.transit_p = transit_p
@@ -649,10 +639,7 @@ class BinaryGibbsMetropolis(ArrayStep):
                 if accepted:
                     logp_curr = logp_prop
 
-        stats = {
-            "tune": self.tune,
-        }
-        return q, [stats]
+        return q, [{}]
 
     @staticmethod
     def competence(var):
@@ -695,9 +682,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
 
     name = "categorical_gibbs_metropolis"
 
-    stats_dtypes_shapes = {
-        "tune": (bool, []),
-    }
+    stats_dtypes_shapes = {}
 
     _state_class = CategoricalGibbsMetropolisState
 
@@ -793,7 +778,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
                 logp_curr = logp_prop
 
         # This step doesn't have any tunable parameters
-        return q, [{"tune": False}]
+        return q, [{}]
 
     def astep_prop(self, apoint: RaveledVars, *args) -> tuple[RaveledVars, StatsType]:
         logp = args[0]
@@ -811,7 +796,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
             logp_curr = self.metropolis_proportional(q, logp, logp_curr, dim, k)
 
         # This step doesn't have any tunable parameters
-        return q, [{"tune": False}]
+        return q, [{}]
 
     def astep(self, apoint: RaveledVars, *args) -> tuple[RaveledVars, StatsType]:
         raise NotImplementedError()
@@ -919,7 +904,6 @@ class DEMetropolis(PopulationArrayStepShared):
     stats_dtypes_shapes = {
         "accept": (np.float64, []),
         "accepted": (bool, []),
-        "tune": (bool, []),
         "scaling": (np.float64, []),
         "lambda": (np.float64, []),
     }
@@ -1011,7 +995,6 @@ class DEMetropolis(PopulationArrayStepShared):
         self.steps_until_tune -= 1
 
         stats = {
-            "tune": self.tune,
             "scaling": self.scaling,
             "lambda": self.lamb,
             "accept": np.exp(accept),
@@ -1090,7 +1073,6 @@ class DEMetropolisZ(ArrayStepShared):
     stats_dtypes_shapes = {
         "accept": (np.float64, []),
         "accepted": (bool, []),
-        "tune": (bool, []),
         "scaling": (np.float64, []),
         "lambda": (np.float64, []),
     }
@@ -1213,7 +1195,6 @@ class DEMetropolisZ(ArrayStepShared):
         self.steps_until_tune -= 1
 
         stats = {
-            "tune": self.tune,
             "scaling": np.mean(self.scaling),
             "lambda": self.lamb,
             "accept": np.exp(accept),

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -72,7 +72,6 @@ class Slice(ArrayStepShared):
     name = "slice"
     default_blocked = False
     stats_dtypes_shapes = {
-        "tune": (bool, []),
         "nstep_out": (int, []),
         "nstep_in": (int, []),
     }
@@ -184,7 +183,6 @@ class Slice(ArrayStepShared):
             self.n_tunes += 1
 
         stats = {
-            "tune": self.tune,
             "nstep_out": nstep_out,
             "nstep_in": nstep_in,
         }
@@ -202,18 +200,17 @@ class Slice(ArrayStepShared):
     @staticmethod
     def _progressbar_config(n_chains=1):
         columns = [
-            TextColumn("{task.fields[tune]}", table_column=Column("Tuning", ratio=1)),
             TextColumn("{task.fields[nstep_out]}", table_column=Column("Steps out", ratio=1)),
             TextColumn("{task.fields[nstep_in]}", table_column=Column("Steps in", ratio=1)),
         ]
 
-        stats = {"tune": [True] * n_chains, "nstep_out": [0] * n_chains, "nstep_in": [0] * n_chains}
+        stats = {"nstep_out": [0] * n_chains, "nstep_in": [0] * n_chains}
 
         return columns, stats
 
     @staticmethod
     def _make_progressbar_update_functions():
         def update_stats(step_stats):
-            return {key: step_stats[key] for key in {"tune", "nstep_out", "nstep_in"}}
+            return {key: step_stats[key] for key in {"nstep_out", "nstep_in"}}
 
         return (update_stats,)

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1598,7 +1598,7 @@ class Approximation(WithMemoization):
         try:
             trace.setup(draws=draws, chain=0)
             for point in points:
-                trace.record(point)
+                trace.record(point, in_warmup=False)
         finally:
             trace.close()
 

--- a/tests/backends/fixtures.py
+++ b/tests/backends/fixtures.py
@@ -195,11 +195,11 @@ class ModelBackendSampledTestCase:
                 stats2 = [
                     {key: val[idx] for key, val in stats.items()} for stats in cls.expected_stats[1]
                 ]
-                strace0.record(point=point0, sampler_stats=stats1)
-                strace1.record(point=point1, sampler_stats=stats2)
+                strace0.record(point=point0, sampler_stats=stats1, in_warmup=False)
+                strace1.record(point=point1, sampler_stats=stats2, in_warmup=False)
             else:
-                strace0.record(point=point0)
-                strace1.record(point=point1)
+                strace0.record(point=point0, in_warmup=False)
+                strace1.record(point=point1, in_warmup=False)
         strace0.close()
         strace1.close()
         cls.mtrace = base.MultiTrace([strace0, strace1])
@@ -244,9 +244,9 @@ class SamplingTestCase(ModelBackendSetupTestCase):
         }
         if self.sampler_vars is not None:
             stats = [{key: dtype(val) for key, dtype in vars.items()} for vars in self.sampler_vars]
-            self.strace.record(point=point, sampler_stats=stats)
+            self.strace.record(point=point, sampler_stats=stats, in_warmup=False)
         else:
-            self.strace.record(point=point)
+            self.strace.record(point=point, in_warmup=False)
 
     def test_standard_close(self):
         for idx in range(self.draws):
@@ -270,7 +270,7 @@ class SamplingTestCase(ModelBackendSetupTestCase):
     def test_missing_stats(self):
         if self.sampler_vars is not None:
             with pytest.raises(ValueError):
-                self.strace.record(point=self.test_point)
+                self.strace.record(point=self.test_point, in_warmup=False)
 
     def test_clean_interrupt(self):
         self.record_point(0)

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -749,9 +749,9 @@ class TestPyMCWarmupHandling:
         post_prefix = "" if draws > 0 else "~"
         test_dict = {
             f"{post_prefix}posterior": ["u1", "n1"],
-            f"{post_prefix}sample_stats": ["~tune", "accept"],
+            f"{post_prefix}sample_stats": ["~in_warmup", "accept"],
             f"{warmup_prefix}warmup_posterior": ["u1", "n1"],
-            f"{warmup_prefix}warmup_sample_stats": ["~tune"],
+            f"{warmup_prefix}warmup_sample_stats": ["~in_warmup"],
             "~warmup_log_likelihood": [],
             "~log_likelihood": [],
         }
@@ -786,9 +786,9 @@ class TestPyMCWarmupHandling:
             idata = to_inference_data(trace, save_warmup=True)
             test_dict = {
                 "posterior": ["u1", "n1"],
-                "sample_stats": ["~tune", "accept"],
+                "sample_stats": ["~in_warmup", "accept"],
                 "warmup_posterior": ["u1", "n1"],
-                "warmup_sample_stats": ["~tune", "accept"],
+                "warmup_sample_stats": ["~in_warmup", "accept"],
             }
             fails = check_multiple_attrs(test_dict, idata)
             assert not fails
@@ -800,7 +800,7 @@ class TestPyMCWarmupHandling:
                 idata = to_inference_data(trace[-30:], save_warmup=True)
             test_dict = {
                 "posterior": ["u1", "n1"],
-                "sample_stats": ["~tune", "accept"],
+                "sample_stats": ["~in_warmup", "accept"],
                 "~warmup_posterior": [],
                 "~warmup_sample_stats": [],
             }

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -43,7 +43,7 @@ class TestInitTrace:
             B = pm.Uniform("B")
             strace = pm.backends.ndarray.NDArray(vars=[A, B])
             strace.setup(10, 0)
-            strace.record({"A": 2, "B_interval__": 0.1})
+            strace.record({"A": 2, "B_interval__": 0.1}, in_warmup=False)
             assert len(strace) == 1
             with pytest.raises(ValueError, match="Continuation of traces"):
                 _init_trace(

--- a/tests/backends/test_mcbackend.py
+++ b/tests/backends/test_mcbackend.py
@@ -119,7 +119,8 @@ def test_make_runmeta_and_point_fn(simple_model):
     assert not vars["vector"].is_deterministic
     assert not vars["vector_interval__"].is_deterministic
     assert vars["matrix"].is_deterministic
-    assert len(rmeta.sample_stats) == len(step.stats_dtypes[0])
+    assert "in_warmup" in {s.name for s in rmeta.sample_stats}
+    assert len(rmeta.sample_stats) == len(step.stats_dtypes[0]) + 1
 
     with simple_model:
         step = pm.NUTS()
@@ -201,7 +202,7 @@ class TestChainRecordAdapter:
         for i in range(N):
             draw = {"a": rng.normal(), "b_interval__": rng.normal()}
             stats = [{"tune": (i <= 5), "s1": i, "accepted": bool(rng.randint(0, 2))}]
-            cra.record(draw, stats)
+            cra.record(draw, stats, in_warmup=i <= 5)
 
         # Check final state of the chain
         assert len(cra) == N
@@ -254,7 +255,7 @@ class TestChainRecordAdapter:
                 {"tune": tune, "s1": i, "accepted": bool(rng.randint(0, 2))},
                 {"tune": tune, "s2": i, "accepted": bool(rng.randint(0, 2))},
             ]
-            cra.record(draw, stats)
+            cra.record(draw, stats, in_warmup=tune)
 
         # The 'accepted' stat was emitted by both samplers
         assert cra.get_sampler_stats("accepted", sampler_idx=None).shape == (N, 2)
@@ -293,11 +294,20 @@ class TestMcBackendSampling:
                 return_inferencedata=False,
             )
         assert isinstance(mtrace, pm.backends.base.MultiTrace)
-        # warmup is tracked by the sampling driver
+        in_warmup = mtrace.get_sampler_stats("in_warmup", combine=False, squeeze=False)
+        assert len(in_warmup) == 3
+        assert all(s.dtype == np.dtype(bool) for s in in_warmup)
+
+        # Warmup is tracked by the sampling driver and persisted via `in_warmup`.
         if discard_warmup:
             assert len(mtrace) == 7
+            assert all(len(s) == 7 for s in in_warmup)
+            assert all(not np.any(s) for s in in_warmup)
         else:
             assert len(mtrace) == 12
+            assert all(len(s) == 12 for s in in_warmup)
+            assert all(np.all(s[:5]) for s in in_warmup)
+            assert all(not np.any(s[5:]) for s in in_warmup)
 
     @pytest.mark.parametrize("cores", [1, 3])
     def test_return_inferencedata(self, simple_model, cores):

--- a/tests/backends/test_mcbackend.py
+++ b/tests/backends/test_mcbackend.py
@@ -293,13 +293,11 @@ class TestMcBackendSampling:
                 return_inferencedata=False,
             )
         assert isinstance(mtrace, pm.backends.base.MultiTrace)
-        tune = mtrace._straces[0].get_sampler_stats("tune")
-        assert isinstance(tune, np.ndarray)
+        # warmup is tracked by the sampling driver
         if discard_warmup:
-            assert tune.shape == (7, 3)
+            assert len(mtrace) == 7
         else:
-            assert tune.shape == (12, 3)
-        pass
+            assert len(mtrace) == 12
 
     @pytest.mark.parametrize("cores", [1, 3])
     def test_return_inferencedata(self, simple_model, cores):

--- a/tests/backends/test_zarr.py
+++ b/tests/backends/test_zarr.py
@@ -132,7 +132,7 @@ def test_record(model, model_step, include_transformed, draws_per_chunk):
         else:
             manually_collected_draws.append(point)
             manually_collected_stats.append(stats)
-        trace.straces[0].record(point, stats)
+        trace.straces[0].record(point, stats, in_warmup=tuning)
     trace.straces[0].record_sampling_state(model_step)
     assert {group_name for group_name, _ in trace.root.groups()} == expected_groups
 

--- a/tests/step_methods/hmc/test_nuts.py
+++ b/tests/step_methods/hmc/test_nuts.py
@@ -157,7 +157,6 @@ class TestNutsCheckTrace:
             "step_size",
             "step_size_bar",
             "tree_size",
-            "tune",
             "perf_counter_diff",
             "perf_counter_start",
             "process_time_diff",

--- a/tests/step_methods/test_compound.py
+++ b/tests/step_methods/test_compound.py
@@ -36,11 +36,11 @@ from tests.helpers import StepMethodTester
 from tests.models import simple_2model_continuous
 
 
-def test_all_stepmethods_emit_tune_stat():
+def test_stepmethods_do_not_require_tune_stat():
     step_types = pm.step_methods.STEP_METHODS
     assert len(step_types) > 5
     for cls in step_types:
-        assert "tune" in cls.stats_dtypes_shapes
+        assert "tune" not in cls.stats_dtypes_shapes
 
 
 class TestCompoundStep:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
I tried to make “tuning vs draws” a driver owned concept again. Right now, parts of sampling/postprocessing infer warmup length from a per-step `"tune"` sampler stat, which can get out of sync (e.g. a step method returning `"tune": False` everywhere makes PyMC think `n_tune == 0`, so warmup isn’t discarded and the logs look wrong).


## Related Issues
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
Fixes: [#7997](https://github.com/pymc-devs/pymc/issues/7997) 
Context: [#7776](https://github.com/pymc-devs/pymc/pull/7776) (progressbar/stat refactor that exposed the mismatch)
Related discussion/attempts: [#7730](https://github.com/pymc-devs/pymc/pull/7730), [#7721](https://github.com/pymc-devs/pymc/issues/7721), [#7724](https://github.com/pymc-devs/pymc/issues/7724), [#8014](https://github.com/pymc-devs/pymc/pull/8014)


