### PR TITLE
Speedup PyMC import

### DIFF
--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -22,7 +22,7 @@ dependencies:
 - numpyro>=0.8.0
 - pandas>=0.24.0
 - pip
-- pytensor>=3.0,<3.1
+- pytensor>=3.0.2,<3.1
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=3.0,<3.1
+- pytensor>=3.0.2,<3.1
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -11,7 +11,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=3.0,<3.1
+- pytensor>=3.0.2,<3.1
 - python-graphviz
 - rich>=13.7.1
 - scipy>=1.4.1

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -15,7 +15,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=3.0,<3.1
+- pytensor>=3.0.2,<3.1
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=3.0,<3.1
+- pytensor>=3.0.2,<3.1
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -16,7 +16,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=3.0,<3.1
+- pytensor>=3.0.2,<3.1
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -59,7 +59,7 @@ from pymc.model_graph import model_to_graphviz, model_to_mermaid, model_to_netwo
 from pymc.pytensorf import compile
 from pymc.sampling import *
 from pymc.smc import *
-from pymc.stats import compute_log_likelihood
+from pymc.stats.log_density import compute_log_likelihood
 from pymc.step_methods import *
 from pymc.tuning import *
 from pymc.variational import *

--- a/pymc/backends/__init__.py
+++ b/pymc/backends/__init__.py
@@ -63,6 +63,9 @@ Saved backends can be loaded using `arviz.from_netcdf`
 
 from __future__ import annotations
 
+import importlib.util
+import warnings
+
 from collections.abc import Mapping, Sequence
 from copy import copy
 from typing import TYPE_CHECKING, Optional, TypeAlias, Union
@@ -106,16 +109,14 @@ class _ZarrTraceBase:
     def split_warmup_groups(self) -> None: ...
 
 
-HAS_MCB = False
-try:
-    from mcbackend import Backend, Run
+HAS_MCB = importlib.util.find_spec("mcbackend") is not None
 
-    from pymc.backends.mcbackend import init_chain_adapters
+if TYPE_CHECKING and HAS_MCB:
+    from mcbackend import Backend, Run
 
     TraceOrBackend: TypeAlias = BaseTrace | Backend
     RunType: TypeAlias = Run
-    HAS_MCB = True
-except ImportError:
+else:
     TraceOrBackend = BaseTrace  # type: ignore[assignment, misc]
     RunType = type(None)  # type: ignore[assignment, misc]
 
@@ -180,14 +181,26 @@ def init_traces(
             test_point=initial_point,
         )
         return None, backend.straces
-    if HAS_MCB and isinstance(backend, Backend):
-        return init_chain_adapters(
-            backend=backend,
-            chains=chains,
-            initial_point=initial_point,
-            step=step,
-            model=model,
-        )
+    if HAS_MCB:
+        try:
+            with warnings.catch_warnings():
+                # mcbackend touches arviz.InferenceData on import; the
+                # MigrationWarning is emitted from arviz, so filter by message.
+                warnings.filterwarnings("ignore", "arviz.InferenceData")
+                from mcbackend import Backend
+        except ImportError:
+            pass
+        else:
+            if isinstance(backend, Backend):
+                from pymc.backends.mcbackend import init_chain_adapters
+
+                return init_chain_adapters(
+                    backend=backend,
+                    chains=chains,
+                    initial_point=initial_point,
+                    step=step,
+                    model=model,
+                )
 
     assert backend is None or isinstance(backend, BaseTrace)
     traces = [

--- a/pymc/backends/__init__.py
+++ b/pymc/backends/__init__.py
@@ -61,9 +61,11 @@ Saved backends can be loaded using `arviz.from_netcdf`
 
 """
 
+from __future__ import annotations
+
 from collections.abc import Mapping, Sequence
 from copy import copy
-from typing import Optional, TypeAlias, Union
+from typing import TYPE_CHECKING, Optional, TypeAlias, Union
 
 import numpy as np
 
@@ -72,10 +74,37 @@ from pytensor.tensor.variable import TensorVariable
 from pymc.backends.arviz import predictions_to_inference_data, to_inference_data
 from pymc.backends.base import BaseTrace, IBaseTrace
 from pymc.backends.ndarray import NDArray
-from pymc.backends.zarr import ZarrTrace
 from pymc.blocking import PointType
 from pymc.model import Model
 from pymc.step_methods.compound import BlockedStep, CompoundStep
+
+if TYPE_CHECKING:
+    from pymc.backends.zarr import ZarrTrace
+
+
+class _ZarrChainBase:
+    """Marker base for :class:`pymc.backends.zarr.ZarrChain`.
+
+    Importing the real class pulls the optional ``zarr`` dependency. Callers that
+    only need an ``isinstance`` check (e.g. dispatch in ``pymc.sampling``) can
+    import this base instead and skip the zarr import. The method stubs mirror
+    the subset of ``ZarrChain`` invoked through this base so type checkers can
+    validate calls guarded by ``isinstance(_, _ZarrChainBase)``.
+    """
+
+    def link_stepper(self, step_method) -> None: ...
+    def record_sampling_state(self, step=None) -> None: ...
+    def store_sampling_state(self, sampling_state) -> None: ...
+
+
+class _ZarrTraceBase:
+    """Marker base for :class:`pymc.backends.zarr.ZarrTrace`. See ``_ZarrChainBase``."""
+
+    straces: Sequence[BaseTrace]
+
+    def init_trace(self, *args, **kwargs) -> None: ...
+    def split_warmup_groups(self) -> None: ...
+
 
 HAS_MCB = False
 try:
@@ -92,6 +121,15 @@ except ImportError:
 
 
 __all__ = ["predictions_to_inference_data", "to_inference_data"]
+
+
+# ZarrTrace requires the optional zarr dependency, so we keep it lazy.
+def __getattr__(name):
+    if name == "ZarrTrace":
+        from pymc.backends.zarr import ZarrTrace
+
+        return ZarrTrace
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _init_trace(
@@ -131,7 +169,7 @@ def init_traces(
     tune: int = 0,
 ) -> tuple[RunType | None, Sequence[IBaseTrace]]:
     """Initialize a trace recorder for each chain."""
-    if isinstance(backend, ZarrTrace):
+    if isinstance(backend, _ZarrTraceBase):
         backend.init_trace(
             chains=chains,
             draws=expected_length - tune,

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -13,6 +13,8 @@
 #   limitations under the License.
 """PyMC-ArviZ conversion code."""
 
+from __future__ import annotations
+
 import json
 import logging
 import warnings
@@ -21,17 +23,12 @@ from collections.abc import Iterable, Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
-    Optional,
-    Union,
     cast,
 )
 
 import numpy as np
 import xarray
 
-from arviz_base import dict_to_dataset, make_attrs, rcParams
-from arviz_base.base import requires
-from arviz_base.types import CoordSpec, DimSpec
 from pytensor.graph import ancestors
 from pytensor.tensor.sharedvar import SharedVariable
 from rich.progress import Console
@@ -46,7 +43,43 @@ from pymc.pytensorf import PointFunc, extract_obs_data
 from pymc.util import get_default_varnames
 
 if TYPE_CHECKING:
+    from arviz_base.types import CoordSpec, DimSpec
+
     from pymc.backends.base import MultiTrace
+
+
+class requires:
+    """Decorator that returns None if all required attributes on the wrapped instance are None."""
+
+    def __init__(self, *props):
+        self.props = props
+
+    def __call__(self, func):
+        def wrapped(cls):
+            for prop in self.props:
+                prop_list = [prop] if isinstance(prop, str) else prop
+                if all(getattr(cls, prop_i) is None for prop_i in prop_list):
+                    return None
+            return func(cls)
+
+        return wrapped
+
+
+# Self-replacing lazy stubs. First call imports arviz_base, rebinds the module-level
+# name to the real implementation, then forwards. Subsequent calls go straight to it.
+def dict_to_dataset(*args, **kwargs):  # noqa: F811
+    global dict_to_dataset
+    from arviz_base import dict_to_dataset
+
+    return dict_to_dataset(*args, **kwargs)
+
+
+def make_attrs(*args, **kwargs):  # noqa: F811
+    global make_attrs
+    from arviz_base import make_attrs
+
+    return make_attrs(*args, **kwargs)
+
 
 ___all__ = [""]
 
@@ -101,7 +134,7 @@ def dict_to_dataset_drop_incompatible_coords(
     return ds
 
 
-def find_observations(model: "Model") -> dict[str, Var]:
+def find_observations(model: Model) -> dict[str, Var]:
     """If there are observations available, return them as a dictionary."""
     observations = {}
     for obs in model.observed_RVs:
@@ -118,7 +151,7 @@ def find_observations(model: "Model") -> dict[str, Var]:
     return observations
 
 
-def find_constants(model: "Model") -> dict[str, Var]:
+def find_constants(model: Model) -> dict[str, Var]:
     """If there are constants available, return them as a dictionary."""
     model_vars = model.basic_RVs + model.deterministics + model.potentials
     value_vars = set(model.rvs_to_values.values())
@@ -141,7 +174,7 @@ def find_constants(model: "Model") -> dict[str, Var]:
 
 def patch_nutpie_idata(
     idata: DataTree,
-    model: "Model",
+    model: Model,
     sampling_time: float,
 ) -> None:
     """Fix up the ``DataTree`` returned by ``nutpie.sample`` in place.
@@ -271,7 +304,11 @@ class DataTreeConverter:
         save_warmup: bool | None = None,
         include_transformed: bool = False,
     ):
