### PR TITLE
Fix TP reparameterized prior

### DIFF
--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -319,21 +319,21 @@ class TP(Latent):
 
     def _build_prior(self, name, X, reparameterize=True, jitter=JITTER_DEFAULT, **kwargs):
         mu = self.mean_func(X)
-        cov = stabilize(self.cov_func(X), jitter)
+        scale = stabilize(self.cov_func(X), jitter)
         if reparameterize:
             if "dims" in kwargs:
                 v = pm.Normal(name + "_rotated_", mu=0.0, sigma=1.0, **kwargs)
             else:
                 size = np.shape(X)[0]
                 v = pm.Normal(name + "_rotated_", mu=0.0, sigma=1.0, size=size, **kwargs)
-            scale = pm.Gamma(name + "_scale", alpha=self.nu / 2, beta=self.nu / 2)
+            mixing_scale = pm.Gamma(name + "_scale", alpha=self.nu / 2, beta=self.nu / 2)
             f = pm.Deterministic(
                 name,
-                mu + cholesky(cov).dot(v) / pt.sqrt(scale),
+                mu + cholesky(scale).dot(v) / pt.sqrt(mixing_scale),
                 dims=kwargs.get("dims", None),
             )
         else:
-            f = pm.MvStudentT(name, nu=self.nu, mu=mu, scale=cov, **kwargs)
+            f = pm.MvStudentT(name, nu=self.nu, mu=mu, scale=scale, **kwargs)
         return f
 
     def prior(self, name, X, reparameterize=True, jitter=JITTER_DEFAULT, **kwargs):

--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -275,24 +275,45 @@ class TP(Latent):
 
     The usage is nearly identical to that of `gp.Latent`.  The differences
     are that it must be initialized with a degrees of freedom parameter, and
