### PR TITLE
Fix off-by-one progress bar bugs

### DIFF
--- a/pymc/progress_bar/marimo_progress.py
+++ b/pymc/progress_bar/marimo_progress.py
@@ -183,12 +183,7 @@ class MarimoProgressBackend:
         self._task_state[task_id]["stats"] = stats
 
         if is_last:
-            # Ensure bar is fully filled on completion
-            total = self._task_state[task_id]["total"]
-            completed = self._task_state[task_id]["completed"]
-            remaining = total - completed
-            if remaining > 0:
-                self._task_state[task_id]["completed"] = total
+            self._task_state[task_id]["completed"] = self._task_state[task_id]["total"]
 
         self._render()
 

--- a/pymc/progress_bar/progress.py
+++ b/pymc/progress_bar/progress.py
@@ -310,7 +310,9 @@ class MCMCProgressBarManager(ProgressBarManager):
         if not self._show_progress:
             return
 
-        self.completed_draws += 1
+        if not is_last:
+            self.completed_draws += 1
+
         if self.combined_progress:
             draw = self.completed_draws
             chain_idx = 0

--- a/pymc/progress_bar/progress.py
+++ b/pymc/progress_bar/progress.py
@@ -316,7 +316,7 @@ class MCMCProgressBarManager(ProgressBarManager):
             chain_idx = 0
 
         failing, all_step_stats = self._extract_stats(stats)
