### PR TITLE
Feature/transform aware bounds checking

### DIFF
--- a/pymc/distributions/dist_math.py
+++ b/pymc/distributions/dist_math.py
@@ -65,7 +65,7 @@ def check_parameters(
     Note that check_parameter should not be used to enforce the logic of the
     expression under the normal parameter support as it can be disabled by the user via
     check_bounds = False in pm.Model()
-    
+
     Parameters
     ----------
     expr : Variable
@@ -89,9 +89,13 @@ def check_parameters(
     ]
     all_true_scalar = pt.all([pt.all(cond) for cond in conditions_])
 
-    return CheckParameterValue(
-        msg, can_be_replaced_by_ninf, rv, param_idx, constraint_type
-    )(expr, all_true_scalar)
+    op = CheckParameterValue(
+        msg, can_be_replaced_by_ninf, param_idx=param_idx, constraint_type=constraint_type
+    )
+
+    if rv is not None:
+        return op(expr, all_true_scalar, rv)
+    return op(expr, all_true_scalar)
 
 
 check_icdf_parameters = partial(check_parameters, can_be_replaced_by_ninf=False)

--- a/pymc/distributions/dist_math.py
+++ b/pymc/distributions/dist_math.py
@@ -50,6 +50,9 @@ def check_parameters(
     *conditions: Iterable[Variable],
     msg: str = "",
     can_be_replaced_by_ninf: bool = True,
+    rv: Variable | None = None,
+    param_idx: int | None = None,
+    constraint_type: str | None = None,
 ):
     """Wrap an expression in a CheckParameterValue that asserts several conditions are met.
 
@@ -62,6 +65,23 @@ def check_parameters(
     Note that check_parameter should not be used to enforce the logic of the
     expression under the normal parameter support as it can be disabled by the user via
     check_bounds = False in pm.Model()
+    
+    Parameters
+    ----------
+    expr : Variable
+        The expression to wrap
+    *conditions : Variable
+        Conditions that must be met
+    msg : str
+        Error message
+    can_be_replaced_by_ninf : bool
+        Whether this check can be replaced by -inf switch
+    rv : Variable, optional
+        The random variable whose parameter is being checked
+    param_idx : int, optional
+        Index of the parameter being checked in rv.owner.inputs
+    constraint_type : str, optional
+        Type of constraint: "positive", "unit_interval", "interval", etc.
     """
     # pt.all does not accept True/False, but accepts np.array(True)/np.array(False)
     conditions_ = [
@@ -69,7 +89,9 @@ def check_parameters(
     ]
     all_true_scalar = pt.all([pt.all(cond) for cond in conditions_])
 
-    return CheckParameterValue(msg, can_be_replaced_by_ninf)(expr, all_true_scalar)
+    return CheckParameterValue(
+        msg, can_be_replaced_by_ninf, rv, param_idx, constraint_type
+    )(expr, all_true_scalar)
 
 
 check_icdf_parameters = partial(check_parameters, can_be_replaced_by_ninf=False)

--- a/pymc/logprob/utils.py
+++ b/pymc/logprob/utils.py
@@ -183,7 +183,7 @@ class CheckParameterValue(CheckAndRaise):
     """Implements a parameter value check in a logprob graph.
 
     Raises `ParameterValueError` if the check is not True.
-    
+
     Parameters
     ----------
     msg : str
@@ -198,21 +198,46 @@ class CheckParameterValue(CheckAndRaise):
         Type of constraint: "positive", "unit_interval", "interval", etc.
     """
 
-    __props__ = ("msg", "exc_type", "can_be_replaced_by_ninf", "rv", "param_idx", "constraint_type")
+    __props__ = ("msg", "exc_type", "can_be_replaced_by_ninf", "param_idx", "constraint_type")
 
     def __init__(
-        self, 
-        msg: str = "", 
+        self,
+        msg: str = "",
         can_be_replaced_by_ninf: bool = False,
-        rv: typing.Any = None,
         param_idx: int | None = None,
         constraint_type: str | None = None,
     ):
         super().__init__(ParameterValueError, msg)
         self.can_be_replaced_by_ninf = can_be_replaced_by_ninf
-        self.rv = rv
         self.param_idx = param_idx
         self.constraint_type = constraint_type
+
+    def make_node(self, value, cond, rv=None):
+        """Create a CheckParameterValue node.
+
+        The first input is the value to return, the second is the condition,
+        and the third (optional) is the RV metadata.
+        """
+        from pytensor.scalar.basic import as_scalar
+
+        value = pt.as_tensor_variable(value)
+        cond = as_scalar(cond)
+        if cond.dtype != "bool":
+            cond = cond.astype("bool")
+
+        inputs = [value, cond]
+        if rv is not None:
+            rv = pt.as_tensor_variable(rv)
+            inputs.append(rv)
+
+        return Apply(self, inputs, [value.type()])
+
+    def perform(self, node, inputs, outputs):
+        (out,) = outputs
+        val, cond, *remainder = inputs
+        out[0] = val
+        if not cond:
+            raise self.exc_type(self.msg)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -234,11 +259,7 @@ def local_check_parameter_to_ninf_switch(fgraph, node):
     if not node.op.can_be_replaced_by_ninf:
         return None
 
-    logp_expr, *logp_conds = node.inputs
-    if len(logp_conds) > 1:
-        logp_cond = pt.all(logp_conds)
-    else:
-        (logp_cond,) = logp_conds
+    logp_expr, logp_cond = node.inputs[0], node.inputs[1]
     out = pt.switch(logp_cond, logp_expr, -np.inf)
     out.name = node.op.msg
 
@@ -263,14 +284,14 @@ pytensor.compile.optdb["canonicalize"].register(
 
 def _transform_enforces_constraint(transform, constraint_type: str) -> bool:
     """Check if a transform guarantees a specific constraint.
-    
+
     Parameters
     ----------
     transform : Transform
         The transform applied to the RV
     constraint_type : str
         Type of constraint: "positive", "unit_interval", etc.
-        
+
     Returns
     -------
     bool
@@ -278,69 +299,70 @@ def _transform_enforces_constraint(transform, constraint_type: str) -> bool:
     """
     if transform is None:
         return False
-    
+
     # Avoid circular import
     from pymc.distributions.transforms import Interval, LogOddsTransform, LogTransform
-    
+
     # LogTransform (exp) guarantees positivity
     if constraint_type == "positive":
         return isinstance(transform, LogTransform)
-    
+
     # LogOddsTransform (sigmoid) guarantees (0, 1)
     if constraint_type == "unit_interval":
         return isinstance(transform, LogOddsTransform)
-    
+
     # IntervalTransform guarantees bounds (could be more specific)
     if constraint_type == "interval":
         return isinstance(transform, Interval)
-    
+
     return False
 
 
 def create_transform_aware_check_rewrite(rvs_to_transforms: dict):
     """Create a rewrite that skips checks for parameters with transforms.
-    
+
     Parameters
     ----------
     rvs_to_transforms : dict
         Mapping from RVs to their transforms
-        
+
     Returns
     -------
     callable
         A node_rewriter that applies Switch or removes check based on transforms
     """
+
     @node_rewriter(tracks=[CheckParameterValue])
     def transform_aware_rewrite(fgraph, node):
         """Convert to Switch, but skip if transform enforces the constraint."""
         if not node.op.can_be_replaced_by_ninf:
             return None
-        
+
+        # In the new implementation, rv is the 3rd input if provided
+        logp_expr, all_conds = node.inputs[0], node.inputs[1]
+        rv = node.inputs[2] if len(node.inputs) > 2 else None
+
         # Check if this specific parameter has a transform that enforces the constraint
-        if (node.op.rv is not None and 
-            node.op.constraint_type is not None and
-            node.op.rv in rvs_to_transforms):
-            
-            transform = rvs_to_transforms[node.op.rv]
-            
+        if rv is not None and node.op.constraint_type is not None and rv in rvs_to_transforms:
+            transform = rvs_to_transforms[rv]
+
             if _transform_enforces_constraint(transform, node.op.constraint_type):
                 # Transform guarantees this constraint, remove check
-                return [node.inputs[0]]
-        
+                return [logp_expr]
+
         # Not redundant, apply normal Switch rewrite
-        logp_expr, *logp_conds = node.inputs
-        if len(logp_conds) > 1:
-            logp_cond = pt.all(logp_conds)
-        else:
-            (logp_cond,) = logp_conds
+        # We need to handle the case where conditions was a scalar or a list in the original CheckParameterValue call
+        # CheckParameterValue(msg, ...)(expr, all_true_scalar_condition)
+        logp_cond = all_conds
+
         out = pt.switch(logp_cond, logp_expr, -np.inf)
         out.name = node.op.msg
-        
+
         if out.dtype != node.outputs[0].dtype:
             out = pt.cast(out, node.outputs[0].dtype)
-        
+
         return [out]
-    
+
     return transform_aware_rewrite
 
 

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1652,12 +1652,23 @@ class Model(WithMemoization, metaclass=ContextMeta):
                 )
 
         with self:
+            # Determine the appropriate check_parameter rewrite based on model settings
+            if self.check_bounds and self.rvs_to_transforms:
+                from pymc.logprob.utils import create_transform_aware_check_rewrite
+
+                check_parameter_opt = create_transform_aware_check_rewrite(self.rvs_to_transforms)
+            elif self.check_bounds:
+                check_parameter_opt = "local_check_parameter_to_ninf_switch"
+            else:
+                check_parameter_opt = "local_remove_check_parameter"
+
             fn = compile(
                 inputs,
                 outs,
                 allow_input_downcast=True,
                 accept_inplace=True,
                 mode=mode,
+                check_parameter_opt=check_parameter_opt,
                 **kwargs,
             )
 

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -895,6 +895,7 @@ def compile(
     outputs,
     random_seed: SeedSequenceSeed = None,
     mode=None,
+    check_parameter_opt=None,
     **kwargs,
 ) -> Function:
     """Use ``pytensor.function`` with specialized pymc rewrites always enabled.
@@ -945,27 +946,10 @@ def compile(
         rngs = cast(list[SharedVariable], list(rng_updates))
         reseed_rngs(rngs, random_seed)
 
-    # If called inside a model context, see if check_bounds flag is set to False
-    # and get access to rvs_to_transforms for transform-aware checking
-    try:
-        from pymc.model import modelcontext
-
-        model = modelcontext(None)
-        check_bounds = model.check_bounds
-        rvs_to_transforms = model.rvs_to_transforms
-    except TypeError:
-        check_bounds = True
-        rvs_to_transforms = {}
-    
-    # Use transform-aware rewrite if we have transforms and check_bounds is enabled
-    if check_bounds and rvs_to_transforms:
-        from pymc.logprob.utils import create_transform_aware_check_rewrite
-        
-        check_parameter_opt = create_transform_aware_check_rewrite(rvs_to_transforms)
-    else:
-        check_parameter_opt = (
-            "local_check_parameter_to_ninf_switch" if check_bounds else "local_remove_check_parameter"
-        )
+    # Use provided check_parameter_opt or default to local_check_parameter_to_ninf_switch
+    # The caller (typically Model.compile_fn) is responsible for determining the right rewrite
+    if check_parameter_opt is None:
+        check_parameter_opt = "local_check_parameter_to_ninf_switch"
 
     mode = get_mode(mode)
     opt_qry = mode.provided_optimizer.including("random_make_inplace", check_parameter_opt)


### PR DESCRIPTION
This PR makes bounds checking in PyMC **transform-aware**, allowing redundant runtime checks
(`CheckParameterValue → Switch(condition, logp, -inf)`) to be safely skipped when the associated
constraint is already enforced by a variable transform (e.g., `HalfNormal` with `LogTransform`).

The change introduces optional metadata on `CheckParameterValue` and a transform-aware rewrite
used during `compile()`. Checks are removed **per parameter**, never globally, and only when a
transform provably guarantees the constraint. Existing behavior is preserved when metadata
is absent.

Distribution `logp` implementations are intentionally left unchanged; guidance is requested on
the preferred way to attach RV context in a follow-up.

## Related Issue
- [ ] Closes #
- [x] Related to #8039

## Checklist
- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests covering transformed and untransformed parameters
- [ ] Added necessary documentation (not required for infrastructure change)
- [x] Each commit corresponds to a logical change

## Type of change
- [x] Maintenance
- [ ] New feature/enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Other (please specify):
