### PR TITLE
ENH: support non-overlapping switch logp with non-zero thresholds

### DIFF
--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -408,6 +408,13 @@ class MeasurableSwitchMixture(MeasurableElemwise):
 measurable_switch_mixture = MeasurableSwitchMixture(scalar_switch)
 
 
+class MeasurableNonOverlappingSwitchMixture(MeasurableElemwise):
+    valid_scalar_types = (Switch,)
+
+
+measurable_non_overlapping_switch_mixture = MeasurableNonOverlappingSwitchMixture(scalar_switch)
+
+
 @node_rewriter([switch])
 def find_measurable_switch_mixture(fgraph, node):
     if isinstance(node.op, MeasurableOp):
@@ -451,6 +458,52 @@ def find_measurable_switch_mixture(fgraph, node):
     return [measurable_switch_mixture(switch_cond, *new_components)]
 
 
+@node_rewriter([switch])
+def find_measurable_non_overlapping_switch(fgraph, node):
+    if isinstance(node.op, MeasurableOp):
+        return None
+
+    switch_cond, comp_true, comp_false = node.inputs
+
+    if switch_cond.owner is None:
+        return None
+
+    cond_owner = switch_cond.owner
+    scalar_op = getattr(cond_owner.op, "scalar_op", None)
+    if not isinstance(
+        scalar_op, pytensor.scalar.LT, pytensor.scalar.LE, pytensor.scalar.GT, pytensor.scalar.GE
+    ):
+        return None
+
+    lhs, rhs = cond_owner.inputs
+
+    lhs_measurable = bool(filter_measurable_variables([lhs]))
+    rhs_measurable = bool(filter_measurable_variables([rhs]))
+
+    if lhs_measurable == rhs_measurable:
+        return None
+
+    threshold = rhs if lhs_measurable else lhs
+    if check_potential_measurability([threshold]):
+        return None
+
+    measurable_branches = filter_measurable_variables([comp_true, comp_false])
+    if not measurable_branches:
+        return None
+
+    measurable_set = set(measurable_branches)
+    new_components = []
+    for comp in [comp_true, comp_false]:
+        if comp in measurable_set:
+            new_components.append(comp)
+        else:
+            if check_potential_measurability([comp]):
+                return None
+            new_components.append(dirac_delta(comp))
+
+    return [measurable_non_overlapping_switch_mixture(switch_cond, *new_components)]
+
+
 @_logprob.register(MeasurableSwitchMixture)
 def logprob_switch_mixture(op, values, switch_cond, component_true, component_false, **kwargs):
     [value] = values
@@ -459,6 +512,43 @@ def logprob_switch_mixture(op, values, switch_cond, component_true, component_fa
         switch_cond,
         _logprob_helper(component_true, value),
         _logprob_helper(component_false, value),
+    )
+
+
+@_logprob.register(MeasurableNonOverlappingSwitchMixture)
+def logprob_non_overlapping_switch(op, values, switch_cond, comp_true, comp_false, **kwargs):
+    [value] = values
+
+    cond_owner = switch_cond.owner
+    lhs, rhs = cond_owner.inputs
+    scalar_op = cond_owner.op.scalar_op
+
+    lhs_measurable = bool(filter_measurable_variables([lhs]))
+    threshold = rhs if lhs_measurable else lhs
+
+    if lhs_measurable:
+        if isinstance(scalar_op, pytensor.scalar.GT):
+            value_cond = pt.gt(value, threshold)
+        elif isinstance(scalar_op, pytensor.scalar.GE):
+            value_cond = pt.ge(value, threshold)
+        elif isinstance(scalar_op, pytensor.scalar.LT):
+            value_cond = pt.lt(value, threshold)
+        elif isinstance(scalar_op, pytensor.scalar.LE):
+            value_cond = pt.le(value, threshold)
+    else:
+        if isinstance(scalar_op, pytensor.scalar.GT):
+            value_cond = pt.lt(value, threshold)
+        elif isinstance(scalar_op, pytensor.scalar.GE):
+            value_cond = pt.le(value, threshold)
+        elif isinstance(scalar_op, pytensor.scalar.LT):
+            value_cond = pt.gt(value, threshold)
+        elif isinstance(scalar_op, pytensor.scalar.LE):
+            value_cond = pt.ge(value, threshold)
+
+    return switch(
+        value_cond,
+        _logprob_helper(comp_true, value, **kwargs),
+        _logprob_helper(comp_false, value, **kwargs),
     )
 
 
@@ -585,6 +675,13 @@ early_measurable_ir_rewrites_db.register(
 measurable_ir_rewrites_db.register(
     "find_measurable_ifelse_mixture",
     find_measurable_ifelse_mixture,
+    "basic",
+    "mixture",
+)
+
+measurable_ir_rewrites_db.register(
+    "find_measurable_non_overlapping_switch",
+    find_measurable_non_overlapping_switch,
     "basic",
     "mixture",
 )

--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -471,7 +471,7 @@ def find_measurable_non_overlapping_switch(fgraph, node):
     cond_owner = switch_cond.owner
     scalar_op = getattr(cond_owner.op, "scalar_op", None)
     if not isinstance(
-        scalar_op, pytensor.scalar.LT, pytensor.scalar.LE, pytensor.scalar.GT, pytensor.scalar.GE
+        scalar_op, pytensor.scalar.LT | pytensor.scalar.LE | pytensor.scalar.GT | pytensor.scalar.GE
     ):
         return None
 

--- a/tests/logprob/test_mixture.py
+++ b/tests/logprob/test_mixture.py
@@ -1268,3 +1268,102 @@ def test_advanced_subtensor_none_and_integer():
         match="logprob terms of the following value variables could not be derived: {b_val}",
     ):
         conditional_logp({b: b_val, a: a_val})
