### PR TITLE
Fix multi-output IfElse logp for non-lazy backends

### DIFF
--- a/pymc/logprob/rewriting.py
+++ b/pymc/logprob/rewriting.py
@@ -59,6 +59,7 @@ from pytensor.tensor.random.rewriting import local_subtensor_rv_lift
 from pytensor.tensor.rewriting.basic import register_canonicalize
 from pytensor.tensor.rewriting.math import local_exp_over_1_plus_exp
 from pytensor.tensor.rewriting.shape import ShapeFeature
+from pytensor.tensor.shape import SpecifyShape
 from pytensor.tensor.subtensor import (
     AdvancedIncSubtensor,
     AdvancedIncSubtensor1,
@@ -211,6 +212,14 @@ logprob_rewrites_db.register(
 
 cleanup_ir_rewrites_db.register("remove_DiracDelta", remove_DiracDelta, "cleanup")
 cleanup_ir_rewrites_db.register("local_remove_valued_rv", local_remove_valued_rv, "cleanup")
+
+
+@node_rewriter([SpecifyShape])
+def local_remove_specify_shape(fgraph, node):
+    return [node.inputs[0]]
+
+
+cleanup_ir_rewrites_db.register("local_remove_specify_shape", local_remove_specify_shape, "cleanup")
 
 
 def construct_ir_fgraph(

--- a/tests/logprob/test_mixture.py
+++ b/tests/logprob/test_mixture.py
@@ -41,10 +41,8 @@ import pytest
 import scipy.stats.distributions as sp
 
 from pytensor import function
-from pytensor.compile import get_default_mode
 from pytensor.graph.basic import Variable
 from pytensor.ifelse import ifelse
-from pytensor.link.numba import NumbaLinker
 from pytensor.tensor.random.basic import CategoricalRV
 from pytensor.tensor.shape import shape_tuple
 from pytensor.tensor.subtensor import (
@@ -999,11 +997,6 @@ def test_ifelse_mixture_one_component():
     )
 
 
-@pytest.mark.xfail(
-    condition=isinstance(get_default_mode().linker, NumbaLinker),
-    raises=AssertionError,
-    reason="Logp graph fails when evaluated with a non-lazy approach. https://github.com/pymc-devs/pymc/issues/8036",
-)
 def test_ifelse_mixture_multiple_components():
     rng = np.random.default_rng(968)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
in #8036, a multi output IfElse was being rewritten into separate single output ifelses, which:
- breaks cross output dependencies within a branch (e.g. output 2 depending on output 1), and
- can trigger runtime shape assertions (SpecifyShape) from the dead branch when execution is non lazy.

i tried to fix it by:
- handle it jointly as a measurable IfElse. computing per output logps per branch while substituting cross output dependencies with the corresponding value variables (so each output’s logp can be derived in a measurable IR).
- make logprob evaluation robust to non lazy backends by using "branch safe" value variables: the selected branch stays strict, while the non selected branch uses a shape coerced value to prevent dead branch shape assertions from crashing.
- remove SpecifyShape nodes during logprob IR cleanup, since they only add runtime assertions and can cause dead branch failures under non lazy evaluation.
- keep transform measurability detection from incorrectly treating deterministic wrappers as extra "sources of measurability" unless they contain RandomVariable ancestry, which is needed to keep the new IfElse logprob path measurable.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- Related to #8036 
