### PR TITLE
Add icdf for Wald distribution

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -1072,6 +1072,17 @@ class Wald(PositiveContinuous):
             msg="mu > 0, lam > 0, alpha >= 0",
         )
 
+    def icdf(value, mu, lam, alpha):
+        res = pt.as_tensor_variable(pt.nan) + value * 0
+        res = check_icdf_value(res, value)
+        return check_icdf_parameters(
+            res,
+            mu > 0,
+            lam > 0,
+            alpha >= 0,
+            msg="mu > 0, lam > 0, alpha >= 0",
+        )
+
 
 class BetaClippedRV(BetaRV):
     @classmethod

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -1073,10 +1073,34 @@ class Wald(PositiveContinuous):
         )
 
     def icdf(value, mu, lam, alpha):
-        res = pt.as_tensor_variable(pt.nan) + value * 0
-        res = check_icdf_value(res, value)
+        phi = lam / mu
+        kappa = 3 * mu / (2 * lam)
+        m = mu * (pt.sqrt(1 + kappa**2) - kappa)
+        res = pt.switch(
+            pt.and_(pt.gt(value, 1e-5), pt.lt(value, 1 - 1e-5)),
+            m,
+            pt.switch(
+                pt.gt(value, 1 - 1e-5),
+                Gamma.icdf(value=value, alpha=phi, scale=mu / phi),
+                mu / (phi * Normal.icdf(value=value, mu=0, sigma=1) ** 2),
+            ),
+        )
+
+        def newton_step(q, *_):
+            cdf_q = pt.exp(Wald.logcdf(q, mu, lam, 0))
+            pdf_q = pt.exp(Wald.logp(q, mu, lam, 0))
+            return q + (value - cdf_q) / pdf_q
+
+        q, _ = pytensor.scan(
+            newton_step,
+            outputs_info=[res],
+            n_steps=20,
+        )
+
+        result = q[-1] + alpha
+        result = check_icdf_value(result, value)
         return check_icdf_parameters(
-            res,
+            result,
             mu > 0,
             lam > 0,
             alpha >= 0,

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -348,6 +348,14 @@ class TestMatchesScipy:
             lambda value, mu, alpha: st.invgauss.logcdf(value, mu=mu, loc=alpha),
         )
 
+    def test_wald_icdf(self):
+        check_icdf(
+            pm.Wald,
+            {"mu": Rplus, "alpha": Rplus},  # no lam — defaults to 1
+            lambda q, mu, alpha: st.invgauss.ppf(q, mu=mu, loc=alpha),
+            decimal=4,
+        )
+
     @pytest.mark.parametrize(
         "value,mu,lam,phi,alpha,logp",
         [


### PR DESCRIPTION
## Description
Adds `icdf` (inverse CDF / quantile function) for the Wald (Inverse Gaussian) distribution, as part of the broader effort to implement ICDF methods across all distributions.

Currently a draft skeleton with parameter checks is in place. ICDF formula and tests to follow.

## Related Issue
- [x] Related to #6612

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
