### PR TITLE
MAINT: Deprecate SumTo1 transform withWarning

### DIFF
--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -16,6 +16,7 @@ from functools import singledispatch
 
 import numpy as np
 import pytensor.tensor as pt
+import warnings
 
 from numpy.lib.array_utils import normalize_axis_tuple
 from pytensor.graph import Op
@@ -119,6 +120,9 @@ class SumTo1(Transform):
     Transforms K - 1 dimensional simplex space (K values in [0, 1] that sum to 1) to a K - 1 vector of values in [0, 1].
 
     This transformation operates on the last dimension of the input tensor.
+
+    .. deprecated::
+        SumTo1 is deprecated. Use `simplex` transform instead.
     """
 
     name = "sumto1"

--- a/pymc/step_methods/state.py
+++ b/pymc/step_methods/state.py
@@ -25,7 +25,7 @@ dataclass_state = dataclass(kw_only=True)
 @dataclass_state
 class DataClassState:
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]] = {}
-    
+
     def __eq__(self, other):
         return equal_dataclass_values(self, other)
 

--- a/pymc/step_methods/state.py
+++ b/pymc/step_methods/state.py
@@ -25,8 +25,10 @@ dataclass_state = dataclass(kw_only=True)
 @dataclass_state
 class DataClassState:
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]] = {}
+    
     def __eq__(self, other):
         return equal_dataclass_values(self, other)
+
 
 def equal_dataclass_values(v1, v2):
     if v1.__class__ != v2.__class__:

--- a/pymc/step_methods/state.py
+++ b/pymc/step_methods/state.py
@@ -25,7 +25,8 @@ dataclass_state = dataclass(kw_only=True)
 @dataclass_state
 class DataClassState:
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]] = {}
-
+    def __eq__(self, other):
+        return equal_dataclass_values(self, other)
 
 def equal_dataclass_values(v1, v2):
     if v1.__class__ != v2.__class__:

--- a/pymc/step_methods/state.py
+++ b/pymc/step_methods/state.py
@@ -25,7 +25,6 @@ dataclass_state = dataclass(kw_only=True)
 @dataclass_state
 class DataClassState:
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]] = {}
-    
     def __eq__(self, other):
         return equal_dataclass_values(self, other)
 

--- a/pymc/step_methods/state.py
+++ b/pymc/step_methods/state.py
@@ -25,6 +25,7 @@ dataclass_state = dataclass(kw_only=True)
 @dataclass_state
 class DataClassState:
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]] = {}
+    
     def __eq__(self, other):
         return equal_dataclass_values(self, other)
 

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -148,11 +148,14 @@ def test_simplex_accuracy():
 
 
 def test_sum_to_1():
-    check_vector_transform(tr.sum_to_1, Simplex(2))
-    check_vector_transform(tr.sum_to_1, Simplex(4))
+    with pytest.warns(FutureWarning, match="SumTo1.*deprecated"):
+        transform = tr.SumTo1()
+
+    check_vector_transform(transform, Simplex(2))
+    check_vector_transform(transform, Simplex(4))
 
     check_jacobian_det(
-        tr.sum_to_1,
+        transform,
         Vector(Unit, 2),
         pt.vector,
         floatX(np.array([0, 0])),


### PR DESCRIPTION
## Description
SumTo1 is an old transform that was replaced by SimplexTransform. Added a FutureWarning when SumTo1 (or sum_to_1) is instantiated to let users know it's deprecated and will be removed in a future version, pointing them to use simplex instead.
changes:
 - added FutureWarning to SumTo1.__init__ in pymc/distributions/transforms.py
 - updated test_sum_to_1 in tests/distributions/test_transform.py to assert the warning fires while confirming the transform still works

## Related Issue
- [x] Closes #8130 
- [ ] Related to #7009

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
