### PR TITLE
Support non-default initvals in model_to_fgraph

### DIFF
--- a/pymc/model/fgraph.py
+++ b/pymc/model/fgraph.py
@@ -145,9 +145,6 @@ def fgraph_from_model(
     memo: Dict
         A dictionary mapping original model variables to the equivalent nodes in the fgraph.
     """
-    if any(v is not None for v in model.rvs_to_initial_values.values()):
-        raise NotImplementedError("Cannot convert models with non-default initial_values")
-
     if model.parent is not None:
         raise ValueError(
             "Nested sub-models cannot be converted to fgraph. Convert the parent model instead"
@@ -195,8 +192,20 @@ def fgraph_from_model(
         if var not in old_value_vars
     ]
 
+    # Variable initvals ride along as trailing outputs so the clone reaches them.
+    rvs_to_initial_values = model.rvs_to_initial_values
+    variable_initvals = [
+        iv for iv in rvs_to_initial_values.values() if isinstance(iv, Variable)
+    ]
+
     model_vars = (
-        rvs + potentials + deterministics + other_named_vars + named_value_vars + unnamed_value_vars
+        rvs
+        + potentials
+        + deterministics
+        + other_named_vars
+        + named_value_vars
+        + unnamed_value_vars
+        + variable_initvals
     )
 
     memo = {}
@@ -223,6 +232,11 @@ def fgraph_from_model(
     # Copy model meta-info to fgraph
     fgraph._coords = model._coords.copy()
     fgraph._dim_lengths = {k: memo.get(v, v) for k, v in model._dim_lengths.items()}
+    fgraph._initvals = {
+        rv.name: (memo[iv] if isinstance(iv, Variable) else iv)
+        for rv, iv in rvs_to_initial_values.items()
+        if iv is not None
+    }
 
     rvs_to_transforms = model.rvs_to_transforms
     named_vars_to_dims = model.named_vars_to_dims
@@ -237,9 +251,9 @@ def fgraph_from_model(
     deterministics = [memo[k] for k in deterministics]
     named_vars = [memo[k] for k in other_named_vars + named_value_vars]
 
-    vars = fgraph.outputs
+    model_outputs = fgraph.outputs[: len(fgraph.outputs) - len(variable_initvals)]
     new_vars = []
-    for var in vars:
+    for var in model_outputs:
         dims = named_vars_to_dims.get(var.name, ())
         if var in free_rvs_to_values:
             new_var = model_free_rv(
@@ -258,7 +272,7 @@ def fgraph_from_model(
             new_var = var
         new_vars.append(new_var)
 
-    replacements = tuple(zip(vars, new_vars))
+    replacements = tuple(zip(model_outputs, new_vars))
     toposort_replace(fgraph, replacements, reverse=True)
 
     # Reference model vars in memo
@@ -272,8 +286,10 @@ def fgraph_from_model(
         original_var = inverse_memo[var]
         memo[original_var] = model_var
 
-    # Remove the last outputs corresponding to unnamed value variables, now that they are graph inputs
-    first_idx_to_remove = len(fgraph.outputs) - len(unnamed_value_vars)
+    # Remove the last outputs corresponding to unnamed value variables
+    first_idx_to_remove = (
+        len(fgraph.outputs) - len(unnamed_value_vars) - len(variable_initvals)
+    )
     for _ in unnamed_value_vars:
         fgraph.remove_output(first_idx_to_remove)
 
@@ -308,13 +324,16 @@ def model_from_fgraph(fgraph: FunctionGraph, mutate_fgraph: bool = False) -> Mod
 
     _coords = getattr(fgraph, "_coords", {})
     _dim_lengths = getattr(fgraph, "_dim_lengths", {})
+    _initvals = getattr(fgraph, "_initvals", {})
 
     if not mutate_fgraph:
         fgraph, memo = fgraph.clone_get_equiv(check_integrity=False, attach_feature=False)
-        # Shared dim lengths are not extracted from the fgraph representation,
-        # so we need to update after we clone the fgraph
-        # TODO: Consider representing/extracting them from the fgraph!
+        # Side metadata is keyed on fgraph variables, so it must be remapped through the clone memo.
         _dim_lengths = {k: memo.get(v, v) for k, v in _dim_lengths.items()}
+        _initvals = {
+            name: (memo.get(iv, iv) if isinstance(iv, Variable) else iv)
+            for name, iv in _initvals.items()
+        }
 
     model._coords = _coords
     model._dim_lengths = _dim_lengths
@@ -342,7 +361,7 @@ def model_from_fgraph(fgraph: FunctionGraph, mutate_fgraph: bool = False) -> Mod
             model.create_value_var(
                 var, transform=transform, default_transform=None, value_var=value
             )
-            model.set_initval(var, initval=None)
+            model.set_initval(var, initval=_initvals.get(model_var.name))
         elif isinstance(model_var.owner.op, ModelObservedRV):
             var, value, *dims = model_var.owner.inputs
             model.observed_RVs.append(var)

--- a/pymc/model/transform/optimization.py
+++ b/pymc/model/transform/optimization.py
@@ -15,6 +15,7 @@ from collections.abc import Sequence
 
 from pytensor.compile import SharedVariable
 from pytensor.graph import Constant, FunctionGraph
+from pytensor.graph.basic import Variable
 from pytensor.graph.replace import clone_replace
 
 from pymc import Model
@@ -96,15 +97,21 @@ def freeze_dims_and_data(
     }
 
     old_outs, old_coords, old_dim_lenghts = fg.outputs, fg._coords, fg._dim_lengths  # type: ignore[attr-defined]
+    old_initvals = fg._initvals  # type: ignore[attr-defined]
     # Rebuild strict will force the recreation of RV nodes with updated static types
     new_outs = clone_replace(old_outs, replace=frozen_replacements, rebuild_strict=False)  # type: ignore[arg-type]
     for old_out, new_out in zip(old_outs, new_outs):
         new_out.name = old_out.name
+    old_to_new = dict(zip(old_outs, new_outs))
     fg = FunctionGraph(outputs=new_outs, clone=False)
     fg._coords = old_coords  # type: ignore[attr-defined]
     fg._dim_lengths = {  # type: ignore[attr-defined]
         dim: frozen_replacements.get(dim_length, dim_length)
         for dim, dim_length in old_dim_lenghts.items()
+    }
+    fg._initvals = {  # type: ignore[attr-defined]
+        name: (old_to_new.get(iv, iv) if isinstance(iv, Variable) else iv)
+        for name, iv in old_initvals.items()
     }
 
     # Recreate value variables from new RVs to propagate static types to logp graphs

--- a/tests/model/test_fgraph.py
+++ b/tests/model/test_fgraph.py
@@ -397,3 +397,42 @@ def test_multivariate_transform():
     new_ip = new_m.initial_point()
     np.testing.assert_allclose(ip["x_simplex__"], new_ip["x_simplex__"])
     np.testing.assert_allclose(ip["y_cholesky-cov-packed__"], new_ip["y_cholesky-cov-packed__"])
+
+
+@pytest.mark.parametrize("initval", [3.14, "prior"])
+def test_round_trip_scalar_or_strategy_initval(initval):
+    with pm.Model() as m_old:
+        pm.Normal("x", initval=initval)
+
+    m_new = model_from_fgraph(fgraph_from_model(m_old)[0])
+    assert m_new.rvs_to_initial_values[m_new["x"]] == initval
+
+
+def test_round_trip_ndarray_initval():
+    with pm.Model() as m_old:
+        pm.Normal("x", shape=(3,), initval=np.array([1.0, 2.0, 3.0]))
+
+    m_new = model_from_fgraph(fgraph_from_model(m_old)[0])
+    np.testing.assert_array_equal(
+        m_new.rvs_to_initial_values[m_new["x"]], [1.0, 2.0, 3.0]
+    )
+
+
+def test_round_trip_initval_variable_depending_on_data():
+    with pm.Model() as m_old:
+        x_data = pm.Data("x_data", np.array([2.0, 4.0, 6.0]))
+        pm.Normal("x", shape=(3,), initval=x_data * 2)
+
+    m_new = model_from_fgraph(fgraph_from_model(m_old)[0])
+    new_initval = m_new.rvs_to_initial_values[m_new["x"]]
+
+    assert x_data not in graph_inputs([new_initval])
+    np.testing.assert_allclose(m_new.initial_point()["x"], [4.0, 8.0, 12.0])
+
+
+def test_clone_model_preserves_initval():
+    with pm.Model() as m_old:
+        pm.Normal("x", initval=2.5)
+
+    m_new = clone_model(m_old)
+    assert m_new.rvs_to_initial_values[m_new["x"]] == 2.5

--- a/tests/model/transform/test_conditioning.py
+++ b/tests/model/transform/test_conditioning.py
@@ -378,3 +378,29 @@ def test_remove_value_transforms():
     new_p = new_m["p"]
     new_q = new_m["q"]
     assert new_m.rvs_to_transforms == {new_p: logodds, new_q: None}
+
+
+def test_do_drops_initval_of_intervened_rv_and_preserves_others():
+    with pm.Model() as m:
+        pm.Normal("a", initval=1.0)
+        pm.Normal("b", initval=2.0)
+        pm.Normal("c", initval=3.0)
+        pm.Normal("d")
+
+    new_m = do(m, {m["b"]: 5.0})
+
+    assert {
+        rv.name: new_m.rvs_to_initial_values[rv] for rv in new_m.free_RVs
+    } == {"a": 1.0, "c": 3.0, "d": None}
+    np.testing.assert_array_equal(new_m["b"].eval(), 5.0)
+
+
+def test_do_rewires_variable_initval_through_intervened_data():
+    with pm.Model() as m:
+        mu_data = pm.Data("mu_data", np.array([1.0, 2.0, 3.0]))
+        pm.Normal("a", shape=(3,), initval=mu_data + 10)
+
+    new_m = do(m, {mu_data: np.array([0.0, 0.0, 0.0])}, make_interventions_shared=False)
+
+    assert isinstance(new_m["mu_data"], Constant)
+    np.testing.assert_array_equal(new_m.initial_point()["a"], [10.0, 10.0, 10.0])

--- a/tests/model/transform/test_optimization.py
+++ b/tests/model/transform/test_optimization.py
@@ -15,7 +15,7 @@ import numpy as np
 import pytest
 
 from pytensor.compile import SharedVariable
-from pytensor.graph import Constant
+from pytensor.graph import Constant, graph_inputs
 
 from pymc import Deterministic, do
 from pymc.data import Data
@@ -159,3 +159,23 @@ def test_freeze_dims_and_data_partially_observed_rv():
 
     frozen_y = freeze_dims_and_data(model)["y"]
     assert constant_fold([frozen_y.shape]) == (3,)
+
+
+def test_freeze_dims_and_data_with_initval():
+    with Model() as m:
+        Normal("x", initval=1.5)
+
+    frozen_m = freeze_dims_and_data(m)
+    assert frozen_m.initial_point()["x"] == 1.5
+
+
+def test_freeze_dims_and_data_with_initval_depending_on_data():
+    with Model(coords={"d": range(3)}) as m:
+        mu_data = Data("mu_data", np.array([1.0, 2.0, 3.0]), dims="d")
+        Normal("x", shape=(3,), initval=mu_data + 10)
+
+    frozen_m = freeze_dims_and_data(m)
+    new_initval = frozen_m.rvs_to_initial_values[frozen_m["x"]]
+
+    assert mu_data not in graph_inputs([new_initval])
+    np.testing.assert_array_equal(frozen_m.initial_point()["x"], [11.0, 12.0, 13.0])


### PR DESCRIPTION
`fgraph_to_model` currently rejects any model whose free RVs carray a non-default initval. This ends up blocking stuff like `freeze_dims_and_data`, `do`, `observed`, etc., which is a bummer. This PR gathers and forwards the initvals through the model -> fgraph -> model chain, the same way `_dim_lengths` already is.

I also tried a formulation where the initvals lived on the `ModelFreeRV` Ops, but the blast radius was too large. It's also the wrong abstraction, because `initval` on RVs is just syntatic sugar -- initvals are actually a concept at the model level.

I elected not to clone the initvals because we don't clone anything else. 