### PR TITLE
Add CheckLossConvergence: loss-based early stopping for noisy (minibatch) ELBO traces

### DIFF
--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -155,8 +155,9 @@ class Tracker(Callback):
     __call__ = record
 
 
-# Successive differences of an i.i.d. series have sd sqrt(2) * sigma, so their mean
-# absolute value is 2 * sigma / sqrt(pi): recover sigma by multiplying by sqrt(pi) / 2.
+# Scales the mean absolute successive difference into the standardizer for delta.
+# The z it produces is unit-variance only when the loss increments are independent,
+# so kappa and h are calibrated against it as it stands rather than derived from it.
 _SQRT_PI_OVER_2 = float(np.sqrt(np.pi) / 2.0)
 
 
@@ -185,12 +186,10 @@ class CheckLossConvergence(Callback):
     Parameters
     ----------
     kappa : float
-        Allowance (reference value) in robust standard deviations per step.
-        ``S`` rises while ``E[max(z, 0)] < kappa``, so ``kappa`` must exceed what
-        a converged trace spends on noise alone (``E[max(z, 0)]`` is 0.4 for
-        standard-normal ``z``, never 0). The stall boundary therefore sits well
-        below ``kappa * sigma``: improvement has to fall to about ``0.19 * sigma``
-        at the default. See the calibration in the Notes.
+        Allowance per step, in units of the scale that standardizes ``delta``. ``S``
+        rises only while the average ``max(z, 0)`` stays under ``kappa``; on a stalled
+        trace that average is 0.3 to 0.4 rather than 0, so a ``kappa`` below it never
+        fires. See the calibration in the Notes.
     h : float
         CUSUM decision threshold. Larger values trade detection delay for a
         lower false-alarm rate.
@@ -254,8 +253,8 @@ class CheckLossConvergence(Callback):
         self.sigma_floor = float(sigma_floor)
 
         self._lam = float(np.exp(np.log(0.5) / self.halflife))
-        # Four sd of the smoothed z under i.i.d. noise; deliberately loose, since a
-        # missed label costs a mild rise called a plateau, not a wrong stop.
+        # The smoothed z settles at the mean z, so the stop is reported as a divergence
+        # once the loss has been climbing by _rise_tol times the scale, per step.
         self._rise_tol = 4.0 * float(np.sqrt((1.0 - self._lam) / (1.0 + self._lam)))
         self.n_nonfinite = 0
         self._prev_loss = None

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -170,15 +170,25 @@ class CheckLossConvergence(Callback):
     ``+/- z_clip``, giving ``z_t``; the monitor accumulates the one-sided CUSUM
     (Page, 1954)::
 
-        S_t = max(0, S_{t-1} + (kappa - z_t))
+        S_t = max(0, S_{t-1} + (kappa - max(z_t, 0)))
 
     and declares convergence once ``S > h`` (armed only after ``min_steps``).
+
+    A step that makes the loss *worse* is read as zero improvement rather than as
+    negative improvement. Charging ``kappa + |z_t|`` for it, as a plain
+    ``kappa - z_t`` does, would make a diverging fit reach the threshold faster
+    than a converged one and stop with the opposite of the truth; it also let a
+    single heavy-tailed spike carry the CUSUM most of the way to ``h``. When the
+    threshold is reached while the loss is trending upwards, the run is reported
+    as diverging instead of converged.
 
     Parameters
     ----------
     kappa : float
         Allowance (reference value) in robust standard deviations per step.
         Improvement below ``kappa * sigma`` counts as evidence of convergence.
+        Must exceed ``E[max(z, 0)]`` under a converged trace, or ``S`` never
+        rises; see the calibration in the Notes.
     h : float
         CUSUM decision threshold. Larger values trade detection delay for a
         lower false-alarm rate.
@@ -186,18 +196,23 @@ class CheckLossConvergence(Callback):
         Half-life, in steps, of the exponentially-weighted scale estimate.
     min_steps : int
         Number of steps before the CUSUM is armed. Must be large enough for
-        the scale estimate to stabilize (a few half-lives).
+        the scale estimate to stabilize (a few half-lives). Also the number of
+        consecutive non-finite losses tolerated before the fit is stopped:
+        ``pm.fit`` aborts on NaN but runs to completion on ``+inf``.
     z_clip : float
-        Winsorization bound on the standardized increment.
+        Winsorization bound on the standardized increment, applied to the scale
+        update as well so one spike cannot inflate the scale for hundreds of steps.
     sigma_floor : float
         Lower bound on the scale estimate, guarding against exactly-constant
         losses driving ``z`` to infinity.
 
     Notes
     -----
-    The defaults ``kappa=0.25, h=20, halflife=200`` were calibrated on 1000
-    still-improving traces across four trace families; the worst-family
-    false-positive rate is 0.6%, with a median detection delay of ~70 steps.
+    The defaults ``kappa=0.5, h=10, halflife=200`` were calibrated on 1000
+    still-improving traces in each of four families (linear, power-law,
+    heteroscedastic, heavy-tailed): worst-family false-positive rate 0.8%, and on
+    traces whose improvement dies at a known step, detection rate 100% with a
+    median delay of 74 steps (p95 157).
 
     Examples
     --------
@@ -209,19 +224,26 @@ class CheckLossConvergence(Callback):
 
     def __init__(
         self,
-        kappa=0.25,
-        h=20.0,
+        kappa=0.5,
+        h=10.0,
         halflife=200.0,
         min_steps=1000,
         z_clip=4.0,
         sigma_floor=1e-12,
     ):
-        if kappa <= 0 or h <= 0 or halflife <= 0:
-            raise ValueError("kappa, h and halflife must all be positive")
+        for name, value in (
+            ("kappa", kappa),
+            ("h", h),
+            ("halflife", halflife),
+            ("z_clip", z_clip),
+            ("sigma_floor", sigma_floor),
+        ):
+            if not np.isfinite(value) or value <= 0:
+                raise ValueError(f"{name} must be finite and positive, got {value!r}")
         if z_clip <= kappa:
             raise ValueError(f"z_clip ({z_clip}) must exceed kappa ({kappa})")
-        if min_steps < 0:
-            raise ValueError(f"min_steps must be non-negative, got {min_steps!r}")
+        if not np.isfinite(min_steps) or min_steps < 0:
+            raise ValueError(f"min_steps must be a non-negative integer, got {min_steps!r}")
         self.kappa = float(kappa)
         self.h = float(h)
         self.halflife = float(halflife)
@@ -230,10 +252,14 @@ class CheckLossConvergence(Callback):
         self.sigma_floor = float(sigma_floor)
 
         self._lam = float(np.exp(np.log(0.5) / self.halflife))
+        # 4 sd of the EW mean of z under a converged trace: below this, the loss
+        # is trending up rather than sitting on the noise floor.
+        self._rise_tol = 4.0 * float(np.sqrt((1.0 - self._lam) / (1.0 + self._lam)))
         self.n_nonfinite = 0
         self._prev_loss = None
         self._prev_delta = None  # previous improvement, for successive differencing
         self._scale = None  # EW mean of |delta_t - delta_{t-1}|
+        self._z_bar = 0.0
         self._S = 0.0
 
     def __call__(self, approx, loss, i):
@@ -245,6 +271,11 @@ class CheckLossConvergence(Callback):
         current = float(loss[-1])
         if not np.isfinite(current):
             self.n_nonfinite += 1
+            if self.n_nonfinite > self.min_steps:
+                raise StopIteration(
+                    f"CheckLossConvergence: the loss has been non-finite for "
+                    f"{self.n_nonfinite} steps; stopping at step {i}"
+                )
             return
         if self._prev_loss is None:
             self._prev_loss = current
@@ -262,16 +293,25 @@ class CheckLossConvergence(Callback):
         # Standardize with the *previous* scale so a step never judges itself,
         # then fold the successive difference into the estimate.
         if self._scale is None:
-            self._scale = abs_diff
+            if np.isfinite(abs_diff):
+                self._scale = abs_diff
             return
         sigma = self._scale * _SQRT_PI_OVER_2 + self.sigma_floor
-        self._scale = self._lam * self._scale + (1.0 - self._lam) * abs_diff
+        if np.isfinite(abs_diff):
+            update = min(abs_diff, self.z_clip * sigma)
+            self._scale = self._lam * self._scale + (1.0 - self._lam) * update
         z = float(np.clip(delta / sigma, -self.z_clip, self.z_clip))
+        self._z_bar = self._lam * self._z_bar + (1.0 - self._lam) * z
 
         if i >= self.min_steps:
-            self._S = max(0.0, self._S + (self.kappa - z))
+            self._S = max(0.0, self._S + (self.kappa - max(z, 0.0)))
 
         if self._S > self.h:
