### PR TITLE
Improve links and references in dims module notebook

### DIFF
--- a/docs/source/learn/core_notebooks/dims_module.ipynb
+++ b/docs/source/learn/core_notebooks/dims_module.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "(dims_module)=\n",
     "\n",
-    "# PyMC dims module"
+    "# Dims module"
    ]
   },
   {
@@ -31,6 +31,11 @@
     "\n",
     ":::{warning}The `dims` module is experimental, not exhaustively tested and the API is being iteratively worked on, and is therefore subject to changes between any two PyMC releases. We welcome users to test it and provide feedback, but we don't yet endorse its use for production.:::\n",
     "\n",
+    "\n",
+    "**Related API References: ** \n",
+        "- {doc}`Dims — distributions </api/dims/distributions>`\n",
+        "- {doc}`Dims — transforms </api/dims/transforms>`\n",
+        "- {doc}`Dims — math </api/dims/math>`\n",
     "\n",
     "## A simple example\n",
     "\n",
@@ -309,13 +314,13 @@
     "\n",
     "There are some notable differences:\n",
     "\n",
-    "1. `ZeroSumNormal` takes a `core_dims` argument instead of `n_zerosum_axes`. This tells PyMC which of the `dims` that define the distribution are constrained to be zero-summed. All distributions that take non-scalar parameters now require a `core_dims` argument. Previously, they were assumed to be right-aligned by the user (see more in {doc}`dimensionality`). Now you don't have to worry about the order of the dimensions in your model, just their meaning!\n",
+    "1. The {class}`~pymc.distributions.ZeroSumNormal` takes a `core_dims` argument instead of `n_zerosum_axes`. This tells PyMC which of the `dims` that define the distribution are constrained to be zero-summed. All distributions that take non-scalar parameters now require a `core_dims` argument. Previously, they were assumed to be right-aligned by the user (see more in {doc}`dimensionality`). Now you don't have to worry about the order of the dimensions in your model, just their meaning!\n",
     "\n",
     "2. The `trial_preference` computation aligns dimensions for broadcasting automatically. Note we use {func}`pymc.dims.Deterministic` and not {func}`pymc.Deterministic`, which automatically propagates the `dims` to the model object.\n",
     "\n",
     "3. The `softmax` operation specifies the `dim` argument, not the positional axis. Note: The parameter is called `dim` and not `core_dims` because we try to stay as close as possible to the Xarray API, which uses `dim` throughout. But we make an exception for distributions because they already have the `dims` argument.\n",
     "\n",
-    "4. The `Categorical` observed variable, like `ZeroSumNormal`, requires a `core_dims` argument to specify which dimension corresponds to the probability vector. Previously, it was necessary to place this dimension explicitly on the rightmost axis -- not any more!\n",
+    "4. The {class}`~pymc.distributions.Categorical` observed variable, like `ZeroSumNormal`, requires a `core_dims` argument to specify which dimension corresponds to the probability vector. Previously, it was necessary to place this dimension explicitly on the rightmost axis -- not any more!\n",
     "\n",
     "5. Even though dims were not specified for either `trial_preference` or `response`, PyMC automatically infers them.\n",
     "\n",
@@ -885,7 +890,7 @@
     "\n",
     " * All vector arguments (and observed values) must have known dims. An error is raised otherwise.\n",
     "\n",
-    " * Distributions with non-scalar inputs will require a `core_dims` argument. The meaning of the `core_dims` argument will be denoted in the docstrings of each distribution. For example, for the MvNormal, the `core_dims` are the two dimensions of the covariance matrix, one (and only one) of which must also be present in the mean parameter. The shared `core_dim` is the one that persists in the output. Sometimes the order of `core_dims` will be important!\n",
+    " * Distributions with non-scalar inputs will require a `core_dims` argument. The meaning of the `core_dims` argument will be denoted in the docstrings of each distribution. For example, for the {class}`~pymc.distributions.MvNormal`, the `core_dims` are the two dimensions of the covariance matrix, one (and only one) of which must also be present in the mean parameter. The shared `core_dim` is the one that persists in the output. Sometimes the order of `core_dims` will be important!\n",
     "\n",
     " * `dims` accept ellipsis, and variables are transposed to match the user-specified `dims` argument.\n",
     "\n",


### PR DESCRIPTION
## Description
This PR improves the dims module notebook by adding proper links to the relevant
dims API documentation (distributions, transforms, and math) and by using  a Sphinx `{doc}` instead of
hard-coded URLs with references for better robustness and
version-awareness.

Where specific distributions (e.g. `ZeroSumNormal`, `Categorical`) are mentioned,
the notebook now links to their corresponding API documentation entries, making
it easier for readers to explore related functionality.

No behavioural or API changes are introduced; this PR only improves documentation
clarity and navigation.

## Related Issue
- [x] Closes #7864 
- [ ] Related to #

## Checklist
- [x] Checked that the pre-commit linting/style checks pass
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a relevant logical change

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):

