### PR TITLE
Fix erroneous nesting of equation structures in pymc_overview notebook

### DIFF
--- a/docs/source/learn/core_notebooks/pymc_overview.ipynb
+++ b/docs/source/learn/core_notebooks/pymc_overview.ipynb
@@ -2239,14 +2239,12 @@
     "\n",
     "Finally, to allow the NUTS sampler to sample the $\\beta_i$ more efficiently, we will re-parameterize it as follows:\n",
     "\n",
-    "$$\n",
     "\\begin{align*}\n",
     "    z_i\n",
     "        & \\sim N(0, 1), \\\\\n",
     "     \\beta_i\n",
     "         & = z_i \\cdot \\tau \\cdot \\tilde{\\lambda_i}.\n",
     "\\end{align*}\n",
-    "$$\n",
     "\n",
     "You will run into this reparameterization a lot in practice.\n"
    ]


### PR DESCRIPTION
## Summary
- Removes `$$` delimiters wrapping `\begin{align*}...\end{align*}` in the reparameterization section of the "Introductory Overview of PyMC" notebook
- Sphinx converts `$$...\begin{align*}...\end{align*}...$$` into `\[\begin{split}\begin{align*}...\end{align*}\end{split}\]` — triple-nesting display math environments, which MathJax 4 rejects as **"Erroneous nesting of equation structures"**
- Using `\begin{align*}` without `$$` avoids the extra wrapping and renders correctly

## Rendering issue

The equation after *"Finally, to allow the NUTS sampler to sample the β_i more efficiently, we will re-parameterize it as follows:"* shows an error on the [live docs](https://www.pymc.io/projects/docs/en/stable/learn/core_notebooks/pymc_overview.html#pymc-overview).

### Before (broken — live PyMC docs)
![before](https://raw.githubusercontent.com/gordonkoehn/pymc/1c19d47a3/docs/before_fix.png)

### After (fixed — local MathJax 4 verification)
![after](https://raw.githubusercontent.com/gordonkoehn/pymc/1c19d47a3/docs/after_fix.png)

## Test plan
- [x] Reproduced the error locally using MathJax 4 with the Sphinx-generated HTML
- [x] Verified the fix renders the align block correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)