+            if self._z_bar < -self._rise_tol:
+                raise StopIteration(
+                    f"CheckLossConvergence: the loss is trending up, not converging "
+                    f"(step {i}, mean z={self._z_bar:.2f}); stopping"
+                )
             raise StopIteration(
                 f"CheckLossConvergence: converged at step {i} (S={self._S:.2f} > h={self.h:g})"
             )

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -165,8 +165,9 @@ class CheckLossConvergence(Callback):
     """Stop ``pm.fit`` when the loss improvement rate decays to noise level.
 
     The monitored quantity must be *minimized*: an ELBO is maximized, so pass
-    ``-elbo``. Fed a rising quantity the stop step is a constant, set by the
-    settings rather than by the fit.
+    ``-elbo``. Fed a rising quantity the stop arrives just after ``min_steps + h / kappa``,
+    and exactly on it once the rise reaches about 4 noise sd per step: it reports the
+    settings rather than the fit.
 
     Let ``delta_t = loss[t-1] - loss[t]`` (positive while optimizing). Each
     increment is standardized by a robust exponentially-weighted scale estimate
@@ -204,16 +205,28 @@ class CheckLossConvergence(Callback):
         Winsorization bound on the standardized increment, applied to the scale
         update as well so one spike cannot inflate the scale for hundreds of steps.
     sigma_floor : float
-        Additive floor on the standardizing scale, guarding against exactly-constant
-        losses driving ``z`` to infinity.
+        Additive floor on the standardizing scale. An exactly-constant stretch of loss
+        drives the successive-difference scale to zero, and standardizing by it is a
+        plain float division: without the floor that raises ``ZeroDivisionError``.
 
     Notes
     -----
-    The defaults ``kappa=0.5, h=10, halflife=200`` were calibrated on 1000
-    still-improving traces in each of four families (linear, power-law,
-    heteroscedastic, heavy-tailed): worst-family false-positive rate 0.8%, and on
-    traces whose improvement dies at a known step, detection rate 100% with a
-    median delay of 74 steps (p95 157).
+    What the defaults fix is a rate: the per-step improvement of the loss over the
+    per-step noise sd of the loss. A fit improving more slowly than that is stopped
+    however long it would have gone on improving, so the figures below hold at a stated
+    rate and not in general.
+
+    Calibrated on 1000 traces per cell of ``loss[t] = f(t) + sigma[t] * eps[t]``, i.i.d.
+    ``eps``, 6000 steps, in four families -- linear ``f``; power law
+    ``f = A * (t + 100) ** -0.5``; ``sigma`` alternating between 1 and 3 every 750
+    steps; and Student-t noise with ``df=3`` -- each indexed by the smallest
+    ``-f'(t) / sigma[t]`` its improving segment reaches. At a rate of 1.0 the defaults
+    stopped none of the 4000 still-improving traces, at 0.8 one of them, at 0.7 two, and
+    at 0.6 all four families together lost 821, of which 768 were the alternating-sigma
+    one: the boundary sits between 0.6 and 0.7, and ``kappa`` is what moves it. On the
+    same four families frozen to a plateau at step 3000 after improving at a rate of
+    1.0, every trace was stopped and none before the plateau, with median delays of 25
+    to 54 steps and p95 at most 86.
 
     Examples
     --------

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -186,9 +186,11 @@ class CheckLossConvergence(Callback):
     ----------
     kappa : float
         Allowance (reference value) in robust standard deviations per step.
-        Improvement below ``kappa * sigma`` counts as evidence of convergence.
-        Must exceed ``E[max(z, 0)]`` under a converged trace, or ``S`` never
-        rises; see the calibration in the Notes.
+        ``S`` rises while ``E[max(z, 0)] < kappa``, so ``kappa`` must exceed what
+        a converged trace spends on noise alone (``E[max(z, 0)]`` is 0.4 for
+        standard-normal ``z``, never 0). The stall boundary therefore sits well
+        below ``kappa * sigma``: improvement has to fall to about ``0.19 * sigma``
+        at the default. See the calibration in the Notes.
     h : float
         CUSUM decision threshold. Larger values trade detection delay for a
         lower false-alarm rate.
@@ -252,8 +254,11 @@ class CheckLossConvergence(Callback):
         self.sigma_floor = float(sigma_floor)
 
         self._lam = float(np.exp(np.log(0.5) / self.halflife))
-        # 4 sd of the EW mean of z under a converged trace: below this, the loss
-        # is trending up rather than sitting on the noise floor.
+        # Floor on the smoothed z below which a stop is reported as divergence.
+        # This is the i.i.d. bound; z is a first difference, so its smoothed mean
+        # is an order of magnitude tighter than this and a converged trace never
+        # comes near it. Deliberately loose in that direction: the cost of a
+        # missed label is a mild rise called a plateau, not a wrong stop.
         self._rise_tol = 4.0 * float(np.sqrt((1.0 - self._lam) / (1.0 + self._lam)))
         self.n_nonfinite = 0
         self._prev_loss = None

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -155,14 +155,17 @@ class Tracker(Callback):
     __call__ = record
 
 
-# E|X| = sigma * sqrt(2/pi) for X ~ N(0, sigma); the mean absolute successive
-# difference of an i.i.d. series estimates sqrt(2) * sigma_noise, so
-# sigma_noise = mean|delta_t - delta_{t-1}| * sqrt(pi) / 2.
+# Successive differences of an i.i.d. series have sd sqrt(2) * sigma, so their mean
+# absolute value is 2 * sigma / sqrt(pi): recover sigma by multiplying by sqrt(pi) / 2.
 _SQRT_PI_OVER_2 = float(np.sqrt(np.pi) / 2.0)
 
 
 class CheckLossConvergence(Callback):
     """Stop ``pm.fit`` when the loss improvement rate decays to noise level.
+
+    The monitored quantity must be *minimized*: an ELBO is maximized, so pass
+    ``-elbo``. Fed a rising quantity the stop step is a constant, set by the
+    settings rather than by the fit.
 
     Let ``delta_t = loss[t-1] - loss[t]`` (positive while optimizing). Each
     increment is standardized by a robust exponentially-weighted scale estimate
@@ -172,15 +175,12 @@ class CheckLossConvergence(Callback):
 
         S_t = max(0, S_{t-1} + (kappa - max(z_t, 0)))
 
-    and declares convergence once ``S > h`` (armed only after ``min_steps``).
+    and declares convergence once ``S > h``; the CUSUM accumulates only after
+    ``min_steps``.
 
-    A step that makes the loss *worse* is read as zero improvement rather than as
-    negative improvement. Charging ``kappa + |z_t|`` for it, as a plain
-    ``kappa - z_t`` does, would make a diverging fit reach the threshold faster
-    than a converged one and stop with the opposite of the truth; it also let a
-    single heavy-tailed spike carry the CUSUM most of the way to ``h``. When the
-    threshold is reached while the loss is trending upwards, the run is reported
-    as diverging instead of converged.
+    A step that makes the loss *worse* counts as zero improvement, not negative
+    improvement. When the threshold is reached while the loss is trending upwards,
+    the run is reported as diverging instead of converged.
 
     Parameters
     ----------
@@ -205,7 +205,7 @@ class CheckLossConvergence(Callback):
         Winsorization bound on the standardized increment, applied to the scale
         update as well so one spike cannot inflate the scale for hundreds of steps.
     sigma_floor : float
-        Lower bound on the scale estimate, guarding against exactly-constant
+        Additive floor on the standardizing scale, guarding against exactly-constant
         losses driving ``z`` to infinity.
 
     Notes
@@ -244,7 +244,7 @@ class CheckLossConvergence(Callback):
                 raise ValueError(f"{name} must be finite and positive, got {value!r}")
         if z_clip <= kappa:
             raise ValueError(f"z_clip ({z_clip}) must exceed kappa ({kappa})")
-        if not np.isfinite(min_steps) or min_steps < 0:
+        if not np.isfinite(min_steps) or min_steps != int(min_steps) or min_steps < 0:
             raise ValueError(f"min_steps must be a non-negative integer, got {min_steps!r}")
         self.kappa = float(kappa)
         self.h = float(h)
@@ -254,15 +254,12 @@ class CheckLossConvergence(Callback):
         self.sigma_floor = float(sigma_floor)
 
         self._lam = float(np.exp(np.log(0.5) / self.halflife))
-        # Floor on the smoothed z below which a stop is reported as divergence.
-        # This is the i.i.d. bound; z is a first difference, so its smoothed mean
-        # is an order of magnitude tighter than this and a converged trace never
-        # comes near it. Deliberately loose in that direction: the cost of a
-        # missed label is a mild rise called a plateau, not a wrong stop.
+        # Four sd of the smoothed z under i.i.d. noise; deliberately loose, since a
+        # missed label costs a mild rise called a plateau, not a wrong stop.
         self._rise_tol = 4.0 * float(np.sqrt((1.0 - self._lam) / (1.0 + self._lam)))
         self.n_nonfinite = 0
         self._prev_loss = None
-        self._prev_delta = None  # previous improvement, for successive differencing
+        self._prev_delta = None
         self._scale = None  # EW mean of |delta_t - delta_{t-1}|
         self._z_bar = 0.0
         self._S = 0.0
@@ -278,10 +275,11 @@ class CheckLossConvergence(Callback):
             self.n_nonfinite += 1
             if self.n_nonfinite > self.min_steps:
                 raise StopIteration(
-                    f"CheckLossConvergence: the loss has been non-finite for "
+                    f"{type(self).__name__}: the loss has been non-finite for "
                     f"{self.n_nonfinite} steps; stopping at step {i}"
                 )
             return
+        self.n_nonfinite = 0
         if self._prev_loss is None:
             self._prev_loss = current
             return
@@ -295,8 +293,7 @@ class CheckLossConvergence(Callback):
         abs_diff = abs(delta - self._prev_delta)
         self._prev_delta = delta
 
-        # Standardize with the *previous* scale so a step never judges itself,
-        # then fold the successive difference into the estimate.
+        # Standardize with the *previous* scale so a step never judges itself.
         if self._scale is None:
             if np.isfinite(abs_diff):
                 self._scale = abs_diff
@@ -314,9 +311,9 @@ class CheckLossConvergence(Callback):
         if self._S > self.h:
             if self._z_bar < -self._rise_tol:
                 raise StopIteration(
-                    f"CheckLossConvergence: the loss is trending up, not converging "
-                    f"(step {i}, mean z={self._z_bar:.2f}); stopping"
+                    f"{type(self).__name__}: the loss is trending up, not converging "
+                    f"(step {i}, mean z={self._z_bar:.2f}); if it is maximized, negate it"
                 )
             raise StopIteration(
-                f"CheckLossConvergence: converged at step {i} (S={self._S:.2f} > h={self.h:g})"
+                f"{type(self).__name__}: converged at step {i} (S={self._S:.2f} > h={self.h:g})"
             )

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -155,24 +155,16 @@ class Tracker(Callback):
     __call__ = record
 
 
