### PR TITLE
ENH: Adding Zero-One-Inflated Beta

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,6 +139,7 @@ jobs:
 
           - |
             tests/dims/distributions/test_core.py
+            tests/dims/distributions/test_censored.py
             tests/dims/distributions/test_scalar.py
             tests/dims/distributions/test_vector.py
             tests/dims/test_model.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.11.13
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: [--fix, --show-fixes]
     - id: ruff-format
 - repo: local

--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -22,7 +22,7 @@ dependencies:
 - numpyro>=0.8.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.38.0,<2.39
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.38.0,<2.39
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -11,7 +11,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.38.0,<2.39
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - rich>=13.7.1
 - scipy>=1.4.1

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -14,7 +14,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=2.38.0,<2.39
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.38.0,<2.39
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -15,7 +15,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=2.38.0,<2.39
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/docs/source/api/dims/distributions.rst
+++ b/docs/source/api/dims/distributions.rst
@@ -39,3 +39,14 @@ Vector distributions
    Categorical
    MvNormal
    ZeroSumNormal
+
+
+Higher-Order distributions
+==========================
+
+.. currentmodule:: pymc.dims
+.. autosummary::
+   :toctree: generated/
+   :template: distribution.rst
+
+   Censored

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -333,7 +333,7 @@ class InferenceDataConverter:
         data_warmup = {}
         for stat in self.trace.stat_names:
             name = rename_key.get(stat, stat)
