### PR TITLE
Eagerly clean rv shape references introduced by maybe_resize

### DIFF
--- a/pymc/distributions/shape_utils.py
+++ b/pymc/distributions/shape_utils.py
@@ -31,7 +31,7 @@ from pytensor.tensor.type_other import NoneTypeT
 from pytensor.tensor.variable import TensorVariable
 
 from pymc.model import modelcontext
-from pymc.pytensorf import convert_observed_data
+from pymc.pytensorf import convert_observed_data, resolve_shapes
 
 __all__ = [
     "change_dist_size",
@@ -484,5 +484,8 @@ def maybe_resize(a: TensorVariable, size) -> TensorVariable:
         if (missing_size_entries := a.ndim - size_len) > 0:
             # Allow expression to broadcast beyond size
             size = (*a.shape[:missing_size_entries], *size)
+        else:
+            size = tuple(size)
+        size = resolve_shapes(size)
         a = pt.alloc(a, *size)  # type: ignore[assignment]
     return a

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -39,7 +39,7 @@ from pytensor.graph.replace import clone_replace
 from pytensor.graph.traversal import explicit_graph_inputs, graph_inputs, walk
 from pytensor.scalar.basic import Cast
 from pytensor.scan.op import Scan
-from pytensor.tensor.basic import _as_tensor_variable
+from pytensor.tensor.basic import _as_tensor_variable, infer_shape_db
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.random.op import RandomVariable, RNGConsumerOp
 from pytensor.tensor.random.type import RandomType
@@ -1006,6 +1006,29 @@ def constant_fold(
     return tuple(
         folded_x.data if isinstance(folded_x, Constant) else folded_x for folded_x in folded_xs
     )
+
+
+def resolve_shapes(
+    shapes: Sequence[TensorVariable],
+) -> tuple[TensorVariable, ...]:
+    """Rewrite shape expressions via ShapeFeature + infer_shape rewrites.
+
+    Replaces Shape(rv) and similar references with equivalent expressions
+    derived from the op's inputs (e.g. distribution parameters).
+    """
+    shape_fg = FunctionGraph(
+        outputs=list(shapes), features=[ShapeFeature()], clone=True, copy_inputs=False
+    )
+    with pytensor.config.change_flags(optdb__max_use_ratio=10, cxx=""):
+        infer_shape_db.default_query.rewrite(shape_fg)
+    return cast(tuple[TensorVariable, ...], tuple(shape_fg.outputs))
+
+
+def get_symbolic_rv_shapes(
+    rvs: Sequence[TensorVariable],
+) -> tuple[TensorVariable, ...]:
+    """Compute symbolic shapes of random variables without referencing the RVs themselves."""
+    return resolve_shapes([rv.shape for rv in rvs])
 
 
 def rewrite_pregrad(graph):

--- a/tests/logprob/test_basic.py
+++ b/tests/logprob/test_basic.py
@@ -475,3 +475,26 @@ def test_ir_ops_can_be_evaluated_with_warning():
 
     assert _eval_values[0].sum() == 3
     assert _eval_values[1] == np.exp(-1.5)
+
+
+def test_broadcasted_logp_does_not_reference_rv():
+    """Size referencing another RV's shape should not leak into the logp graph.
+
+    RVs in distribution parameters (e.g. Normal(mu=rv)) are expected — they
+    represent statistical dependencies. But RVs in the size are shape artifacts
+    from broadcast_shape(rv, ...) that have no role in the logp computation.
+    """
+    rv1 = pm.Normal.dist([0, 1, 2])
+    rv2 = pm.Normal.dist(0, 1, size=rv1.shape)
+    assert_no_rvs(pm.logp(rv2, 0))
+
+    # Faithful regression case for #8301
+    def logp(value, sigma):
+        inner = pm.Truncated.dist(pm.Normal.dist(sigma=sigma), lower=-5.0, upper=5.0)
+        outer = pm.Truncated.dist(inner, lower=0.1)
+        return pm.logp(outer, value)
+
+    with pm.Model() as m:
+        pm.CustomDist("x", np.ones(3), logp=logp)
+
+    assert_no_rvs(m.logp())


### PR DESCRIPTION
Closes #8301 

Size arguments don't make it into regular logprob expressions, so we monkey patch that with `maybe_resize` in #8105 

Otherwise it's fine for arguments to include shape(rv) in their arguments, PyTensor conditional_logprob will replace those with references to the shape(value)  before the logprob function is invoked. TruncatedRV however can refer the shape of a variable that is not in the graph (the generating untruncated `dist`) and introduce that in a way that conditional_logprob wouldn't clean.

This PR is not the ultimate answer to this question. First the current check could be said to be too eager, RV in the graph just inside the `shape` argument are plausible fine. Or we could always try to call `resolve_shape` before failing. Still seems like a good place to do this for now, we can iterate later if it is not good enough.

The new helpers have long been needed and reinvented in multiple places, so it's good to have them regardless.  