### PR TITLE
Speed up test_weakref_leak and test_step_args

### DIFF
--- a/tests/logprob/test_transform_value.py
+++ b/tests/logprob/test_transform_value.py
@@ -634,9 +634,8 @@ def test_weakref_leak():
     rvs_to_values = {pt.random.beta(1, 1, name=f"p_{i}"): pt.scalar(f"p_{i}") for i in range(30)}
     tr = TransformValuesRewrite(dict.fromkeys(rvs_to_values.values(), logodds))
 
-    for i in range(20):
+    for i in range(6):
         conditional_logp(rvs_to_values, extra_rewrites=tr)
         res = _growth()
-        # Only start checking after warmup
-        if i > 15:
+        if i > 2:
             assert not res, "Object counts are still growing"

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -691,10 +691,12 @@ def test_step_args():
 
     with pm.Model() as model:
         a = pm.Normal("a")
-        idata_default = pm.sample(random_seed=1410)
-        idata0 = pm.sample(target_accept=0.5, random_seed=1410)
-        idata1 = pm.sample(nuts={"target_accept": 0.5}, random_seed=1410 * 2)
-        idata2 = pm.sample(target_accept=0.5, nuts={"max_treedepth": 10}, random_seed=1410)
+        idata_default = pm.sample(draws=200, tune=200, random_seed=1410)
+        idata0 = pm.sample(draws=200, tune=200, target_accept=0.5, random_seed=1410)
+        idata1 = pm.sample(draws=200, tune=200, nuts={"target_accept": 0.5}, random_seed=1410 * 2)
+        idata2 = pm.sample(
+            draws=200, tune=200, target_accept=0.5, nuts={"max_treedepth": 10}, random_seed=1410
+        )
 
         with pytest.raises(ValueError, match="`target_accept` was defined twice."):
             pm.sample(target_accept=0.5, nuts={"target_accept": 0.95}, random_seed=1410)
@@ -709,13 +711,17 @@ def test_step_args():
     with pm.Model() as model:
         a = pm.Normal("a")
         b = pm.Poisson("b", 1)
-        idata0 = pm.sample(target_accept=0.5, random_seed=1418)
+        idata0 = pm.sample(draws=200, tune=200, target_accept=0.5, random_seed=1418)
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", "invalid value encountered in double_scalars", RuntimeWarning
             )
             idata1 = pm.sample(
-                nuts={"target_accept": 0.5}, metropolis={"scaling": 0}, random_seed=1418 * 2
+                draws=200,
+                tune=200,
+                nuts={"target_accept": 0.5},
+                metropolis={"scaling": 0},
+                random_seed=1418 * 2,
             )
 
     npt.assert_almost_equal(accept(idata0).mean(), 0.5, decimal=1)


### PR DESCRIPTION
Addresses #7686 — profiling-backed optimizations targeting tests where iteration reduction yields meaningful savings.

## Changes

### test_weakref_leak (89s → ~30s estimated on CI)

Object count profiling shows memory state stabilizes at **iteration 2**:

```
Iteration | Growing objects | Details
    0     | 10 growing      | function:+67554, tuple:+50400, dict:+30266
    1     |  1 growing      | list:+1
    2     |  0 growing      | STABLE
    3     |  0 growing      | STABLE
   ...    |  0 growing      | STABLE (all remaining iterations)
```

The original test ran 20 iterations but only checked after iteration 15 — 16 warmup iterations when 3 is sufficient. Reduced to 6 total (3 warmup + 3 check). Each `conditional_logp` call costs ~4.5s on CI, so removing 14 iterations saves ~63s.

### test_step_args (62s → ~25s estimated on CI)

This test verifies `target_accept` argument plumbing, checking `acceptance_rate.mean() ≈ 0.5` with `decimal=1` precision. The default `pm.sample()` uses 1000 draws/tune, but 200 is more than sufficient for this loose tolerance (verified stable over 10 runs with different seeds).

Profiling: first `pm.sample()` with 1000 draws takes 2.20s locally, with 200 draws takes 0.29s. The test calls `pm.sample()` 5 times.

## Changes NOT made (profiling showed negligible impact)

| Test | CI time | Bottleneck | Iteration savings |
|------|---------|------------|-------------------|
| test_default_value_transform_logprob | 35s | Compile: 8.85s, Loop(10): 0.0014s | 0.6ms total |
| TestMatchesScipy::test_interpolated | 33s | Compile: 91.8%, Array: 7.9% | ~296ms across 56 iters |

Compilation dominates these tests — reducing iteration counts has near-zero impact, consistent with @ricardoV94's review feedback.