### PR TITLE
ADD: Show remaining time in marimo progress bar

### DIFF
--- a/pymc/progress_bar/marimo_progress.py
+++ b/pymc/progress_bar/marimo_progress.py
@@ -16,6 +16,7 @@ from time import perf_counter
 from typing import Any, Self
 
 from pymc.progress_bar.marimo_progress_css import DEFAULT_CSS
+from pymc.progress_bar.utils import compute_remaining_time
 
 
 def format_time(seconds: float) -> str:
@@ -252,12 +253,12 @@ class MarimoProgressBackend:
         pct = (completed / total * 100) if total > 0 else 0
         elapsed = perf_counter() - self._start_times[task_id]
 
-        if completed > 0 and completed < total:
-            rate = completed / max(elapsed, 1e-6)
-            remaining = (total - completed) / rate
-            remaining_str = format_time(remaining)
-        else:
+        remaining = compute_remaining_time(completed, total, elapsed)
+
+        if remaining is None:
             remaining_str = "--:--"
+        else:
+            remaining_str = format_time(remaining)
 
         action = self.step_name.lower()
         speed = completed / max(elapsed, 1e-6)

--- a/pymc/progress_bar/marimo_progress.py
+++ b/pymc/progress_bar/marimo_progress.py
@@ -225,7 +225,7 @@ class MarimoProgressBackend:
         }
         header_cells += [abbreviations.get(k, k[:6].capitalize()) for k in stat_keys]
 
-        header_cells += ["Speed", "Elapsed"]
+        header_cells += ["Speed", "Elapsed", "Remaining"]
 
         header_row = "<tr>" + "".join(f"<th>{h}</th>" for h in header_cells) + "</tr>"
 
@@ -251,6 +251,13 @@ class MarimoProgressBackend:
 
         pct = (completed / total * 100) if total > 0 else 0
         elapsed = perf_counter() - self._start_times[task_id]
+
+        if completed > 0 and completed < total:
+            rate = completed / max(elapsed, 1e-6)
+            remaining = (total - completed) / rate
+            remaining_str = format_time(remaining)
+        else:
+            remaining_str = "--:--"
 
         action = self.step_name.lower()
         speed = completed / max(elapsed, 1e-6)
@@ -280,6 +287,7 @@ class MarimoProgressBackend:
 
         cells.append(f"<td>{speed:.1f} {unit}</td>")
         cells.append(f"<td>{format_time(elapsed)}</td>")
+        cells.append(f"<td>{remaining_str}</td>")
 
         return "<tr>" + "".join(cells) + "</tr>"
 

--- a/pymc/progress_bar/utils.py
+++ b/pymc/progress_bar/utils.py
@@ -1,0 +1,20 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+def compute_remaining_time(
+    completed: int | float, total: int | float, elapsed: float
+) -> float | None:
+    """Estimate remaining time based on elapsed progress."""
+    if completed <= 0 or completed >= total or elapsed <= 0:
+        return None
+    return elapsed * (total / completed - 1)

--- a/tests/progress_bar/test_marimo.py
+++ b/tests/progress_bar/test_marimo.py
@@ -107,3 +107,24 @@ class TestMarimoProgressBackend:
             html = backend._render_html()
 
             assert "0.25" in html or "Step" in html
+
+    def test_render_html_remaining(self, step_method):
+        with patch("pymc.progress_bar.progress.in_marimo_notebook", return_value=True):
+            manager = MCMCProgressBarManager(
+                step_method=step_method,
+                chains=1,
+                draws=100,
+                tune=50,
+                progressbar=True,
+            )
+            backend = manager._backend
+
+            backend._initialize_tasks()
+
+            backend._task_state = [{"completed": 50, "total": 100, "failing": False, "stats": {}}]
+            backend._start_times = [backend._start_times[0] - 10]
+
+            html = backend._render_html()
+
+            assert "Remaining" in html
+            assert "--:--" not in html


### PR DESCRIPTION
While using marimo notebooks, it was hard to tell how much longer a sampling run would take. This change adds a remaining-time (ETA) column to the marimo progress bar to make that clearer. The change is purely visual and does not affect sampling behavior, and a focused test is included to lock in the new output.