### PR TITLE
Fix update_node_formatters to accept string keys matching NodeType values

### DIFF
--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -201,7 +201,15 @@ DEFAULT_NODE_FORMATTERS: NodeTypeFormatterMapping = {
 
 
 def update_node_formatters(node_formatters: NodeTypeFormatterMapping) -> NodeTypeFormatterMapping:
-    node_formatters = {**DEFAULT_NODE_FORMATTERS, **node_formatters}
+    # Convert string keys matching NodeType values to NodeType members
+    value_to_node_type = {nt.value: nt for nt in NodeType}
+    converted = {}
+    for key, formatter in node_formatters.items():
+        if isinstance(key, str) and key in value_to_node_type:
+            converted[value_to_node_type[key]] = formatter
+        else:
+            converted[key] = formatter
+    node_formatters = {**DEFAULT_NODE_FORMATTERS, **converted}
 
     unknown_keys = set(node_formatters.keys()) - set(NodeType)
     if unknown_keys:


### PR DESCRIPTION
## Description

Fixes #8091

The  function in  validates keys against the  enum, but the documented examples in  and  show users passing string keys like `"Free Random Variable"` and `"Observed Random Variable"`.

Since these strings match `NodeType.value` but are not `NodeType` enum members, the validation raises a `ValueError`.

**This fix** converts string keys that match a `NodeType.value` to the corresponding `NodeType` member before validation. This also makes the existing tests `test_custom_node_formatting_networkx` and `test_custom_node_formatting_graphviz` pass, which already use string keys.

## Changes
- Modified `update_node_formatters` to convert string keys matching `NodeType.value` to `NodeType` enum members before merging with defaults and validating.