### PR TITLE
Pack unpack join nonshared inputs

### DIFF
--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -48,6 +48,7 @@ from pytensor.tensor.rewriting.shape import ShapeFeature
 from pytensor.tensor.sharedvar import SharedVariable
 from pytensor.tensor.subtensor import AdvancedIncSubtensor, AdvancedIncSubtensor1
 from pytensor.tensor.variable import TensorVariable
+from pytensor.tensor.reshape import unpack
 
 from pymc.exceptions import NotConstantValueError
 from pymc.util import makeiter
@@ -583,16 +584,12 @@ def join_nonshared_inputs(
     if pytensor.config.compute_test_value != "off":
         joined_inputs.tag.test_value = raveled_inputs.tag.test_value
 
-    replace: dict[Variable, Variable] = {}
-    last_idx = 0
-    for var in inputs:
-        shape = point[var.name].shape
-        arr_len = np.prod(shape, dtype=int)
-        replacement_var = (
-            joined_inputs[last_idx : last_idx + arr_len].reshape(shape).astype(var.dtype)
-        )
-        replace[var] = var.type.filter_variable(replacement_var)
-        last_idx += arr_len
+    packed_shapes = [point[var.name].shape for var in inputs]
+    unpacked = unpack(joined_inputs, axes=None, packed_shapes=packed_shapes)
+    replace: dict[Variable, Variable] = {
+        var: var.type.filter_variable(u.astype(var.dtype))
+        for var, u in zip(inputs, unpacked)
+    }
 
     if shared_inputs is not None:
         replace.update(shared_inputs)
@@ -612,7 +609,7 @@ class PointFunc:
         self.f = f
 
     def __call__(self, state):
-        return self.f(**state)
+        return self.f(**state
 
     def dprint(self, **kwrags):
         return self.f.dprint(**kwrags)

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -609,7 +609,7 @@ class PointFunc:
         self.f = f
 
     def __call__(self, state):
-        return self.f(**state
+        return self.f(**state)
 
     def dprint(self, **kwrags):
         return self.f.dprint(**kwrags)


### PR DESCRIPTION
## Description
This PR simplifies the `join_nonshared_inputs` function by using `unpack` from PyTensor instead of a manual loop to split and reshape inputs.
Only `unpack` is used (not `pack`).

## Related Issue
- [x] Closes #8042
- [ ] Related to #

## Checklist
- [ ] Checked that the pre-commit linting/style checks pass
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a relevant logical change

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