-        self.save_warmup = rcParams["data.save_warmup"] if save_warmup is None else save_warmup
+        if save_warmup is None:
+            from arviz_base import rcParams
+
+            save_warmup = rcParams["data.save_warmup"]
+        self.save_warmup = save_warmup
         self.include_transformed = include_transformed
         self.trace = trace
 
@@ -325,7 +362,7 @@ class DataTreeConverter:
 
         self.observations = find_observations(self.model)
 
-    def split_trace(self) -> tuple[Union[None, "MultiTrace"], Union[None, "MultiTrace"]]:
+    def split_trace(self) -> tuple[MultiTrace | None, MultiTrace | None]:
         """Split MultiTrace object into posterior and warmup.
 
         Returns
@@ -574,7 +611,7 @@ class DataTreeConverter:
 
 
 def to_inference_data(
-    trace: Optional["MultiTrace"] = None,
+    trace: MultiTrace | None = None,
     *,
     prior: Mapping[str, Any] | None = None,
     posterior_predictive: Mapping[str, Any] | None = None,
@@ -583,7 +620,7 @@ def to_inference_data(
     coords: CoordSpec | None = None,
     dims: DimSpec | None = None,
     sample_dims: list | None = None,
-    model: "Model" = None,
+    model: Model = None,
     save_warmup: bool | None = None,
     include_transformed: bool = False,
 ) -> DataTree:
@@ -651,8 +688,8 @@ def to_inference_data(
 ### perhaps we should have an inplace argument?
 def predictions_to_inference_data(
     predictions,
-    posterior_trace: Optional["MultiTrace"] = None,
-    model: Optional["Model"] = None,
+    posterior_trace: MultiTrace | None = None,
+    model: Model | None = None,
     coords: CoordSpec | None = None,
     dims: DimSpec | None = None,
     sample_dims: list | None = None,

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -586,7 +586,7 @@ def to_inference_data(
     model: "Model" = None,
     save_warmup: bool | None = None,
     include_transformed: bool = False,
-) -> xarray.DataTree:
+) -> DataTree:
     """Convert pymc data into an InferenceData object.
 
     All three of them are optional arguments, but at least one of ``trace``,
