### PR TITLE
Fix regression where passing a model into `fit` stopped working

### DIFF
--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1565,7 +1565,7 @@ class Approximation(WithMemoization):
             for i in range(draws)
         )
 
-        model = modelcontext(None)
+        model = pm.Model.get_context(error_if_none=False) or self.model
 
         trace = NDArray(
             model=model,

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -503,3 +503,15 @@ def test_multiple_minibatch_variables():
         )
         mean_field = pm.fit(10_000, obj_optimizer=pm.adam(learning_rate=0.01), progressbar=False)
     np.testing.assert_allclose(mean_field.mean.get_value(), true_weights, rtol=1e-1)
+
+
+def test_sample_outside_model_context():
+    with pm.Model() as model:
+        mu = pm.Normal("mu", 0, 1)
+
+    # Fit with explicit model, then exit the model context
+    approx = pm.fit(10, method="advi", model=model, progressbar=False)
+
+    # sample() should work without an active model context
+    trace = approx.sample(50)
+    assert trace.posterior["mu"].shape == (1, 50)


### PR DESCRIPTION
## Description
This fixes a regression introduces in #7940 . 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
