### PR TITLE
Clarify ZarrTrace behavior with external samplers in pm.sample docs

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -628,9 +628,10 @@ def sample(
         of their execution will write the partial results onto the storage. If the
         storage persist on disk, these results should be available even after a server
         crash. See :class:`~pymc.backends.zarr.ZarrTrace` for more information.
-            The ``ZarrTrace`` backend is only supported when using PyMC's internal samplers.
-            When specifying external samplers such as ``nuts_sampler="numpyro"``, the
-            ``trace`` argument is ignored and ``ZarrTrace`` is not used.
+        
+        The ``ZarrTrace`` backend is only supported when using PyMC's internal samplers.
+        When specifying external samplers such as ``nuts_sampler="numpyro"``, the
+        ``trace`` argument is ignored and ``ZarrTrace`` is not used.
     discard_tuned_samples : bool
         Whether to discard posterior samples of the tune interval.
     compute_convergence_checks : bool, default=True

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -628,7 +628,6 @@ def sample(
         of their execution will write the partial results onto the storage. If the
         storage persist on disk, these results should be available even after a server
         crash. See :class:`~pymc.backends.zarr.ZarrTrace` for more information.
-        .. note::
             The ``ZarrTrace`` backend is only supported when using PyMC's internal samplers.
             When specifying external samplers such as ``nuts_sampler="numpyro"``, the
             ``trace`` argument is ignored and ``ZarrTrace`` is not used.

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -620,7 +620,7 @@ def sample(
     n_init : int
         Number of iterations of initializer. Only works for 'ADVI' init methods.
     trace : backend, optional
-        A backend instance or None.
+        A backend instance or None. Ignored when ``nuts_sampler`` is not ``"pymc"``.
         If ``None``, a ``MultiTrace`` object with underlying ``NDArray`` trace objects
         is used. If ``trace`` is a :class:`~pymc.backends.zarr.ZarrTrace` instance,
         the drawn samples will be written onto the desired storage while sampling is
@@ -628,10 +628,6 @@ def sample(
         of their execution will write the partial results onto the storage. If the
         storage persist on disk, these results should be available even after a server
         crash. See :class:`~pymc.backends.zarr.ZarrTrace` for more information.
-        
-        The ``ZarrTrace`` backend is only supported when using PyMC's internal samplers.
-        When specifying external samplers such as ``nuts_sampler="numpyro"``, the
-        ``trace`` argument is ignored and ``ZarrTrace`` is not used.
     discard_tuned_samples : bool
         Whether to discard posterior samples of the tune interval.
     compute_convergence_checks : bool, default=True

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -628,6 +628,10 @@ def sample(
         of their execution will write the partial results onto the storage. If the
         storage persist on disk, these results should be available even after a server
         crash. See :class:`~pymc.backends.zarr.ZarrTrace` for more information.
+        .. note::
+            The ``ZarrTrace`` backend is only supported when using PyMC's internal samplers.
+            When specifying external samplers such as ``nuts_sampler="numpyro"``, the
+            ``trace`` argument is ignored and ``ZarrTrace`` is not used.
     discard_tuned_samples : bool
         Whether to discard posterior samples of the tune interval.
     compute_convergence_checks : bool, default=True

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -620,7 +620,7 @@ def sample(
     n_init : int
         Number of iterations of initializer. Only works for 'ADVI' init methods.
     trace : backend, optional
-        A backend instance or None. Ignored when ``nuts_sampler`` is not ``"pymc"``.
+        A backend instance or None. Raises a ``ValueError`` when ``nuts_sampler`` is not ``"pymc"``.
         If ``None``, a ``MultiTrace`` object with underlying ``NDArray`` trace objects
         is used. If ``trace`` is a :class:`~pymc.backends.zarr.ZarrTrace` instance,
         the drawn samples will be written onto the desired storage while sampling is


### PR DESCRIPTION
This PR clarifies that the `ZarrTrace` backend is only supported when using PyMC's internal samplers.

When external samplers such as `nuts_sampler="numpyro"` are used, the `trace` argument is ignored and `ZarrTrace` is not used.

Closes #7923    