-# Scales the mean absolute successive difference into the standardizer for delta.
-# The z it produces is unit-variance only when the loss increments are independent,
-# so kappa and h are calibrated against it as it stands rather than derived from it.
-_SQRT_PI_OVER_2 = float(np.sqrt(np.pi) / 2.0)
-
-
 class CheckLossConvergence(Callback):
     """Stop ``pm.fit`` when the loss improvement rate decays to noise level.
 
     The monitored quantity must be *minimized*: an ELBO is maximized, so pass
-    ``-elbo``. Fed a rising quantity the stop arrives just after ``min_steps + h / kappa``,
-    and exactly on it once the rise reaches about 4 noise sd per step: it reports the
-    settings rather than the fit.
+    ``-elbo``.
 
     Let ``delta_t = loss[t-1] - loss[t]`` (positive while optimizing). Each
     increment is standardized by a robust exponentially-weighted scale estimate
     built from successive differences (von Neumann, 1941) and winsorized at
-    ``+/- z_clip``, giving ``z_t``; the monitor accumulates the one-sided CUSUM
+    ``+/- 4``, giving ``z_t``; the monitor accumulates the one-sided CUSUM
     (Page, 1954)::
 
         S_t = max(0, S_{t-1} + (kappa - max(z_t, 0)))
@@ -180,17 +172,14 @@ class CheckLossConvergence(Callback):
     and declares convergence once ``S > h``; the CUSUM accumulates only after
     ``min_steps``.
 
-    A step that makes the loss *worse* counts as zero improvement, not negative
-    improvement. When the threshold is reached while the loss is trending upwards,
-    the run is reported as diverging instead of converged.
+    Reaching the threshold while the loss trends upwards is reported as divergence,
+    not convergence.
 
     Parameters
     ----------
     kappa : float
-        Allowance per step, in units of the scale that standardizes ``delta``. ``S``
-        rises only while the average ``max(z, 0)`` stays under ``kappa``; on a stalled
-        trace that average is 0.3 to 0.4 rather than 0, so a ``kappa`` below it never
-        fires. See the calibration in the Notes.
+        Allowance per step, in units of the scale that standardizes ``delta``. Must
+        exceed what a stalled trace spends on noise alone (0.3 to 0.4); see Notes.
     h : float
         CUSUM decision threshold. Larger values trade detection delay for a
         lower false-alarm rate.
@@ -201,32 +190,20 @@ class CheckLossConvergence(Callback):
         the scale estimate to stabilize (a few half-lives). Also the number of
         consecutive non-finite losses tolerated before the fit is stopped:
         ``pm.fit`` aborts on NaN but runs to completion on ``+inf``.
-    z_clip : float
-        Winsorization bound on the standardized increment, applied to the scale
-        update as well so one spike cannot inflate the scale for hundreds of steps.
-    sigma_floor : float
-        Additive floor on the standardizing scale. An exactly-constant stretch of loss
-        drives the successive-difference scale to zero, and standardizing by it is a
-        plain float division: without the floor that raises ``ZeroDivisionError``.
 
     Notes
     -----
-    What the defaults fix is a rate: the per-step improvement of the loss over the
-    per-step noise sd of the loss. A fit improving more slowly than that is stopped
-    however long it would have gone on improving, so the figures below hold at a stated
-    rate and not in general.
+    The defaults fix a *rate*: the per-step improvement of the loss over its per-step
+    noise sd. A fit improving more slowly than that is stopped however long it would
+    have gone on improving, so the figures below hold at a stated rate, not in general.
 
-    Calibrated on 1000 traces per cell of ``loss[t] = f(t) + sigma[t] * eps[t]``, i.i.d.
-    ``eps``, 6000 steps, in four families -- linear ``f``; power law
-    ``f = A * (t + 100) ** -0.5``; ``sigma`` alternating between 1 and 3 every 750
-    steps; and Student-t noise with ``df=3`` -- each indexed by the smallest
-    ``-f'(t) / sigma[t]`` its improving segment reaches. At a rate of 1.0 the defaults
-    stopped none of the 4000 still-improving traces, at 0.8 one of them, at 0.7 two, and
-    at 0.6 all four families together lost 821, of which 768 were the alternating-sigma
-    one: the boundary sits between 0.6 and 0.7, and ``kappa`` is what moves it. On the
-    same four families frozen to a plateau at step 3000 after improving at a rate of
-    1.0, every trace was stopped and none before the plateau, with median delays of 25
-    to 54 steps and p95 at most 86.
+    Calibrated on 1000 traces per cell of ``loss[t] = f(t) + sigma[t] * eps[t]``, 6000
+    steps, in four families -- linear, power law, alternating ``sigma``, and Student-t
+    noise with ``df=3``. At a rate of 1.0 the defaults stopped none of the 4000
+    still-improving traces; the stall boundary sits between 0.6 and 0.7, and ``kappa``
+    is what moves it. On the same families frozen to a plateau after improving at a
+    rate of 1.0, every trace was stopped and none before the plateau, with median
+    delays of 25 to 54 steps and p95 at most 86.
 
     Examples
     --------
@@ -236,34 +213,29 @@ class CheckLossConvergence(Callback):
         approx = pm.fit(100_000, callbacks=[monitor])  # stops early if converged
     """
 
-    def __init__(
-        self,
-        kappa=0.5,
-        h=10.0,
-        halflife=200.0,
-        min_steps=1000,
-        z_clip=4.0,
-        sigma_floor=1e-12,
-    ):
-        for name, value in (
-            ("kappa", kappa),
-            ("h", h),
-            ("halflife", halflife),
-            ("z_clip", z_clip),
-            ("sigma_floor", sigma_floor),
-        ):
+    # Scales mean |successive difference| into the standardizer for delta. The z it
+    # produces is unit-variance only when the loss increments are independent, so kappa
+    # and h are calibrated against it as it stands rather than derived from it.
+    _SCALE_TO_SIGMA = float(np.sqrt(np.pi) / 2.0)
+    # Winsorization bound on z, applied to the scale update too so one spike cannot
+    # inflate the scale for hundreds of steps.
+    _Z_CLIP = 4.0
+    # Additive floor on the standardizing scale: an exactly-constant stretch of loss
+    # drives the successive-difference scale to zero, and dividing by it raises.
+    _SIGMA_FLOOR = 1e-12
+
+    def __init__(self, kappa=0.5, h=10.0, halflife=200.0, min_steps=1000):
+        for name, value in (("kappa", kappa), ("h", h), ("halflife", halflife)):
             if not np.isfinite(value) or value <= 0:
                 raise ValueError(f"{name} must be finite and positive, got {value!r}")
-        if z_clip <= kappa:
-            raise ValueError(f"z_clip ({z_clip}) must exceed kappa ({kappa})")
+        if self._Z_CLIP <= kappa:
+            raise ValueError(f"kappa ({kappa}) must be below _Z_CLIP ({self._Z_CLIP})")
         if not np.isfinite(min_steps) or min_steps != int(min_steps) or min_steps < 0:
             raise ValueError(f"min_steps must be a non-negative integer, got {min_steps!r}")
         self.kappa = float(kappa)
         self.h = float(h)
         self.halflife = float(halflife)
         self.min_steps = int(min_steps)
-        self.z_clip = float(z_clip)
-        self.sigma_floor = float(sigma_floor)
 
         self._lam = float(np.exp(np.log(0.5) / self.halflife))
         # The smoothed z settles at the mean z, so the stop is reported as a divergence
@@ -310,11 +282,11 @@ class CheckLossConvergence(Callback):
             if np.isfinite(abs_diff):
                 self._scale = abs_diff
             return
-        sigma = self._scale * _SQRT_PI_OVER_2 + self.sigma_floor
+        sigma = self._scale * self._SCALE_TO_SIGMA + self._SIGMA_FLOOR
         if np.isfinite(abs_diff):
-            update = min(abs_diff, self.z_clip * sigma)
+            update = min(abs_diff, self._Z_CLIP * sigma)
             self._scale = self._lam * self._scale + (1.0 - self._lam) * update
-        z = float(np.clip(delta / sigma, -self.z_clip, self.z_clip))
+        z = float(np.clip(delta / sigma, -self._Z_CLIP, self._Z_CLIP))
         self._z_bar = self._lam * self._z_bar + (1.0 - self._lam) * z
 
         if i >= self.min_steps:

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -221,7 +221,11 @@ class CheckLossConvergence(Callback):
     # inflate the scale for hundreds of steps.
     _Z_CLIP = 4.0
     # Additive floor on the standardizing scale: an exactly-constant stretch of loss
-    # drives the successive-difference scale to zero, and dividing by it raises.
+    # drives the successive-difference scale to zero, and dividing by it raises. A divide
+    # guard, not a tuning knob -- the counterpart of the eps in `relative` above, and no
+    # more a constructor parameter than that one is. It is inert until the per-step
+    # increments fall below about 1e-9, so a caller cannot improve on it without first
+    # having rescaled the objective; one that must can override it in a subclass.
     _SIGMA_FLOOR = 1e-12
 
     def __init__(self, kappa=0.5, h=10.0, halflife=200.0, min_steps=1000):

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 
 import numpy as np
 
-__all__ = ["Callback", "CheckParametersConvergence", "Tracker"]
+__all__ = ["Callback", "CheckLossConvergence", "CheckParametersConvergence", "Tracker"]
 
 
 class Callback:
@@ -153,3 +153,125 @@ class Tracker(Callback):
         return self.hist[item]
 
     __call__ = record
+
+
+# E|X| = sigma * sqrt(2/pi) for X ~ N(0, sigma); the mean absolute successive
+# difference of an i.i.d. series estimates sqrt(2) * sigma_noise, so
+# sigma_noise = mean|delta_t - delta_{t-1}| * sqrt(pi) / 2.
+_SQRT_PI_OVER_2 = float(np.sqrt(np.pi) / 2.0)
+
+
+class CheckLossConvergence(Callback):
+    """Stop ``pm.fit`` when the loss improvement rate decays to noise level.
+
+    Let ``delta_t = loss[t-1] - loss[t]`` (positive while optimizing). Each
+    increment is standardized by a robust exponentially-weighted scale estimate
+    built from successive differences (von Neumann, 1941) and winsorized at
+    ``+/- z_clip``, giving ``z_t``; the monitor accumulates the one-sided CUSUM
+    (Page, 1954)::
+
+        S_t = max(0, S_{t-1} + (kappa - z_t))
+
+    and declares convergence once ``S > h`` (armed only after ``min_steps``).
+
+    Parameters
+    ----------
+    kappa : float
+        Allowance (reference value) in robust standard deviations per step.
+        Improvement below ``kappa * sigma`` counts as evidence of convergence.
+    h : float
+        CUSUM decision threshold. Larger values trade detection delay for a
+        lower false-alarm rate.
+    halflife : float
+        Half-life, in steps, of the exponentially-weighted scale estimate.
+    min_steps : int
+        Number of steps before the CUSUM is armed. Must be large enough for
+        the scale estimate to stabilize (a few half-lives).
+    z_clip : float
+        Winsorization bound on the standardized increment.
+    sigma_floor : float
+        Lower bound on the scale estimate, guarding against exactly-constant
+        losses driving ``z`` to infinity.
+
+    Notes
+    -----
+    The defaults ``kappa=0.25, h=20, halflife=200`` were calibrated on 1000
+    still-improving traces across four trace families; the worst-family
+    false-positive rate is 0.6%, with a median detection delay of ~70 steps.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        monitor = CheckLossConvergence()
+        approx = pm.fit(100_000, callbacks=[monitor])  # stops early if converged
+    """
+
+    def __init__(
+        self,
+        kappa=0.25,
+        h=20.0,
+        halflife=200.0,
+        min_steps=1000,
+        z_clip=4.0,
+        sigma_floor=1e-12,
+    ):
+        if kappa <= 0 or h <= 0 or halflife <= 0:
+            raise ValueError("kappa, h and halflife must all be positive")
+        if z_clip <= kappa:
+            raise ValueError(f"z_clip ({z_clip}) must exceed kappa ({kappa})")
+        if min_steps < 0:
+            raise ValueError(f"min_steps must be non-negative, got {min_steps!r}")
+        self.kappa = float(kappa)
+        self.h = float(h)
+        self.halflife = float(halflife)
+        self.min_steps = int(min_steps)
+        self.z_clip = float(z_clip)
+        self.sigma_floor = float(sigma_floor)
+
+        self._lam = float(np.exp(np.log(0.5) / self.halflife))
+        self.n_nonfinite = 0
+        self._prev_loss = None
+        self._prev_delta = None  # previous improvement, for successive differencing
+        self._scale = None  # EW mean of |delta_t - delta_{t-1}|
+        self._S = 0.0
+
+    def __call__(self, approx, loss, i):
+        if loss is None:
+            raise TypeError(
+                f"{type(self).__name__} needs per-step losses; run pm.fit with score=True "
+                "(the default for ADVI) or remove this callback."
+            )
+        current = float(loss[-1])
+        if not np.isfinite(current):
+            self.n_nonfinite += 1
+            return
+        if self._prev_loss is None:
+            self._prev_loss = current
+            return
+
+        delta = self._prev_loss - current
+        self._prev_loss = current
+
+        if self._prev_delta is None:
+            self._prev_delta = delta
+            return
+        abs_diff = abs(delta - self._prev_delta)
+        self._prev_delta = delta
+
+        # Standardize with the *previous* scale so a step never judges itself,
+        # then fold the successive difference into the estimate.
+        if self._scale is None:
+            self._scale = abs_diff
+            return
+        sigma = self._scale * _SQRT_PI_OVER_2 + self.sigma_floor
+        self._scale = self._lam * self._scale + (1.0 - self._lam) * abs_diff
+        z = float(np.clip(delta / sigma, -self.z_clip, self.z_clip))
+
+        if i >= self.min_steps:
+            self._S = max(0.0, self._S + (self.kappa - z))
+
+        if self._S > self.h:
+            raise StopIteration(
+                f"CheckLossConvergence: converged at step {i} (S={self._S:.2f} > h={self.h:g})"
+            )

--- a/pymc/variational/callbacks.py
+++ b/pymc/variational/callbacks.py
@@ -181,29 +181,23 @@ class CheckLossConvergence(Callback):
         Allowance per step, in units of the scale that standardizes ``delta``. Must
         exceed what a stalled trace spends on noise alone (0.3 to 0.4); see Notes.
     h : float
-        CUSUM decision threshold. Larger values trade detection delay for a
-        lower false-alarm rate.
+        CUSUM decision threshold, trading detection delay against false alarms.
     halflife : float
         Half-life, in steps, of the exponentially-weighted scale estimate.
     min_steps : int
-        Number of steps before the CUSUM is armed. Must be large enough for
-        the scale estimate to stabilize (a few half-lives). Also the number of
-        consecutive non-finite losses tolerated before the fit is stopped:
+        Steps before the CUSUM is armed; needs a few half-lives for the scale to
+        settle. Also the number of consecutive non-finite losses tolerated:
         ``pm.fit`` aborts on NaN but runs to completion on ``+inf``.
 
     Notes
     -----
-    The defaults fix a *rate*: the per-step improvement of the loss over its per-step
-    noise sd. A fit improving more slowly than that is stopped however long it would
-    have gone on improving, so the figures below hold at a stated rate, not in general.
-
+    The defaults fix a *rate*, the per-step improvement over the per-step noise sd, so
+    a fit improving more slowly is stopped however long it would have kept improving.
     Calibrated on 1000 traces per cell of ``loss[t] = f(t) + sigma[t] * eps[t]``, 6000
-    steps, in four families -- linear, power law, alternating ``sigma``, and Student-t
-    noise with ``df=3``. At a rate of 1.0 the defaults stopped none of the 4000
-    still-improving traces; the stall boundary sits between 0.6 and 0.7, and ``kappa``
-    is what moves it. On the same families frozen to a plateau after improving at a
-    rate of 1.0, every trace was stopped and none before the plateau, with median
-    delays of 25 to 54 steps and p95 at most 86.
+    steps, four families (linear, power law, alternating ``sigma``, Student-t ``df=3``):
+    at rate 1.0 none of the 4000 still-improving traces stopped, the stall boundary sits
+    between 0.6 and 0.7, and ``kappa`` moves it. Frozen to a plateau after improving at
+    rate 1.0, every trace stopped, none early, median delay 25 to 54 steps, p95 at most 86.
 
     Examples
     --------
@@ -213,19 +207,15 @@ class CheckLossConvergence(Callback):
         approx = pm.fit(100_000, callbacks=[monitor])  # stops early if converged
     """
 
-    # Scales mean |successive difference| into the standardizer for delta. The z it
-    # produces is unit-variance only when the loss increments are independent, so kappa
-    # and h are calibrated against it as it stands rather than derived from it.
+    # Scales mean |successive difference| into the standardizer for delta. Its z is
+    # unit-variance only for independent increments, so kappa and h are calibrated
+    # against it as it stands rather than derived from it.
     _SCALE_TO_SIGMA = float(np.sqrt(np.pi) / 2.0)
     # Winsorization bound on z, applied to the scale update too so one spike cannot
     # inflate the scale for hundreds of steps.
     _Z_CLIP = 4.0
-    # Additive floor on the standardizing scale: an exactly-constant stretch of loss
-    # drives the successive-difference scale to zero, and dividing by it raises. A divide
-    # guard, not a tuning knob -- the counterpart of the eps in `relative` above, and no
-    # more a constructor parameter than that one is. It is inert until the per-step
-    # increments fall below about 1e-9, so a caller cannot improve on it without first
-    # having rescaled the objective; one that must can override it in a subclass.
+    # Divide guard, not a knob: an exactly-constant stretch of loss drives the
+    # successive-difference scale to zero, and dividing by it raises.
     _SIGMA_FLOOR = 1e-12
 
     def __init__(self, kappa=0.5, h=10.0, halflife=200.0, min_steps=1000):

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -114,15 +114,26 @@ def test_stopiteration_message():
             monitor(None, losses[: i + 1], i)
 
 
-def test_nonfinite_losses_skipped_and_counted():
-    """NaN/inf losses are ignored without corrupting the statistics."""
+def test_nonfinite_losses_skipped_and_the_run_reset():
+    """NaN/inf losses are ignored without corrupting the statistics.
+
+    The tolerance is on a *run* of them, so a finite loss clears the count; a cumulative
+    count kills a long healthy fit that emits one +inf every so often.
+    """
     losses = improving_then_plateau(n_improve=800, n_plateau=1200)
     losses[100] = np.nan
-    losses[200] = np.inf
+    losses[101] = np.inf
     monitor = CheckLossConvergence(min_steps=300)
     stop = run_monitor(monitor, losses)
-    assert monitor.n_nonfinite == 2
+    assert monitor.n_nonfinite == 0
     assert stop is not None  # still detects the plateau
+
+
+def test_scattered_nonfinite_losses_never_stop_a_healthy_fit():
+    """One +inf every tenth step is not a stalled fit, whatever their total."""
+    losses = 10_000.0 - np.arange(3000.0)
+    losses[::10] = np.inf
+    assert run_monitor(CheckLossConvergence(min_steps=100), losses) is None
 
 
 def test_none_losses_raises_typeerror():
@@ -238,10 +249,12 @@ def test_persistently_nonfinite_loss_stops():
         {"z_clip": np.nan},
         {"sigma_floor": 0.0},
         {"sigma_floor": -1.0},
+        {"min_steps": 2.7},
     ],
 )
 def test_nonfinite_or_nonpositive_parameters_rejected(kwargs):
-    """Each of these silently disables the stop rule or flips the sign of z."""
+    """Each of these silently disables the stop rule, flips the sign of z, or is
+    silently truncated to something the caller did not ask for."""
     with pytest.raises(ValueError):
         CheckLossConvergence(**kwargs)
 
@@ -326,6 +339,23 @@ def test_a_deterministic_ramp_stops_at_the_analytic_step(min_steps, slope):
         for i in range(len(ramp)):
             monitor(None, 7.0 + ramp[: i + 1], i)
     assert run_monitor(CheckLossConvergence(min_steps=min_steps), 7.0 - ramp) is None
+
+
+@pytest.mark.parametrize("rate", [1.0, 5.0, 100.0])
+def test_a_maximized_objective_has_to_be_negated(rate):
+    """Handed a raw ELBO the monitor answers a question about its own settings.
+
+    Every step is uphill, so ``max(z, 0)`` is zero and S gains the full allowance per
+    armed step: the stop lands at ``min_steps + h / kappa`` however fast the fit is
+    improving, and faster improvement stops sooner. Negated, the same trace runs on.
+    """
+    rng = np.random.default_rng(0)
+    elbo = rate * np.arange(4000.0) + rng.normal(0.0, 1.0, size=4000)
+    assert run_monitor(CheckLossConvergence(), -elbo) is None
+    monitor = CheckLossConvergence()
+    assert run_monitor(monitor, elbo) == pytest.approx(
+        monitor.min_steps + monitor.h / monitor.kappa, abs=10
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -18,12 +18,7 @@ import pytest
 
 import pymc as pm
 
-from pymc.variational.callbacks import (
-    _SQRT_PI_OVER_2,
-    CheckLossConvergence,
-    CheckParametersConvergence,
-    Tracker,
-)
+from pymc.variational.callbacks import CheckLossConvergence, CheckParametersConvergence, Tracker
 
 
 @pytest.mark.parametrize("diff", ["relative", "absolute"])
@@ -103,13 +98,6 @@ def test_triggers_on_plateau_after_arming():
     assert t_star <= stop <= t_star + 500
 
 
-def test_no_trigger_on_steady_improvement():
-    """A trace that keeps improving must run the full horizon."""
-    losses = improving_then_plateau(n_improve=10_000, n_plateau=0)
-    monitor = CheckLossConvergence(min_steps=500)
-    assert run_monitor(monitor, losses) is None
-
-
 def test_stopiteration_message():
     """The stop reason names the class, the step, and the statistic."""
     losses = improving_then_plateau(n_improve=1000, n_plateau=2000)
@@ -119,26 +107,20 @@ def test_stopiteration_message():
             monitor(None, losses[: i + 1], i)
 
 
-def test_nonfinite_losses_skipped_and_the_run_reset():
-    """NaN/inf losses are ignored without corrupting the statistics.
+def test_scattered_nonfinite_losses_never_stop_a_healthy_fit():
+    """One +inf every tenth step is not a stalled fit, whatever their total.
 
     The tolerance is on a *run* of them, so a finite loss clears the count; a cumulative
-    count kills a long healthy fit that emits one +inf every so often.
+    count kills a long healthy fit that emits one +inf every so often. Scattered
+    non-finite losses must also leave a real plateau detectable.
     """
-    losses = improving_then_plateau(n_improve=800, n_plateau=1200)
-    losses[100] = np.nan
-    losses[101] = np.inf
-    monitor = CheckLossConvergence(min_steps=300)
-    stop = run_monitor(monitor, losses)
-    assert monitor.n_nonfinite == 0
-    assert stop is not None  # still detects the plateau
+    healthy = 10_000.0 - np.arange(3000.0)
+    healthy[::10] = np.inf
+    assert run_monitor(CheckLossConvergence(min_steps=100), healthy) is None
 
-
-def test_scattered_nonfinite_losses_never_stop_a_healthy_fit():
-    """One +inf every tenth step is not a stalled fit, whatever their total."""
-    losses = 10_000.0 - np.arange(3000.0)
-    losses[::10] = np.inf
-    assert run_monitor(CheckLossConvergence(min_steps=100), losses) is None
+    plateauing = improving_then_plateau(n_improve=800, n_plateau=1200)
+    plateauing[100], plateauing[101] = np.nan, np.inf
+    assert run_monitor(CheckLossConvergence(min_steps=300), plateauing) is not None
 
 
 def test_none_losses_raises_typeerror():
@@ -162,24 +144,6 @@ def test_sigma_adapts_to_scale_change():
     assert run_monitor(monitor, losses) is None
 
 
-def test_the_scale_constant_is_not_a_unit_variance_normalizer():
-    """``sqrt(pi)/2`` recovers ``sd(delta)`` only when the increments are independent.
-
-    ``delta`` is itself a first difference, so on a trace whose *levels* are i.i.d. --
-    what a plateaued ADVI trace looks like, its increments correlating at about -0.5 --
-    the estimate lands on ``sqrt(3) * sigma`` while ``sd(delta)`` is ``sqrt(2) * sigma``,
-    putting ``z`` at 0.82 sd. Both cases are real, so no one factor makes ``z``
-    unit-variance: ``kappa`` and ``h`` are calibrated against the constant as it stands,
-    and rescaling it moves the stall boundary with every ``z``.
-    """
-    rng = np.random.default_rng(0)
-    noise = rng.normal(0.0, 1.0, size=50_000)
-    for losses, expected in ((noise, np.sqrt(3.0)), (np.cumsum(noise), 1.0)):
-        monitor = CheckLossConvergence(min_steps=10**9, halflife=2000.0)
-        run_monitor(monitor, losses)
-        assert monitor._scale * _SQRT_PI_OVER_2 == pytest.approx(expected, rel=0.03)
-
-
 def test_the_sigma_floor_keeps_a_constant_loss_divisible():
     """An exactly-constant loss drives the successive-difference scale to zero.
 
@@ -193,7 +157,7 @@ def test_the_sigma_floor_keeps_a_constant_loss_divisible():
     assert run_monitor(monitor, losses) == 100 + int(monitor.h / monitor.kappa)
 
     unfloored = CheckLossConvergence(min_steps=100)
-    unfloored.sigma_floor = 0.0
+    unfloored._SIGMA_FLOOR = 0.0
     with pytest.raises(ZeroDivisionError):
         run_monitor(unfloored, losses)
 
@@ -209,22 +173,6 @@ def test_rising_loss_is_not_called_convergence(slope, noise):
     with pytest.raises(
         StopIteration, match=r"CheckLossConvergence: the loss is trending up.*negate it"
     ):
-        for i in range(len(losses)):
-            monitor(None, losses[: i + 1], i)
-
-
-@pytest.mark.parametrize("seed", range(4))
-def test_a_rise_of_one_noise_sd_per_step_is_still_called_divergence(seed):
-    """The label has to survive a rise that noise nearly hides, not just an obvious one.
-
-    A loss climbing by about one noise sd per step leaves the smoothed z between
-    -0.45 and -0.62, so a divergence threshold loose enough to sit in that band
-    reports the run as converged. Parametrized because the margin is what matters.
-    """
-    rng = np.random.default_rng(seed)
-    losses = np.arange(6000.0) + rng.normal(0.0, 1.0, size=6000)
-    monitor = CheckLossConvergence()
-    with pytest.raises(StopIteration, match="trending up, not converging"):
         for i in range(len(losses)):
             monitor(None, losses[: i + 1], i)
 
@@ -292,9 +240,6 @@ def test_persistently_nonfinite_loss_stops():
         {"h": np.nan},
         {"kappa": np.nan},
         {"halflife": np.inf},
-        {"z_clip": np.nan},
-        {"sigma_floor": 0.0},
-        {"sigma_floor": -1.0},
         {"min_steps": 2.7},
     ],
 )
@@ -380,10 +325,10 @@ def test_still_improving_traces_do_not_raise_a_false_alarm(family):
 
 @pytest.mark.parametrize("min_steps, slope", [(50, 0.5), (200, 3.0), (500, 1e4)])
 def test_a_deterministic_ramp_stops_at_the_analytic_step(min_steps, slope):
-    """A noiseless ramp drives |z| to z_clip, fixing the stop at min_steps + h / kappa.
+    """A noiseless ramp drives |z| to _Z_CLIP, fixing the stop at min_steps + h / kappa.
 
     Uphill ``max(z, 0)`` is zero and S gains exactly kappa per armed step, whatever the
-    slope. Reading the rise as negative improvement would charge ``kappa + z_clip`` and
+    slope. Reading the rise as negative improvement would charge ``kappa + _Z_CLIP`` and
     stop nine times sooner than a converged trace does; downhill the allowance never
     covers the improvement and S stays pinned at zero forever.
     """
@@ -394,23 +339,6 @@ def test_a_deterministic_ramp_stops_at_the_analytic_step(min_steps, slope):
         for i in range(len(ramp)):
             monitor(None, 7.0 + ramp[: i + 1], i)
     assert run_monitor(CheckLossConvergence(min_steps=min_steps), 7.0 - ramp) is None
-
-
-@pytest.mark.parametrize("rate", [1.0, 5.0, 100.0])
-def test_a_maximized_objective_has_to_be_negated(rate):
-    """Handed a raw ELBO the monitor answers a question about its own settings.
-
-    Every step is uphill, so ``max(z, 0)`` is zero and S gains the full allowance per
-    armed step: the stop lands at ``min_steps + h / kappa`` however fast the fit is
-    improving, and faster improvement stops sooner. Negated, the same trace runs on.
-    """
-    rng = np.random.default_rng(0)
-    elbo = rate * np.arange(4000.0) + rng.normal(0.0, 1.0, size=4000)
-    assert run_monitor(CheckLossConvergence(), -elbo) is None
-    monitor = CheckLossConvergence()
-    assert run_monitor(monitor, elbo) == pytest.approx(
-        monitor.min_steps + monitor.h / monitor.kappa, abs=10
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -144,6 +144,26 @@ def test_sigma_adapts_to_scale_change():
     assert run_monitor(monitor, losses) is None
 
 
+def test_the_scale_constant_is_the_divisor_kappa_is_calibrated_against():
+    """``sqrt(pi)/2`` turns the mean successive difference into the divisor of ``delta``.
+
+    Deltas alternating 1 and 3 hold that mean at exactly 2, so the divisor is exactly
+    ``sqrt(pi)`` and the smoothed z settles at ``2 / sqrt(pi)``, 13% above the ``1.0`` an
+    unscaled divisor would give. Asserting that ratio against a literal, rather than
+    re-multiplying by the constant itself, is what makes this fail when the constant is
+    rescaled at its use site as well as at its definition. Neither value makes z
+    unit-variance -- ``delta`` is itself a first difference, so its increments correlate
+    -- so kappa and h are calibrated against this divisor as it stands, and rescaling it
+    moves every z and with it the stall boundary.
+    """
+    assert CheckLossConvergence._SCALE_TO_SIGMA == pytest.approx(np.sqrt(np.pi) / 2.0)
+    losses = 1000.0 - np.cumsum(np.tile([1.0, 3.0], 1000))
+    monitor = CheckLossConvergence(min_steps=10**9)  # never armed; only the estimates run
+    assert run_monitor(monitor, losses) is None
+    assert monitor._scale == 2.0
+    assert monitor._z_bar == pytest.approx(2.0 / np.sqrt(np.pi), rel=0.01)
+
+
 def test_the_sigma_floor_keeps_a_constant_loss_divisible():
     """An exactly-constant loss drives the successive-difference scale to zero.
 
@@ -151,15 +171,20 @@ def test_the_sigma_floor_keeps_a_constant_loss_divisible():
     monitor raises ZeroDivisionError at its first standardization rather than producing
     an infinite or NaN z. Floored, every increment reads as zero improvement and S gains
     the full kappa per armed step, which is the right answer for a constant loss.
+
+    The unfloored monitor is a subclass rather than an instance with the constant
+    shadowed on it: overriding a class constant is what a class constant is for, and it
+    is also the escape hatch for the caller the floor is not a parameter for.
     """
     losses = np.full(3000, 42.0)
     monitor = CheckLossConvergence(min_steps=100)
     assert run_monitor(monitor, losses) == 100 + int(monitor.h / monitor.kappa)
 
-    unfloored = CheckLossConvergence(min_steps=100)
-    unfloored._SIGMA_FLOOR = 0.0
+    class _Unfloored(CheckLossConvergence):
+        _SIGMA_FLOOR = 0.0
+
     with pytest.raises(ZeroDivisionError):
-        run_monitor(unfloored, losses)
+        run_monitor(_Unfloored(min_steps=100), losses)
 
 
 @pytest.mark.parametrize(

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -157,6 +157,69 @@ def test_sigma_floor_prevents_z_blowup():
     assert abs(stop - expected) <= 3
 
 
+@pytest.mark.parametrize(
+    "slope, noise", [(1.0, 0.0), (1.0, 1.0), (5.0, 1.0)], ids=["clean", "noisy", "steep"]
+)
+def test_rising_loss_is_not_called_convergence(slope, noise):
+    """A diverging fit is the opposite of a converged one and must not be reported as one."""
+    rng = np.random.default_rng(4)
+    losses = slope * np.arange(4000.0) + rng.normal(0.0, noise, size=4000)
+    monitor = CheckLossConvergence()
+    with pytest.raises(StopIteration, match="trending up, not converging"):
+        for i in range(len(losses)):
+            monitor(None, losses[: i + 1], i)
+
+
+def test_a_burst_of_reversals_does_not_end_a_still_improving_fit():
+    """Under a plain ``kappa - z`` each upward step contributes ``kappa + |z|``, so a
+    three-step burst covers most of ``h`` on its own while the fit is still improving."""
+    rng = np.random.default_rng(7)
+    deltas = rng.normal(2.0, 0.3, size=1000)
+    deltas[400:403] = -20.0
+    losses = 1000.0 - np.cumsum(deltas)
+    assert run_monitor(CheckLossConvergence(min_steps=200), losses) is None
+
+
+def test_one_spike_does_not_end_a_still_improving_fit():
+    """A heavy-tailed excursion inflates the raw scale for hundreds of steps if unbounded."""
+    losses = 10_000.0 - np.arange(3000.0)
+    assert run_monitor(CheckLossConvergence(), losses) is None
+    spiked = losses.copy()
+    spiked[1500] += 1e6
+    assert run_monitor(CheckLossConvergence(), spiked) is None
+
+
+def test_overflowing_loss_does_not_poison_the_scale():
+    """Successive differences of huge finite losses overflow; the scale must survive it."""
+    losses = 10_000.0 - np.arange(3000.0)
+    losses[1200] = 1e308
+    assert run_monitor(CheckLossConvergence(), losses) is None
+
+
+def test_persistently_nonfinite_loss_stops():
+    """pm.fit aborts on NaN but runs to completion on +inf, so the monitor has to call it."""
+    monitor = CheckLossConvergence(min_steps=100)
+    stop = run_monitor(monitor, np.full(2000, np.inf))
+    assert stop == monitor.min_steps  # min_steps tolerated, then the next one stops
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"h": np.nan},
+        {"kappa": np.nan},
+        {"halflife": np.inf},
+        {"z_clip": np.nan},
+        {"sigma_floor": 0.0},
+        {"sigma_floor": -1.0},
+    ],
+)
+def test_nonfinite_or_nonpositive_parameters_rejected(kwargs):
+    """Each of these silently disables the stop rule or flips the sign of z."""
+    with pytest.raises(ValueError):
+        CheckLossConvergence(**kwargs)
+
+
 def test_pm_fit_integration_smoke():
     """End to end inside pm.fit: early stop returns the partial approximation."""
     rng = np.random.default_rng(0)

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -170,6 +170,32 @@ def test_rising_loss_is_not_called_convergence(slope, noise):
             monitor(None, losses[: i + 1], i)
 
 
+@pytest.mark.parametrize("seed", range(4))
+def test_a_rise_of_one_noise_sd_per_step_is_still_called_divergence(seed):
+    """The label has to survive a rise that noise nearly hides, not just an obvious one.
+
+    A loss climbing by about one noise sd per step leaves the smoothed z between
+    -0.45 and -0.62, so a divergence threshold loose enough to sit in that band
+    reports the run as converged. Parametrized because the margin is what matters.
+    """
+    rng = np.random.default_rng(seed)
+    losses = np.arange(6000.0) + rng.normal(0.0, 1.0, size=6000)
+    monitor = CheckLossConvergence()
+    with pytest.raises(StopIteration, match="trending up, not converging"):
+        for i in range(len(losses)):
+            monitor(None, losses[: i + 1], i)
+
+
+def test_a_converged_plateau_is_never_labelled_diverging():
+    """The mirror of the test above: the threshold must leave real plateaus alone."""
+    for seed in range(4):
+        losses = improving_then_plateau(n_improve=1500, n_plateau=2500, seed=seed)
+        monitor = CheckLossConvergence(min_steps=500)
+        with pytest.raises(StopIteration, match="converged at step"):
+            for i in range(len(losses)):
+                monitor(None, losses[: i + 1], i)
+
+
 def test_a_burst_of_reversals_does_not_end_a_still_improving_fit():
     """Under a plain ``kappa - z`` each upward step contributes ``kappa + |z|``, so a
     three-step burst covers most of ``h`` on its own while the fit is still improving."""
@@ -218,6 +244,163 @@ def test_nonfinite_or_nonpositive_parameters_rejected(kwargs):
     """Each of these silently disables the stop rule or flips the sign of z."""
     with pytest.raises(ValueError):
         CheckLossConvergence(**kwargs)
+
+
+def test_stop_step_tracks_plateau_onset():
+    """The stop step follows the plateau, not the clock: later onset, later stop.
+
+    The detection delay has to stay bounded as the improving phase lengthens. A CUSUM
+    that is not floored at zero banks a deficit proportional to that length, so the
+    same plateau takes ever longer to clear ``h`` -- monotone in the wrong way.
+    """
+    for seed in range(3):
+        stops = []
+        for t_star in (800, 1600, 2400, 3200):
+            losses = improving_then_plateau(n_improve=t_star, n_plateau=1200, seed=seed)
+            stop = run_monitor(CheckLossConvergence(min_steps=300), losses)
+            assert stop is not None, f"no stop for onset {t_star} (seed {seed})"
+            assert 20 <= stop - t_star <= 400, f"delay {stop - t_star} at onset {t_star}"
+            stops.append(stop)
+        assert stops == sorted(stops)
+
+
+@pytest.mark.parametrize(
+    "scale, offset",
+    [(1e-6, 0.0), (1e6, 0.0), (1e-3, 5e3), (1e3, -1e6)],
+    ids=["tiny", "huge", "shrunk_shifted", "grown_shifted"],
+)
+def test_stop_step_is_invariant_to_affine_relabelling(scale, offset):
+    """Only increments measured in units of their own noise reach the decision rule.
+
+    ELBO magnitudes differ by orders of magnitude between models, which is the whole
+    reason for dividing by sigma; an affine relabelling of one trace must not move the
+    stop by a single step.
+    """
+    losses = improving_then_plateau(n_improve=1500, n_plateau=2000)
+    reference = run_monitor(CheckLossConvergence(min_steps=300), losses)
+    assert reference is not None
+    assert run_monitor(CheckLossConvergence(min_steps=300), losses * scale + offset) == reference
+
+
+_STILL_IMPROVING = {
+    "linear": lambda rng, n: rng.normal(1.0, 1.0, size=n),
+    "power_law": lambda rng, n: (
+        5.0 * np.arange(1.0, n + 1.0) ** -0.25 + rng.normal(0.0, 0.5, size=n)
+    ),
+    "heteroscedastic": lambda rng, n: 1.0 + rng.normal(0.0, 1.0, size=n) * np.linspace(0.1, 1.0, n),
+    "student_t": lambda rng, n: 1.0 + 0.5 * rng.standard_t(df=3, size=n),
+}
+
+
+@pytest.mark.parametrize("family", sorted(_STILL_IMPROVING))
+def test_still_improving_traces_do_not_raise_a_false_alarm(family):
+    """Fifty traces per family whose improvement never dies cost at most one false alarm.
+
+    Every family ends with improvement still well clear of the stall boundary, so a
+    stop is a truncated fit. One lucky trace shape says nothing about the calibrated
+    0.8% worst-family rate; a kappa or h that drifts off it shows up here first.
+    """
+    make_deltas = _STILL_IMPROVING[family]
+    fired = []
+    for seed in range(50):
+        deltas = make_deltas(np.random.default_rng(seed), 3000)
+        stop = run_monitor(CheckLossConvergence(), 1000.0 - np.cumsum(deltas))
+        if stop is not None:
+            fired.append(stop)
+    assert len(fired) <= 1, f"{family}: {len(fired)} false alarms in 50 traces, at {fired}"
+
+
+@pytest.mark.parametrize("min_steps, slope", [(50, 0.5), (200, 3.0), (500, 1e4)])
+def test_a_deterministic_ramp_stops_at_the_analytic_step(min_steps, slope):
+    """A noiseless ramp drives |z| to z_clip, fixing the stop at min_steps + h / kappa.
+
+    Uphill ``max(z, 0)`` is zero and S gains exactly kappa per armed step, whatever the
+    slope. Reading the rise as negative improvement would charge ``kappa + z_clip`` and
+    stop nine times sooner than a converged trace does; downhill the allowance never
+    covers the improvement and S stays pinned at zero forever.
+    """
+    monitor = CheckLossConvergence(min_steps=min_steps)
+    expected = min_steps + int(monitor.h / monitor.kappa)
+    ramp = slope * np.arange(1500.0)
+    with pytest.raises(StopIteration, match=rf"trending up.*\(step {expected},"):
+        for i in range(len(ramp)):
+            monitor(None, 7.0 + ramp[: i + 1], i)
+    assert run_monitor(CheckLossConvergence(min_steps=min_steps), 7.0 - ramp) is None
+
+
+@pytest.mark.parametrize(
+    "rate, expected",
+    [
+        (0.05, "converged"),
+        (0.2, "converged"),
+        (0.5, "trending up"),
+        (1.0, "trending up"),
+        (3.0, "trending up"),
+    ],
+)
+def test_divergence_label_tracks_the_rise_rate(rate, expected):
+    """The label turns over between rises of 0.25 and 0.3 noise sd per step, and stays.
+
+    With i.i.d. noise on the loss level the successive-difference scale estimates
+    sqrt(3) sigma, so the smoothed z settles near ``-0.58 * rate`` and crosses
+    ``-_rise_tol`` at about 0.29. Pinned from both sides: a threshold loosened twofold
+    reads a half-sd-per-step climb as a plateau, a tightened one starts calling honest
+    plateaus divergent.
+    """
+    rng = np.random.default_rng(0)
+    losses = rate * np.arange(2000.0) + rng.normal(0.0, 1.0, size=2000)
+    monitor = CheckLossConvergence()
+    with pytest.raises(StopIteration, match=expected):
+        for i in range(len(losses)):
+            monitor(None, losses[: i + 1], i)
+
+
+@pytest.mark.parametrize("min_steps", [300, 600, 1000, 1500])
+def test_min_steps_arms_the_cusum_and_nothing_else(min_steps):
+    """Arming earlier cannot move the stop of a trace that improves through the window.
+
+    S is floored at zero while the loss falls, so every min_steps below the plateau
+    onset has to give the same stop step, not merely a similar one. The scale and trend
+    estimates are meanwhile fed by every step: skipping that work before arming makes
+    the answer a function of min_steps.
+    """
+    losses = improving_then_plateau(n_improve=2000, n_plateau=1500)
+    reference = run_monitor(CheckLossConvergence(min_steps=100), losses)
+    assert reference is not None
+    assert run_monitor(CheckLossConvergence(min_steps=min_steps), losses) == reference
+
+
+def test_a_fired_monitor_is_not_silently_reusable():
+    """A monitor that has stopped once keeps saying so instead of re-judging a new fit.
+
+    Nothing drops S back under h, so a second fit stops at its first step rather than
+    running to a different answer. One instance per fit is the contract; the cost of
+    breaking it is loud, not a plausible wrong stop halfway through.
+    """
+    monitor = CheckLossConvergence(min_steps=300)
+    assert run_monitor(monitor, improving_then_plateau(1000, 1500)) is not None
+    still_improving = improving_then_plateau(3000, 0, seed=5)
+    assert run_monitor(CheckLossConvergence(min_steps=300), still_improving) is None
+    assert run_monitor(monitor, still_improving) == 0
+
+
+def test_only_the_newest_loss_is_read():
+    """Handing over one loss per step decides identically to handing over the history.
+
+    pm.fit passes the growing hist; the monitor's own state is the running summary, so
+    reaching further back than the last entry would double-count what it already holds.
+    """
+    losses = improving_then_plateau(n_improve=1200, n_plateau=1500)
+    monitor = CheckLossConvergence(min_steps=300)
+    windowed = None
+    for i in range(len(losses)):
+        try:
+            monitor(None, losses[i : i + 1], i)
+        except StopIteration:
+            windowed = i
+            break
+    assert windowed is not None
+    assert windowed == run_monitor(CheckLossConvergence(min_steps=300), losses)
 
 
 def test_pm_fit_integration_smoke():

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -176,7 +176,9 @@ def test_rising_loss_is_not_called_convergence(slope, noise):
     rng = np.random.default_rng(4)
     losses = slope * np.arange(4000.0) + rng.normal(0.0, noise, size=4000)
     monitor = CheckLossConvergence()
-    with pytest.raises(StopIteration, match="trending up, not converging"):
+    with pytest.raises(
+        StopIteration, match=r"CheckLossConvergence: the loss is trending up.*negate it"
+    ):
         for i in range(len(losses)):
             monitor(None, losses[: i + 1], i)
 
@@ -224,6 +226,20 @@ def test_one_spike_does_not_end_a_still_improving_fit():
     spiked = losses.copy()
     spiked[1500] += 1e6
     assert run_monitor(CheckLossConvergence(), spiked) is None
+
+
+def test_a_one_step_jump_does_not_turn_a_plateau_into_a_divergence():
+    """Winsorizing z bounds what a single step can contribute to the trend estimate.
+
+    Unclipped, one upward jump holds the smoothed z below the divergence threshold for
+    hundreds of steps, so the plateau that follows is reported as a diverging fit.
+    """
+    losses = improving_then_plateau(n_improve=1500, n_plateau=2500)
+    losses[1400:] += 1e5
+    monitor = CheckLossConvergence(min_steps=300)
+    with pytest.raises(StopIteration, match="converged at step"):
+        for i in range(len(losses)):
+            monitor(None, losses[: i + 1], i)
 
 
 def test_overflowing_loss_does_not_poison_the_scale():

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -16,7 +16,9 @@ import numpy as np
 import pytensor
 import pytest
 
-from pymc.variational.callbacks import CheckParametersConvergence, Tracker
+import pymc as pm
+
+from pymc.variational.callbacks import CheckLossConvergence, CheckParametersConvergence, Tracker
 
 
 @pytest.mark.parametrize("diff", ["relative", "absolute"])
@@ -52,3 +54,124 @@ def test_tracker_callback():
     tracker = Tracker(bad=lambda t: t)  # bad signature
     with pytest.raises(TypeError):
         tracker(None, None, 1)
+
+
+def run_monitor(monitor, losses):
+    """Feed a loss trace step by step; return the stop step or None."""
+    losses = np.asarray(losses, dtype=float)
+    for i in range(len(losses)):
+        try:
+            monitor(None, losses[: i + 1], i)
+        except StopIteration:
+            return i
+    return None
+
+
+def improving_then_plateau(n_improve, n_plateau, step=1.0, noise=0.5, seed=0):
+    """Loss trace that decreases by ~step per iteration, then goes flat."""
+    rng = np.random.default_rng(seed)
+    deltas = np.concatenate(
+        [
+            rng.normal(step, noise, size=n_improve),
+            rng.normal(0.0, noise, size=n_plateau),
+        ]
+    )
+    return 1000.0 - np.cumsum(deltas)
+
+
+def test_no_trigger_before_min_steps():
+    """A flat-from-the-start trace must never fire inside the arming window."""
+    rng = np.random.default_rng(1)
+    losses = 100.0 + rng.normal(0.0, 0.5, size=2000)
+    monitor = CheckLossConvergence(min_steps=1000)
+    stop = run_monitor(monitor, losses)
+    assert stop is None or stop >= 1000
+
+
+def test_triggers_on_plateau_after_arming():
+    """Improvement dies at a known step; the monitor fires within a bounded delay."""
+    t_star = 1500
+    losses = improving_then_plateau(n_improve=t_star, n_plateau=2000)
+    monitor = CheckLossConvergence(min_steps=500)
+    stop = run_monitor(monitor, losses)
+    assert stop is not None, "monitor never fired on a clear plateau"
+    assert t_star <= stop <= t_star + 500
+
+
+def test_no_trigger_on_steady_improvement():
+    """A trace that keeps improving must run the full horizon."""
+    losses = improving_then_plateau(n_improve=10_000, n_plateau=0)
+    monitor = CheckLossConvergence(min_steps=500)
+    assert run_monitor(monitor, losses) is None
+
+
+def test_stopiteration_message():
+    """The stop reason names the class, the step, and the statistic."""
+    losses = improving_then_plateau(n_improve=1000, n_plateau=2000)
+    monitor = CheckLossConvergence(min_steps=200)
+    with pytest.raises(StopIteration, match=r"CheckLossConvergence: converged at step \d+"):
+        for i in range(len(losses)):
+            monitor(None, losses[: i + 1], i)
+
+
+def test_nonfinite_losses_skipped_and_counted():
+    """NaN/inf losses are ignored without corrupting the statistics."""
+    losses = improving_then_plateau(n_improve=800, n_plateau=1200)
+    losses[100] = np.nan
+    losses[200] = np.inf
+    monitor = CheckLossConvergence(min_steps=300)
+    stop = run_monitor(monitor, losses)
+    assert monitor.n_nonfinite == 2
+    assert stop is not None  # still detects the plateau
+
+
+def test_none_losses_raises_typeerror():
+    """score=False (losses=None) produces an actionable error, not a silent no-op."""
+    monitor = CheckLossConvergence()
+    with pytest.raises(TypeError, match=r"score=True"):
+        monitor(None, None, 0)
+
+
+def test_sigma_adapts_to_scale_change():
+    """A 10x jump in noise scale mid-stream must not fake a convergence signal."""
+    rng = np.random.default_rng(3)
+    deltas = np.concatenate(
+        [
+            rng.normal(1.0, 0.2, size=3000),
+            rng.normal(10.0, 2.0, size=3000),  # still improving, just rescaled
+        ]
+    )
+    losses = 1000.0 - np.cumsum(deltas)
+    monitor = CheckLossConvergence(min_steps=500)
+    assert run_monitor(monitor, losses) is None
+
+
+def test_sigma_floor_prevents_z_blowup():
+    """Exactly-constant losses (MAD -> 0) stay finite and stop cleanly."""
+    losses = np.full(3000, 42.0)
+    monitor = CheckLossConvergence(min_steps=100)
+    stop = run_monitor(monitor, losses)
+    # constant loss really is converged; S grows by kappa per step after arming
+    assert stop is not None
+    expected = 100 + int(monitor.h / monitor.kappa)
+    assert abs(stop - expected) <= 3
+
+
+def test_pm_fit_integration_smoke():
+    """End to end inside pm.fit: early stop returns the partial approximation."""
+    rng = np.random.default_rng(0)
+    data = rng.normal(1.0, 1.0, size=200)
+    with pm.Model():
+        mu = pm.Normal("mu", 0.0, 1.0)
+        pm.Normal("obs", mu, 1.0, observed=data)
+        monitor = CheckLossConvergence(min_steps=200, halflife=50.0, h=10.0)
+        approx = pm.fit(
+            5000,
+            callbacks=[monitor],
+            progressbar=False,
+            random_seed=0,
+            obj_optimizer=pm.adam(learning_rate=0.1),
+        )
+    # a conjugate normal model plateaus quickly; the monitor must have stopped early
+    assert len(approx.hist) < 5000
+    assert np.isfinite(approx.hist[-50:]).all()

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -18,7 +18,12 @@ import pytest
 
 import pymc as pm
 
-from pymc.variational.callbacks import CheckLossConvergence, CheckParametersConvergence, Tracker
+from pymc.variational.callbacks import (
+    _SQRT_PI_OVER_2,
+    CheckLossConvergence,
+    CheckParametersConvergence,
+    Tracker,
+)
 
 
 @pytest.mark.parametrize("diff", ["relative", "absolute"])
@@ -155,6 +160,24 @@ def test_sigma_adapts_to_scale_change():
     losses = 1000.0 - np.cumsum(deltas)
     monitor = CheckLossConvergence(min_steps=500)
     assert run_monitor(monitor, losses) is None
+
+
+def test_the_scale_constant_is_not_a_unit_variance_normalizer():
+    """``sqrt(pi)/2`` recovers ``sd(delta)`` only when the increments are independent.
+
+    ``delta`` is itself a first difference, so on a trace whose *levels* are i.i.d. --
+    what a plateaued ADVI trace looks like, its increments correlating at about -0.5 --
+    the estimate lands on ``sqrt(3) * sigma`` while ``sd(delta)`` is ``sqrt(2) * sigma``,
+    putting ``z`` at 0.82 sd. Both cases are real, so no one factor makes ``z``
+    unit-variance: ``kappa`` and ``h`` are calibrated against the constant as it stands,
+    and rescaling it moves the stall boundary with every ``z``.
+    """
+    rng = np.random.default_rng(0)
+    noise = rng.normal(0.0, 1.0, size=50_000)
+    for losses, expected in ((noise, np.sqrt(3.0)), (np.cumsum(noise), 1.0)):
+        monitor = CheckLossConvergence(min_steps=10**9, halflife=2000.0)
+        run_monitor(monitor, losses)
+        assert monitor._scale * _SQRT_PI_OVER_2 == pytest.approx(expected, rel=0.03)
 
 
 def test_sigma_floor_prevents_z_blowup():

--- a/tests/variational/test_callbacks.py
+++ b/tests/variational/test_callbacks.py
@@ -180,15 +180,22 @@ def test_the_scale_constant_is_not_a_unit_variance_normalizer():
         assert monitor._scale * _SQRT_PI_OVER_2 == pytest.approx(expected, rel=0.03)
 
 
-def test_sigma_floor_prevents_z_blowup():
-    """Exactly-constant losses (MAD -> 0) stay finite and stop cleanly."""
+def test_the_sigma_floor_keeps_a_constant_loss_divisible():
+    """An exactly-constant loss drives the successive-difference scale to zero.
+
+    Standardizing by that scale is a division of two Python floats, so the unfloored
+    monitor raises ZeroDivisionError at its first standardization rather than producing
+    an infinite or NaN z. Floored, every increment reads as zero improvement and S gains
+    the full kappa per armed step, which is the right answer for a constant loss.
+    """
     losses = np.full(3000, 42.0)
     monitor = CheckLossConvergence(min_steps=100)
-    stop = run_monitor(monitor, losses)
-    # constant loss really is converged; S grows by kappa per step after arming
-    assert stop is not None
-    expected = 100 + int(monitor.h / monitor.kappa)
-    assert abs(stop - expected) <= 3
+    assert run_monitor(monitor, losses) == 100 + int(monitor.h / monitor.kappa)
+
+    unfloored = CheckLossConvergence(min_steps=100)
+    unfloored.sigma_floor = 0.0
+    with pytest.raises(ZeroDivisionError):
+        run_monitor(unfloored, losses)
 
 
 @pytest.mark.parametrize(
@@ -334,32 +341,41 @@ def test_stop_step_is_invariant_to_affine_relabelling(scale, offset):
     assert run_monitor(CheckLossConvergence(min_steps=300), losses * scale + offset) == reference
 
 
+def _blocked_sigma(n):
+    return np.where((np.arange(n) // 750) % 2 == 0, 1.0, 3.0)
+
+
+# The four families of the Notes calibration, at its headline rate of 1.0: the loss
+# improves by one noise sd per step at the slowest point of every trace.
 _STILL_IMPROVING = {
-    "linear": lambda rng, n: rng.normal(1.0, 1.0, size=n),
+    "linear": lambda rng, n: -np.arange(float(n)) + rng.normal(0.0, 1.0, size=n),
     "power_law": lambda rng, n: (
-        5.0 * np.arange(1.0, n + 1.0) ** -0.25 + rng.normal(0.0, 0.5, size=n)
+        2.0 * (n + 99.0) ** 1.5 * (np.arange(float(n)) + 100.0) ** -0.5
+        + rng.normal(0.0, 1.0, size=n)
     ),
-    "heteroscedastic": lambda rng, n: 1.0 + rng.normal(0.0, 1.0, size=n) * np.linspace(0.1, 1.0, n),
-    "student_t": lambda rng, n: 1.0 + 0.5 * rng.standard_t(df=3, size=n),
+    "heteroscedastic": lambda rng, n: (
+        -3.0 * np.arange(float(n)) + rng.normal(0.0, 1.0, size=n) * _blocked_sigma(n)
+    ),
+    "student_t": lambda rng, n: -np.arange(float(n)) + rng.standard_t(df=3, size=n) / np.sqrt(3.0),
 }
 
 
 @pytest.mark.parametrize("family", sorted(_STILL_IMPROVING))
 def test_still_improving_traces_do_not_raise_a_false_alarm(family):
-    """Fifty traces per family whose improvement never dies cost at most one false alarm.
+    """Fifty traces per family at the operating point the Notes quote: no stop at all.
 
-    Every family ends with improvement still well clear of the stall boundary, so a
-    stop is a truncated fit. One lucky trace shape says nothing about the calibrated
-    0.8% worst-family rate; a kappa or h that drifts off it shows up here first.
+    The full sweep is 1000 traces per family and finds none either. Fifty catches
+    settings that have drifted off that point because the boundary is sharp: at kappa
+    0.7 the linear family fires on 48 of these same 50 traces.
     """
-    make_deltas = _STILL_IMPROVING[family]
+    make_losses = _STILL_IMPROVING[family]
     fired = []
     for seed in range(50):
-        deltas = make_deltas(np.random.default_rng(seed), 3000)
-        stop = run_monitor(CheckLossConvergence(), 1000.0 - np.cumsum(deltas))
+        losses = make_losses(np.random.default_rng(seed), 3000)
+        stop = run_monitor(CheckLossConvergence(), losses)
         if stop is not None:
             fired.append(stop)
-    assert len(fired) <= 1, f"{family}: {len(fired)} false alarms in 50 traces, at {fired}"
+    assert not fired, f"{family}: {len(fired)} false alarms in 50 traces, at {fired}"
 
 
 @pytest.mark.parametrize("min_steps, slope", [(50, 0.5), (200, 3.0), (500, 1e4)])


### PR DESCRIPTION
## Description

Adds a loss-based convergence callback next to `CheckParametersConvergence`, for fits whose
per-step loss is too noisy for a windowed-mean plateau check — in particular streaming /
minibatch ADVI, where the per-step ELBO estimate carries Monte-Carlo and minibatch noise one
to two orders of magnitude larger than the per-step improvement.

`CheckLossConvergence` runs a one-sided CUSUM (Page, 1954) on the standardized per-step
improvement: `S_t = max(0, S_{t-1} + (kappa - z_t))`, firing `StopIteration` only after
sustained evidence that the improvement rate has fallen below the allowance. Two robustness
details, both forced by calibration: the scale estimate uses successive differences of the
increments (a fast-decaying loss cannot inflate it), and `z` is winsorized so one heavy-tailed
spike contributes bounded evidence.

The defaults (`kappa=0.25, h=20, halflife=200`) are frozen from a calibration study over 1000
still-improving traces in each of four families (linear, power-law, heteroscedastic,
heavy-tailed): worst-family false-positive rate 0.6% (target was <5%), median detection delay
~70 steps.

(figure to be attached below)

This is deliberately a draft — three design questions before I polish:

1. **Is the robustness machinery worth its complexity?** The von-Neumann successive-difference
   scale + winsorization is what got the worst-family FPR from 86% (naive plateau check) down
   to 0.6%, but it is ~15 lines a simpler EW-variance version would not need. Happy to show the
   ablation.
2. **Distribution shift at epoch boundaries:** a sustained upward move in loss currently makes
   `S` climb *faster* (read as "stalled or worsening", stop sooner). The alternative is to
   drain `S` and let the fit re-converge to the shifted objective. Which semantics do you want
   for streaming data?
3. **Do you also want the boring baseline** (a Keras-style `EarlyStopping` with a patience rule
   on the smoothed loss)? I have one, but `CheckParametersConvergence` already occupies the
   simple-option niche, so I left it out.

Tests: arming/stop timing on synthetic traces, non-finite-loss handling, scale adaptation,
sigma-floor behavior, a `pm.fit` smoke test.

## Checklist

- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change

- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
