### PR TITLE
chore: place Maintenance before Documentation in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -16,9 +16,9 @@ changelog:
     - title: Bugfixes 🪲
       labels:
         - bug
-    - title: Documentation 📖
-      labels:
-        - docs
     - title: Maintenance 🔧
       labels:
         - "*"
+    - title: Documentation 📖
+      labels:
+        - docs


### PR DESCRIPTION
Closes #8296.

Swaps the order of the Maintenance and Documentation categories in `.github/release.yml`, so that Documentation renders at the bottom of the auto-generated release notes (rationale from the issue: docs entries are usually typos and minor, so they belong last).

```diff
     - title: Bugfixes 🪲
       labels:
         - bug
-    - title: Documentation 📖
-      labels:
-        - docs
     - title: Maintenance 🔧
       labels:
         - "*"
+    - title: Documentation 📖
+      labels:
+        - docs
```

Per [GitHub's docs on automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes), `"*"` is a catch-all for PRs not matched by any other category, regardless of its position in the list. So `docs`-labeled PRs continue to land in Documentation; only the display order changes. The change only takes effect at the next release.