### PR TITLE
Add FutureWarning to SumTo1 transform deprecation

### DIFF
--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -12,10 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import warnings
+
 from functools import singledispatch
 
 import numpy as np
-import warnings
 import pytensor.tensor as pt
 
 from numpy.lib.array_utils import normalize_axis_tuple
@@ -123,6 +124,7 @@ class SumTo1(Transform):
     """
 
     name = "sumto1"
+
     def __init__(self):
         warnings.warn(
             "SumTo1 is deprecated and will be removed in a future version. "

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -15,6 +15,7 @@
 from functools import singledispatch
 
 import numpy as np
+import warnings
 import pytensor.tensor as pt
 
 from numpy.lib.array_utils import normalize_axis_tuple
@@ -122,6 +123,13 @@ class SumTo1(Transform):
     """
 
     name = "sumto1"
+    def __init__(self):
+        warnings.warn(
+            "SumTo1 is deprecated and will be removed in a future version. "
+            "Use the Simplex transform instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
     def backward(self, value, *inputs):
         remaining = 1 - pt.sum(value[..., :], axis=-1, keepdims=True)

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -159,9 +159,11 @@ def test_sum_to_1():
         lambda x: x[:-1],
     )
 
+
 def test_sum_to_1_deprecation_warning():
     with pytest.warns(FutureWarning, match="SumTo1 is deprecated"):
         tr.SumTo1()
+
 
 def test_log():
     check_transform(tr.log, Rplusbig)

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -159,6 +159,9 @@ def test_sum_to_1():
         lambda x: x[:-1],
     )
 
+def test_sum_to_1_deprecation_warning():
+    with pytest.warns(FutureWarning, match="SumTo1 is deprecated"):
+        tr.SumTo1()
 
 def test_log():
     check_transform(tr.log, Rplusbig)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7009 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

Added a FutureWarning to the SumTo1 transform to notify users it is deprecated 
and will be removed in a future version, pointing them to use the Simplex 
transform instead. Also added a test to verify the warning is raised on instantiation.