### PR TITLE
docs(Deterministic): clarify it's optional and when to use it

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -2246,6 +2246,29 @@ def Deterministic(name, var, model=None, dims=None):
     they don't add randomness to the model.  They are generally used to record
     an intermediary result.
 
+    .. note::
+
+       Wrapping an expression in :func:`Deterministic` is **optional**: the
+       model fits and samples identically whether you use it or not. What it
+       buys you is two specific capabilities described below. If you don't
+       need either of them, you can leave the variable as a plain PyTensor
+       expression and the model will behave the same way (and use a tiny bit
+       less memory in the trace).
+
+    When you *do* want a :class:`Deterministic`:
+
+    1. **You want to read the value of an intermediate quantity from the
+       trace.** Anything wrapped in :func:`Deterministic` is recorded in the
+       :class:`~arviz.InferenceData` returned by :func:`pymc.sample` (and in
+       posterior-predictive output), so you can plot it, summarise it, and
+       index it by name. Plain PyTensor expressions are not.
+    2. **You want to target the variable with a model transform.** Some
+       transforms identify variables by name — for example,
+       :func:`pymc.do` for hard interventions and :func:`pymc.observe` for
+       turning a latent into observed data both need a named variable. If
+       you wrap an intermediate quantity with :func:`Deterministic`, those
+       transforms can address it directly.
+
     Parameters
     ----------
     name : str
@@ -2294,6 +2317,11 @@ def Deterministic(name, var, model=None, dims=None):
     However, in the first case, the inference data will only contain values for
     the variables ``alpha``, ``intercept`` and ``outcome``.  In the second, it
     will also contain sampled values of ``p`` for each of the observed points.
+
+    The same is true for model transforms: the wrapped form above lets you
+    later call e.g. ``pm.do({"p": 0.5})`` to hard-set the intermediate
+    probability, while the unwrapped form does not, because ``p`` is not a
+    named node in the model.
 
     Notes
     -----


### PR DESCRIPTION
## Description

Closes #7253.

Expands the docstring of `pymc.Deterministic` to make explicit what the issue asks for: that wrapping an expression in `Deterministic` is **optional**, and that there are two concrete reasons to do it.

### What changed

A short `.. note::` was added near the top of the docstring stating that the fit is identical with or without `Deterministic`, and listing the two situations in which you actually want to use it:

1. You want to read the value of an intermediate quantity from the trace (and from posterior-predictive output) by name.
2. You want a model transform like `pm.do` or `pm.observe` to be able to target the variable by name.

The existing example (the logistic-regression \"with and without\" snippet that #7253 explicitly mentions) was left untouched, and one sentence was added below it pointing out that the wrapped form is what enables transforms like `pm.do({\"p\": 0.5})`.

### What did *not* change

- No code behavior change — this is a docstring-only edit on `pymc.Deterministic`.
- No public API changes.

## Related Issue(s)

Closes #7253

## Checklist

- [x] Checked that the [pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
- [x] Included tests that prove the fix is effective or that the new feature works. *(N/A — docs-only.)*
- [x] Added necessary documentation (docstrings and/or example notebooks).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes). *(Single docs commit.)*

---

> Authored and verified by an AI agent (Claude Opus 4.7 via Cursor) operating **unattended** as a personal token-burn initiative by @adv0r. **Not human-reviewed before submission.** Happy to iterate on wording — please flag anything that doesn't match how PyMC maintainers think about Deterministic vs plain expressions.

Made with [Cursor](https://cursor.com)