### PR TITLE
`dims.Data` creates `XTensorSharedVariables`

### DIFF
--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -22,7 +22,7 @@ dependencies:
 - numpyro>=0.8.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.37.0,<2.38
+- pytensor>=2.38.0,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.37.0,<2.38
+- pytensor>=2.38.0,<2.39
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -11,7 +11,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.37.0,<2.38
+- pytensor>=2.38.0,<2.39
 - python-graphviz
 - rich>=13.7.1
 - scipy>=1.4.1

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -14,7 +14,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=2.37.0,<2.38
+- pytensor>=2.38.0,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.37.0,<2.38
+- pytensor>=2.38.0,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -15,7 +15,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=2.37.0,<2.38
+- pytensor>=2.38.0,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -32,7 +32,7 @@ import pytensor.sparse as sparse
 import pytensor.tensor as pt
 import scipy.sparse as sps
 
-from pytensor.compile import DeepCopyOp, Function, ProfileStats, get_mode
+from pytensor.compile import DeepCopyOp, Function, ProfileStats, get_mode, view_op
 from pytensor.compile.sharedvalue import SharedVariable
 from pytensor.graph.basic import Constant, Variable
 from pytensor.graph.traversal import ancestors, explicit_graph_inputs, graph_inputs
@@ -2263,7 +2263,7 @@ def Deterministic(name, var, model=None, dims=None):
     random variables.
     """
     model = modelcontext(model)
-    var = var.copy(model.name_for(name))
+    var = view_op(var, name=model.name_for(name))
     model.deterministics.append(var)
     model.add_named_variable(var, dims)
 

--- a/pymc/model/transform/optimization.py
+++ b/pymc/model/transform/optimization.py
@@ -15,18 +15,14 @@ from collections.abc import Sequence
 
 from pytensor import clone_replace
 from pytensor.compile import SharedVariable
-from pytensor.graph import FunctionGraph
-from pytensor.tensor import constant
-from pytensor.tensor.sharedvar import TensorSharedVariable
-from pytensor.tensor.variable import TensorConstant
+from pytensor.graph import Constant, FunctionGraph
 
 from pymc import Model
 from pymc.model.fgraph import ModelFreeRV, fgraph_from_model, model_from_fgraph
 
 
-def _constant_from_shared(shared: SharedVariable) -> TensorConstant:
-    assert isinstance(shared, TensorSharedVariable)
-    return constant(shared.get_value(), name=shared.name, dtype=shared.type.dtype)
+def _constant_from_shared(shared: SharedVariable) -> Constant:
+    return shared.type.constant_type(type=shared.type, data=shared.get_value(), name=shared.name)
 
 
 def freeze_dims_and_data(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
 pymc-sphinx-theme>=0.16.0
-pytensor>=2.37.0,<2.38
+pytensor>=2.38.0,<2.39
 pytest-cov>=2.5
 pytest>=3.0
 rich>=13.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cachetools>=4.2.1,<7
 cloudpickle
 numpy>=1.25.0
 pandas>=0.24.0
-pytensor>=2.37.0,<2.38.0
+pytensor>=2.38.0,<2.39
 rich>=13.7.1
 scipy>=1.4.1
 threadpoolctl>=3.1.0,<4.0.0


### PR DESCRIPTION
Depends on https://github.com/pymc-devs/pytensor/pull/1882

We were registering regular TensorSharedVariables in `pymc.dims.Data`, and then wrapping those in `as_xtensor`. The problem with that is that when you then try to act on `m["x"]` you were not acting on the same variable that `pymc.dims.Data` returned to you, instead  you were acting on the input of `as_xtensor`...

This made it hard to adopt it in pymc-marketing