### PR TITLE
docs(sample_smc): describe the `start` parameter format

### DIFF
--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -69,9 +69,40 @@ def sample_smc(
         independent chains. Defaults to 2000.
     kernel : SMC_kernel, optional
         SMC kernel used. Defaults to :class:`pymc.smc.smc.IMH` (Independent Metropolis Hastings)
-    start : dict or array of dict, optional
-        Starting point in parameter space. It should be a list of dict with length `chains`.
-        When None (default) the starting point is sampled from the prior distribution.
+    start : dict or sequence of dict, optional
+        Starting population for the SMC particles. Unlike :func:`pymc.sample`, where ``start``
+        is a *single point* per chain, SMC needs ``draws`` particles per chain, so each
+        starting "value" here is itself a *population*. ``start`` can be:
+
+        - ``None`` (default): sample the initial population from the model prior.
+        - ``dict``: a single starting population, reused for every chain.
+        - sequence of ``dict``: one starting population per chain. Length must equal
+          ``chains``, otherwise :class:`ValueError` is raised.
+
+        Each starting population is a dict mapping the *value-variable name* of every
+        free random variable in the model to a NumPy array of shape ``(draws, *var.shape)``.
+        Row ``i`` of every array is the value used by particle ``i``.
+
+        The value-variable name is the name of ``model.rvs_to_values[rv]`` and may differ
+        from the random-variable name when an automatic transform is applied (e.g. the
+        value variable for ``pm.HalfNormal("sigma")`` is named ``"sigma_log__"``, and you
+        should supply the starting values on the unconstrained scale). The free random
+        variables of a model are :attr:`pymc.Model.free_RVs`.
+
+        Example::
+
+            with pm.Model() as model:
+                mu = pm.Normal("mu", 0.0, 1.0)
+                sigma = pm.HalfNormal("sigma", 1.0)
+                obs = pm.Normal("y", mu=mu, sigma=sigma, observed=data)
+
+            draws = 2000
+            rng = np.random.default_rng(0)
+            start = {
+                "mu": rng.normal(size=draws),         # untransformed
+                "sigma_log__": rng.normal(size=draws),  # transformed
+            }
+            idata = pm.sample_smc(draws=draws, start=start, chains=4)
     model : Model (optional if in ``with`` context).
     random_seed :  int, array_like of int, RandomState or numpy_Generator, optional
         Random seed(s) used by the sampling steps. If a list, tuple or array of ints


### PR DESCRIPTION
## Description

Closes #7283.

The `start` argument of `pymc.sample_smc` works differently from `start` in `pymc.sample`, but the docstring did not actually explain how — it only said it is "a list of dict with length `chains`". The issue asked specifically for a clear description of the dict format.

### What this PR does

Rewrites the `start` entry in the `sample_smc` docstring to spell out:

- That for SMC each "start" is a starting *population* of `draws` particles, not a single point per chain.
- The three accepted forms (`None`, `dict`, sequence of `dict`) and the validation rule that the sequence length must equal `chains`.
- The dict shape: keys are the **value-variable names** of the model's free RVs (i.e. `model.rvs_to_values[rv].name`), and each value is an array of shape `(draws, *var.shape)` where row `i` is particle `i`.
- The transform subtlety: automatic transforms are reflected in the value-variable names (`pm.HalfNormal(\"sigma\")` becomes `\"sigma_log__\"`), so starting values for such variables are expected on the unconstrained scale.
- A short, self-contained example for a `Normal`/`HalfNormal` model.

I tried to keep the example minimal so it stays in sync with the actual contract used by `_initialize_kernel` in `pymc/smc/kernels.py`.

### What this PR does *not* do

No code or behavioral change — docstring-only edit on `pymc.sample_smc`. If maintainers prefer a different format (e.g. a dedicated subsection in the SMC docs or a User Guide page), happy to move the content.

## Related Issue(s)

Closes #7283

## Checklist

- [x] Checked that the pre-commit linting/style checks pass.
- [x] Included tests that prove the fix is effective or that the new feature works. *(N/A — docs-only.)*
- [x] Added necessary documentation (docstrings and/or example notebooks).

---

> Authored and verified by an AI agent (Claude Opus 4.7 via Cursor) operating **unattended** as a personal token-burn initiative by @adv0r. **Not human-reviewed before submission.** Please double-check the value-variable / transform claims against the current SMC code path; that's the most error-prone part of the doc.

Made with [Cursor](https://cursor.com)