+
+
+@pytest.mark.parametrize(
+    "op, threshold, x_true, x_false",
+    [
+        # GT: x > k, true branch when x > k
+        (pt.gt, 5.0, 8.0, 2.0),
+        # GE: x >= k
+        (pt.ge, 5.0, 8.0, 2.0),
+        # LT: x < k, true branch when x < k
+        (pt.lt, 500.0, 2.0, 800.0),
+        # LE: x <= k
+        (pt.le, 500.0, 2.0, 800.0),
+        # Negative threshold
+        (pt.gt, -3.0, 0.0, -5.0),
+        # Zero threshold (should still work)
+        (pt.gt, 0.0, 2.0, -2.0),
+    ],
+)
+def test_non_overlapping_switch_nonzero_threshold(op, threshold, x_true, x_false):
+    """Test that non-overlapping switch logp works for non-zero thresholds with all comparison ops."""
+    srng = pt.random.RandomStream(1234)
+
+    X_rv = srng.normal(0, 10, name="X")
+    k = pt.constant(threshold)
+
+    # Branches are constructed so they don't overlap:
+    # true branch shifts far positive, false branch shifts far negative
+    Z_rv = pt.switch(op(X_rv, k), X_rv + 100, X_rv - 100)
+    Z_rv.name = "Z"
+
+    z_vv = Z_rv.clone()
+    z_vv.name = "z"
+
+    # Should not raise — logp must be derivable
+    z_logp = logp(Z_rv, z_vv)
+    assert_no_rvs(z_logp)
+
+    decimals = 6 if pytensor.config.floatX == "float64" else 4
+
+    # Value from true branch: x_true shifted by +100
+    true_val = np.array(x_true + 100, dtype=pytensor.config.floatX)
+    logp_true = z_logp.eval({z_vv: true_val})
+    # Should match Normal(0, 10).logpdf(x_true)
+    exp_true = sp.norm(0, 10).logpdf(x_true)
+    np.testing.assert_almost_equal(logp_true, exp_true, decimal=decimals)
+
+    # Value from false branch: x_false shifted by -100
+    false_val = np.array(x_false - 100, dtype=pytensor.config.floatX)
+    logp_false = z_logp.eval({z_vv: false_val})
+    exp_false = sp.norm(0, 10).logpdf(x_false)
+    np.testing.assert_almost_equal(logp_false, exp_false, decimal=decimals)
+
+
+def test_non_overlapping_switch_threshold_on_rhs():
+    """Test switch where the measurable variable is on the LHS: switch(x > k, ...)."""
+    srng = pt.random.RandomStream(5678)
+
+    X_rv = srng.normal(0, 10, name="X")
+    k = pt.constant(3.0)
+
+    Z_rv = pt.switch(pt.gt(X_rv, k), X_rv + 100, X_rv - 100)
+    Z_rv.name = "Z"
+    z_vv = Z_rv.clone()
+
+    z_logp = logp(Z_rv, z_vv)
+    assert_no_rvs(z_logp)
+
+    decimals = 6 if pytensor.config.floatX == "float64" else 4
+
+    # x=5 > 3, so true branch: observed value = 5 + 100 = 105
+    np.testing.assert_almost_equal(
+        z_logp.eval({z_vv: np.array(105.0, dtype=pytensor.config.floatX)}),
+        sp.norm(0, 10).logpdf(5.0),
+        decimal=decimals,
+    )
+
+    # x=-2 <= 3, so false branch: observed value = -2 - 100 = -102
+    np.testing.assert_almost_equal(
+        z_logp.eval({z_vv: np.array(-102.0, dtype=pytensor.config.floatX)}),
+        sp.norm(0, 10).logpdf(-2.0),
+        decimal=decimals,
+    )
+
+
+def test_non_overlapping_switch_dirac_branch():
+    """Test non-overlapping switch where one branch is a constant (DiracDelta)."""
+    srng = pt.random.RandomStream(9999)
+
+    X_rv = srng.normal(10, 1, name="X")
+    k = pt.constant(5.0)
+
+    # false branch is a constant -999 (DiracDelta), true branch is measurable
+    Z_rv = pt.switch(pt.gt(X_rv, k), X_rv, pt.as_tensor(-999.0))
+    Z_rv.name = "Z"
+    z_vv = Z_rv.clone()
+
+    z_logp = logp(Z_rv, z_vv)
+    assert_no_rvs(z_logp)


### PR DESCRIPTION
## Description

so basically the existing non-overlapping switch logp only worked with zero thresholds like `switch(x > 0, ...)`. this PR extends it to work with any scalar constant k like `switch(x > k, ...)`
- Previously only `switch(x > 0, ...)` was supported
- Now handles `switch(x > k, ...)` where k can be any scalar constant (positive, negative, zero)
- Added `MeasurableNonOverlappingSwitchMixture` class with its own rewriter and logprob function
- Handles all comparison operators (GT, GE, LT, LE)
- Works whether the measurable variable is on the left or right side of the condition

## Related Issue

- [x] Closes #8052

## Checklist

- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)

## Type of change

- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):