### PR TITLE
Investigate test custom dist float32

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -240,6 +240,9 @@ def test_get_value_vars_from_user_vars():
         x2 = pm.Normal("x2", mu=0, sigma=1)
         y2 = pm.Normal("y2", mu=0, sigma=1)
         det2 = pm.Deterministic("det2", x2 + y2)
+        
+    with pm.Model() as model:
+        assert get_value_vars_from_user_vars([], model) == []
 
     prefix = "The following variables are not random variables in the model:"
     with pytest.raises(ValueError, match=rf"{prefix} \['x2', 'y2'\]"):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -240,7 +240,7 @@ def test_get_value_vars_from_user_vars():
         x2 = pm.Normal("x2", mu=0, sigma=1)
         y2 = pm.Normal("y2", mu=0, sigma=1)
         det2 = pm.Deterministic("det2", x2 + y2)
-        
+
     with pm.Model() as model:
         assert get_value_vars_from_user_vars([], model) == []
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
This is a draft PR opened to track ongoing investigation of a CI failure in
`TestSimulator.test_custom_dist_sum_stat[float32]`.

At the moment, the failure:
- occurs on CI with Python 3.14
- has not been reproducible locally on Python 3.12
- persists even when matching numba/scipy versions

This PR is opened early to:
- signal that investigation is in progress
- avoid duplicated effort from other contributors
- collect feedback from maintainers if needed

No functional changes have been introduced yet.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #8012 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
