### PR TITLE
Add logccdf tests for Censored distributions

### DIFF
--- a/tests/distributions/test_censored.py
+++ b/tests/distributions/test_censored.py
@@ -18,7 +18,7 @@ import scipy as sp
 
 import pymc as pm
 
-from pymc import logcdf, logp
+from pymc import logccdf, logcdf, logp
 from pymc.distributions.shape_utils import change_dist_size
 
 
@@ -171,6 +171,47 @@ class TestCensored:
             rtol=1e-6,
         )
 
+    def test_censored_logccdf_continuous(self):
+        norm = pm.Normal.dist(0, 1)
+        eval_points = np.array([-np.inf, -2, -1, 0, 1, 2, np.inf])
+        expected_logccdf_uncensored = sp.stats.norm.logsf(eval_points)
+
+        # No censoring
+        censored_norm = pm.Censored.dist(norm, lower=None, upper=None)
+        censored_eval = logccdf(censored_norm, eval_points).eval()
+        np.testing.assert_allclose(censored_eval, expected_logccdf_uncensored)
+
+        # Left censoring
+        censored_norm = pm.Censored.dist(norm, lower=-1, upper=None)
+        expected_left = np.where(eval_points < -1, 0.0, expected_logccdf_uncensored)
+        censored_eval = logccdf(censored_norm, eval_points).eval()
+        np.testing.assert_allclose(
+            censored_eval,
+            expected_left,
+            rtol=1e-6,
+        )
+
+        # Right censoring
+        censored_norm = pm.Censored.dist(norm, lower=None, upper=1)
+        expected_right = np.where(eval_points >= 1, -np.inf, expected_logccdf_uncensored)
+        censored_eval = logccdf(censored_norm, eval_points).eval()
+        np.testing.assert_allclose(
+            censored_eval,
+            expected_right,
+            rtol=1e-6,
+        )
+
+        # Interval censoring
+        censored_norm = pm.Censored.dist(norm, lower=-1, upper=1)
+        expected_interval = np.where(eval_points < -1, 0.0, expected_logccdf_uncensored)
+        expected_interval = np.where(eval_points >= 1, -np.inf, expected_interval)
+        censored_eval = logccdf(censored_norm, eval_points).eval()
+        np.testing.assert_allclose(
+            censored_eval,
+            expected_interval,
+            rtol=1e-6,
+        )
+
     def test_censored_logcdf_discrete(self):
         probs = [0.1, 0.2, 0.2, 0.3, 0.2]
         cat = pm.Categorical.dist(probs)
@@ -211,6 +252,49 @@ class TestCensored:
         expected_interval = np.where(eval_points >= 3, 0.0, expected_interval)
         np.testing.assert_allclose(
             logcdf(censored_cat, eval_points).eval(),
+            expected_interval,
+        )
+
+    def test_censored_logccdf_discrete(self):
+        probs = [0.1, 0.2, 0.2, 0.3, 0.2]
+        cat = pm.Categorical.dist(probs)
+        eval_points = np.array([-1, 0, 1, 2, 3, 4, 5])
+
+        ccdf = 1 - np.cumsum(probs)
+        log_ccdf_base = np.log(ccdf)
+        expected_logccdf_uncensored = np.full_like(eval_points, -np.inf, dtype=float)
+        expected_logccdf_uncensored[0] = 0.0
+        expected_logccdf_uncensored[1:6] = log_ccdf_base
+
+        # No censoring
+        censored_cat = pm.Censored.dist(cat, lower=None, upper=None)
+        np.testing.assert_allclose(
+            logccdf(censored_cat, eval_points).eval(),
+            expected_logccdf_uncensored,
+        )
+
+        # Left censoring
+        censored_cat = pm.Censored.dist(cat, lower=1, upper=None)
+        expected_left = np.where(eval_points < 1, 0.0, expected_logccdf_uncensored)
+        np.testing.assert_allclose(
+            logccdf(censored_cat, eval_points).eval(),
+            expected_left,
+        )
+
+        # Right censoring
+        censored_cat = pm.Censored.dist(cat, lower=None, upper=3)
+        expected_right = np.where(eval_points >= 3, -np.inf, expected_logccdf_uncensored)
+        np.testing.assert_allclose(
+            logccdf(censored_cat, eval_points).eval(),
+            expected_right,
+        )
+
+        # Interval censoring
+        censored_cat = pm.Censored.dist(cat, lower=1, upper=3)
+        expected_interval = np.where(eval_points < 1, 0.0, expected_logccdf_uncensored)
+        expected_interval = np.where(eval_points >= 3, -np.inf, expected_interval)
+        np.testing.assert_allclose(
+            logccdf(censored_cat, eval_points).eval(),
             expected_interval,
         )
 


### PR DESCRIPTION
## Description

Adds test coverage for `logccdf` (log survival function) on censored distributions, mirroring the existing `test_censored_logcdf_continuous` and `test_censored_logcdf_discrete` tests.

The censoring module (`pymc/logprob/censoring.py`) already uses `_logccdf_helper` internally for computing right-censored `logp`, but the `logccdf` dispatch for censored distributions had no direct test coverage.

Tests verify all four censoring configurations (uncensored, left, right, interval) for both continuous (Normal) and discrete (Categorical) base distributions.

## Related Issue

- [ ] Closes #
- [x] Related to #8166 (logccdf infrastructure)

## Checklist

- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] Each commit corresponds to a relevant logical change

## Type of change

- [x] New feature / enhancement