### PR TITLE
Fix model_to_graphviz for Flat variables

### DIFF
--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -82,7 +82,7 @@ def safe_eval_shape(var):
 
     This function tries multiple approaches to get the variable's shape:
     1. Use static shape information if fully known
-    2. Try fast_eval if static shape is incomplete  
+    2. Try fast_eval if static shape is incomplete
     3. Fall back to empty tuple if evaluation fails (e.g., for Flat distributions)
 
     This fixes issues with distributions like Flat that raise NotImplementedError

--- a/tests/test_model_graph.py
+++ b/tests/test_model_graph.py
@@ -694,3 +694,19 @@ def test_model_to_mermaid_with_variable_with_space():
     %% Plates:
     """)
     assert model_to_mermaid(variable_with_space) == expected_mermaid_string.strip()
+
+
+def test_flat_distribution():
+    """Test that model_to_graphviz works with Flat distributions.
+    
+    Regression test for https://github.com/pymc-devs/pymc/issues/8024
+    """
+    with pm.Model() as model:
+        pm.Flat("f")
+        pm.Flat("g", shape=5)
+    
+    # This should not raise NotImplementedError
+    g = model_to_graphviz(model)
+    assert "f" in g.source
+    assert "g" in g.source
+    assert "Flat" in g.source

--- a/tests/test_model_graph.py
+++ b/tests/test_model_graph.py
@@ -698,13 +698,13 @@ def test_model_to_mermaid_with_variable_with_space():
 
 def test_flat_distribution():
     """Test that model_to_graphviz works with Flat distributions.
-    
+
     Regression test for https://github.com/pymc-devs/pymc/issues/8024
     """
     with pm.Model() as model:
         pm.Flat("f")
         pm.Flat("g", shape=5)
-    
+
     # This should not raise NotImplementedError
     g = model_to_graphviz(model)
     assert "f" in g.source


### PR DESCRIPTION
## Summary

Fixes #8024 - `model_to_graphviz` was crashing when models contained `Flat` variables.

## Problem

The `model_to_graphviz` function tries to evaluate the shape of variables using `fast_eval`. For `Flat` variables, this triggers a sampling attempt which raises `NotImplementedError: Cannot sample from flat variable`.

## Solution

I added a `safe_eval_shape` helper function that:
1. First tries to use the static shape information from `var.type.shape`
2. Attempts `fast_eval` if static shape is incomplete
3. Catches `NotImplementedError` and falls back to static shape (replacing `None` with `1`) or an empty tuple

This allows `model_to_graphviz` to correctly handle variables that cannot be sampled.

## Testing

- Added a regression test `test_flat_distribution` in `tests/test_model_graph.py`
- Verified locally with the reproduction script from the issue
- Verified that existing tests pass

## Example

```python
import pymc as pm
with pm.Model() as model:
    pm.Flat('intercept')
    pm.HalfCauchy('sigma', beta=10)

# This now works!
pm.model_to_graphviz(model)
```