### PR TITLE
fix: restore blackjax>=1.6 compatibility for nuts_sampler="blackjax"

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -293,7 +293,6 @@ def _blackjax_inference_loop(
             _, (samples, stats) = jax.lax.scan(_one_step, last_state, (jnp.arange(draws), keys))
     else:
         _, (samples, stats) = jax.lax.scan(_one_step, last_state, (jnp.arange(draws), keys))
-    
     return samples, stats
 
 

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -250,6 +250,12 @@ def _blackjax_inference_loop(
     else:
         raise ValueError("Only supporting 'nuts' or 'hmc' as algorithm to draw samples.")
 
+    # Must be popped before calling window_adaptation: blackjax >= 1.6 removed
+    # the progress_bar parameter from window_adaptation and forwards any
+    # unrecognized kwargs straight into the NUTS kernel, which raises
+    # TypeError. See https://github.com/pymc-devs/pymc/issues/8367.
+    progress_bar = adaptation_kwargs.pop("progress_bar", False)
+
     adapt = blackjax.window_adaptation(
         algorithm=algorithm,
         logdensity_fn=logp_fn,
@@ -274,12 +280,20 @@ def _blackjax_inference_loop(
         }
         return state, (position, stats)
 
-    progress_bar = adaptation_kwargs.pop("progress_bar", False)
-
     keys = jax.random.split(seed, draws)
-    scan_fn = blackjax.progress_bar.gen_scan_fn(draws, progress_bar)
-    _, (samples, stats) = scan_fn(_one_step, last_state, (jnp.arange(draws), keys))
-
+    if hasattr(blackjax.progress_bar, "gen_scan_fn"):
+        # blackjax < 1.6: progress_bar is a module exposing gen_scan_fn,
+        # which wraps jax.lax.scan directly.
+        scan_fn = blackjax.progress_bar.gen_scan_fn(draws, progress_bar)
+        _, (samples, stats) = scan_fn(_one_step, last_state, (jnp.arange(draws), keys))
+    elif progress_bar:
+        # blackjax >= 1.6: progress_bar is a context manager that
+        # monkeypatches jax.lax.scan for its duration instead.
+        with blackjax.progress_bar(label="NUTS"):
+            _, (samples, stats) = jax.lax.scan(_one_step, last_state, (jnp.arange(draws), keys))
+    else:
+        _, (samples, stats) = jax.lax.scan(_one_step, last_state, (jnp.arange(draws), keys))
+    
     return samples, stats
 
 

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -295,6 +295,21 @@ def _blackjax_inference_loop(
         _, (samples, stats) = jax.lax.scan(_one_step, last_state, (jnp.arange(draws), keys))
     return samples, stats
 
+    keys = jax.random.split(seed, draws)
+    if hasattr(blackjax.progress_bar, "gen_scan_fn"):
+        # blackjax < 1.6: progress_bar is a module exposing gen_scan_fn,
+        # which wraps jax.lax.scan directly.
+        scan_fn = blackjax.progress_bar.gen_scan_fn(draws, progress_bar)
+        _, (samples, stats) = scan_fn(_one_step, last_state, (jnp.arange(draws), keys))
+    elif progress_bar:
+        # blackjax >= 1.6: progress_bar is a context manager that
+        # monkeypatches jax.lax.scan for its duration instead.
+        with blackjax.progress_bar(label="NUTS"):
+            _, (samples, stats) = jax.lax.scan(_one_step, last_state, (jnp.arange(draws), keys))
+    else:
+        _, (samples, stats) = jax.lax.scan(_one_step, last_state, (jnp.arange(draws), keys))
+    return samples, stats
+
 
 def _sample_blackjax_nuts(
     model: Model,

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -281,7 +281,7 @@ def _blackjax_inference_loop(
         return state, (position, stats)
 
     keys = jax.random.split(seed, draws)
-   if hasattr(blackjax.progress_bar, "gen_scan_fn"):
+    if hasattr(blackjax.progress_bar, "gen_scan_fn"):
         # blackjax < 1.6: progress_bar is a module exposing gen_scan_fn,
         # which wraps jax.lax.scan directly.
         scan_fn = blackjax.progress_bar.gen_scan_fn(draws, progress_bar)

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -281,35 +281,27 @@ def _blackjax_inference_loop(
         return state, (position, stats)
 
     keys = jax.random.split(seed, draws)
-    if hasattr(blackjax.progress_bar, "gen_scan_fn"):
+   if hasattr(blackjax.progress_bar, "gen_scan_fn"):
         # blackjax < 1.6: progress_bar is a module exposing gen_scan_fn,
         # which wraps jax.lax.scan directly.
         scan_fn = blackjax.progress_bar.gen_scan_fn(draws, progress_bar)
         _, (samples, stats) = scan_fn(_one_step, last_state, (jnp.arange(draws), keys))
     elif progress_bar:
-        # blackjax >= 1.6: progress_bar is a context manager that
-        # monkeypatches jax.lax.scan for its duration instead.
-        with blackjax.progress_bar(label="NUTS"):
+        try:
+            with blackjax.progress_bar(label="NUTS"):
+                _, (samples, stats) = jax.lax.scan(_one_step, last_state, (jnp.arange(draws), keys))
+        except ImportError:
+            warnings.warn(
+                "blackjax progress bar needs the 'progress' extra "
+                "(pip install 'blackjax[progress]'); sampling without it.",
+                UserWarning,
+                stacklevel=2,
+            )
             _, (samples, stats) = jax.lax.scan(_one_step, last_state, (jnp.arange(draws), keys))
     else:
         _, (samples, stats) = jax.lax.scan(_one_step, last_state, (jnp.arange(draws), keys))
-    return samples, stats
 
-    keys = jax.random.split(seed, draws)
-    if hasattr(blackjax.progress_bar, "gen_scan_fn"):
-        # blackjax < 1.6: progress_bar is a module exposing gen_scan_fn,
-        # which wraps jax.lax.scan directly.
-        scan_fn = blackjax.progress_bar.gen_scan_fn(draws, progress_bar)
-        _, (samples, stats) = scan_fn(_one_step, last_state, (jnp.arange(draws), keys))
-    elif progress_bar:
-        # blackjax >= 1.6: progress_bar is a context manager that
-        # monkeypatches jax.lax.scan for its duration instead.
-        with blackjax.progress_bar(label="NUTS"):
-            _, (samples, stats) = jax.lax.scan(_one_step, last_state, (jnp.arange(draws), keys))
-    else:
-        _, (samples, stats) = jax.lax.scan(_one_step, last_state, (jnp.arange(draws), keys))
     return samples, stats
-
 
 def _sample_blackjax_nuts(
     model: Model,

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -303,6 +303,7 @@ def _blackjax_inference_loop(
 
     return samples, stats
 
+
 def _sample_blackjax_nuts(
     model: Model,
     target_accept: float,

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -502,3 +502,78 @@ def test_convergence_warnings(caplog, nuts_sampler):
 
     [record] = caplog.records
     assert re.match(r"There were \d+ divergences after tuning", record.message)
+
+class TestBlackjaxProgressBarCompat:
+    """Regression tests for https://github.com/pymc-devs/pymc/issues/8367.
+
+    blackjax >= 1.6 removed the progress_bar parameter from
+    window_adaptation (unknown kwargs get forwarded straight into the NUTS
+    kernel and raise TypeError) and replaced the progress_bar module
+    (with its gen_scan_fn helper) with a context-manager function.
+    """
+
+    def test_sample_blackjax_nuts_progressbar_false(self):
+        # This is the exact reproduction from the issue: progress_bar
+        # reaching window_adaptation used to raise
+        # "TypeError: ... got an unexpected keyword argument 'progress_bar'"
+        # on any blackjax >= 1.6.
+        with pm.Model():
+            x = pm.Normal("x", 0.0, 1.0)
+            pm.Normal("obs", x, 1.0, observed=np.array([0.3, -0.1, 0.5]))
+            idata = pm.sample(
+                draws=10,
+                tune=10,
+                chains=1,
+                cores=1,
+                nuts_sampler="blackjax",
+                progressbar=False,
+            )
+        assert idata.posterior["x"].shape == (1, 10)
+
+    def test_sample_blackjax_nuts_progressbar_true(self):
+        # Exercises the progress_bar=True path specifically, which on
+        # blackjax >= 1.6 (after fixing the TypeError above) used to hit a
+        # second break: AttributeError, since blackjax.progress_bar is no
+        # longer a module with a gen_scan_fn attribute.
+        with pm.Model():
+            x = pm.Normal("x", 0.0, 1.0)
+            pm.Normal("obs", x, 1.0, observed=np.array([0.3, -0.1, 0.5]))
+            idata = pm.sample(
+                draws=10,
+                tune=10,
+                chains=1,
+                cores=1,
+                nuts_sampler="blackjax",
+                progressbar=True,
+            )
+        assert idata.posterior["x"].shape == (1, 10)
+
+    def test_progress_bar_popped_before_window_adaptation(self):
+        # Directly asserts the ordering fix: progress_bar must never reach
+        # blackjax.window_adaptation's kwargs, regardless of blackjax
+        # version/API shape.
+        import blackjax
+
+        from pymc.sampling.jax import _blackjax_inference_loop
+
+        original_window_adaptation = blackjax.window_adaptation
+
+        def spy_window_adaptation(*args, **kwargs):
+            assert "progress_bar" not in kwargs, "progress_bar leaked into window_adaptation kwargs"
+            return original_window_adaptation(*args, **kwargs)
+
+        with pm.Model() as model:
+            x = pm.Normal("x", 0.0, 1.0)
+            pm.Normal("obs", x, 1.0, observed=np.array([0.3, -0.1, 0.5]))
+            logp_fn = get_jaxified_logp(model)
+
+        with mock.patch("blackjax.window_adaptation", side_effect=spy_window_adaptation):
+            _blackjax_inference_loop(
+                seed=jax.random.PRNGKey(0),
+                init_position=[np.array(0.0)],
+                logp_fn=logp_fn,
+                draws=5,
+                tune=5,
+                target_accept=0.8,
+                progress_bar=False,
+            )

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -503,6 +503,7 @@ def test_convergence_warnings(caplog, nuts_sampler):
     [record] = caplog.records
     assert re.match(r"There were \d+ divergences after tuning", record.message)
 
+
 class TestBlackjaxProgressBarCompat:
     """Regression tests for https://github.com/pymc-devs/pymc/issues/8367.
 

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -32,6 +32,7 @@ from pytensor.graph import graph_inputs
 
 import pymc as pm
 
+from pymc.exceptions import ImputationWarning
 from pymc.sampling.jax import (
     _blackjax_inference_loop,
     _get_batched_jittered_initial_points,
@@ -550,7 +551,7 @@ class TestBlackjaxProgressBarCompat:
             )
         assert idata.posterior["x"].shape == (1, 10)
 
-   def test_progress_bar_popped_before_window_adaptation(self):
+    def test_progress_bar_popped_before_window_adaptation(self):
         # Directly asserts the ordering fix: progress_bar must never reach
         # blackjax.window_adaptation's kwargs, regardless of blackjax
         # version/API shape.

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 from typing import Any
 from unittest import mock
 
+import blackjax
 import jax
 import numpy as np
 import pytensor
@@ -31,8 +32,8 @@ from pytensor.graph import graph_inputs
 
 import pymc as pm
 
-from pymc.exceptions import ImputationWarning
 from pymc.sampling.jax import (
+    _blackjax_inference_loop,
     _get_batched_jittered_initial_points,
     _get_log_likelihood,
     _replace_shared_variables,
@@ -549,14 +550,10 @@ class TestBlackjaxProgressBarCompat:
             )
         assert idata.posterior["x"].shape == (1, 10)
 
-    def test_progress_bar_popped_before_window_adaptation(self):
+   def test_progress_bar_popped_before_window_adaptation(self):
         # Directly asserts the ordering fix: progress_bar must never reach
         # blackjax.window_adaptation's kwargs, regardless of blackjax
         # version/API shape.
-        import blackjax
-
-        from pymc.sampling.jax import _blackjax_inference_loop
-
         original_window_adaptation = blackjax.window_adaptation
 
         def spy_window_adaptation(*args, **kwargs):


### PR DESCRIPTION
blackjax 1.6 removed the progress_bar parameter from window_adaptation
(unknown kwargs now forward into the NUTS kernel and raise TypeError)
and replaced the progress_bar module (gen_scan_fn helper) with a
context-manager function.

- Pop progress_bar from adaptation_kwargs before calling
  window_adaptation, not after
- Dispatch on hasattr(blackjax.progress_bar, "gen_scan_fn") to support
  both the old module-based API and the new context-manager API

Closes #8367

