### PR TITLE
Fix windows CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -210,6 +210,7 @@ jobs:
       - uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462 # v2.0.7
         with:
           environment-file: conda-envs/windows-environment-test.yml
+          micromamba-version: "2.6.0-0"
           create-args: >-
             python=${{matrix.python-version}}
           environment-name: pymc-test
@@ -367,6 +368,7 @@ jobs:
       - uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462 # v2.0.7
         with:
           environment-file: conda-envs/windows-environment-test.yml
+          micromamba-version: "2.6.0-0"
           create-args: >-
             python=${{matrix.python-version}}
           environment-name: pymc-test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -196,7 +196,7 @@ jobs:
           - tests/step_methods/test_metropolis.py tests/step_methods/test_slicer.py tests/step_methods/hmc/test_nuts.py tests/step_methods/test_compound.py tests/step_methods/hmc/test_hmc.py tests/step_methods/test_state.py
 
       fail-fast: false
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
       PYTENSOR_FLAGS: linker=${{ matrix.linker }}
@@ -348,7 +348,7 @@ jobs:
     strategy:
       matrix:
         linker: [cvm, numba]
-        os: [windows-latest]
+        os: [windows-2022]
         python-version: ["3.14"]
         test-subset:
           - tests/sampling/test_mcmc.py tests/ode/test_ode.py tests/ode/test_utils.py tests/distributions/test_transform.py


### PR DESCRIPTION
Windows CI started failing due to micromamba incompatibility: https://github.com/mamba-org/micromamba-releases/issues/97

Also got an email from Github actions window changes, and did what I think is pinning to the current behavior: https://github.com/actions/runner-images/issues/14017