### PR TITLE
Broadcast probability functions with value and size

### DIFF
--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -7,7 +7,7 @@ dependencies:
 # Base dependencies
 - arviz>=0.13.0
 - blas
-- cachetools>=4.2.1
+- cachetools>=4.2.1,<7
 - cloudpickle
 - zarr>=2.5.0,<3
 - numba

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
 # Base dependencies
 - arviz>=0.13.0
 - blas
-- cachetools>=4.2.1
+- cachetools>=4.2.1,<7
 - cloudpickle
 - numpy>=1.25.0
 - pandas>=0.24.0

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 # Base dependencies
 - arviz>=0.13.0
-- cachetools>=4.2.1
+- cachetools>=4.2.1,<7
 - cloudpickle
 - numpy>=1.25.0
 - pandas>=0.24.0

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -7,7 +7,7 @@ dependencies:
 # Base dependencies
 - arviz>=0.13.0
 - blas
-- cachetools>=4.2.1
+- cachetools>=4.2.1,<7
 - cloudpickle
 - jax
 - numpy>=1.25.0

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
 # Base dependencies (see install guide for Windows)
 - arviz>=0.13.0
 - blas
-- cachetools>=4.2.1
+- cachetools>=4.2.1,<7
 - cloudpickle
 - numpy>=1.25.0
 - pandas>=0.24.0

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -7,7 +7,7 @@ dependencies:
 # Base dependencies (see install guide for Windows)
 - arviz>=0.13.0
 - blas
-- cachetools>=4.2.1
+- cachetools>=4.2.1,<7
 - cloudpickle
 - libpython
 - mkl-service>=2.3.0

--- a/pymc/distributions/moments/means.py
+++ b/pymc/distributions/moments/means.py
@@ -80,7 +80,7 @@ from pymc.distributions.multivariate import (
     StickBreakingWeightsRV,
     _LKJCholeskyCovRV,
 )
-from pymc.distributions.shape_utils import rv_size_is_none
+from pymc.distributions.shape_utils import maybe_resize, rv_size_is_none
 from pymc.exceptions import UndefinedMomentException
 
 __all__ = ["mean"]
