### PR TITLE
Clarify dims error message to reference as_xtensor

### DIFF
--- a/pymc/dims/distributions/core.py
+++ b/pymc/dims/distributions/core.py
@@ -134,7 +134,7 @@ class DimDistribution:
             raise ValueError(
                 f"Variable {x} must have dims associated with it.\n"
                 "To avoid subtle bugs, PyMC does not make any assumptions about the dims of parameters.\n"
-                "Use `pytensor.xtensor.as_xtensor(..., dims=...)` to specify the dims explicitly."
+                "Use `pymc.dims.as_xtensor(..., dims=...)` to specify the dims explicitly."
             )
 
     def __new__(

--- a/pymc/dims/distributions/core.py
+++ b/pymc/dims/distributions/core.py
@@ -134,7 +134,7 @@ class DimDistribution:
             raise ValueError(
                 f"Variable {x} must have dims associated with it.\n"
                 "To avoid subtle bugs, PyMC does not make any assumptions about the dims of parameters.\n"
-                "Use `as_xtensor` with the `dims` keyword argument to specify the dims explicitly."
+                "Use `pytensor.xtensor.as_xtensor(..., dims=...)` to specify the dims explicitly."
             )
 
     def __new__(


### PR DESCRIPTION
## Description
This PR clarifies an error message raised when variables are missing associated dims.
The message now explicitly references `pytensor.xtensor.as_xtensor(..., dims=...)`,
making it clearer how users should attach dims to observed data and reducing
confusion about where `as_xtensor` is defined.

No behaviour changes are introduced; this PR only improves a user-facing error message

## Related Issue
- [x] Closes #8060 
- [ ] Related to #

## Checklist
- [x] Checked that the pre-commit linting/style checks pass
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a relevant logical change

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance