### PR TITLE
Reuse compiled functions when sampling a frozen model repeatedly

### DIFF
--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -34,7 +34,6 @@ import pytensor
 
 from pymc.backends.report import SamplerReport
 from pymc.model import modelcontext
-from pymc.pytensorf import compile
 from pymc.util import get_var_name
 
 logger = logging.getLogger(__name__)
@@ -183,9 +182,11 @@ class BaseTrace(IBaseTrace):
 
         if fn is None:
             # borrow=True avoids deepcopy when inputs=output which is the case for untransformed value variables
-            fn = compile(
+            # Routed through the model so the compilation is reused on frozen models.
+            fn = model.compile_fn(
+                outs=[pytensor.Out(v, borrow=True) for v in vars],
                 inputs=[pytensor.In(v, borrow=True) for v in model.value_vars],
-                outputs=[pytensor.Out(v, borrow=True) for v in vars],
+                point_fn=False,
                 on_unused_input="ignore",
             )
             fn.trust_input = True

--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -188,8 +188,8 @@ class BaseTrace(IBaseTrace):
                 inputs=[pytensor.In(v, borrow=True) for v in model.value_vars],
                 point_fn=False,
                 on_unused_input="ignore",
+                trust_input=True,
             )
-            fn.trust_input = True
 
         # Get variable shapes. Most backends will need this
         # information.

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -104,8 +104,7 @@ def make_initial_point_fns_per_chain(
         # One strategy for all chains
         # Only one function compilation is needed.
         ipfns = [
-            make_initial_point_fn(
-                model=model,
+            model._make_initial_point(
                 overrides=overrides,
                 jitter_rvs=jitter_rvs,
                 return_transformed=True,
@@ -113,8 +112,7 @@ def make_initial_point_fns_per_chain(
         ] * chains
     elif len(overrides) == chains:
         ipfns = [
-            make_initial_point_fn(
-                model=model,
+            model._make_initial_point(
                 jitter_rvs=jitter_rvs,
                 overrides=chain_overrides,
                 return_transformed=True,

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 from __future__ import annotations
 
+import copy
 import functools
 import sys
 import threading
@@ -298,6 +299,33 @@ class ValueGradFunction:
             grad_vars = (grad_vars,)
 
         return self._pytensor_function(*grad_vars)
+
+    def copy(self):
+        """Return a function that reuses the compiled graph but owns its shared variables.
+
+        The shared variables holding the extra values and the cost weights are runtime state
+        of a single caller, so a shared instance cannot be handed out twice. Copying them is
+        orders of magnitude cheaper than compiling the graph again.
+        """
+        new = copy.copy(self)
+        # The static shape must be preserved, or the swapped variables won't have the type
+        # the compiled function expects.
+        new_shared = {
+            old: pytensor.shared(old.get_value(), old.name, shape=old.type.shape)
+            for old in (self._weights, *self._extra_vars_shared.values())
+        }
+        # An unused cost weight (a single cost) is not an input of the compiled function,
+        # and `Function.copy` rejects swaps for variables it doesn't have.
+        fn_inputs = {inp.variable for inp in self._pytensor_function.maker.inputs}
+        new._pytensor_function = self._pytensor_function.copy(
+            swap={old: shared for old, shared in new_shared.items() if old in fn_inputs}
+        )
+        new._weights = new_shared[self._weights]
+        new._extra_vars_shared = {
+            name: new_shared[old] for name, old in self._extra_vars_shared.items()
+        }
+        new._extra_are_set = False
+        return new
 
     @property
     def profile(self):
@@ -2228,9 +2256,15 @@ class FrozenModel(BaseModel):
     d2logp = locally_cachedmethod(BaseModel.d2logp)
     # The initial point only seeds the runtime-settable extra variables, so it is not part
     # of the cache key (it is re-applied by `logp_dlogp_function` on every call).
-    _logp_dlogp_function = locally_cachedmethod(
+    _cached_logp_dlogp_function = locally_cachedmethod(
         BaseModel._logp_dlogp_function, ignore=("initial_point",)
     )
+
+    def _logp_dlogp_function(self, *args, **kwargs):
+        # Unlike the graphs and functions cached above, a `ValueGradFunction` owns mutable
+        # state, so callers get their own shared variables on top of the cached graph.
+        return self._cached_logp_dlogp_function(*args, **kwargs).copy()
+
     _make_initial_point = locally_cachedmethod(BaseModel._make_initial_point)
 
     @overload

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -942,9 +942,14 @@ class BaseModel(WithMemoization, metaclass=ContextMeta):
         fn = self._make_initial_point()
         return Point(fn(random_seed), model=self)
 
-    def _make_initial_point(self):
+    def _make_initial_point(self, *, overrides=None, jitter_rvs=None, return_transformed=True):
         # Compiled function takes the seed as an argument, so the cache is seed-independent.
-        return make_initial_point_fn(model=self, return_transformed=True)
+        return make_initial_point_fn(
+            model=self,
+            overrides=overrides,
+            jitter_rvs=jitter_rvs,
+            return_transformed=return_transformed,
+        )
 
     def set_data(
         self,

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -941,9 +941,14 @@ class BaseModel(WithMemoization, metaclass=ContextMeta):
         fn = self._make_initial_point()
         return Point(fn(random_seed), model=self)
 
-    def _make_initial_point(self):
+    def _make_initial_point(self, *, overrides=None, jitter_rvs=None, return_transformed=True):
         # Compiled function takes the seed as an argument, so the cache is seed-independent.
-        return make_initial_point_fn(model=self, return_transformed=True)
+        return make_initial_point_fn(
+            model=self,
+            overrides=overrides,
+            jitter_rvs=jitter_rvs,
+            return_transformed=return_transformed,
+        )
 
     def set_data(
         self,

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -432,6 +432,14 @@ def make_shared_replacements(point, vars, model):
     Returns
     -------
     Dict of variable -> new shared variable
+
+    Notes
+    -----
+    A fresh shared variable per call means the compiled graph differs for every step method
+    instance, so these functions can never be served from a frozen model's compilation cache.
+    Making the shared variables depend only on the model, and swapping in per-instance ones
+    with ``Function.copy`` afterwards (as :meth:`ValueGradFunction.copy` does), would let
+    these steps reuse a cached graph as well.
     """
     vars_set = set(vars)
     return {

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -25,6 +25,7 @@ import numpy as np
 
 from cachetools import LRUCache, cachedmethod
 from pytensor.compile import SharedVariable
+from pytensor.compile.io import In, Out
 from pytensor.graph.basic import Variable
 from xarray import Dataset, DataTree
 
@@ -302,6 +303,13 @@ def hashable(a=None) -> int:
         # lists are mutable and not hashable by default
         # for memoization, we need the hash to depend on the items
         return hash(tuple(hashable(i) for i in a))
+    if isinstance(a, set | frozenset):
+        # same as for lists, but order-insensitive
+        return hash(frozenset(hashable(i) for i in a))
+    if isinstance(a, In | Out):
+        # these wrap a variable with compilation options and are hashed by identity,
+        # so hash what they hold instead
+        return hashable(a.__dict__)
     try:
         return hash(a)
     except TypeError:
@@ -321,18 +329,28 @@ def hash_key(*args, **kwargs):
 
 
 class HashableWrapper:
-    __slots__ = ("obj",)
+    __slots__ = ("_hash", "obj")
 
     def __init__(self, obj):
         self.obj = obj
+        self._hash = hashable(obj)
 
     def __hash__(self):
         """Return a hash of the object."""
-        return hashable(self.obj)
+        return self._hash
 
     def __eq__(self, other):
-        """Compare this object with `other`."""
-        return self.obj == other
+        """Compare this object with `other`.
+
+        Compares the types and the hashes computed by :func:`hashable`, since the wrapped
+        objects may not support equality that returns a bool (arrays, or containers holding
+        them).
+        """
+        return (
+            isinstance(other, HashableWrapper)
+            and type(self.obj) is type(other.obj)
+            and self._hash == other._hash
+        )
 
     def __repr__(self):
         """Return a string representation of the object."""

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -1401,8 +1401,10 @@ class TestFrozenModelCaching:
         fm = freeze_model(m)
         f1 = fm.logp_dlogp_function(ravel_inputs=True)
         f2 = fm.logp_dlogp_function(ravel_inputs=True)
-        assert f1 is f2
-        assert "_logp_dlogp_function" in fm._cache
+        # Each caller gets its own shared variables on top of a single compiled graph.
+        assert f1 is not f2
+        # The cache bucket is named after the wrapped method, `BaseModel._logp_dlogp_function`.
+        assert len(fm._cache["_logp_dlogp_function"]) == 1
 
     def test_logp_dlogp_d2logp_graphs_are_cached(self):
         # Memoized graph construction returns the same object, so a freshly requested logp
@@ -1439,20 +1441,41 @@ class TestFrozenModelCaching:
         # The cached function must reflect each call's extra values, not a stale set.
         with pm.Model() as m:
             x = pm.Normal("x", 0, 1)
-            pm.Normal("y", 0, 1)
-            pm.Normal("obs", m["x"] + m["y"], 1, observed=[0.0])
+            # A shaped extra value checks that the per-caller shared variables keep the
+            # static shape the compiled function was built for.
+            y = pm.Normal("y", 0, 1, shape=3)
+            pm.Normal("obs", x + y.sum(), 1, observed=[0.0])
 
         fm = freeze_model(m)
         x_val = fm.rvs_to_values[fm["x"]]
         # Values must be arrays, as in a point returned by `initial_point`.
-        point_a = {"x": np.array(0.0), "y": np.array(1.0)}
-        point_b = {"x": np.array(0.0), "y": np.array(2.0)}
+        point_a = {"x": np.array(0.0), "y": np.ones(3)}
+        point_b = {"x": np.array(0.0), "y": np.full(3, 2.0)}
         f_a = fm.logp_dlogp_function([x_val], ravel_inputs=True, initial_point=point_a)
         logp_a, _ = f_a(np.array([0.0]))
         f_b = fm.logp_dlogp_function([x_val], ravel_inputs=True, initial_point=point_b)
         logp_b, _ = f_b(np.array([0.0]))
-        assert f_a is f_b  # same compiled function reused
-        assert not np.isclose(logp_a, logp_b)  # but the extra value (y) took effect
+        assert f_a is not f_b
+        assert not np.isclose(logp_a, logp_b)  # the extra value (y) took effect
+
+        # Handing out the cached function must not share its extra values across callers,
+        # neither those set when `f_b` was created nor those set on it afterwards.
+        np.testing.assert_allclose(f_a(np.array([0.0]))[0], logp_a)
+        f_b.set_extra_values({"x": np.array(0.0), "y": np.full(3, 3.0)})
+        np.testing.assert_allclose(f_a(np.array([0.0]))[0], logp_a)
+
+    def test_logp_dlogp_function_weights_are_per_call(self):
+        with pm.Model() as m:
+            pm.Normal("x", 0, 1)
+            pm.Normal("obs", m["x"], 1, observed=[0.0])
+
+        fm = freeze_model(m)
+        f_a = fm.logp_dlogp_function(tempered=True, ravel_inputs=True)
+        f_b = fm.logp_dlogp_function(tempered=True, ravel_inputs=True)
+        logp_a, _ = f_a(np.array([0.0]))
+        f_b.set_weights(np.array([0.5]))
+        np.testing.assert_allclose(f_a(np.array([0.0]))[0], logp_a)
+        assert not np.isclose(f_b(np.array([0.0]))[0], logp_a)
 
     def test_initial_point_is_cached(self):
         with pm.Model() as m:

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -1464,6 +1464,34 @@ class TestFrozenModelCaching:
         np.testing.assert_allclose(ip1["x"], fm.initial_point(0)["x"])
         np.testing.assert_allclose(ip1["x"], m.initial_point(0)["x"])  # matches unfrozen
 
+    def test_repeated_sampling_does_not_recompile(self):
+        with pm.Model() as m:
+            x = pm.Normal("x", 0, 1, size=2)
+            pm.Normal("y", x, 1, observed=[0.3, -0.5])
+
+        sample_kwargs = {
+            "draws": 5,
+            "tune": 5,
+            "chains": 1,
+            "progressbar": False,
+            "nuts_sampler": "pymc",
+            "compute_convergence_checks": False,
+        }
+        fm = freeze_model(m)
+        with fm:
+            pm.sample(random_seed=0, **sample_kwargs)
+
+        n_compiles = [0]
+        orig_function = pytensor.function
+
+        def counting_function(*args, **kwargs):
+            n_compiles[0] += 1
+            return orig_function(*args, **kwargs)
+
+        with patch("pytensor.function", counting_function), fm:
+            pm.sample(random_seed=1, **sample_kwargs)
+        assert n_compiles[0] == 0
+
 
 def test_model_parent_set_programmatically():
     with pm.Model() as model:

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -1442,6 +1442,34 @@ class TestFrozenModelCaching:
         np.testing.assert_allclose(ip1["x"], fm.initial_point(0)["x"])
         np.testing.assert_allclose(ip1["x"], m.initial_point(0)["x"])  # matches unfrozen
 
+    def test_repeated_sampling_does_not_recompile(self):
+        with pm.Model() as m:
+            x = pm.Normal("x", 0, 1, size=2)
+            pm.Normal("y", x, 1, observed=[0.3, -0.5])
+
+        sample_kwargs = {
+            "draws": 5,
+            "tune": 5,
+            "chains": 1,
+            "progressbar": False,
+            "nuts_sampler": "pymc",
+            "compute_convergence_checks": False,
+        }
+        fm = freeze_model(m)
+        with fm:
+            pm.sample(random_seed=0, **sample_kwargs)
+
+        n_compiles = [0]
+        orig_function = pytensor.function
+
+        def counting_function(*args, **kwargs):
+            n_compiles[0] += 1
+            return orig_function(*args, **kwargs)
+
+        with patch("pytensor.function", counting_function), fm:
+            pm.sample(random_seed=1, **sample_kwargs)
+        assert n_compiles[0] == 0
+
 
 def test_model_parent_set_programmatically():
     with pm.Model() as model:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -15,10 +15,12 @@ import re
 
 import arviz
 import numpy as np
+import pytensor.tensor as pt
 import pytest
 import xarray
 
 from cachetools import cached
+from pytensor.compile.io import In, Out
 
 import pymc as pm
 
@@ -115,6 +117,39 @@ def test_hashing_of_rv_tuples():
                 (freerv, []),
             ]:
                 assert isinstance(hashable(structure), int)
+
+
+def test_hashable_of_sets():
+    # Sets used to fall through to being pickled as a whole, which is not stable across
+    # calls, so equal sets got different hashes.
+    with pm.Model():
+        rv = pm.Normal("rv")
+
+    assert hashable({rv}) == hashable({rv})
+    assert hashable({rv}) != hashable(set())
+    assert hashable({1, 2}) == hashable({2, 1})  # order-insensitive
+    assert hashable(frozenset({1, 2})) == hashable(frozenset({1, 2}))
+
+
+def test_hashable_of_function_inputs_and_outputs():
+    # In/Out wrap a variable with compilation options and are hashed by identity, but
+    # callers rebuild them on every call.
+    x = pt.vector("x")
+    assert hashable(In(x, borrow=True)) == hashable(In(x, borrow=True))
+    assert hashable(In(x, borrow=True)) != hashable(In(x, borrow=False))
+    assert hashable(Out(x, borrow=True)) == hashable(Out(x, borrow=True))
+
+
+def test_hash_key_of_arrays():
+    # Looking a key up compares it with the stored one, which must not raise for arrays or
+    # for the containers holding them.
+    key = hash_key({"x": np.zeros(3)})
+    same = hash_key({"x": np.zeros(3)})
+    other = hash_key({"x": np.ones(3)})
+
+    assert key == same
+    assert key != other
+    assert {key: "value"}[same] == "value"
 
 
 def test_hash_key():


### PR DESCRIPTION
## Description

Two things, now that #8330 is merged.

### 1. Cache keys that raise or never match

`pymc.util.hashable` and `HashableWrapper` back `hash_key` and `locally_cachedmethod`, and mishandle three kinds of values:

- **Keys holding arrays raise on lookup.** `HashableWrapper.__eq__` compared the wrapped objects, so a cache keyed on an array — or on a dict holding one, such as an initial point or `initvals` — raises `ValueError: truth value of an array with more than one element is ambiguous` as soon as a lookup compares keys. Keys are now compared by type and by the hash `hashable` computes for them.
- **Sets silently defeat the cache.** `hashable` has branches for `dict`, `list` and `tuple`, but not for `set`, so sets fell through to being pickled whole. That is not stable across calls, so two equal sets get different hashes and every call stores a new entry instead of hitting the existing one. Sets are now hashed by their elements, like the containers above them.
- **`In`/`Out` never match.** They wrap a variable together with compilation options, but are hashed by identity, and callers rebuild them on every call. A key holding one therefore never matched its entry. They are now hashed by what they hold.

### 2. Reuse the initial point and trace functions when sampling

Repeated `pm.sample` on a frozen model still recompiled the initial-point and trace functions, so the caching #8330 added never fired on the path that matters most. `make_initial_point_fns_per_chain` and `BaseTrace` now go through the model, which the fixes above make possible.

Repeated sampling of a frozen model goes from 4 compiles to **0**.

## Related Issue

- Follows #8330, split out of it during review.

## Checklist

- [x] Pre-commit linting/style checks pass
- [x] Included tests: one per cache-key issue in `tests/test_util.py`, plus a frozen-model test asserting that a second `pm.sample` compiles nothing

## Type of change

- [x] Bug fix
- [x] Performance