-    TP is not additive. Given a mean and covariance function, and a degrees of
+    TP is not additive. Given a mean and a kernel function, and a degrees of
     freedom parameter, the function :math:`f(x)` is modeled as,
 
     .. math::
 
        f(X) \sim \mathcal{TP}\left( \mu(X), k(X, X'), \nu \right)
 
+    How the kernel :math:`k` is interpreted is controlled by the
+    ``paper_covariance`` argument. The default (``False``) treats
+    :math:`k` as the scale matrix of an underlying :class:`~pymc.MvStudentT`,
+    which makes the actual prior covariance equal to
+    :math:`\nu / (\nu - 2) \, k`. Passing ``True`` treats :math:`k` as the
+    actual covariance, matching the convention in Shah, Wilson, and
+    Ghahramani (2014). The default will change to ``True`` in a future
+    release; see the ``paper_covariance`` parameter below for migration
+    guidance.
 
     Parameters
     ----------
     mean_func : Mean, default ~pymc.gp.mean.Zero
         The mean function.
     scale_func : 2D array-like, or Covariance, default ~pymc.gp.cov.Constant
-        The covariance function.
+        The kernel function. Interpreted as the scale matrix or the actual
+        covariance depending on the ``paper_covariance`` argument.
     cov_func : 2D array-like, or Covariance, default None
         Deprecated, previous version of "scale_func"
     nu : float
-        The degrees of freedom
+        The degrees of freedom. For ``paper_covariance=True`` the kernel
+        only equals the prior covariance when :math:`\nu > 2`.
+    paper_covariance : bool, optional
+        Whether the kernel returned by ``scale_func`` is interpreted as the
+        actual prior covariance, matching Shah, Wilson, and Ghahramani
+        (2014). When ``False`` (the current default), the kernel is the
+        scale matrix of the underlying multivariate Student-t and the
+        actual prior covariance is ``nu / (nu - 2)`` times the kernel.
+        When left unspecified, ``False`` is used and a
+        :class:`FutureWarning` is emitted because the default will change
+        in a future release. Pass the value explicitly to silence the
+        warning.
 
     References
     ----------
@@ -300,7 +321,15 @@ class TP(Latent):
         Processes as Alternatives to Gaussian Processes.  arXiv preprint arXiv:1402.4306.
     """
 
-    def __init__(self, *, mean_func=Zero(), scale_func=Constant(0.0), cov_func=None, nu=None):
+    def __init__(
+        self,
+        *,
+        mean_func=Zero(),
+        scale_func=Constant(0.0),
+        cov_func=None,
+        nu=None,
+        paper_covariance=None,
+    ):
         if nu is None:
             raise ValueError("Student's T process requires a degrees of freedom parameter, 'nu'")
         if cov_func is not None:
@@ -310,16 +339,49 @@ class TP(Latent):
                 FutureWarning,
             )
             scale_func = cov_func
+        if paper_covariance is None:
+            warnings.warn(
+                "The current default for pm.gp.TP treats the kernel returned by "
+                "scale_func as the scale matrix of the underlying MvStudentT, "
+                "which makes the actual prior covariance equal to nu / (nu - 2) "
+                "times the kernel. This does not match the convention in Shah, "
+                "Wilson, and Ghahramani (2014) where the kernel is the actual "
+                "covariance. A future release will change the default to "
+                "paper_covariance=True to match the paper. To preserve the "
+                "current behavior, pass paper_covariance=False explicitly. To "
+                "opt in to the paper-correct behavior now, pass "
+                "paper_covariance=True.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            paper_covariance = False
+        if not isinstance(paper_covariance, bool):
+            raise TypeError(
+                f"paper_covariance must be a bool, got {type(paper_covariance).__name__}"
+            )
         self.nu = nu
+        self.paper_covariance = paper_covariance
         super().__init__(mean_func=mean_func, cov_func=scale_func)
 
     def __add__(self, other):
         """Add two Student's T processes."""
         raise TypeError("Student's T processes aren't additive")
 
+    def _kernel_to_scale(self, K):
+        """Map the user-facing kernel to the MvStudentT scale matrix.
+
+        With ``paper_covariance=False`` the kernel is the scale matrix
+        directly. With ``paper_covariance=True`` the kernel is the desired
+        covariance, so the scale matrix is ``(nu - 2) / nu * K`` so that
+        ``nu / (nu - 2) * scale == K``.
+        """
+        if self.paper_covariance:
+            return (self.nu - 2) / self.nu * K
+        return K
+
     def _build_prior(self, name, X, reparameterize=True, jitter=JITTER_DEFAULT, **kwargs):
         mu = self.mean_func(X)
-        scale = stabilize(self.cov_func(X), jitter)
+        scale = self._kernel_to_scale(stabilize(self.cov_func(X), jitter))
         if reparameterize:
             if "dims" in kwargs:
                 v = pm.Normal(name + "_rotated_", mu=0.0, sigma=1.0, **kwargs)
@@ -376,7 +438,16 @@ class TP(Latent):
         mu = self.mean_func(Xnew) + pt.dot(pt.transpose(A), v)
         beta = pt.dot(v, v)
         nu2 = self.nu + X.shape[0]
-        covT = (self.nu + beta - 2) / (nu2 - 2) * cov
+        # The Shah/Wilson/Ghahramani (2014) conditional covariance is
+        # (nu + beta - 2) / (nu + n - 2) * (Kss - Kxs^T Kxx^-1 Kxs).
+        # With paper_covariance=False we pass that quantity directly as the
+        # MvStudentT scale; with paper_covariance=True the scale must be
+        # divided by nu2 / (nu2 - 2) so that the actual covariance matches
+        # the paper. The two scaling factors collapse to the expression below.
+        if self.paper_covariance:
+            covT = (self.nu + beta - 2) / nu2 * cov
+        else:
+            covT = (self.nu + beta - 2) / (nu2 - 2) * cov
         return nu2, mu, covT
 
     def conditional(self, name, Xnew, jitter=JITTER_DEFAULT, **kwargs):

--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -321,9 +321,17 @@ class TP(Latent):
         mu = self.mean_func(X)
         cov = stabilize(self.cov_func(X), jitter)
         if reparameterize:
-            size = np.shape(X)[0]
-            v = pm.StudentT(name + "_rotated_", mu=0.0, sigma=1.0, nu=self.nu, size=size, **kwargs)
-            f = pm.Deterministic(name, mu + cholesky(cov).dot(v), dims=kwargs.get("dims", None))
+            if "dims" in kwargs:
+                v = pm.Normal(name + "_rotated_", mu=0.0, sigma=1.0, **kwargs)
+            else:
+                size = np.shape(X)[0]
+                v = pm.Normal(name + "_rotated_", mu=0.0, sigma=1.0, size=size, **kwargs)
+            scale = pm.Gamma(name + "_scale", alpha=self.nu / 2, beta=self.nu / 2)
+            f = pm.Deterministic(
+                name,
+                mu + cholesky(cov).dot(v) / pt.sqrt(scale),
+                dims=kwargs.get("dims", None),
+            )
         else:
             f = pm.MvStudentT(name, nu=self.nu, mu=mu, scale=cov, **kwargs)
         return f

--- a/tests/gp/test_gp.py
+++ b/tests/gp/test_gp.py
@@ -20,8 +20,11 @@ import numpy.testing as npt
 import pytensor.tensor as pt
 import pytest
 
+from scipy.integrate import quad
+
 import pymc as pm
 
+from pymc.gp.util import JITTER_DEFAULT
 from pymc.math import cartesian
 
 
@@ -354,6 +357,7 @@ class TestTP:
             f = gp.prior("f", X, reparameterize=False)
             p = gp.conditional("p", Xnew)
         self.gp_latent_logp = model1.compile_logp()({"f": y, "p": pnew})
+        self.gp_latent_conditional_logp = model1.compile_logp(vars=[p])({"f": y, "p": pnew})
         self.X = X
         self.y = y
         self.Xnew = Xnew
@@ -379,10 +383,65 @@ class TestTP:
             p = tp.conditional("p", self.Xnew)
         assert tuple(f.shape.eval()) == (self.X.shape[0],)
         assert tuple(p.shape.eval()) == (self.Xnew.shape[0],)
-        chol = np.linalg.cholesky(scale_func(self.X).eval())
+        cov = scale_func(self.X).eval() + JITTER_DEFAULT * np.eye(self.X.shape[0])
+        chol = np.linalg.cholesky(cov)
         f_rotated = np.linalg.solve(chol, self.y)
-        tp_logp = model.compile_logp()({"f_rotated_": f_rotated, "p": self.pnew})
-        npt.assert_allclose(self.gp_latent_logp, tp_logp, atol=0, rtol=1e-2)
+        tp_logp = model.compile_logp(vars=[p])(
+            {"f_rotated_": f_rotated, "f_scale_log__": 0.0, "p": self.pnew}
+        )
+        npt.assert_allclose(self.gp_latent_conditional_logp, tp_logp, atol=0, rtol=1e-2)
+
+    def testTPReparameterizedPriorUsesSharedScale(self):
+        X = np.array([[0.0], [1.0]])
+        y = np.array([0.5, -0.75])
+        scale_value = 4.0
+        scale_func = pm.gp.cov.ExpQuad(1, ls=1.3)
+
+        with pm.Model() as model:
+            tp = pm.gp.TP(scale_func=scale_func, nu=3.0)
+            f = tp.prior("f", X, reparameterize=True, jitter=0.0)
+            (f_value,) = model.replace_rvs_by_values([f])
+            f_fn = model.compile_fn(f_value)
+
+        chol = np.linalg.cholesky(scale_func(X).eval())
+        f_rotated = np.linalg.solve(chol, y * np.sqrt(scale_value))
+        npt.assert_allclose(
+            f_fn({"f_rotated_": f_rotated, "f_scale_log__": np.log(scale_value)}),
+            y,
+        )
+
+    def testTPReparameterizedPriorMatchesMvStudentT(self):
+        nu = 3.0
+        X = np.array([[0.0], [1.0]])
+        y = np.array([0.5, -0.75])
+        scale_func = pm.gp.cov.ExpQuad(1, ls=1.3)
+
+        with pm.Model() as reparam_model:
+            tp = pm.gp.TP(scale_func=scale_func, nu=nu)
+            tp.prior("f", X, reparameterize=True, jitter=0.0)
+            reparam_logp_fn = reparam_model.compile_logp()
+
+        with pm.Model() as direct_model:
+            tp = pm.gp.TP(scale_func=scale_func, nu=nu)
+            tp.prior("f", X, reparameterize=False, jitter=0.0)
+            direct_logp_fn = direct_model.compile_logp()
+
+        chol = np.linalg.cholesky(scale_func(X).eval())
+        n = X.shape[0]
+        log_det_chol = np.log(np.linalg.det(chol))
+
+        def integrand(log_scale):
+            scale = np.exp(log_scale)
+            f_rotated = np.linalg.solve(chol, y * np.sqrt(scale))
+            log_integrand = (
+                reparam_logp_fn({"f_rotated_": f_rotated, "f_scale_log__": log_scale})
+                + (n / 2) * log_scale
+                - log_det_chol
+            )
+            return np.exp(log_integrand)
+
+        integral, _ = quad(integrand, -30, 30, epsabs=1e-10, epsrel=1e-10)
+        npt.assert_allclose(np.log(integral), direct_logp_fn({"f": y}), rtol=1e-6)
 
     def testAdditiveTPRaises(self):
         with pm.Model() as model:

--- a/tests/gp/test_gp.py
+++ b/tests/gp/test_gp.py
@@ -410,7 +410,7 @@ class TestTP:
             y,
         )
 
-    def testTPReparameterizedPriorMatchesMvStudentT(self):
+    def testTPReparameterizedPriorMatchesNonReparameterizedPrior(self):
         nu = 3.0
         X = np.array([[0.0], [1.0]])
         y = np.array([0.5, -0.75])
@@ -431,8 +431,8 @@ class TestTP:
         log_det_chol = np.log(np.linalg.det(chol))
 
         def integrand(log_scale):
-            scale = np.exp(log_scale)
-            f_rotated = np.linalg.solve(chol, y * np.sqrt(scale))
+            mixing_scale = np.exp(log_scale)
+            f_rotated = np.linalg.solve(chol, y * np.sqrt(mixing_scale))
             log_integrand = (
                 reparam_logp_fn({"f_rotated_": f_rotated, "f_scale_log__": log_scale})
                 + (n / 2) * log_scale

--- a/tests/gp/test_gp.py
+++ b/tests/gp/test_gp.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import warnings
+
 from functools import reduce
 from operator import add
 
@@ -19,8 +21,10 @@ import numpy as np
 import numpy.testing as npt
 import pytensor.tensor as pt
 import pytest
+import scipy.stats as st
 
 from scipy.integrate import quad
+from scipy.special import gammaln
 
 import pymc as pm
 
@@ -367,7 +371,7 @@ class TestTP:
     def testTPvsLatent(self):
         with pm.Model() as model:
             scale_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
-            tp = pm.gp.TP(scale_func=scale_func, nu=self.nu)
+            tp = pm.gp.TP(scale_func=scale_func, nu=self.nu, paper_covariance=False)
             f = tp.prior("f", self.X, reparameterize=False)
             p = tp.conditional("p", self.Xnew)
         assert tuple(f.shape.eval()) == (self.X.shape[0],)
@@ -378,7 +382,7 @@ class TestTP:
     def testTPvsLatentReparameterized(self):
         with pm.Model() as model:
             scale_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
-            tp = pm.gp.TP(scale_func=scale_func, nu=self.nu)
+            tp = pm.gp.TP(scale_func=scale_func, nu=self.nu, paper_covariance=False)
             f = tp.prior("f", self.X, reparameterize=True)
             p = tp.conditional("p", self.Xnew)
         assert tuple(f.shape.eval()) == (self.X.shape[0],)
@@ -398,7 +402,7 @@ class TestTP:
         scale_func = pm.gp.cov.ExpQuad(1, ls=1.3)
 
         with pm.Model() as model:
-            tp = pm.gp.TP(scale_func=scale_func, nu=3.0)
+            tp = pm.gp.TP(scale_func=scale_func, nu=3.0, paper_covariance=False)
             f = tp.prior("f", X, reparameterize=True, jitter=0.0)
             (f_value,) = model.replace_rvs_by_values([f])
             f_fn = model.compile_fn(f_value)
@@ -417,12 +421,12 @@ class TestTP:
         scale_func = pm.gp.cov.ExpQuad(1, ls=1.3)
 
         with pm.Model() as reparam_model:
-            tp = pm.gp.TP(scale_func=scale_func, nu=nu)
+            tp = pm.gp.TP(scale_func=scale_func, nu=nu, paper_covariance=False)
             tp.prior("f", X, reparameterize=True, jitter=0.0)
             reparam_logp_fn = reparam_model.compile_logp()
 
         with pm.Model() as direct_model:
-            tp = pm.gp.TP(scale_func=scale_func, nu=nu)
+            tp = pm.gp.TP(scale_func=scale_func, nu=nu, paper_covariance=False)
             tp.prior("f", X, reparameterize=False, jitter=0.0)
             direct_logp_fn = direct_model.compile_logp()
 
@@ -446,10 +450,136 @@ class TestTP:
     def testAdditiveTPRaises(self):
         with pm.Model() as model:
             scale_func = pm.gp.cov.ExpQuad(3, [0.1, 0.2, 0.3])
-            gp1 = pm.gp.TP(scale_func=scale_func, nu=10)
-            gp2 = pm.gp.TP(scale_func=scale_func, nu=10)
+            gp1 = pm.gp.TP(scale_func=scale_func, nu=10, paper_covariance=False)
+            gp2 = pm.gp.TP(scale_func=scale_func, nu=10, paper_covariance=False)
             with pytest.raises(Exception) as e_info:
                 gp1 + gp2
+
+    def testTPDefaultPaperCovarianceEmitsFutureWarning(self):
+        scale_func = pm.gp.cov.ExpQuad(1, ls=1.0)
+        with pytest.warns(FutureWarning, match="paper_covariance"):
+            pm.gp.TP(scale_func=scale_func, nu=5.0)
+        # Explicit values must not emit the deprecation warning.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            pm.gp.TP(scale_func=scale_func, nu=5.0, paper_covariance=False)
+            pm.gp.TP(scale_func=scale_func, nu=5.0, paper_covariance=True)
+
+    def testTPInvalidPaperCovarianceRaises(self):
+        scale_func = pm.gp.cov.ExpQuad(1, ls=1.0)
+        with pytest.raises(TypeError, match="paper_covariance must be a bool"):
+            pm.gp.TP(scale_func=scale_func, nu=5.0, paper_covariance="not a bool")
+
+    def testTPPaperCovarianceFalseLogpMatchesMvStudentT(self):
+        """paper_covariance=False keeps the kernel as the MvStudentT scale matrix."""
+        nu = 5.0
+        X = np.array([[0.0], [1.0], [2.0]])
+        y = np.array([0.5, -0.75, 0.3])
+        scale_func = pm.gp.cov.ExpQuad(1, ls=1.0)
+
+        with pm.Model() as model:
+            tp = pm.gp.TP(scale_func=scale_func, nu=nu, paper_covariance=False)
+            tp.prior("f", X, reparameterize=False, jitter=0.0)
+            logp_fn = model.compile_logp()
+
+        K = scale_func(X).eval()
+        expected = st.multivariate_t.logpdf(y, loc=np.zeros(len(y)), shape=K, df=nu)
+        npt.assert_allclose(logp_fn({"f": y}), expected, rtol=1e-6)
+
+    def testTPPaperCovarianceTrueLogpMatchesPaper(self):
+        """paper_covariance=True reproduces the Shah/Wilson/Ghahramani density."""
+        nu = 5.0
+        X = np.array([[0.0], [1.0], [2.0]])
+        y = np.array([0.5, -0.75, 0.3])
+        scale_func = pm.gp.cov.ExpQuad(1, ls=1.0)
+
+        with pm.Model() as model:
+            tp = pm.gp.TP(scale_func=scale_func, nu=nu, paper_covariance=True)
+            tp.prior("f", X, reparameterize=False, jitter=0.0)
+            logp_fn = model.compile_logp()
+
+        K = scale_func(X).eval()
+        n = X.shape[0]
+        beta = float(y @ np.linalg.solve(K, y))
+        expected = (
+            gammaln((nu + n) / 2)
+            - gammaln(nu / 2)
+            - (n / 2) * np.log(np.pi * (nu - 2))
+            - 0.5 * np.linalg.slogdet(K)[1]
+            - ((nu + n) / 2) * np.log1p(beta / (nu - 2))
+        )
+        npt.assert_allclose(logp_fn({"f": y}), expected, rtol=1e-6)
+
+    def testTPPaperCovarianceReparameterizedMatchesDirect(self):
+        """Under paper_covariance=True the two prior paths still agree."""
+        nu = 3.0
+        X = np.array([[0.0], [1.0]])
+        y = np.array([0.5, -0.75])
+        scale_func = pm.gp.cov.ExpQuad(1, ls=1.3)
+
+        with pm.Model() as reparam_model:
+            tp = pm.gp.TP(scale_func=scale_func, nu=nu, paper_covariance=True)
+            tp.prior("f", X, reparameterize=True, jitter=0.0)
+            reparam_logp_fn = reparam_model.compile_logp()
+
+        with pm.Model() as direct_model:
+            tp = pm.gp.TP(scale_func=scale_func, nu=nu, paper_covariance=True)
+            tp.prior("f", X, reparameterize=False, jitter=0.0)
+            direct_logp_fn = direct_model.compile_logp()
+
+        # Same Cholesky as the kernel-as-scale variant, just rescaled by (nu-2)/nu.
+        scale = (nu - 2) / nu * scale_func(X).eval()
+        chol = np.linalg.cholesky(scale)
+        n = X.shape[0]
+        log_det_chol = np.log(np.linalg.det(chol))
+
+        def integrand(log_scale):
+            mixing_scale = np.exp(log_scale)
+            f_rotated = np.linalg.solve(chol, y * np.sqrt(mixing_scale))
+            log_integrand = (
+                reparam_logp_fn({"f_rotated_": f_rotated, "f_scale_log__": log_scale})
+                + (n / 2) * log_scale
+                - log_det_chol
+            )
+            return np.exp(log_integrand)
+
+        integral, _ = quad(integrand, -30, 30, epsabs=1e-10, epsrel=1e-10)
+        npt.assert_allclose(np.log(integral), direct_logp_fn({"f": y}), rtol=1e-6)
+
+    def testTPPaperCovarianceConditionalMatchesPaper(self):
+        """Conditional under paper_covariance=True matches the paper covariance."""
+        nu = 5.0
+        X = np.array([[0.0], [1.0], [2.0]])
+        y = np.array([0.5, -0.75, 0.3])
+        Xnew = np.array([[0.5], [1.5]])
+        pnew = np.array([0.1, -0.2])
+        scale_func = pm.gp.cov.ExpQuad(1, ls=1.0)
+
+        with pm.Model() as model:
+            tp = pm.gp.TP(scale_func=scale_func, nu=nu, paper_covariance=True)
+            tp.prior("f", X, reparameterize=False, jitter=0.0)
+            p = tp.conditional("p", Xnew, jitter=0.0)
+            logp_fn = model.compile_logp(vars=[p])
+
+        # Paper conditional covariance under paper_covariance=True:
+        # K' = (nu + beta - 2) / (nu + n - 2) * (Kss - Kxs^T Kxx^-1 Kxs)
+        Kxx = scale_func(X).eval()
+        Kxs = scale_func(X, Xnew).eval()
+        Kss = scale_func(Xnew).eval()
+        Kxx_inv = np.linalg.inv(Kxx)
+        cov_gp = Kss - Kxs.T @ Kxx_inv @ Kxs
+        beta = float(y @ Kxx_inv @ y)
+        n = X.shape[0]
+        nu2 = nu + n
+        cov_paper = (nu + beta - 2) / (nu2 - 2) * cov_gp
+        mu_post = Kxs.T @ Kxx_inv @ y
+
+        # scipy.stats.multivariate_t.shape == MvStudentT scale, so to get a
+        # predictive with actual covariance == cov_paper we need shape =
+        # (nu2 - 2) / nu2 * cov_paper.
+        shape_for_scipy = (nu2 - 2) / nu2 * cov_paper
+        expected = st.multivariate_t.logpdf(pnew, loc=mu_post, shape=shape_for_scipy, df=nu2)
+        npt.assert_allclose(logp_fn({"f": y, "p": pnew}), expected, rtol=1e-6)
 
 
 class TestLatentKron:


### PR DESCRIPTION
**closes #8290** 
### Summary

I fixed `pm.gp.TP.prior(..., reparameterize=True)` so it uses a shared Gamma scale with a standard Normal rotated variable.

This makes the reparameterized TP prior match the direct `MvStudentT` prior.

I also added regression tests for the shared scale behavior and checked the marginal density against `MvStudentT`.


### Tests

- `ruff check pymc/gp/gp.py tests/gp/test_gp.py`
- `pytest tests/gp/test_gp.py::TestTP -q`
- `pytest tests/gp/test_gp.py -q`

cc: @ferrine @ricardoV94 