### PR TITLE
Stabilize gp.Latent.conditional covariance with jitter (fixes #8108)

### DIFF
--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -224,7 +224,7 @@ class Latent(Base):
         mu = self.mean_func(Xnew) + pt.dot(pt.transpose(A), v).T
 
         Kss = self.cov_func(Xnew)
-        cov = Kss - pt.dot(pt.transpose(A), A)
+        cov = stabilize(Kss - pt.dot(pt.transpose(A), A), jitter)
 
         return mu, cov
 
@@ -363,7 +363,7 @@ class TP(Latent):
         Kss = self.cov_func(Xnew)
         L = cholesky(stabilize(Kxx, jitter))
         A = solve_lower(L, Kxs)
-        cov = Kss - pt.dot(pt.transpose(A), A)
+        cov = stabilize(Kss - pt.dot(pt.transpose(A), A), jitter)
         v = solve_lower(L, f - self.mean_func(X))
         mu = self.mean_func(Xnew) + pt.dot(pt.transpose(A), v)
         beta = pt.dot(v, v)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

Stabilize gp.Latent.conditional covariance with jitter (fixes #8108)

## Description

With large `Xnew` arrays, `gp.Latent.conditional` could raise `LinAlgError: Matrix is not positive definite` because the conditional covariance matrix was not numerically stabilized. The `jitter` argument was only applied to the prior covariance `K(X,X)` before Cholesky, not to the conditional covariance `K(Xnew,Xnew) - K(Xnew,X) K(X,X)^{-1} K(X,Xnew)`.

**Changes:**
- Apply `stabilize(..., jitter)` to the conditional covariance in `Latent._build_conditional` so `jitter` is used for conditional covariance passed to `MvNormal`.
- Same in `TP._build_conditional` for consistency.
- Add a regression test `testLatentConditionalLargeXnewJitter` that builds the model from issue #8108 (99 training points, 500 prediction points, ExpQuad, `jitter=1e-4`) and evaluates the compiled logp to ensure no LinAlgError.


## Related Issue
- [x] Closes #8108 
- [ ] Related to #

## Checklist
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change]


## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
