### PR TITLE
Implement Uniform and TruncatedNormal dims distributions

### DIFF
--- a/docs/source/api/dims/distributions.rst
+++ b/docs/source/api/dims/distributions.rst
@@ -12,8 +12,10 @@ Scalar distributions
 
    Flat
    HalfFlat
+   Uniform,
    Normal
    HalfNormal
+   TruncatedNormal
    LogNormal
    StudentT
    HalfStudentT

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1722,9 +1722,9 @@ class Model(WithMemoization, metaclass=ContextMeta):
             transform = self.rvs_to_transforms[rv]
             if transform is not None:
                 names.append(get_transformed_name(rv.name, transform))
-                outputs.append(transform.forward(rv, *rv.owner.inputs).shape)
+                outputs.append(pt.as_tensor(transform.forward(rv, *rv.owner.inputs).shape))
             names.append(rv.name)
-            outputs.append(rv.shape)
+            outputs.append(pt.as_tensor(rv.shape))
         f = pytensor.function(
             inputs=[],
             outputs=outputs,

--- a/tests/dims/test_model.py
+++ b/tests/dims/test_model.py
@@ -58,6 +58,14 @@ def test_simple_model():
     for value, xvalue in zip(ip.values(), xip.values()):
         np.testing.assert_allclose(value, xvalue)
 
+    rv_shapes = model.eval_rv_shapes()
+    assert rv_shapes == {
+        "x": (3, 5),
+        "sigma_log__": (3,),
+        "sigma": (3,),
+        "y": (5, 3),
+    }
+
     logp = model.compile_logp()(ip)
     xlogp = xmodel.compile_logp()(xip)
     np.testing.assert_allclose(logp, xlogp)


### PR DESCRIPTION
With the constraint that for free rvs the bounds must be constant. This touches on a limitation we have on transforms that depend on parameters. The previous strategy was to pass the rv inputs to the transform, but this doesn't work for derived variables like `XTensorFromTensor` and `DimShuffled` RVs, since the inputs of those are not the ones needed for the transform.

I'll be thinking about how to better handle this, so we can lift the restriction.

Also fixes a bug in `eval_rv_shapes` with `XTensorVariables` for which `.shape` returns tuples instead of a tensor