### PR TITLE
Add Stan vs PyMC Rosetta Stone notebook (refs #7771)

### DIFF
--- a/docs/source/learn/core_notebooks/index.md
+++ b/docs/source/learn/core_notebooks/index.md
@@ -12,6 +12,7 @@ pymc_pytensor
 dims_module
 GLM_linear
 Gaussian_Processes
+rosetta_stone_pymc_stan
 :::
 
 :::{note}

--- a/docs/source/learn/core_notebooks/rosetta_stone_pymc_stan.ipynb
+++ b/docs/source/learn/core_notebooks/rosetta_stone_pymc_stan.ipynb
@@ -1,0 +1,1716 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {
+    "id": "Sdp0Vl7pKKjj"
+   },
+   "source": [
+    "(rosetta_stone_pymc_stan)=\n",
+    "\n",
+    "# A rosetta stone for PyMC and Stan\n",
+    "\n",
+    "This notebook discusses how models can be translated between PyMC and Stan, highlighting syntax differences as well as general emphasis in how a model is constructed and used between the two libraries.\n",
+    "\n",
+    ":::{note}\n",
+    "This notebook requires [PyStan](https://pystan.readthedocs.io/) and `nest_asyncio`, which are not PyMC dependencies. If they are not installed, they will be installed automatically when running the notebook.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {
+    "id": "vt4UPvCxQyAi"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/arviz/__init__.py:50: FutureWarning: \n",
+      "ArviZ is undergoing a major refactor to improve flexibility and extensibility while maintaining a user-friendly interface.\n",
+      "Some upcoming changes may be backward incompatible.\n",
+      "  warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running on PyMC v5.27.1+4.ge30641e9a.dirty\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "try:\n",
+    "    import nest_asyncio\n",
+    "    import stan\n",
+    "except ImportError:\n",
+    "    !{sys.executable} -m pip install -q pystan nest_asyncio\n",
+    "    import nest_asyncio\n",
+    "    import stan\n",
+    "\n",
+    "import pymc as pm\n",
+    "\n",
+    "from pymc.distributions import transforms\n",
+    "\n",
+    "print(f\"Running on PyMC v{pm.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RANDOM_SEED = 42\n",
+    "rng = np.random.default_rng(RANDOM_SEED)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {
+    "id": "ilClJudBSkFr"
+   },
+   "outputs": [],
+   "source": [
+    "nest_asyncio.apply()  # Needed for stan in a Jupyter/Colab environment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {
+    "id": "Xik9csu6Kx9T"
+   },
+   "source": [
+    "## A simple model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {
+    "id": "Zp3Qjzm2K4tE"
+   },
+   "source": [
+    "Let's define a very simple model in both libraries.\n",
+    "\n",
+    "$$\n",
+    "\\begin{align*}\n",
+    "x_i &\\sim \\text{Exponential}(1) \\quad \\text{for } i = 1, 2, 3 \\\\\n",
+    "\\sigma_i &= x_i + 1 \\\\\n",
+    "y_i &\\sim \\text{Normal}(0, \\sigma_i) \\quad \\text{for } i = 1, 2, 3 \\\\\n",
+    "\\end{align*}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {
+    "id": "1_i7fGCYP-uH"
+   },
+   "outputs": [],
+   "source": [
+    "with pm.Model() as pymc_model:\n",
+    "    x = pm.Exponential(\"x\", 1, shape=(3,))\n",
+    "    sigma = x + 1\n",
+    "    pm.Normal(\"y\", 0, sigma, observed=[1, 2, 3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "_ybxeIKlQjOm",
+    "outputId": "585317ca-bc19-4082-c954-3a3087eba81a"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Building..."
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "In file included from /Users/micheledigiovanni/Library/Caches/httpstan/4.13.0/models/w66bdixb/model_w66bdixb.cpp:2:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/model/model_header.hpp:4:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math.hpp:19:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev.hpp:4:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/fun/Eigen.hpp:23:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/Sparse:26:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/SparseCore:61:\n",
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/src/SparseCore/TriangularSolver.h:273:13: warning: variable 'count' set but not used [-Wunused-but-set-variable]\n",
+      "  273 |       Index count = 0;\n",
+      "      |             ^\n",
+      "In file included from /Users/micheledigiovanni/Library/Caches/httpstan/4.13.0/models/w66bdixb/model_w66bdixb.cpp:2:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/model/model_header.hpp:4:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math.hpp:19:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev.hpp:4:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/fun/Eigen.hpp:23:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/Sparse:29:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/SparseLU:35:\n",
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/src/SparseLU/SparseLU_heap_relax_snode.h:78:9: warning: variable 'nsuper_et_post' set but not used [-Wunused-but-set-variable]\n",
+      "   78 |   Index nsuper_et_post = 0; // Number of relaxed snodes in postordered etree \n",
+      "      |         ^\n",
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/src/SparseLU/SparseLU_heap_relax_snode.h:79:9: warning: variable 'nsuper_et' set but not used [-Wunused-but-set-variable]\n",
+      "   79 |   Index nsuper_et = 0; // Number of relaxed snodes in the original etree \n",
+      "      |         ^\n",
+      "In file included from /Users/micheledigiovanni/Library/Caches/httpstan/4.13.0/models/w66bdixb/model_w66bdixb.cpp:2:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/model/model_header.hpp:4:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math.hpp:19:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev.hpp:12:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev/fun.hpp:56:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev/fun/elt_multiply.hpp:9:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev/fun/multiply.hpp:7:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/fun.hpp:35:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/fun/binomial_coefficient_log.hpp:13:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/functor/partials_propagator.hpp:8:\n",
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/functor/operands_and_partials.hpp:57:1: warning: 'ops_partials_edge' defined as a struct template here but previously declared as a class template; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]\n",
+      "   57 | struct ops_partials_edge<ViewElt, Op, require_st_arithmetic<Op>> {\n",
+      "      | ^\n",
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/functor/operands_and_partials.hpp:45:1: note: did you mean struct here?\n",
+      "   45 | class ops_partials_edge;\n",
+      "      | ^~~~~\n",
+      "      | struct\n",
+      "In file included from /Users/micheledigiovanni/Library/Caches/httpstan/4.13.0/models/w66bdixb/model_w66bdixb.cpp:2:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/model/model_header.hpp:4:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math.hpp:19:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev.hpp:12:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev/fun.hpp:56:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev/fun/elt_multiply.hpp:9:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev/fun/multiply.hpp:7:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/fun.hpp:137:\n",
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/fun/hypergeometric_1F0.hpp:32:25: warning: unused variable 'function' [-Wunused-variable]\n",
+      "   32 |   constexpr const char* function = \"hypergeometric_1f0\";\n",
+      "      |                         ^~~~~~~~\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "5 warnings generated.\n",
+      "ld: warning: duplicate -rpath '/opt/miniconda3/envs/stan-notebook/lib' ignored\n",
+      "ld: warning: object file (/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/stan_services.o) was built for newer 'macOS' version (15.0) than being linked (11.0)\n",
+      "\n",
+      "Building: 5.9s, done."
+     ]
+    }
+   ],
+   "source": [
+    "stan_model_code = \"\"\"\n",
+    "data {\n",
+    "  int< lower=0 > N;\n",
+    "  vector[N] y;\n",
+    "}\n",
+    "\n",
+    "parameters {\n",
+    "  vector< lower=0 >[3] x;\n",
+    "}\n",
+    "\n",
+    "model {\n",
+    "    x ~ exponential(1);\n",
+    "    vector[N] sigma = x + 1;\n",
+    "    y ~ normal(0, sigma);\n",
+    "}\n",
+    "\"\"\"\n",
+    "\n",
+    "data = {\"N\": 3, \"y\": [1, 2, 3]}\n",
+    "stan_model = stan.build(program_code=stan_model_code, data=data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {
+    "id": "Hnw4OkYGTa2d"
+   },
+   "source": [
+    "Before we compare the syntaxes, let's confirm they are equivalent, by checking the log_prob matches.\n",
+    "\n",
+    "By default STAN drops normalizing constants out of densities, whereas PyMC does not, so we'll have to check that the delta between two points matches."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
+   "metadata": {
+    "id": "a_kwgSyLTKCt"
+   },
+   "outputs": [],
+   "source": [
+    "x_log_test_value1 = [-1, 0, 1]\n",
+    "x_log_test_value2 = [1, 1, 2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b118ea5561624da68c537baed56e602f",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "id": "_9GTEzUrQ88E",
+    "outputId": "97359799-1b39-4c1f-86e3-d9d1214066f3"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'res1=-7.499, res2=-13.824, res1-res2=6.325'"
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res1 = stan_model.log_prob(x_log_test_value1)\n",
+    "res2 = stan_model.log_prob(x_log_test_value2)\n",
+    "f\"{res1=:.3f}, {res2=:.3f}, {res1-res2=:.3f}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "938c804e27f84196a10c8828c723f798",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "id": "hzUNvbIFTPYa",
+    "outputId": "d94ce2e1-35a3-4eb3-e1c6-bce0a5c4b5e5"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'res1=-10.255, res2=-16.581, res1-res2=6.325'"
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pymc_log_prob = pymc_model.compile_logp()\n",
+    "res1 = pymc_log_prob({\"x_log__\": x_log_test_value1})\n",
+    "res2 = pymc_log_prob({\"x_log__\": x_log_test_value2})\n",
+    "f\"{res1=:.3f}, {res2=:.3f}, {res1-res2=:.3f}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "504fb2a444614c0babb325280ed9130a",
+   "metadata": {
+    "id": "6_GrpV1kUuzD"
+   },
+   "source": [
+    "## Line by line comparison"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59bbdb311c014d738909a11f9e486628",
+   "metadata": {
+    "id": "xKac5bDPxWx9"
+   },
+   "source": [
+    "### Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b43b363d81ae4b689946ece5c682cd59",
+   "metadata": {
+    "id": "o7uaSpn9U_5l"
+   },
+   "source": [
+    "The first Stan block defines the data by specifying it's a vector of length `N`, called `y`.\n",
+    "\n",
+    "```stan\n",
+    "data {\n",
+    "  int< lower=0 > N;\n",
+    "  vector[N] y;\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "This is all defined implicitly in the PyMC model by specifying `observed = [1, 2, 3]`, but can be done explicitly by using a {class}`~pymc.Data` container:\n",
+    "\n",
+    "```python\n",
+    "with pm.Model() as pymc_model:\n",
+    "  y_data = pm.Data(\"y_data\", [1, 2, 3])\n",
+    "  ...\n",
+    "  pm.Normal(\"y\", ..., observed=y_data)\n",
+    "```\n",
+    "\n",
+    "Note we have to give a different name to the data container and the y variable. This is so we can access either by name later (`pymc_model[\"y\"]` and `pymc_model[\"y_data\"]`)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a65eabff63a45729fe45fb5ade58bdc",
+   "metadata": {
+    "id": "5brozJ-XWW5K"
+   },
+   "source": [
+    "### Parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3933fab20d04ec698c2621248eb3be0",
+   "metadata": {
+    "id": "oq2mDSmOxoyx"
+   },
+   "source": [
+    "One of the largest differences between the two libraries, is that in Stan you have to explicitly define the model parameters and constraints, separately from how they \"are distributed\"."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dd4641cc4064e0191573fe9c69df29b",
+   "metadata": {
+    "id": "91DrPv_jxgqL"
+   },
+   "source": [
+    "```\n",
+    "parameters {\n",
+    "  vector< lower=0 >[3] x;\n",
+    "}\n",
+    "```\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8309879909854d7188b41380fd92a7c3",
+   "metadata": {
+    "id": "YmAeQQ4Xx2_S"
+   },
+   "source": [
+    "In PyMC a parameter is implicitly defined every time a \"named variable\" is defined inside a model.\n",
+    "\n",
+    "```python\n",
+    "x = pm.Exponential(\"x\", 1, shape=(3,))\n",
+    "```\n",
+    "\n",
+    "Note the repetition of `x`. The Python variable name need not match the model  variable name, and you can also reassign it to other Python variables just like you would expect from python objects.\n",
+    "\n",
+    "If you do not need to use `x`, you don't need to assign it to any python Variable, like we do with `y` later.\n",
+    "\n",
+    "\n",
+    "The variable assigned to `x` in PyMC is rather different in nature than the Stan one. It is not a \"parameter\", but a \"random variable\" that you can evaluate to take random draws."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "3ed186c9a28b402fb0bc4494df01f08d",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "wrTS4u-iyNpP",
+    "outputId": "120de97f-b760-4987-a030-5cee3393546a"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "array([1.82026853, 1.22990623, 0.05622997])"
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm.draw(x, random_seed=rng)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb1e1581032b452c9409d6c6813c49d1",
+   "metadata": {
+    "id": "0s8QoIsjySIb"
+   },
+   "source": [
+    "The actual parameter is tucked away inside the model in `rvs_to_values`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "379cbbc1e968416e875cc15c1202d7eb",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "0MKAGg3TyRMC",
+    "outputId": "c588c3e7-7b71-400e-9abf-8eff19ac1ecb"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "x_log__"
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pymc_model.rvs_to_values[x]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "277c27b1587741f2af2001be3712ef0d",
+   "metadata": {
+    "id": "EoForEBjyjyK"
+   },
+   "source": [
+    "Unlike Stan, the positive constraint transform is automatically applied, because in regular applications of PyMC a parameter \"belongs\" to a specific distribution.\n",
+    "\n",
+    "Because, an `Exponential` is a positive-domain distribution, PyMC applies a default log transform to the parameter `x`, that encodes the constraint and frees the samplers from boundary conditions.\n",
+    "\n",
+    "The transform can be found in `rvs_to_transforms`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "db7b79bc585a40fcaf58bf750017e135",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "9Hv87P_cWMfA",
+    "outputId": "8eafbe55-504d-4343-ca86-57f3e48be996"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<pymc.logprob.transforms.LogTransform at 0x13b2bd490>"
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pymc_model.rvs_to_transforms[x]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "916684f9a58a4a2aa5f864670399430d",
+   "metadata": {
+    "id": "1sxlW5jWWYdL"
+   },
+   "source": [
+    "The constraint can be customized/disabled by passing an appropriate value to `default_transform` when defining the random variable as in:\n",
+    "\n",
+    "`x = pm.Exponential(\"x\", default_transform=None)`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1671c31a24314836a5b85d7ef7fbf015",
+   "metadata": {
+    "id": "nEh2DMLizbto"
+   },
+   "source": [
+    "Both PyMC and Stan apply the jacobian correction of the transformation by default, so that the prior is respected when sampling from the unconstrained space. Both can also be opted out:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "33b0902fd34d4ace834912fa1002cf8e",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "id": "mBTqqdtLJzHk",
+    "outputId": "4d09c679-aff1-4ca9-a290-53daf61a682e"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'res1=-7.499, res2=-17.824, res1-res2=10.325'"
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res1 = stan_model.log_prob(x_log_test_value1, adjust_transform=False)\n",
+    "res2 = stan_model.log_prob(x_log_test_value2, adjust_transform=False)\n",
+    "f\"{res1=:.3f}, {res2=:.3f}, {res1-res2=:.3f}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f6fa52606d8c4a75a9b52967216f8f3f",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "id": "-KSDHhwq2Qw9",
+    "outputId": "30628499-f016-4e8c-a711-fbff16f58601"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'res1=-10.255, res2=-20.581, res1-res2=10.325'"
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pymc_log_prob = pymc_model.compile_logp(jacobian=False)\n",
+    "res1 = pymc_log_prob({\"x_log__\": x_log_test_value1})\n",
+    "res2 = pymc_log_prob({\"x_log__\": x_log_test_value2})\n",
+    "f\"{res1=:.3f}, {res2=:.3f}, {res1-res2=:.3f}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5a1fa73e5044315a093ec459c9be902",
+   "metadata": {
+    "id": "ynXDFB09zyzi"
+   },
+   "source": [
+    "### Intermediate variables"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdf66aed5cc84ca1b48e60bad68798a8",
+   "metadata": {
+    "id": "NbNGXycXz4cz"
+   },
+   "source": [
+    "In Stan, if you explicitly assign intermediate variables, you have to define their type:\n",
+    "\n",
+    "```stan\n",
+    "vector[N] sigma = x + 1;\n",
+    "```\n",
+    "\n",
+    "\n",
+    "In PyMC the type is inferred automatically\n",
+    "```python\n",
+    "sigma = x + 1\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "28d3efd5258a48a79c179ea5c6759f01",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "73xRPffe0Ya8",
+    "outputId": "25636268-26b3-4b7f-bffc-9811c14bcdef"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "TensorType(float64, shape=(3,))"
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sigma.type"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f9bc0b9dd2c44919cc8dcca39b469f8",
+   "metadata": {
+    "id": "-M9rp0TY0bFo"
+   },
+   "source": [
+    "Both Stan and PyMC allow you to save these intermediate variables during sampling.\n",
+    "\n",
+    "For Stan you include the variable definition inside a `generated quantities` block.\n",
+    "\n",
+    "For PyMC you wrap the variable in a {class}`~pymc.Deterministic` block (even though the variable need not be deterministic!)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e382214b5f147d187d36a2058b9c724",
+   "metadata": {
+    "id": "Z4ed24Wi084s"
+   },
+   "source": [
+    "### Likelihood"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b09d5ef5b5e4bb6ab9b829b10b6a29f",
+   "metadata": {
+    "id": "z4XzUoYZ20D_"
+   },
+   "source": [
+    "In Stan, after having specified `y` is data, we assign its density like we do with a regular parameter\n",
+    "\n",
+    "```stan\n",
+    "y ~ normal(0, sigma);\n",
+    "```\n",
+    "\n",
+    "In PyMC you pass the observed argument instead.\n",
+    "\n",
+    "```python\n",
+    "pm.Normal(\"y\", ..., observed=y_data)\n",
+    "```\n",
+    "\n",
+    "Because we don't intend to use `y` anywhere else, we didn't assign it to a Python variable. We can still retrieve it, and we'll see that like `x` this is just another \"random variable\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "a50416e276a0479cbe66534ed1713a40",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "1JToXgXv2zbx",
+    "outputId": "4b74cd88-91d0-49e1-ad88-c4356f5e1ec9"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "array([ 0.66102545,  1.17860474, -0.74218733])"
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y = pymc_model[\"y\"]\n",
+    "pm.draw(y, random_seed=rng)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46a27a456b804aa2a380d5edf15a5daf",
+   "metadata": {
+    "id": "QsE6OCe00XRY"
+   },
+   "source": [
+    "The only immediate sign of the `observed` argument is the shape is automatically derived from the observed data.\n",
+    "\n",
+    "Under the hood, the variable is distinguished by being stored in a separate model property: `observed_RVs`, instead of `free_RVs`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "1944c39560714e6e80c856f20744a8e5",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "p2YF-dpmz2gh",
+    "outputId": "65d9bc06-2320-4083-d113-3190a85ba684"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "([y ~ Normal(0, f(x))], [x ~ Exponential(f())])"
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pymc_model.observed_RVs, pymc_model.free_RVs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6ca27006b894b04b6fc8b79396e2797",
+   "metadata": {
+    "id": "o0dafWks31la"
+   },
+   "source": [
+    "The `observed` constitutes the \"value\" of the `y` RV, which is a constant, not a parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "f61877af4e7f4313ad8234302950b331",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "PzMNhpCn3yoW",
+    "outputId": "ebf883b6-6e57-4e32-9e4c-1f606cdf9060"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "TensorConstant(TensorType(float64, shape=(3,)), data=array([1., 2., 3.]))"
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pymc_model.rvs_to_values[y]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84d5ab97d17b4c38ab41a2b065bbd0c0",
+   "metadata": {
+    "id": "oF_AhqVn4GkI"
+   },
+   "source": [
+    "### Aside: observed can be deferred.\n",
+    "\n",
+    "PyMC introduced a {func}`~pymc.observe` model transformation, which allows one to define the observed quantities at a later time. In this case the shape (or dims) have to be provided explicitly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "35ffc1ce1c7b4df9ace1bc936b8b1dc2",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Qd483_Y04r50",
+    "outputId": "63f3c825-a9b4-45fc-8a9b-35507fa22ecd"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[x, y] []\n",
+      "[x] [y]\n"
+     ]
+    }
+   ],
+   "source": [
+    "with pm.Model() as raw_model:\n",
+    "    # Not assigning to Python variables to avoid shadowing the ones from the original example\n",
+    "    pm.Exponential(\"x\", 1, shape=(3,))\n",
+    "    pm.Normal(\"y\", 0, raw_model[\"x\"] + 1, shape=(3,))\n",
+    "\n",
+    "print(raw_model.free_RVs, raw_model.observed_RVs)\n",
+    "\n",
+    "observed_model = pm.observe(raw_model, {\"y\": [1, 2, 3]})\n",
+    "\n",
+    "print(observed_model.free_RVs, observed_model.observed_RVs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76127f4a2f6a44fba749ea7800e59d51",
+   "metadata": {
+    "id": "DdKrkv3E4sRN"
+   },
+   "source": [
+    "These shapes can be defined in a way that the lengths are not pre-committed, but the user must still pre-commit to the dimensionality (`ndim`) of the variable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "903197826d2e44dfa0208e8f97c69327",
+   "metadata": {
+    "id": "7e43BB2r5WR4"
+   },
+   "source": [
+    "## Forward draws"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "015066fb96f841e5be1e03a9eaadc3b6",
+   "metadata": {
+    "id": "241gyPmz5ZGj"
+   },
+   "source": [
+    "When we define a PyMC model we are actually defining the random graph of the model, from which we can take draws by simply evaluating the nodes in a \"forward sampling scheme\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "81ff116bae5b45f6b6dae177083008cf",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "hEhdXe275X3I",
+    "outputId": "472b468c-a61e-4a9d-f09b-79852f213777"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "array([2.10782338, 0.36699214, 0.3459135 ])"
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm.draw(x, random_seed=rng)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "9075f00cfa8d463f84130041b1e44ca7",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "2CczQoWc53De",
+    "outputId": "741c225a-6b09-4b3f-a5be-b088e27d820a"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "array([0.94514318, 3.51777377, 1.43089558])"
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm.draw(y, random_seed=rng)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15abde8c5d2e435093904b13db685a53",
+   "metadata": {
+    "id": "J7xqUe0H56r7"
+   },
+   "source": [
+    "When calling {func}`~pymc.draw` on `y` alone, new draws of `x` are implicitly drawn as well, just not returned.\n",
+    "\n",
+    "One can request draws from multiple variables simultaneously to get the joint \"consistent\" forward samples of both random variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "5e20a2a0e21149b5b06860e930401eb5",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "IIFGEOKl54iP",
+    "outputId": "f05652e4-849c-4fed-ccad-86839ca755a3"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[array([0.76208373, 0.86580959, 1.40981902]),\n array([ 1.39574537, -1.28594051,  1.33773923])]"
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm.draw([x, y], random_seed=rng)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72c31777baf4441b988909d29205560c",
+   "metadata": {
+    "id": "hojmhnn-6Q2c"
+   },
+   "source": [
+    "PyMC does just this for prior predictive sampling, avoiding running a more expensive mcmc sampler/ worrying about convergence issues.\n",
+    "\n",
+    "Similarly, for posterior predictive sampling, PyMC takes forward draws of the observed variables, but reuses the posterior draws of the free variables instead of evaluating them again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "5734001bcbac423990a4356310d8df13",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "yFFU-WqH6s49",
+    "outputId": "d97ec18d-0bfc-4fd0-a9ca-90c97fc57d36"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "array([-3.00510196,  0.87239497,  5.70361907])"
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "implausible_posterior_x_sample = np.array([1, 10, 100.0])\n",
+    "pm.draw(y, givens={x: implausible_posterior_x_sample}, random_seed=rng)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27531e93873647d9a5bf1112f2051a59",
+   "metadata": {
+    "id": "fbbAsewg7rLU"
+   },
+   "source": [
+    "To perform forward sampling in Stan one must redefine the equivalent variables using random number generators in the `generated_quantities` block.\n",
+    "\n",
+    "```stan\n",
+    "generated quantities {\n",
+    "    vector[N] y_sim;\n",
+    "    for (n in 1:N) {\n",
+    "        y_sim[n] = normal_rng(0, sigma);\n",
+    "    }\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "(Not sure if vectorized rng functions are provided or must still be done in a loop)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3041e9ffdb2416ea2009d3a6a4c5716",
+   "metadata": {
+    "id": "GwBvBAtI3_ym"
+   },
+   "source": [
+    "## The one parameter ↔ one distribution assumption"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94ae71b6e24e4355a139fb9fe2e09b64",
+   "metadata": {
+    "id": "i2xU7kIS4EtE"
+   },
+   "source": [
+    "It's worth discussing this PyMC assumption a bit further, as it is where it deviates the most from Stan.\n",
+    "\n",
+    "In Stan it's valid and (straightforward) to assign multiple densities to the same parameter, or assign widely different densities to different dimensions of the parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9141936c6c8a4c478a75aea4ff665469",
+   "metadata": {
+    "id": "LD_WnxqnNiL_"
+   },
+   "source": [
+    "Let's use a new example to illustrate this. It's almost the same as the previous model, except the first two entries of x are first assigned an Exponential density, and the last one a HalfNormal density.\n",
+    "\n",
+    "Then all entries are assigned a second Normal density on top of the first one."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd7c096f4dcf400fbdceb075ef31fca3",
+   "metadata": {
+    "id": "kKeEfmYCOCxj"
+   },
+   "source": [
+    "And a cringe mathematical-like definition:\n",
+    "\n",
+    "$$\n",
+    "\\begin{align*}\n",
+    "x_i &\\sim \\text{Exponential}(1) \\quad \\text{for } i = 1, 2 \\\\\n",
+    "x_3 &\\sim \\text{HalfNormal}(1) \\\\\n",
+    "x_i &\\sim \\text{Normal}(0, 1) \\quad \\text{for } i = 1, 2, 3 \\\\\n",
+    "y_i &\\sim \\text{Normal}(0, x_i + 1) \\quad \\text{for } i = 1, 2, 3 \\\\\n",
+    "\\end{align*}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "b427a666a1b549ef9b573d6f946bfc3b",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "NBmTe5OR_PSi",
+    "outputId": "8139ee24-d184-41be-90c6-11356bf2ea19"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Building..."
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "In file included from /Users/micheledigiovanni/Library/Caches/httpstan/4.13.0/models/wr3wzqpt/model_wr3wzqpt.cpp:2:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/model/model_header.hpp:4:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math.hpp:19:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev.hpp:4:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/fun/Eigen.hpp:23:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/Sparse:26:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/SparseCore:61:\n",
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/src/SparseCore/TriangularSolver.h:273:13: warning: variable 'count' set but not used [-Wunused-but-set-variable]\n",
+      "  273 |       Index count = 0;\n",
+      "      |             ^\n",
+      "In file included from /Users/micheledigiovanni/Library/Caches/httpstan/4.13.0/models/wr3wzqpt/model_wr3wzqpt.cpp:2:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/model/model_header.hpp:4:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math.hpp:19:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev.hpp:4:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/fun/Eigen.hpp:23:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/Sparse:29:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/SparseLU:35:\n",
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/src/SparseLU/SparseLU_heap_relax_snode.h:78:9: warning: variable 'nsuper_et_post' set but not used [-Wunused-but-set-variable]\n",
+      "   78 |   Index nsuper_et_post = 0; // Number of relaxed snodes in postordered etree \n",
+      "      |         ^\n",
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/Eigen/src/SparseLU/SparseLU_heap_relax_snode.h:79:9: warning: variable 'nsuper_et' set but not used [-Wunused-but-set-variable]\n",
+      "   79 |   Index nsuper_et = 0; // Number of relaxed snodes in the original etree \n",
+      "      |         ^\n",
+      "In file included from /Users/micheledigiovanni/Library/Caches/httpstan/4.13.0/models/wr3wzqpt/model_wr3wzqpt.cpp:2:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/model/model_header.hpp:4:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math.hpp:19:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev.hpp:12:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev/fun.hpp:56:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev/fun/elt_multiply.hpp:9:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev/fun/multiply.hpp:7:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/fun.hpp:35:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/fun/binomial_coefficient_log.hpp:13:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/functor/partials_propagator.hpp:8:\n",
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/functor/operands_and_partials.hpp:57:1: warning: 'ops_partials_edge' defined as a struct template here but previously declared as a class template; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]\n",
+      "   57 | struct ops_partials_edge<ViewElt, Op, require_st_arithmetic<Op>> {\n",
+      "      | ^\n",
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/functor/operands_and_partials.hpp:45:1: note: did you mean struct here?\n",
+      "   45 | class ops_partials_edge;\n",
+      "      | ^~~~~\n",
+      "      | struct\n",
+      "In file included from /Users/micheledigiovanni/Library/Caches/httpstan/4.13.0/models/wr3wzqpt/model_wr3wzqpt.cpp:2:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/model/model_header.hpp:4:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math.hpp:19:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev.hpp:12:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev/fun.hpp:56:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev/fun/elt_multiply.hpp:9:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/rev/fun/multiply.hpp:7:\n",
+      "In file included from /opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/fun.hpp:137:\n",
+      "/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/include/stan/math/prim/fun/hypergeometric_1F0.hpp:32:25: warning: unused variable 'function' [-Wunused-variable]\n",
+      "   32 |   constexpr const char* function = \"hypergeometric_1f0\";\n",
+      "      |                         ^~~~~~~~\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "5 warnings generated.\n",
+      "ld: warning: duplicate -rpath '/opt/miniconda3/envs/stan-notebook/lib' ignored\n",
+      "ld: warning: object file (/opt/miniconda3/envs/stan-notebook/lib/python3.12/site-packages/httpstan/stan_services.o) was built for newer 'macOS' version (15.0) than being linked (11.0)\n",
+      "\n",
+      "Building: 5.5s, done.Messages from stanc:\n",
+      "Warning: The parameter x has 3 priors.\n"
+     ]
+    }
+   ],
+   "source": [
+    "stan_model_code2 = \"\"\"\n",
+    "data {\n",
+    "  int< lower=0 > N;\\\n",
+    "  vector[N] y;\n",
+    "}\n",
+    "\n",
+    "parameters {\n",
+    "  vector< lower=0 >[3] x;\n",
+    "}\n",
+    "\n",
+    "model {\n",
+    "    x[1:2] ~ exponential(1);\n",
+    "    x[3] ~ normal(0, 1);\n",
+    "    x ~ normal(0, 1);\n",
+    "    y ~ normal(0, x + 1);\n",
+    "}\n",
+    "\"\"\"\n",
+    "data = {\"N\": 3, \"y\": [1, 2, 3]}\n",
+    "\n",
+    "stan_model2 = stan.build(program_code=stan_model_code2, data=data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0310869696a145bf841235dd6c036af8",
+   "metadata": {
+    "id": "LWOB3rH8_ya0"
+   },
+   "source": [
+    "Stan emits a warning saying the parameter has 3 priors (technically it only has 2 ^^)\n",
+    "\n",
+    "Stan doesn't have a HalfNormal distribution, instead we get one implicitly by assigning a zero-centered Normal to a positively constrained parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91f166d9f0ce4939b04b8e9245f75c27",
+   "metadata": {
+    "id": "73TmiC-L_YcL"
+   },
+   "source": [
+    "PyMC doesn't really have an equivalent version of this model, at least not the sort of PyMC usage that you're likely to find in the wild. But we can achieve the same if we really want to.\n",
+    "\n",
+    "I'll show two approaches, to give a better picture."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c10029e1707434ab3fe295caea7d13f",
+   "metadata": {
+    "id": "YMLT6WWqALof"
+   },
+   "source": [
+    "### CustomDist for crazy distributions\n",
+    "\n",
+    "For the first two densities we can stay in PyMC-approved land, by using {class}`~pymc.CustomDist`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "f68f0888c55a4478ace3eac39384dff4",
+   "metadata": {
+    "id": "TuwU59KIAYz0"
+   },
+   "outputs": [],
+   "source": [
+    "with pm.Model() as pymc_model2:\n",
+    "\n",
+    "    def first_two_exponential_third_normal_dist(_):\n",
+    "        return pm.math.concatenate(\n",
+    "            [\n",
+    "                pm.Exponential.dist(\n",
+    "                    1,\n",
+    "                    shape=(2,),\n",
+    "                ),\n",
+    "                pm.HalfNormal.dist(1, shape=(1,)),\n",
+    "            ]\n",
+    "        )\n",
+    "\n",
+    "    x = pm.CustomDist(\n",
+    "        \"x\",\n",
+    "        dist=first_two_exponential_third_normal_dist,\n",
+    "        transform=transforms.log,\n",
+    "    )\n",
+    "    y = pm.Normal(\"y\", 0, x + 1, observed=[0, 1, 2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f94f5a17fa734d288763e7d9a3758173",
+   "metadata": {
+    "id": "SfzM-e7lBNEV"
+   },
+   "source": [
+    "{class}`~pymc.CustomDist` accepts a callable as the `dist` argument, that defines an implicit distribution from a generative random graph. In this case the concatenation of two Exponential random variables and one HalfNormal random variable.\n",
+    "\n",
+    "We have to use the `.dist` to define floating random variables. These are not model variables and have no parameters, they exist just to define the graph that represents the distribution we care about. The actual random variable and parameters are the `\"x\"` defined by the {class}`~pymc.CustomDist`.\n",
+    "\n",
+    "We still live in the land of one parameter, one distribution, just a \"custom\" one. Because it was defined via the random graph, PyMC has no trouble taking draws from it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "421b839107204e409e0496d3d944026c",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "v3M3fDXJB53B",
+    "outputId": "b76438db-16f5-4b99-dce1-0f221c5bd123"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "array([0.35237034, 1.18868032, 0.78625866])"
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm.draw(x, random_seed=rng)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e981b37c798e44f684168605b9db02c6",
+   "metadata": {
+    "id": "n5ha7BpqCPG0"
+   },
+   "source": [
+    "We no longer get default transforms, they have to be defined explicitly. I'm purposely using the argument `transform` instead of `default_transform` here, to highlight this difference.\n",
+    "\n",
+    "**Note that the transforms don't have any effect in the random graph. Had we used a Normal instead of a HalfNormal, we would see negative values on the third entry half of the time.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40c1800d1c114147a536b8aa907907c7",
+   "metadata": {
+    "id": "BbCvtVrMCZBU"
+   },
+   "source": [
+    "PyMC can also get the log_prob of our `CustomDist`, by reasoning symbolically about the random forward graph implied in the `dist` function. In this case it's a trivial question of pairing the right entries of the parameter with the respective densities, but it can be richer than this.\n",
+    "\n",
+    "If you are curious about what sorts of densities PyMC can infer from random graphs, check out [30 short puzzles on probability](https://colab.research.google.com/github/ricardoV94/probability-puzzles/blob/main/puzzles.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "9082857fd66e4025bba99b1a80c5d976",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "e4omtzFgCzCg",
+    "outputId": "e7e8451a-607e-4a90-e698-ba764edfdb10"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "array(-10.63434397)"
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pymc_model2.compile_logp()({\"x_log__\": [-1, 0, 1]})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71b4158a9f3d49279f06ec9197b84529",
+   "metadata": {
+    "id": "Yb6LRFa7C6gh"
+   },
+   "source": [
+    "### Breaking free with Potentials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6038e703eb6b4df2ba5a71336b77ea4e",
+   "metadata": {
+    "id": "3kicC6AqC-nZ"
+   },
+   "source": [
+    "For the second density assignment we have to break free with our dream of having automatically matching random and log_prob graphs under a single PyMC model.\n",
+    "\n",
+    "PyMC provides {class}`~pymc.Potential` to define arbitrary terms that should be added to the model joint logp, and which have no random counterpart."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "82ca0f16c5be4617b5535c40faa36c79",
+   "metadata": {
+    "id": "jSXJqltuDaLX"
+   },
+   "outputs": [],
+   "source": [
+    "with pymc_model2:\n",
+    "    pm.Potential(\"non_default_density_on_x\", pm.Normal.logp(x, 0, 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04aa693c20bd460494e518b8cb84ef11",
+   "metadata": {
+    "id": "r9785_O7ERJr"
+   },
+   "source": [
+    "(Annoyingly you have to give them unique names...)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8acbee542ae4f9e87d350f4747cb88d",
+   "metadata": {
+    "id": "EFOMzZ3gEUQO"
+   },
+   "source": [
+    "Now the two models should be equivalent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "e0a51dd6baab431990c6adcc83aa7fba",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "id": "1snvneTcEdvK",
+    "outputId": "58586252-9e5a-4211-d5c5-bce18bd70827"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'res1=-12.737, res2=-68.422, res1-res2=55.685'"
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res1 = stan_model2.log_prob(x_log_test_value1)\n",
+    "res2 = stan_model2.log_prob(x_log_test_value2)\n",
+    "f\"{res1=:.3f}, {res2=:.3f}, {res1-res2=:.3f}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "d84866adce69467fa81441dc6c47fd8a",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "id": "TJjhoSsKEsUf",
+    "outputId": "52993698-c628-46fe-d797-49b7ec8a7e46"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'res1=-17.653, res2=-73.981, res1-res2=56.328'"
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pymc_log_prob = pymc_model2.compile_logp()\n",
+    "res1 = pymc_log_prob({\"x_log__\": x_log_test_value1})\n",
+    "res2 = pymc_log_prob({\"x_log__\": x_log_test_value2})\n",
+    "f\"{res1=:.3f}, {res2=:.3f}, {res1-res2=:.3f}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "deb6c23654f54f5b91a38c31054c5587",
+   "metadata": {
+    "id": "7ar_vEeeKBdt"
+   },
+   "source": [
+    "(It's not exactly the same though, so I may be missing something small, or we see rounding errors here)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9768d501ade64311a8ed6e9eb433fa9b",
+   "metadata": {
+    "id": "ifsPmtt5E4yM"
+   },
+   "source": [
+    "And if you try to use a forward sampling routine like {func}`~pymc.sample_prior_predictive` or {func}`~pymc.sample_posterior_predictive` PyMC will warn you that Potential terms are simply ignored by those."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "061962c182f9482c8b1341b2a6f73cd5",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "4RrRZHBkE2dr",
+    "outputId": "bb0f90a4-8d18-4a7d-810a-472f4899c0d4"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/hj/jxyj0gnn2z32ctp8p186tv6m0000gn/T/ipykernel_32805/755570405.py:2: UserWarning: The effect of Potentials on other parameters is ignored during prior predictive sampling. This is likely to lead to invalid or biased predictive samples.\n",
+      "  pm.sample_prior_predictive(random_seed=rng)\n",
+      "Sampling: [x, y]\n"
+     ]
+    }
+   ],
+   "source": [
+    "with pymc_model2:\n",
+    "    pm.sample_prior_predictive(random_seed=rng)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8edfd84aa00d4424a71141df99c55e72",
+   "metadata": {
+    "id": "MPlDl3vwRrur"
+   },
+   "source": [
+    "We want to add a [second warning](https://github.com/pymc-devs/pymc/discussions/5404) for when a user defines a `transform` (not a `default_transform`), for similar reasons. Custom transforms don't have any effect on forward draws, and can cause a mismatch between the forward and logp sampling methods of the same model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c55fba33aa346cf939c9cd632996673",
+   "metadata": {
+    "id": "JonZi-rgFKok"
+   },
+   "source": [
+    "{func}`~pymc.draw` has no concept of a Model, and simply evaluates the random graph without any warnings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "ab13b4b6e2874167b7f2debb11dcd1d9",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "H4dYhCyuEy6g",
+    "outputId": "67d092a0-9baa-4b55-b312-4b555d789b62"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "array([1.185285  , 0.31633438, 0.44142085])"
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm.draw(x, random_seed=rng)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47d658866ccb404681cf21a4419000da",
+   "metadata": {
+    "id": "8af9ec7hFZVf"
+   },
+   "source": [
+    "## Writing PyMC models as if it were Stan"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d973992396c4b758db40b17e80dc1fc",
+   "metadata": {
+    "id": "VtM1vBenFhtP"
+   },
+   "source": [
+    "It is possible, although not pretty, and likely silly, to translate Stan models to PyMC line-by-line.\n",
+    "\n",
+    "The trick is to force PyMC to create parameters without assigned-densities, using {class}`~pymc.Flat`, and providing custom `transform`s to define the constraints on these parameters.\n",
+    "\n",
+    "Once we have the variable returned by `Flat` we can chain arbitrary Potential terms like Stan does once you strip the syntactic sugar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "1c9cbe9d9a794dbd8aaa1fa72bce99a9",
+   "metadata": {
+    "id": "CIcJPSFSza4T"
+   },
+   "outputs": [],
+   "source": [
+    "with pm.Model() as pymc_model2_eq:\n",
+    "    x = pm.Flat(\"x\", shape=(3,), default_transform=transforms.log)\n",
+    "\n",
+    "    pm.Potential(\"x_term[1:2]\", pm.Exponential.logp(x[:2], 1))\n",
+    "    pm.Potential(\"x_term[3]\", pm.Normal.logp(x[2], 0, 1))\n",
+    "    pm.Potential(\"x_term\", pm.Normal.logp(x, 0, 1))\n",
+    "    pm.Potential(\"y_term\", pm.Normal.logp(np.array([0, 1, 2]), 0, x + 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "b434e0d67d894725aa1f6d707a143313",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "id": "cFUTMrkwU8B4",
+    "outputId": "e9d10eb8-ffb9-4729-a969-986b4450f030"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'res1=-18.347, res2=-74.674, res1-res2=56.328'"
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pymc_log_prob = pymc_model2_eq.compile_logp()\n",
+    "res1 = pymc_log_prob({\"x_log__\": x_log_test_value1})\n",
+    "res2 = pymc_log_prob({\"x_log__\": x_log_test_value2})\n",
+    "f\"{res1=:.3f}, {res2=:.3f}, {res1-res2=:.3f}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "594a68b434714bab9e1df903f88edcdd",
+   "metadata": {
+    "id": "6AfmlSU1ZCbo"
+   },
+   "source": [
+    "### Note on requesting densities from PyMC\n",
+    "\n",
+    "Final note, for brevity I used `Normal.logp(x, 0, 1)` syntax which is discouraged, as not all Distributions have a `.logp` method and the parametrization accepted by them can be non-intuitive. The \"valid\" way to get the logp would be:\n",
+    "\n",
+    "```python\n",
+    "pm.logp(pm.Normal.dist(0, 1), x)\n",
+    "```\n",
+    "Where we create a dummy `Normal` random variate just to extract the corresponding logp term. This will work with any distribution / parametrization, as well as arbitrary graphs of random variables, as long as PyMC can derive its density."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "4d59fedcae41437686ad1a71a1884d48",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Last updated: Wed, 04 Feb 2026\n",
+      "\n",
+      "Python implementation: CPython\n",
+      "Python version       : 3.12.12\n",
+      "IPython version      : 9.7.0\n",
+      "\n",
+      "pytensor: 2.37.0\n",
+      "\n",
+      "nest_asyncio: 1.6.0\n",
+      "numpy       : 2.3.5\n",
+      "pandas      : 3.0.0\n",
+      "pymc        : 5.27.1+4.ge30641e9a\n",
+      "stan        : 3.10.0\n",
+      "\n",
+      "Watermark: 2.6.0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext watermark\n",
+    "%watermark -n -u -v -iv -w -p pytensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74a36f4709894f8e822f9c383b5c8674",
+   "metadata": {
+    "id": "zNqZ7vIlH5dR"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pymc-dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/learn/core_notebooks/rosetta_stone_pymc_stan.ipynb
+++ b/docs/source/learn/core_notebooks/rosetta_stone_pymc_stan.ipynb
@@ -254,7 +254,7 @@
    "source": [
     "Before we compare the syntaxes, let's confirm they are equivalent, by checking the log_prob matches.\n",
     "\n",
-    "By default STAN drops normalizing constants out of densities, whereas PyMC does not, so we'll have to check that the delta between two points matches."
+    "By default Stan drops normalizing constants out of densities, whereas PyMC does not, so we'll have to check that the delta between two points matches."
    ]
   },
   {
@@ -1027,7 +1027,7 @@
     "}\n",
     "```\n",
     "\n",
-    "(Not sure if vectorized rng functions are provided or must still be done in a loop)"
+    "Stan also provides vectorized RNG functions (for example, `normal_rng`) that can generate draws for entire vectors or arrays in a single call."
    ]
   },
   {
@@ -1475,7 +1475,7 @@
     "id": "7ar_vEeeKBdt"
    },
    "source": [
-    "(It's not exactly the same though, so I may be missing something small, or we see rounding errors here)"
+    "Note that the values are not exactly identical; small differences are expected due to implementation details and numerical precision differences between Stan and PyMC."
    ]
   },
   {


### PR DESCRIPTION
Integrate the “Rosetta Stone” notebook by Ricardo Vieira comparing how models are defined in PyMC and Stan. The notebook focuses on syntax differences, parameterization, forward draws / prior predictive, and the “one-parameter-one-distribution” assumption.

Closes #7771

## Description
This PR:
- adds `docs/source/learn/core_notebooks/rosetta_stone_pymc_stan.ipynb`
- updates `docs/source/learn/index.md` to include the notebook in the Learn docs navigation

## Related Issue
- [x] Closes #7771
- [ ] Related to #

## Checklist
- [x] Checked that the pre-commit linting/style checks pass (for the modified files)
- [x] Included tests that prove the fix is effective or that the new feature works (N/A: docs-only notebook)
- [x] Added necessary documentation (example notebook)
- [ ] If you are a pro: each commit corresponds to a relevant logical change

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):