### PR TITLE
docs: fix usage overview see-also links

### DIFF
--- a/docs/source/learn/usage_overview.rst
+++ b/docs/source/learn/usage_overview.rst
@@ -67,8 +67,8 @@ The sample is returned as arrays inside a ``MultiTrace`` object, which is then p
 See also
 ========
 
-* `Tutorials <nb_tutorials/index.html>`__
-* `Examples <nb_examples/index.html>`__
+* :doc:`Tutorials <learn/core_notebooks/index>`
+* :doc:`Examples <nb:gallery>`
 
 
 .. |NumFOCUS| image:: https://numfocus.org/wp-content/uploads/2017/07/NumFocus_LRG.png


### PR DESCRIPTION
Addresses the broken-link portion of #8126.

## What changed
- Updated the two outdated "See also" links in `docs/source/learn/usage_overview.rst`:
  - `nb_tutorials/index.html` -> `:doc:`Tutorials <learn/core_notebooks/index>``
  - `nb_examples/index.html` -> `:doc:`Examples <nb:gallery>``

## Checks run
- `rg -n "nb_tutorials/index.html|nb_examples/index.html" docs/source/learn/usage_overview.rst` (before: both present)
- `rg -n "nb_tutorials/index.html|nb_examples/index.html|Tutorials <learn/core_notebooks/index>|Examples <nb:gallery>" docs/source/learn/usage_overview.rst` (after: only new targets present)
- Verified docs targets exist/referenced:
  - `docs/source/learn/core_notebooks/index.md`
  - `docs/source/learn.md` and `docs/source/learn/core_notebooks/index.md` reference `nb:gallery`
- Attempted docs linkcheck command from task plan:
  - `make -C docs linkcheck` (not available in this repo; no `linkcheck` make target)

## Residual uncertainty
- I did not run a full docs build in this run; this PR keeps the change minimal and only updates two stale link targets.
