### PR TITLE
BUG: Add __eq__ to DataClassState to fix == comparison

### DIFF
--- a/pymc/step_methods/state.py
+++ b/pymc/step_methods/state.py
@@ -25,7 +25,7 @@ dataclass_state = dataclass(kw_only=True)
 @dataclass_state
 class DataClassState:
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]] = {}
-    
+
     def __eq__(self, other):
         return equal_dataclass_values(self, other)
 

--- a/pymc/step_methods/state.py
+++ b/pymc/step_methods/state.py
@@ -25,8 +25,10 @@ dataclass_state = dataclass(kw_only=True)
 @dataclass_state
 class DataClassState:
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]] = {}
+    
     def __eq__(self, other):
         return equal_dataclass_values(self, other)
+
 
 def equal_dataclass_values(v1, v2):
     if v1.__class__ != v2.__class__:

--- a/pymc/step_methods/state.py
+++ b/pymc/step_methods/state.py
@@ -25,7 +25,8 @@ dataclass_state = dataclass(kw_only=True)
 @dataclass_state
 class DataClassState:
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]] = {}
-
+    def __eq__(self, other):
+        return equal_dataclass_values(self, other)
 
 def equal_dataclass_values(v1, v2):
     if v1.__class__ != v2.__class__:

--- a/pymc/step_methods/state.py
+++ b/pymc/step_methods/state.py
@@ -25,7 +25,6 @@ dataclass_state = dataclass(kw_only=True)
 @dataclass_state
 class DataClassState:
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]] = {}
-    
     def __eq__(self, other):
         return equal_dataclass_values(self, other)
 

--- a/pymc/step_methods/state.py
+++ b/pymc/step_methods/state.py
@@ -25,6 +25,7 @@ dataclass_state = dataclass(kw_only=True)
 @dataclass_state
 class DataClassState:
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]] = {}
+    
     def __eq__(self, other):
         return equal_dataclass_values(self, other)
 

--- a/tests/step_methods/test_state.py
+++ b/tests/step_methods/test_state.py
@@ -156,3 +156,15 @@ def test_sampling_state_rng(step):
     values2 = step.rng.random(100)
     assert np.array_equal(values1, values2, equal_nan=True)
     assert equal_sampling_states(step.sampling_state, final_state)
+
+
+def test_dataclass_state_eq():
+    """Regression test for #8132 - DataClassState subclasses should be == comparable."""
+    s1 = State1(a=1, b=2.0, c="c", d=np.array([1.0, 2.0]), e=[1, 2], f={"a": 1})
+    s2 = State1(a=1, b=2.0, c="c", d=np.array([1.0, 2.0]), e=[1, 2], f={"a": 1})
+    s3 = State1(a=1, b=2.0, c="c", d=np.array([9.0, 9.0]), e=[1, 2], f={"a": 1})
+
+    # Before the fix this raised:
+    # ValueError: The truth value of an array with more than one element is ambiguous
+    assert s1 == s2
+    assert s1 != s3

--- a/tests/step_methods/test_state.py
+++ b/tests/step_methods/test_state.py
@@ -164,7 +164,5 @@ def test_dataclass_state_eq():
     s2 = State1(a=1, b=2.0, c="c", d=np.array([1.0, 2.0]), e=[1, 2], f={"a": 1})
     s3 = State1(a=1, b=2.0, c="c", d=np.array([9.0, 9.0]), e=[1, 2], f={"a": 1})
 
-    # Before the fix this raised:
-    # ValueError: The truth value of an array with more than one element is ambiguous
     assert s1 == s2
     assert s1 != s3


### PR DESCRIPTION
**Description**

DataClassState subclasses like BaseHMCState were not == comparable because the auto-generated __eq__ from @dataclass_state would try to do field1 == field2 on numpy array fields, which returns an array of booleans instead of a single True/False 
The fix is to connect equal_dataclass_values (which already existed and worked fine) to __eq__ in the function DataClassState.

- [x] Closes #8132

 Type of change

- [x]  Bug fix