### PR TITLE
cachetools library dependency removal

### DIFF
--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -7,7 +7,6 @@ dependencies:
 # Base dependencies
 - arviz>=0.13.0,<1.0
 - blas
-- cachetools>=4.2.1,<7
 - cloudpickle
 - zarr>=2.5.0,<3
 - numba

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -7,7 +7,6 @@ dependencies:
 # Base dependencies
 - arviz>=0.13.0,<1.0
 - blas
-- cachetools>=4.2.1,<7
 - cloudpickle
 - numpy>=1.25.0
 - pandas>=0.24.0

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -6,7 +6,6 @@ channels:
 dependencies:
 # Base dependencies
 - arviz>=0.13.0,<1.0
-- cachetools>=4.2.1,<7
 - cloudpickle
 - numpy>=1.25.0
 - pandas>=0.24.0

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -7,7 +7,6 @@ dependencies:
 # Base dependencies
 - arviz>=0.13.0,<1.0
 - blas
-- cachetools>=4.2.1,<7
 - cloudpickle
 - jax
 - numpy>=1.25.0

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -7,7 +7,6 @@ dependencies:
 # Base dependencies (see install guide for Windows)
 - arviz>=0.13.0,<1.0
 - blas
-- cachetools>=4.2.1,<7
 - cloudpickle
 - numpy>=1.25.0
 - pandas>=0.24.0

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -7,7 +7,6 @@ dependencies:
 # Base dependencies (see install guide for Windows)
 - arviz>=0.13.0,<1.0
 - blas
-- cachetools>=4.2.1,<7
 - cloudpickle
 - libpython
 - mkl-service>=2.3.0

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -18,6 +18,7 @@ import re
 from collections import namedtuple
 from collections.abc import Sequence
 from copy import deepcopy
+from functools import lru_cache, wraps
 from typing import cast
 
 import arviz
@@ -25,7 +26,6 @@ import cloudpickle
 import numpy as np
 import xarray
 
-from cachetools import LRUCache, cachedmethod
 from pytensor import Variable
 from pytensor.compile import SharedVariable
 
@@ -346,16 +346,45 @@ class WithMemoization:
         self.__dict__.update(state)
 
 
-def locally_cachedmethod(f):
-    from collections import defaultdict
+class _LRUCacheWrapper:
+    def __init__(self, func, maxsize):
+        @lru_cache(maxsize=maxsize)
+        def cached(*args, **kwargs):
+            return func(*args, **kwargs)
 
-    def self_cache_fn(f_name):
-        def cf(self):
-            return self.__dict__.setdefault("_cache", defaultdict(lambda: LRUCache(128)))[f_name]
+        self._cached = cached
 
-        return cf
+    def __call__(self, *args, **kwargs):
+        return self._cached(*args, **kwargs)
 
-    return cachedmethod(self_cache_fn(f.__name__), key=hash_key)(f)
+    def __len__(self):
+        # emulate cachetools.LRUCache length
+        return self._cached.cache_info().currsize
+
+    def clear(self):
+        self._cached.cache_clear()
+
+    cache_clear = clear
+
+
+def locally_cachedmethod(func, maxsize=128):
+    name = func.__name__
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        caches = self.__dict__.setdefault("_cache", {})
+        cached = caches.get(name)
+
+        if cached is None:
+            cached = _LRUCacheWrapper(
+                lambda *a, **k: func(self, *a, **k),
+                maxsize=maxsize,
+            )
+            caches[name] = cached
+
+        return cached(*args, **kwargs)
+
+    return wrapper
 
 
 def check_dist_not_registered(dist, model=None):

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -347,6 +347,25 @@ class WithMemoization:
 
 
 class _LRUCacheWrapper:
+    """
+    Lightweight callable LRU cache wrapper built on ``functools.lru_cache``.
+
+    This class adapts the standard-library ``lru_cache`` decorator to behave
+    similarly to ``cachetools.LRUCache``.
+
+    * callable behavior (cached function execution)
+    * ``len(cache)`` returning the current cache size
+    * explicit cache clearing via ``clear()`` / ``cache_clear()``
+
+    Parameters
+    ----------
+    func : callable
+        Function whose results should be memoized.
+    maxsize : int
+        Maximum number of entries retained in the cache. When the limit is
+        exceeded, least-recently-used entries are evicted.
+    """
+
     def __init__(self, func, maxsize):
         @lru_cache(maxsize=maxsize)
         def cached(*args, **kwargs):
@@ -368,6 +387,24 @@ class _LRUCacheWrapper:
 
 
 def locally_cachedmethod(func, maxsize=128):
+    """
+    Decorator to cache the results of instance methods with a per-instance LRU cache.
+
+    Parameters
+    ----------
+    func : callable
+        The instance method to be cached.
+    maxsize : int, optional
+        Maximum number of results to keep in the cache for this method. When the
+        limit is reached, least-recently-used entries are evicted. Default is 128.
+
+    Returns
+    -------
+    callable
+        A wrapped method that caches results per instance. The cache is stored
+        in ``self._cache[method_name]`` as an ``_LRUCacheWrapper`` object.
+
+    """
     name = func.__name__
 
     @wraps(func)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@
 # See that file for comments about the need/usage of each dependency.
 
 arviz>=0.13.0,<1.0
-cachetools>=4.2.1,<7
 cloudpickle
 ipython>=7.16
 jupyter-sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 arviz>=0.13.0,<1.0
-cachetools>=4.2.1,<7
 cloudpickle
 numpy>=1.25.0
 pandas>=0.24.0

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,12 +13,12 @@
 #   limitations under the License.
 import re
 
+from functools import wraps
+
 import arviz
 import numpy as np
 import pytest
 import xarray
-
-from cachetools import cached
 
 import pymc as pm
 
@@ -115,6 +115,26 @@ def test_hashing_of_rv_tuples():
                 (freerv, []),
             ]:
                 assert isinstance(hashable(structure), int)
+
+
+def cached(cache, key=hash_key):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            k = key(*args, **kwargs)
+
+            if k in cache:
+                return cache[k]
+
+            result = func(*args, **kwargs)
+            cache[k] = result
+            return result
+
+        wrapper.cache = cache
+        wrapper.cache_clear = cache.clear
+        return wrapper
+
+    return decorator
 
 
 def test_hash_key():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -118,6 +118,27 @@ def test_hashing_of_rv_tuples():
 
 
 def cached(cache, key=hash_key):
+    """
+    Decorator implementing explicit memoization using a user-provided cache
+    mapping.
+
+    Parameters
+    ----------
+    cache : MutableMapping
+        Mapping used to store cached results. The mapping must support
+        ``__contains__``, item access, and assignment.
+        The cache object is used directly and is not copied.
+    key : callable, optional
+        Function used to construct a cache key from ``(*args, **kwargs)``.
+        It must return a hashable object. Defaults to ``hash_key``.
+
+    Returns
+    -------
+    callable
+        A decorated function whose return values are memoized in ``cache``.
+
+    """
+
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
This PR addresses the dependency that PyMC has on the `cachetools` library. We use this library very minimally in some VI and testing utilities. I replaced the functionality that was leveraging the `cachetools` library with equivalents built from python standard libraries. 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #8106 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