@@ -98,12 +98,6 @@ def mean(rv: TensorVariable) -> TensorVariable:
     for which the value is to be derived.
     """
     return _mean(rv.owner.op, rv, *rv.owner.inputs)
-
-
-def maybe_resize(a: TensorVariable, size) -> TensorVariable:
-    if not rv_size_is_none(size):
-        a = pt.full(size, a)
-    return a
 
 
 @_mean.register(AsymmetricLaplaceRV)

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -489,3 +489,13 @@ def implicit_size_from_params(
         ),
         dtype="int64",  # In case it's empty, as_tensor will default to floatX
     )
+
+
+def maybe_resize(a: TensorVariable, size) -> TensorVariable:
+    if not (size is None or isinstance(size.type, NoneTypeT)):
+        [size_len] = size.type.shape
+        if (missing_size_entries := a.ndim - size_len) > 0:
+            # Allow expression to broadcast beyond size
+            size = (*a.shape[:missing_size_entries], *size)
+        a = pt.alloc(a, *size)  # type: ignore[assignment]
+    return a

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -124,6 +124,7 @@ from pymc.logprob.utils import (
     filter_measurable_variables,
     find_negated_var,
 )
+from pymc.math import logdiffexp
 
 
 class Transform(abc.ABC):
@@ -269,7 +270,7 @@ def measurable_transform_logcdf(op: MeasurableTransform, value, *inputs, **kwarg
             logcdf_zero = _logcdf_helper(measurable_input, 0)
             logcdf = pt.switch(
                 pt.lt(backward_value, 0),
-                pt.log(pt.exp(logcdf_zero) - pt.exp(logcdf)),
+                logdiffexp(logcdf_zero, logcdf),
                 pt.logaddexp(logccdf, logcdf_zero),
             )
     else:

--- a/pymc/math.py
+++ b/pymc/math.py
@@ -281,7 +281,12 @@ def kron_diag(*diags):
 
 def logdiffexp(a, b):
     """Return log(exp(a) - exp(b))."""
-    return a + pt.log1mexp(b - a)
+    # Handle cases of -inf, -inf safely
+    return pt.switch(
+        pt.isneginf(b),
+        a,
+        a + pt.log1mexp(b - a),
+    )
 
 
 invlogit = sigmoid

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # See that file for comments about the need/usage of each dependency.
 
 arviz>=0.13.0
-cachetools>=4.2.1
+cachetools>=4.2.1,<7
 cloudpickle
 ipython>=7.16
 jupyter-sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arviz>=0.13.0
-cachetools>=4.2.1
+cachetools>=4.2.1,<7
 cloudpickle
 numpy>=1.25.0
 pandas>=0.24.0

--- a/tests/dims/distributions/test_core.py
+++ b/tests/dims/distributions/test_core.py
@@ -29,6 +29,7 @@ from pymc.dims import Normal
 pytestmark = pytest.mark.filterwarnings(
     "error",
     "ignore::numba.core.errors.NumbaPerformanceWarning",
+    "ignore:create_index_for_new_dim:UserWarning",
 )
 
 

--- a/tests/distributions/test_censored.py
+++ b/tests/distributions/test_censored.py
@@ -114,14 +114,14 @@ class TestCensored:
         assert tuple(x.owner.inputs[0].shape.eval()) == (3, 4, 2)
 
     def test_censored_categorical(self):
-        cat = pm.Categorical.dist([0.1, 0.2, 0.2, 0.3, 0.2], shape=(5,))
+        cat = pm.Categorical.dist([0.1, 0.2, 0.2, 0.3, 0.2], shape=())
 
         np.testing.assert_allclose(
             logp(cat, [-1, 0, 1, 2, 3, 4, 5]).exp().eval(),
             [0, 0.1, 0.2, 0.2, 0.3, 0.2, 0],
         )
 
-        censored_cat = pm.Censored.dist(cat, lower=1, upper=3, shape=(5,))
+        censored_cat = pm.Censored.dist(cat, lower=1, upper=3, shape=())
 
         np.testing.assert_allclose(
             logp(censored_cat, [-1, 0, 1, 2, 3, 4, 5]).exp().eval(),

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -737,10 +737,10 @@ class TestMatchesScipy:
         ns = np.arange(n + 1)
         ns_dm = np.vstack((ns, n - ns)).T  # convert ns=1 to ns_dm=[1, 4], for all ns...
 
-        bb = pm.BetaBinomial.dist(n=n, alpha=a, beta=b, size=2)
+        bb = pm.BetaBinomial.dist(n=n, alpha=a, beta=b, size=6)
         bb_logp = logp(bb, ns).eval()
 
-        dm = pm.DirichletMultinomial.dist(n=n, a=[a, b], size=2)
+        dm = pm.DirichletMultinomial.dist(n=n, a=[a, b], size=6)
         dm_logp = logp(dm, ns_dm).eval().ravel()
 
         npt.assert_almost_equal(

--- a/tests/logprob/test_mixture.py
+++ b/tests/logprob/test_mixture.py
@@ -1039,6 +1039,11 @@ def test_switch_mixture_constant_branch_broadcast_ok():
     assert np.isneginf(bad_dirac[0])
 
 
+@pytest.mark.xfail(
+    condition=isinstance(get_default_mode().linker, NumbaLinker),
+    raises=AssertionError,
+    reason="Logp graph fails when evaluated with a non-lazy approach. https://github.com/pymc-devs/pymc/issues/8036",
+)
 def test_ifelse_mixture_one_component():
     if_rv = pt.random.bernoulli(0.5, name="if")
     scale_rv = pt.random.halfnormal(name="scale")
@@ -1107,6 +1112,11 @@ def test_ifelse_mixture_multiple_components():
     )
 
 
+@pytest.mark.xfail(
+    condition=isinstance(get_default_mode().linker, NumbaLinker),
+    raises=AssertionError,
+    reason="Logp graph fails when evaluated with a non-lazy approach. https://github.com/pymc-devs/pymc/issues/8036",
+)
 def test_ifelse_mixture_shared_component():
     rng = np.random.default_rng(1009)
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -12,7 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import warnings
 
 import numpy as np
 import pytensor
@@ -142,11 +141,17 @@ def test_log1mexp_deprecation_warnings():
 
 
 def test_logdiffexp():
-    a = np.log([1, 2, 3, 4])
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "divide by zero encountered in log", RuntimeWarning)
-        b = np.log([0, 1, 2, 3])
-    assert np.allclose(logdiffexp(a, b).eval(), 0)
+    a = pt.vector("a")
+    b = pt.vector("b")
+    a_test = np.log([1, 2, 3, 4])
+    with np.errstate(divide="ignore"):
+        b_test = np.log([0, 1, 2, 3])
+    np.testing.assert_allclose(logdiffexp(a, b).eval({a: a_test, b: b_test}), 0, atol=1e-15)
+
+    np.testing.assert_array_equal(
+        logdiffexp(a, b).eval({a: [-np.inf, -np.inf, -1], b: [-1, -np.inf, -np.inf]}),
+        [np.nan, -np.inf, -1],
+    )
 
 
 class TestLogDet:


### PR DESCRIPTION
Since our syntax is `foo(rv, value)`, we should respect the shape of the rv. We were only respecting the one implied by the parameters, but not size. 

`pm.logp(pm.Normal.dist(size=(10, 3)), 0))` would return a single item tensor

This PR also tests we are allowed to further broadcast with value.

`pm.logp(pm.Normal.dist(size=(10, 3)), zeros((3, 10, 3))`

Impl-wise I think it's cleaner to not include size in the definitions themselves as they are our construct. 

This should also be compatible out of the box when we replace ours by those in pytensor-distributions.