### PR TITLE
Change install command to use v6

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -6,7 +6,7 @@ We recommend using [Anaconda](https://www.anaconda.com/) (or [Miniforge](https:/
 Once you have installed one of the above, PyMC can be installed into a new conda environment as follows:
 
 ```console
-conda create -c conda-forge -n pymc_env "pymc>=5"
+conda create -c conda-forge -n pymc_env "pymc>=6"
 conda activate pymc_env
 ```
 If you like, replace the name `pymc_env` with whatever environment name you prefer.


### PR DESCRIPTION
The current install instructions use `pymc>=5`; this updates to `=>6`

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
