### PR TITLE
DOC: Clarify Wishart distribution usage in docstring

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,6 +139,7 @@ jobs:
 
           - |
             tests/dims/distributions/test_core.py
+            tests/dims/distributions/test_censored.py
             tests/dims/distributions/test_scalar.py
             tests/dims/distributions/test_vector.py
             tests/dims/test_model.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.11.13
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: [--fix, --show-fixes]
     - id: ruff-format
 - repo: local

--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -22,7 +22,7 @@ dependencies:
 - numpyro>=0.8.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.38.0,<2.39
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.38.0,<2.39
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -11,7 +11,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.38.0,<2.39
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - rich>=13.7.1
 - scipy>=1.4.1

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -14,7 +14,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=2.38.0,<2.39
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.38.0,<2.39
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -15,7 +15,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=2.38.0,<2.39
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/docs/source/api/dims/distributions.rst
+++ b/docs/source/api/dims/distributions.rst
@@ -39,3 +39,14 @@ Vector distributions
    Categorical
    MvNormal
    ZeroSumNormal
+
+
+Higher-Order distributions
+==========================
+
+.. currentmodule:: pymc.dims
+.. autosummary::
+   :toctree: generated/
+   :template: distribution.rst
+
+   Censored

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -333,7 +333,7 @@ class InferenceDataConverter:
         data_warmup = {}
         for stat in self.trace.stat_names:
             name = rename_key.get(stat, stat)
