### PR TITLE
DOC: Fix RandomWalk docstring formatting and kwargs

### DIFF
--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -122,9 +122,28 @@ class RandomWalkRV(SymbolicRandomVariable):
 
 
 class RandomWalk(Distribution):
-    r"""RandomWalk Distribution.
+    r"""
+    Random Walk distribution.
 
-    TODO: Expand docstrings
+        A random walk is a stochastic process where the position at    time :math:`t`
+        is the sum of the position at time :math:`t-1` and a random step (innovation).
+
+        .. math::
+            X_t = X_{t-1} + \epsilon_t
+
+        where :math:`\epsilon_t` follows the distribution specified by `innovation_dist`.
+
+    Parameters
+    ----------
+        innovation_dist : Distribution
+            The distribution of the innovations (steps). This should be an instance
+            of a PyMC distribution (created via `.dist()`), describing the random
+            noise added at each step.
+        steps : int, optional
+            The number of steps in the random walk.
+        kwargs
+            Additional arguments passed to the distribution, such as `init_dist`
+            (distribution of the initial state) or dimensions.
     """
 
     rv_type = RandomWalkRV

--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -122,28 +122,27 @@ class RandomWalkRV(SymbolicRandomVariable):
 
 
 class RandomWalk(Distribution):
-    r"""
-    Random Walk distribution.
+    r"""Random Walk distribution.
 
-        A random walk is a stochastic process where the position at    time :math:`t`
-        is the sum of the position at time :math:`t-1` and a random step (innovation).
+    A random walk is a stochastic process where the position at    time :math:`t`
+    is the sum of the position at time :math:`t-1` and a random step (innovation).
 
-        .. math::
-            X_t = X_{t-1} + \epsilon_t
+    .. math::
+       X_t = X_{t-1} + \epsilon_t
 
-        where :math:`\epsilon_t` follows the distribution specified by `innovation_dist`.
+    where :math:`\epsilon_t` follows the distribution specified by `innovation_dist`.
 
     Parameters
     ----------
-        innovation_dist : Distribution
-            The distribution of the innovations (steps). This should be an instance
-            of a PyMC distribution (created via `.dist()`), describing the random
-            noise added at each step.
-        steps : int, optional
-            The number of steps in the random walk.
-        kwargs
-            Additional arguments passed to the distribution, such as `init_dist`
-            (distribution of the initial state) or dimensions.
+    innovation_dist : Distribution
+        The distribution of the innovations (steps). This should be an instance
+        of a PyMC distribution (created via `.dist()`), describing the random
+        noise added at each step.
+    steps : int, optional
+        The number of steps in the random walk.
+    **kwargs
+       Additional arguments passed to the distribution, such as `init_dist`
+       (distribution of the initial state) or dimensions.
     """
 
     rv_type = RandomWalkRV


### PR DESCRIPTION
## Description
This PR fixes formatting issues in the `RandomWalk` docstring as requested by @ricardoV94 in closed PR #8059.

Changes applied:
- Moved the summary to the first line.
- Fixed indentation of the parameter descriptions.
- Added `**` to `kwargs` to correctly indicate keyword arguments.
- Pre-commit checks are passing.

## Related Issue
- [ ] Closes #
- [x] Related to #8059

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):