### PR TITLE
Apply PyMC brand theme to Model._display_ mermaid diagram

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -443,7 +443,20 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         from pymc.model_graph import model_to_mermaid
 
-        return mo.mermaid(model_to_mermaid(self))
+        diagram = model_to_mermaid(self)
+        try:
+            return mo.mermaid(
+                diagram,
+                theme_variables={
+                    "primaryColor": "#12698A",
+                    "primaryTextColor": "#FFFFFF",
+                    "primaryBorderColor": "#0E5A7A",
+                    "lineColor": "#504A4E",
+                    "tertiaryColor": "#F0F5F8",
+                },
+            )
+        except TypeError:
+            return mo.mermaid(diagram)
 
     @staticmethod
     def _validate_name(name):


### PR DESCRIPTION
Add PyMC brand styling (teal #12698A nodes, white text, dark gray edges) to the mermaid graph rendered in marimo via `Model._display_`. Falls back to the default theme if the marimo version does not support `theme_variables`.

This requires marimo >= 0.23.7 (unreleased) for the full experience. (https://github.com/marimo-team/marimo/pull/9478)