### PR TITLE
GP Doc improvements

### DIFF
--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -54,18 +54,6 @@ class Base:
         cov_total = self.cov_func + other.cov_func
         return self.__class__(mean_func=mean_total, cov_func=cov_total)
 
-    def prior(self, name, X, *args, **kwargs):
-        raise NotImplementedError
-
-    def marginal_likelihood(self, name, X, *args, **kwargs):
-        raise NotImplementedError
-
-    def conditional(self, name, Xnew, *args, **kwargs):
-        raise NotImplementedError
-
-    def predict(self, Xnew, point=None, given=None, diag=False, model=None):
-        raise NotImplementedError
-
 
 @conditioned_vars(["X", "f"])
 class Latent(Base):

--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -54,6 +54,18 @@ class Base:
         cov_total = self.cov_func + other.cov_func
         return self.__class__(mean_func=mean_total, cov_func=cov_total)
 
+    def prior(self, name, X, *args, **kwargs):
+        raise NotImplementedError
+
+    def marginal_likelihood(self, name, X, *args, **kwargs):
+        raise NotImplementedError
+
+    def conditional(self, name, Xnew, *args, **kwargs):
+        raise NotImplementedError
+
+    def predict(self, Xnew, point=None, given=None, diag=False, model=None):
+        raise NotImplementedError
+
 
 @conditioned_vars(["X", "f"])
 class Latent(Base):

--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -60,21 +60,21 @@ class Latent(Base):
     R"""
     Latent Gaussian process.
 
-    The `gp.Latent` class is a direct implementation of a GP.  No additive
+    The :class:`~pymc.gp.Latent` class is a direct implementation of a GP.  No additive
     noise is assumed.  It is called "Latent" because the underlying function
-    values are treated as latent variables.  It has a `prior` method and a
-    `conditional` method.  Given a mean and covariance function the
-    function :math:`f(x)` is modeled as,
+    values are treated as latent variables.  It has a :meth:`prior` method and a
+    :meth:`conditional` method.  Given a mean and covariance function, the
+    function :math:`f(x)` is modeled as
 
     .. math::
 
-       f(x) \sim \mathcal{GP}\left(\mu(x), k(x, x')\right)
+       f(x) \sim \mathcal{GP}\left(\mu(x), k(x, x')\right).
 
-    Use the `prior` and `conditional` methods to actually construct random
+    Use the :meth:`prior` and :meth:`conditional` methods to actually construct random
     variables representing the unknown, or latent, function whose
     distribution is the GP prior or GP conditional.  This GP implementation
     can be used to implement regression on data that is not normally
-    distributed.  For more information on the `prior` and `conditional` methods,
+    distributed.  For more information on the :meth:`prior` and :meth:`conditional` methods,
     see their docstrings.
 
     Parameters
@@ -261,7 +261,7 @@ class TP(Latent):
     r"""
     Student's T process prior.
 
-    The usage is nearly identical to that of `gp.Latent`.  The differences
+    The usage is nearly identical to that of :class:`~pymc.gp.Latent`.  The differences
     are that it must be initialized with a degrees of freedom parameter, and
     TP is not additive. Given a mean and covariance function, and a degrees of
     freedom parameter, the function :math:`f(x)` is modeled as,
@@ -392,12 +392,10 @@ class Marginal(Base):
     R"""
     Marginal Gaussian process.
 
-    The `gp.Marginal` class is an implementation of the sum of a GP
-    prior and additive noise.  It has `marginal_likelihood`, `conditional`
-    and `predict` methods.  This GP implementation can be used to
-    implement regression on data that is normally distributed.  For more
-    information on the `marginal_likelihood`, `conditional`
-    and `predict` methods, see their docstrings.
+    The :class:`~pymc.gp.Marginal` class is an implementation of the sum of a GP
+    prior and additive noise.  It has :meth:`marginal_likelihood`, :meth:`conditional`
+    and :meth:`predict` methods.  This GP implementation can be used to
+    implement regression on data that is normally distributed.
 
     Parameters
     ----------
@@ -658,9 +656,9 @@ class MarginalApprox(Marginal):
     R"""
     Approximate marginal Gaussian process.
 
-    The `gp.MarginalApprox` class is an implementation of the sum of a GP
-    prior and additive noise.  It has `marginal_likelihood`, `conditional`
-    and `predict` methods.  This GP implementation can be used to
+    The :class:`~pymc.gp.MarginalApprox` class is an implementation of the sum of a GP
+    prior and additive noise.  It has :meth:`marginal_likelihood`, :meth:`conditional`
+    and :meth:`predict` methods.  This GP implementation can be used to
     implement regression on data that is normally distributed.  The
     available approximations are:
 
@@ -899,16 +897,13 @@ class LatentKron(Base):
     R"""
     Latent Gaussian process whose covariance is a tensor product kernel.
 
-    The `gp.LatentKron` class is a direct implementation of a GP with a
+    The :class:`~pymc.gp.LatentKron` class is a direct implementation of a GP with a
     Kronecker structured covariance, without reference to any noise or
-    specific likelihood.  The GP is constructed with the `prior` method,
+    specific likelihood.  The GP is constructed with the :meth:`prior` method,
     and the conditional GP over new input locations is constructed with
-    the `conditional` method. For more
-    information on these methods, see their docstrings.  This GP
-    implementation can be used to model a Gaussian process whose inputs
-    cover evenly spaced grids on more than one dimension.  `LatentKron`
-    relies on the `KroneckerNormal` distribution, see its docstring
-    for more information.
+    the :meth:`conditional` method. This GP implementation can be used to model a Gaussian process whose inputs
+    cover evenly spaced grids on more than one dimension. :class:`~pymc.gp.LatentKron`
+    relies on the :class:`~pymc.KroneckerNormal` distribution.
 
     Parameters
     ----------
@@ -1054,16 +1049,13 @@ class MarginalKron(Base):
     R"""
     Marginal Gaussian process whose covariance is a tensor product kernel.
 