-            if name == "tune":
+            if name in {"tune", "in_warmup"}:
                 continue
             if self.warmup_trace:
                 data_warmup[name] = np.array(

--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -113,7 +113,13 @@ class IBaseTrace(ABC, Sized):
         """
         raise NotImplementedError()
 
-    def record(self, draw: Mapping[str, np.ndarray], stats: Sequence[Mapping[str, Any]]):
+    def record(
+        self,
+        draw: Mapping[str, np.ndarray],
+        stats: Sequence[Mapping[str, Any]],
+        *,
+        in_warmup: bool,
+    ):
         """Record results of a sampling iteration.
 
         Parameters
@@ -122,6 +128,9 @@ class IBaseTrace(ABC, Sized):
             Values mapped to variable names
         stats: list of dicts
             The diagnostic values for each sampler
+        in_warmup: bool
+            Whether this draw belongs to the warmup phase. This is a driver-owned
+            concept and is intended for storage/backends to persist warmup information.
         """
         raise NotImplementedError()
 

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -97,7 +97,7 @@ class NDArray(base.BaseTrace):
                     new = np.zeros(draws, dtype=dtype)
                     data[varname] = np.concatenate([old, new])
 
-    def record(self, point, sampler_stats=None) -> None:
+    def record(self, point, sampler_stats=None, *, in_warmup: bool) -> None:
         """Record results of a sampling iteration.
 
         Parameters
@@ -238,5 +238,5 @@ def point_list_to_multitrace(
 
         chain.fn = point_fun
         for point in point_list:
-            chain.record(point)
+            chain.record(point, in_warmup=False)
     return MultiTrace([chain])

--- a/pymc/backends/zarr.py
+++ b/pymc/backends/zarr.py
@@ -159,7 +159,11 @@ class ZarrChain(BaseTrace):
         buffer[var_name].append(value)
 
     def record(
-        self, draw: Mapping[str, np.ndarray], stats: Sequence[Mapping[str, Any]]
+        self,
+        draw: Mapping[str, np.ndarray],
+        stats: Sequence[Mapping[str, Any]],
+        *,
+        in_warmup: bool,
     ) -> bool | None:
         """Record the step method's returned draw and stats.
 
@@ -185,6 +189,7 @@ class ZarrChain(BaseTrace):
                 self.buffer(group="posterior", var_name=var_name, value=var_value)
         for var_name, var_value in self.stats_bijection.map(stats).items():
             self.buffer(group="sample_stats", var_name=var_name, value=var_value)
+        self.buffer(group="sample_stats", var_name="in_warmup", value=bool(in_warmup))
         self._buffered_draws += 1
         if self._buffered_draws == self.draws_until_flush:
             self.flush()
@@ -525,6 +530,7 @@ class ZarrTrace:
         stats_dtypes_shapes = get_stats_dtypes_shapes_from_steps(
             [step] if isinstance(step, BlockedStep) else step.methods
         )
+        stats_dtypes_shapes = {"in_warmup": (bool, [])} | stats_dtypes_shapes
         self.init_group_with_empty(
             group=self.root.create_group(name="sample_stats", overwrite=True),
             var_dtype_and_shape=stats_dtypes_shapes,
@@ -683,6 +689,7 @@ class ZarrTrace:
                 for i, shape_i in enumerate(shape):
                     dim = f"{name}_dim_{i}"
                     dims.append(dim)
+                    assert shape_i is not None, f"{dim} shape is None"
                     group_coords[dim] = np.arange(shape_i, dtype="int")
             dims = ("chain", "draw", *dims)
             attrs = extra_var_attrs[name] if extra_var_attrs is not None else {}

--- a/pymc/dims/distributions/__init__.py
+++ b/pymc/dims/distributions/__init__.py
@@ -11,5 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from pymc.dims.distributions.censored import Censored
 from pymc.dims.distributions.scalar import *
 from pymc.dims.distributions.vector import *

--- a/pymc/dims/distributions/censored.py
+++ b/pymc/dims/distributions/censored.py
@@ -1,0 +1,51 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import numpy as np
+
+from pymc.dims.distributions.core import DimDistribution, copy_docstring, expand_dist_dims
+from pymc.distributions.censored import Censored as RegularCensored
+
+
+@copy_docstring(RegularCensored)
+class Censored(DimDistribution):
+    @classmethod
+    def dist(cls, dist, *, lower=None, upper=None, dim_lengths, **kwargs):
+        if lower is None:
+            lower = -np.inf
+        if upper is None:
+            upper = np.inf
+        return super().dist([dist, lower, upper], dim_lengths=dim_lengths, **kwargs)
+
+    @classmethod
+    def xrv_op(cls, dist, lower, upper, core_dims=None, extra_dims=None, rng=None):
+        if extra_dims is None:
+            extra_dims = {}
+
+        dist = cls._as_xtensor(dist)
+        lower = cls._as_xtensor(lower)
+        upper = cls._as_xtensor(upper)
+
+        # Any dimensions in extra_dims, or only present in lower, upper,
+        # must propagate back to the dist as `extra_dims`
+        bounds_sizes = lower.sizes | upper.sizes
+        dist_dims_set = set(dist.dims)
+        extra_dist_dims = extra_dims | {
+            dim: size for dim, size in bounds_sizes.items() if dim not in dist_dims_set
+        }
+        if extra_dist_dims:
+            dist = expand_dist_dims(dist, extra_dist_dims)
+
+        # Probability is inferred from the clip operation
+        # TODO: Make this a SymbolicRandomVariable that can itself be resized
+        return dist.clip(lower, upper)

--- a/pymc/dims/distributions/core.py
+++ b/pymc/dims/distributions/core.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 from collections.abc import Callable, Sequence
 from itertools import chain
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 
@@ -25,7 +25,9 @@ from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.xtensor import as_xtensor
 from pytensor.xtensor.basic import XTensorFromTensor, xtensor_from_tensor
+from pytensor.xtensor.shape import Transpose
 from pytensor.xtensor.type import XTensorVariable
+from pytensor.xtensor.vectorization import XRV
 
 from pymc import SymbolicRandomVariable, modelcontext
 from pymc.dims.distributions.transforms import DimTransform, log_odds_transform, log_transform
@@ -345,3 +347,25 @@ class UnitDimDistribution(DimDistribution):
     """Base class for unit-valued distributions."""
 
     default_transform = log_odds_transform
+
+
+def expand_dist_dims(dist: XTensorVariable, extra_dims: dict[str, Any]) -> XTensorVariable:
+    if overlap := (set(extra_dims) & set(dist.dims)):
+        raise ValueError(f"extra_dims already present in distribution: {sorted(overlap)}")
+
+    op = None if dist.owner is None else dist.owner.op
+    match op:
+        case XRV():
+            # Recreate dist with new extra dims
+            dist_props = dist.owner.op._props_dict()
+            dist_props["extra_dims"] = (*(extra_dims.keys()), *dist_props["extra_dims"])
+            new_dist_op = type(dist.owner.op)(**dist_props)
+            _old_rng, *params_and_dim_lengths = dist.owner.inputs
+            new_rng = None  # We don't propagate the old RNG, because we don't want the new and old dists to be correlated
+            return new_dist_op(new_rng, *extra_dims.values(), *params_and_dim_lengths)
+        case Transpose():
+            return expand_dist_dims(dist.owner.inputs[0], extra_dims=extra_dims).transpose(
+                ..., *dist.dims
+            )
+        case _:
+            raise NotImplementedError(f"expand_dist_dims not implemented for {dist} with op {op}")

--- a/pymc/dims/distributions/transforms.py
+++ b/pymc/dims/distributions/transforms.py
@@ -203,6 +203,4 @@ class ZeroSumTransform(DimTransform):
         return value
 
     def log_jac_det(self, value, *rv_inputs):
-        # Use following once broadcast_like is implemented
-        # as_xtensor(0).broadcast_like(value, exclude=self.dims)`
-        return value.sum(self.dims) * 0
+        return as_xtensor(0.0).broadcast_like(value, exclude=self.dims)

--- a/pymc/dims/distributions/vector.py
+++ b/pymc/dims/distributions/vector.py
@@ -238,8 +238,8 @@ class ZeroSumNormal(VectorDimDistribution):
         )
 
     @classmethod
-    def xrv_op(self, sigma, support_dims, core_dims, extra_dims=None, rng=None):
-        sigma = as_xtensor(sigma)
+    def xrv_op(cls, sigma, support_dims, core_dims, extra_dims=None, rng=None):
+        sigma = cls._as_xtensor(sigma)
         support_dims = as_xtensor(support_dims, dims=("_",))
         support_shape = support_dims.values
         core_rv = ZeroSumNormalRV.rv_op(sigma=sigma.values, support_shape=support_shape).owner.op

--- a/pymc/dims/distributions/vector.py
+++ b/pymc/dims/distributions/vector.py
@@ -229,7 +229,8 @@ class ZeroSumNormal(VectorDimDistribution):
             raise ValueError("ZeroSumNormal requires atleast 1 core_dims")
 
         support_dims = as_xtensor(
-            as_tensor([dim_lengths[core_dim] for core_dim in core_dims]), dims=("_",)
+            as_tensor([dim_lengths[core_dim] for core_dim in core_dims]),
+            dims=("__support_shape__",),
         )
         sigma = cls._as_xtensor(sigma)
 
@@ -238,16 +239,25 @@ class ZeroSumNormal(VectorDimDistribution):
         )
 
     @classmethod
-    def xrv_op(cls, sigma, support_dims, core_dims, extra_dims=None, rng=None):
-        sigma = cls._as_xtensor(sigma)
-        support_dims = as_xtensor(support_dims, dims=("_",))
-        support_shape = support_dims.values
-        core_rv = ZeroSumNormalRV.rv_op(sigma=sigma.values, support_shape=support_shape).owner.op
+    def xrv_op(cls, sigma, support_shape, core_dims, extra_dims=None, rng=None):
+        # ZeroSumNormal expects dummy dimensions on sigma for the support_shape
+        sigma = cls._as_xtensor(sigma).expand_dims(core_dims)
+        support_shape = as_xtensor(support_shape, dims=("__support_shape__",))
+        core_rv = ZeroSumNormalRV.rv_op(
+            sigma=sigma.values, support_shape=support_shape.values
+        ).owner.op
+        core_dims_map = tuple(range(1, len(core_dims) + 1))
         xop = pxr.as_xrv(
             core_rv,
-            core_inps_dims_map=[(), (0,)],
-            core_out_dims_map=tuple(range(1, len(core_dims) + 1)),
+            core_inps_dims_map=[core_dims_map, (0,)],
+            core_out_dims_map=core_dims_map,
         )
         # Dummy "_" core dim to absorb the support_shape vector
         # If ZeroSumNormal expected a scalar per support dim, this wouldn't be needed
-        return xop(sigma, support_dims, core_dims=("_", *core_dims), extra_dims=extra_dims, rng=rng)
+        return xop(
+            sigma,
+            support_shape,
+            core_dims=("__support_shape__", *core_dims),
+            extra_dims=extra_dims,
+            rng=rng,
+        )

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -392,7 +392,7 @@ class SymbolicRandomVariable(MeasurableOp, RNGConsumerOp, OpFromGraph):
             )
             if size_arg_idx is not None and len(rng_arg_idxs) == 1:
                 new_size_type = normalize_size_param(inputs[size_arg_idx]).type
-                if not self.input_types[size_arg_idx].in_same_class(new_size_type):
+                if not self.input_types[size_arg_idx].is_super(new_size_type):
                     params = [inputs[idx] for idx in param_idxs]
                     size = inputs[size_arg_idx]
                     rng = inputs[rng_arg_idxs[0]]

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -405,7 +405,7 @@ class SymbolicRandomVariable(MeasurableOp, RNGConsumerOp, OpFromGraph):
 
         Returns a dictionary with the symbolic expressions required for correct updating
         of random state input variables repeated function evaluations. This is used by
-        `pytensorf.compile_pymc`.
+        `pytensorf.compile`.
         """
         return collect_default_updates_inner_fgraph(node)
 

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -952,6 +952,8 @@ class WishartRV(RandomVariable):
     @classmethod
     def rng_fn(cls, rng, nu, V, size):
         scipy_size = size if size else 1  # Default size for Scipy's wishart.rvs is 1
+        # Scipy doesn't accept batch nu or V
+        nu = _squeeze_to_ndim(nu, 0)
         V = _squeeze_to_ndim(V, 2)
         result = stats.wishart.rvs(int(nu), V, size=scipy_size, random_state=rng)
         if size == (1,):

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -998,8 +998,17 @@ class Wishart(Continuous):
 
     Notes
     -----
-    This distribution is unusable in a PyMC model. You should instead
-    use LKJCholeskyCov or LKJCorr.
+    The Wishart distribution is generally unusable as a prior distribution for
+    MCMC sampling. The probability of sampling a symmetric positive definite
+    matrix is effectively zero, since MCMC proposals in unconstrained space
+    almost never land exactly on the SPD manifold.
+
+    For modeling covariance matrices, you should instead use
+    :class:`LKJCholeskyCov` or :class:`LKJCorr`.
+
+    However, the Wishart distribution may be used as a likelihood with
+    ``observed`` in some cases, where the distribution is evaluated at
+    fixed observed values rather than sampled during MCMC.
     """
 
     rv_op = wishart

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2659,9 +2659,9 @@ class ZeroSumNormalRV(SymbolicRandomVariable):
 
     @classmethod
     def rv_op(cls, sigma, support_shape, *, size=None, rng=None):
+        support_shape = _squeeze_to_ndim(pt.as_tensor(support_shape), ndim=1)
         n_zerosum_axes = pt.get_vector_length(support_shape)
         sigma = pt.as_tensor(sigma)
-        support_shape = pt.as_tensor(support_shape, ndim=1)
         rng = normalize_rng_param(rng)
         size = normalize_size_param(size)
 

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2677,8 +2677,10 @@ class ZeroSumNormalRV(SymbolicRandomVariable):
         for axis in range(n_zerosum_axes):
             zerosum_rv -= zerosum_rv.mean(axis=-axis - 1, keepdims=True)
 
+        # sigma has core_shape = (1, 1, ...) (as many as there are zerosum axes)
+        ones = ",".join("1" for _ in range(n_zerosum_axes))
         support_str = ",".join([f"d{i}" for i in range(n_zerosum_axes)])
-        extended_signature = f"[rng],[size],(),(s)->[rng],({support_str})"
+        extended_signature = f"[rng],[size],({ones}),(s)->[rng],({support_str})"
         return cls(
             inputs=[rng, size, sigma, support_shape],
             outputs=[next_rng, zerosum_rv],
@@ -2774,7 +2776,7 @@ class ZeroSumNormal(Distribution):
     def dist(cls, sigma=1.0, n_zerosum_axes=None, support_shape=None, **kwargs):
         n_zerosum_axes = cls.check_zerosum_axes(n_zerosum_axes)
 
-        sigma = pt.as_tensor(sigma)
+        sigma = pt.atleast_Nd(pt.as_tensor(sigma), n=n_zerosum_axes)
         if not all(sigma.type.broadcastable[-n_zerosum_axes:]):
             raise ValueError("sigma must have length one across the zero-sum axes")
 

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -309,7 +309,7 @@ class ZeroSumTransform(Transform):
         return value
 
     def log_jac_det(self, value, *rv_inputs):
-        return pt.constant(0.0)
+        return value.sum(self.zerosum_axes).zeros_like()
 
 
 log_exp_m1 = LogExpM1()

--- a/pymc/logprob/basic.py
+++ b/pymc/logprob/basic.py
@@ -144,7 +144,7 @@ def logp(rv: Variable, value: Variable | TensorLike, warn_rvs=True, **kwargs) ->
         print(rv_logp.eval({value: 0.9, mu: 0.0}))  # -1.32393853
 
         # Compile a function for repeated evaluations
-        rv_logp_fn = pm.compile_pymc([value, mu], rv_logp)
+        rv_logp_fn = pm.compile([value, mu], rv_logp)
         print(rv_logp_fn(value=0.9, mu=0.0))  # -1.32393853
 
 
@@ -166,7 +166,7 @@ def logp(rv: Variable, value: Variable | TensorLike, warn_rvs=True, **kwargs) ->
         print(exp_rv_logp.eval({value: 0.9, mu: 0.0}))  # -0.81912844
 
         # Compile a function for repeated evaluations
-        exp_rv_logp_fn = pm.compile_pymc([value, mu], exp_rv_logp)
+        exp_rv_logp_fn = pm.compile([value, mu], exp_rv_logp)
         print(exp_rv_logp_fn(value=0.9, mu=0.0))  # -0.81912844
 
 
@@ -244,7 +244,7 @@ def logcdf(rv: Variable, value: Variable | TensorLike, warn_rvs=True, **kwargs) 
         print(rv_logcdf.eval({value: 0.9, mu: 0.0}))  # -0.2034146
 
         # Compile a function for repeated evaluations
-        rv_logcdf_fn = pm.compile_pymc([value, mu], rv_logcdf)
+        rv_logcdf_fn = pm.compile([value, mu], rv_logcdf)
         print(rv_logcdf_fn(value=0.9, mu=0.0))  # -0.2034146
 
 
@@ -266,7 +266,7 @@ def logcdf(rv: Variable, value: Variable | TensorLike, warn_rvs=True, **kwargs) 
         print(exp_rv_logcdf.eval({value: 0.9, mu: 0.0}))  # -0.78078813
 
         # Compile a function for repeated evaluations
-        exp_rv_logcdf_fn = pm.compile_pymc([value, mu], exp_rv_logcdf)
+        exp_rv_logcdf_fn = pm.compile([value, mu], exp_rv_logcdf)
         print(exp_rv_logcdf_fn(value=0.9, mu=0.0))  # -0.78078813
 
 
@@ -349,7 +349,7 @@ def logccdf(rv: Variable, value: Variable | TensorLike, warn_rvs=True, **kwargs)
         print(rv_logccdf.eval({value: 0.9, mu: 0.0}))  # -1.5272506
 
         # Compile a function for repeated evaluations
-        rv_logccdf_fn = pm.compile_pymc([value, mu], rv_logccdf)
+        rv_logccdf_fn = pm.compile([value, mu], rv_logccdf)
         print(rv_logccdf_fn(value=0.9, mu=0.0))  # -1.5272506
 
     """
@@ -410,7 +410,7 @@ def icdf(rv: Variable, value: Variable | TensorLike, warn_rvs=True, **kwargs) ->
         print(rv_icdf.eval({value: 0.9, mu: 0.0}))  # 1.28155157
 
         # Compile a function for repeated evaluations
-        rv_icdf_fn = pm.compile_pymc([value, mu], rv_icdf)
+        rv_icdf_fn = pm.compile([value, mu], rv_icdf)
         print(rv_icdf_fn(value=0.9, mu=0.0))  # 1.28155157
 
 
@@ -432,7 +432,7 @@ def icdf(rv: Variable, value: Variable | TensorLike, warn_rvs=True, **kwargs) ->
         print(exp_rv_icdf.eval({value: 0.9, mu: 0.0}))  # 3.60222448
 
         # Compile a function for repeated evaluations
-        exp_rv_icdf_fn = pm.compile_pymc([value, mu], exp_rv_icdf)
+        exp_rv_icdf_fn = pm.compile([value, mu], exp_rv_icdf)
         print(exp_rv_icdf_fn(value=0.9, mu=0.0))  # 3.60222448
 
     """

--- a/pymc/logprob/transform_value.py
+++ b/pymc/logprob/transform_value.py
@@ -16,6 +16,7 @@ import warnings
 from collections.abc import Sequence
 
 import numpy as np
+import pytensor.tensor as pt
 
 from pytensor.graph import Apply, Op
 from pytensor.graph.features import AlreadyThere, Feature
@@ -113,10 +114,18 @@ def transformed_value_logprob(op, values, *rv_outs, use_jacobian=True, **kwargs)
             )
         # Check there is no broadcasting between logp and jacobian
         if logp.type.broadcastable != log_jac_det.type.broadcastable:
-            raise ValueError(
-                f"The logp of {rv_op} and log_jac_det of {transform} are not allowed to broadcast together. "
-                "There is a bug in the implementation of either one."
-            )
+            lb, jb = logp.type.broadcastable, log_jac_det.type.broadcastable
+            broadcastable_axes = [
+                i for i, (ai, bi) in enumerate(zip(lb, jb, strict=True)) if ai or bi
+            ]
+            try:
+                logp = pt.specify_broadcastable(logp, *broadcastable_axes)
+                log_jac_det = pt.specify_broadcastable(log_jac_det, *broadcastable_axes)
+            except ValueError as err:
+                raise ValueError(
+                    f"The logp of {rv_op} and log_jac_det of {transform} are not allowed to broadcast together. "
+                    "There is a bug in the implementation of either one."
+                ) from err
 
         if use_jacobian:
             if value.name:

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1638,7 +1638,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             Whether to wrap the compiled function in a PointFunc, which takes a Point
             dictionary with model variable names and values as input.
         Other keyword arguments :
-            Any other keyword argument is sent to :py:func:`pymc.pytensorf.compile_pymc`.
+            Any other keyword argument is sent to :py:func:`pymc.pytensorf.compile`.
 
         Returns
         -------

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -21,11 +21,11 @@ from pytensor.compile import SharedVariable
 from pytensor.graph.basic import Constant, Variable
 from pytensor.graph.traversal import walk
 from pytensor.tensor.elemwise import DimShuffle
-from pytensor.tensor.random.basic import RandomVariable
 from pytensor.tensor.random.type import RandomType
 from pytensor.tensor.type_other import NoneTypeT
 from pytensor.tensor.variable import TensorVariable
 
+from pymc.logprob.abstract import MeasurableOp
 from pymc.model import Model
 
 __all__ = [
@@ -41,20 +41,23 @@ def str_for_dist(dist: Variable, formatting: str = "plain", include_params: bool
     This can be either LaTeX or plain, optionally with distribution parameter
     values included.
     """
+    dist_op = dist.owner.op
+
     if include_params:
-        if isinstance(dist.owner.op, RandomVariable) or getattr(
-            dist.owner.op, "extended_signature", None
-        ):
+        try:
+            dist_args = dist.owner.op.dist_params(dist.owner)
+        except Exception:
+            # Can happen with SymbolicRandomVariable without extended_signature
             dist_args = [
-                _str_for_input_var(x, formatting=formatting)
-                for x in dist.owner.op.dist_params(dist.owner)
+                x for x in dist.owner.inputs if not isinstance(x.type, RandomType | NoneTypeT)
             ]
-        else:
-            dist_args = [
-                _str_for_input_var(x, formatting=formatting)
-                for x in dist.owner.inputs
-                if not isinstance(x.type, RandomType | NoneTypeT)
-            ]
+
+        dist_args_str = [_str_for_input_var(a, formatting=formatting) for a in dist_args]
+
+    if (print_name := getattr(dist_op, "_print_name", None)) is not None:
+        dist_name = print_name[formatting == "latex"]
+    else:
+        dist_name = "Unknown"
 
     print_name = dist.name
 
@@ -63,30 +66,22 @@ def str_for_dist(dist: Variable, formatting: str = "plain", include_params: bool
             print_name = r"\text{" + _latex_escape(print_name.strip("$")) + "}"
             print_name = _format_underscore(print_name)
 
-        op_name = (
-            dist.owner.op._print_name[1]
-            if hasattr(dist.owner.op, "_print_name")
-            else r"\\operatorname{Unknown}"
-        )
         if include_params:
-            params = ",~".join([d.strip("$") for d in dist_args])
+            params = ",~".join([d.strip("$") for d in dist_args_str])
             if print_name:
-                return rf"${print_name} \sim {op_name}({params})$"
+                return rf"${print_name} \sim {dist_name}({params})$"
             else:
-                return rf"${op_name}({params})$"
+                return rf"${dist_name}({params})$"
 
         else:
             if print_name:
-                return rf"${print_name} \sim {op_name}$"
+                return rf"${print_name} \sim {dist_name}$"
             else:
-                return rf"${op_name}$"
+                return rf"${dist_name}$"
 
     else:  # plain
-        dist_name = (
-            dist.owner.op._print_name[0] if hasattr(dist.owner.op, "_print_name") else "Unknown"
-        )
         if include_params:
-            params = ", ".join(dist_args)
+            params = ", ".join(dist_args_str)
             if print_name:
                 return rf"{print_name} ~ {dist_name}({params})"
             else:
@@ -169,10 +164,9 @@ def str_for_potential_or_deterministic(
 
 
 def _str_for_input_var(var: Variable, formatting: str) -> str:
-    # Avoid circular import
-    from pymc.distributions.distribution import SymbolicRandomVariable
-
     def _is_potential_or_deterministic(var: Variable) -> bool:
+        # FIXME: This is an (insufficient) hack. For model_repr we know which nodes are named variables
+        # and we should propagate that information instead of guessing based on whether something was monkey-patched
         if not hasattr(var, "str_repr"):
             return False
         try:
@@ -183,9 +177,7 @@ def _str_for_input_var(var: Variable, formatting: str) -> str:
 
     if isinstance(var, Constant | SharedVariable):
         return _str_for_constant(var, formatting)
-    elif isinstance(
-        var.owner.op, RandomVariable | SymbolicRandomVariable
-    ) or _is_potential_or_deterministic(var):
+    elif isinstance(var.owner.op, MeasurableOp) or _is_potential_or_deterministic(var):
         # show the names for RandomVariables, Deterministics, and Potentials, rather
         # than the full expression
         return _str_for_input_rv(var, formatting)
@@ -227,25 +219,23 @@ def _str_for_constant(var: Constant | SharedVariable, formatting: str) -> str:
 
 def _str_for_expression(var: Variable, formatting: str) -> str:
     # Avoid circular import
-    from pymc.distributions.distribution import SymbolicRandomVariable
 
     # construct a string like f(a1, ..., aN) listing all random variables a as arguments
     def _expand(x):
-        if x.owner and (not isinstance(x.owner.op, RandomVariable | SymbolicRandomVariable)):
+        if x.owner and not isinstance(x.owner.op, MeasurableOp):
             return reversed(x.owner.inputs)
 
     parents = []
     names = []
     for x in walk(nodes=var.owner.inputs, expand=_expand):
         assert isinstance(x, Variable)
-        if x.owner and isinstance(x.owner.op, RandomVariable | SymbolicRandomVariable):
+        if x.owner and isinstance(x.owner.op, MeasurableOp):
             parents.append(x)
             xname = x.name
             if xname is None:
                 # If the variable is unnamed, we show the op's name as we do
                 # with constants
-                opname = x.owner.op.name
-                if opname is not None:
+                if (opname := getattr(x.owner.op, "name", None)) is not None:
                     xname = rf"<{opname}>"
             assert xname is not None
             names.append(xname)

--- a/pymc/progress_bar/rich_progress.py
+++ b/pymc/progress_bar/rich_progress.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 from collections.abc import Iterable
+from sys import stderr
 from typing import Any, Self
 
 from rich.box import SIMPLE_HEAD
@@ -212,7 +213,7 @@ class RichProgressBackend:
                 finished_style=Style.parse("rgb(31,119,180)"),
             ),
             *columns,
-            console=Console(theme=theme),
+            console=Console(file=stderr, theme=theme),
             include_headers=True,
         )
 
@@ -323,5 +324,5 @@ def RichSimpleProgress(theme: Theme | None):
         TimeRemainingColumn(),
         TextColumn("/"),
         TimeElapsedColumn(),
-        console=Console(theme=default_progress_theme if theme is None else theme),
+        console=Console(file=stderr, theme=default_progress_theme if theme is None else theme),
     )

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -294,7 +294,7 @@ def draw(
     random_seed : int, RandomState or numpy_Generator, optional
         Seed for the random number generator.
     **kwargs : dict, optional
-        Keyword arguments for :func:`pymc.pytensorf.compile_pymc`.
+        Keyword arguments for :func:`pymc.pytensorf.compile`.
 
     Returns
     -------
@@ -410,7 +410,7 @@ def sample_prior_predictive(
     idata_kwargs : dict, optional
         Keyword arguments for :func:`pymc.to_inference_data`
     compile_kwargs: dict, optional
-        Keyword arguments for :func:`pymc.pytensorf.compile_pymc`.
+        Keyword arguments for :func:`pymc.pytensorf.compile`.
     samples : int
         Number of samples from the prior predictive to generate. Deprecated in favor of `draws`.
 
@@ -580,7 +580,7 @@ def sample_posterior_predictive(
         Keyword arguments for :func:`pymc.to_inference_data` if ``predictions=False`` or to
         :func:`pymc.predictions_to_inference_data` otherwise.
     compile_kwargs: dict, optional
-        Keyword arguments for :func:`pymc.pytensorf.compile_pymc`.
+        Keyword arguments for :func:`pymc.pytensorf.compile`.
 
     Returns
     -------

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1124,18 +1124,10 @@ def _sample_return(
     else:
         traces, length = _choose_chains(traces, 0)
     mtrace = MultiTrace(traces)[:length]
-    # count the number of tune/draw iterations that happened
-    # ideally via the "tune" statistic, but not all samplers record it!
-    if "tune" in mtrace.stat_names:
-        # Get the tune stat directly from chain 0, sampler 0
-        stat = mtrace._straces[0].get_sampler_stats("tune", sampler_idx=0)
-        stat = tuple(stat)
-        n_tune = stat.count(True)
-        n_draws = stat.count(False)
-    else:
-        # these may be wrong when KeyboardInterrupt happened, but they're better than nothing
-        n_tune = min(tune, len(mtrace))
-        n_draws = max(0, len(mtrace) - n_tune)
+    # Count the number of tune/draw iterations that happened.
+    # The warmup/draw boundary is owned by the sampling driver.
+    n_tune = min(tune, len(mtrace))
+    n_draws = max(0, len(mtrace) - n_tune)
 
     if discard_tuned_samples:
         mtrace = mtrace[n_tune:]
@@ -1304,7 +1296,7 @@ def _sample(
     try:
         for it, stats in enumerate(sampling_gen):
             progress_manager.update(
-                chain_idx=chain, is_last=False, draw=it, stats=stats, tuning=it > tune
+                chain_idx=chain, is_last=False, draw=it, stats=stats, tuning=it < tune
             )
 
         if not progress_manager.combined_progress or chain == progress_manager.chains - 1:
@@ -1375,7 +1367,7 @@ def _iter_sample(
                 step.stop_tuning()
 
             point, stats = step.step(point)
-            trace.record(point, stats)
+            trace.record(point, stats, in_warmup=i < tune)
             log_warning_stats(stats)
 
             if callback is not None:
@@ -1488,7 +1480,7 @@ def _mp_sample(
                     strace = traces[draw.chain]
                     if not zarr_recording:
                         # Zarr recording happens in each process
-                        strace.record(draw.point, draw.stats)
+                        strace.record(draw.point, draw.stats, in_warmup=draw.tuning)
                     log_warning_stats(draw.stats)
 
                     if callback is not None:

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -249,7 +249,7 @@ class _Process:
                 raise KeyboardInterrupt()
             elif msg[0] == "write_next":
                 if zarr_recording:
-                    self._zarr_chain.record(point, stats)
+                    self._zarr_chain.record(point, stats, in_warmup=tuning)
                 self._write_point(point)
                 is_last = draw + 1 == self._draws + self._tune
                 self._msg_pipe.send(("writing_done", is_last, draw, tuning, stats))

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -458,7 +458,7 @@ def _iter_population(
                 # apply the update to the points and record to the traces
                 for c, strace in enumerate(traces):
                     points[c], stats = updates[c]
-                    flushed = strace.record(points[c], stats)
+                    flushed = strace.record(points[c], stats, in_warmup=i < tune)
                     log_warning_stats(stats)
                     if flushed and isinstance(strace, ZarrChain):
                         sampling_state = popstep.request_sampling_state(c)

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -414,7 +414,7 @@ def _build_trace_from_kernel_state(
                 var_samples = np.round(var_samples).astype(var.dtype)
             value.append(var_samples.reshape(shape))
             size += new_size
-        strace.record(point=dict(zip(varnames, value)))
+        strace.record(point=dict(zip(varnames, value)), in_warmup=False)
 
     return strace
 

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -273,7 +273,6 @@ class BaseHMC(GradientSharedStep):
         self.iter_count += 1
 
         stats: dict[str, Any] = {
-            "tune": self.tune,
             "diverging": diverging,
             "divergences": self.divergences,
             "perf_counter_diff": perf_end - perf_start,

--- a/pymc/step_methods/hmc/hmc.py
+++ b/pymc/step_methods/hmc/hmc.py
@@ -53,7 +53,6 @@ class HamiltonianMC(BaseHMC):
     stats_dtypes_shapes = {
         "step_size": (np.float64, []),
         "n_steps": (np.int64, []),
-        "tune": (bool, []),
         "step_size_bar": (np.float64, []),
         "accept": (np.float64, []),
         "diverging": (bool, []),

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -110,7 +110,6 @@ class NUTS(BaseHMC):
     stats_dtypes_shapes = {
         "depth": (np.int64, []),
         "step_size": (np.float64, []),
-        "tune": (bool, []),
         "mean_tree_accept": (np.float64, []),
         "step_size_bar": (np.float64, []),
         "tree_size": (np.float64, []),

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -993,7 +993,7 @@ class DEMetropolis(PopulationArrayStepShared):
         self.steps_until_tune -= 1
 
         stats = {
-            "scaling": self.scaling,
+            "scaling": np.mean(self.scaling),
             "lambda": self.lamb,
             "accept": np.exp(accept),
             "accepted": accepted,

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -72,7 +72,6 @@ class Slice(ArrayStepShared):
     name = "slice"
     default_blocked = False
     stats_dtypes_shapes = {
-        "tune": (bool, []),
         "nstep_out": (int, []),
         "nstep_in": (int, []),
     }
@@ -184,7 +183,6 @@ class Slice(ArrayStepShared):
             self.n_tunes += 1
 
         stats = {
-            "tune": self.tune,
             "nstep_out": nstep_out,
             "nstep_in": nstep_in,
         }
@@ -202,18 +200,17 @@ class Slice(ArrayStepShared):
     @staticmethod
     def _progressbar_config(n_chains=1):
         columns = [
-            TextColumn("{task.fields[tune]}", table_column=Column("Tuning", ratio=1)),
             TextColumn("{task.fields[nstep_out]}", table_column=Column("Steps out", ratio=1)),
             TextColumn("{task.fields[nstep_in]}", table_column=Column("Steps in", ratio=1)),
         ]
 
-        stats = {"tune": [True] * n_chains, "nstep_out": [0] * n_chains, "nstep_in": [0] * n_chains}
+        stats = {"nstep_out": [0] * n_chains, "nstep_in": [0] * n_chains}
 
         return columns, stats
 
     @staticmethod
     def _make_progressbar_update_functions():
         def update_stats(step_stats):
-            return {key: step_stats[key] for key in {"tune", "nstep_out", "nstep_in"}}
+            return {key: step_stats[key] for key in {"nstep_out", "nstep_in"}}
 
         return (update_stats,)

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1598,7 +1598,7 @@ class Approximation(WithMemoization):
         try:
             trace.setup(draws=draws, chain=0)
             for point in points:
-                trace.record(point)
+                trace.record(point, in_warmup=False)
         finally:
             trace.close()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
 pymc-sphinx-theme>=0.16.0
-pytensor>=2.38.0,<2.39
+pytensor>=2.38.2,<2.39
 pytest-cov>=2.5
 pytest>=3.0
 rich>=13.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cachetools>=4.2.1,<7
 cloudpickle
 numpy>=1.25.0
 pandas>=0.24.0
-pytensor>=2.38.0,<2.39
+pytensor>=2.38.2,<2.39
 rich>=13.7.1
 scipy>=1.4.1
 threadpoolctl>=3.1.0,<4.0.0

--- a/tests/backends/fixtures.py
+++ b/tests/backends/fixtures.py
@@ -195,11 +195,11 @@ class ModelBackendSampledTestCase:
                 stats2 = [
                     {key: val[idx] for key, val in stats.items()} for stats in cls.expected_stats[1]
                 ]
-                strace0.record(point=point0, sampler_stats=stats1)
-                strace1.record(point=point1, sampler_stats=stats2)
+                strace0.record(point=point0, sampler_stats=stats1, in_warmup=False)
+                strace1.record(point=point1, sampler_stats=stats2, in_warmup=False)
             else:
-                strace0.record(point=point0)
-                strace1.record(point=point1)
+                strace0.record(point=point0, in_warmup=False)
+                strace1.record(point=point1, in_warmup=False)
         strace0.close()
         strace1.close()
         cls.mtrace = base.MultiTrace([strace0, strace1])
@@ -244,9 +244,9 @@ class SamplingTestCase(ModelBackendSetupTestCase):
         }
         if self.sampler_vars is not None:
             stats = [{key: dtype(val) for key, dtype in vars.items()} for vars in self.sampler_vars]
-            self.strace.record(point=point, sampler_stats=stats)
+            self.strace.record(point=point, sampler_stats=stats, in_warmup=False)
         else:
-            self.strace.record(point=point)
+            self.strace.record(point=point, in_warmup=False)
 
     def test_standard_close(self):
         for idx in range(self.draws):
@@ -270,7 +270,7 @@ class SamplingTestCase(ModelBackendSetupTestCase):
     def test_missing_stats(self):
         if self.sampler_vars is not None:
             with pytest.raises(ValueError):
-                self.strace.record(point=self.test_point)
+                self.strace.record(point=self.test_point, in_warmup=False)
 
     def test_clean_interrupt(self):
         self.record_point(0)

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -749,9 +749,9 @@ class TestPyMCWarmupHandling:
         post_prefix = "" if draws > 0 else "~"
         test_dict = {
             f"{post_prefix}posterior": ["u1", "n1"],
-            f"{post_prefix}sample_stats": ["~tune", "accept"],
+            f"{post_prefix}sample_stats": ["~in_warmup", "accept"],
             f"{warmup_prefix}warmup_posterior": ["u1", "n1"],
-            f"{warmup_prefix}warmup_sample_stats": ["~tune"],
+            f"{warmup_prefix}warmup_sample_stats": ["~in_warmup"],
             "~warmup_log_likelihood": [],
             "~log_likelihood": [],
         }
@@ -786,9 +786,9 @@ class TestPyMCWarmupHandling:
             idata = to_inference_data(trace, save_warmup=True)
             test_dict = {
                 "posterior": ["u1", "n1"],
-                "sample_stats": ["~tune", "accept"],
+                "sample_stats": ["~in_warmup", "accept"],
                 "warmup_posterior": ["u1", "n1"],
-                "warmup_sample_stats": ["~tune", "accept"],
+                "warmup_sample_stats": ["~in_warmup", "accept"],
             }
             fails = check_multiple_attrs(test_dict, idata)
             assert not fails
@@ -800,7 +800,7 @@ class TestPyMCWarmupHandling:
                 idata = to_inference_data(trace[-30:], save_warmup=True)
             test_dict = {
                 "posterior": ["u1", "n1"],
-                "sample_stats": ["~tune", "accept"],
+                "sample_stats": ["~in_warmup", "accept"],
                 "~warmup_posterior": [],
                 "~warmup_sample_stats": [],
             }

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -43,7 +43,7 @@ class TestInitTrace:
             B = pm.Uniform("B")
             strace = pm.backends.ndarray.NDArray(vars=[A, B])
             strace.setup(10, 0)
-            strace.record({"A": 2, "B_interval__": 0.1})
+            strace.record({"A": 2, "B_interval__": 0.1}, in_warmup=False)
             assert len(strace) == 1
             with pytest.raises(ValueError, match="Continuation of traces"):
                 _init_trace(

--- a/tests/backends/test_zarr.py
+++ b/tests/backends/test_zarr.py
@@ -132,7 +132,7 @@ def test_record(model, model_step, include_transformed, draws_per_chunk):
         else:
             manually_collected_draws.append(point)
             manually_collected_stats.append(stats)
-        trace.straces[0].record(point, stats)
+        trace.straces[0].record(point, stats, in_warmup=tuning)
     trace.straces[0].record_sampling_state(model_step)
     assert {group_name for group_name, _ in trace.root.groups()} == expected_groups
 

--- a/tests/dims/distributions/test_censored.py
+++ b/tests/dims/distributions/test_censored.py
@@ -1,0 +1,88 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import numpy as np
+import pytest
+
+from pytensor.xtensor import as_xtensor
+from pytensor.xtensor.shape import Transpose
+from pytensor.xtensor.vectorization import XRV
+
+import pymc.distributions as regular_distributions
+
+from pymc.dims import Censored, Normal
+from pymc.model.core import Model
+from tests.dims.utils import assert_equivalent_logp_graph, assert_equivalent_random_graph
+
+
+@pytest.mark.parametrize("lower", [None, -1])
+@pytest.mark.parametrize("upper", [None, 1])
+def test_censored_basic(lower, upper):
+    coords = {"space": range(3), "time": range(4)}
+
+    with Model(coords=coords) as model:
+        dist = Normal.dist(np.pi, np.e)
+        Censored("y", dist, lower=lower, upper=upper, dims=("space", "time"))
+
+    with Model(coords=coords) as reference_model:
+        dist = regular_distributions.Normal.dist(np.pi, np.e)
+        regular_distributions.Censored(
+            "y", dist=dist, lower=lower, upper=upper, dims=("space", "time")
+        )
+
+    assert_equivalent_random_graph(model, reference_model)
+    assert_equivalent_logp_graph(model, reference_model)
+
+
+def test_censored_dims():
+    """Test that both censored (and the underlying dist) have all the implied and explicit dims."""
+    coords = {
+        "a": range(3),
+        "b": range(4),
+        "c": range(5),
+        "d": range(6),
+    }
+    with Model(coords=coords) as model:
+        dist = Normal.dist(
+            mu=as_xtensor([0, 1, 2], dims=("a",)),
+            sigma=as_xtensor([1, 2, 3], dims=("b",)),
+            dim_lengths={"c": model.dim_lengths["c"]},
+        )
+        assert set(dist.dims) == {"c", "a", "b"}
+
+        c0 = Censored("c0", dist)
+        assert c0.dims == ("c", "a", "b")
+        c0_dist = c0.owner.inputs[0]
+        assert isinstance(c0_dist.owner.op, XRV)
+        assert c0_dist.dims == ("c", "a", "b")
+
+        c1 = Censored("c1", dist, dims=("a", "b", "c"))
+        assert c1.dims == ("a", "b", "c")
+        assert isinstance(c1.owner.op, Transpose)
+        c1_dist = c1.owner.inputs[0].owner.inputs[0]
+        assert isinstance(c1_dist.owner.op, XRV)
+        assert c1_dist.dims == ("c", "a", "b")
+
+        c2 = Censored("c2", dist, dims=(..., "d"))
+        assert c2.dims == ("c", "a", "b", "d")
+        assert isinstance(c1.owner.op, Transpose)
+        c2_dist = c2.owner.inputs[0].owner.inputs[0]
+        assert isinstance(c2_dist.owner.op, XRV)
+        assert c2_dist.dims == ("d", "c", "a", "b")
+
+        lower = as_xtensor(np.zeros((6, 5)), dims=("d", "c"))
+        c3 = Censored("c3", dist, lower=lower)
+        assert c3.dims == ("d", "c", "a", "b")
+        c3_dist = c3.owner.inputs[0]
+        assert isinstance(c3_dist.owner.op, XRV)
+        assert c3_dist.dims == ("d", "c", "a", "b")

--- a/tests/dims/distributions/test_vector.py
+++ b/tests/dims/distributions/test_vector.py
@@ -99,3 +99,23 @@ def test_zerosumnormal():
     # Logp is correct, but we have join(..., -1) and join(..., 1), that don't get canonicalized to the same
     # Should work once https://github.com/pymc-devs/pytensor/issues/1505 is fixed
     # assert_equivalent_logp_graph(model, reference_model)
+
+
+def test_zerosumnormal_batch_sigma():
+    coords = {"a": range(3), "b": range(5)}
+    sigma = np.array([1, 2, 3.0])
+    with Model(coords=coords) as model:
+        ZeroSumNormal(
+            "x",
+            sigma=as_xtensor(sigma, dims=("a",)),
+            core_dims=("b",),
+        )
+
+    with Model(coords=coords) as ref_model:
+        regular_distributions.ZeroSumNormal("x", sigma=sigma[:, None], dims=("a", "b"))
+
+    ip = model.initial_point()
+    np.testing.assert_allclose(
+        model.compile_logp(sum=False)(ip),
+        ref_model.compile_logp(sum=False)(ip),
+    )

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -1763,6 +1763,13 @@ class TestZeroSumNormal:
                 sigma=batch_test_sigma[None, :, None], n_zerosum_axes=2, support_shape=(3, 2)
             )
 
+    def test_batched_transformed_logp_shape(self):
+        with pm.Model() as m:
+            x = pm.ZeroSumNormal("x", sigma=np.ones(3)[:, None], support_shape=(2,))
+            assert x.type.shape == (3, 2)
+        assert m.logp(sum=False)[0].type.shape == (3,)
+        assert m.logp(sum=False, jacobian=False)[0].type.shape == (3,)
+
 
 class TestMvStudentTCov(BaseTestDistributionRandom):
     def mvstudentt_rng_fn(self, size, nu, mu, scale, rng):

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -657,12 +657,12 @@ def test_invalid_jacobian_broadcast_raises():
 
     buggy_transform = BuggyTransform()
 
-    with pm.Model() as m:
-        pm.Uniform("x", shape=(4, 3), default_transform=buggy_transform)
+    import numpy as np
 
     for jacobian_val in (True, False):
-        with pytest.raises(
-            ValueError,
-            match="are not allowed to broadcast together. There is a bug in the implementation of either one",
-        ):
-            m.logp(jacobian=jacobian_val)
+        with pm.Model() as m:
+            pm.Uniform("x", shape=(4, 3), default_transform=buggy_transform)
+
+        logp_fn = m.compile_logp(jacobian=jacobian_val)
+        with pytest.raises(AssertionError, match="SpecifyShape"):
+            logp_fn({"x_buggy__": np.zeros((4, 3))})

--- a/tests/logprob/test_transform_value.py
+++ b/tests/logprob/test_transform_value.py
@@ -578,6 +578,20 @@ def test_scan_transform():
     np.testing.assert_allclose(logp_fn(**test_point), ref_logp_fn(**test_point))
 
 
+def test_halfstudent_t_with_frozen_dims():
+    """Regression test: log_jac_det had mismatched broadcastable dims vs logp when
+    dims were frozen to a single-element coordinate, causing a ValueError.
+    """
+    from pymc.model.transform.optimization import freeze_dims_and_data
+
+    with pm.Model(coords={"x_dim": ["only_one"]}) as model:
+        pm.HalfStudentT("x", nu=7, sigma=1, dims="x_dim")
+
+    fmodel = freeze_dims_and_data(model)
+    [x_logp] = fmodel.logp(sum=False)
+    assert x_logp.type.shape == (1,)
+
+
 def test_weakref_leak():
     """Check that the rewrite does not have a growing memory footprint.
 

--- a/tests/step_methods/hmc/test_nuts.py
+++ b/tests/step_methods/hmc/test_nuts.py
@@ -157,7 +157,6 @@ class TestNutsCheckTrace:
             "step_size",
             "step_size_bar",
             "tree_size",
-            "tune",
             "perf_counter_diff",
             "perf_counter_start",
             "process_time_diff",

--- a/tests/step_methods/test_compound.py
+++ b/tests/step_methods/test_compound.py
@@ -36,11 +36,11 @@ from tests.helpers import StepMethodTester
 from tests.models import simple_2model_continuous
 
 
-def test_all_stepmethods_emit_tune_stat():
+def test_stepmethods_do_not_require_tune_stat():
     step_types = pm.step_methods.STEP_METHODS
     assert len(step_types) > 5
     for cls in step_types:
-        assert "tune" in cls.stats_dtypes_shapes
+        assert "tune" not in cls.stats_dtypes_shapes
 
 
 class TestCompoundStep:

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -319,6 +319,57 @@ def test_custom_dist_repr():
     assert str_repr == "\n".join(["x ~ CustomDistNormal", "y ~ CustomRandomNormal"])
 
 
+class TestDimsDist:
+    def setup_class(self):
+        from pymc.dims.distributions import Normal as DimsNormal
+        from pymc.dims.distributions import ZeroSumNormal as DimsZeroSumNormal
+
+        with Model(coords={"group": range(3), "obs": range(5)}) as self.model:
+            mu = DimsNormal("mu", 0, 10, dims=("group",))
+            sigma = DimsNormal("sigma", 0, 1)
+            zsn = DimsZeroSumNormal("zsn", sigma=1, core_dims="group")
+            DimsNormal("y", mu + zsn, sigma, dims=("obs", "group"))
+
+        self.expected = {
+            ("plain", True): [
+                r"mu ~ Normal(0, 10)",
+                r"sigma ~ Normal(0, 1)",
+                r"zsn ~ ZeroSumNormal(f(), f())",
+                r"y ~ Normal(f(mu, zsn), sigma)",
+            ],
+            ("plain", False): [
+                r"mu ~ Normal",
+                r"sigma ~ Normal",
+                r"zsn ~ ZeroSumNormal",
+                r"y ~ Normal",
+            ],
+            ("latex", True): [
+                r"\text{mu} &\sim & \operatorname{Normal}(0,~10)",
+                r"\text{sigma} &\sim & \operatorname{Normal}(0,~1)",
+                r"\text{zsn} &\sim & \operatorname{ZeroSumNormal}(f(),~f())",
+                r"\text{y} &\sim & \operatorname{Normal}(f(\text{mu},~\text{zsn}),~\text{sigma})",
+            ],
+            ("latex", False): [
+                r"\text{mu} &\sim & \operatorname{Normal}",
+                r"\text{sigma} &\sim & \operatorname{Normal}",
+                r"\text{zsn} &\sim & \operatorname{ZeroSumNormal}",
+                r"\text{y} &\sim & \operatorname{Normal}",
+            ],
+        }
+
+    def test_str_repr(self):
+        for formatting, include_params in [("plain", True), ("plain", False)]:
+            model_text = self.model.str_repr(formatting=formatting, include_params=include_params)
+            for text in self.expected[(formatting, include_params)]:
+                assert text in model_text
+
+    def test_latex_repr(self):
+        for formatting, include_params in [("latex", True), ("latex", False)]:
+            model_text = self.model.str_repr(formatting=formatting, include_params=include_params)
+            for text in self.expected[(formatting, include_params)]:
+                assert text in model_text
+
+
 class TestLatexRepr:
     @staticmethod
     def simple_model() -> Model:


### PR DESCRIPTION
## Description

This PR improves the documentation for the Wishart distribution to clarify its practical limitations and use cases.

### Changes
- Updated the Notes section to distinguish between prior use (not recommended) and likelihood use (allowed)
- Added explanation of why Wishart is problematic for MCMC sampling (SPD manifold)
- Referenced LKJCholeskyCov/LKJCorr as alternatives
- Made the documentation more precise than the previous "unusable" statement

### Issue
Closes #8196