-            if name == "tune":
+            if name in {"tune", "in_warmup"}:
                 continue
             if self.warmup_trace:
                 data_warmup[name] = np.array(

--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -113,7 +113,13 @@ class IBaseTrace(ABC, Sized):
         """
         raise NotImplementedError()
 
-    def record(self, draw: Mapping[str, np.ndarray], stats: Sequence[Mapping[str, Any]]):
+    def record(
+        self,
+        draw: Mapping[str, np.ndarray],
+        stats: Sequence[Mapping[str, Any]],
+        *,
+        in_warmup: bool,
+    ):
         """Record results of a sampling iteration.
 
         Parameters
@@ -122,6 +128,9 @@ class IBaseTrace(ABC, Sized):
             Values mapped to variable names
         stats: list of dicts
             The diagnostic values for each sampler
+        in_warmup: bool
+            Whether this draw belongs to the warmup phase. This is a driver-owned
+            concept and is intended for storage/backends to persist warmup information.
         """
         raise NotImplementedError()
 

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -97,7 +97,7 @@ class NDArray(base.BaseTrace):
                     new = np.zeros(draws, dtype=dtype)
                     data[varname] = np.concatenate([old, new])
 
-    def record(self, point, sampler_stats=None) -> None:
+    def record(self, point, sampler_stats=None, *, in_warmup: bool) -> None:
         """Record results of a sampling iteration.
 
         Parameters
@@ -238,5 +238,5 @@ def point_list_to_multitrace(
 
         chain.fn = point_fun
         for point in point_list:
-            chain.record(point)
+            chain.record(point, in_warmup=False)
     return MultiTrace([chain])

--- a/pymc/backends/zarr.py
+++ b/pymc/backends/zarr.py
@@ -159,7 +159,11 @@ class ZarrChain(BaseTrace):
         buffer[var_name].append(value)
 
     def record(
-        self, draw: Mapping[str, np.ndarray], stats: Sequence[Mapping[str, Any]]
+        self,
+        draw: Mapping[str, np.ndarray],
+        stats: Sequence[Mapping[str, Any]],
+        *,
+        in_warmup: bool,
     ) -> bool | None:
         """Record the step method's returned draw and stats.
 
@@ -185,6 +189,7 @@ class ZarrChain(BaseTrace):
                 self.buffer(group="posterior", var_name=var_name, value=var_value)
         for var_name, var_value in self.stats_bijection.map(stats).items():
             self.buffer(group="sample_stats", var_name=var_name, value=var_value)
+        self.buffer(group="sample_stats", var_name="in_warmup", value=bool(in_warmup))
         self._buffered_draws += 1
         if self._buffered_draws == self.draws_until_flush:
             self.flush()
@@ -525,6 +530,7 @@ class ZarrTrace:
         stats_dtypes_shapes = get_stats_dtypes_shapes_from_steps(
             [step] if isinstance(step, BlockedStep) else step.methods
         )
+        stats_dtypes_shapes = {"in_warmup": (bool, [])} | stats_dtypes_shapes
         self.init_group_with_empty(
             group=self.root.create_group(name="sample_stats", overwrite=True),
             var_dtype_and_shape=stats_dtypes_shapes,
@@ -683,6 +689,7 @@ class ZarrTrace:
                 for i, shape_i in enumerate(shape):
                     dim = f"{name}_dim_{i}"
                     dims.append(dim)
+                    assert shape_i is not None, f"{dim} shape is None"
                     group_coords[dim] = np.arange(shape_i, dtype="int")
             dims = ("chain", "draw", *dims)
             attrs = extra_var_attrs[name] if extra_var_attrs is not None else {}

--- a/pymc/dims/distributions/__init__.py
+++ b/pymc/dims/distributions/__init__.py
@@ -11,5 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from pymc.dims.distributions.censored import Censored
 from pymc.dims.distributions.scalar import *
 from pymc.dims.distributions.vector import *

--- a/pymc/dims/distributions/censored.py
+++ b/pymc/dims/distributions/censored.py
@@ -1,0 +1,51 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import numpy as np
+
+from pymc.dims.distributions.core import DimDistribution, copy_docstring, expand_dist_dims
+from pymc.distributions.censored import Censored as RegularCensored
+
+
+@copy_docstring(RegularCensored)
+class Censored(DimDistribution):
+    @classmethod
+    def dist(cls, dist, *, lower=None, upper=None, dim_lengths, **kwargs):
+        if lower is None:
+            lower = -np.inf
+        if upper is None:
+            upper = np.inf
+        return super().dist([dist, lower, upper], dim_lengths=dim_lengths, **kwargs)
+
+    @classmethod
+    def xrv_op(cls, dist, lower, upper, core_dims=None, extra_dims=None, rng=None):
+        if extra_dims is None:
+            extra_dims = {}
+
+        dist = cls._as_xtensor(dist)
+        lower = cls._as_xtensor(lower)
+        upper = cls._as_xtensor(upper)
+
+        # Any dimensions in extra_dims, or only present in lower, upper,
+        # must propagate back to the dist as `extra_dims`
+        bounds_sizes = lower.sizes | upper.sizes
+        dist_dims_set = set(dist.dims)
+        extra_dist_dims = extra_dims | {
+            dim: size for dim, size in bounds_sizes.items() if dim not in dist_dims_set
+        }
+        if extra_dist_dims:
+            dist = expand_dist_dims(dist, extra_dist_dims)
+
+        # Probability is inferred from the clip operation
+        # TODO: Make this a SymbolicRandomVariable that can itself be resized
+        return dist.clip(lower, upper)

--- a/pymc/dims/distributions/core.py
+++ b/pymc/dims/distributions/core.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 from collections.abc import Callable, Sequence
 from itertools import chain
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 
@@ -25,7 +25,9 @@ from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.xtensor import as_xtensor
 from pytensor.xtensor.basic import XTensorFromTensor, xtensor_from_tensor
+from pytensor.xtensor.shape import Transpose
 from pytensor.xtensor.type import XTensorVariable
+from pytensor.xtensor.vectorization import XRV
 
 from pymc import SymbolicRandomVariable, modelcontext
 from pymc.dims.distributions.transforms import DimTransform, log_odds_transform, log_transform
@@ -345,3 +347,25 @@ class UnitDimDistribution(DimDistribution):
     """Base class for unit-valued distributions."""
 
     default_transform = log_odds_transform
+
+
+def expand_dist_dims(dist: XTensorVariable, extra_dims: dict[str, Any]) -> XTensorVariable:
+    if overlap := (set(extra_dims) & set(dist.dims)):
+        raise ValueError(f"extra_dims already present in distribution: {sorted(overlap)}")
+
+    op = None if dist.owner is None else dist.owner.op
+    match op:
+        case XRV():
+            # Recreate dist with new extra dims
+            dist_props = dist.owner.op._props_dict()
+            dist_props["extra_dims"] = (*(extra_dims.keys()), *dist_props["extra_dims"])
+            new_dist_op = type(dist.owner.op)(**dist_props)
+            _old_rng, *params_and_dim_lengths = dist.owner.inputs
+            new_rng = None  # We don't propagate the old RNG, because we don't want the new and old dists to be correlated
+            return new_dist_op(new_rng, *extra_dims.values(), *params_and_dim_lengths)
+        case Transpose():
+            return expand_dist_dims(dist.owner.inputs[0], extra_dims=extra_dims).transpose(
+                ..., *dist.dims
+            )
+        case _:
+            raise NotImplementedError(f"expand_dist_dims not implemented for {dist} with op {op}")

--- a/pymc/dims/distributions/transforms.py
+++ b/pymc/dims/distributions/transforms.py
@@ -203,6 +203,4 @@ class ZeroSumTransform(DimTransform):
         return value
 
     def log_jac_det(self, value, *rv_inputs):
-        # Use following once broadcast_like is implemented
-        # as_xtensor(0).broadcast_like(value, exclude=self.dims)`
-        return value.sum(self.dims) * 0
+        return as_xtensor(0.0).broadcast_like(value, exclude=self.dims)

--- a/pymc/dims/distributions/vector.py
+++ b/pymc/dims/distributions/vector.py
@@ -238,8 +238,8 @@ class ZeroSumNormal(VectorDimDistribution):
         )
 
     @classmethod
-    def xrv_op(self, sigma, support_dims, core_dims, extra_dims=None, rng=None):
-        sigma = as_xtensor(sigma)
+    def xrv_op(cls, sigma, support_dims, core_dims, extra_dims=None, rng=None):
+        sigma = cls._as_xtensor(sigma)
         support_dims = as_xtensor(support_dims, dims=("_",))
         support_shape = support_dims.values
         core_rv = ZeroSumNormalRV.rv_op(sigma=sigma.values, support_shape=support_shape).owner.op

--- a/pymc/dims/distributions/vector.py
+++ b/pymc/dims/distributions/vector.py
@@ -229,7 +229,8 @@ class ZeroSumNormal(VectorDimDistribution):
             raise ValueError("ZeroSumNormal requires atleast 1 core_dims")
 
         support_dims = as_xtensor(
-            as_tensor([dim_lengths[core_dim] for core_dim in core_dims]), dims=("_",)
+            as_tensor([dim_lengths[core_dim] for core_dim in core_dims]),
+            dims=("__support_shape__",),
         )
         sigma = cls._as_xtensor(sigma)
 
@@ -238,16 +239,25 @@ class ZeroSumNormal(VectorDimDistribution):
         )
 
     @classmethod
-    def xrv_op(cls, sigma, support_dims, core_dims, extra_dims=None, rng=None):
-        sigma = cls._as_xtensor(sigma)
-        support_dims = as_xtensor(support_dims, dims=("_",))
-        support_shape = support_dims.values
-        core_rv = ZeroSumNormalRV.rv_op(sigma=sigma.values, support_shape=support_shape).owner.op
+    def xrv_op(cls, sigma, support_shape, core_dims, extra_dims=None, rng=None):
+        # ZeroSumNormal expects dummy dimensions on sigma for the support_shape
+        sigma = cls._as_xtensor(sigma).expand_dims(core_dims)
+        support_shape = as_xtensor(support_shape, dims=("__support_shape__",))
+        core_rv = ZeroSumNormalRV.rv_op(
+            sigma=sigma.values, support_shape=support_shape.values
+        ).owner.op
+        core_dims_map = tuple(range(1, len(core_dims) + 1))
         xop = pxr.as_xrv(
             core_rv,
-            core_inps_dims_map=[(), (0,)],
-            core_out_dims_map=tuple(range(1, len(core_dims) + 1)),
+            core_inps_dims_map=[core_dims_map, (0,)],
+            core_out_dims_map=core_dims_map,
         )
         # Dummy "_" core dim to absorb the support_shape vector
         # If ZeroSumNormal expected a scalar per support dim, this wouldn't be needed
-        return xop(sigma, support_dims, core_dims=("_", *core_dims), extra_dims=extra_dims, rng=rng)
+        return xop(
+            sigma,
+            support_shape,
+            core_dims=("__support_shape__", *core_dims),
+            extra_dims=extra_dims,
+            rng=rng,
+        )

--- a/pymc/distributions/__init__.py
+++ b/pymc/distributions/__init__.py
@@ -51,6 +51,7 @@ from pymc.distributions.continuous import (
     VonMises,
     Wald,
     Weibull,
+    ZeroOneInflatedBeta,
 )
 from pymc.distributions.custom import CustomDist, DensityDist
 from pymc.distributions.discrete import (
@@ -204,5 +205,6 @@ __all__ = [
     "ZeroInflatedBinomial",
     "ZeroInflatedNegativeBinomial",
     "ZeroInflatedPoisson",
+    "ZeroOneInflatedBeta"
     "ZeroSumNormal",
 ]

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -89,7 +89,11 @@ from pymc.distributions.dist_math import (
     normal_lcdf,
     zvalue,
 )
-from pymc.distributions.distribution import DIST_PARAMETER_TYPES, Continuous, SymbolicRandomVariable
+from pymc.distributions.distribution import (
+    DIST_PARAMETER_TYPES,
+    Continuous,
+    SymbolicRandomVariable,
+)
 from pymc.distributions.shape_utils import implicit_size_from_params, rv_size_is_none
 from pymc.distributions.transforms import _default_transform
 from pymc.math import invlogit, logdiffexp
@@ -129,6 +133,7 @@ __all__ = [
     "VonMises",
     "Wald",
     "Weibull",
+    "ZeroOneInflatedBeta",
 ]
 
 
@@ -169,7 +174,9 @@ def circ_cont_transform(op, rv):
 @_default_transform.register(BoundedContinuous)
 def bounded_cont_transform(op, rv, bound_args_indices=None):
     if bound_args_indices is None:
-        raise ValueError(f"Must specify bound_args_indices for {op} bounded distribution")
+        raise ValueError(
+            f"Must specify bound_args_indices for {op} bounded distribution"
+        )
 
     def transform_params(*args):
         lower, upper = None, None
@@ -377,7 +384,9 @@ class Flat(Continuous):
 
     def logcdf(value):
         return pt.switch(
-            pt.eq(value, -np.inf), -np.inf, pt.switch(pt.eq(value, np.inf), 0, pt.log(0.5))
+            pt.eq(value, -np.inf),
+            -np.inf,
+            pt.switch(pt.eq(value, np.inf), 0, pt.log(0.5)),
         )
 
 
@@ -412,7 +421,9 @@ class HalfFlat(PositiveContinuous):
         return pt.switch(pt.lt(value, 0), -np.inf, pt.zeros_like(value))
 
     def logcdf(value):
-        return pt.switch(pt.lt(value, np.inf), -np.inf, pt.switch(pt.eq(value, np.inf), 0, -np.inf))
+        return pt.switch(
+            pt.lt(value, np.inf), -np.inf, pt.switch(pt.eq(value, np.inf), 0, -np.inf)
+        )
 
 
 class Normal(Continuous):
@@ -497,7 +508,11 @@ class Normal(Continuous):
         return mu
 
     def logp(value, mu, sigma):
-        res = -0.5 * pt.pow((value - mu) / sigma, 2) - pt.log(pt.sqrt(2.0 * np.pi)) - pt.log(sigma)
+        res = (
+            -0.5 * pt.pow((value - mu) / sigma, 2)
+            - pt.log(pt.sqrt(2.0 * np.pi))
+            - pt.log(sigma)
+        )
         return check_parameters(
             res,
             sigma > 0,
@@ -654,8 +669,12 @@ class TruncatedNormal(BoundedContinuous):
         sigma = pt.as_tensor_variable(sigma)
         mu = pt.as_tensor_variable(mu)
 
-        lower = pt.as_tensor_variable(lower) if lower is not None else pt.constant(-np.inf)
-        upper = pt.as_tensor_variable(upper) if upper is not None else pt.constant(np.inf)
+        lower = (
+            pt.as_tensor_variable(lower) if lower is not None else pt.constant(-np.inf)
+        )
+        upper = (
+            pt.as_tensor_variable(upper) if upper is not None else pt.constant(np.inf)
+        )
         return super().dist([mu, sigma, lower, upper], **kwargs)
 
     def support_point(rv, size, mu, sigma, lower, upper):
@@ -687,7 +706,9 @@ class TruncatedNormal(BoundedContinuous):
         is_lower_bounded = not (
             isinstance(lower, TensorConstant) and np.all(np.isneginf(lower.value))
         )
-        is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value)))
+        is_upper_bounded = not (
+            isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value))
+        )
 
         if is_lower_bounded and is_upper_bounded:
             norm = log_diff_normal_cdf(mu, sigma, upper, lower)
@@ -723,7 +744,9 @@ class TruncatedNormal(BoundedContinuous):
         is_lower_bounded = not (
             isinstance(lower, TensorConstant) and np.all(np.isneginf(lower.value))
         )
-        is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value)))
+        is_upper_bounded = not (
+            isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value))
+        )
 
         if is_lower_bounded:
             logcdf = pt.switch(value < lower, -np.inf, logcdf)
@@ -834,7 +857,11 @@ class HalfNormal(PositiveContinuous):
         return support_point
 
     def logp(value, loc, sigma):
-        res = -0.5 * pt.pow((value - loc) / sigma, 2) + pt.log(pt.sqrt(2.0 / np.pi)) - pt.log(sigma)
+        res = (
+            -0.5 * pt.pow((value - loc) / sigma, 2)
+            + pt.log(pt.sqrt(2.0 / np.pi))
+            - pt.log(sigma)
+        )
         res = pt.switch(pt.ge(value, loc), res, -np.inf)
         return check_parameters(
             res,
@@ -1180,7 +1207,9 @@ class Beta(UnitContinuous):
             + pt.switch(pt.eq(beta, 1.0), 0.0, (beta - 1.0) * pt.log1p(-value))
             - (pt.gammaln(alpha) + pt.gammaln(beta) - pt.gammaln(alpha + beta))
         )
-        res = pt.switch(pt.bitwise_and(pt.ge(value, 0.0), pt.le(value, 1.0)), res, -np.inf)
+        res = pt.switch(
+            pt.bitwise_and(pt.ge(value, 0.0), pt.le(value, 1.0)), res, -np.inf
+        )
         return check_parameters(
             res,
             alpha > 0,
@@ -1215,6 +1244,176 @@ class Beta(UnitContinuous):
             beta > 0,
             msg="alpha > 0, beta > 0",
         )
+
+
+class ZeroOneInflatedBeta(UnitContinuous):
+    r"""
+    Zero-One-Inflated Beta Distribution.
+
+    The pdf of this distribution is:
+
+    .. math::
+
+        f(x \mid \text{zoi}, \text{coi}, \alpha, \beta) =
+        \begin{cases}
+            \text{zoi} \cdot (1 - \text{coi})
+                & \text{if } x = 0 \\
+            \text{zoi} \cdot \text{coi}
+                & \text{if } x = 1 \\
+            (1 - \text{zoi}) \cdot \dfrac{x^{\alpha - 1} (1 - x)^{\beta - 1}}{B(\alpha, \beta)}
+                & \text{if } x \in (0, 1)
+        \end{cases}
+
+    where :math:`B` is the Beta function, :math:`\alpha = \mu \kappa`, and :math:`\beta = (1 - \mu) \kappa`.
+
+
+    Examples
+    --------
+    Model proportion data with structural zeros and ones:
+
+    .. code-block:: python
+
+        import pymc as pm
+        import numpy as np
+
+        # Data with 30% boundary values, 40% of which are ones
+        true_zoi = 0.3
+        true_coi = 0.4
+        true_mu = 0.4
+        true_kappa = 20.0
+        n = 1000
+
+        rng = np.random.default_rng(100)
+        u = rng.random(n)
+        alpha = true_mu * true_kappa
+        beta  = (1 - true_mu) * true_kappa
+        beta_data = rng.beta(alpha, beta, n)
+        data = np.where(u < true_zoi * (1 - true_coi), 0.0,
+               np.where(u < true_zoi, 1.0,
+               beta_data))
+
+        # Fit model
+        with pm.Model() as model:
+            zoi   = pm.Beta("zoi", alpha=1, beta=1)
+            coi   = pm.Beta("coi", alpha=1, beta=1)
+            mu    = pm.Beta("mu", alpha=2, beta=2)
+            kappa = pm.Gamma("kappa", alpha=2, beta=0.1)
+
+            y = pm.ZeroOneInflatedBeta(
+                "y", zoi=zoi, coi=coi, mu=mu, kappa=kappa,
+                observed=data
+            )
+            trace = pm.sample(1000, tune=1000)
+
+
+    ========  ===============================================
+    Support   :math:`y \in [0, 1]`
+    Mean      :math:`(1 - \text{zoi})\mu + \text{zoi} \cdot \text{coi}`
+    Variance  :math:`(1-\text{zoi})\left[\dfrac{\mu(1-\mu)}{\kappa+1} + \text{zoi} \cdot \text{coi} \cdot (1 - \text{coi})\right] + \text{zoi}(1-\text{zoi})\mu^2`
+    ========  ===============================================
+
+    Setting :math:`coi = 0` recovers the Zero-Inflated Beta (ZIB) distribution.
+    Setting :math:`coi = 1` recovers the One-Inflated Beta (OIB) distribution.
+
+
+    Parameters
+    ----------
+    zoi : tensor_like of float
+        Probability of a structural value at 0 or 1, :math:`0 \leq zoi \leq 1`.
+    coi : tensor_like of float
+        Conditional probability given a structural value that it is a structural 1, :math:`0 \leq coi \leq 1`.
+    alpha : tensor_like of float, optional
+        ``alpha`` > 0. If not specified, then calculated using ``mu`` and ``sigma``.
+    beta : tensor_like of float, optional
+        ``beta`` > 0. If not specified, then calculated using ``mu`` and ``sigma``.
+    mu : tensor_like of float, optional
+        Mean of the Beta component, :math:`0 < \mu < 1`.
+    kappa : tensor_like of float, optional
+        Precision of the Beta component, :math:`\kappa > 0`.
+
+
+    References
+    ----------
+    .. [1] Ospina, R., & Ferrari, S. L. (2010). Inflated beta distributions.
+    .. [2] Ospina, R., & Ferrari, S. L. (2012). A general class of zero-or-one inflated
+           beta regression models.
+
+    Notes
+    -----
+    ZeroOneInflatedBeta is appropriate for modeling proportion data when exact zeros
+    or ones represent distinct processes (structural zeros and ones), separate from
+    the tails of the Beta component.
+    """
+
+    rv_op = None
+
+    @classmethod
+    def dist(cls, zoi, coi, mu=None, kappa=None, alpha=None, beta=None, **kwargs):
+        if (
+            (alpha is not None)
+            and (beta is not None)
+            and (mu is not None or kappa is not None)
+        ):
+            warnings.warn(
+                "Both parametrizations provided. Proceeding with alpha and beta.",
+                UserWarning,
+            )
+        if (alpha is not None) and (beta is not None):
+            pass
+        elif (mu is not None) and (kappa is not None):
+            alpha = mu * kappa
+            beta = (1.0 - mu) * kappa
+        else:
+            raise ValueError(
+                "Incompatible parametrization. Must specify alpha and beta, or mu and kappa."
+            )
+        zoi = pt.as_tensor_variable(zoi)
+        coi = pt.as_tensor_variable(coi)
+        alpha = pt.as_tensor_variable(alpha)
+        beta = pt.as_tensor_variable(beta)
+        return super().dist([zoi, coi, alpha, beta], **kwargs)
+
+        def support_point(rv, size, zoi, coi, alpha, beta):
+            mean = zoi * coi + (1.0 - zoi) * (alpha / (alpha + beta))
+            if not rv_size_is_none(size):
+                mean = pt.full(size, mean)
+            return mean
+
+        def logp(value, zoi, coi, alpha, beta):
+            # Beta log-probability
+            logp_beta = (
+                pt.switch(pt.eq(alpha, 1.0), 0.0, (alpha - 1.0) * pt.log(value))
+                + pt.switch(pt.eq(beta, 1.0), 0.0, (beta - 1.0) * pt.log1p(-value))
+                - (pt.gammaln(alpha) + pt.gammaln(beta) - pt.gammaln(alpha + beta))
+            )
+
+            # Cases
+            res = pt.switch(
+                pt.eq(value, 0),
+                pt.log(zoi) + pt.log1p(-coi),
+                pt.switch(
+                    pt.eq(value, 1),
+                    pt.log(zoi) + pt.log(coi),
+                    pt.log1p(-zoi) + logp_beta,
+                ),
+            )
+
+            # Guard against values outside [0, 1]
+            res = pt.switch(
+                pt.bitwise_and(pt.ge(value, 0.0), pt.le(value, 1.0)),
+                res,
+                -np.inf,
+            )
+            return check_parameters(
+                res,
+                zoi >= 0,
+                zoi <= 1,
+                coi >= 0,
+                coi <= 1,
+                alpha > 0,
+                beta > 0,
+                msg="0 <= zoi <= 1, 0 <= coi <= 1, alpha > 0, beta > 0",
+            )
 
 
 class KumaraswamyRV(SymbolicRandomVariable):
@@ -1293,13 +1492,23 @@ class Kumaraswamy(UnitContinuous):
         return super().dist([a, b], *args, **kwargs)
 
     def support_point(rv, size, a, b):
-        mean = pt.exp(pt.log(b) + pt.gammaln(1 + 1 / a) + pt.gammaln(b) - pt.gammaln(1 + 1 / a + b))
+        mean = pt.exp(
+            pt.log(b)
+            + pt.gammaln(1 + 1 / a)
+            + pt.gammaln(b)
+            - pt.gammaln(1 + 1 / a + b)
+        )
         if not rv_size_is_none(size):
             mean = pt.full(size, mean)
         return mean
 
     def logp(value, a, b):
-        res = pt.log(a) + pt.log(b) + (a - 1) * pt.log(value) + (b - 1) * pt.log(1 - value**a)
+        res = (
+            pt.log(a)
+            + pt.log(b)
+            + (a - 1) * pt.log(value)
+            + (b - 1) * pt.log(1 - value**a)
+        )
         res = pt.switch(
             pt.or_(pt.lt(value, 0), pt.gt(value, 1)),
             -np.inf,
@@ -1331,7 +1540,9 @@ class Kumaraswamy(UnitContinuous):
         )
 
     def icdf(value, a, b):
-        res = pt.exp(pt.reciprocal(a) * pt.log1mexp(pt.reciprocal(b) * pt.log1p(-value)))
+        res = pt.exp(
+            pt.reciprocal(a) * pt.log1mexp(pt.reciprocal(b) * pt.log1p(-value))
+        )
         res = check_icdf_value(res, value)
         return check_icdf_parameters(
             res,
@@ -1389,7 +1600,9 @@ class Exponential(PositiveContinuous):
         if lam is None and scale is None:
             scale = 1.0
         elif lam is not None and scale is not None:
-            raise ValueError("Incompatible parametrization. Can't specify both lam and scale.")
+            raise ValueError(
+                "Incompatible parametrization. Can't specify both lam and scale."
+            )
         elif lam is not None:
             scale = pt.reciprocal(lam)
 
@@ -1523,7 +1736,9 @@ class Laplace(Continuous):
 
     def icdf(value, mu, b):
         res = pt.switch(
-            pt.le(value, 0.5), mu + b * np.log(2 * value), mu - b * np.log(2 - 2 * value)
+            pt.le(value, 0.5),
+            mu + b * np.log(2 * value),
+            mu - b * np.log(2 - 2 * value),
         )
         res = check_icdf_value(res, value)
         return check_icdf_parameters(res, b > 0, msg="b > 0")
@@ -1543,7 +1758,9 @@ class AsymmetricLaplaceRV(SymbolicRandomVariable):
         size = normalize_size_param(size)
 
         if rv_size_is_none(size):
-            size = implicit_size_from_params(b, kappa, mu, ndims_params=cls.ndims_params)
+            size = implicit_size_from_params(
+                b, kappa, mu, ndims_params=cls.ndims_params
+            )
 
         next_rng, u = uniform(size=size, rng=rng).owner.outputs
         switch = kappa**2 / (1 + kappa**2)
@@ -1883,8 +2100,10 @@ class StudentT(Continuous):
     def icdf(value, nu, mu, sigma):
         res = pt.switch(
             pt.lt(value, 0.5),
-            -pt.sqrt(nu) * pt.sqrt((1.0 / betaincinv(nu * 0.5, 0.5, 2.0 * value)) - 1.0),
-            pt.sqrt(nu) * pt.sqrt((1.0 / betaincinv(nu * 0.5, 0.5, 2.0 * (1 - value))) - 1.0),
+            -pt.sqrt(nu)
+            * pt.sqrt((1.0 / betaincinv(nu * 0.5, 0.5, 2.0 * value)) - 1.0),
+            pt.sqrt(nu)
+            * pt.sqrt((1.0 / betaincinv(nu * 0.5, 0.5, 2.0 * (1 - value))) - 1.0),
         )
         res = mu + res * sigma
         res = check_icdf_value(res, value)
@@ -1905,7 +2124,9 @@ class SkewStudentTRV(RandomVariable):
     @classmethod
     def rng_fn(cls, rng, a, b, mu, sigma, size=None) -> np.ndarray:
         return np.asarray(
-            stats.jf_skew_t.rvs(a=a, b=b, loc=mu, scale=sigma, size=size, random_state=rng)
+            stats.jf_skew_t.rvs(
+                a=a, b=b, loc=mu, scale=sigma, size=size, random_state=rng
+            )
         )
 
 
@@ -2199,7 +2420,9 @@ class Cauchy(Continuous):
         return alpha
 
     def logp(value, alpha, beta):
-        res = -pt.log(np.pi) - pt.log(beta) - pt.log1p(pt.pow((value - alpha) / beta, 2))
+        res = (
+            -pt.log(np.pi) - pt.log(beta) - pt.log1p(pt.pow((value - alpha) / beta, 2))
+        )
         return check_parameters(
             res,
             beta > 0,
@@ -2235,7 +2458,9 @@ class HalfCauchyRV(SymbolicRandomVariable):
         rng = normalize_rng_param(rng)
         size = normalize_size_param(size)
 
-        next_rng, cauchy_draws = cauchy(loc=0, scale=beta, size=size, rng=rng).owner.outputs
+        next_rng, cauchy_draws = cauchy(
+            loc=0, scale=beta, size=size, rng=rng
+        ).owner.outputs
         draws = pt.abs(cauchy_draws)
 
         return cls(inputs=[rng, size, beta], outputs=[next_rng, draws])(rng, size, beta)
@@ -2425,7 +2650,12 @@ class Gamma(PositiveContinuous):
 
     def logp(value, alpha, scale):
         beta = pt.reciprocal(scale)
-        res = -pt.gammaln(alpha) + logpow(beta, alpha) - beta * value + logpow(value, alpha - 1)
+        res = (
+            -pt.gammaln(alpha)
+            + logpow(beta, alpha)
+            - beta * value
+            + logpow(value, alpha - 1)
+        )
         res = pt.switch(pt.ge(value, 0.0), res, -np.inf)
         return check_parameters(
             res,
@@ -2543,7 +2773,12 @@ class InverseGamma(PositiveContinuous):
         return alpha, beta
 
     def logp(value, alpha, beta):
-        res = -pt.gammaln(alpha) + logpow(beta, alpha) - beta / value + logpow(value, -alpha - 1)
+        res = (
+            -pt.gammaln(alpha)
+            + logpow(beta, alpha)
+            - beta / value
+            + logpow(value, -alpha - 1)
+        )
         res = pt.switch(pt.ge(value, 0.0), res, -np.inf)
         return check_parameters(
             res,
@@ -2643,7 +2878,9 @@ class WeibullBetaRV(SymbolicRandomVariable):
         if rv_size_is_none(size):
             size = implicit_size_from_params(alpha, beta, ndims_params=cls.ndims_params)
 
-        next_rng, raw_weibull = pt.random.weibull(alpha, size=size, rng=rng).owner.outputs
+        next_rng, raw_weibull = pt.random.weibull(
+            alpha, size=size, rng=rng
+        ).owner.outputs
         draws = beta * raw_weibull
         return cls(
             inputs=[rng, size, alpha, beta],
@@ -2770,7 +3007,9 @@ class HalfStudentTRV(SymbolicRandomVariable):
         next_rng, t_draws = t(df=nu, scale=sigma, size=size, rng=rng).owner.outputs
         draws = pt.abs(t_draws)
 
-        return cls(inputs=[rng, size, nu, sigma], outputs=[next_rng, draws])(rng, size, nu, sigma)
+        return cls(inputs=[rng, size, nu, sigma], outputs=[next_rng, draws])(
+            rng, size, nu, sigma
+        )
 
 
 class HalfStudentT(PositiveContinuous):
@@ -2890,10 +3129,16 @@ class ExGaussianRV(SymbolicRandomVariable):
         size = normalize_size_param(size)
 
         if rv_size_is_none(size):
-            size = implicit_size_from_params(mu, sigma, nu, ndims_params=cls.ndims_params)
+            size = implicit_size_from_params(
+                mu, sigma, nu, ndims_params=cls.ndims_params
+            )
 
-        next_rng, normal_draws = normal(loc=mu, scale=sigma, size=size, rng=rng).owner.outputs
-        final_rng, exponential_draws = exponential(scale=nu, size=size, rng=next_rng).owner.outputs
+        next_rng, normal_draws = normal(
+            loc=mu, scale=sigma, size=size, rng=rng
+        ).owner.outputs
+        final_rng, exponential_draws = exponential(
+            scale=nu, size=size, rng=next_rng
+        ).owner.outputs
         draws = normal_draws + exponential_draws
 
         return cls(inputs=[rng, size, mu, sigma, nu], outputs=[final_rng, draws])(
@@ -3086,7 +3331,9 @@ class VonMises(CircularContinuous):
 
     def logp(value, mu, kappa):
         res = kappa * pt.cos(mu - value) - pt.log(2 * np.pi) - pt.log(pt.i0(kappa))
-        res = pt.switch(pt.bitwise_and(pt.ge(value, -np.pi), pt.le(value, np.pi)), res, -np.inf)
+        res = pt.switch(
+            pt.bitwise_and(pt.ge(value, -np.pi), pt.le(value, np.pi)), res, -np.inf
+        )
         return check_parameters(
             res,
             kappa > 0,
@@ -3103,7 +3350,9 @@ class SkewNormalRV(RandomVariable):
     @classmethod
     def rng_fn(cls, rng, mu, sigma, alpha, size=None) -> np.ndarray:
         return np.asarray(
-            stats.skewnorm.rvs(a=alpha, loc=mu, scale=sigma, size=size, random_state=rng)
+            stats.skewnorm.rvs(
+                a=alpha, loc=mu, scale=sigma, size=size, random_state=rng
+            )
         )
 
 
@@ -3284,7 +3533,9 @@ class Triangular(BoundedContinuous):
             pt.log(2 * (value - lower) / ((upper - lower) * (c - lower))),
             pt.log(2 * (upper - value) / ((upper - lower) * (upper - c))),
         )
-        res = pt.switch(pt.bitwise_and(pt.le(lower, value), pt.le(value, upper)), res, -np.inf)
+        res = pt.switch(
+            pt.bitwise_and(pt.le(lower, value), pt.le(value, upper)), res, -np.inf
+        )
         return check_parameters(
             res,
             lower <= c,
@@ -3720,7 +3971,11 @@ class LogitNormal:
 
 
 def _interpolated_argcdf(p, pdf, cdf, x):
-    if np.prod(cdf.shape[:-1]) != 1 or np.prod(pdf.shape[:-1]) != 1 or np.prod(x.shape[:-1]) != 1:
+    if (
+        np.prod(cdf.shape[:-1]) != 1
+        or np.prod(pdf.shape[:-1]) != 1
+        or np.prod(x.shape[:-1]) != 1
+    ):
         raise NotImplementedError(
             "Function not implemented for batched points. "
             "Open an issue in https://github.com/pymc-devs/pymc if you need this functionality"
@@ -3740,7 +3995,9 @@ def _interpolated_argcdf(p, pdf, cdf, x):
     # This warning happens when we divide by slope = 0: we can ignore it
     # because the other result will be returned
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", ".*invalid value encountered in.*", RuntimeWarning)
+        warnings.filterwarnings(
+            "ignore", ".*invalid value encountered in.*", RuntimeWarning
+        )
         large_slopes = (
             -pdf[index] + np.sqrt(pdf[index] ** 2 + 2 * slope * (p - cdf[index]))
         ) / slope
@@ -3838,7 +4095,8 @@ class Interpolated(BoundedContinuous):
         """Estimates the expectation integral using the trapezoid rule; cdf_points are not used."""
         x_fx = pt.mul(x_points, pdf_points)  # x_i * f(x_i) for all xi's in x_points
         support_point = (
-            pt.sum(pt.mul(pt.diff(x_points, axis=-1), x_fx[..., 1:] + x_fx[..., :-1])) / 2
+            pt.sum(pt.mul(pt.diff(x_points, axis=-1), x_fx[..., 1:] + x_fx[..., :-1]))
+            / 2
         )
 
         if not rv_size_is_none(size):
@@ -3849,7 +4107,9 @@ class Interpolated(BoundedContinuous):
     def logp(value, x_points, pdf_points, cdf_points):
         # x_points and pdf_points are expected to be non-symbolic arrays wrapped
         # within a tensor.constant. We use the .data method to retrieve them
-        interp = InterpolatedUnivariateSpline(x_points.data, pdf_points.data, k=1, ext="zeros")
+        interp = InterpolatedUnivariateSpline(
+            x_points.data, pdf_points.data, k=1, ext="zeros"
+        )
         Z = interp.integral(x_points.data[..., 0], x_points.data[..., -1])
 
         # interp and Z are converted to symbolic variables here
@@ -3949,7 +4209,11 @@ class Moyal(Continuous):
 
     def logp(value, mu, sigma):
         scaled = (value - mu) / sigma
-        res = -(1 / 2) * (scaled + pt.exp(-scaled)) - pt.log(sigma) - (1 / 2) * pt.log(2 * np.pi)
+        res = (
+            -(1 / 2) * (scaled + pt.exp(-scaled))
+            - pt.log(sigma)
+            - (1 / 2) * pt.log(2 * np.pi)
+        )
         return check_parameters(
             res,
             sigma > 0,
@@ -4010,7 +4274,9 @@ class PolyaGammaRV(RandomVariable):
         if size is None:
             size = np.broadcast_shapes(h.shape, z.shape)
         return np.asarray(
-            random_polyagamma(h, z, size=size, random_state=rng).astype(pytensor.config.floatX)
+            random_polyagamma(h, z, size=size, random_state=rng).astype(
+                pytensor.config.floatX
+            )
         )
 
 

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -392,7 +392,7 @@ class SymbolicRandomVariable(MeasurableOp, RNGConsumerOp, OpFromGraph):
             )
             if size_arg_idx is not None and len(rng_arg_idxs) == 1:
                 new_size_type = normalize_size_param(inputs[size_arg_idx]).type
-                if not self.input_types[size_arg_idx].in_same_class(new_size_type):
+                if not self.input_types[size_arg_idx].is_super(new_size_type):
                     params = [inputs[idx] for idx in param_idxs]
                     size = inputs[size_arg_idx]
                     rng = inputs[rng_arg_idxs[0]]

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -952,6 +952,8 @@ class WishartRV(RandomVariable):
     @classmethod
     def rng_fn(cls, rng, nu, V, size):
         scipy_size = size if size else 1  # Default size for Scipy's wishart.rvs is 1
+        # Scipy doesn't accept batch nu or V
+        nu = _squeeze_to_ndim(nu, 0)
         V = _squeeze_to_ndim(V, 2)
         result = stats.wishart.rvs(int(nu), V, size=scipy_size, random_state=rng)
         if size == (1,):

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2659,9 +2659,9 @@ class ZeroSumNormalRV(SymbolicRandomVariable):
 
     @classmethod
     def rv_op(cls, sigma, support_shape, *, size=None, rng=None):
+        support_shape = _squeeze_to_ndim(pt.as_tensor(support_shape), ndim=1)
         n_zerosum_axes = pt.get_vector_length(support_shape)
         sigma = pt.as_tensor(sigma)
-        support_shape = pt.as_tensor(support_shape, ndim=1)
         rng = normalize_rng_param(rng)
         size = normalize_size_param(size)
 

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2677,8 +2677,10 @@ class ZeroSumNormalRV(SymbolicRandomVariable):
         for axis in range(n_zerosum_axes):
             zerosum_rv -= zerosum_rv.mean(axis=-axis - 1, keepdims=True)
 
+        # sigma has core_shape = (1, 1, ...) (as many as there are zerosum axes)
+        ones = ",".join("1" for _ in range(n_zerosum_axes))
         support_str = ",".join([f"d{i}" for i in range(n_zerosum_axes)])
-        extended_signature = f"[rng],[size],(),(s)->[rng],({support_str})"
+        extended_signature = f"[rng],[size],({ones}),(s)->[rng],({support_str})"
         return cls(
             inputs=[rng, size, sigma, support_shape],
             outputs=[next_rng, zerosum_rv],
@@ -2774,7 +2776,7 @@ class ZeroSumNormal(Distribution):
     def dist(cls, sigma=1.0, n_zerosum_axes=None, support_shape=None, **kwargs):
         n_zerosum_axes = cls.check_zerosum_axes(n_zerosum_axes)
 
-        sigma = pt.as_tensor(sigma)
+        sigma = pt.atleast_Nd(pt.as_tensor(sigma), n=n_zerosum_axes)
         if not all(sigma.type.broadcastable[-n_zerosum_axes:]):
             raise ValueError("sigma must have length one across the zero-sum axes")
 

--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -309,8 +309,7 @@ def change_rv_size(op, rv, new_size, expand) -> TensorVariable:
     # to not unnecessarily pick up a `Cast` in some cases (see #4652).
     new_size = pt.as_tensor(new_size, ndim=1, dtype="int64")
 
-    new_rv = rv_node.op(*dist_params, size=new_size, dtype=rv.type.dtype)
-
+    new_rv = rv_node.op(*dist_params, size=new_size)
     # Replicate "traditional" rng default_update, if that was set for old_rng
     default_update = getattr(old_rng, "default_update", None)
     if default_update is not None:

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -309,7 +309,7 @@ class ZeroSumTransform(Transform):
         return value
 
     def log_jac_det(self, value, *rv_inputs):
-        return pt.constant(0.0)
+        return value.sum(self.zerosum_axes).zeros_like()
 
 
 log_exp_m1 = LogExpM1()

--- a/pymc/logprob/transform_value.py
+++ b/pymc/logprob/transform_value.py
@@ -16,6 +16,7 @@ import warnings
 from collections.abc import Sequence
 
 import numpy as np
+import pytensor.tensor as pt
 
 from pytensor.graph import Apply, Op
 from pytensor.graph.features import AlreadyThere, Feature
@@ -113,10 +114,18 @@ def transformed_value_logprob(op, values, *rv_outs, use_jacobian=True, **kwargs)
             )
         # Check there is no broadcasting between logp and jacobian
         if logp.type.broadcastable != log_jac_det.type.broadcastable:
-            raise ValueError(
-                f"The logp of {rv_op} and log_jac_det of {transform} are not allowed to broadcast together. "
-                "There is a bug in the implementation of either one."
-            )
+            lb, jb = logp.type.broadcastable, log_jac_det.type.broadcastable
+            broadcastable_axes = [
+                i for i, (ai, bi) in enumerate(zip(lb, jb, strict=True)) if ai or bi
+            ]
+            try:
+                logp = pt.specify_broadcastable(logp, *broadcastable_axes)
+                log_jac_det = pt.specify_broadcastable(log_jac_det, *broadcastable_axes)
+            except ValueError as err:
+                raise ValueError(
+                    f"The logp of {rv_op} and log_jac_det of {transform} are not allowed to broadcast together. "
+                    "There is a bug in the implementation of either one."
+                ) from err
 
         if use_jacobian:
             if value.name:

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -21,11 +21,11 @@ from pytensor.compile import SharedVariable
 from pytensor.graph.basic import Constant, Variable
 from pytensor.graph.traversal import walk
 from pytensor.tensor.elemwise import DimShuffle
-from pytensor.tensor.random.basic import RandomVariable
 from pytensor.tensor.random.type import RandomType
 from pytensor.tensor.type_other import NoneTypeT
 from pytensor.tensor.variable import TensorVariable
 
+from pymc.logprob.abstract import MeasurableOp
 from pymc.model import Model
 
 __all__ = [
@@ -41,20 +41,23 @@ def str_for_dist(dist: Variable, formatting: str = "plain", include_params: bool
     This can be either LaTeX or plain, optionally with distribution parameter
     values included.
     """
+    dist_op = dist.owner.op
+
     if include_params:
-        if isinstance(dist.owner.op, RandomVariable) or getattr(
-            dist.owner.op, "extended_signature", None
-        ):
+        try:
+            dist_args = dist.owner.op.dist_params(dist.owner)
+        except Exception:
+            # Can happen with SymbolicRandomVariable without extended_signature
             dist_args = [
-                _str_for_input_var(x, formatting=formatting)
-                for x in dist.owner.op.dist_params(dist.owner)
+                x for x in dist.owner.inputs if not isinstance(x.type, RandomType | NoneTypeT)
             ]
-        else:
-            dist_args = [
-                _str_for_input_var(x, formatting=formatting)
-                for x in dist.owner.inputs
-                if not isinstance(x.type, RandomType | NoneTypeT)
-            ]
+
+        dist_args_str = [_str_for_input_var(a, formatting=formatting) for a in dist_args]
+
+    if (print_name := getattr(dist_op, "_print_name", None)) is not None:
+        dist_name = print_name[formatting == "latex"]
+    else:
+        dist_name = "Unknown"
 
     print_name = dist.name
 
@@ -63,30 +66,22 @@ def str_for_dist(dist: Variable, formatting: str = "plain", include_params: bool
             print_name = r"\text{" + _latex_escape(print_name.strip("$")) + "}"
             print_name = _format_underscore(print_name)
 
-        op_name = (
-            dist.owner.op._print_name[1]
-            if hasattr(dist.owner.op, "_print_name")
-            else r"\\operatorname{Unknown}"
-        )
         if include_params:
-            params = ",~".join([d.strip("$") for d in dist_args])
+            params = ",~".join([d.strip("$") for d in dist_args_str])
             if print_name:
-                return rf"${print_name} \sim {op_name}({params})$"
+                return rf"${print_name} \sim {dist_name}({params})$"
             else:
-                return rf"${op_name}({params})$"
+                return rf"${dist_name}({params})$"
 
         else:
             if print_name:
-                return rf"${print_name} \sim {op_name}$"
+                return rf"${print_name} \sim {dist_name}$"
             else:
-                return rf"${op_name}$"
+                return rf"${dist_name}$"
 
     else:  # plain
-        dist_name = (
-            dist.owner.op._print_name[0] if hasattr(dist.owner.op, "_print_name") else "Unknown"
-        )
         if include_params:
-            params = ", ".join(dist_args)
+            params = ", ".join(dist_args_str)
             if print_name:
                 return rf"{print_name} ~ {dist_name}({params})"
             else:
@@ -169,10 +164,9 @@ def str_for_potential_or_deterministic(
 
 
 def _str_for_input_var(var: Variable, formatting: str) -> str:
-    # Avoid circular import
-    from pymc.distributions.distribution import SymbolicRandomVariable
-
     def _is_potential_or_deterministic(var: Variable) -> bool:
+        # FIXME: This is an (insufficient) hack. For model_repr we know which nodes are named variables
+        # and we should propagate that information instead of guessing based on whether something was monkey-patched
         if not hasattr(var, "str_repr"):
             return False
         try:
@@ -183,9 +177,7 @@ def _str_for_input_var(var: Variable, formatting: str) -> str:
 
     if isinstance(var, Constant | SharedVariable):
         return _str_for_constant(var, formatting)
-    elif isinstance(
-        var.owner.op, RandomVariable | SymbolicRandomVariable
-    ) or _is_potential_or_deterministic(var):
+    elif isinstance(var.owner.op, MeasurableOp) or _is_potential_or_deterministic(var):
         # show the names for RandomVariables, Deterministics, and Potentials, rather
         # than the full expression
         return _str_for_input_rv(var, formatting)
@@ -227,25 +219,23 @@ def _str_for_constant(var: Constant | SharedVariable, formatting: str) -> str:
 
 def _str_for_expression(var: Variable, formatting: str) -> str:
     # Avoid circular import
-    from pymc.distributions.distribution import SymbolicRandomVariable
 
     # construct a string like f(a1, ..., aN) listing all random variables a as arguments
     def _expand(x):
-        if x.owner and (not isinstance(x.owner.op, RandomVariable | SymbolicRandomVariable)):
+        if x.owner and not isinstance(x.owner.op, MeasurableOp):
             return reversed(x.owner.inputs)
 
     parents = []
     names = []
     for x in walk(nodes=var.owner.inputs, expand=_expand):
         assert isinstance(x, Variable)
-        if x.owner and isinstance(x.owner.op, RandomVariable | SymbolicRandomVariable):
+        if x.owner and isinstance(x.owner.op, MeasurableOp):
             parents.append(x)
             xname = x.name
             if xname is None:
                 # If the variable is unnamed, we show the op's name as we do
                 # with constants
-                opname = x.owner.op.name
-                if opname is not None:
+                if (opname := getattr(x.owner.op, "name", None)) is not None:
                     xname = rf"<{opname}>"
             assert xname is not None
             names.append(xname)

--- a/pymc/progress_bar/marimo_progress.py
+++ b/pymc/progress_bar/marimo_progress.py
@@ -183,12 +183,7 @@ class MarimoProgressBackend:
         self._task_state[task_id]["stats"] = stats
 
         if is_last:
-            # Ensure bar is fully filled on completion
-            total = self._task_state[task_id]["total"]
-            completed = self._task_state[task_id]["completed"]
-            remaining = total - completed
-            if remaining > 0:
-                self._task_state[task_id]["completed"] = total
+            self._task_state[task_id]["completed"] = self._task_state[task_id]["total"]
 
         self._render()
 

--- a/pymc/progress_bar/marimo_progress.py
+++ b/pymc/progress_bar/marimo_progress.py
@@ -20,6 +20,8 @@ from pymc.progress_bar.marimo_progress_css import DEFAULT_CSS
 
 def format_time(seconds: float) -> str:
     """Format elapsed time as mm:ss or hh:mm:ss."""
+    if seconds < 1:
+        return f"{seconds:.1f}s"
     minutes, secs = divmod(int(seconds), 60)
     hours, minutes = divmod(minutes, 60)
     if hours > 0:
@@ -201,24 +203,26 @@ class MarimoProgressBackend:
         """Generate HTML for all progress bars as a table with headers."""
         stat_keys = []
         if self.full_stats and self._task_state and self._task_state[0]["stats"]:
-            stat_keys = list(self._task_state[0]["stats"].keys())
+            stat_keys = [
+                k for k in self._task_state[0]["stats"].keys() if k != self.step_name.lower()
+            ]
 
         header_cells = ["Progress", self.step_name]
 
-        abbreviations = {
-            "divergences": "Div",
-            "diverging": "Div",
-            "step_size": "Step",
-            "tree_size": "Tree",
-            "tree_depth": "Depth",
-            "n_steps": "Steps",
-            "energy_error": "E-err",
-            "max_energy_error": "Max-E",
-            "mean_tree_accept": "Accept",
-            "scaling": "Scale",
+        column_names = {
+            "divergences": "Divergences",
+            "diverging": "Divergences",
+            "step_size": "Step size",
+            "tree_size": "Grad evals",
+            "tree_depth": "Tree depth",
+            "n_steps": "Grad evals",
+            "energy_error": "Energy error",
+            "max_energy_error": "Max energy error",
+            "mean_tree_accept": "Mean tree accept",
+            "scaling": "Scaling",
             "tune": "Tune",
         }
-        header_cells += [abbreviations.get(k, k[:6].capitalize()) for k in stat_keys]
+        header_cells += [column_names.get(k, k.replace("_", " ").capitalize()) for k in stat_keys]
 
         header_cells += ["Speed", "Elapsed"]
 

--- a/pymc/progress_bar/marimo_progress.py
+++ b/pymc/progress_bar/marimo_progress.py
@@ -114,6 +114,8 @@ class MarimoProgressBackend:
         self._mo_replace: Callable[[object], None] | None = None
         self._task_state: list[dict[str, Any]] = []
         self._start_times: list[float] = []
+        self._last_render_time: float = 0.0
+        self._min_render_interval: float = 0.1
 
     @property
     def is_enabled(self) -> bool:
@@ -187,7 +189,10 @@ class MarimoProgressBackend:
         if is_last:
             self._task_state[task_id]["completed"] = self._task_state[task_id]["total"]
 
-        self._render()
+        now = perf_counter()
+        if is_last or (now - self._last_render_time) >= self._min_render_interval:
+            self._last_render_time = now
+            self._render()
 
     def _render(self) -> None:
         """Render HTML progress display to marimo output."""
@@ -299,6 +304,8 @@ class MarimoSimpleProgress:
         self._mo_replace: Callable[[object], None] | None = None
         self._start_time: float = 0.0
         self._task_id = 0
+        self._last_render_time: float = 0.0
+        self._min_render_interval: float = 0.1
 
     def __enter__(self) -> Self:
         """Enter the context manager."""
@@ -313,7 +320,7 @@ class MarimoSimpleProgress:
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """Exit the context manager with final render."""
-        self._render()
+        self._render(force=True)
 
     def add_task(
         self, description: str, completed: int = 0, total: int | None = None, **kwargs
@@ -368,13 +375,18 @@ class MarimoSimpleProgress:
         if refresh:
             self._render()
 
-    def _render(self) -> None:
+    def _render(self, force: bool = False) -> None:
         """Render HTML progress to marimo output."""
         if self._mo_replace is None:
             return
 
+        now = perf_counter()
+        if not force and (now - self._last_render_time) < self._min_render_interval:
+            return
+
         import marimo as mo
 
+        self._last_render_time = now
         html = self._render_html()
         self._mo_replace(mo.Html(html))
 

--- a/pymc/progress_bar/progress.py
+++ b/pymc/progress_bar/progress.py
@@ -214,7 +214,7 @@ class MCMCProgressBarManager(ProgressBarManager):
     Tracks progress via draw count with support for tuning phases.
     """
 
-    step_name: str = "Draws"
+    step_name: str = "Draw"
 
     def __init__(
         self,
@@ -249,7 +249,7 @@ class MCMCProgressBarManager(ProgressBarManager):
         )
 
         progress_columns, progress_stats = step_method._progressbar_config(chains)
-        progress_stats["draws"] = [0] * chains
+        progress_stats["draw"] = [0] * chains
 
         self.progress_stats = progress_stats
         self.update_stats_functions = step_method._make_progressbar_update_functions()
@@ -318,7 +318,7 @@ class MCMCProgressBarManager(ProgressBarManager):
             chain_idx = 0
 
         failing, all_step_stats = self._extract_stats(stats)
-        all_step_stats["draws"] = draw + 1 if not self.combined_progress else draw
+        all_step_stats["draw"] = draw + 1 if not self.combined_progress else draw
 
         self._backend.update(
             task_id=chain_idx,

--- a/pymc/progress_bar/progress.py
+++ b/pymc/progress_bar/progress.py
@@ -310,13 +310,15 @@ class MCMCProgressBarManager(ProgressBarManager):
         if not self._show_progress:
             return
 
-        self.completed_draws += 1
+        if not is_last:
+            self.completed_draws += 1
+
         if self.combined_progress:
             draw = self.completed_draws
             chain_idx = 0
 
         failing, all_step_stats = self._extract_stats(stats)
-        all_step_stats["draws"] = draw
+        all_step_stats["draws"] = draw + 1 if not self.combined_progress else draw
 
         self._backend.update(
             task_id=chain_idx,

--- a/pymc/progress_bar/rich_progress.py
+++ b/pymc/progress_bar/rich_progress.py
@@ -199,7 +199,7 @@ class RichProgressBackend:
         columns += [
             TextColumn(
                 "{task.fields[sampling_speed]:0.2f} {task.fields[speed_unit]}",
-                table_column=Column("Sampling Speed", ratio=1),
+                table_column=Column("Speed", ratio=1),
             ),
             TimeElapsedColumn(table_column=Column("Elapsed", ratio=1)),
             TimeRemainingColumn(table_column=Column("Remaining", ratio=1)),
@@ -285,8 +285,6 @@ class RichProgressBackend:
             self._progress.update(
                 rich_task_id,
                 completed=self.total if not self.combined else self.total * self.n_bars,
-                sampling_speed=0,
-                speed_unit="",
                 failing=failing,
                 refresh=True,
                 **stats,

--- a/pymc/progress_bar/rich_progress.py
+++ b/pymc/progress_bar/rich_progress.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 from collections.abc import Iterable
+from sys import stderr
 from typing import Any, Self
 
 from rich.box import SIMPLE_HEAD
@@ -212,7 +213,7 @@ class RichProgressBackend:
                 finished_style=Style.parse("rgb(31,119,180)"),
             ),
             *columns,
-            console=Console(theme=theme),
+            console=Console(file=stderr, theme=theme),
             include_headers=True,
         )
 
@@ -323,5 +324,5 @@ def RichSimpleProgress(theme: Theme | None):
         TimeRemainingColumn(),
         TextColumn("/"),
         TimeElapsedColumn(),
-        console=Console(theme=default_progress_theme if theme is None else theme),
+        console=Console(file=stderr, theme=default_progress_theme if theme is None else theme),
     )

--- a/pymc/progress_bar/rich_progress.py
+++ b/pymc/progress_bar/rich_progress.py
@@ -231,7 +231,7 @@ class RichProgressBackend:
                 self._progress.add_task(
                     "Sampling",
                     completed=0,
-                    total=self.total * self.n_bars - 1,
+                    total=self.total * self.n_bars,
                     task_idx=0,
                     sampling_speed=0,
                     speed_unit="draws/s",
@@ -244,7 +244,7 @@ class RichProgressBackend:
                 self._progress.add_task(
                     "Sampling",
                     completed=0,
-                    total=self.total - 1,
+                    total=self.total,
                     task_idx=task_idx,
                     sampling_speed=0,
                     speed_unit="draws/s",
@@ -281,6 +281,18 @@ class RichProgressBackend:
         if rich_task_id is None:
             return
 
+        if is_last:
+            self._progress.update(
+                rich_task_id,
+                completed=self.total if not self.combined else self.total * self.n_bars,
+                sampling_speed=0,
+                speed_unit="",
+                failing=failing,
+                refresh=True,
+                **stats,
+            )
+            return
+
         self._progress.advance(rich_task_id, advance=advance)
 
         task = self._progress.tasks[task_id]
@@ -302,18 +314,6 @@ class RichProgressBackend:
             failing=failing,
             **stats,
         )
-
-        if is_last:
-            # Ensure bar is fully filled on completion
-            remaining = task.total - task.completed if task.total else 0
-            if remaining > 0:
-                self._progress.advance(rich_task_id, advance=remaining)
-            self._progress.update(
-                rich_task_id,
-                failing=failing,
-                **stats,
-                refresh=True,
-            )
 
 
 def RichSimpleProgress(theme: Theme | None):

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1124,18 +1124,10 @@ def _sample_return(
     else:
         traces, length = _choose_chains(traces, 0)
     mtrace = MultiTrace(traces)[:length]
-    # count the number of tune/draw iterations that happened
-    # ideally via the "tune" statistic, but not all samplers record it!
-    if "tune" in mtrace.stat_names:
-        # Get the tune stat directly from chain 0, sampler 0
-        stat = mtrace._straces[0].get_sampler_stats("tune", sampler_idx=0)
-        stat = tuple(stat)
-        n_tune = stat.count(True)
-        n_draws = stat.count(False)
-    else:
-        # these may be wrong when KeyboardInterrupt happened, but they're better than nothing
-        n_tune = min(tune, len(mtrace))
-        n_draws = max(0, len(mtrace) - n_tune)
+    # Count the number of tune/draw iterations that happened.
+    # The warmup/draw boundary is owned by the sampling driver.
+    n_tune = min(tune, len(mtrace))
+    n_draws = max(0, len(mtrace) - n_tune)
 
     if discard_tuned_samples:
         mtrace = mtrace[n_tune:]
@@ -1304,7 +1296,7 @@ def _sample(
     try:
         for it, stats in enumerate(sampling_gen):
             progress_manager.update(
-                chain_idx=chain, is_last=False, draw=it, stats=stats, tuning=it > tune
+                chain_idx=chain, is_last=False, draw=it, stats=stats, tuning=it < tune
             )
 
         if not progress_manager.combined_progress or chain == progress_manager.chains - 1:
@@ -1375,7 +1367,7 @@ def _iter_sample(
                 step.stop_tuning()
 
             point, stats = step.step(point)
-            trace.record(point, stats)
+            trace.record(point, stats, in_warmup=i < tune)
             log_warning_stats(stats)
 
             if callback is not None:
@@ -1488,7 +1480,7 @@ def _mp_sample(
                     strace = traces[draw.chain]
                     if not zarr_recording:
                         # Zarr recording happens in each process
-                        strace.record(draw.point, draw.stats)
+                        strace.record(draw.point, draw.stats, in_warmup=draw.tuning)
                     log_warning_stats(draw.stats)
 
                     if callback is not None:

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -249,7 +249,7 @@ class _Process:
                 raise KeyboardInterrupt()
             elif msg[0] == "write_next":
                 if zarr_recording:
-                    self._zarr_chain.record(point, stats)
+                    self._zarr_chain.record(point, stats, in_warmup=tuning)
                 self._write_point(point)
                 is_last = draw + 1 == self._draws + self._tune
                 self._msg_pipe.send(("writing_done", is_last, draw, tuning, stats))

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -458,7 +458,7 @@ def _iter_population(
                 # apply the update to the points and record to the traces
                 for c, strace in enumerate(traces):
                     points[c], stats = updates[c]
-                    flushed = strace.record(points[c], stats)
+                    flushed = strace.record(points[c], stats, in_warmup=i < tune)
                     log_warning_stats(stats)
                     if flushed and isinstance(strace, ZarrChain):
                         sampling_state = popstep.request_sampling_state(c)

--- a/pymc/smc/parallel.py
+++ b/pymc/smc/parallel.py
@@ -402,7 +402,9 @@ class ParallelSMCSampler:
                         sample_settings,
                     ) = result[2:]
 
-                    progress_manager.update(proc.chain, stage, beta, is_last=True)
+                    old_beta = chain_betas[proc.chain]
+                    chain_betas[proc.chain] = beta
+                    progress_manager.update(proc.chain, stage, beta, old_beta, is_last=True)
 
                     proc.join()
                     self._active.remove(proc)

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -414,7 +414,7 @@ def _build_trace_from_kernel_state(
                 var_samples = np.round(var_samples).astype(var.dtype)
             value.append(var_samples.reshape(shape))
             size += new_size
-        strace.record(point=dict(zip(varnames, value)))
+        strace.record(point=dict(zip(varnames, value)), in_warmup=False)
 
     return strace
 

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -482,7 +482,9 @@ def _sample_smc_sequentially(
 
                 stage += 1
 
-            progress_manager.update(chain_idx=i, stage=stage, beta=kernel.beta, is_last=True)
+            progress_manager.update(
+                chain_idx=i, stage=stage, beta=kernel.beta, old_beta=kernel.beta, is_last=True
+            )
 
             trace = _build_trace_from_kernel_state(
                 tempered_posterior=kernel.tempered_posterior,

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -273,7 +273,6 @@ class BaseHMC(GradientSharedStep):
         self.iter_count += 1
 
         stats: dict[str, Any] = {
-            "tune": self.tune,
             "diverging": diverging,
             "divergences": self.divergences,
             "perf_counter_diff": perf_end - perf_start,

--- a/pymc/step_methods/hmc/hmc.py
+++ b/pymc/step_methods/hmc/hmc.py
@@ -53,7 +53,6 @@ class HamiltonianMC(BaseHMC):
     stats_dtypes_shapes = {
         "step_size": (np.float64, []),
         "n_steps": (np.int64, []),
-        "tune": (bool, []),
         "step_size_bar": (np.float64, []),
         "accept": (np.float64, []),
         "diverging": (bool, []),

--- a/pymc/step_methods/hmc/nuts.py
+++ b/pymc/step_methods/hmc/nuts.py
@@ -110,7 +110,6 @@ class NUTS(BaseHMC):
     stats_dtypes_shapes = {
         "depth": (np.int64, []),
         "step_size": (np.float64, []),
-        "tune": (bool, []),
         "mean_tree_accept": (np.float64, []),
         "step_size_bar": (np.float64, []),
         "tree_size": (np.float64, []),

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -993,7 +993,7 @@ class DEMetropolis(PopulationArrayStepShared):
         self.steps_until_tune -= 1
 
         stats = {
-            "scaling": self.scaling,
+            "scaling": np.mean(self.scaling),
             "lambda": self.lamb,
             "accept": np.exp(accept),
             "accepted": accepted,

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -72,7 +72,6 @@ class Slice(ArrayStepShared):
     name = "slice"
     default_blocked = False
     stats_dtypes_shapes = {
-        "tune": (bool, []),
         "nstep_out": (int, []),
         "nstep_in": (int, []),
     }
@@ -184,7 +183,6 @@ class Slice(ArrayStepShared):
             self.n_tunes += 1
 
         stats = {
-            "tune": self.tune,
             "nstep_out": nstep_out,
             "nstep_in": nstep_in,
         }
@@ -202,18 +200,17 @@ class Slice(ArrayStepShared):
     @staticmethod
     def _progressbar_config(n_chains=1):
         columns = [
-            TextColumn("{task.fields[tune]}", table_column=Column("Tuning", ratio=1)),
             TextColumn("{task.fields[nstep_out]}", table_column=Column("Steps out", ratio=1)),
             TextColumn("{task.fields[nstep_in]}", table_column=Column("Steps in", ratio=1)),
         ]
 
-        stats = {"tune": [True] * n_chains, "nstep_out": [0] * n_chains, "nstep_in": [0] * n_chains}
+        stats = {"nstep_out": [0] * n_chains, "nstep_in": [0] * n_chains}
 
         return columns, stats
 
     @staticmethod
     def _make_progressbar_update_functions():
         def update_stats(step_stats):
-            return {key: step_stats[key] for key in {"tune", "nstep_out", "nstep_in"}}
+            return {key: step_stats[key] for key in {"nstep_out", "nstep_in"}}
 
         return (update_stats,)

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1598,7 +1598,7 @@ class Approximation(WithMemoization):
         try:
             trace.setup(draws=draws, chain=0)
             for point in points:
-                trace.record(point)
+                trace.record(point, in_warmup=False)
         finally:
             trace.close()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
 pymc-sphinx-theme>=0.16.0
-pytensor>=2.38.0,<2.39
+pytensor>=2.38.2,<2.39
 pytest-cov>=2.5
 pytest>=3.0
 rich>=13.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cachetools>=4.2.1,<7
 cloudpickle
 numpy>=1.25.0
 pandas>=0.24.0
-pytensor>=2.38.0,<2.39
+pytensor>=2.38.2,<2.39
 rich>=13.7.1
 scipy>=1.4.1
 threadpoolctl>=3.1.0,<4.0.0

--- a/tests/backends/fixtures.py
+++ b/tests/backends/fixtures.py
@@ -195,11 +195,11 @@ class ModelBackendSampledTestCase:
                 stats2 = [
                     {key: val[idx] for key, val in stats.items()} for stats in cls.expected_stats[1]
                 ]
-                strace0.record(point=point0, sampler_stats=stats1)
-                strace1.record(point=point1, sampler_stats=stats2)
+                strace0.record(point=point0, sampler_stats=stats1, in_warmup=False)
+                strace1.record(point=point1, sampler_stats=stats2, in_warmup=False)
             else:
-                strace0.record(point=point0)
-                strace1.record(point=point1)
+                strace0.record(point=point0, in_warmup=False)
+                strace1.record(point=point1, in_warmup=False)
         strace0.close()
         strace1.close()
         cls.mtrace = base.MultiTrace([strace0, strace1])
@@ -244,9 +244,9 @@ class SamplingTestCase(ModelBackendSetupTestCase):
         }
         if self.sampler_vars is not None:
             stats = [{key: dtype(val) for key, dtype in vars.items()} for vars in self.sampler_vars]
-            self.strace.record(point=point, sampler_stats=stats)
+            self.strace.record(point=point, sampler_stats=stats, in_warmup=False)
         else:
-            self.strace.record(point=point)
+            self.strace.record(point=point, in_warmup=False)
 
     def test_standard_close(self):
         for idx in range(self.draws):
@@ -270,7 +270,7 @@ class SamplingTestCase(ModelBackendSetupTestCase):
     def test_missing_stats(self):
         if self.sampler_vars is not None:
             with pytest.raises(ValueError):
-                self.strace.record(point=self.test_point)
+                self.strace.record(point=self.test_point, in_warmup=False)
 
     def test_clean_interrupt(self):
         self.record_point(0)

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -749,9 +749,9 @@ class TestPyMCWarmupHandling:
         post_prefix = "" if draws > 0 else "~"
         test_dict = {
             f"{post_prefix}posterior": ["u1", "n1"],
-            f"{post_prefix}sample_stats": ["~tune", "accept"],
+            f"{post_prefix}sample_stats": ["~in_warmup", "accept"],
             f"{warmup_prefix}warmup_posterior": ["u1", "n1"],
-            f"{warmup_prefix}warmup_sample_stats": ["~tune"],
+            f"{warmup_prefix}warmup_sample_stats": ["~in_warmup"],
             "~warmup_log_likelihood": [],
             "~log_likelihood": [],
         }
@@ -786,9 +786,9 @@ class TestPyMCWarmupHandling:
             idata = to_inference_data(trace, save_warmup=True)
             test_dict = {
                 "posterior": ["u1", "n1"],
-                "sample_stats": ["~tune", "accept"],
+                "sample_stats": ["~in_warmup", "accept"],
                 "warmup_posterior": ["u1", "n1"],
-                "warmup_sample_stats": ["~tune", "accept"],
+                "warmup_sample_stats": ["~in_warmup", "accept"],
             }
             fails = check_multiple_attrs(test_dict, idata)
             assert not fails
@@ -800,7 +800,7 @@ class TestPyMCWarmupHandling:
                 idata = to_inference_data(trace[-30:], save_warmup=True)
             test_dict = {
                 "posterior": ["u1", "n1"],
-                "sample_stats": ["~tune", "accept"],
+                "sample_stats": ["~in_warmup", "accept"],
                 "~warmup_posterior": [],
                 "~warmup_sample_stats": [],
             }

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -43,7 +43,7 @@ class TestInitTrace:
             B = pm.Uniform("B")
             strace = pm.backends.ndarray.NDArray(vars=[A, B])
             strace.setup(10, 0)
-            strace.record({"A": 2, "B_interval__": 0.1})
+            strace.record({"A": 2, "B_interval__": 0.1}, in_warmup=False)
             assert len(strace) == 1
             with pytest.raises(ValueError, match="Continuation of traces"):
                 _init_trace(

--- a/tests/backends/test_zarr.py
+++ b/tests/backends/test_zarr.py
@@ -132,7 +132,7 @@ def test_record(model, model_step, include_transformed, draws_per_chunk):
         else:
             manually_collected_draws.append(point)
             manually_collected_stats.append(stats)
-        trace.straces[0].record(point, stats)
+        trace.straces[0].record(point, stats, in_warmup=tuning)
     trace.straces[0].record_sampling_state(model_step)
     assert {group_name for group_name, _ in trace.root.groups()} == expected_groups
 

--- a/tests/dims/distributions/test_censored.py
+++ b/tests/dims/distributions/test_censored.py
@@ -1,0 +1,88 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import numpy as np
+import pytest
+
+from pytensor.xtensor import as_xtensor
+from pytensor.xtensor.shape import Transpose
+from pytensor.xtensor.vectorization import XRV
+
+import pymc.distributions as regular_distributions
+
+from pymc.dims import Censored, Normal
+from pymc.model.core import Model
+from tests.dims.utils import assert_equivalent_logp_graph, assert_equivalent_random_graph
+
+
+@pytest.mark.parametrize("lower", [None, -1])
+@pytest.mark.parametrize("upper", [None, 1])
+def test_censored_basic(lower, upper):
+    coords = {"space": range(3), "time": range(4)}
+
+    with Model(coords=coords) as model:
+        dist = Normal.dist(np.pi, np.e)
+        Censored("y", dist, lower=lower, upper=upper, dims=("space", "time"))
+
+    with Model(coords=coords) as reference_model:
+        dist = regular_distributions.Normal.dist(np.pi, np.e)
+        regular_distributions.Censored(
+            "y", dist=dist, lower=lower, upper=upper, dims=("space", "time")
+        )
+
+    assert_equivalent_random_graph(model, reference_model)
+    assert_equivalent_logp_graph(model, reference_model)
+
+
+def test_censored_dims():
+    """Test that both censored (and the underlying dist) have all the implied and explicit dims."""
+    coords = {
+        "a": range(3),
+        "b": range(4),
+        "c": range(5),
+        "d": range(6),
+    }
+    with Model(coords=coords) as model:
+        dist = Normal.dist(
+            mu=as_xtensor([0, 1, 2], dims=("a",)),
+            sigma=as_xtensor([1, 2, 3], dims=("b",)),
+            dim_lengths={"c": model.dim_lengths["c"]},
+        )
+        assert set(dist.dims) == {"c", "a", "b"}
+
+        c0 = Censored("c0", dist)
+        assert c0.dims == ("c", "a", "b")
+        c0_dist = c0.owner.inputs[0]
+        assert isinstance(c0_dist.owner.op, XRV)
+        assert c0_dist.dims == ("c", "a", "b")
+
+        c1 = Censored("c1", dist, dims=("a", "b", "c"))
+        assert c1.dims == ("a", "b", "c")
+        assert isinstance(c1.owner.op, Transpose)
+        c1_dist = c1.owner.inputs[0].owner.inputs[0]
+        assert isinstance(c1_dist.owner.op, XRV)
+        assert c1_dist.dims == ("c", "a", "b")
+
+        c2 = Censored("c2", dist, dims=(..., "d"))
+        assert c2.dims == ("c", "a", "b", "d")
+        assert isinstance(c1.owner.op, Transpose)
+        c2_dist = c2.owner.inputs[0].owner.inputs[0]
+        assert isinstance(c2_dist.owner.op, XRV)
+        assert c2_dist.dims == ("d", "c", "a", "b")
+
+        lower = as_xtensor(np.zeros((6, 5)), dims=("d", "c"))
+        c3 = Censored("c3", dist, lower=lower)
+        assert c3.dims == ("d", "c", "a", "b")
+        c3_dist = c3.owner.inputs[0]
+        assert isinstance(c3_dist.owner.op, XRV)
+        assert c3_dist.dims == ("d", "c", "a", "b")

--- a/tests/dims/distributions/test_vector.py
+++ b/tests/dims/distributions/test_vector.py
@@ -99,3 +99,23 @@ def test_zerosumnormal():
     # Logp is correct, but we have join(..., -1) and join(..., 1), that don't get canonicalized to the same
     # Should work once https://github.com/pymc-devs/pytensor/issues/1505 is fixed
     # assert_equivalent_logp_graph(model, reference_model)
+
+
+def test_zerosumnormal_batch_sigma():
+    coords = {"a": range(3), "b": range(5)}
+    sigma = np.array([1, 2, 3.0])
+    with Model(coords=coords) as model:
+        ZeroSumNormal(
+            "x",
+            sigma=as_xtensor(sigma, dims=("a",)),
+            core_dims=("b",),
+        )
+
+    with Model(coords=coords) as ref_model:
+        regular_distributions.ZeroSumNormal("x", sigma=sigma[:, None], dims=("a", "b"))
+
+    ip = model.initial_point()
+    np.testing.assert_allclose(
+        model.compile_logp(sum=False)(ip),
+        ref_model.compile_logp(sum=False)(ip),
+    )

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -1763,6 +1763,13 @@ class TestZeroSumNormal:
                 sigma=batch_test_sigma[None, :, None], n_zerosum_axes=2, support_shape=(3, 2)
             )
 
+    def test_batched_transformed_logp_shape(self):
+        with pm.Model() as m:
+            x = pm.ZeroSumNormal("x", sigma=np.ones(3)[:, None], support_shape=(2,))
+            assert x.type.shape == (3, 2)
+        assert m.logp(sum=False)[0].type.shape == (3,)
+        assert m.logp(sum=False, jacobian=False)[0].type.shape == (3,)
+
 
 class TestMvStudentTCov(BaseTestDistributionRandom):
     def mvstudentt_rng_fn(self, size, nu, mu, scale, rng):

--- a/tests/distributions/test_random_alternative_backends.py
+++ b/tests/distributions/test_random_alternative_backends.py
@@ -11,8 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from contextlib import nullcontext
-
 import numpy as np
 import pytest
 
@@ -44,15 +42,13 @@ def test_dirichlet_multinomial_dims(mode):
     with pm.Model(coords={"trial": range(3), "item": range(3)}) as m:
         dm = DirichletMultinomial("dm", n=5, a=np.eye(3) * 1e6 + 0.01, dims=("trial", "item"))
 
-    # JAX does not allow us to JIT a function with dynamic shape
-    expected_ctxt = pytest.raises(TypeError) if mode == "JAX" else nullcontext()
-    with expected_ctxt:
-        pm.draw(dm, mode=mode)
-
-    # Should be fine after freezing the dims that specify the shape
-    frozen_dm = freeze_dims_and_data(m)["dm"]
-    dm_draws = pm.draw(frozen_dm, mode=mode, random_seed=36)
+    dm_draws = pm.draw(dm, mode=mode, random_seed=36)
     np.testing.assert_equal(dm_draws, np.eye(3) * 5)
+
+    # Should also work after freezing the dims that specify the shape
+    frozen_dm = freeze_dims_and_data(m)["dm"]
+    frozen_dm_draws = pm.draw(frozen_dm, mode=mode, random_seed=36)
+    np.testing.assert_equal(frozen_dm_draws, np.eye(3) * 5)
 
 
 def test_mvstudentt(mode):

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -657,12 +657,12 @@ def test_invalid_jacobian_broadcast_raises():
 
     buggy_transform = BuggyTransform()
 
-    with pm.Model() as m:
-        pm.Uniform("x", shape=(4, 3), default_transform=buggy_transform)
+    import numpy as np
 
     for jacobian_val in (True, False):
-        with pytest.raises(
-            ValueError,
-            match="are not allowed to broadcast together. There is a bug in the implementation of either one",
-        ):
-            m.logp(jacobian=jacobian_val)
+        with pm.Model() as m:
+            pm.Uniform("x", shape=(4, 3), default_transform=buggy_transform)
+
+        logp_fn = m.compile_logp(jacobian=jacobian_val)
+        with pytest.raises(AssertionError, match="SpecifyShape"):
+            logp_fn({"x_buggy__": np.zeros((4, 3))})

--- a/tests/logprob/test_transform_value.py
+++ b/tests/logprob/test_transform_value.py
@@ -578,6 +578,20 @@ def test_scan_transform():
     np.testing.assert_allclose(logp_fn(**test_point), ref_logp_fn(**test_point))
 
 
+def test_halfstudent_t_with_frozen_dims():
+    """Regression test: log_jac_det had mismatched broadcastable dims vs logp when
+    dims were frozen to a single-element coordinate, causing a ValueError.
+    """
+    from pymc.model.transform.optimization import freeze_dims_and_data
+
+    with pm.Model(coords={"x_dim": ["only_one"]}) as model:
+        pm.HalfStudentT("x", nu=7, sigma=1, dims="x_dim")
+
+    fmodel = freeze_dims_and_data(model)
+    [x_logp] = fmodel.logp(sum=False)
+    assert x_logp.type.shape == (1,)
+
+
 def test_weakref_leak():
     """Check that the rewrite does not have a growing memory footprint.
 

--- a/tests/progress_bar/test_manager.py
+++ b/tests/progress_bar/test_manager.py
@@ -12,11 +12,143 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from unittest.mock import patch
+
 import pytest
 
 import pymc as pm
 
-from pymc.progress_bar import MCMCProgressBarManager
+from pymc.progress_bar import MCMCProgressBarManager, SMCProgressBarManager
+from pymc.smc.kernels import IMH
+
+NUTS_DUMMY_STATS = [{"divergences": 0, "step_size": 0.5, "tree_size": 7}]
+
+
+@pytest.fixture
+def imh_kernel():
+    with pm.Model():
+        pm.Normal("x", 0, 1)
+        kernel = IMH()
+    return kernel
+
+
+def _get_task(manager, idx=0):
+    return manager._backend._progress.tasks[idx]
+
+
+def test_mcmc_split_bar_starts_at_zero_ends_at_total():
+    draws, tune, chains = 10, 5, 2
+    captured = {}
+
+    orig_init = MCMCProgressBarManager.__init__
+
+    def capturing_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        captured["manager"] = self
+
+    with patch.object(MCMCProgressBarManager, "__init__", capturing_init):
+        with pm.Model():
+            pm.Normal("x")
+            pm.sample(
+                draws=draws,
+                tune=tune,
+                chains=chains,
+                cores=1,
+                progressbar=True,
+                compute_convergence_checks=False,
+            )
+
+    manager = captured["manager"]
+    total = draws + tune
+    for chain in range(chains):
+        task = _get_task(manager, chain)
+        assert task.completed == task.total == total
+        assert task.fields["draws"] == total
+
+
+def test_mcmc_combined_bar_ends_at_total():
+    draws, tune, chains = 10, 5, 2
+    captured = {}
+
+    orig_init = MCMCProgressBarManager.__init__
+
+    def capturing_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        captured["manager"] = self
+
+    with patch.object(MCMCProgressBarManager, "__init__", capturing_init):
+        with pm.Model():
+            pm.Normal("x")
+            pm.sample(
+                draws=draws,
+                tune=tune,
+                chains=chains,
+                cores=1,
+                progressbar="combined+stats",
+                compute_convergence_checks=False,
+            )
+
+    manager = captured["manager"]
+    total = (draws + tune) * chains
+    task = _get_task(manager, 0)
+    assert task.completed == task.total == total
+    assert task.fields["draws"] == total
+
+
+def test_mcmc_draws_stat_shows_completed_count():
+    with pm.Model():
+        pm.Normal("x")
+        step = pm.NUTS()
+
+    manager = MCMCProgressBarManager(step_method=step, chains=1, draws=10, tune=5, progressbar=True)
+
+    with manager:
+        manager.update(chain_idx=0, is_last=False, draw=0, tuning=True, stats=NUTS_DUMMY_STATS)
+        assert _get_task(manager).fields["draws"] == 1
+
+        for i in range(1, 15):
+            manager.update(
+                chain_idx=0, is_last=i == 14, draw=i, tuning=i < 5, stats=NUTS_DUMMY_STATS
+            )
+        assert _get_task(manager).fields["draws"] == 15
+
+
+def test_smc_bar_starts_at_zero_ends_at_one(imh_kernel):
+    manager = SMCProgressBarManager(kernel=imh_kernel, chains=1, progressbar=True)
+
+    with manager:
+        task = _get_task(manager)
+        assert task.total == 1.0
+        assert task.completed == 0
+        assert task.percentage == 0.0
+
+        betas = [0.2, 0.5, 0.8, 1.0]
+        old_beta = 0.0
+        for stage, beta in enumerate(betas):
+            manager.update(
+                chain_idx=0, stage=stage, beta=beta, old_beta=old_beta, is_last=beta >= 1.0
+            )
+            old_beta = beta
+
+        task = _get_task(manager)
+        assert task.completed == pytest.approx(task.total)
+        assert task.fields["beta"] == pytest.approx(1.0)
+
+
+def test_smc_multi_chain(imh_kernel):
+    chains = 3
+    manager = SMCProgressBarManager(kernel=imh_kernel, chains=chains, progressbar=True)
+
+    with manager:
+        for chain in range(chains):
+            assert _get_task(manager, chain).completed == 0
+
+        for chain in range(chains):
+            manager.update(chain_idx=chain, stage=0, beta=0.4, old_beta=0.0)
+            manager.update(chain_idx=chain, stage=1, beta=1.0, old_beta=0.4, is_last=True)
+
+        for chain in range(chains):
+            assert _get_task(manager, chain).completed == pytest.approx(1.0)
 
 
 def test_progressbar_nested_compound():
@@ -47,79 +179,3 @@ def test_progressbar_nested_compound():
             pm.sample(**kwargs, cores=cores, progressbar="combined")
             pm.sample(**kwargs, cores=cores, progressbar="split")
             pm.sample(**kwargs, cores=cores, progressbar=False)
-
-
-class TestProgressBarManagerConfiguration:
-    @pytest.fixture
-    def step_method(self):
-        with pm.Model():
-            x = pm.Normal("x")
-            step = pm.NUTS([x])
-        return step
-
-    def test_init_split_mode(self, step_method):
-        manager = MCMCProgressBarManager(
-            step_method=step_method,
-            chains=2,
-            draws=100,
-            tune=50,
-            progressbar=True,
-        )
-        assert manager.combined_progress is False
-        assert manager.full_stats is True
-        assert manager._show_progress is True
-        assert manager.chains == 2
-        assert manager.total_draws == 150
-
-    def test_init_combined_mode(self, step_method):
-        manager = MCMCProgressBarManager(
-            step_method=step_method,
-            chains=2,
-            draws=100,
-            tune=50,
-            progressbar="combined",
-        )
-        assert manager.combined_progress is True
-        assert manager.full_stats is False
-
-    def test_init_combined_stats_mode(self, step_method):
-        manager = MCMCProgressBarManager(
-            step_method=step_method,
-            chains=2,
-            draws=100,
-            tune=50,
-            progressbar="combined+stats",
-        )
-        assert manager.combined_progress is True
-        assert manager.full_stats is True
-
-    def test_init_split_stats_mode(self, step_method):
-        manager = MCMCProgressBarManager(
-            step_method=step_method,
-            chains=2,
-            draws=100,
-            tune=50,
-            progressbar="split+stats",
-        )
-        assert manager.combined_progress is False
-        assert manager.full_stats is True
-
-    def test_init_disabled(self, step_method):
-        manager = MCMCProgressBarManager(
-            step_method=step_method,
-            chains=2,
-            draws=100,
-            tune=50,
-            progressbar=False,
-        )
-        assert manager._show_progress is False
-
-    def test_invalid_progressbar_value(self, step_method):
-        with pytest.raises(ValueError, match="Invalid value for `progressbar`"):
-            MCMCProgressBarManager(
-                step_method=step_method,
-                chains=2,
-                draws=100,
-                tune=50,
-                progressbar="invalid",
-            )

--- a/tests/progress_bar/test_manager.py
+++ b/tests/progress_bar/test_manager.py
@@ -63,7 +63,7 @@ def test_mcmc_split_bar_starts_at_zero_ends_at_total():
     for chain in range(chains):
         task = _get_task(manager, chain)
         assert task.completed == task.total == total
-        assert task.fields["draws"] == total
+        assert task.fields["draw"] == total
 
 
 def test_mcmc_combined_bar_ends_at_total():
@@ -92,7 +92,7 @@ def test_mcmc_combined_bar_ends_at_total():
     total = (draws + tune) * chains
     task = _get_task(manager, 0)
     assert task.completed == task.total == total
-    assert task.fields["draws"] == total
+    assert task.fields["draw"] == total
 
 
 def test_mcmc_draws_stat_shows_completed_count():
@@ -104,13 +104,13 @@ def test_mcmc_draws_stat_shows_completed_count():
 
     with manager:
         manager.update(chain_idx=0, is_last=False, draw=0, tuning=True, stats=NUTS_DUMMY_STATS)
-        assert _get_task(manager).fields["draws"] == 1
+        assert _get_task(manager).fields["draw"] == 1
 
         for i in range(1, 15):
             manager.update(
                 chain_idx=0, is_last=i == 14, draw=i, tuning=i < 5, stats=NUTS_DUMMY_STATS
             )
-        assert _get_task(manager).fields["draws"] == 15
+        assert _get_task(manager).fields["draw"] == 15
 
 
 def test_smc_bar_starts_at_zero_ends_at_one(imh_kernel):

--- a/tests/progress_bar/test_marimo.py
+++ b/tests/progress_bar/test_marimo.py
@@ -107,3 +107,35 @@ class TestMarimoProgressBackend:
             html = backend._render_html()
 
             assert "0.25" in html or "Step" in html
+
+    def test_is_last_sets_completed_to_total(self):
+        backend = MarimoProgressBackend(
+            step_name="Draws", n_bars=2, total=150, combined=False, full_stats=False
+        )
+        backend._initialize_tasks()
+
+        for _ in range(150):
+            backend.update(task_id=0, advance=1, failing=False, stats={}, is_last=False)
+        backend.update(task_id=0, advance=1, failing=False, stats={}, is_last=True)
+
+        assert backend._task_state[0]["completed"] == 150
+        assert backend._task_state[1]["completed"] == 0
+
+    def test_marimo_smc_progress(self):
+        backend = MarimoProgressBackend(
+            step_name="Stage", n_bars=1, total=1.0, combined=False, full_stats=False
+        )
+        backend._initialize_tasks()
+
+        assert backend._task_state[0]["total"] == 1.0
+        assert backend._task_state[0]["completed"] == 0
+
+        betas = [0.3, 0.7, 1.0]
+        old = 0.0
+        for beta in betas:
+            backend.update(
+                task_id=0, advance=beta - old, failing=False, stats={}, is_last=beta >= 1.0
+            )
+            old = beta
+
+        assert backend._task_state[0]["completed"] == 1.0

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -35,6 +35,7 @@ from scipy import stats
 import pymc as pm
 
 from pymc.backends.base import MultiTrace
+from pymc.distributions.shape_utils import change_dist_size
 from pymc.model.transform.optimization import freeze_dims_and_data
 from pymc.pytensorf import compile, rvs_in_graph
 from pymc.sampling.forward import (
@@ -1988,3 +1989,12 @@ def test_vectorize_over_posterior_with_intermediate_rvs():
     assert np.array_equiv(a_ancestor1.eval(), idata.posterior.a.data)
     assert isinstance(a_ancestor2, TensorConstant)
     assert np.array_equiv(a_ancestor2.eval(), idata.posterior.a.data)
+
+
+def test_change_dist_size_zero_sum_normal():
+    with pm.Model():
+        intercept = pm.ZeroSumNormal("intercept", sigma=1.0, shape=2)
+
+    resized = change_dist_size(intercept, new_size=(10,), expand=True)
+
+    assert resized.type.shape == (10, 2)

--- a/tests/step_methods/hmc/test_nuts.py
+++ b/tests/step_methods/hmc/test_nuts.py
@@ -157,7 +157,6 @@ class TestNutsCheckTrace:
             "step_size",
             "step_size_bar",
             "tree_size",
-            "tune",
             "perf_counter_diff",
             "perf_counter_start",
             "process_time_diff",

--- a/tests/step_methods/test_compound.py
+++ b/tests/step_methods/test_compound.py
@@ -36,11 +36,11 @@ from tests.helpers import StepMethodTester
 from tests.models import simple_2model_continuous
 
 
-def test_all_stepmethods_emit_tune_stat():
+def test_stepmethods_do_not_require_tune_stat():
     step_types = pm.step_methods.STEP_METHODS
     assert len(step_types) > 5
     for cls in step_types:
-        assert "tune" in cls.stats_dtypes_shapes
+        assert "tune" not in cls.stats_dtypes_shapes
 
 
 class TestCompoundStep:

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -319,6 +319,57 @@ def test_custom_dist_repr():
     assert str_repr == "\n".join(["x ~ CustomDistNormal", "y ~ CustomRandomNormal"])
 
 
+class TestDimsDist:
+    def setup_class(self):
+        from pymc.dims.distributions import Normal as DimsNormal
+        from pymc.dims.distributions import ZeroSumNormal as DimsZeroSumNormal
+
+        with Model(coords={"group": range(3), "obs": range(5)}) as self.model:
+            mu = DimsNormal("mu", 0, 10, dims=("group",))
+            sigma = DimsNormal("sigma", 0, 1)
+            zsn = DimsZeroSumNormal("zsn", sigma=1, core_dims="group")
+            DimsNormal("y", mu + zsn, sigma, dims=("obs", "group"))
+
+        self.expected = {
+            ("plain", True): [
+                r"mu ~ Normal(0, 10)",
+                r"sigma ~ Normal(0, 1)",
+                r"zsn ~ ZeroSumNormal(f(), f())",
+                r"y ~ Normal(f(mu, zsn), sigma)",
+            ],
+            ("plain", False): [
+                r"mu ~ Normal",
+                r"sigma ~ Normal",
+                r"zsn ~ ZeroSumNormal",
+                r"y ~ Normal",
+            ],
+            ("latex", True): [
+                r"\text{mu} &\sim & \operatorname{Normal}(0,~10)",
+                r"\text{sigma} &\sim & \operatorname{Normal}(0,~1)",
+                r"\text{zsn} &\sim & \operatorname{ZeroSumNormal}(f(),~f())",
+                r"\text{y} &\sim & \operatorname{Normal}(f(\text{mu},~\text{zsn}),~\text{sigma})",
+            ],
+            ("latex", False): [
+                r"\text{mu} &\sim & \operatorname{Normal}",
+                r"\text{sigma} &\sim & \operatorname{Normal}",
+                r"\text{zsn} &\sim & \operatorname{ZeroSumNormal}",
+                r"\text{y} &\sim & \operatorname{Normal}",
+            ],
+        }
+
+    def test_str_repr(self):
+        for formatting, include_params in [("plain", True), ("plain", False)]:
+            model_text = self.model.str_repr(formatting=formatting, include_params=include_params)
+            for text in self.expected[(formatting, include_params)]:
+                assert text in model_text
+
+    def test_latex_repr(self):
+        for formatting, include_params in [("latex", True), ("latex", False)]:
+            model_text = self.model.str_repr(formatting=formatting, include_params=include_params)
+            for text in self.expected[(formatting, include_params)]:
+                assert text in model_text
+
+
 class TestLatexRepr:
     @staticmethod
     def simple_model() -> Model:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Implements the ZeroOneInflatedBeta as a new distribution, which models proportion data on [0, 1] with zeros and ones in excess. 

The distribution uses the following parameterizations:
- zoi (zero-or-one inflation probability)
- coi (conditional probability of one given a boundary value)
- mu/kappa (mean/precision) for the Beta component
- alpha/beta as an alternate parameterization for the Beta component

Setting zoi to 0 recovers the Beta distribution.
For zoi ≠ 0:
- Setting coi = 0 recovers Zero-Inflated Beta (ZIB)
- Setting coi = 1 recovers One-Inflated Beta (OIB)

## Related Issue
- [ ] Closes #
- [x] Related to # 8190

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Notes
rv_op is set to None. I would appreciate maintainer guidance on the preferred approach to implement for sampling-dependent tests. 

The example notebook, as well as the logp and support_point tests, will be added soon. 