### PR TITLE
docs(sample): document the progressbar_theme parameter

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -674,6 +674,46 @@ def sample(
                 are also displayed.
 
             If True, the default is "split+stats" is used.
+    progressbar_theme : rich.theme.Theme or str, optional
+        How to style the live progress bar that the ``pymc`` and ``nutpie`` samplers
+        render through `rich <https://rich.readthedocs.io/>`_. Three kinds of values
+        are accepted:
+
+        - ``None`` (default) — fall back to PyMC's built-in theme
+          (``pymc.progress_bar.default_progress_theme``), which paints the bar in
+          PyMC blue (``#1764f4``).
+        - A :class:`rich.theme.Theme` instance — used as-is to construct the
+          underlying :class:`rich.console.Console` and :class:`rich.progress.Progress`
+          objects. Keys you typically want to override are ``bar.complete``,
+          ``bar.finished``, ``bar.pulse``, ``progress.remaining`` and
+          ``progress.elapsed``.
+        - A string — passed straight through as ``css_theme`` when sampling inside
+          a Jupyter notebook (`nutpie` only). This lets you reuse the CSS theme
+          name that ``nutpie`` ships, for example to match a dark-mode notebook.
+
+        The argument is ignored entirely when ``progressbar=False``, when
+        ``quiet=True``, and when the selected ``nuts_sampler`` does not render
+        its own progress bar (``numpyro`` and ``blackjax``).
+
+        Example:
+
+        .. code-block:: python
+
+            from rich.theme import Theme
+            import pymc as pm
+
+            my_theme = Theme(
+                {
+                    "bar.complete": "magenta",
+                    "bar.finished": "magenta",
+                    "progress.remaining": "dim",
+                }
+            )
+
+            with pm.Model():
+                pm.Normal("x")
+                idata = pm.sample(progressbar_theme=my_theme)
+
     quiet : bool, default False
         If True, suppress all logging output and progress bars during sampling.
         This is useful when sampling in loops or when no output is desired.


### PR DESCRIPTION
> **AI disclaimer:** Authored, tested, and verified by an AI agent (Claude Opus 4.7 via Cursor) operating **unattended** as a personal token-burn initiative by @adv0r before subscription renewal. **Not human-reviewed before submission.** The agent read the issue, the public \`pm.sample()\` signature in \`pymc/sampling/mcmc.py\` (3 overloads + the implementation), and the actual call sites of \`progressbar_theme\` in \`pymc/progress_bar/progress.py\`, \`pymc/progress_bar/rich_progress.py\`, and \`pymc/backends/arviz.py\` to verify the documented behaviour matches what the code does.

## What changed

Closes #7468.

`pm.sample(progressbar_theme=...)` was a public, type-annotated parameter (`Theme | str | None`) but missing from the docstring. This PR adds a complete `progressbar_theme` entry to the `pm.sample` docstring, directly after the existing `progressbar` entry, covering:

- The three accepted forms:
  - `None` (default) → fall back to PyMC's built-in `default_progress_theme` (the PyMC-blue \`#1764f4\` bar).
  - A \`rich.theme.Theme\` instance → used as-is to style the underlying \`rich.console.Console\` / \`rich.progress.Progress\`.
  - A \`str\` → forwarded as \`css_theme\` for nutpie's Jupyter progress bar.
- Which \`rich\` theme keys users typically want to override (\`bar.complete\`, \`bar.finished\`, \`bar.pulse\`, \`progress.remaining\`, \`progress.elapsed\`) — the same keys that the default theme actually sets.
- The conditions under which the argument is silently ignored (\`progressbar=False\`, \`quiet=True\`, or \`nuts_sampler\` is \`numpyro\` / \`blackjax\` — those samplers don't render their own rich-styled progress bar).
- A short worked example.

Diff: `1 file changed, 40 insertions(+)`. Documentation-only.

## How verified

- AST-parsed `pymc/sampling/mcmc.py` after the edit to make sure the docstring stays a valid string literal.
- Cross-checked the documented behaviour against the actual implementation:
  - `pymc/progress_bar/rich_progress.py:35` — `default_progress_theme` definition, including the `#1764f4` bar colour I reference in the example.
  - `pymc/progress_bar/progress.py:181-195` — the branch that uses `css_theme=...` when the theme is a `str` (Jupyter / nutpie), vs. the `Theme` branch.
  - `pymc/sampling/mcmc.py:505-530` — the numpyro / blackjax branch, which does not forward `progressbar_theme` (justifying the "ignored when nuts_sampler is numpyro/blackjax" sentence).
  - `pymc/sampling/mcmc.py:1607-1610` — the existing terse docstring for the internal `_mp_sample` function, which I left untouched (only the public API needed expansion per the issue).
- Sanity-checked the Sphinx-style rST inside the docstring (\`\`.. code-block:: python\`\`, \`\`:class:\`rich.theme.Theme\`\`\`, bullet list indentation).

## Out of scope

- The issue reporter also asks about getting \"\[sampled/total\] display back\" — that's about progress-bar **columns**, not themes. It is a separate ask and would touch \`make_tasks_table\` / column construction, not the documentation of an existing public parameter. Happy to file a follow-up issue if maintainers want one, but keeping this PR scoped to what #7468 actually says.
- Not touching the internal terse docstring for \`_mp_sample\` at \`mcmc.py:1607-1610\`. It's internal and already mentions \`progressbar_theme\`.

Made with [Cursor](https://cursor.com)