### PR TITLE
Allow samplers to choose default number of steps

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 """PyMC-ArviZ conversion code."""
 
+import json
 import logging
 import warnings
 
@@ -42,7 +43,7 @@ import pymc
 from pymc.model import Model, modelcontext
 from pymc.progress_bar import CustomProgress, default_progress_theme
 from pymc.pytensorf import PointFunc, extract_obs_data
-from pymc.util import get_default_varnames, get_untransformed_name, is_transformed_name
+from pymc.util import get_default_varnames
 
 if TYPE_CHECKING:
     from pymc.backends.base import MultiTrace
@@ -141,42 +142,17 @@ def find_constants(model: "Model") -> dict[str, Var]:
 def patch_nutpie_idata(
     idata: DataTree,
     model: "Model",
-    tune: int,
     sampling_time: float,
-    include_transformed: bool = False,
 ) -> None:
     """Fix up the ``DataTree`` returned by ``nutpie.sample`` in place.
 
     Work-around for gaps in what nutpie attaches to the returned ``DataTree``:
 
-    - drops transformed variables from ``posterior`` / ``warmup_posterior``
-      (when ``include_transformed`` is ``False``) or moves them into
-      ``unconstrained_posterior`` / ``warmup_unconstrained_posterior``
-      (when ``True``). Drop once
-      https://github.com/pymc-devs/nutpie/pull/298 and
-      https://github.com/pymc-devs/nutpie/issues/78 are released;
     - attaches ``constant_data`` / ``observed_data`` groups gathered from the
       model. Drop once https://github.com/pymc-devs/nutpie/issues/74 is released;
     - stamps ``sampling_time`` / ``tuning_steps`` attrs onto the posterior.
     """
     import nutpie
-
-    for src, dst in (
-        ("posterior", "unconstrained_posterior"),
-        ("warmup_posterior", "warmup_unconstrained_posterior"),
-    ):
-        if src not in idata.children:
-            continue
-        ds = idata[src].to_dataset()
-        transformed = [v for v in ds.data_vars if is_transformed_name(v)]
-        if not transformed:
-            continue
-        idata[src] = DataTree(ds.drop_vars(transformed))
-        if include_transformed:
-            unconstrained = ds[transformed].rename(
-                {v: get_untransformed_name(v) for v in transformed}
-            )
-            idata[dst] = DataTree(unconstrained)
 
     coords, dims = coords_and_dims_for_inferencedata(model)
     idata["constant_data"] = DataTree(
@@ -198,8 +174,9 @@ def patch_nutpie_idata(
         )
     )
 
+    nutpie_settings = json.loads(idata.sample_stats.attrs["inference_library_settings"])
     attrs = make_attrs(
-        {"sampling_time": sampling_time, "tuning_steps": tune},
+        {"sampling_time": sampling_time, "tuning_steps": nutpie_settings["settings"]["num_tune"]},
         inference_library=nutpie,
     )
     for k, v in attrs.items():

--- a/pymc/progress_bar/marimo_progress.py
+++ b/pymc/progress_bar/marimo_progress.py
@@ -70,7 +70,7 @@ class MarimoProgressBackend:
 
         self._mo_replace: Callable[[object], None] | None = None
         self._task_state: list[dict[str, Any]] = []
-        self._start_times: list[float] = []
+        self._start_times: list[float | None] = []
         self._last_render_time: float = 0.0
         self._min_render_interval: float = 0.1
 
@@ -103,7 +103,10 @@ class MarimoProgressBackend:
             }
             for _ in range(self.n_bars)
         ]
