### PR TITLE
Add Poisson and NegativeBinomial to pymc.dims

### DIFF
--- a/pymc/dims/distributions/scalar.py
+++ b/pymc/dims/distributions/scalar.py
@@ -312,6 +312,6 @@ class NegativeBinomial(DimDistribution):
     xrv_op = ptxr.nbinom
 
     @classmethod
-    def dist(cls, mu=None, alpha=None, p=None, n=None, **kwargs):
+    def dist(cls, mu=None, alpha=None, *, p=None, n=None, **kwargs):
         n, p = RegularNegativeBinomial.get_n_p(mu=mu, alpha=alpha, p=p, n=n)
         return super().dist([n, p], **kwargs)

--- a/pymc/dims/distributions/scalar.py
+++ b/pymc/dims/distributions/scalar.py
@@ -36,6 +36,7 @@ from pymc.distributions.continuous import (
     halfflat,
     truncated_normal,
 )
+from pymc.distributions.discrete import NegativeBinomial as RegularNegativeBinomial
 from pymc.util import UNSET
 
 
@@ -295,3 +296,22 @@ class Weibull(PositiveDimDistribution):
         core_rv = WeibullBetaRV.rv_op(alpha=alpha.values, beta=beta.values).owner.op
         xop = ptxr.as_xrv(core_rv)
         return xop(alpha, beta, core_dims=core_dims, extra_dims=extra_dims, rng=rng, **kwargs)
+
+
+@copy_docstring(regular_dists.Poisson)
+class Poisson(DimDistribution):
+    xrv_op = ptxr.poisson
+
+    @classmethod
+    def dist(cls, mu, **kwargs):
+        return super().dist([mu], **kwargs)
+
+
+@copy_docstring(regular_dists.NegativeBinomial)
+class NegativeBinomial(DimDistribution):
+    xrv_op = ptxr.nbinom
+
+    @classmethod
+    def dist(cls, mu=None, alpha=None, p=None, n=None, **kwargs):
+        n, p = RegularNegativeBinomial.get_n_p(mu=mu, alpha=alpha, p=p, n=n)
+        return super().dist([n, p], **kwargs)

--- a/tests/dims/distributions/test_scalar.py
+++ b/tests/dims/distributions/test_scalar.py
@@ -31,7 +31,9 @@ from pymc.dims import (
     InverseGamma,
     Laplace,
     LogNormal,
+    NegativeBinomial,
     Normal,
+    Poisson,
     StudentT,
     TruncatedNormal,
     Uniform,
@@ -308,6 +310,30 @@ def test_weibull():
 
     with Model(coords=coords) as reference_model:
         regular_distributions.Weibull("x", alpha=1, beta=2, dims="a")
+
+    assert_equivalent_random_graph(model, reference_model)
+    assert_equivalent_logp_graph(model, reference_model)
+
+
+def test_poisson():
+    coords = {"a": range(3)}
+    with Model(coords=coords) as model:
+        Poisson("x", mu=2.0, dims="a")
+
+    with Model(coords=coords) as reference_model:
+        regular_distributions.Poisson("x", mu=2.0, dims="a")
+
+    assert_equivalent_random_graph(model, reference_model)
+    assert_equivalent_logp_graph(model, reference_model)
+
+
+def test_negative_binomial():
+    coords = {"a": range(3)}
+    with Model(coords=coords) as model:
+        NegativeBinomial("x", mu=5.0, alpha=2.0, dims="a")
+
+    with Model(coords=coords) as reference_model:
+        regular_distributions.NegativeBinomial("x", mu=5.0, alpha=2.0, dims="a")
 
     assert_equivalent_random_graph(model, reference_model)
     assert_equivalent_logp_graph(model, reference_model)


### PR DESCRIPTION
## Summary

Add `Poisson` and `NegativeBinomial` to `pymc.dims` to unblock the Bass model dimension migration (pymc-labs/pymc-marketing#2598). These are the last two distributions needed before the Bass model can migrate from `create_dim_handler` to the `xdist=True` / `pymc.dims` pattern used by the rest of pymc-marketing.

## Changes

- **`pymc/dims/distributions/scalar.py`**: Add `Poisson` (wraps `ptxr.poisson`, accepts `mu`) and `NegativeBinomial` (wraps `ptxr.nbinom`, accepts `mu`/`alpha` or `n`/`p` parameterization) as `DimDistribution` subclasses

- **`tests/dims/distributions/test_scalar.py`**: Add `test_poisson` and `test_negative_binomial` following the existing pattern — create a model with the dims distribution + reference model with the regular distribution, assert equivalent random and logp graphs

## Background

These are the first discrete count distributions in `pymc.dims`. `Poisson` is the default likelihood for the Bass model, and `NegativeBinomial` is the alternative. `DiracDelta` is out of scope (can be handled by supporting non-Prior configurations in pymc-marketing).

The underlying PyTensor xtensor operations (`ptxr.poisson`, `ptxr.nbinom`) already existed — only the `pymc.dims` wrapper classes were missing.