### PR TITLE
Add ADVI float32 test to test_vi_float_precision (#5678)

### DIFF
--- a/tests/variational/test_vi_float.py
+++ b/tests/variational/test_vi_float.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pymc as pm
+import pytest
+import pytensor
+
+
+@pytest.mark.parametrize("dtype_str", ["float32", "float64"])
+def test_vi_float_precision(dtype_str):
+    """
+    Test that Variational Inference (ADVI) works under float32 and float64 precision.
+    """
+    rng = np.random.default_rng(123)
+
+    # Temporarily override floatX only within this test scope
+    with pytensor.config.change_flags(floatX=dtype_str):
+        data = rng.normal(loc=1.0, scale=1.0, size=50).astype(dtype_str)
+
+        with pm.Model():
+            mu = pm.Normal(
+                "mu",
+                mu=np.array(0.0, dtype=dtype_str),
+                sigma=np.array(1.0, dtype=dtype_str),
+            )
+            sigma = pm.HalfNormal(
+                "sigma",
+                sigma=np.array(1.0, dtype=dtype_str),
+            )
+            pm.Normal("obs", mu=mu, sigma=sigma, observed=data)
+
+            approx = pm.fit(
+                n=100,
+                method="advi",
+                progressbar=False,
+                random_seed=123,
+            )
+
+        assert approx is not None
+
+        # Request MultiTrace so dtype checks are straightforward
+        trace = approx.sample(
+            draws=10,
+            return_inferencedata=False,
+            random_seed=123,
+        )
+
+        assert trace.get_values("mu").dtype == np.dtype(dtype_str)
+        assert trace.get_values("sigma").dtype == np.dtype(dtype_str)


### PR DESCRIPTION
This PR adds a parameterized test for Variational Inference (ADVI) under float32 precision.
It ensures VI does not break when using float32, complementing the existing float64 tests.

- Parameterized test using `pytest.mark.parametrize` for float32 and float64
- Overrides `pytensor.config.floatX` within the test
- Asserts that posterior samples (`mu` and `sigma`) have the correct dtype

Closes #5678.