-        all_step_stats["draws"] = draw
+        all_step_stats["draws"] = draw + 1 if not self.combined_progress else draw
 
         self._backend.update(
             task_id=chain_idx,

--- a/pymc/progress_bar/rich_progress.py
+++ b/pymc/progress_bar/rich_progress.py
@@ -231,7 +231,7 @@ class RichProgressBackend:
                 self._progress.add_task(
                     "Sampling",
                     completed=0,
-                    total=self.total * self.n_bars - 1,
+                    total=self.total * self.n_bars,
                     task_idx=0,
                     sampling_speed=0,
                     speed_unit="draws/s",
@@ -244,7 +244,7 @@ class RichProgressBackend:
                 self._progress.add_task(
                     "Sampling",
                     completed=0,
-                    total=self.total - 1,
+                    total=self.total,
                     task_idx=task_idx,
                     sampling_speed=0,
                     speed_unit="draws/s",

--- a/pymc/progress_bar/rich_progress.py
+++ b/pymc/progress_bar/rich_progress.py
@@ -281,6 +281,18 @@ class RichProgressBackend:
         if rich_task_id is None:
             return
 
+        if is_last:
+            self._progress.update(
+                rich_task_id,
+                completed=self.total if not self.combined else self.total * self.n_bars,
+                sampling_speed=0,
+                speed_unit="",
+                failing=failing,
+                refresh=True,
+                **stats,
+            )
+            return
+
         self._progress.advance(rich_task_id, advance=advance)
 
         task = self._progress.tasks[task_id]
@@ -302,18 +314,6 @@ class RichProgressBackend:
             failing=failing,
             **stats,
         )
-
-        if is_last:
-            # Ensure bar is fully filled on completion
-            remaining = task.total - task.completed if task.total else 0
-            if remaining > 0:
-                self._progress.advance(rich_task_id, advance=remaining)
-            self._progress.update(
-                rich_task_id,
-                failing=failing,
-                **stats,
-                refresh=True,
-            )
 
 
 def RichSimpleProgress(theme: Theme | None):

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1295,11 +1295,13 @@ def _sample(
     )
     try:
         for it, stats in enumerate(sampling_gen):
-            is_last = it + 1 == draws and (
-                not progress_manager.combined_progress or chain == progress_manager.chains - 1
-            )
             progress_manager.update(
-                chain_idx=chain, is_last=is_last, draw=it, stats=stats, tuning=it < tune
+                chain_idx=chain, is_last=False, draw=it, stats=stats, tuning=it < tune
+            )
+
+        if not progress_manager.combined_progress or chain == progress_manager.chains - 1:
+            progress_manager.update(
+                chain_idx=chain, is_last=True, draw=it, stats=stats, tuning=False
             )
 
     except KeyboardInterrupt:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1295,13 +1295,11 @@ def _sample(
     )
     try:
         for it, stats in enumerate(sampling_gen):
-            progress_manager.update(
-                chain_idx=chain, is_last=False, draw=it, stats=stats, tuning=it < tune
+            is_last = it + 1 == draws and (
+                not progress_manager.combined_progress or chain == progress_manager.chains - 1
             )
-
-        if not progress_manager.combined_progress or chain == progress_manager.chains - 1:
             progress_manager.update(
-                chain_idx=chain, is_last=True, draw=it, stats=stats, tuning=False
+                chain_idx=chain, is_last=is_last, draw=it, stats=stats, tuning=it < tune
             )
 
     except KeyboardInterrupt:

--- a/pymc/smc/parallel.py
+++ b/pymc/smc/parallel.py
@@ -402,7 +402,9 @@ class ParallelSMCSampler:
                         sample_settings,
                     ) = result[2:]
 
-                    progress_manager.update(proc.chain, stage, beta, is_last=True)
+                    old_beta = chain_betas[proc.chain]
+                    chain_betas[proc.chain] = beta
+                    progress_manager.update(proc.chain, stage, beta, old_beta, is_last=True)
 
                     proc.join()
                     self._active.remove(proc)

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -473,19 +473,18 @@ def _sample_smc_sequentially(
                 old_beta = kernel.beta
                 kernel.update_beta_and_weights()
 
-                is_last = kernel.beta >= 1
                 progress_manager.update(
-                    chain_idx=i,
-                    stage=stage,
-                    beta=kernel.beta,
-                    old_beta=old_beta,
-                    is_last=is_last,
+                    chain_idx=i, stage=stage, beta=kernel.beta, old_beta=old_beta, is_last=False
                 )
 
                 for stat, value in kernel.step().items():
                     chain_sample_stats[stat].append(value)
 
                 stage += 1
+
+            progress_manager.update(
+                chain_idx=i, stage=stage, beta=kernel.beta, old_beta=kernel.beta, is_last=True
+            )
 
             trace = _build_trace_from_kernel_state(
                 tempered_posterior=kernel.tempered_posterior,

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -473,16 +473,19 @@ def _sample_smc_sequentially(
                 old_beta = kernel.beta
                 kernel.update_beta_and_weights()
 
+                is_last = kernel.beta >= 1
                 progress_manager.update(
-                    chain_idx=i, stage=stage, beta=kernel.beta, old_beta=old_beta, is_last=False
+                    chain_idx=i,
+                    stage=stage,
+                    beta=kernel.beta,
+                    old_beta=old_beta,
+                    is_last=is_last,
                 )
 
                 for stat, value in kernel.step().items():
                     chain_sample_stats[stat].append(value)
 
                 stage += 1
-
-            progress_manager.update(chain_idx=i, stage=stage, beta=kernel.beta, is_last=True)
 
             trace = _build_trace_from_kernel_state(
                 tempered_posterior=kernel.tempered_posterior,

--- a/tests/progress_bar/test_manager.py
+++ b/tests/progress_bar/test_manager.py
@@ -12,11 +12,143 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from unittest.mock import patch
+
 import pytest
 
 import pymc as pm
 
-from pymc.progress_bar import MCMCProgressBarManager
+from pymc.progress_bar import MCMCProgressBarManager, SMCProgressBarManager
+from pymc.smc.kernels import IMH
+
+NUTS_DUMMY_STATS = [{"divergences": 0, "step_size": 0.5, "tree_size": 7}]
+
+
+@pytest.fixture
+def imh_kernel():
+    with pm.Model():
+        pm.Normal("x", 0, 1)
+        kernel = IMH()
+    return kernel
+
+
+def _get_task(manager, idx=0):
+    return manager._backend._progress.tasks[idx]
+
+
+def test_mcmc_split_bar_starts_at_zero_ends_at_total():
+    draws, tune, chains = 10, 5, 2
+    captured = {}
+
+    orig_init = MCMCProgressBarManager.__init__
+
+    def capturing_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        captured["manager"] = self
+
+    with patch.object(MCMCProgressBarManager, "__init__", capturing_init):
+        with pm.Model():
+            pm.Normal("x")
+            pm.sample(
+                draws=draws,
+                tune=tune,
+                chains=chains,
+                cores=1,
+                progressbar=True,
+                compute_convergence_checks=False,
+            )
+
+    manager = captured["manager"]
+    total = draws + tune
+    for chain in range(chains):
+        task = _get_task(manager, chain)
+        assert task.completed == task.total == total
+        assert task.fields["draws"] == total
+
+
+def test_mcmc_combined_bar_ends_at_total():
+    draws, tune, chains = 10, 5, 2
+    captured = {}
+
+    orig_init = MCMCProgressBarManager.__init__
+
+    def capturing_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        captured["manager"] = self
+
+    with patch.object(MCMCProgressBarManager, "__init__", capturing_init):
+        with pm.Model():
+            pm.Normal("x")
+            pm.sample(
+                draws=draws,
+                tune=tune,
+                chains=chains,
+                cores=1,
+                progressbar="combined+stats",
+                compute_convergence_checks=False,
+            )
+
+    manager = captured["manager"]
+    total = (draws + tune) * chains
+    task = _get_task(manager, 0)
+    assert task.completed == task.total == total
+    assert task.fields["draws"] == total
+
+
+def test_mcmc_draws_stat_shows_completed_count():
+    with pm.Model():
+        pm.Normal("x")
+        step = pm.NUTS()
+
+    manager = MCMCProgressBarManager(step_method=step, chains=1, draws=10, tune=5, progressbar=True)
+
+    with manager:
+        manager.update(chain_idx=0, is_last=False, draw=0, tuning=True, stats=NUTS_DUMMY_STATS)
+        assert _get_task(manager).fields["draws"] == 1
+
+        for i in range(1, 15):
+            manager.update(
+                chain_idx=0, is_last=i == 14, draw=i, tuning=i < 5, stats=NUTS_DUMMY_STATS
+            )
+        assert _get_task(manager).fields["draws"] == 15
+
+
+def test_smc_bar_starts_at_zero_ends_at_one(imh_kernel):
+    manager = SMCProgressBarManager(kernel=imh_kernel, chains=1, progressbar=True)
+
+    with manager:
+        task = _get_task(manager)
+        assert task.total == 1.0
+        assert task.completed == 0
+        assert task.percentage == 0.0
+
+        betas = [0.2, 0.5, 0.8, 1.0]
+        old_beta = 0.0
+        for stage, beta in enumerate(betas):
+            manager.update(
+                chain_idx=0, stage=stage, beta=beta, old_beta=old_beta, is_last=beta >= 1.0
+            )
+            old_beta = beta
+
+        task = _get_task(manager)
+        assert task.completed == pytest.approx(task.total)
+        assert task.fields["beta"] == pytest.approx(1.0)
+
+
+def test_smc_multi_chain(imh_kernel):
+    chains = 3
+    manager = SMCProgressBarManager(kernel=imh_kernel, chains=chains, progressbar=True)
+
+    with manager:
+        for chain in range(chains):
+            assert _get_task(manager, chain).completed == 0
+
+        for chain in range(chains):
+            manager.update(chain_idx=chain, stage=0, beta=0.4, old_beta=0.0)
+            manager.update(chain_idx=chain, stage=1, beta=1.0, old_beta=0.4, is_last=True)
+
+        for chain in range(chains):
+            assert _get_task(manager, chain).completed == pytest.approx(1.0)
 
 
 def test_progressbar_nested_compound():
@@ -47,79 +179,3 @@ def test_progressbar_nested_compound():
             pm.sample(**kwargs, cores=cores, progressbar="combined")
             pm.sample(**kwargs, cores=cores, progressbar="split")
             pm.sample(**kwargs, cores=cores, progressbar=False)
-
-
-class TestProgressBarManagerConfiguration:
-    @pytest.fixture
-    def step_method(self):
-        with pm.Model():
-            x = pm.Normal("x")
-            step = pm.NUTS([x])
-        return step
-
-    def test_init_split_mode(self, step_method):
-        manager = MCMCProgressBarManager(
-            step_method=step_method,
-            chains=2,
-            draws=100,
-            tune=50,
-            progressbar=True,
-        )
-        assert manager.combined_progress is False
-        assert manager.full_stats is True
-        assert manager._show_progress is True
-        assert manager.chains == 2
-        assert manager.total_draws == 150
-
-    def test_init_combined_mode(self, step_method):
-        manager = MCMCProgressBarManager(
-            step_method=step_method,
-            chains=2,
-            draws=100,
-            tune=50,
-            progressbar="combined",
-        )
-        assert manager.combined_progress is True
-        assert manager.full_stats is False
-
-    def test_init_combined_stats_mode(self, step_method):
-        manager = MCMCProgressBarManager(
-            step_method=step_method,
-            chains=2,
-            draws=100,
-            tune=50,
-            progressbar="combined+stats",
-        )
-        assert manager.combined_progress is True
-        assert manager.full_stats is True
-
-    def test_init_split_stats_mode(self, step_method):
-        manager = MCMCProgressBarManager(
-            step_method=step_method,
-            chains=2,
-            draws=100,
-            tune=50,
-            progressbar="split+stats",
-        )
-        assert manager.combined_progress is False
-        assert manager.full_stats is True
-
-    def test_init_disabled(self, step_method):
-        manager = MCMCProgressBarManager(
-            step_method=step_method,
-            chains=2,
-            draws=100,
-            tune=50,
-            progressbar=False,
-        )
-        assert manager._show_progress is False
-
-    def test_invalid_progressbar_value(self, step_method):
-        with pytest.raises(ValueError, match="Invalid value for `progressbar`"):
-            MCMCProgressBarManager(
-                step_method=step_method,
-                chains=2,
-                draws=100,
-                tune=50,
-                progressbar="invalid",
-            )

--- a/tests/progress_bar/test_marimo.py
+++ b/tests/progress_bar/test_marimo.py
@@ -107,3 +107,35 @@ class TestMarimoProgressBackend:
             html = backend._render_html()
 
             assert "0.25" in html or "Step" in html
+
+    def test_is_last_sets_completed_to_total(self):
+        backend = MarimoProgressBackend(
+            step_name="Draws", n_bars=2, total=150, combined=False, full_stats=False
+        )
+        backend._initialize_tasks()
+
+        for _ in range(150):
+            backend.update(task_id=0, advance=1, failing=False, stats={}, is_last=False)
+        backend.update(task_id=0, advance=1, failing=False, stats={}, is_last=True)
+
+        assert backend._task_state[0]["completed"] == 150
+        assert backend._task_state[1]["completed"] == 0
+
+    def test_marimo_smc_progress(self):
+        backend = MarimoProgressBackend(
+            step_name="Stage", n_bars=1, total=1.0, combined=False, full_stats=False
+        )
+        backend._initialize_tasks()
+
+        assert backend._task_state[0]["total"] == 1.0
+        assert backend._task_state[0]["completed"] == 0
+
+        betas = [0.3, 0.7, 1.0]
+        old = 0.0
+        for beta in betas:
+            backend.update(
+                task_id=0, advance=beta - old, failing=False, stats={}, is_last=beta >= 1.0
+            )
+            old = beta
+
+        assert backend._task_state[0]["completed"] == 1.0


### PR DESCRIPTION
Progress bar is currently off by one when it completes, and @ricardoV94 is bullying me about it. The issue was we added a `-1` factor to the total at some point when we shouldn't have. This caused the samplers to stop at `n-1 / n` (for which I was bullied). In the case of SMC sampling, it caused the progressbar maximum to be 0, so progress immediately stopped and no timing info is given.

I also re-wrote the test_manager tests. They weren't testing anything, just type checks and deterministic code paths. I added some tests that would have caught these off-by-one bugs.

I also simplified the `is_last` logic. Previously it was trying to calculate the remaining steps then advancing by that much, then doing a cleanup step. Now we just directly set the total completed to the expected total. This should be 100% bulletproof against embarrassing off-by-one bugs.  