### PR TITLE
Implement batch evaluation of RV shapes in get_plates

### DIFF
--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -342,9 +342,7 @@ class ModelGraph:
         all_vars = self.vars_to_plot(var_names)
         all_nodes = [self.model[v] for v in all_vars]
 
-        import pytensor
-
-        shapes_fn = pytensor.function([], [v.shape for v in all_nodes], mode=_cheap_eval_mode)
+        shapes_fn = function([], [v.shape for v in all_nodes], mode=_cheap_eval_mode)
         all_shapes = shapes_fn()
 
         var_shapes: dict[str, tuple[int, ...]] = {

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -326,13 +326,13 @@ class ModelGraph:
     def get_plates(
         self,
         var_names: Iterable[str] | None = None,
-        ) -> list[Plate]:
+    ) -> list[Plate]:
         """Rough but surprisingly accurate plate detection.
 
         Just groups by the shape of the underlying distribution.  Will be wrong
         if there are two plates with the same shape.
 
-         Returns
+        Returns
         -------
         dict
         Maps plate labels to the set of strings inside the plate.
@@ -343,6 +343,7 @@ class ModelGraph:
         all_nodes = [self.model[v] for v in all_vars]
 
         import pytensor
+
         shapes_fn = pytensor.function([], [v.shape for v in all_nodes], mode=_cheap_eval_mode)
         all_shapes = shapes_fn()
 
@@ -384,7 +385,7 @@ class ModelGraph:
                 variables=list(variables),
             )
             for dim_info, variables in plates.items()
-    ]
+        ]
 
     def edges(
         self,


### PR DESCRIPTION
Implement batch evaluation of RV shapes in ModelGraph.get_plates

## Description
Implements the TODO in `ModelGraph.get_plates` to evaluate all random variables (RV) shapes at once instead of indiviually.

## Related Issue
- [ ] Closes #
- [x] Related to TODO in `ModelGraph.get_plates`

## Type of change
- [X] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
