### PR TITLE
Visually split tuning/draw phase in progress bar

### DIFF
--- a/pymc/progress_bar/progress.py
+++ b/pymc/progress_bar/progress.py
@@ -261,7 +261,9 @@ class MCMCProgressBarManager(ProgressBarManager):
         self.completed_draws = 0
         total_draws = draws + tune
         self.total_draws = total_draws * chains if self.combined_progress else total_draws
+        self._tune_total = tune * chains if self.combined_progress else tune
 
+        progress_stats["marker_pos"] = [self._tune_total] * chains
         self._backend = self._create_backend(
             total=self.total_draws,
             progress_columns=progress_columns,
@@ -323,7 +325,12 @@ class MCMCProgressBarManager(ProgressBarManager):
             chain_idx = 0
 
         failing, all_step_stats = self._extract_stats(stats)
-        all_step_stats["draw"] = draw + 1 if not self.combined_progress else draw
+
+        count = draw + 1 if not self.combined_progress else draw
+        if count <= self._tune_total:
+            all_step_stats["draw"] = count
+        else:
+            all_step_stats["draw"] = count - self._tune_total
 
         self._backend.update(
             task_id=chain_idx,
@@ -373,6 +380,7 @@ class NutpieProgressBarManager(ProgressBarManager):
         # Used to compute delta draws between calls
         self._previous_finished = [0] * chains
         self._chain_completed = [False] * chains
+        self._draws = draws
 
         progress_columns = [
             TextColumn("{task.fields[divergences]}", table_column=Column("Divergences", ratio=1)),
@@ -382,16 +390,29 @@ class NutpieProgressBarManager(ProgressBarManager):
         progress_stats = {
             stat: [0] * chains for stat in ("divergences", "step_size", "tree_size", "draw")
         }
+        self._tune_total: int | None = None
         self._backend = self._create_backend(
             total=None,  # Will be set on first callback
             progress_columns=progress_columns,
             progress_stats=progress_stats,
         )
 
+    def _reset_draw(self, count: int) -> int:
+        if self._tune_total and count > self._tune_total:
+            return count - self._tune_total
+        return count
+
     def update(self, chain_progresses) -> None:
         """Consume a list of ``nutpie.ChainProgress`` objects and advance each bar."""
         if not self._show_progress:
             return
+
+        if self._tune_total is None:
+            for cp in chain_progresses:
+                if cp.started:
+                    tune = cp.total_draws - self._draws
+                    self._tune_total = tune * self.n_bars if self.combined_progress else tune
+                    break
 
         if self.combined_progress:
             stats = {
@@ -409,6 +430,10 @@ class NutpieProgressBarManager(ProgressBarManager):
                 stats["tree_size"] = max(stats["tree_size"], cp.latest_num_steps)
                 stats["draw"] += cp_finished_draws
             bar_total: int = cp.total_draws * len(chain_progresses)
+            total_finished = stats["draw"]
+            stats["draw"] = self._reset_draw(total_finished)
+            if self._tune_total:
+                stats["marker_pos"] = self._tune_total
             # Use the slowest chain's runtime as the combined bar's elapsed.
             max_runtime_ms = max(cp.runtime_ms for cp in chain_progresses)
             if max_runtime_ms > 0:
@@ -418,7 +443,7 @@ class NutpieProgressBarManager(ProgressBarManager):
                 advance=delta,
                 failing=stats["divergences"] > 0,
                 stats=stats,
-                is_last=stats["draw"] >= bar_total,
+                is_last=total_finished >= bar_total,
                 total=bar_total,
             )
         else:
@@ -442,8 +467,10 @@ class NutpieProgressBarManager(ProgressBarManager):
                     "divergences": len(cp.divergent_draws),
                     "step_size": cp.step_size,
                     "tree_size": cp.latest_num_steps,
-                    "draw": cp_finished_draws,
+                    "draw": self._reset_draw(cp_finished_draws),
                 }
+                if self._tune_total:
+                    stats["marker_pos"] = self._tune_total
                 self._backend.update(
                     task_id=chain_idx,
                     advance=delta,

--- a/pymc/progress_bar/rich_progress.py
+++ b/pymc/progress_bar/rich_progress.py
@@ -12,15 +12,18 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import warnings
+
 from collections.abc import Iterable
 from sys import stderr
 from typing import Any, Self
 
 from rich.box import SIMPLE_HEAD
-from rich.console import Console
+from rich.console import Console, ConsoleOptions, RenderResult
 from rich.progress import (
     BarColumn,
     Progress,
+    ProgressBar,
     ProgressColumn,
     Task,
     TaskID,
@@ -28,6 +31,7 @@ from rich.progress import (
     TimeElapsedColumn,
     TimeRemainingColumn,
 )
+from rich.segment import Segment
 from rich.style import Style
 from rich.table import Column, Table
 from rich.theme import Theme
@@ -106,8 +110,44 @@ class CustomProgress(Progress):
         return table
 
 
-class RecolorOnFailureBarColumn(BarColumn):
-    """Rich colorbar that changes color when a chain has detected a failure."""
+class MarkerProgressBar(ProgressBar):
+    """A progress bar with a thin gap at a given position (e.g. tune/draw boundary)."""
+
+    def __init__(self, *args, marker_pos: int | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.marker_pos = marker_pos
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        if self.marker_pos is None or not self.total:
+            yield from super().__rich_console__(console, options)
+            return
+
+        width = min(self.width or options.max_width, options.max_width)
+        # Map marker_pos (in task units) to a column index (in characters).
+        marker_col = max(0, min(int(width * self.marker_pos / self.total), width - 1))
+
+        # Rich yields ~3-5 bulk Segments (e.g. "━━━━━" for completed, "━━━" for
+        # remaining). We iterate those and split only the one that spans the
+        # marker column, replacing one character with a thin-space gap.
+        pos = 0
+        seg: Segment
+        for seg in super().__rich_console__(console, options):  # type: ignore[assignment]
+            seg_len = len(seg.text)
+            seg_end = pos + seg_len
+            if pos <= marker_col < seg_end:
+                i = marker_col - pos
+                if i > 0:
+                    yield Segment(seg.text[:i], seg.style)
+                yield Segment(" ", Style.null())  # thin space (U+2009)
+                if i + 1 < seg_len:
+                    yield Segment(seg.text[i + 1 :], seg.style)
+            else:
+                yield seg
+            pos = seg_end
+
+
+class CustomBarColumn(BarColumn):
+    """Bar column that recolors on divergences and renders a separator marker."""
 
     def __init__(self, *args, failing_color: str = "red", **kwargs):
         from matplotlib.colors import to_rgb
@@ -128,6 +168,20 @@ class RecolorOnFailureBarColumn(BarColumn):
         else:
             self.complete_style = self.default_complete_style
             self.finished_style = self.default_finished_style
+
+    def render(self, task: Task) -> ProgressBar:
+        return MarkerProgressBar(
+            total=max(0, task.total) if task.total is not None else None,
+            completed=max(0, task.completed),
+            width=None if self.bar_width is None else max(1, self.bar_width),
+            pulse=not task.started,
+            animation_time=task.get_time(),
+            style=self.style,
+            complete_style=self.complete_style,
+            finished_style=self.finished_style,
+            pulse_style=self.pulse_style,
+            marker_pos=task.fields.get("marker_pos"),
+        )
 
 
 class RichProgressBackend:
@@ -207,7 +261,7 @@ class RichProgressBackend:
         ]
 
         return CustomProgress(
-            RecolorOnFailureBarColumn(
+            CustomBarColumn(
                 bar_width=None,
                 table_column=Column("Progress", ratio=2),
                 failing_color="tab:red",
@@ -337,3 +391,14 @@ def RichSimpleProgress(theme: Theme | None):
         TimeElapsedColumn(),
         console=Console(file=stderr, theme=default_progress_theme if theme is None else theme),
     )
+
+
+def __getattr__(name: str):
+    if name == "RecolorOnFailureBarColumn":
+        warnings.warn(
+            "RecolorOnFailureBarColumn has been renamed to CustomBarColumn.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return CustomBarColumn
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/progress_bar/test_manager.py
+++ b/tests/progress_bar/test_manager.py
@@ -66,7 +66,7 @@ def test_mcmc_split_bar_starts_at_zero_ends_at_total():
     for chain in range(chains):
         task = _get_task(manager, chain)
         assert task.completed == task.total == total
-        assert task.fields["draw"] == total
+        assert task.fields["draw"] == draws
 
 
 def test_mcmc_combined_bar_ends_at_total():
@@ -97,7 +97,7 @@ def test_mcmc_combined_bar_ends_at_total():
     total = (draws + tune) * chains
     task = _get_task(manager, 0)
     assert task.completed == task.total == total
-    assert task.fields["draw"] == total
+    assert task.fields["draw"] == draws * chains
 
 
 def test_mcmc_draws_stat_shows_completed_count():
@@ -115,7 +115,7 @@ def test_mcmc_draws_stat_shows_completed_count():
             manager.update(
                 chain_idx=0, is_last=i == 14, draw=i, tuning=i < 5, stats=NUTS_DUMMY_STATS
             )
-        assert _get_task(manager).fields["draw"] == 15
+        assert _get_task(manager).fields["draw"] == 10
 
 
 def test_smc_bar_starts_at_zero_ends_at_one(imh_kernel):


### PR DESCRIPTION
Add a white space to visually split tune/draw bar. Counts reset after tuning is over

https://github.com/user-attachments/assets/bd408f04-aa39-423f-8273-c0e513aeba07