-        self._start_times = [perf_counter() for _ in range(self.n_bars)]
+        # Per-bar clocks start lazily on the first update so that, with
+        # ``cores < chains``, later chains aren't timed from the first chain's
+        # start.
+        self._start_times = [None] * self.n_bars
 
     def update(
         self,
@@ -135,6 +138,9 @@ class MarimoProgressBackend:
         """
         if total is not None:
             self._task_state[task_id]["total"] = total
+
+        if self._start_times[task_id] is None:
+            self._start_times[task_id] = perf_counter()
 
         self._task_state[task_id]["completed"] += advance
         self._task_state[task_id]["failing"] = failing
@@ -208,10 +214,16 @@ class MarimoProgressBackend:
         stats = state["stats"]
 
         pct = (completed / total * 100) if total else 0
-        elapsed = perf_counter() - self._start_times[task_id]
+        start_time = self._start_times[task_id]
+        elapsed = 0.0 if start_time is None else perf_counter() - start_time
 
         action = self.step_name.lower()
-        speed = completed / max(elapsed, 1e-6)
+        # Wait for a small window of elapsed time before computing speed so the
+        # first reading isn't ``completed / ~0 ≈ infinity``.
+        if elapsed > 0.25:
+            speed = completed / elapsed
+        else:
+            speed = 0
         if speed > 1 or speed == 0:
             unit = f"{action}s/s"
         else:

--- a/pymc/progress_bar/marimo_progress.py
+++ b/pymc/progress_bar/marimo_progress.py
@@ -94,27 +94,16 @@ class MarimoProgressBackend:
 
     def _initialize_tasks(self) -> None:
         """Initialize progress tracking state for all tasks."""
-        if self.combined:
-            self._task_state = [
-                {
-                    "completed": 0,
-                    "total": self.total * self.n_bars,
-                    "failing": False,
-                    "stats": {},
-                }
-            ]
-            self._start_times = [perf_counter()]
-        else:
-            self._task_state = [
-                {
-                    "completed": 0,
-                    "total": self.total,
-                    "failing": False,
-                    "stats": {},
-                }
-                for _ in range(self.n_bars)
-            ]
-            self._start_times = [perf_counter() for _ in range(self.n_bars)]
+        self._task_state = [
+            {
+                "completed": 0,
+                "total": self.total,
+                "failing": False,
+                "stats": {},
+            }
+            for _ in range(self.n_bars)
+        ]
+        self._start_times = [perf_counter() for _ in range(self.n_bars)]
 
     def update(
         self,

--- a/pymc/progress_bar/marimo_progress.py
+++ b/pymc/progress_bar/marimo_progress.py
@@ -56,7 +56,7 @@ class MarimoProgressBackend:
         self,
         step_name: str,
         n_bars: int,
-        total: int | float,
+        total: int | float | None,
         combined: bool,
         full_stats: bool,
         css_theme: str | None = None,
@@ -112,6 +112,7 @@ class MarimoProgressBackend:
         failing: bool,
         stats: dict[str, Any],
         is_last: bool,
+        total: int | None = None,
     ) -> None:
         """Update progress for a specific task.
 
@@ -127,7 +128,14 @@ class MarimoProgressBackend:
             Statistics to display
         is_last : bool
             Whether this is the final update
+        total : int, optional
+            Updated total for the bar. If None, the existing total is kept.
+            Pass an integer when the total wasn't known at construction time
+            (e.g. nutpie's tune count) or changes mid-run.
         """
+        if total is not None:
+            self._task_state[task_id]["total"] = total
+
         self._task_state[task_id]["completed"] += advance
         self._task_state[task_id]["failing"] = failing
         self._task_state[task_id]["stats"] = stats
@@ -199,7 +207,7 @@ class MarimoProgressBackend:
         failing = state["failing"]
         stats = state["stats"]
 
-        pct = (completed / total * 100) if total > 0 else 0
+        pct = (completed / total * 100) if total else 0
         elapsed = perf_counter() - self._start_times[task_id]
 
         action = self.step_name.lower()
@@ -216,9 +224,10 @@ class MarimoProgressBackend:
         elif pct >= 100:
             bar_class += " finished"
 
+        total_str = "?" if total is None else str(total)
         cells = [
             f'<td><div class="pymc-progress-bar-container"><div class="{bar_class}" style="width: {pct:.1f}%"></div></div></td>',
-            f"<td>{completed}/{total} ({pct:.0f}%)</td>",
+            f"<td>{completed}/{total_str} ({pct:.0f}%)</td>",
         ]
 
         for key in stat_keys:

--- a/pymc/progress_bar/progress.py
+++ b/pymc/progress_bar/progress.py
@@ -257,10 +257,11 @@ class MCMCProgressBarManager(ProgressBarManager):
         self.update_stats_functions = step_method._make_progressbar_update_functions()
 
         self.completed_draws = 0
-        self.total_draws = draws + tune
+        total_draws = draws + tune
+        self.total_draws = total_draws * chains if self.combined_progress else total_draws
 
         self._backend = self._create_backend(
-            total=self.total_draws * chains if self.combined_progress else self.total_draws,
+            total=self.total_draws,
             progress_columns=progress_columns,
             progress_stats=progress_stats,
         )
@@ -378,26 +379,47 @@ class NutpieProgressBarManager(ProgressBarManager):
         if not self._show_progress:
             return
 
-        for chain_idx, cp in enumerate(chain_progresses):
-            delta = cp.finished_draws - self._previous_finished[chain_idx]
-            if delta <= 0:
-                continue
-            self._previous_finished[chain_idx] = cp.finished_draws
-            is_last = cp.finished_draws >= cp.total_draws
+        if self.combined_progress:
             stats = {
-                "divergences": cp.divergences,
-                "step_size": cp.step_size,
-                "tree_size": cp.latest_num_steps,
-                "draw": cp.finished_draws,
+                "divergences": 0,
+                "step_size": 0,
+                "tree_size": 0,
+                "draw": 0,
             }
-            task_id = 0 if self.combined_progress else chain_idx
+            delta = 0
+            for chain_idx, cp in enumerate(chain_progresses):
+                cp_finished_draws = cp.finished_draws
+                delta += cp_finished_draws - self._previous_finished[chain_idx]
+                self._previous_finished[chain_idx] = cp_finished_draws
+                stats["divergences"] += len(cp.divergent_draws)
+                stats["tree_size"] = max(stats["tree_size"], cp.latest_num_steps)
+                stats["draw"] += cp_finished_draws
+            bar_total = cp.total_draws * len(chain_progresses)
             self._backend.update(
-                task_id=task_id,
+                task_id=0,
                 advance=delta,
-                failing=cp.divergences > 0,
+                failing=stats["divergences"] > 0,
                 stats=stats,
-                is_last=is_last,
+                is_last=stats["draw"] >= bar_total,
             )
+        else:
+            for chain_idx, cp in enumerate(chain_progresses):
+                cp_finished_draws = cp.finished_draws
+                delta = cp_finished_draws - self._previous_finished[chain_idx]
+                self._previous_finished[chain_idx] = cp_finished_draws
+                stats = {
+                    "divergences": len(cp.divergent_draws),
+                    "step_size": cp.step_size,
+                    "tree_size": cp.latest_num_steps,
+                    "draw": cp_finished_draws,
+                }
+                self._backend.update(
+                    task_id=chain_idx,
+                    advance=delta,
+                    failing=bool(cp.divergent_draws),
+                    stats=stats,
+                    is_last=cp_finished_draws >= cp.total_draws,
+                )
 
 
 class SMCProgressBarManager(ProgressBarManager):

--- a/pymc/progress_bar/progress.py
+++ b/pymc/progress_bar/progress.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from contextlib import nullcontext
+from time import perf_counter
 from typing import TYPE_CHECKING, Any, Literal, Protocol, Self
 
 from rich.progress import TextColumn
@@ -394,6 +395,10 @@ class NutpieProgressBarManager(ProgressBarManager):
                 stats["tree_size"] = max(stats["tree_size"], cp.latest_num_steps)
                 stats["draw"] += cp_finished_draws
             bar_total: int = cp.total_draws * len(chain_progresses)
+            # Use the slowest chain's runtime as the combined bar's elapsed.
+            max_runtime_ms = max(cp.runtime_ms for cp in chain_progresses)
+            if max_runtime_ms > 0:
+                self._set_task_elapsed(0, max_runtime_ms / 1000.0)
             self._backend.update(
                 task_id=0,
                 advance=delta,
@@ -404,9 +409,18 @@ class NutpieProgressBarManager(ProgressBarManager):
             )
         else:
             for chain_idx, cp in enumerate(chain_progresses):
+                # With ``cores < chains`` queued chains haven't started yet;
+                # skip them so their bar doesn't show progress or elapsed time.
+                if not cp.started:
+                    continue
                 cp_finished_draws = cp.finished_draws
                 delta = cp_finished_draws - self._previous_finished[chain_idx]
                 self._previous_finished[chain_idx] = cp_finished_draws
+                # Use nutpie's per-chain runtime as the source of truth for
+                # elapsed/speed, so reads aren't skewed by the wait time
+                # before this chain started.
+                if cp.runtime_ms > 0:
+                    self._set_task_elapsed(chain_idx, cp.runtime_ms / 1000.0)
                 stats = {
                     "divergences": len(cp.divergent_draws),
                     "step_size": cp.step_size,
@@ -421,6 +435,19 @@ class NutpieProgressBarManager(ProgressBarManager):
                     is_last=cp_finished_draws >= cp.total_draws,
                     total=cp.total_draws,
                 )
+
+    def _set_task_elapsed(self, task_id: int, elapsed_seconds: float) -> None:
+        """Override the backend's elapsed clock to match nutpie's per-chain runtime."""
+        backend = self._backend
+        now = perf_counter()
+        if isinstance(backend, RichProgressBackend):
+            rich_task_id = backend._tasks[task_id]
+            if rich_task_id is None:
+                return
+            backend._progress.tasks[task_id].start_time = now - elapsed_seconds
+            backend._started[task_id] = True
+        elif isinstance(backend, MarimoProgressBackend):
+            backend._start_times[task_id] = now - elapsed_seconds
 
 
 class SMCProgressBarManager(ProgressBarManager):

--- a/pymc/progress_bar/progress.py
+++ b/pymc/progress_bar/progress.py
@@ -65,6 +65,7 @@ class ProgressBackend(Protocol):
         failing: bool,
         stats: dict[str, Any],
         is_last: bool,
+        total: int | None = None,
     ) -> None: ...
 
 
@@ -147,7 +148,7 @@ class ProgressBarManager(ABC):
 
     def _create_backend(
         self,
-        total: int | float,
+        total: int | float | None,
         progress_columns: list,
         progress_stats: dict[str, list[Any]],
     ) -> ProgressBackend:
@@ -329,6 +330,7 @@ class MCMCProgressBarManager(ProgressBarManager):
             failing=failing,
             stats=all_step_stats,
             is_last=is_last,
+            total=self.total_draws,
         )
 
 
@@ -346,7 +348,6 @@ class NutpieProgressBarManager(ProgressBarManager):
         self,
         chains: int,
         draws: int,
-        tune: int,
         progressbar: bool | ProgressBarOptions = True,
         progressbar_theme: Theme | str | None = None,
     ):
@@ -355,6 +356,8 @@ class NutpieProgressBarManager(ProgressBarManager):
             progressbar=progressbar,
             progressbar_theme=progressbar_theme,
         )
+        # Used to compute delta draws between calls
+        self._previous_finished = [0] * chains
 
         progress_columns = [
             TextColumn("{task.fields[divergences]}", table_column=Column("Divergences", ratio=1)),
@@ -364,12 +367,8 @@ class NutpieProgressBarManager(ProgressBarManager):
         progress_stats = {
             stat: [0] * chains for stat in ("divergences", "step_size", "tree_size", "draw")
         }
-
-        self._previous_finished = [0] * chains
-        total_draws = draws + tune
-
         self._backend = self._create_backend(
-            total=total_draws * chains if self.combined_progress else total_draws,
+            total=None,  # Will be set on first callback
             progress_columns=progress_columns,
             progress_stats=progress_stats,
         )
@@ -394,13 +393,14 @@ class NutpieProgressBarManager(ProgressBarManager):
                 stats["divergences"] += len(cp.divergent_draws)
                 stats["tree_size"] = max(stats["tree_size"], cp.latest_num_steps)
                 stats["draw"] += cp_finished_draws
-            bar_total = cp.total_draws * len(chain_progresses)
+            bar_total: int = cp.total_draws * len(chain_progresses)
             self._backend.update(
                 task_id=0,
                 advance=delta,
                 failing=stats["divergences"] > 0,
                 stats=stats,
                 is_last=stats["draw"] >= bar_total,
+                total=bar_total,
             )
         else:
             for chain_idx, cp in enumerate(chain_progresses):
@@ -419,6 +419,7 @@ class NutpieProgressBarManager(ProgressBarManager):
                     failing=bool(cp.divergent_draws),
                     stats=stats,
                     is_last=cp_finished_draws >= cp.total_draws,
+                    total=cp.total_draws,
                 )
 
 

--- a/pymc/progress_bar/rich_progress.py
+++ b/pymc/progress_bar/rich_progress.py
@@ -200,7 +200,7 @@ class RichProgressBackend:
         columns += [
             TextColumn(
                 "{task.fields[sampling_speed]:0.2f} {task.fields[speed_unit]}",
-                table_column=Column("Speed", ratio=1),
+                table_column=Column("Speed", ratio=2, no_wrap=True),
             ),
             TimeElapsedColumn(table_column=Column("Elapsed", ratio=1)),
             TimeRemainingColumn(table_column=Column("Remaining", ratio=1)),
@@ -229,9 +229,13 @@ class RichProgressBackend:
         self._progress.__exit__(exc_type, exc_val, exc_tb)
 
     def _initialize_tasks(self) -> None:
+        # ``start=False`` defers the per-task clock until ``start_task`` is
+        # called on the first ``update``. With ``cores < chains``, later chains
+        # would otherwise be timed against the first chain's start.
         self._tasks = [
             self._progress.add_task(
                 "Sampling",
+                start=False,
                 completed=0,
                 total=self.initial_total,
                 task_idx=task_idx,
@@ -242,6 +246,7 @@ class RichProgressBackend:
             )
             for task_idx in range(self.n_bars)
         ]
+        self._started: list[bool] = [False] * self.n_bars
 
     def update(
         self,
@@ -276,6 +281,10 @@ class RichProgressBackend:
         if rich_task_id is None:
             return
 
+        if not self._started[task_id]:
+            self._progress.start_task(rich_task_id)
+            self._started[task_id] = True
+
         if is_last:
             if total is None:
                 total = self._progress.tasks[task_id].total  # type: ignore[assignment]
@@ -296,7 +305,12 @@ class RichProgressBackend:
         elapsed = task.elapsed if task.elapsed is not None else 0.0
 
         action = self.step_name.lower()
-        speed = completed / max(elapsed, 1e-6)
+        # Wait for a small window of elapsed time before computing speed so the
+        # first reading isn't ``completed / ~0 ≈ infinity``.
+        if elapsed > 0.25:
+            speed = completed / elapsed
+        else:
+            speed = 0
         if speed > 1 or speed == 0:
             unit = f"{action}s/s"
         else:

--- a/pymc/progress_bar/rich_progress.py
+++ b/pymc/progress_bar/rich_progress.py
@@ -36,6 +36,7 @@ default_progress_theme = Theme(
     {
         "bar.complete": "#1764f4",
         "bar.finished": "#1764f4",
+        "bar.pulse": "grey23",
         "progress.remaining": "none",
         "progress.elapsed": "none",
     }
@@ -140,7 +141,7 @@ class RichProgressBackend:
         self,
         step_name: str,
         n_bars: int,
-        total: int | float,
+        total: int | float | None,
         combined: bool,
         full_stats: bool,
         progress_columns: list,
@@ -170,7 +171,7 @@ class RichProgressBackend:
         """
         self.step_name = step_name
         self.n_bars = n_bars
-        self.total = total
+        self.initial_total = total
         self.combined = combined
         self.full_stats = full_stats
         self.progress_stats = progress_stats
@@ -207,14 +208,16 @@ class RichProgressBackend:
 
         return CustomProgress(
             RecolorOnFailureBarColumn(
+                bar_width=None,
                 table_column=Column("Progress", ratio=2),
                 failing_color="tab:red",
                 complete_style=Style.parse("rgb(31,119,180)"),
                 finished_style=Style.parse("rgb(31,119,180)"),
             ),
             *columns,
-            console=Console(file=stderr, theme=theme),
+            console=Console(theme=theme),
             include_headers=True,
+            expand=True,
         )
 
     def __enter__(self) -> Self:
@@ -230,7 +233,7 @@ class RichProgressBackend:
             self._progress.add_task(
                 "Sampling",
                 completed=0,
-                total=self.total,
+                total=self.initial_total,
                 task_idx=task_idx,
                 sampling_speed=0,
                 speed_unit="draws/s",
@@ -247,6 +250,7 @@ class RichProgressBackend:
         failing: bool,
         stats: dict[str, Any],
         is_last: bool,
+        total: int | None = None,
     ) -> None:
         """Update a progress bar.
 
@@ -262,17 +266,25 @@ class RichProgressBackend:
             Statistics to display
         is_last : bool
             Whether this is the final update
+        total : int, optional
+            Updated total for the bar. If None, the existing total is kept —
+            use this when the total is fixed at construction time. Pass an
+            integer when the total is only known later (e.g. nutpie chooses
+            its own tune count) or can change mid-run.
         """
         rich_task_id = self._tasks[task_id]
         if rich_task_id is None:
             return
 
         if is_last:
+            if total is None:
+                total = self._progress.tasks[task_id].total  # type: ignore[assignment]
             self._progress.update(
                 rich_task_id,
-                completed=self.total,
+                completed=total,
                 failing=failing,
                 refresh=True,
+                total=total,
                 **stats,
             )
             return
@@ -296,6 +308,7 @@ class RichProgressBackend:
             sampling_speed=speed,
             speed_unit=unit,
             failing=failing,
+            total=total,
             **stats,
         )
 

--- a/pymc/progress_bar/rich_progress.py
+++ b/pymc/progress_bar/rich_progress.py
@@ -226,33 +226,19 @@ class RichProgressBackend:
         self._progress.__exit__(exc_type, exc_val, exc_tb)
 
     def _initialize_tasks(self) -> None:
-        if self.combined:
-            self._tasks = [
-                self._progress.add_task(
-                    "Sampling",
-                    completed=0,
-                    total=self.total * self.n_bars,
-                    task_idx=0,
-                    sampling_speed=0,
-                    speed_unit="draws/s",
-                    failing=False,
-                    **{stat: value[0] for stat, value in self.progress_stats.items()},
-                )
-            ]
-        else:
-            self._tasks = [
-                self._progress.add_task(
-                    "Sampling",
-                    completed=0,
-                    total=self.total,
-                    task_idx=task_idx,
-                    sampling_speed=0,
-                    speed_unit="draws/s",
-                    failing=False,
-                    **{stat: value[task_idx] for stat, value in self.progress_stats.items()},
-                )
-                for task_idx in range(self.n_bars)
-            ]
+        self._tasks = [
+            self._progress.add_task(
+                "Sampling",
+                completed=0,
+                total=self.total,
+                task_idx=task_idx,
+                sampling_speed=0,
+                speed_unit="draws/s",
+                failing=False,
+                **{stat: value[task_idx] for stat, value in self.progress_stats.items()},
+            )
+            for task_idx in range(self.n_bars)
+        ]
 
     def update(
         self,
@@ -284,7 +270,7 @@ class RichProgressBackend:
         if is_last:
             self._progress.update(
                 rich_task_id,
-                completed=self.total if not self.combined else self.total * self.n_bars,
+                completed=self.total,
                 failing=failing,
                 refresh=True,
                 **stats,

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -69,6 +69,7 @@ from pymc.stats.convergence import (
 )
 from pymc.step_methods import NUTS, STEP_METHODS, CompoundStep
 from pymc.step_methods.arraystep import BlockedStep, PopulationArrayStepShared
+from pymc.step_methods.compound import flatten_steps
 from pymc.step_methods.hmc import quadpotential
 from pymc.util import (
     RandomSeed,
@@ -97,6 +98,23 @@ __all__ = [
 ]
 
 Step: TypeAlias = BlockedStep | CompoundStep
+
+
+def get_default_tune_steps(step: "Step", tune: int | None, default_tune_steps: int = 1000) -> int:
+    """Get the default number of tuning steps.
+
+    If ``tune`` is an explicit integer, return it directly.
+
+    If ``tune`` is ``None``, ask each step method how many tune steps it needs via its ``default_tune_steps``
+    and return the maximum. Step methods that leave ``default_tune_steps=None`` fall back to ``default_tune_steps``
+    """
+    if tune is not None:
+        return tune
+
+    tune_steps = [getattr(step, "default_tune_steps", None) for step in flatten_steps(step)]
+    return max(
+        (default_tune_steps if t is None else t for t in tune_steps), default=default_tune_steps
+    )
 
 
 class SamplingIteratorCallback(Protocol):
@@ -330,7 +348,8 @@ def all_continuous(vars):
 def _sample_external_nuts(
     sampler: Literal["nutpie", "numpyro", "blackjax"],
     draws: int,
-    tune: int,
+    *,
+    tune: int | None = None,
     chains: int,
     cores: int | None,
     random_seed: RandomState | None,
@@ -422,7 +441,6 @@ def _sample_external_nuts(
         pb_manager = NutpieProgressBarManager(
             chains=chains,
             draws=draws,
-            tune=tune,
             progressbar=progressbar,
             progressbar_theme=progressbar_theme,
         )
@@ -468,9 +486,10 @@ def _sample_external_nuts(
 
         jax_nuts_kwargs = dict(nuts_kwargs)
         jax_target_accept = jax_nuts_kwargs.pop("target_accept", 0.8)
+        # Don't forward tune=None: let `sample_jax_nuts`'s own default kick in.
+        tune_kwarg = {"tune": tune} if tune is not None else {}
         idata = pymc_jax.sample_jax_nuts(
             draws=draws,
-            tune=tune,
             chains=chains,
             target_accept=jax_target_accept,
             # jax samplers take a single master seed; `random_seed` here is the
@@ -485,6 +504,7 @@ def _sample_external_nuts(
             nuts_kwargs=jax_nuts_kwargs,
             idata_kwargs=idata_kwargs,
             compute_convergence_checks=compute_convergence_checks,
+            **tune_kwarg,
         )
         return idata
 
@@ -564,7 +584,7 @@ def sample(
 def sample(
     draws: int = 1000,
     *,
-    tune: int = 1000,
+    tune: int | None = None,
     chains: int | None = None,
     cores: int | None = None,
     random_seed: RandomState = None,
@@ -998,6 +1018,8 @@ def sample(
         )
         if isinstance(step, list):
             step = CompoundStep(step)
+
+    tune = get_default_tune_steps(step, tune)
 
     if var_names is not None:
         trace_vars = [v for v in model.unobserved_RVs if v.name in var_names]

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -17,6 +17,7 @@ import importlib.util
 import logging
 import multiprocessing
 import pickle
+import re
 import sys
 import time
 import warnings
@@ -377,6 +378,16 @@ def _sample_external_nuts(
             )
         import nutpie
 
+        # Strip pre-release suffixes like "rc1" from each component.
+        version_tuple = tuple(
+            int(re.match(r"\d+", p).group()) for p in nutpie.__version__.split(".")[:3]
+        )
+        if version_tuple < (0, 16, 10):
+            raise ImportError(
+                f"pymc requires nutpie>=0.16.10 (found {nutpie.__version__}). "
+                "Upgrade with `pip install -U nutpie` or `conda install -c conda-forge 'nutpie>=0.16.10'`."
+            )
+
         if isinstance(initvals, dict):
             compile_kwargs.setdefault("initial_points", initvals)
         elif initvals is not None:
@@ -426,18 +437,13 @@ def _sample_external_nuts(
                 cores=cores,
                 seed=int(random_seed[0]),
                 save_warmup=not discard_tuned_samples,
+                store_unconstrained=include_transformed,
                 progress_bar=False,
                 progress_callback=pb_manager.update,
                 **nuts_kwargs,
             )
         t_sample = time.time() - t_start
-        patch_nutpie_idata(
-            idata,
-            model,
-            tune=tune,
-            sampling_time=t_sample,
-            include_transformed=include_transformed,
-        )
+        patch_nutpie_idata(idata, model, sampling_time=t_sample)
         if log_likelihood:
             warnings.warn(
                 "Passing `log_likelihood` via `idata_kwargs` is deprecated and will be removed "

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -126,6 +126,9 @@ class BlockedStep(ABC, WithSamplingState):
     vars: list[Variable] = []
     """Variables that the step method is assigned to."""
 
+    default_tune_steps: int | None = None
+    """Number of default tuning steps this step method needs."""
+
     def __new__(cls, *args, **kwargs):
         blocked = kwargs.get("blocked")
         if blocked is None:

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -488,6 +488,7 @@ class BinaryMetropolis(ArrayStep):
         q0 = apoint.data
 
         # Convert adaptive_scale_factor to a jump probability
+        # TODO: No reason to compute this in every step
         p_jump = 1.0 - 0.5**self.scaling
 
         rand_array = self.rng.random(q0.shape)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ with open(REQUIREMENTS_FILE) as f:
 test_reqs = ["pytest", "pytest-cov"]
 
 extras_require = {
-    "nutpie": ["nutpie>=0.16.8"],
+    "nutpie": ["nutpie>=0.16.10,<1"],
 }
 
 if __name__ == "__main__":

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -33,7 +33,7 @@ import pymc as pm
 from pymc.backends.ndarray import NDArray
 from pymc.distributions import transforms
 from pymc.exceptions import SamplingError
-from pymc.sampling.mcmc import assign_step_methods
+from pymc.sampling.mcmc import assign_step_methods, get_default_tune_steps
 from pymc.stats.convergence import SamplerWarning, WarningType
 from pymc.step_methods import (
     NUTS,
@@ -1017,3 +1017,74 @@ class TestQuietMode:
 
         pymc_logs = [r for r in caplog.records if r.name.startswith("pymc")]
         assert len(pymc_logs) > 0
+
+
+class TestDefaultTuneSteps:
+    def test_default(self):
+        with pm.Model():
+            x = pm.Normal("x")
+            step = pm.Metropolis([x])
+
+        assert get_default_tune_steps(step, 42) == 42
+        assert get_default_tune_steps(step, 0) == 0
+        assert get_default_tune_steps(step, None) == 1000
+
+        assert get_default_tune_steps(step, 37, default_tune_steps=999) == 37
+        assert get_default_tune_steps(step, 0, default_tune_steps=999) == 0
+        assert get_default_tune_steps(step, None, default_tune_steps=999) == 999
+
+    def test_custom_step(self):
+        class PerfectMetropolis(pm.Metropolis):
+            default_tune_steps = 0
+
+        with pm.Model():
+            y = pm.Categorical("y", p=[0.25, 0.25, 0.5])
+            step = PerfectMetropolis([y])
+
+        assert get_default_tune_steps(step, None) == 0
+        assert get_default_tune_steps(step, 15) == 15
+
+    def test_compound_step(self):
+        class PerfectMetropolis(pm.Metropolis):
+            default_tune_steps = 0
+
+        class AlmostPerfectMetropolis(pm.Metropolis):
+            default_tune_steps = 50
+
+        with pm.Model():
+            x = pm.Normal("x")
+            y = pm.Categorical("y", p=[0.25, 0.25, 0.5])
+            step0 = pm.CompoundStep([pm.NUTS([x]), AlmostPerfectMetropolis([y])])
+            step1 = pm.CompoundStep([PerfectMetropolis([x]), AlmostPerfectMetropolis([y])])
+
+        assert get_default_tune_steps(step0, None) == 1000
+        assert get_default_tune_steps(step0, None, default_tune_steps=999) == 999
+        assert get_default_tune_steps(step0, 999) == 999
+        assert get_default_tune_steps(step0, 1001) == 1001
+
+        assert get_default_tune_steps(step1, None) == 50
+        assert get_default_tune_steps(step1, None, default_tune_steps=999) == 50
+        assert get_default_tune_steps(step1, 999) == 999
+
+    def test_sample(self):
+        class PerfectMetropolis(pm.Metropolis):
+            default_tune_steps = 0
+
+        with pm.Model():
+            y = pm.Bernoulli("y", p=0.25)
+            step = PerfectMetropolis([y])
+
+            kwargs = {
+                "draws": 10,
+                "step": step,
+                "chains": 1,
+                "discard_tuned_samples": False,
+                "progressbar": False,
+                "compute_convergence_checks": False,
+            }
+
+            idata = pm.sample(tune=None, **kwargs)
+            assert not hasattr(idata, "warmup_posterior")
+
+            idata = pm.sample(tune=10, **kwargs)
+            assert idata.warmup_posterior.sizes["draw"] == 10

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -208,18 +208,22 @@ def test_nutpie_progress_bar_manager_update():
     pb._show_progress = True  # force the update path even without a real backend
 
     cp0 = SimpleNamespace(
+        started=True,
         finished_draws=5,
         total_draws=20,
         divergent_draws=[],
         step_size=0.5,
         latest_num_steps=3,
+        runtime_ms=10,
     )
     cp1 = SimpleNamespace(
+        started=True,
         finished_draws=4,
         total_draws=20,
         divergent_draws=[],
         step_size=0.4,
         latest_num_steps=7,
+        runtime_ms=8,
     )
     pb.update([cp0, cp1])
     assert pb._backend.update.call_count == 2

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -203,21 +203,21 @@ def test_initvals(nuts_sampler, initvals):
 
 
 def test_nutpie_progress_bar_manager_update():
-    pb = NutpieProgressBarManager(chains=2, draws=10, tune=10, progressbar=False)
+    pb = NutpieProgressBarManager(chains=2, draws=10, progressbar=False)
     pb._backend = mock.Mock()
     pb._show_progress = True  # force the update path even without a real backend
 
     cp0 = SimpleNamespace(
         finished_draws=5,
         total_draws=20,
-        divergences=0,
+        divergent_draws=[],
         step_size=0.5,
         latest_num_steps=3,
     )
     cp1 = SimpleNamespace(
         finished_draws=4,
         total_draws=20,
-        divergences=1,
+        divergent_draws=[],
         step_size=0.4,
         latest_num_steps=7,
     )
@@ -230,17 +230,23 @@ def test_nutpie_progress_bar_manager_update():
     second_call = pb._backend.update.call_args_list[1].kwargs
     assert second_call["task_id"] == 1
     assert second_call["advance"] == 4
-    assert second_call["failing"] is True
+    assert second_call["stats"]["divergences"] == 0
+    assert second_call["failing"] is False
 
-    # A second update only advances by the delta since the previous call.
+    # Both chains complete; cp1 gained a divergence.
     cp0.finished_draws = 20
     cp1.finished_draws = 20
+    cp1.divergent_draws = [12]
     pb._backend.update.reset_mock()
     pb.update([cp0, cp1])
     deltas = [c.kwargs["advance"] for c in pb._backend.update.call_args_list]
     is_last_flags = [c.kwargs["is_last"] for c in pb._backend.update.call_args_list]
+    divergences = [c.kwargs["stats"]["divergences"] for c in pb._backend.update.call_args_list]
+    failing = [c.kwargs["failing"] for c in pb._backend.update.call_args_list]
     assert deltas == [15, 16]
     assert is_last_flags == [True, True]
+    assert divergences == [0, 1]
+    assert failing == [False, True]
 
 
 def test_nutpie_end_to_end():


### PR DESCRIPTION
Subsumes and closes #8110
Closes #8080

Needed some work on the progressbar backend to allow lazy total (rich is fine with it)
Also cleaned up some other logic and fixed the speed for sequential progressbar to be relative to the first draw of each chain, and not the first chain (otherwise later progress bars always seemed slower)