### PR TITLE
Feature/print value helper

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,7 @@ jobs:
             tests/sampling/test_mcmc.py
             tests/sampling/test_parallel.py
             tests/test_printing.py
+            tests/test_print_value.py
 
           - |
             tests/distributions/test_timeseries.py

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,0 @@
-from pymc.printing import print_value

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from pymc.printing import print_value

--- a/printing.py
+++ b/printing.py
@@ -1,0 +1,47 @@
+# pymc/printing.py
+
+"""Helper utilities for debugging PyMC models."""
+
+from pytensor.printing import Print
+
+__all__ = ["print_value"]
+
+
+def print_value(var, name=None):
+    """Print the value of a variable each time it is computed during sampling.
+
+    This wraps the variable in a ``pytensor.printing.Print`` op, which is a
+    pass-through that prints the variable's value as a side effect whenever it
+    is evaluated.
+
+    .. warning::
+        This may significantly affect sampling performance. Use only for
+        debugging purposes.
+
+    Parameters
+    ----------
+    var : TensorVariable
+        The PyMC variable to debug-print.
+    name : str, optional
+        Label shown in the printed output. Defaults to ``var.name``.
+
+    Returns
+    -------
+    TensorVariable
+        The same variable, wrapped in a Print op (value is unchanged).
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import pymc as pm
+
+        with pm.Model():
+            mu = pm.Normal("mu", mu=0, sigma=1)
+            mu = pm.print_value(mu, name="mu")   # prints mu during sampling
+            obs = pm.Normal("obs", mu=mu, sigma=1, observed=[1, 2, 3])
+            idata = pm.sample()
+    """
+    if name is None:
+        name = getattr(var, "name", "value")
+    return Print(name)(var)

--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -78,5 +78,5 @@ from pymc.tuning import *
 from pymc.util import drop_warning_stat
 from pymc.variational import *
 from pymc.vartypes import *
-
+from pymc.printing import print_value
 __version__ = _version.get_versions()["version"]

--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -78,5 +78,4 @@ from pymc.tuning import *
 from pymc.util import drop_warning_stat
 from pymc.variational import *
 from pymc.vartypes import *
-from pymc.printing import print_value
 __version__ = _version.get_versions()["version"]

--- a/tests/test_print_value.py
+++ b/tests/test_print_value.py
@@ -1,0 +1,39 @@
+# tests/test_printing.py
+
+import pymc as pm
+import pytensor.tensor as pt
+from pytensor.printing import Print
+from pymc.printing import print_value
+
+
+def test_print_value_is_passthrough():
+    """print_value should not change the variable's value."""
+    x = pt.vector("x")
+    x_printed = print_value(x, name="test_x")
+
+    import pytensor
+    import numpy as np
+
+    f = pytensor.function([x], x_printed)
+    result = f([1.0, 2.0, 3.0])
+    np.testing.assert_array_equal(result, [1.0, 2.0, 3.0])
+
+
+def test_print_value_default_name():
+    """print_value should use var.name if no name is given."""
+    x = pt.vector("my_var")
+    x_printed = print_value(x)
+    # The Print op's message should match the variable name
+    assert x_printed.owner.op.message == "my_var"
+
+
+def test_print_value_custom_name():
+    """print_value should use the custom name when provided."""
+    x = pt.vector("x")
+    x_printed = print_value(x, name="custom_label")
+    assert x_printed.owner.op.message == "custom_label"
+
+
+def test_print_value_accessible_from_pm():
+    """print_value should be accessible as pm.print_value."""
+    assert hasattr(pm, "print_value")

--- a/tests/test_print_value.py
+++ b/tests/test_print_value.py
@@ -1,4 +1,17 @@
-# tests/test_printing.py
+# Copyright (c) 2024, PyMC Developers
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# tests/test_print_value.py
 
 import pymc as pm
 import pytensor.tensor as pt

--- a/tests/test_print_value.py
+++ b/tests/test_print_value.py
@@ -2,7 +2,6 @@
 
 import pymc as pm
 import pytensor.tensor as pt
-from pytensor.printing import Print
 from pymc.printing import print_value
 
 


### PR DESCRIPTION
## Summary
Adds a `pm.print_value()` helper function as proposed in #6841.

Previously, users had to manually initialize `pytensor.printing.Print`
which is an unusual API. This helper wraps that op with a clean,
discoverable interface.

## Usage
```python
with pm.Model():
    x = pm.Normal("x", mu=0, sigma=1)
    x = pm.print_value(x, name="x")  # prints x during sampling
```

## Changes
- `pymc/printing.py` — new `print_value()` helper
- `pymc/__init__.py` — expose as `pm.print_value`
- `tests/test_print_value.py` — tests for pass-through and naming

Closes #6841

The print_value helper is the clearest, self-contained piece to contribute from this issue. The JAX backend part lives in pytensor (a separate repo), so that would be a follow-up contribution if you want to go further.test_printing already existed so i created 
test_print_value.py11:17 PMSmart move. Now let's make sure your test file is properly structured and doesn't clash with anything in the existing test_printing.py. What does the existing file test?
bash# Run this in your cloned repo to see what's already there:
cat tests/test_printing.py
Also run:
bashgrep -n "print_value\|Print" tests/test_printing.py
Share the output and I'll help you make sure your test_print_value.py doesn't duplicate anything, has the right imports, and is structured to pass cleanly. Then we can get your PR opened.