### PR TITLE
Fix model.debug() crash with Potentials

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1888,15 +1888,32 @@ class Model(WithMemoization, metaclass=ContextMeta):
         print_(f"point={point}\n")
 
         rvs_to_check = list(self.basic_RVs)
-        if fn in ("logp", "dlogp"):
-            rvs_to_check += [self.replace_rvs_by_values(p) for p in self.potentials]
+        replaced_potentials: list = []
+        if fn == "logp":
+            # The replaced potential expression IS the logp contribution; add it directly.
+            # Potentials are skipped for dlogp because they have no associated value variable.
+            replaced_potentials = [self.replace_rvs_by_values([p])[0] for p in self.potentials]
+            rvs_to_check += replaced_potentials
 
         found_problem = False
         for rv in rvs_to_check:
+            is_potential = rv in replaced_potentials
             if fn == "logp":
-                rv_fn = pytensor.function(
-                    self.value_vars, self.logp(vars=rv, sum=False)[0], on_unused_input="ignore"
-                )
+                if is_potential:
+                    # Use the replaced potential expression directly to avoid calling
+                    # self.logp(), which only accepts the original potential objects.
+                    try:
+                        rv_fn = pytensor.function(self.value_vars, rv, on_unused_input="ignore")
+                    except Exception as exc:
+                        found_problem = True
+                        print_(f"The potential {rv} could not be compiled: {first_line(exc)}\n")
+                        if verbose:
+                            print_(exc)
+                        continue
+                else:
+                    rv_fn = pytensor.function(
+                        self.value_vars, self.logp(vars=rv, sum=False)[0], on_unused_input="ignore"
+                    )
             elif fn == "dlogp":
                 rv_fn = pytensor.function(
                     self.value_vars, self.dlogp(vars=rv), on_unused_input="ignore"
@@ -1938,8 +1955,8 @@ class Model(WithMemoization, metaclass=ContextMeta):
                 if not np.all(np.isfinite(rv_fn_eval)):
                     found_problem = True
                     debug_parameters(rv)
-                    if fn == "random" or rv is self.potentials:
-                        print_("This combination seems able to generate non-finite values")
+                    if fn == "random" or is_potential:
+                        print_("This combination seems able to generate non-finite values\n")
                     else:
                         # Find which values are associated with non-finite evaluation
                         values = self.rvs_to_values[rv]

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -1721,6 +1721,45 @@ class TestModelDebug:
         )
         assert "value = 0.53 -> logp = -inf" in out
 
+    @pytest.mark.parametrize("fn", ("logp", "dlogp"))
+    def test_potential_no_crash(self, fn, capfd):
+        """debug() must not crash when the model contains a Potential (issue #6966).
+
+        Potentials are not random variables and have no associated value variable, so
+        the original code failed with ValueError when it tried to call self.logp() or
+        self.dlogp() with the replaced-potential expression.
+        """
+        with pm.Model() as m:
+            x = pm.Normal("x", mu=0, sigma=1)
+            pm.Potential("pot", -0.5 * x**2)
+        # Must not raise
+        m.debug(fn=fn)
+        out, _ = capfd.readouterr()
+        assert "No problems found" in out
+
+    @pytest.mark.parametrize("fn", ("logp", "dlogp"))
+    def test_potential_dynamic_shape_no_crash(self, fn, capfd):
+        """debug() must not crash for Potentials whose shape depends on observed data (issue #6966)."""
+        data = np.array([1.0, 2.0, 3.0])
+        with pm.Model() as m:
+            mu = pm.Normal("mu", mu=0, sigma=1)
+            # Potential whose shape is determined by the length of 'data' at runtime
+            pm.Potential("pot_yhat", pm.logp(pm.Normal.dist(mu=mu, sigma=1), data))
+        # Must not raise regardless of dynamic shape
+        m.debug(fn=fn)
+        out, _ = capfd.readouterr()
+        assert "No problems found" in out
+
+    def test_potential_non_finite_reported(self, capfd):
+        """debug() should report non-finite Potential values instead of crashing."""
+        with pm.Model() as m:
+            x = pm.Normal("x", mu=0, sigma=1)
+            pm.Potential("bad_pot", pt.log(x))  # -inf when x <= 0
+        # Evaluate at the default initial point (x=0), where log(0) = -inf
+        m.debug(point={"x": 0.0})
+        out, _ = capfd.readouterr()
+        assert "This combination seems able to generate non-finite values" in out
+
 
 def test_model_logp_fast_compile():
     # Issue #5618


### PR DESCRIPTION
## Description

`model.debug(fn='logp')` raised `ValueError: Length of pot_yhat cannot be determined` when the model contained Potentials with dynamic shapes.

Investigation revealed four related bugs in the `debug()` method:

1. `replace_rvs_by_values(p)` passed a single tensor where a sequence is required — changed to `replace_rvs_by_values([p])[0]`
2. Replaced potentials were passed to `self.logp(vars=...)` which couldn't find them among model variables — use the replaced expression directly as the logp contribution
3. Potentials were added to `dlogp` checks despite having no value variable to differentiate — only add when `fn == "logp"`
4. `rv is self.potentials` (tensor vs list) always evaluated to `False` — replaced with `is_potential` boolean

Tests added:
- `test_potential_no_crash` — basic Potential doesn't crash `debug()`
- `test_potential_dynamic_shape_no_crash` — exact issue #6966 scenario
- `test_potential_non_finite_reported` — non-finite values reported gracefully

## Related Issue

- [x] Closes #6966
- [ ] Related to #

## Checklist

- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a relevant logical change

## Type of change

- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):