### PR TITLE
Forward top-level kwargs (chain_method, etc.) to jax NUTS samplers

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -507,6 +507,40 @@ def _sample_external_nuts(
 
         jax_nuts_kwargs = dict(nuts_kwargs)
         jax_target_accept = jax_nuts_kwargs.pop("target_accept", 0.8)
+
+        # jax-specific sampler options (chain execution + postprocessing) are
+        # named parameters of `sample_jax_nuts`. Historically they leaked in via
+        # `**kwargs` on `pm.sample`; forwarding arbitrary top-level kwargs is
+        # fragile (each sampler needs a different set), so instead detect the
+        # known jax options explicitly, warn that the top-level route is
+        # deprecated, and pass them on by name. Anything left over is a stray
+        # kwarg the jax samplers don't understand -- warn that it is ignored.
+        jax_sampler_kwargs = {}
+        for key in (
+            "chain_method",
+            "postprocessing_backend",
+            "postprocessing_vectorize",
+            "postprocessing_chunks",
+        ):
+            if key in kwargs:
+                warnings.warn(
+                    f"Passing `{key}` as a top-level argument to `pm.sample` is "
+                    "deprecated and will be removed in a future release; the jax "
+                    "NUTS samplers will accept it through a dedicated route "
+                    "instead. See https://github.com/pymc-devs/pymc/issues/8366.",
+                    FutureWarning,
+                    stacklevel=2,
+                )
+                jax_sampler_kwargs[key] = kwargs.pop(key)
+
+        if kwargs:
+            warnings.warn(
+                f"The following keyword arguments are not understood by the "
+                f"{sampler!r} sampler and will be ignored: {sorted(kwargs)}.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # Don't forward tune=None: let `sample_jax_nuts`'s own default kick in.
         tune_kwarg = {"tune": tune} if tune is not None else {}
         idata = pymc_jax.sample_jax_nuts(
@@ -525,12 +559,7 @@ def _sample_external_nuts(
             nuts_kwargs=jax_nuts_kwargs,
             idata_kwargs=idata_kwargs,
             compute_convergence_checks=compute_convergence_checks,
-            # Forward any remaining top-level kwargs (e.g. `chain_method`,
-            # `postprocessing_backend`) that `sample_jax_nuts` accepts directly.
-            # Previously these were captured by `**kwargs` above and never passed
-            # on, so `pm.sample(..., chain_method="vectorized")` silently had no
-            # effect (a regression from pymc 5.x). See GH #8366.
-            **kwargs,
+            **jax_sampler_kwargs,
             **tune_kwarg,
         )
         return idata

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -525,6 +525,12 @@ def _sample_external_nuts(
             nuts_kwargs=jax_nuts_kwargs,
             idata_kwargs=idata_kwargs,
             compute_convergence_checks=compute_convergence_checks,
+            # Forward any remaining top-level kwargs (e.g. `chain_method`,
+            # `postprocessing_backend`) that `sample_jax_nuts` accepts directly.
+            # Previously these were captured by `**kwargs` above and never passed
+            # on, so `pm.sample(..., chain_method="vectorized")` silently had no
+            # effect (a regression from pymc 5.x). See GH #8366.
+            **kwargs,
             **tune_kwarg,
         )
         return idata

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -511,27 +511,29 @@ def _sample_external_nuts(
         # jax-specific sampler options (chain execution + postprocessing) are
         # named parameters of `sample_jax_nuts`. Historically they leaked in via
         # `**kwargs` on `pm.sample`; forwarding arbitrary top-level kwargs is
-        # fragile (each sampler needs a different set), so instead detect the
-        # known jax options explicitly, warn that the top-level route is
-        # deprecated, and pass them on by name. Anything left over is a stray
-        # kwarg the jax samplers don't understand -- warn that it is ignored.
+        # fragile (each sampler needs a different set), so instead pull them out
+        # of `nuts_kwargs` -- the `nuts={...}` route -- and pass them on by name.
+        # The old top-level route still works but warns, and anything left over
+        # is a stray kwarg the jax samplers don't understand.
         jax_sampler_kwargs = {}
-        for key in (
+        jax_option_names = (
             "chain_method",
             "postprocessing_backend",
             "postprocessing_vectorize",
             "postprocessing_chunks",
-        ):
+        )
+        for key in jax_option_names:
+            if key in jax_nuts_kwargs:
+                jax_sampler_kwargs[key] = jax_nuts_kwargs.pop(key)
             if key in kwargs:
                 warnings.warn(
                     f"Passing `{key}` as a top-level argument to `pm.sample` is "
-                    "deprecated and will be removed in a future release; the jax "
-                    "NUTS samplers will accept it through a dedicated route "
-                    "instead. See https://github.com/pymc-devs/pymc/issues/8366.",
+                    f"deprecated and will be removed in a future release. Pass it "
+                    f'via `nuts={{"{key}": ...}}` instead.',
                     FutureWarning,
                     stacklevel=2,
                 )
-                jax_sampler_kwargs[key] = kwargs.pop(key)
+                jax_sampler_kwargs.setdefault(key, kwargs.pop(key))
 
         if kwargs:
             warnings.warn(

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -488,17 +488,22 @@ class TestExternalSamplerLogging:
 
 
 class TestJaxSamplerKwargForwarding:
-    """Top-level `pm.sample` kwargs must reach the jax NUTS samplers.
+    """jax-specific `pm.sample` options must reach the jax NUTS samplers.
 
     Regression test for GH #8366: since pymc 6.x, `_sample_external_nuts`
     captured extra top-level kwargs in `**kwargs` but never forwarded them to
     `sample_jax_nuts`, so `pm.sample(..., chain_method="vectorized")` (and
     similar jax-only arguments such as `postprocessing_backend`) were silently
     dropped instead of reaching the sampler.
+
+    Following review feedback (GH #8369), the known jax options are now detected
+    explicitly and forwarded by name (rather than blindly splatting arbitrary
+    `**kwargs`), the deprecated top-level route emits a ``FutureWarning``, and
+    any leftover unrecognised kwargs emit a ``UserWarning`` and are dropped.
     """
 
     @pytest.mark.parametrize("nuts_sampler", ["numpyro", "blackjax"])
-    def test_top_level_kwargs_reach_sample_jax_nuts(self, nuts_sampler):
+    def test_jax_options_reach_sample_jax_nuts_with_futurewarning(self, nuts_sampler):
         pytest.importorskip(nuts_sampler)
 
         import pymc.sampling.jax as pymc_jax
@@ -512,17 +517,49 @@ class TestJaxSamplerKwargForwarding:
         with mock.patch.object(pymc_jax, "sample_jax_nuts", side_effect=fake_sample_jax_nuts):
             with Model():
                 Normal("x", 0, 1)
-                sample(
-                    draws=2,
-                    tune=2,
-                    chains=2,
-                    nuts_sampler=nuts_sampler,
-                    chain_method="vectorized",
-                    postprocessing_backend="cpu",
-                    progressbar=False,
-                    compute_convergence_checks=False,
-                    random_seed=42,
-                )
+                with pytest.warns(FutureWarning, match="deprecated"):
+                    sample(
+                        draws=2,
+                        tune=2,
+                        chains=2,
+                        nuts_sampler=nuts_sampler,
+                        chain_method="vectorized",
+                        postprocessing_backend="cpu",
+                        progressbar=False,
+                        compute_convergence_checks=False,
+                        random_seed=42,
+                    )
 
+        # The known jax options are forwarded to `sample_jax_nuts` by name.
         assert captured.get("chain_method") == "vectorized"
         assert captured.get("postprocessing_backend") == "cpu"
+
+    @pytest.mark.parametrize("nuts_sampler", ["numpyro", "blackjax"])
+    def test_stray_kwargs_warn_and_are_dropped(self, nuts_sampler):
+        pytest.importorskip(nuts_sampler)
+
+        import pymc.sampling.jax as pymc_jax
+
+        captured = {}
+
+        def fake_sample_jax_nuts(*args, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace()
+
+        with mock.patch.object(pymc_jax, "sample_jax_nuts", side_effect=fake_sample_jax_nuts):
+            with Model():
+                Normal("x", 0, 1)
+                with pytest.warns(UserWarning, match="not understood"):
+                    sample(
+                        draws=2,
+                        tune=2,
+                        chains=2,
+                        nuts_sampler=nuts_sampler,
+                        not_a_real_kwarg=123,
+                        progressbar=False,
+                        compute_convergence_checks=False,
+                        random_seed=42,
+                    )
+
+        # Stray kwargs are dropped rather than forwarded to the sampler.
+        assert "not_a_real_kwarg" not in captured

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -485,3 +485,44 @@ class TestExternalSamplerLogging:
 
         pymc_logs = [r for r in caplog.records if r.name.startswith("pymc")]
         assert pymc_logs == []
+
+
+class TestJaxSamplerKwargForwarding:
+    """Top-level `pm.sample` kwargs must reach the jax NUTS samplers.
+
+    Regression test for GH #8366: since pymc 6.x, `_sample_external_nuts`
+    captured extra top-level kwargs in `**kwargs` but never forwarded them to
+    `sample_jax_nuts`, so `pm.sample(..., chain_method="vectorized")` (and
+    similar jax-only arguments such as `postprocessing_backend`) were silently
+    dropped instead of reaching the sampler.
+    """
+
+    @pytest.mark.parametrize("nuts_sampler", ["numpyro", "blackjax"])
+    def test_top_level_kwargs_reach_sample_jax_nuts(self, nuts_sampler):
+        pytest.importorskip(nuts_sampler)
+
+        import pymc.sampling.jax as pymc_jax
+
+        captured = {}
+
+        def fake_sample_jax_nuts(*args, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace()
+
+        with mock.patch.object(pymc_jax, "sample_jax_nuts", side_effect=fake_sample_jax_nuts):
+            with Model():
+                Normal("x", 0, 1)
+                sample(
+                    draws=2,
+                    tune=2,
+                    chains=2,
+                    nuts_sampler=nuts_sampler,
+                    chain_method="vectorized",
+                    postprocessing_backend="cpu",
+                    progressbar=False,
+                    compute_convergence_checks=False,
+                    random_seed=42,
+                )
+
+        assert captured.get("chain_method") == "vectorized"
+        assert captured.get("postprocessing_backend") == "cpu"

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -563,3 +563,43 @@ class TestJaxSamplerKwargForwarding:
 
         # Stray kwargs are dropped rather than forwarded to the sampler.
         assert "not_a_real_kwarg" not in captured
+
+    @pytest.mark.parametrize("nuts_sampler", ["numpyro", "blackjax"])
+    def test_jax_options_via_nuts_dict_do_not_warn(self, nuts_sampler):
+        """The `nuts={...}` route is the supported replacement and is silent."""
+        pytest.importorskip(nuts_sampler)
+
+        import pymc.sampling.jax as pymc_jax
+
+        captured = {}
+
+        def fake_sample_jax_nuts(*args, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace()
+
+        with mock.patch.object(pymc_jax, "sample_jax_nuts", side_effect=fake_sample_jax_nuts):
+            with Model():
+                Normal("x", 0, 1)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error", FutureWarning)
+                    warnings.simplefilter("error", UserWarning)
+                    sample(
+                        draws=2,
+                        tune=2,
+                        chains=2,
+                        nuts_sampler=nuts_sampler,
+                        nuts={
+                            "chain_method": "vectorized",
+                            "postprocessing_backend": "cpu",
+                        },
+                        progressbar=False,
+                        compute_convergence_checks=False,
+                        random_seed=42,
+                    )
+
+        # The jax options reach the sampler by name...
+        assert captured.get("chain_method") == "vectorized"
+        assert captured.get("postprocessing_backend") == "cpu"
+        # ...and are not also left in nuts_kwargs, which goes to the inner MCMC.
+        assert "chain_method" not in captured.get("nuts_kwargs", {})
+        assert "postprocessing_backend" not in captured.get("nuts_kwargs", {})


### PR DESCRIPTION
Since pymc 6.x, `pm.sample` no longer forwards jax-only, top-level arguments
(most visibly `chain_method`, but also `postprocessing_backend` and the other
parameters `sample_jax_nuts` accepts) to the `numpyro`/`blackjax` backends. They
are accepted by `pm.sample` without complaint and then silently dropped, so e.g.

```python
pm.sample(..., nuts_sampler="blackjax", chain_method="vectorized")
```

has no effect — `chain_method` stays at its default `"parallel"`.

### Root cause

`_sample_external_nuts` (`pymc/sampling/mcmc.py`) declares a trailing `**kwargs`
in its signature, so any top-level `pm.sample` argument that isn't one of its
named parameters lands there. In the `nutpie` branch that's fine, but in the
`numpyro`/`blackjax` branch the call to `pymc.sampling.jax.sample_jax_nuts`
listed each argument explicitly and never unpacked `**kwargs` — so everything
captured there was thrown away. In pymc 5.x, `_sample_external_nuts` spread these
kwargs into the `sample_jax_nuts` call, which is how `chain_method` used to reach
the sampler; the routing change in 6.x looks unintentional.

### The fix

Forward the captured `**kwargs` into the `sample_jax_nuts` call in the
numpyro/blackjax branch. These extra keys correspond directly to
`sample_jax_nuts`'s own top-level parameters (`chain_method`,
`postprocessing_backend`, `postprocessing_vectorize`, `jitter`,
`keep_untransformed`, …), so unpacking them restores the documented 5.x
behavior. One line, plus a comment explaining why.

### How it was tested

Added `TestJaxSamplerKwargForwarding` in
`tests/sampling/test_mcmc_external.py`, mirroring the existing mock-intercept
pattern in that file (it patches `pymc.sampling.jax.sample_jax_nuts` so no real
sampling runs). It calls `pm.sample(..., chain_method="vectorized",
postprocessing_backend="cpu")` for both the `numpyro` and `blackjax` backends
and asserts those values actually reach the sampler.

- Against the current (buggy) code the new test fails with
  `assert None == 'vectorized'` — `chain_method` never arrives.
- With the fix it passes for both backends.
- The rest of `tests/sampling/test_mcmc_external.py` shows no new failures: the
  pre-existing failures on this machine (missing `nutpie`, and the blackjax 1.6
  `build_kernel() got an unexpected keyword argument` / pmap-squeeze errors) are
  identical with and without this change — I confirmed by stashing the diff and
  re-running.
- `ruff check` and `ruff format --check` (pinned `v0.11.13`) are clean on both
  changed files, and `scripts/run_mypy.py` still passes.

Note: this addresses the top-level spelling (`pm.sample(..., chain_method=...)`),
which is the clean public path. The separate `nuts={"chain_method": ...}` routing
mentioned in the issue (which lands the key in the NUTS *kernel* kwargs) is a
distinct concern and is intentionally left out of this minimal change.

Fixes #8366