@@ -627,7 +627,7 @@ def to_inference_data(
 
     Returns
     -------
-    xarray.DataTree
+    DataTree
     """
     if isinstance(trace, DataTree):
         return trace
@@ -656,9 +656,9 @@ def predictions_to_inference_data(
     coords: CoordSpec | None = None,
     dims: DimSpec | None = None,
     sample_dims: list | None = None,
-    idata_orig: xarray.DataTree | None = None,
+    idata_orig: DataTree | None = None,
     inplace: bool = False,
-) -> xarray.DataTree:
+) -> DataTree:
     """Translate out-of-sample predictions into ``DataTree``.
 
     Parameters

--- a/pymc/backends/zarr.py
+++ b/pymc/backends/zarr.py
@@ -17,7 +17,6 @@ from typing import Any
 import numpy as np
 import xarray as xr
 
-from arviz_base.base import make_attrs
 from pytensor.tensor.variable import TensorVariable
 from xarray import DataTree
 
@@ -28,6 +27,7 @@ from pymc.backends.arviz import (
     coords_and_dims_for_inferencedata,
     find_constants,
     find_observations,
+    make_attrs,
 )
 from pymc.backends.base import BaseTrace
 from pymc.blocking import StatDtype, StatShape

--- a/pymc/backends/zarr.py
+++ b/pymc/backends/zarr.py
@@ -23,6 +23,7 @@ from xarray import DataTree
 
 import pymc
 
+from pymc.backends import _ZarrChainBase, _ZarrTraceBase
 from pymc.backends.arviz import (
     coords_and_dims_for_inferencedata,
     find_constants,
@@ -63,7 +64,7 @@ except ImportError:
 WARMUP_TAG = "warmup_"
 
 
-class ZarrChain(BaseTrace):
+class ZarrChain(_ZarrChainBase, BaseTrace):
     """Interface object to interact with a single chain in a :class:`~.ZarrTrace`.
 
     Parameters
@@ -275,7 +276,7 @@ def get_initial_fill_value_and_codec(
     return fill_value, _dtype, codec
 
 
-class ZarrTrace:
+class ZarrTrace(_ZarrTraceBase):
     """Object that stores and enables access to MCMC draws stored in a :class:`zarr.hierarchy.Group` objects.
 
     This class creates a zarr hierarchy to represent the sampling information which is

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -71,8 +71,7 @@ except ImportError:  # pragma: no cover
         raise RuntimeError("polyagamma package is not installed!")
 
 
-from scipy import stats
-from scipy.interpolate import InterpolatedUnivariateSpline
+from pytensor.utils import lazy_scipy_module
 
 from pymc.distributions import transforms
 from pymc.distributions.dist_math import (
@@ -93,6 +92,9 @@ from pymc.distributions.distribution import DIST_PARAMETER_TYPES, Continuous, Sy
 from pymc.distributions.shape_utils import implicit_size_from_params, rv_size_is_none
 from pymc.distributions.transforms import _default_transform
 from pymc.math import invlogit, logdiffexp
+
+stats = lazy_scipy_module("stats")
+interpolate = lazy_scipy_module("interpolate")
 
 __all__ = [
     "AsymmetricLaplace",
@@ -3860,7 +3862,7 @@ class Interpolated(BoundedContinuous):
 
     @classmethod
     def dist(cls, x_points, pdf_points, *args, **kwargs):
-        interp = InterpolatedUnivariateSpline(x_points, pdf_points, k=1, ext="zeros")
+        interp = interpolate.InterpolatedUnivariateSpline(x_points, pdf_points, k=1, ext="zeros")
 
         Z = interp.integral(x_points[0], x_points[-1])
         cdf_points = interp.antiderivative()(x_points) / Z
@@ -3891,7 +3893,9 @@ class Interpolated(BoundedContinuous):
     def logp(value, x_points, pdf_points, cdf_points):
         # x_points and pdf_points are expected to be non-symbolic arrays wrapped
         # within a tensor.constant. We use the .data method to retrieve them
-        interp = InterpolatedUnivariateSpline(x_points.data, pdf_points.data, k=1, ext="zeros")
+        interp = interpolate.InterpolatedUnivariateSpline(
+            x_points.data, pdf_points.data, k=1, ext="zeros"
+        )
         Z = interp.integral(x_points.data[..., 0], x_points.data[..., -1])
 
         # interp and Z are converted to symbolic variables here

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -30,7 +30,7 @@ from pytensor.tensor.random.basic import (
     uniform,
 )
 from pytensor.tensor.random.utils import normalize_size_param
-from scipy import stats
+from pytensor.utils import lazy_scipy_module
 
 import pymc as pm
 
@@ -50,6 +50,9 @@ from pymc.distributions.distribution import Discrete, SymbolicRandomVariable
 from pymc.distributions.shape_utils import implicit_size_from_params, rv_size_is_none
 from pymc.logprob.basic import logcdf, logp
 from pymc.math import sigmoid
+from pymc.pytensorf import normalize_rng_param
+
+stats = lazy_scipy_module("stats")
 
 __all__ = [
     "Bernoulli",
@@ -65,8 +68,6 @@ __all__ = [
     "OrderedProbit",
     "Poisson",
 ]
-
-from pymc.pytensorf import normalize_rng_param
 
 
 class Binomial(Discrete):

--- a/pymc/distributions/dist_math.py
+++ b/pymc/distributions/dist_math.py
@@ -24,18 +24,20 @@ from functools import partial
 import numpy as np
 import pytensor
 import pytensor.tensor as pt
-import scipy.linalg
-import scipy.stats
 
 from pytensor.graph.basic import Apply, Variable
 from pytensor.graph.op import Op
 from pytensor.scalar import UnaryScalarOp, upgrade_to_float_no_complex
 from pytensor.tensor import gammaln
 from pytensor.tensor.elemwise import Elemwise
+from pytensor.utils import lazy_scipy_module
 
 from pymc.distributions.shape_utils import to_tuple
 from pymc.logprob.utils import CheckParameterValue
 from pymc.pytensorf import floatX
+
+special = lazy_scipy_module("special")
+stats = lazy_scipy_module("stats")
 
 f = floatX
 c = -0.5 * np.log(2.0 * np.pi)
@@ -274,7 +276,7 @@ class I1e(UnaryScalarOp):
     nfunc_spec = ("scipy.special.i1e", 1, 1)
 
     def impl(self, x):
-        return scipy.special.i1e(x)
+        return special.i1e(x)
 
 
 i1e_scalar = I1e(upgrade_to_float_no_complex, name="i1e")
@@ -287,7 +289,7 @@ class I0e(UnaryScalarOp):
     nfunc_spec = ("scipy.special.i0e", 1, 1)
 
     def impl(self, x):
-        return scipy.special.i0e(x)
+        return special.i0e(x)
 
     def grad(self, inp, grads):
         (x,) = inp
@@ -378,7 +380,7 @@ def clipped_beta_rvs(a, b, size=None, random_state=None, dtype="float64"):
         is shifted to ``np.nextafter(1, 0, dtype=dtype)``.
 
     """
-    out = scipy.stats.beta.rvs(a, b, size=size, random_state=random_state).astype(dtype)
+    out = stats.beta.rvs(a, b, size=size, random_state=random_state).astype(dtype)
     lower, upper = _beta_clip_values[dtype]
     return np.maximum(np.minimum(out, upper), lower)
 

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -19,13 +19,10 @@ from functools import partial, reduce
 import numpy as np
 import pytensor
 import pytensor.tensor as pt
-import scipy
 
 from pytensor.graph import node_rewriter
 from pytensor.graph.basic import Variable
 from pytensor.raise_op import Assert
-from pytensor.sparse.basic import DenseFromSparse
-from pytensor.sparse.math import sp_sum
 from pytensor.tensor import (
     TensorConstant,
     TensorVariable,
@@ -43,6 +40,7 @@ from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.utils import (
     normalize_size_param,
 )
+from pytensor.utils import lazy_scipy_module
 
 import pymc as pm
 
@@ -84,6 +82,9 @@ from pymc.logprob.rewriting import (
 from pymc.math import kron_diag, kron_dot
 from pymc.pytensorf import normalize_rng_param
 from pymc.util import check_dist_not_registered
+
+sparse = lazy_scipy_module("sparse")
+linalg = lazy_scipy_module("linalg")
 
 __all__ = [
     "CAR",
@@ -2119,17 +2120,17 @@ class CARRV(RandomVariable):
         #  we will have some expensive dense_from_sparse and sparse_from_dense
         #  operations that we should avoid. See https://github.com/pymc-devs/pytensor/issues/839
         W = _squeeze_to_ndim(W, 2)
-        if not scipy.sparse.issparse(W):
-            W = scipy.sparse.csr_matrix(W)
-        tau = scipy.sparse.csr_matrix(_squeeze_to_ndim(tau, 0))
-        alpha = scipy.sparse.csr_matrix(_squeeze_to_ndim(alpha, 0))
+        if not sparse.issparse(W):
+            W = sparse.csr_matrix(W)
+        tau = sparse.csr_matrix(_squeeze_to_ndim(tau, 0))
+        alpha = sparse.csr_matrix(_squeeze_to_ndim(alpha, 0))
 
         s = np.asarray(W.sum(axis=0))[0]
-        D = scipy.sparse.diags(s)
+        D = sparse.diags(s)
 
         Q = tau.multiply(D - alpha.multiply(W))
 
-        perm_array = scipy.sparse.csgraph.reverse_cuthill_mckee(Q, symmetric_mode=True)
+        perm_array = sparse.csgraph.reverse_cuthill_mckee(Q, symmetric_mode=True)
         inv_perm = np.argsort(perm_array)
 
         Q = Q[perm_array, :][:, perm_array]
@@ -2140,7 +2141,7 @@ class CARRV(RandomVariable):
             Qb = np.vstack((np.pad(Q.diagonal(u), (u, 0), constant_values=(0, 0)), Qb))
             u += 1
 
-        L = scipy.linalg.cholesky_banded(Qb, lower=False)
+        L = linalg.cholesky_banded(Qb, lower=False)
 
         size = tuple(size or ())
         if size:
@@ -2148,7 +2149,7 @@ class CARRV(RandomVariable):
         z = rng.normal(size=mu.shape)
         samples = np.empty(z.shape)
         for idx in np.ndindex(mu.shape[:-1]):
-            samples[idx] = scipy.linalg.cho_solve_banded((L, False), z[idx]) + mu[idx][perm_array]
+            samples[idx] = linalg.cho_solve_banded((L, False), z[idx]) + mu[idx][perm_array]
         samples = samples[..., inv_perm]
         return samples
 
@@ -2250,6 +2251,9 @@ class CAR(Continuous):
                 W = W.owner.inputs[0]
             else:
                 W = pt.squeeze(W, axis=tuple(range(extra_dims)))
+
+        from pytensor.sparse.basic import DenseFromSparse
+        from pytensor.sparse.math import sp_sum
 
         if W.owner and isinstance(W.owner.op, DenseFromSparse):
             W = W.owner.inputs[0]

--- a/pymc/distributions/simulator.py
+++ b/pymc/distributions/simulator.py
@@ -22,7 +22,6 @@ from pytensor.graph.op import Apply, Op
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.utils import safe_signature
 from pytensor.tensor.variable import TensorVariable
-from scipy.spatial import cKDTree
 
 from pymc.distributions.distribution import Distribution, _support_point
 from pymc.logprob.abstract import _logprob
@@ -303,6 +302,8 @@ class KullbackLeibler:
     """Approximate Kullback-Leibler."""
 
     def __init__(self, obs_data):
+        from scipy.spatial import cKDTree
+
         if obs_data.ndim == 1:
             obs_data = obs_data[:, None]
         n, d = obs_data.shape
@@ -313,6 +314,8 @@ class KullbackLeibler:
         self.obs_data = obs_data
 
     def __call__(self, epsilon, obs_data, sim_data):
+        from scipy.spatial import cKDTree
+
         if sim_data.ndim == 1:
             sim_data = sim_data[:, None]
         nu_d, _ = cKDTree(sim_data).query(self.obs_data, 1)

--- a/pymc/func_utils.py
+++ b/pymc/func_utils.py
@@ -19,9 +19,11 @@ import numpy as np
 import pytensor.tensor as pt
 
 from pytensor.gradient import NullTypeGradError
-from scipy import optimize
+from pytensor.utils import lazy_scipy_module
 
 import pymc as pm
+
+optimize = lazy_scipy_module("optimize")
 
 __all__ = ["find_constrained_prior"]
 

--- a/pymc/gp/util.py
+++ b/pymc/gp/util.py
@@ -20,7 +20,6 @@ import pytensor.tensor as pt
 from pytensor.compile import SharedVariable
 from pytensor.graph import ancestors
 from pytensor.tensor.variable import TensorConstant
-from scipy.cluster.vq import kmeans
 
 from pymc.model.core import modelcontext
 from pymc.pytensorf import compile
@@ -125,6 +124,8 @@ def kmeans_inducing_points(n_inducing, X, **kmeans_kwargs):
 
     if "k_or_guess" in kmeans_kwargs:
         warnings.warn("Use `n_inducing` to set the `k_or_guess` parameter instead.")
+
+    from scipy.cluster.vq import kmeans
 
     Xu, distortion = kmeans(Xw, k_or_guess=n_inducing, **kmeans_kwargs)
     return Xu * scaling

--- a/pymc/math.py
+++ b/pymc/math.py
@@ -18,7 +18,6 @@ from functools import partial, reduce
 
 import numpy as np
 import pytensor
-import pytensor.sparse
 import pytensor.tensor as pt
 
 from pytensor.graph.basic import Apply

--- a/pymc/math.py
+++ b/pymc/math.py
@@ -133,6 +133,7 @@ from pytensor.tensor import (
     zeros_like,
 )
 from pytensor.tensor.linalg import (
+    block_diag,
     cho_solve,
     cholesky,
     det,
@@ -166,7 +167,7 @@ __all__ = [
     "as_tensor",
     "batched_diag",
     "betainc",
-    "block_diagonal",
+    "block_diag",
     "broadcast_arrays",
     "broadcast_to",
     "cartesian",
@@ -582,30 +583,3 @@ def batched_diag(C):
         return C[..., idx, idx]
     else:
         raise ValueError("Input should be 2 or 3 dimensional")
-
-
-def block_diagonal(matrices, sparse=False, format="csr"):
-    r"""See pt.linalg.block_diag or pytensor.sparse.basic.block_diag for reference.
-
-    Parameters
-    ----------
-    matrices: tensors
-    format: str (default 'csr')
-        must be one of: 'csr', 'csc'
-    sparse: bool (default False)
-        if True return sparse format
-
-    Returns
-    -------
-    matrix
-    """
-    warnings.warn(
-        "pymc.math.block_diagonal is deprecated in favor of `pytensor.tensor.linalg.block_diag` and "
-        "`pytensor.sparse.block_diag` functions. This function will be removed in a future release",
-    )
-    if len(matrices) == 1:  # graph optimization
-        return matrices[0]
-    if sparse:
-        return pytensor.sparse.basic.block_diag(*matrices, format=format)
-    else:
-        return pt.linalg.block_diag(*matrices)

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -28,9 +28,7 @@ from typing import (
 
 import numpy as np
 import pytensor
-import pytensor.sparse as sparse
 import pytensor.tensor as pt
-import scipy.sparse as sps
 
 from pytensor.compile import DeepCopyOp, Function, ProfileStats, get_mode, view_op
 from pytensor.compile.sharedvalue import SharedVariable
@@ -41,6 +39,7 @@ from pytensor.tensor.math import variadic_add
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.type import RandomType
 from pytensor.tensor.variable import TensorConstant, TensorVariable
+from pytensor.utils import lazy_scipy_module
 
 from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.data import MinibatchOp, is_valid_observed
@@ -77,6 +76,8 @@ from pymc.util import (
     treelist,
 )
 from pymc.vartypes import continuous_types, discrete_types, typefilter
+
+sparse = lazy_scipy_module("sparse")
 
 __all__ = [
     "Deterministic",
@@ -1355,8 +1356,10 @@ class Model(WithMemoization, metaclass=ContextMeta):
             rv_var = Deterministic(name, joined_rv, self, dims)
 
         else:
-            if sps.issparse(data):
-                data = sparse.basic.as_sparse(data, name=name)
+            if sparse.issparse(data):
+                import pytensor.sparse as pt_sparse
+
+                data = pt_sparse.basic.as_sparse(data, name=name)
             elif not isinstance(data, Variable):
                 data = pt.as_tensor_variable(data, name=name)
 

--- a/pymc/plots/__init__.py
+++ b/pymc/plots/__init__.py
@@ -21,12 +21,19 @@ See https://arviz-devs.github.io/arviz/ for details on plots.
 
 import sys
 
-import arviz_plots as azp
 
-# Makes this module as identical to arviz.plots as possible
-azp_exports = [attr for attr in dir(azp) if not attr.startswith("_")]
+def __getattr__(name):
+    import arviz_plots as azp
 
-for attr in azp_exports:
-    setattr(sys.modules[__name__], attr, getattr(azp, attr))
+    try:
+        value = getattr(azp, name)
+    except AttributeError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+    setattr(sys.modules[__name__], name, value)
+    return value
 
-__all__ = azp_exports
+
+def __dir__():
+    import arviz_plots as azp
+
+    return [attr for attr in dir(azp) if not attr.startswith("_")]

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -14,6 +14,7 @@
 
 
 import re
+import sys
 
 from collections.abc import Iterable
 from functools import partial
@@ -356,18 +357,29 @@ def _default_repr_pretty(obj: Variable | Model, p, cycle):
                 p.text(output_line)
     except AttributeError:
         # the default fallback option (no str_repr method)
+        import IPython.lib.pretty
+
         IPython.lib.pretty._repr_pprint(obj, p, cycle)
 
 
-try:
-    # register our custom pretty printer in ipython shells
-    import IPython
+def _register_ipython_pretty_printers():
+    """Register our pretty printer with IPython if it is already loaded.
 
-    IPython.lib.pretty.for_type(TensorVariable, _default_repr_pretty)
-    IPython.lib.pretty.for_type(Model, _default_repr_pretty)
-except (ModuleNotFoundError, AttributeError):
-    # no ipython shell
-    pass
+    Doing this only when IPython is in ``sys.modules`` avoids importing it
+    eagerly via pymc — IPython is heavy and irrelevant outside REPLs, and any
+    REPL that cares will have imported IPython before pymc.
+    """
+    ipython = sys.modules.get("IPython")
+    if ipython is None:
+        return
+    try:
+        ipython.lib.pretty.for_type(TensorVariable, _default_repr_pretty)
+        ipython.lib.pretty.for_type(Model, _default_repr_pretty)
+    except AttributeError:
+        pass
+
+
+_register_ipython_pretty_printers()
 
 
 def _format_underscore(variable: str) -> str:

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -11,6 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
 import warnings
 
 from collections.abc import Iterable, Sequence
@@ -20,7 +21,6 @@ import numpy as np
 import pandas as pd
 import pytensor
 import pytensor.tensor as pt
-import scipy.sparse as sps
 
 from pytensor.compile import Function, Mode, get_mode
 from pytensor.compile.builders import OpFromGraph
@@ -49,10 +49,13 @@ from pytensor.tensor.rewriting.shape import ShapeFeature
 from pytensor.tensor.sharedvar import SharedVariable
 from pytensor.tensor.subtensor import AdvancedIncSubtensor, AdvancedIncSubtensor1
 from pytensor.tensor.variable import TensorVariable
+from pytensor.utils import lazy_scipy_module
 
 from pymc.exceptions import NotConstantValueError
 from pymc.util import makeiter
 from pymc.vartypes import continuous_types, isgenerator, typefilter
+
+sparse = lazy_scipy_module("sparse")
 
 PotentialShapeType = int | np.ndarray | Sequence[int | Variable] | TensorVariable
 
@@ -116,7 +119,7 @@ def convert_data(data) -> np.ndarray | Variable:
                 ret = data
     elif isinstance(data, Variable):
         ret = data
-    elif sps.issparse(data):
+    elif sparse.issparse(data):
         ret = data
     else:
         ret = np.asarray(data)

--- a/pymc/sampling/deterministic.py
+++ b/pymc/sampling/deterministic.py
@@ -13,9 +13,7 @@
 #   limitations under the License.
 from collections.abc import Sequence
 
-import xarray
-
-from xarray import Dataset
+from xarray import Dataset, DataTree, merge
 
 from pymc.backends.arviz import apply_function_over_dataset, coords_and_dims_for_inferencedata
 from pymc.model.core import Model, modelcontext
@@ -104,7 +102,7 @@ def compute_deterministics(
 
     coords, dims = coords_and_dims_for_inferencedata(model)
 
-    is_datatree = isinstance(dataset, xarray.DataTree)
+    is_datatree = isinstance(dataset, DataTree)
     input_dataset = dataset.dataset if is_datatree else dataset
     input_dataset = input_dataset[[rv.name for rv in model.free_RVs]]
 
@@ -120,6 +118,6 @@ def compute_deterministics(
 
     if merge_dataset:
         original_dataset = dataset.to_dataset() if is_datatree else dataset
-        new_dataset = xarray.merge([original_dataset, new_dataset], compat="override")
+        new_dataset = merge([original_dataset, new_dataset], compat="override")
 
     return new_dataset

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -25,8 +25,6 @@ from typing import (
 )
 
 import numpy as np
-import xarray
-import xarray as xr
 
 from pytensor import tensor as pt
 from pytensor.graph import vectorize_graph
@@ -39,6 +37,7 @@ from pytensor.graph.traversal import ancestors, general_toposort, walk
 from pytensor.tensor.random.type import RandomType
 from pytensor.tensor.sharedvar import SharedVariable, TensorSharedVariable
 from rich.theme import Theme
+from xarray import Dataset, DataTree
 
 import pymc as pm
 
@@ -482,7 +481,7 @@ def sample_prior_predictive(
     idata_kwargs: dict | None = None,
     backend: str | None = None,
     compile_kwargs: dict | None = None,
-) -> xarray.DataTree: ...
+) -> DataTree: ...
 @overload
 def sample_prior_predictive(
     draws: int = 500,
@@ -503,7 +502,7 @@ def sample_prior_predictive(
     idata_kwargs: dict | None = None,
     backend: str | None = None,
     compile_kwargs: dict | None = None,
-) -> xarray.DataTree | dict[str, np.ndarray]:
+) -> DataTree | dict[str, np.ndarray]:
     """Generate samples from the prior predictive distribution.
 
     Parameters
@@ -530,7 +529,7 @@ def sample_prior_predictive(
 
     Returns
     -------
-    xarray.DataTree or dict
+    DataTree or dict
         A ``DataTree`` object containing the prior and prior predictive samples (default),
         or a dictionary with variable names as keys and samples as numpy arrays.
     """
@@ -611,7 +610,7 @@ def sample_posterior_predictive(
     idata_kwargs: dict | None = None,
     backend: str | None = None,
     compile_kwargs: dict | None = None,
-) -> xarray.DataTree: ...
+) -> DataTree: ...
 @overload
 def sample_posterior_predictive(
     trace,
@@ -648,7 +647,7 @@ def sample_posterior_predictive(
     idata_kwargs: dict | None = None,
     backend: str | None = None,
     compile_kwargs: dict | None = None,
-) -> xarray.DataTree | dict[str, np.ndarray]:
+) -> DataTree | dict[str, np.ndarray]:
     """Generate forward samples for `var_names`, conditioned on the posterior samples of variables found in the `trace`.
 
     This method can be used to perform different kinds of model predictions, including posterior predictive checks.
@@ -661,7 +660,7 @@ def sample_posterior_predictive(
 
     Parameters
     ----------
-    trace : backend, list, xarray.Dataset, xarray.DataTree, or MultiTrace
+    trace : backend, list, Dataset, DataTree, or MultiTrace
         Trace generated from MCMC sampling, or a list of dicts (eg. points or from :func:`~pymc.find_MAP`),
         or :class:`xarray.Dataset` (eg. DataTree.posterior or DataTree.prior)
     model : Model (optional if in ``with`` context)
@@ -695,7 +694,7 @@ def sample_posterior_predictive(
     sample_dims : list of str, optional
         Dimensions over which to loop and generate posterior predictive samples.
         When ``sample_dims`` is ``None`` (default) both "chain" and "draw" are considered sample
-        dimensions. Only taken into account when `trace` is xarray.DataTree or Dataset.
+        dimensions. Only taken into account when `trace` is DataTree or Dataset.
     random_seed : int, RandomState or Generator, optional
         Seed for the random number generator.
     progressbar : bool
@@ -710,7 +709,7 @@ def sample_posterior_predictive(
         already contains a group that would be added (e.g. ``posterior_predictive``), a warning
         is issued and the existing group is overwritten.
     predictions : bool, default False
-        Flag used to set the location of posterior predictive samples within the returned ``xarray.DataTree`` object.
+        Flag used to set the location of posterior predictive samples within the returned ``DataTree`` object.
         If False, assumes samples are generated based on the fitting data to be used for posterior predictive checks,
         and samples are stored in the ``posterior_predictive``. If True, assumes samples are generated based on
         out-of-sample data as predictions, and samples are stored in the ``predictions`` group.
@@ -725,8 +724,8 @@ def sample_posterior_predictive(
 
     Returns
     -------
-    xarray.DataTree or Dict
-        A ``xarray.DataTree`` object containing the posterior predictive samples (default), or
+    DataTree or Dict
+        A ``DataTree`` object containing the posterior predictive samples (default), or
         a dictionary with variable names as keys, and samples as numpy arrays.
 
 
@@ -1041,10 +1040,10 @@ def sample_posterior_predictive(
     trace_coords: dict[str, np.ndarray] = {}
     if "coords" not in idata_kwargs:
         idata_kwargs["coords"] = {}
-    idata: xarray.DataTree | None = None
+    idata: DataTree | None = None
     observed_data = None
     stacked_dims = None
-    if isinstance(trace, xarray.DataTree):
+    if isinstance(trace, DataTree):
         _constant_data = getattr(trace, "constant_data", None)
         if _constant_data is not None:
             trace_coords.update({str(k): v.data for k, v in _constant_data.coords.items()})
@@ -1055,7 +1054,7 @@ def sample_posterior_predictive(
             trace = trace["posterior"].dataset
         else:
             trace = trace.dataset
-    if isinstance(trace, xarray.Dataset):
+    if isinstance(trace, Dataset):
         trace_coords.update({str(k): v.data for k, v in trace.coords.items()})
         _trace, stacked_dims = dataset_to_point_list(trace, sample_dims)
         nchain = 1
@@ -1187,7 +1186,7 @@ def sample_posterior_predictive(
     if not output_vars:
         # Nothing to produce — neither sampled nor copied from the trace.
         if return_inferencedata and not extend_inferencedata:
-            return xr.DataTree()
+            return DataTree()
         elif return_inferencedata and extend_inferencedata:
             return trace if idata is None else idata
         return {}
@@ -1325,7 +1324,7 @@ def sample_posterior_predictive(
 
 def vectorize_over_posterior(
     outputs: list[Variable],
-    posterior: xr.Dataset,
+    posterior: Dataset,
     input_rvs: list[Variable],
     allow_rvs_in_graph: bool = True,
     sample_dims: tuple[str, ...] = ("chain", "draw"),
@@ -1340,7 +1339,7 @@ def vectorize_over_posterior(
     ----------
     outputs : list[Variable]
         The list of variables to vectorize over the posterior samples.
-    posterior : xr.Dataset
+    posterior : Dataset
         The posterior samples to use as replacements for the `input_rvs`.
     input_rvs : list[Variable]
         The list of random variables to replace with their posterior samples.

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from __future__ import annotations
+
 import contextlib
 import importlib.util
 import logging
@@ -24,10 +26,10 @@ import warnings
 
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     TypeAlias,
-    cast,
     overload,
 )
 
@@ -45,10 +47,15 @@ from xarray import DataTree
 
 import pymc as pm
 
-from pymc.backends import RunType, TraceOrBackend, init_traces
+from pymc.backends import (
+    RunType,
+    TraceOrBackend,
+    _ZarrChainBase,
+    _ZarrTraceBase,
+    init_traces,
+)
 from pymc.backends.arviz import patch_nutpie_idata
 from pymc.backends.base import IBaseTrace, MultiTrace, _choose_chains
-from pymc.backends.zarr import ZarrChain, ZarrTrace
 from pymc.blocking import DictToArrayBijection
 from pymc.exceptions import SamplingError
 from pymc.initial_point import PointType, StartDict, make_initial_point_fns_per_chain
@@ -82,10 +89,8 @@ from pymc.util import (
 )
 from pymc.vartypes import discrete_types
 
-try:
-    from zarr.storage import MemoryStore
-except ImportError:
-    MemoryStore = type("MemoryStore", (), {})
+if TYPE_CHECKING:
+    from pymc.backends.zarr import ZarrChain, ZarrTrace
 
 NUTPIE_INSTALLED = importlib.util.find_spec("nutpie") is not None
 NUTPIE_MIN_VERSION = (0, 16, 10)
@@ -119,7 +124,7 @@ __all__ = [
 Step: TypeAlias = BlockedStep | CompoundStep
 
 
-def get_default_tune_steps(step: "Step", tune: int | None, default_tune_steps: int = 1000) -> int:
+def get_default_tune_steps(step: Step, tune: int | None, default_tune_steps: int = 1000) -> int:
     """Get the default number of tuning steps.
 
     If ``tune`` is an explicit integer, return it directly.
@@ -887,7 +892,11 @@ def sample(
     rngs = get_random_generator(random_seed).spawn(chains)
     random_seed_list = [rng.integers(2**30) for rng in rngs]
 
-    if not discard_tuned_samples and not return_inferencedata and not isinstance(trace, ZarrTrace):
+    if (
+        not discard_tuned_samples
+        and not return_inferencedata
+        and not isinstance(trace, _ZarrTraceBase)
+    ):
         warnings.warn(
             "Tuning samples will be included in the returned `MultiTrace` object, which can lead to"
             " complications in your downstream analysis. Please consider to switch to `InferenceData`:\n"
@@ -1153,7 +1162,7 @@ def sample(
     # into a function to make it easier to test and refactor.
     return _sample_return(
         run=run,
-        traces=trace if isinstance(trace, ZarrTrace) else traces,
+        traces=trace if isinstance(trace, _ZarrTraceBase) else traces,
         tune=tune,
         t_sampling=t_sampling,
         discard_tuned_samples=discard_tuned_samples,
@@ -1231,7 +1240,7 @@ def _sample_return(
             stacklevel=2,
         )
 
-    if isinstance(traces, ZarrTrace):
+    if isinstance(traces, _ZarrTraceBase):
         # Split warmup from posterior samples
         traces.split_warmup_groups()
 
@@ -1521,7 +1530,7 @@ def _iter_sample(
     step.set_rng(rng)
 
     point = start
-    if isinstance(trace, ZarrChain):
+    if isinstance(trace, _ZarrChainBase):
         trace.link_stepper(step)
 
     try:
@@ -1547,13 +1556,13 @@ def _iter_sample(
             yield stats
 
     except (KeyboardInterrupt, BaseException):
-        if isinstance(trace, ZarrChain):
+        if isinstance(trace, _ZarrChainBase):
             trace.record_sampling_state(step=step)
         trace.close()
         raise
 
     else:
-        if isinstance(trace, ZarrChain):
+        if isinstance(trace, _ZarrChainBase):
             trace.record_sampling_state(step=step)
         trace.close()
 
@@ -1615,8 +1624,10 @@ def _mp_sample(
     draws -= tune
     zarr_chains: list[ZarrChain] | None = None
     zarr_recording = False
-    if all(isinstance(trace, ZarrChain) for trace in traces):
-        if isinstance(cast(ZarrChain, traces[0])._posterior.store, MemoryStore):
+    if all(isinstance(trace, _ZarrChainBase) for trace in traces):
+        from zarr.storage import MemoryStore
+
+        if isinstance(traces[0]._posterior.store, MemoryStore):  # type: ignore[attr-defined]
             warnings.warn(
                 "Parallel sampling with MemoryStore zarr store wont write the processes "
                 "step method sampling state. If you wish to be able to access the step "
@@ -1624,7 +1635,7 @@ def _mp_sample(
                 "DirectoryStore or ZipStore"
             )
         else:
-            zarr_chains = cast(list[ZarrChain], traces)
+            zarr_chains = traces  # type: ignore[assignment]
             zarr_recording = True
 
     sampler = ps.ParallelSampler(

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -11,6 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import annotations
 
 import ctypes
 import logging
@@ -24,7 +25,7 @@ import warnings
 from collections import namedtuple
 from collections.abc import Sequence
 from contextlib import nullcontext
-from typing import cast
+from typing import TYPE_CHECKING
 
 import cloudpickle
 import numpy as np
@@ -34,8 +35,12 @@ from pytensor.link.jax.linker import JAXLinker
 from rich.theme import Theme
 from threadpoolctl import threadpool_limits
 
-from pymc.backends.zarr import ZarrChain
+from pymc.backends import _ZarrChainBase
 from pymc.blocking import DictToArrayBijection
+
+if TYPE_CHECKING:
+    from pymc.backends.zarr import ZarrChain
+
 from pymc.exceptions import SamplingError
 from pymc.progress_bar import MCMCProgressBarManager, default_progress_theme
 from pymc.util import (
@@ -169,7 +174,7 @@ class _Process:
         if zarr_chains_is_pickled:
             self._zarr_chain = cloudpickle.loads(zarr_chains)[self.chain]
         elif zarr_chains is not None:
-            self._zarr_chain = cast(list[ZarrChain], zarr_chains)[self.chain]
+            self._zarr_chain = zarr_chains[self.chain]  # type: ignore[assignment]
         self._zarr_recording = self._zarr_chain is not None
 
         self._shared_point = shared_point
@@ -493,7 +498,7 @@ class ParallelSampler:
         zarr_chains_pickled = None
         self.zarr_recording = False
         if zarr_chains is not None:
-            assert all(isinstance(zarr_chain, ZarrChain) for zarr_chain in zarr_chains)
+            assert all(isinstance(zarr_chain, _ZarrChainBase) for zarr_chain in zarr_chains)
             self.zarr_recording = True
         if mp_ctx.get_start_method() != "fork":
             step_method_pickled = cloudpickle.dumps(step_method, protocol=-1)

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -26,8 +26,8 @@ import numpy as np
 
 from rich.progress import BarColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 
+from pymc.backends import _ZarrChainBase
 from pymc.backends.base import BaseTrace
-from pymc.backends.zarr import ZarrChain
 from pymc.initial_point import PointType
 from pymc.model import Model, modelcontext
 from pymc.progress_bar import CustomProgress
@@ -460,7 +460,7 @@ def _iter_population(
                     points[c], stats = updates[c]
                     flushed = strace.record(points[c], stats, in_warmup=i < tune)
                     log_warning_stats(stats)
-                    if flushed and isinstance(strace, ZarrChain):
+                    if flushed and isinstance(strace, _ZarrChainBase):
                         sampling_state = popstep.request_sampling_state(c)
                         strace.store_sampling_state(sampling_state)
                 # yield the state of all chains in parallel

--- a/pymc/smc/kernels.py
+++ b/pymc/smc/kernels.py
@@ -24,10 +24,9 @@ from pytensor import shared
 from pytensor.graph.replace import clone_replace
 from pytensor.link.jax import JAXLinker
 from pytensor.tensor.random.type import RandomGeneratorType
+from pytensor.utils import lazy_scipy_module
 from rich.progress import TextColumn
 from rich.table import Column
-from scipy.special import logsumexp
-from scipy.stats import multivariate_normal
 
 from pymc.blocking import DictToArrayBijection
 from pymc.initial_point import make_initial_point_expression
@@ -41,6 +40,9 @@ from pymc.pytensorf import (
 from pymc.sampling.forward import draw
 from pymc.step_methods.metropolis import MultivariateNormalProposal
 from pymc.vartypes import discrete_types
+
+special = lazy_scipy_module("special")
+stats = lazy_scipy_module("stats")
 
 SMCStats: TypeAlias = dict[str, int | float]
 SMCSettings: TypeAlias = dict[str, int | float]
@@ -322,8 +324,8 @@ class SMC_KERNEL(ABC):
         while up_beta - low_beta > 1e-6:
             new_beta = (low_beta + up_beta) / 2.0
             log_weights_un = (new_beta - old_beta) * self.likelihood_logp
-            log_weights = log_weights_un - logsumexp(log_weights_un)
-            ESS = int(np.exp(-logsumexp(log_weights * 2)))
+            log_weights = log_weights_un - special.logsumexp(log_weights_un)
+            ESS = int(np.exp(-special.logsumexp(log_weights * 2)))
             if ESS == rN:
                 break
             elif ESS < rN:
@@ -333,13 +335,13 @@ class SMC_KERNEL(ABC):
         if new_beta >= 1:
             new_beta = 1
             log_weights_un = (new_beta - old_beta) * self.likelihood_logp
-            log_weights = log_weights_un - logsumexp(log_weights_un)
+            log_weights = log_weights_un - special.logsumexp(log_weights_un)
 
         self.beta = new_beta
         self.weights = np.exp(log_weights)
         # We normalize again to correct for small numerical errors that might build up
         self.weights /= self.weights.sum()
-        self.log_marginal_likelihood += logsumexp(log_weights_un) - np.log(self.draws)
+        self.log_marginal_likelihood += special.logsumexp(log_weights_un) - np.log(self.draws)
 
     def resample(self):
         """Resample particles based on importance weights."""
@@ -479,7 +481,7 @@ class IMH(SMC_KERNEL):
         if np.isnan(cov).any() or np.isinf(cov).any():
             raise ValueError('Sample covariances not valid! Likely "draws" is too small!')
         mean = np.average(self.tempered_posterior, axis=0)
-        self.proposal_dist = multivariate_normal(mean, cov)
+        self.proposal_dist = stats.multivariate_normal(mean, cov)
 
     def mutate(self):
         """Independent Metropolis-Hastings perturbation."""

--- a/pymc/stats/__init__.py
+++ b/pymc/stats/__init__.py
@@ -21,13 +21,24 @@ See https://arviz-devs.github.io/arviz/ for details.
 
 import sys
 
-import arviz_stats as azs
-
-azs_exports = [attr for attr in dir(azs) if not attr.startswith("_")]
-
-for attr in azs_exports:
-    setattr(sys.modules[__name__], attr, getattr(azs, attr))
-
 from pymc.stats.log_density import compute_log_likelihood, compute_log_prior
 
-__all__ = ("compute_log_likelihood", "compute_log_prior", *azs_exports)
+__all__ = ("compute_log_likelihood", "compute_log_prior")
+
+
+def __getattr__(name):
+    import arviz_stats as azs
+
+    try:
+        value = getattr(azs, name)
+    except AttributeError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+    setattr(sys.modules[__name__], name, value)
+    return value
+
+
+def __dir__():
+    import arviz_stats as azs
+
+    own = ["compute_log_likelihood", "compute_log_prior"]
+    return own + [attr for attr in dir(azs) if not attr.startswith("_")]

--- a/pymc/stats/convergence.py
+++ b/pymc/stats/convergence.py
@@ -18,8 +18,6 @@ import logging
 from collections.abc import Sequence
 from typing import Any
 
-import arviz
-
 from xarray import DataTree
 
 from pymc.util import get_untransformed_name, is_transformed_name
@@ -105,8 +103,10 @@ def run_convergence_checks(idata: DataTree, model) -> list[SamplerWarning]:
         if rv_name in idata["posterior"]:
             varnames.append(rv_name)
 
-    ess = arviz.ess(idata, var_names=varnames)
-    rhat = arviz.rhat(idata, var_names=varnames)
+    import arviz_stats
+
+    ess = arviz_stats.ess(idata, var_names=varnames)
+    rhat = arviz_stats.rhat(idata, var_names=varnames)
 
     rhat_max = max(val.max() for val in rhat.values())
     if rhat_max > 1.01:

--- a/pymc/step_methods/hmc/integration.py
+++ b/pymc/step_methods/hmc/integration.py
@@ -16,10 +16,12 @@ from typing import NamedTuple
 
 import numpy as np
 
-from scipy import linalg
+from pytensor.utils import lazy_scipy_module
 
 from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.step_methods.hmc.quadpotential import QuadPotential
+
+linalg = lazy_scipy_module("linalg")
 
 
 class State(NamedTuple):

--- a/pymc/step_methods/hmc/quadpotential.py
+++ b/pymc/step_methods/hmc/quadpotential.py
@@ -17,13 +17,15 @@ from __future__ import annotations
 import warnings
 
 from dataclasses import field
-from typing import Any, overload
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 import pytensor
-import scipy.linalg
 
-from scipy.sparse import issparse
+from pytensor.utils import lazy_scipy_module
+
+if TYPE_CHECKING:
+    import scipy.linalg
 
 from pymc.pytensorf import floatX
 from pymc.step_methods.state import (
@@ -33,6 +35,9 @@ from pymc.step_methods.state import (
     dataclass_state,
 )
 from pymc.util import RandomGenerator, get_random_generator
+
+linalg = lazy_scipy_module("linalg")
+sparse = lazy_scipy_module("sparse")
 
 __all__ = [
     "QuadPotentialDiag",
@@ -65,7 +70,7 @@ def quad_potential(C, is_cov, rng=None):
     -------
     q: Quadpotential
     """
-    if issparse(C):
+    if sparse.issparse(C):
         if not chol_available:
             raise ImportError("Sparse mass matrices require scikits.sparse")
         elif is_cov:
@@ -645,12 +650,12 @@ class QuadPotentialFullInv(QuadPotential):
         if dtype is None:
             dtype = pytensor.config.floatX
         self.dtype = dtype
-        self.L = floatX(scipy.linalg.cholesky(A, lower=True))
+        self.L = floatX(linalg.cholesky(A, lower=True))
         self.rng = get_random_generator(rng)
 
     def velocity(self, x, out=None):
         """Compute the current velocity at a position in parameter space."""
-        vel = scipy.linalg.cho_solve((self.L, True), x)
+        vel = linalg.cho_solve((self.L, True), x)
         if out is None:
             return vel
         out[:] = vel
@@ -693,7 +698,7 @@ class QuadPotentialFull(QuadPotential):
             dtype = pytensor.config.floatX
         self.dtype = dtype
         self._cov = np.array(cov, dtype=self.dtype, copy=True)
-        self._chol = scipy.linalg.cholesky(self._cov, lower=True)
+        self._chol = linalg.cholesky(self._cov, lower=True)
         self._n = len(self._cov)
         self.rng = get_random_generator(rng)
 
@@ -704,7 +709,7 @@ class QuadPotentialFull(QuadPotential):
     def random(self):
         """Draw random value from QuadPotential."""
         vals = self.rng.normal(size=self._n).astype(self.dtype)
-        return scipy.linalg.solve_triangular(self._chol.T, vals, overwrite_b=True)
+        return linalg.solve_triangular(self._chol.T, vals, overwrite_b=True)
 
     def energy(self, x, velocity=None):
         """Compute kinetic energy at a position in parameter space."""
@@ -792,7 +797,7 @@ class QuadPotentialFullAdapt(QuadPotentialFull):
     def reset(self):
         self._previous_update = 0
         self._cov = np.array(self._initial_cov, dtype=self.dtype, copy=True)
-        self._chol = scipy.linalg.cholesky(self._cov, lower=True)
+        self._chol = linalg.cholesky(self._cov, lower=True)
         self._chol_error = None
         self._foreground_cov = _WeightedCovariance(
             self._n, self._initial_mean, self._initial_cov, self._initial_weight, self.dtype
@@ -803,8 +808,8 @@ class QuadPotentialFullAdapt(QuadPotentialFull):
     def _update_from_weightvar(self, weightvar):
         weightvar.current_covariance(out=self._cov)
         try:
-            self._chol = scipy.linalg.cholesky(self._cov, lower=True)
-        except (scipy.linalg.LinAlgError, ValueError) as error:
+            self._chol = linalg.cholesky(self._cov, lower=True)
+        except (linalg.LinAlgError, ValueError) as error:
             self._chol_error = error
 
     def update(self, sample, grad, tune):

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -18,13 +18,12 @@ from typing import Any, cast
 import numpy as np
 import numpy.random as nr
 import pytensor
-import scipy.linalg
-import scipy.special
 
 from pytensor import tensor as pt
 from pytensor.graph.basic import Variable
 from pytensor.graph.fg import MissingInputError
 from pytensor.tensor.random.basic import BernoulliRV, CategoricalRV
+from pytensor.utils import lazy_scipy_module
 from rich.progress import TextColumn
 from rich.table import Column
 
@@ -49,7 +48,11 @@ from pymc.step_methods.arraystep import (
 )
 from pymc.step_methods.compound import Competence, StepMethodState
 from pymc.step_methods.state import dataclass_state
+from pymc.util import RandomGenerator, get_value_vars_from_user_vars
 from pymc.vartypes import discrete_types
+
+linalg = lazy_scipy_module("linalg")
+special = lazy_scipy_module("special")
 
 __all__ = [
     "BinaryGibbsMetropolis",
@@ -64,8 +67,6 @@ __all__ = [
     "NormalProposal",
     "PoissonProposal",
 ]
-
-from pymc.util import RandomGenerator, get_value_vars_from_user_vars
 
 # Available proposal distributions for Metropolis
 
@@ -108,7 +109,7 @@ class MultivariateNormalProposal(Proposal):
         if n != m:
             raise ValueError("Covariance matrix is not symmetric.")
         self.n = n
-        self.chol = scipy.linalg.cholesky(s, lower=True)
+        self.chol = linalg.cholesky(s, lower=True)
 
     def __call__(self, num_draws=None, rng: np.random.Generator | None = None):
         rng_ = rng or nr
@@ -811,7 +812,7 @@ class CategoricalGibbsMetropolis(ArrayStep):
             if candidate_cat != given_cat:
                 q.data[dim] = candidate_cat
                 log_probs[candidate_cat] = logp(q)
-        probs = scipy.special.softmax(log_probs, axis=0)
+        probs = special.softmax(log_probs, axis=0)
         prob_curr, probs[given_cat] = probs[given_cat], 0.0
         probs /= 1.0 - prob_curr
         proposed_cat = self.rng.choice(candidates, p=probs)

--- a/pymc/step_methods/step_sizes.py
+++ b/pymc/step_methods/step_sizes.py
@@ -15,10 +15,12 @@
 
 import numpy as np
 
-from scipy import stats
+from pytensor.utils import lazy_scipy_module
 
 from pymc.stats.convergence import SamplerWarning, WarningType
 from pymc.step_methods.state import DataClassState, WithSamplingState, dataclass_state
+
+stats = lazy_scipy_module("stats")
 
 
 @dataclass_state

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -27,9 +27,9 @@ import pytensor.gradient as tg
 
 from numpy import isfinite
 from pytensor.graph.basic import Variable
+from pytensor.utils import lazy_scipy_module
 from rich.console import Console
 from rich.progress import Progress, TextColumn
-from scipy.optimize import minimize
 
 import pymc as pm
 
@@ -43,6 +43,8 @@ from pymc.util import (
     get_value_vars_from_user_vars,
 )
 from pymc.vartypes import discrete_types, typefilter
+
+optimize = lazy_scipy_module("optimize")
 
 __all__ = ["find_MAP"]
 
@@ -173,7 +175,7 @@ def find_MAP(
 
     with cost_func.progress:
         try:
-            opt_result = minimize(
+            opt_result = optimize.minimize(
                 cost_func, x0.data, method=method, jac=compute_gradient, *args, **kwargs
             )
             mx0 = opt_result["x"]  # r -> opt_result

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -22,11 +22,11 @@ from typing import cast
 
 import cloudpickle
 import numpy as np
-import xarray
 
 from cachetools import LRUCache, cachedmethod
 from pytensor.compile import SharedVariable
 from pytensor.graph.basic import Variable
+from xarray import Dataset, DataTree
 
 from pymc.exceptions import BlockModelAccessError
 
@@ -240,18 +240,18 @@ def biwrap(wrapper):
     return enhanced
 
 
-def drop_warning_stat(dt: xarray.DataTree) -> xarray.DataTree:
+def drop_warning_stat(dt: DataTree) -> DataTree:
     """Return a new ``DataTree`` object with the "warning" stat removed from sample stats groups.
 
     This function should be applied to an ``DataTree`` object obtained with
     ``pm.sample(keep_warning_stat=True)`` before trying to ``.to_netcdf()`` or ``.to_zarr()`` it.
     """
-    tree_dict: dict[str, xarray.Dataset | None] = {}
+    tree_dict: dict[str, Dataset | None] = {}
 
     for gname, group in dt.items():
-        if not isinstance(group, xarray.DataTree):
+        if not isinstance(group, DataTree):
             continue
-        ds: xarray.Dataset | None = group.to_dataset()
+        ds: Dataset | None = group.to_dataset()
 
         if "sample_stat" in gname and ds is not None:
             warning_vars = [
@@ -264,17 +264,17 @@ def drop_warning_stat(dt: xarray.DataTree) -> xarray.DataTree:
         if ds is not None:
             tree_dict[gname] = ds
 
-    new_dt = xarray.DataTree.from_dict(tree_dict)
+    new_dt = DataTree.from_dict(tree_dict)
     new_dt.attrs = dt.attrs
     return new_dt
 
 
-def chains_and_samples(data: xarray.Dataset | xarray.DataTree) -> tuple[int, int]:
+def chains_and_samples(data: Dataset | DataTree) -> tuple[int, int]:
     """Extract and return number of chains and samples in xarray or arviz traces."""
-    dataset: xarray.Dataset
-    if isinstance(data, xarray.Dataset):
+    dataset: Dataset
+    if isinstance(data, Dataset):
         dataset = data
-    elif isinstance(data, xarray.DataTree):
+    elif isinstance(data, DataTree):
         dataset = data["posterior"].dataset
     else:
         raise ValueError(

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -57,12 +57,12 @@ from typing import Any, overload
 import numpy as np
 import pytensor
 import pytensor.tensor as pt
-import xarray
 
 from pytensor.graph.basic import Variable
 from pytensor.graph.replace import graph_replace
 from pytensor.scalar.basic import identity as scalar_identity
 from pytensor.tensor.elemwise import Elemwise
+from xarray import DataArray, Dataset
 
 import pymc as pm
 
@@ -1146,7 +1146,7 @@ class Group(WithMemoization):
         """Return the mean of the latent variables as an unstructured 1-dimensional tensor variable."""
         raise NotImplementedError()
 
-    def var_to_data(self, shared: pt.TensorVariable) -> xarray.Dataset:
+    def var_to_data(self, shared: pt.TensorVariable) -> Dataset:
         """Take a flat 1-dimensional tensor variable and maps it to an xarray data set based on the information in `self.ordering`."""
         # This is somewhat similar to `DictToArrayBijection.rmap`, which doesn't work here since we don't have
         # `RaveledVars` and need to take the information from `self.ordering` instead
@@ -1159,16 +1159,16 @@ class Group(WithMemoization):
             else:
                 coords = None
             values = shared_nda[s].reshape(shape).astype(dtype)
-            result[name] = xarray.DataArray(values, coords=coords, dims=dims, name=name)
-        return xarray.Dataset(result)
+            result[name] = DataArray(values, coords=coords, dims=dims, name=name)
+        return Dataset(result)
 
     @property
-    def mean_data(self) -> xarray.Dataset:
+    def mean_data(self) -> Dataset:
         """Mean of the latent variables as an xarray Dataset."""
         return self.var_to_data(self.mean)
 
     @property
-    def std_data(self) -> xarray.Dataset:
+    def std_data(self) -> Dataset:
         """Standard deviation of the latent variables as an xarray Dataset."""
         return self.var_to_data(self.std)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
 pymc-sphinx-theme>=0.16.0
-pytensor>=3.0,<3.1
+pytensor>=3.0.2,<3.1
 pytest-cov>=2.5
 pytest>=3.0
 rich>=13.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cachetools>=4.2.1,<7
 cloudpickle
 numpy>=1.25.0
 pandas>=0.24.0
-pytensor>=3.0,<3.1
+pytensor>=3.0.2,<3.1
 rich>=13.7.1
 scipy>=1.4.1
 threadpoolctl>=3.1.0,<4.0.0

--- a/tests/dims/distributions/test_vector.py
+++ b/tests/dims/distributions/test_vector.py
@@ -11,6 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import math
+
 import numpy as np
 import pytensor.tensor as pt
 import pytest
@@ -29,15 +31,19 @@ pytestmark = pytest.mark.filterwarnings("error")
 def test_categorical():
     coords = {"a": range(3), "b": range(4)}
     p = pt.as_tensor([0.1, 0.2, 0.3, 0.4])
+    # logit_p values whose softmax is exactly representable in float64
+    # so that the xtensor and tensor constant-folding paths agree bit-for-bit.
+    logit_p = pt.as_tensor([0.0, 0.0, math.log(2), math.log(4)])
     p_xr = as_xtensor(p, dims=("b",))
+    logit_p_xr = as_xtensor(logit_p, dims=("b",))
 
     with Model(coords=coords) as model:
         Categorical("x", p=p_xr, core_dims="b", dims=("a",))
-        Categorical("y", logit_p=p_xr, core_dims="b", dims=("a",))
+        Categorical("y", logit_p=logit_p_xr, core_dims="b", dims=("a",))
 
     with Model(coords=coords) as reference_model:
         regular_distributions.Categorical("x", p=p, dims=("a",))
-        regular_distributions.Categorical("y", logit_p=p, dims=("a",))
+        regular_distributions.Categorical("y", logit_p=logit_p, dims=("a",))
 
     assert_equivalent_random_graph(model, reference_model)
     assert_equivalent_logp_graph(model, reference_model)

--- a/tests/test_root_namespace.py
+++ b/tests/test_root_namespace.py
@@ -12,6 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import subprocess
+import sys
+import textwrap
 import types
 
 import pymc
@@ -83,3 +86,58 @@ def test_root_module_not_polluted():
     )
     assert not unexpected, f"Unexpected names at pymc root: {sorted(unexpected)}. {hint}"
     assert not missing, f"Missing names at pymc root: {sorted(missing)}. {hint}"
+
+
+def test_eager_import_heavy_dependencies():
+    """`import pymc` must not eagerly load heavy optional dependencies.
+
+    These modules are deferred to first use to keep ``import pymc`` fast.
+    Note: ``scipy.sparse`` is intentionally omitted because ``xarray`` pulls it
+    in transitively, which is outside of pymc's control.
+    """
+    expensive_modules = (
+        "arviz_base",
+        "arviz_plots",
+        "arviz_stats",
+        "pytensor.sparse",
+        "scipy.cluster",
+        "scipy.interpolate",
+        "scipy.linalg",
+        "scipy.optimize",
+        "scipy.spatial",
+        "scipy.special",
+        "scipy.stats",
+        "zarr",
+    )
+
+    # The subprocess hooks builtins.__import__ to capture a stack trace the
+    # first time any expensive module is imported, so failures show exactly
+    # which pymc file triggered the eager load.
+    code = textwrap.dedent("""\
+        import builtins, sys, traceback
+        _targets = set({targets})
+        _traces, _real = {{}}, builtins.__import__
+        def _hook(name, *a, **kw):
+            if name in _targets and name not in sys.modules and name not in _traces:
+                _traces[name] = ''.join(traceback.format_stack())
+            return _real(name, *a, **kw)
+        builtins.__import__ = _hook
+        import pymc
+        loaded = [m for m in sorted(_targets) if m in sys.modules]
+        print(','.join(loaded))
+        for m in loaded[:3]:
+            print(f'--- {{m}} ---')
+            print(_traces.get(m, '(no trace)'))
+    """).format(targets=expensive_modules)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    lines = result.stdout.strip().split("\n")
+    loaded = [m for m in lines[0].split(",") if m]
+    assert not loaded, (
+        f"`import pymc` eagerly loaded heavy modules: {loaded}. "
+        "These should be deferred to first use.\n" + "\n".join(lines[1:])
+    )


### PR DESCRIPTION
Imports PyMC 4x faster

* Defer import arviz_base due to https://github.com/arviz-devs/arviz-base/issues/196
* Defer importing slowly (and rarely triggered) scipy.linalg/sparse/stats like https://github.com/pymc-devs/pytensor/pull/2112 (depends on it)
* Lazy import of Zarr
* Lazy import of Ipython
* Keep eager xarray import (which also pulls pandas)

Before
<img width="804" height="482" alt="image" src="https://github.com/user-attachments/assets/0240f2ae-ecdc-4b13-a772-f79cff7e8f65" />


After
<img width="765" height="483" alt="image" src="https://github.com/user-attachments/assets/415607b1-8391-4fc5-85d6-946f3aff5424" />

Sub second import. 50% of which is xarray + pandas, and 25% PyTensor, which seems acceptable. The xarray pulling pandas is unfortunate. And xarray being itself slow.. I guess is the price we accepted for using it as the default backend

Also a separate commit that imports and uses Dataset directly in type-hints
