### PR TITLE
`compute_log_prior`: make subsequent arguments keyword only

### DIFF
--- a/pymc/stats/log_density.py
+++ b/pymc/stats/log_density.py
@@ -74,6 +74,7 @@ def compute_log_likelihood(
 
 def compute_log_prior(
     idata: InferenceData,
+    *,
     var_names: Sequence[str] | None = None,
     extend_inferencedata: bool = True,
     model: Model | None = None,


### PR DESCRIPTION
I closed the previous PR (https://github.com/pymc-devs/pymc/pull/8122) prematurely while trying to resolve pre-commit autofix failures, which ended up being a distraction from the actual change.

This PR keeps things minimal and focused: it enforces keyword-only arguments for compute_log_prior, aligning its signature with compute_log_likelihood and preventing accidental positional argument usage.

As requested in the earlier discussion, the test case has been removed and only the signature fix remains.

