### PR TITLE
Add importorskip for optional test dependencies (jax, graphviz)

### DIFF
--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -19,13 +19,17 @@ from collections.abc import Callable
 from typing import Any
 from unittest import mock
 
+import numpy as np
+import pytest
+
+# Skip all tests in this module if jax is not installed
+pytest.importorskip("jax")
+
 import arviz as az
 import jax
 import jax.numpy as jnp
-import numpy as np
 import pytensor
 import pytensor.tensor as pt
-import pytest
 
 from pytensor.compile import SharedVariable
 from pytensor.graph import graph_inputs

--- a/tests/test_model_graph.py
+++ b/tests/test_model_graph.py
@@ -392,6 +392,7 @@ class BaseModelGraphTest:
         assert self.plates == sort_plates(self.model_graph.get_plates())
 
     def test_graphviz(self):
+        pytest.importorskip("graphviz")
         # just make sure everything runs without error
 
         g = model_to_graphviz(self.model)
@@ -403,6 +404,7 @@ class TestRadonModel(BaseModelGraphTest):
     model_func = radon_model
 
     def test_checks_formatting(self):
+        pytest.importorskip("graphviz")
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             model_to_graphviz(self.model, formatting="plain")
@@ -562,7 +564,8 @@ def simple_model() -> pm.Model:
 
 
 def test_unknown_node_type(simple_model):
-    with pytest.raises(ValueError, match="Node formatters must be of type NodeType."):
+    pytest.importorskip("graphviz")
+    with pytest.raises(ValueError, match=r"Node formatters must be of type NodeType\."):
         model_to_graphviz(simple_model, node_formatters={"Unknown Node Type": "dummy"})
 
 
@@ -582,6 +585,7 @@ def test_custom_node_formatting_networkx(simple_model):
 
 
 def test_custom_node_formatting_graphviz(simple_model):
+    pytest.importorskip("graphviz")
     node_formatters = {
         "Free Random Variable": lambda var: {
             "label": var.name,


### PR DESCRIPTION
Fixes #7914

Tests for JAX and graphviz now gracefully skip when dependencies are not installed instead of failing with ModuleNotFoundError.

Changes:
- tests/sampling/test_jax.py: Add pytest.importorskip for jax at module level
- tests/test_model_graph.py: Add pytest.importorskip for graphviz in tests that use model_to_graphviz

This allows running the test suite without all optional dependencies.