-    The `gp.MarginalKron` class is an implementation of the sum of a
+    The :class:`~pymc.gp.MarginalKron` class is an implementation of the sum of a
     Kronecker GP prior and additive white noise. It has
-    `marginal_likelihood`, `conditional` and `predict` methods. This GP
+    :meth:`marginal_likelihood`, :meth:`conditional` and :meth:`predict` methods. This GP
     implementation can be used to efficiently implement regression on
     data that are normally distributed with a tensor product kernel and
     are measured on a full grid of inputs: `cartesian(*Xs)`.
-    `MarginalKron` is based on the `KroneckerNormal` distribution, see
-    its docstring for more information. For more information on the
-    `marginal_likelihood`, `conditional` and `predict` methods,
-    see their docstrings.
+    :class:`~pymc.gp.MarginalKron` is based on the :class:`~pymc.KroneckerNormal` distribution.
 
     Parameters
     ----------

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -172,21 +172,23 @@ class HSGP(Base):
     R"""
     Hilbert Space Gaussian process approximation.
 
-    The `gp.HSGP` class is an implementation of the Hilbert Space Gaussian process.  It is a
-    reduced rank GP approximation that uses a fixed set of basis vectors whose coefficients are
-    random functions of a stationary covariance function's power spectral density.  Its usage
-    is largely similar to `gp.Latent`.  Like `gp.Latent`, it does not assume a Gaussian noise model
-    and can be used with any likelihood, or as a component anywhere within a model.  Also like
-    `gp.Latent`, it has `prior` and `conditional` methods.  It supports any sum of covariance
-    functions that implement a `power_spectral_density` method. (Note, this excludes the
-    `Periodic` covariance function, which uses a different set of basis functions for a
-    low rank approximation, as described in `HSGPPeriodic`.).
+    The :class:`~pymc.gp.HSGP` class is an implementation of the Hilbert Space Gaussian process.
+    It is a reduced rank GP approximation that uses a fixed set of basis vectors whose
+    coefficients are random functions of a stationary covariance function's power spectral
+    density.  Its usage is largely similar to :class:`~pymc.gp.Latent`.  Like :class:`~pymc.gp.Latent`,
+    it does not assume a Gaussian noise model and can be used with any likelihood, or as a
+    component anywhere within a model.  Also like :class:`~pymc.gp.Latent`, it has :meth:`prior`
+    and :meth:`conditional` methods.  It supports any sum of covariance functions that implement
+    a :meth:`power_spectral_density <pymc.gp.cov.Stationary.power_spectral_density>` method.
+    (Note, this excludes the :class:`~pymc.gp.cov.Periodic` covariance function, which uses a
+    different set of basis functions for a low rank approximation, as described in
+    :class:`~pymc.gp.HSGPPeriodic`.).
 
     For information on choosing appropriate `m`, `L`, and `c`, refer to Ruitort-Mayol et al. or to
     the PyMC examples that use HSGP.
 
     To work with the HSGP in its "linearized" form, as a matrix of basis vectors and a vector of
-    coefficients, see the method `prior_linearized`.
+    coefficients, see the method :meth:`prior_linearized`.
 
     Parameters
     ----------
@@ -208,9 +210,9 @@ class HSGP(Base):
     parametrization: str
         Whether to use the `centered` or `noncentered` parametrization when multiplying the
         basis by the coefficients.
-    cov_func: Covariance function, must be an instance of `Stationary` and implement a
-        `power_spectral_density` method.
-    mean_func: None, instance of Mean
+    cov_func: :class:`~pymc.gp.cov.Stationary`
+    Covariance function. Must implement a :meth:`power_spectral_density <pymc.gp.cov.Stationary.power_spectral_density>` method.
+    mean_func: :class:`~pymc.gp.mean.Mean`, default :class:`~pymc.gp.mean.Zero`
         The mean function.  Defaults to zero.
 
     Examples
@@ -523,14 +525,14 @@ class HSGPPeriodic(Base):
     approximation to a Gaussian process. In this case, the approximation is based on a series of
     stochastic resonators.
 
-    For these reasons, we have followed the same API as `gp.HSGP`, and can be used as a drop-in
-    replacement for `gp.Latent`. Like `gp.Latent`, it has `prior` and `conditional` methods.
+    For these reasons, we have followed the same API as :class:`~pymc.gp.HSGP`, and can be used as a drop-in
+    replacement for :class:`~pymc.gp.Latent`. Like :class:`~pymc.gp.Latent`, it has :meth:`prior` and :meth:`conditional` methods.
 
     For information on choosing appropriate `m`, refer to Ruitort-Mayol et al.. Note, this approximation
     is only implemented for the 1-D case.
 
     To work with the approximation in its "linearized" form, as a matrix of basis vectors and a
-    vector of coefficients, see the method `prior_linearized`.
+    vector of coefficients, see the method :meth:`prior_linearized`.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The GP `Base` class declares several methods to be implemented in the child classes, e.g. `gp.Latent`, `gp.Marginal`, but some classes do not implement these methods, leading to misleading docs. For instance, doc for `gp.Latent` says it has `predict` and `marginal_likelihood` methods, when it does not. I remove these base class instantiations, since they do not add anything as far as I can tell, but just confuse the docs. I also clean up some docstrings, adding hyperlinks to make the module more navigable for users. 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
