### PR TITLE
Implement ICDF for DiracDelta and DiscreteWeibull

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -504,9 +504,7 @@ class DiscreteWeibull(Discrete):
         )
 
     def icdf(value, q, beta):
-        """
-        Inverse cumulative distribution function of the Discrete Weibull distribution.
-        """
+        """Inverse cumulative distribution function of the Discrete Weibull distribution."""
         log_q = pt.log(q)
         # Use log1p(-value) instead of log1m(-value)
         inner = pt.log1p(-value) / log_q
@@ -535,6 +533,7 @@ class DiscreteWeibull(Discrete):
             beta > 0,
             msg="0 < q < 1, beta > 0",
         )
+
 
 class Poisson(Discrete):
     R"""

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -506,7 +506,6 @@ class DiscreteWeibull(Discrete):
     def icdf(value, q, beta):
         """Inverse cumulative distribution function of the Discrete Weibull distribution."""
         log_q = pt.log(q)
-        # Use log1p(-value) instead of log1m(-value)
         inner = pt.log1p(-value) / log_q
         powered = pt.power(inner, 1.0 / beta)
 

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -516,8 +516,7 @@ class DiscreteWeibull(Discrete):
         # Ensure floating point errors don't overshoot
         res_1m = pt.maximum(res - 1, 0)
 
-        # Calculate logcdf at (res - 1) using the math from line 519
-        # logcdf = log(1 - q^((x+1)^beta)) -> log1p(-q^((x+1)^beta))
+        # Calculate logcdf at (res - 1) to check for numerical overshoot
         logcdf_1m = pt.log1p(-pt.power(q, pt.power(res_1m + 1, beta)))
         value_1m = pt.exp(logcdf_1m)
 

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -72,6 +72,8 @@ __all__ = [
     "SymbolicRandomVariable",
 ]
 
+from pymc.distributions.dist_math import check_icdf_value
+
 DIST_PARAMETER_TYPES: TypeAlias = np.ndarray | int | float | TensorVariable
 
 vectorized_ppc: contextvars.ContextVar[Callable | None] = contextvars.ContextVar(
@@ -730,6 +732,16 @@ class DiracDelta(Discrete):
             -np.inf,
             0,
         )
+
+    def icdf(value, c):
+        """
+        Inverse CDF (quantile function) for DiracDelta distribution.
+
+        For any probability p in (0,1), F^{-1}(p) = c since all mass is at c.
+        """
+        res = pt.broadcast_arrays(c, value)[0]
+        res = check_icdf_value(res, value)
+        return res
 
 
 class PartialObservedRV(SymbolicRandomVariable):

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -580,15 +580,15 @@ def check_icdf(
         decimal = select_by_precision(float64=6, float32=3)
 
     dist = create_dist_from_paramdomains(pymc_dist, paramdomains)
-    q = pt.scalar(dtype="float64", name="q")
-    dist_icdf = icdf(dist, q)
+    q_value = pt.scalar(dtype="float64", name="q_value")
+    dist_icdf = icdf(dist, q_value)
     pymc_icdf = pytensor.function(list(inputvars(dist_icdf)), dist_icdf)
 
     # Test pymc and scipy distributions match for values and parameters
     # within the supported domain edges (excluding edges)
     domains = paramdomains.copy()
     domain = Domain([0, 0.1, 0.5, 0.75, 0.95, 0.99, 1])  # Values we test the icdf at
-    domains["q"] = domain
+    domains["q_value"] = domain
 
     for point in product(domains, n_samples=n_samples):
         point = dict(point)
@@ -601,7 +601,7 @@ def check_icdf(
 
     valid_value = domain.vals[0]
     valid_params = {param: paramdomain.vals[0] for param, paramdomain in paramdomains.items()}
-    valid_params["q"] = valid_value
+    valid_params["q_value"] = valid_value
 
     if not skip_paramdomain_outside_edge_test:
         # Test pymc distribution raises ParameterValueError for parameters outside the
@@ -620,11 +620,11 @@ def check_icdf(
                     pytest.fail(f"test_params={point}")
 
     # Test that values below 0 or above 1 evaluate to nan
-    invalid_values = find_invalid_scalar_params({"q": domain})["q"]
+    invalid_values = find_invalid_scalar_params({"q_value": domain})["q_value"]
     for invalid_value in invalid_values:
         if invalid_value is not None:
             point = valid_params.copy()
-            point["q"] = invalid_value
+            point["q_value"] = invalid_value
             npt.assert_equal(
                 pymc_icdf(**point),
                 np.nan,

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -178,7 +178,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.Uniform,
             {"lower": -Rplusunif, "upper": Rplusunif},
-            lambda q, lower, upper: st.uniform.ppf(q=q, loc=lower, scale=upper - lower),
+            lambda q_value, lower, upper: st.uniform.ppf(q=q_value, loc=lower, scale=upper - lower),
             skip_paramdomain_outside_edge_test=True,
         )
         # Custom logp / logcdf check for invalid parameters
@@ -209,7 +209,9 @@ class TestMatchesScipy:
         check_icdf(
             pm.Triangular,
             {"lower": -Rplusunif, "c": Runif, "upper": Rplusunif},
-            lambda q, c, lower, upper: st.triang.ppf(q, c - lower, lower, upper - lower),
+            lambda q_value, c, lower, upper: st.triang.ppf(
+                q_value, c - lower, lower, upper - lower
+            ),
             skip_paramdomain_outside_edge_test=True,
         )
 
@@ -287,7 +289,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.Normal,
             {"mu": R, "sigma": Rplus},
-            lambda q, mu, sigma: st.norm.ppf(q, mu, sigma),
+            lambda q_value, mu, sigma: st.norm.ppf(q_value, mu, sigma),
         )
 
     def test_half_normal(self):
@@ -307,7 +309,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.HalfNormal,
             {"sigma": Rplus},
-            lambda q, sigma: st.halfnorm.ppf(q, scale=sigma),
+            lambda q_value, sigma: st.halfnorm.ppf(q_value, scale=sigma),
         )
 
     def test_chisquared_logp(self):
@@ -416,7 +418,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.Beta,
             {"alpha": Rplus, "beta": Rplus},
-            lambda q, alpha, beta: st.beta.ppf(q, alpha, beta),
+            lambda q_value, alpha, beta: st.beta.ppf(q_value, alpha, beta),
         )
 
     def test_kumaraswamy(self):
@@ -463,7 +465,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.Exponential,
             {"lam": Rplus},
-            lambda q, lam: st.expon.ppf(q, loc=0, scale=1 / lam),
+            lambda q_value, lam: st.expon.ppf(q_value, loc=0, scale=1 / lam),
         )
 
     def test_laplace(self):
@@ -479,7 +481,9 @@ class TestMatchesScipy:
             {"mu": R, "b": Rplus},
             lambda value, mu, b: st.laplace.logcdf(value, mu, b),
         )
-        check_icdf(pm.Laplace, {"mu": R, "b": Rplus}, lambda q, mu, b: st.laplace.ppf(q, mu, b))
+        check_icdf(
+            pm.Laplace, {"mu": R, "b": Rplus}, lambda q_value, mu, b: st.laplace.ppf(q_value, mu, b)
+        )
 
     def test_laplace_asymmetric(self):
         check_logp(
@@ -518,7 +522,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.LogNormal,
             {"mu": R, "tau": Rplusbig},
-            lambda q, mu, tau: floatX(st.lognorm.ppf(q, tau**-0.5, 0, np.exp(mu))),
+            lambda q_value, mu, tau: floatX(st.lognorm.ppf(q_value, tau**-0.5, 0, np.exp(mu))),
         )
         # Because we exponentiate the normal quantile function, setting sigma >= 9.5
         # return extreme values that results in relative errors above 4 digits
@@ -527,7 +531,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.LogNormal,
             {"mu": R, "sigma": custom_rplusbig},
-            lambda q, mu, sigma: floatX(st.lognorm.ppf(q, sigma, 0, np.exp(mu))),
+            lambda q_value, mu, sigma: floatX(st.lognorm.ppf(q_value, sigma, 0, np.exp(mu))),
             decimal=select_by_precision(float64=4, float32=3),
         )
 
@@ -577,14 +581,14 @@ class TestMatchesScipy:
         check_icdf(
             pm.StudentT,
             {"nu": Rplusbig, "mu": R, "sigma": Rplusbig},
-            lambda q, nu, mu, sigma: st.t.ppf(q, nu, mu, sigma),
+            lambda q_value, nu, mu, sigma: st.t.ppf(q_value, nu, mu, sigma),
         )
 
     def test_halfstudentt_icdf(self):
         check_icdf(
             pm.HalfStudentT,
             {"nu": Rplusbig, "sigma": Rplusbig},
-            lambda q, nu, sigma: st.t.ppf(0.5 * (q + 1.0), nu, 0.0, sigma),
+            lambda q_value, nu, sigma: st.t.ppf(0.5 * (q_value + 1.0), nu, 0.0, sigma),
         )
 
     @pytest.mark.skipif(
@@ -603,7 +607,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.SkewStudentT,
             {"a": Rplusbig, "b": Rplusbig, "mu": R, "sigma": Rplusbig},
-            lambda q, a, b, mu, sigma: st.jf_skew_t.ppf(q, a, b, mu, sigma),
+            lambda q_value, a, b, mu, sigma: st.jf_skew_t.ppf(q_value, a, b, mu, sigma),
         )
 
     def test_cauchy(self):
@@ -622,7 +626,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.Cauchy,
             {"alpha": R, "beta": Rplusbig},
-            lambda q, alpha, beta: st.cauchy.ppf(q, alpha, beta),
+            lambda q_value, alpha, beta: st.cauchy.ppf(q_value, alpha, beta),
         )
 
     def test_half_cauchy(self):
@@ -639,7 +643,9 @@ class TestMatchesScipy:
             lambda value, beta: st.halfcauchy.logcdf(value, scale=beta),
         )
         check_icdf(
-            pm.HalfCauchy, {"beta": Rplusbig}, lambda q, beta: st.halfcauchy.ppf(q, scale=beta)
+            pm.HalfCauchy,
+            {"beta": Rplusbig},
+            lambda q_value, beta: st.halfcauchy.ppf(q_value, scale=beta),
         )
 
     def test_gamma_logp(self):
@@ -676,7 +682,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.Gamma,
             {"alpha": Rplusbig, "beta": Rplusbig},
-            lambda q, alpha, beta: st.gamma.ppf(q, alpha, scale=1.0 / beta),
+            lambda q_value, alpha, beta: st.gamma.ppf(q_value, alpha, scale=1.0 / beta),
         )
 
     def test_inverse_gamma_logp(self):
@@ -703,7 +709,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.InverseGamma,
             {"alpha": Rplusbig, "beta": Rplusbig},
-            lambda q, alpha, beta: st.invgamma.ppf(q, alpha, scale=beta),
+            lambda q_value, alpha, beta: st.invgamma.ppf(q_value, alpha, scale=beta),
         )
 
     @pytest.mark.skipif(
@@ -740,7 +746,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.Pareto,
             {"alpha": Rplusbig, "m": Rplusbig},
-            lambda q, alpha, m: st.pareto.ppf(q, alpha, scale=m),
+            lambda q_value, alpha, m: st.pareto.ppf(q_value, alpha, scale=m),
         )
 
     @pytest.mark.skipif(
@@ -774,7 +780,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.Weibull,
             {"alpha": Rplusbig, "beta": Rplusbig},
-            lambda q, alpha, beta: st.exponweib.ppf(q, 1, alpha, scale=beta),
+            lambda q_value, alpha, beta: st.exponweib.ppf(q_value, 1, alpha, scale=beta),
         )
 
     def test_half_studentt(self):
@@ -856,7 +862,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.Gumbel,
             {"mu": R, "beta": Rplusbig},
-            lambda q, mu, beta: st.gumbel_r.ppf(q, loc=mu, scale=beta),
+            lambda q_value, mu, beta: st.gumbel_r.ppf(q_value, loc=mu, scale=beta),
         )
 
     def test_logistic(self):
@@ -877,7 +883,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.Logistic,
             {"mu": R, "s": Rplus},
-            lambda q, mu, s: st.logistic.ppf(q, mu, s),
+            lambda q_value, mu, s: st.logistic.ppf(q_value, mu, s),
             decimal=select_by_precision(float64=6, float32=1),
         )
 
@@ -894,7 +900,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.LogitNormal,
             {"mu": R, "sigma": Rplus},
-            lambda q, mu, sigma: sp.expit(mu + sigma * st.norm.ppf(q)),
+            lambda q_value, mu, sigma: sp.expit(mu + sigma * st.norm.ppf(q_value)),
             decimal=select_by_precision(float64=12, float32=5),
         )
 
@@ -951,7 +957,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.Moyal,
             {"mu": R, "sigma": Rplusbig},
-            lambda q, mu, sigma: floatX(st.moyal.ppf(q, mu, sigma)),
+            lambda q_value, mu, sigma: floatX(st.moyal.ppf(q_value, mu, sigma)),
         )
 
     def test_interpolated(self):

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -362,9 +362,7 @@ class TestMatchesScipy:
         # D. Define the Reference Implementation (NumPy)
         def ref_icdf(v, q, b):
             # The formula you used in your lambda
-            return np.ceil(
-                np.power(np.log1p(-v) / np.log(q), 1.0 / b) - 1
-            ).astype("int64")
+            return np.ceil(np.power(np.log1p(-v) / np.log(q), 1.0 / b) - 1).astype("int64")
 
         # E. Define test values (similar to what check_icdf does internally)
         test_probs = [0.001, 0.1, 0.5, 0.9, 0.99]
@@ -382,9 +380,7 @@ class TestMatchesScipy:
 
                     # Assert they match
                     np.testing.assert_array_equal(
-                        pymc_res,
-                        ref_res,
-                        err_msg=f"Mismatch at prob={p_v}, q={q_v}, beta={b_v}"
+                        pymc_res, ref_res, err_msg=f"Mismatch at prob={p_v}, q={q_v}, beta={b_v}"
                     )
 
                     # Sanity check: Result must be non-negative (Support is 0, 1, 2...)

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -118,7 +118,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.DiscreteUniform,
             {"lower": -Rplusdunif, "upper": Rplusdunif},
-            lambda q, lower, upper: st.randint.ppf(q=q, low=lower, high=upper + 1),
+            lambda q_value, lower, upper: st.randint.ppf(q=q_value, low=lower, high=upper + 1),
             skip_paramdomain_outside_edge_test=True,
         )
         # Custom logp / logcdf check for invalid parameters
@@ -152,7 +152,7 @@ class TestMatchesScipy:
         check_icdf(
             pm.Geometric,
             {"p": Unit},
-            st.geom.ppf,
+            lambda q_value, p: st.geom.ppf(q=q_value, p=p),
         )
 
     def test_hypergeometric(self):
@@ -345,52 +345,14 @@ class TestMatchesScipy:
             Nat,
             {"q": Unit, "beta": NatSmall},
         )
-        # Manual ICDF check used to avoid naming collision between the distribution parameter 'q' and the testing helper's input variable 'q'.
-        # A. Define symbolic variables with unique names
-        q_param = pt.scalar("q_param")
-        beta_param = pt.scalar("beta_param")
-        p_val = pt.scalar("p_val")  # Using "p_val" instead of "q" avoids the collision!
 
-        # B. Instantiate the distribution and call icdf
-        dist = pm.DiscreteWeibull.dist(q=q_param, beta=beta_param)
-        icdf_expr = icdf(dist, p_val)
-
-        # C. Compile the PyTensor function
-        # This creates a function that takes (probability, q, beta) -> integer quantile
-        icdf_fn = pytensor.function([p_val, q_param, beta_param], icdf_expr)
-
-        # D. Define the Reference Implementation (NumPy)
-        def ref_icdf(v, q, b):
-            # The formula you used in your lambda
-            return np.ceil(np.power(np.log1p(-v) / np.log(q), 1.0 / b) - 1).astype("int64")
-
-        # E. Define test values (similar to what check_icdf does internally)
-        test_probs = [0.001, 0.1, 0.5, 0.9, 0.99]
-        q_values = [0.2, 0.5, 0.8]
-        beta_values = [0.5, 1.0, 2.0, 5.0]
-
-        # F. Loop and Verify
-        for q_v in q_values:
-            for b_v in beta_values:
-                for p_v in test_probs:
-                    # Run PyMC implementation
-                    pymc_res = icdf_fn(p_v, q_v, b_v)
-                    # Run Reference implementation
-                    ref_res = ref_icdf(p_v, q_v, b_v)
-
-                    # Assert they match
-                    np.testing.assert_array_equal(
-                        pymc_res, ref_res, err_msg=f"Mismatch at prob={p_v}, q={q_v}, beta={b_v}"
-                    )
-
-                    # Sanity check: Result must be non-negative (Support is 0, 1, 2...)
-                    assert pymc_res >= 0, f"Found negative value {pymc_res} at prob={p_v}"
-
-        #  Boundary Check (p=0 and p=1)
-        # p=0 -> Should be 0 (smallest value in support)
-        assert icdf_fn(0.0, 0.5, 1.0) == 0
-        # p=1 -> Should be infinity (or huge number), but practically we check it doesn't crash
-        # (Note: depending on implementation, 1.0 might return inf or max int)
+        check_icdf(
+            pm.DiscreteWeibull,
+            {"q": Unit, "beta": NatSmall},
+            lambda q_value, q, beta: np.ceil(
+                np.power(np.log1p(-q_value) / np.log(q), 1.0 / beta) - 1
+            ).astype("int64"),
+        )
 
     def test_poisson(self):
         check_logp(

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -52,7 +52,7 @@ from pymc.testing import (
     check_logcdf,
     check_logp,
 )
-
+from pymc.testing import check_icdf, I
 
 class TestBugfixes:
     @pytest.mark.parametrize("dist_cls,kwargs", [(MvNormal, {}), (MvStudentT, {"nu": 2})])
@@ -322,15 +322,19 @@ class TestDiracDelta:
         ]
 
         @pytest.mark.parametrize("floatX", ["float32", "float64"])
-        @pytest.mark.xfail(
-            sys.platform == "win32", reason="https://github.com/aesara-devs/aesara/issues/871"
-        )
         def test_dtype(self, floatX):
             with pytensor.config.change_flags(floatX=floatX):
                 assert pm.DiracDelta.dist(2**4).dtype == "int8"
                 assert pm.DiracDelta.dist(2**16).dtype == "int32"
                 assert pm.DiracDelta.dist(2**32).dtype == "int64"
                 assert pm.DiracDelta.dist(2.0).dtype == floatX
+
+        def test_icdf(self):
+            check_icdf(
+                pm.DiracDelta,
+                {"c": I},
+                lambda q, c: np.full_like(q, c),
+            )
 
 
 class TestPartialObservedRV:

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -11,7 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import sys
 import warnings
 
 import numpy as np
@@ -49,10 +48,11 @@ from pymc.testing import (
     BaseTestDistributionRandom,
     I,
     assert_support_point_is_expected,
+    check_icdf,
     check_logcdf,
     check_logp,
 )
-from pymc.testing import check_icdf, I
+
 
 class TestBugfixes:
     @pytest.mark.parametrize("dist_cls,kwargs", [(MvNormal, {}), (MvStudentT, {"nu": 2})])

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -333,7 +333,7 @@ class TestDiracDelta:
             check_icdf(
                 pm.DiracDelta,
                 {"c": I},
-                lambda q, c: np.full_like(q, c),
+                lambda q_value, c: np.full_like(q_value, c),
             )
 
 


### PR DESCRIPTION
What is this PR about?
Adding icdf (inverse cumulative distribution) functions for existing distributions: DiracDelta and DiscreteWeibull.

Creation of unit tests for the added icdf functions in both test_distribution.py and test_discrete.py.

Major / Breaking Changes
None.

New features
icdf function for DiracDelta distribution in distribution.py.

icdf function for DiscreteWeibull distribution in discrete.py, including a robustness check for floating-point precision.

Bugfixes
None.

Documentation
Updated docstrings for the new icdf methods.

Maintenance
Extended tests/distributions/test_distribution.py with DiracDelta tests.

Extended tests/distributions/test_discrete.py with DiscreteWeibull tests.

Environment & Verification
Local Environment:

OS: Windows 11

Python: 3.12.2

PyTensor version: (Latest from upstream)

Test Results: I have verified the implementation by running the combined test suite for both modified files. All 151 tests passed successfully.
"PS C:\self-study\gsoc\pymc\pymc> py -3.12 -m pytest tests/distributions/test_distribution.py tests/distributions/test_discrete.py
=============================================================================== test session starts ===============================================================================
platform win32 -- Python 3.12.2, pytest-9.0.2, pluggy-1.6.0
rootdir: C:\self-study\gsoc\pymc\pymc
configfile: pyproject.toml
plugins: anyio-4.8.0, dash-3.2.0, cov-7.0.0
collected 151 items                                                                                                                                                                

tests\distributions\test_distribution.py ................................                                                                                                    [ 21%]
tests\distributions\test_discrete.py .......................................................................................................................                 [100%]

================================================================================ warnings summary =================================================================================
tests/distributions/test_distribution.py::TestBugfixes::test_issue_3051[1-MvStudentT-kwargs1]
tests/distributions/test_distribution.py::TestBugfixes::test_issue_3051[2-MvStudentT-kwargs1]
tests/distributions/test_distribution.py::TestBugfixes::test_issue_3051[4-MvStudentT-kwargs1]
  C:\self-study\gsoc\pymc\pymc\pymc\distributions\multivariate.py:457: FutureWarning: Use the scale argument to specify the scale matrix. cov will be removed in future versions.
    warnings.warn(

tests/distributions/test_distribution.py::TestPartialObservedRV::test_univariate[True]
  C:\Users\youss\AppData\Local\Programs\Python\Python312\Lib\site-packages\pytensor\link\c\cmodule.py:2986: UserWarning: PyTensor could not link to a BLAS installation. Operations that might benefit from BLAS will be severely degraded.
  This usually happens when PyTensor is installed via pip. We recommend it be installed via conda/mamba/pixi instead.
  Alternatively, you can use an experimental backend such as Numba or JAX that perform their own BLAS optimizations, by setting `pytensor.config.mode == 'NUMBA'` or passing `mode='NUMBA'` when compiling a PyTensor function.
  For more options and details see https://pytensor.readthedocs.io/en/latest/troubleshooting.html#how-do-i-configure-test-my-blas-library
    warnings.warn(

tests/distributions/test_discrete.py::TestMatchesScipy::test_orderedlogistic[2]
tests/distributions/test_discrete.py::TestMatchesScipy::test_orderedlogistic[3]
tests/distributions/test_discrete.py::TestMatchesScipy::test_orderedlogistic[4]
tests/distributions/test_discrete.py::TestMatchesScipy::test_orderedprobit[2]
tests/distributions/test_discrete.py::TestMatchesScipy::test_orderedprobit[3]
tests/distributions/test_discrete.py::TestMatchesScipy::test_orderedprobit[4]
  C:\Users\youss\AppData\Local\Programs\Python\Python312\Lib\site-packages\numpy\_core\numeric.py:457: RuntimeWarning: invalid value encountered in cast
    multiarray.copyto(res, fill_value, casting='unsafe')

tests/distributions/test_discrete.py::TestOrderedLogistic::test_compute_p
tests/distributions/test_discrete.py::TestOrderedProbit::test_compute_p
  C:\self-study\gsoc\pymc\pymc\pymc\model\core.py:1302: RuntimeWarning: invalid value encountered in cast
    data = convert_observed_data(data).astype(rv_var.dtype)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================== 151 passed, 12 warnings in 22.87s ========================================================================"
Closes #6612
