### PR TITLE
Do not let logpow and bound checks get in the way of underflow stabilization

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -725,26 +725,27 @@ class NegativeBinomial(Discrete):
         return mu
 
     def logp(value, n, p):
+        mu = n * (1 - p) / p
+
+        # binomln subtracts gammaln(value + n) - gammaln(n), whose difference falls below
+        # their shared ulp once n is large, so fall back on the Poisson(mu) limit there.
         res = pt.switch(
-            pt.lt(value, 0),
-            -np.inf,
+            pt.gt(n, 1e10),
+            logpow(mu, value) - mu - factln(value),
             binomln(value + n - 1, value) + logpow(1 - p, value) + logpow(p, n),
         )
+        res = pt.switch(pt.lt(value, 0), -np.inf, res)
 
         # p == 0 is outside the support, but a valid tiny p can round to it: sigmoid(-800)
         # is exactly 0.0 while log(p) is still -800. Checking 0 <= p instead of 0 < p keeps
         # those usable, at the cost of returning the limiting -inf for a degenerate p == 0.
-        negbinom = check_parameters(
+        return check_parameters(
             res,
             0 <= p,
             p <= 1,
             n > 0,
             msg="0 <= p <= 1, n > 0",
         )
-
-        # Return Poisson when n gets very large.
-        mu = n * (1 - p) / p
-        return pt.switch(pt.gt(n, 1e10), logp(Poisson.dist(mu=mu), value), negbinom)
 
     def logcdf(value, n, p):
         res = pt.switch(

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -725,28 +725,26 @@ class NegativeBinomial(Discrete):
         return mu
 
     def logp(value, n, p):
-        alpha = n
-        mu = alpha * (1 - p) / p
-
         res = pt.switch(
             pt.lt(value, 0),
             -np.inf,
-            (
-                binomln(value + alpha - 1, value)
-                + logpow(mu / (mu + alpha), value)
-                + logpow(alpha / (mu + alpha), alpha)
-            ),
+            binomln(value + n - 1, value) + logpow(1 - p, value) + logpow(p, n),
         )
 
+        # p == 0 is outside the support, but a valid tiny p can round to it: sigmoid(-800)
+        # is exactly 0.0 while log(p) is still -800. Checking 0 <= p instead of 0 < p keeps
+        # those usable, at the cost of returning the limiting -inf for a degenerate p == 0.
         negbinom = check_parameters(
             res,
-            mu > 0,
-            alpha > 0,
-            msg="mu > 0, alpha > 0",
+            0 <= p,
+            p <= 1,
+            n > 0,
+            msg="0 <= p <= 1, n > 0",
         )
 
-        # Return Poisson when alpha gets very large.
-        return pt.switch(pt.gt(alpha, 1e10), logp(Poisson.dist(mu=mu), value), negbinom)
+        # Return Poisson when n gets very large.
+        mu = n * (1 - p) / p
+        return pt.switch(pt.gt(n, 1e10), logp(Poisson.dist(mu=mu), value), negbinom)
 
     def logcdf(value, n, p):
         res = pt.switch(

--- a/pymc/distributions/dist_math.py
+++ b/pymc/distributions/dist_math.py
@@ -91,8 +91,19 @@ def check_icdf_value(expr: Variable, value: Variable) -> Variable:
 
 def logpow(x, m):
     """Calculate log(x**m) since m*log(x) will fail when m, x = 0."""
-    # return m * log(x)
-    return pt.switch(pt.eq(x, 0), pt.switch(pt.eq(m, 0), 0.0, -np.inf), m * pt.log(x))
+    # Guard on log(x), not on x. PyTensor stabilizes log(x) as a whole -- log(exp(a))
+    # becomes a, log1p(-sigmoid(a)) becomes -softplus(a) -- so log(x) stays finite
+    # when x merely collapsed to zero through underflow or cancellation, and is -inf
+    # only when x is genuinely zero. Testing x itself cannot tell those apart, and
+    # would discard a perfectly representable m * log(x) in the first case.
+    log_x = pt.log(x)
+    return pt.switch(
+        pt.and_(pt.eq(log_x, -np.inf), pt.le(m, 0)),
+        # 0 * log(0) is nan, and m * log(0) is +inf for m < 0 where we report -inf
+        # at the edge of the support
+        pt.switch(pt.eq(m, 0), 0.0, -np.inf),
+        m * log_x,
+    )
 
 
 def factln(n):

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -751,20 +751,25 @@ class TestNegativeBinomial(BaseTestDistributionRandom):
     checks_to_run = ["check_pymc_params_match_rv_op"]
 
 
-@pytest.mark.xfail(
-    reason="logp reconstructs mu = alpha * (1 - p) / p and then computes mu / (mu + alpha), "
-    "which is just 1 - p, and the round-trip overflows. The mu parametrization additionally "
-    "needs a log(a + exp(x)) -> log(a) + log1pexp(x - log(a)) stabilization in PyTensor, "
-    "since logp only ever sees p = n / (mu + n)."
-)
-def test_negative_binomial_logp_stable_when_parameter_underflows():
+def test_negative_binomial_logp_stable_when_p_underflows():
+    """log(p) and log(1 - p) are rewritten into softplus, so the logp stays finite."""
     a = pt.dscalar("a")
+    logp_expr = pm.logp(pm.NegativeBinomial.dist(n=2.0, p=pt.sigmoid(a)), 3)
 
-    mu_param = pm.logp(pm.NegativeBinomial.dist(mu=pt.exp(a), alpha=2.0), 3)
-    np.testing.assert_allclose(mu_param.eval({a: 710.0}), -1417.2274112777604)
+    np.testing.assert_allclose(logp_expr.eval({a: -800.0}), -1598.6137056388802)
+    np.testing.assert_allclose(logp_expr.eval({a: 37.0}), -109.6137056388801)
+    np.testing.assert_allclose(logp_expr.eval({a: 5000.0}), -14998.61370563888)
 
-    p_param = pm.logp(pm.NegativeBinomial.dist(n=2.0, p=pt.sigmoid(a)), 3)
-    np.testing.assert_allclose(p_param.eval({a: -800.0}), -1598.6137056388802)
+
+@pytest.mark.xfail(
+    reason="Needs a log(a + exp(x)) -> log(a) + log1pexp(x - log(a)) stabilization in "
+    "PyTensor, since logp only ever sees p = n / (mu + n)"
+)
+def test_negative_binomial_logp_stable_when_mu_overflows():
+    a = pt.dscalar("a")
+    logp_expr = pm.logp(pm.NegativeBinomial.dist(mu=pt.exp(a), alpha=2.0), 3)
+
+    np.testing.assert_allclose(logp_expr.eval({a: 710.0}), -1417.2274112777604)
 
 
 class TestNegativeBinomialMuSigma(BaseTestDistributionRandom):

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -751,6 +751,22 @@ class TestNegativeBinomial(BaseTestDistributionRandom):
     checks_to_run = ["check_pymc_params_match_rv_op"]
 
 
+@pytest.mark.xfail(
+    reason="logp reconstructs mu = alpha * (1 - p) / p and then computes mu / (mu + alpha), "
+    "which is just 1 - p, and the round-trip overflows. The mu parametrization additionally "
+    "needs a log(a + exp(x)) -> log(a) + log1pexp(x - log(a)) stabilization in PyTensor, "
+    "since logp only ever sees p = n / (mu + n)."
+)
+def test_negative_binomial_logp_stable_when_parameter_underflows():
+    a = pt.dscalar("a")
+
+    mu_param = pm.logp(pm.NegativeBinomial.dist(mu=pt.exp(a), alpha=2.0), 3)
+    np.testing.assert_allclose(mu_param.eval({a: 710.0}), -1417.2274112777604)
+
+    p_param = pm.logp(pm.NegativeBinomial.dist(n=2.0, p=pt.sigmoid(a)), 3)
+    np.testing.assert_allclose(p_param.eval({a: -800.0}), -1598.6137056388802)
+
+
 class TestNegativeBinomialMuSigma(BaseTestDistributionRandom):
     pymc_dist = pm.NegativeBinomial
     pymc_dist_params = {"mu": 5.0, "alpha": 8.0}

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -761,6 +761,18 @@ def test_negative_binomial_logp_stable_when_p_underflows():
     np.testing.assert_allclose(logp_expr.eval({a: 5000.0}), -14998.61370563888)
 
 
+def test_negative_binomial_logp_large_n():
+    """binomln subtracts gammaln(value + n) - gammaln(n), whose difference falls below
+    their shared ulp once n is large, so the logp falls back on the Poisson(mu) limit.
+    """
+    mu, n = pt.dscalars("mu", "n")
+    logp_expr = pm.logp(pm.NegativeBinomial.dist(mu=mu, alpha=n), 3)
+
+    np.testing.assert_allclose(logp_expr.eval({mu: 5.0, n: 1e12}), -1.9634457319257537)
+    np.testing.assert_allclose(logp_expr.eval({mu: 5.0, n: 1e18}), -1.9634457319257537)
+    np.testing.assert_allclose(logp_expr.eval({mu: 5.0, n: 1e20}), -1.9634457319257537)
+
+
 @pytest.mark.xfail(
     reason="Needs a log(a + exp(x)) -> log(a) + log1pexp(x - log(a)) stabilization in "
     "PyTensor, since logp only ever sees p = n / (mu + n)"

--- a/tests/distributions/test_dist_math.py
+++ b/tests/distributions/test_dist_math.py
@@ -29,6 +29,7 @@ from pymc.distributions.dist_math import (
     clipped_beta_rvs,
     factln,
     i0e,
+    logpow,
     multigammaln,
 )
 from pymc.logprob.utils import ParameterValueError
@@ -99,6 +100,53 @@ class MultinomialB(Discrete):
             pt.all(p <= 1),
             pt.isclose(p.sum(), 1),
         )
+
+
+def test_logpow():
+    x, m = pt.dscalars("x", "m")
+    fn = function([x, m], logpow(x, m))
+
+    assert fn(2.0, 3.0) == 2.0794415416798357
+    assert fn(0.0, 0.0) == 0.0  # x ** 0 == 1 for any x
+    assert fn(2.0, 0.0) == 0.0
+    assert fn(0.0, 3.0) == -np.inf
+    assert fn(0.0, -3.0) == -np.inf  # +inf in exact math, -inf at the edge of the support
+
+
+def test_logpow_underflowed_base():
+    """Check logpow does not discard a base that PyTensor can stabilize.
+
+    Both bases below collapse to exactly zero -- exp(-800) by underflow and
+    1 - sigmoid(800) by cancellation -- but their logs are rewritten into -800
+    either way, so the result is representable and must not be diverted to the
+    guard's +-inf.
+    """
+    a, m = pt.dscalars("a", "m")
+    exp_fn = function([a, m], logpow(pt.exp(a), m))
+    sigmoid_fn = function([a, m], logpow(1 - pt.sigmoid(a), m))
+
+    for fn, a_val in ((exp_fn, -800.0), (sigmoid_fn, 800.0)):
+        assert fn(a_val, 3.0) == -2400.0
+        assert fn(a_val, -3.0) == 2400.0
+        assert fn(a_val, 0.0) == 0.0
+
+
+def test_logpow_stabilization_reaches_logp():
+    """Check the stabilized form survives in the distributions that build on logpow.
+
+    Poisson and Binomial reach it through their parameters, Gamma through a value
+    that underflows (and with alpha < 1, so a negative exponent).
+    """
+    a = pt.dscalar("a")
+
+    poisson = pm.logp(pm.Poisson.dist(mu=pt.exp(a)), 3)
+    np.testing.assert_allclose(poisson.eval({a: -800.0}), -2401.791759469228)
+
+    binomial = pm.logp(pm.Binomial.dist(n=10, logit_p=a), 1)
+    np.testing.assert_allclose(binomial.eval({a: 800.0}), -7197.697414907006)
+
+    gamma = pm.logp(pm.Gamma.dist(alpha=0.5, beta=1.0), pt.exp(a))
+    np.testing.assert_allclose(gamma.eval({a: -800.0}), 399.4276350736618)
 
 
 def test_multinomial_check_parameters():


### PR DESCRIPTION
Related to #8389 

PyMC is already stable for common link functions for Poisson/Binomial/Gamma, but the logpow helper that exists to handle 0 * log(0) case was breaking logp and gradient by checking for the unstable from of x and not the sable log(x) that pytensor would arrive at.

This PR fixes it. It also adds one xfail test for a stabilization missing in NegativeBinomial, I'll open a PR on the PyTensor for that.