### PR TITLE
Docs: expand RandomWalk docstrings in timeseries.py

### DIFF
--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -122,9 +122,47 @@ class RandomWalkRV(SymbolicRandomVariable):
 
 
 class RandomWalk(Distribution):
-    r"""RandomWalk Distribution.
+    r"""
+    Generative Random Walk distribution.
 
-    TODO: Expand docstrings
+    .. math::
+
+       x_t = x_{t-1} + \epsilon_t
+
+    Parameters
+    ----------
+    init_dist : unnamed_distribution
+        Unnamed univariate or multivariate distribution for the initial value (x_0).
+        Unnamed refers to distributions created with the ``.dist()`` API.
+
+        .. warning:: init_dist will be cloned, rendering it independent of the one passed as input.
+
+    innovation_dist : unnamed_distribution
+        Unnamed univariate or multivariate distribution for the innovations (\epsilon_t).
+        Must be created using the ``.dist()`` API.
+
+        .. warning:: innovation_dist will be cloned, rendering it independent of the one passed as input.
+
+    steps : int, optional
+        Number of steps in the random walk (steps > 0). Only needed if shape is not provided.
+
+    Notes
+    -----
+    The init and innovation distributions will be cloned, rendering them distinct from the ones passed as
+    input. Both distributions must have the same support dimensionality and be completely
+    independent.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import pymc as pm
+
+        # Create a Random Walk with Normal innovations
+        with pm.Model() as model:
+            init = pm.Normal.dist(mu=0, sigma=1)
+            innov = pm.Normal.dist(mu=0, sigma=1.0)
+            rw = pm.RandomWalk("rw", init_dist=init, innovation_dist=innov, steps=100)
     """
 
     rv_type = RandomWalkRV


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
I have expanded the docstrings for the RandomWalk class in pymc/distributions/timeseries.py. Previously, there was only a # TODO: Expand docstrings comment. I updated the documentation to match the detailed numpydoc style used in the AR class, including a mathematical definition, parameter descriptions, and a use example.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #(Addressing a TODO found in the source code)

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
