### PR TITLE
Make examples gallery link more prominent on core notebooks page

### DIFF
--- a/docs/source/learn/core_notebooks/index.md
+++ b/docs/source/learn/core_notebooks/index.md
@@ -1,6 +1,12 @@
 (core_notebooks)=
 # Notebooks on core features
 
+:::{note}
+**Looking for more examples?** These are the core notebooks maintained with each
+PyMC release. An even larger gallery of example notebooks is available at the
+{doc}`"Examples" tab <nb:gallery>`.
+:::
+
 :::{toctree}
 :maxdepth: 1
 
@@ -12,12 +18,4 @@ pymc_pytensor
 dims_module
 GLM_linear
 Gaussian_Processes
-:::
-
-:::{note}
-The notebooks above are executed with each version of the library
-(available on the navigation bar). In addition, a much larger gallery
-of example notebooks is available at the {doc}`"Examples" tab <nb:gallery>`.
-These are executed more sparsely and independently.
-They include a watermark to show which versions were used to run them.
 :::


### PR DESCRIPTION
## Summary

Make the examples gallery link more prominent on the core notebooks page.

## Related Issue

Fixes #6534

## What changed

Moved the examples gallery note from below the notebook listing to the top
of the page, with a bold header ("Looking for more examples?") that
immediately directs users to the larger examples gallery.

## Why this approach

The previous note was easily missed at the bottom of the page. Placing it
before the toctree with a prominent header ensures first-time visitors
immediately know that more examples are available.

## Testing done

- sphinx-lint passes clean
- Markdown is structurally valid
- Cross-reference uses the same `nb:gallery` intersphinx role as before

## Checklist

- [x] Tests added/updated — N/A (docs-only change)
- [x] Docs updated
- [x] Lint/format passes
- [x] Linked issue referenced
- [x] No unrelated changes bundled in
