### PR TITLE
Fix xarray DataArray coord unwrapping in Model.add_coord

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1856,6 +1856,13 @@ class Model(BaseModel):
                 f"Either `values` or `length` must be specified for the '{name}' dimension."
             )
         if values is not None:
+            # xarray DataArrays passed as coord values must be unwrapped.
+            # tuple(DataArray) iterates yielding 0-d DataArrays instead of plain values,
+            # which breaks np.array_equal comparisons and InferenceData export.
+            import xarray as xr
+
+            if isinstance(values, xr.DataArray):
+                values = values.values
             # Conversion to a tuple ensures that the coordinate values are immutable.
             # Also unlike numpy arrays the's tuple.index(...) which is handy to work with.
             values = tuple(values)

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -29,6 +29,7 @@ from typing import (
 import numpy as np
 import pytensor
 import pytensor.tensor as pt
+import xarray as xr
 
 from pytensor.compile import DeepCopyOp, Function, ProfileStats, get_mode, view_op
 from pytensor.compile.io import In, Out
@@ -1856,6 +1857,12 @@ class Model(BaseModel):
                 f"Either `values` or `length` must be specified for the '{name}' dimension."
             )
         if values is not None:
+            # xarray DataArrays passed as coord values must be unwrapped.
+            # tuple(DataArray) iterates yielding 0-d DataArrays instead of plain values,
+            # which breaks np.array_equal comparisons and DataTree export.
+            if isinstance(values, xr.DataArray):
+                values = values.values
+
             # Conversion to a tuple ensures that the coordinate values are immutable.
             # Also unlike numpy arrays the's tuple.index(...) which is handy to work with.
             values = tuple(values)

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -31,6 +31,7 @@ import pytest
 import scipy
 import scipy.sparse as sps
 import scipy.stats as st
+import xarray as xr
 
 from pytensor.compile.mode import get_default_mode
 from pytensor.compile.sharedvalue import SharedVariable
@@ -871,6 +872,24 @@ def test_multiple_add_coords_with_same_name():
         d = pm.Deterministic("d", a + b + c)
     variables = get_var_by_name([d], "dim1")
     assert len(variables) == 1 and variables[0] is m.dim_lengths["dim1"]
+
+
+@pytest.mark.parametrize(
+    "coords_dict",
+    [
+        {"city": ["nyc", "la", "chi"]},
+        {"year": [2020, 2021, 2022]},
+        {"time": np.array(["2020-01-01", "2020-01-02"], dtype="datetime64[D]")},
+    ],
+)
+def test_xarray_coord_values_unwrapped(coords_dict):
+    """xarray DataArray coord values are unwrapped to plain tuples of values."""
+    ds = xr.Dataset(coords=coords_dict)
+    with pm.Model(coords=ds.coords) as m:
+        key = next(iter(coords_dict))
+        coord = m.coords[key]
+        assert isinstance(coord, tuple)
+        assert not isinstance(coord[0], xr.DataArray)
 
 
 class TestSetUpdateCoords:

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -31,6 +31,7 @@ import pytest
 import scipy
 import scipy.sparse as sps
 import scipy.stats as st
+import xarray as xr
 
 from pytensor.compile.mode import get_default_mode
 from pytensor.compile.sharedvalue import SharedVariable
@@ -871,6 +872,27 @@ def test_multiple_add_coords_with_same_name():
         d = pm.Deterministic("d", a + b + c)
     variables = get_var_by_name([d], "dim1")
     assert len(variables) == 1 and variables[0] is m.dim_lengths["dim1"]
+
+
+@pytest.mark.parametrize(
+    "coords_dict",
+    [
+        pytest.param({"city": ["nyc", "la", "chi"]}, id="string"),
+        pytest.param({"year": [2020, 2021, 2022]}, id="int"),
+        pytest.param(
+            {"time": np.array(["2020-01-01", "2020-01-02"], dtype="datetime64[D]")},
+            id="datetime64",
+        ),
+    ],
+)
+def test_xarray_coord_values_unwrapped(coords_dict):
+    """xarray DataArray coord values are unwrapped to plain tuples of values."""
+    ds = xr.Dataset(coords=coords_dict)
+    with pm.Model(coords=ds.coords) as m:
+        key = next(iter(coords_dict))
+        coord = m.coords[key]
+        assert isinstance(coord, tuple)
+        assert not isinstance(coord[0], xr.DataArray)
 
 
 class TestSetUpdateCoords:


### PR DESCRIPTION
Passing `ds.coords` directly to `pm.Model(coords=...)` produced tuples of 0-d DataArrays instead of plain values, breaking coord export and duplicate coord detection.

```python
import pymc as pm
import xarray as xr

ds = xr.Dataset(coords={"city": ["nyc", "la", "chi"]})
with pm.Model(coords=ds.coords) as m:
    # coords stored as tuple of DataArrays — not plain values
    assert isinstance(m.coords["city"][0], xr.DataArray)  # True

    # duplicate check also broken
    m.add_coord("city", ds.coords["city"])  # ValueError: Duplicate and incompatible coordinate

    # sampling crashed after MCMC in DataTree export
    idata = pm.sample(1000)
```

Now coords are unwrapped to plain values before `tuple()`:

```python
with pm.Model(coords=ds.coords) as m:
    assert m.coords["city"] == ("nyc", "la", "chi")
```

This eases the typical workflow where data lives in a Dataset:

```python
ds = xr.Dataset(
    {"observed": (["city", "year"], np.random.randn(3, 5))},
    coords={"city": ["NYC", "LA", "Chicago"], "year": range(2019, 2024)},
)

with pm.Model(coords=ds.coords) as m:
    mu = pm.Normal("mu", dims="city")
    sigma = pm.HalfNormal("sigma", dims="city")
    pm.Normal("obs", mu=mu, sigma=sigma, observed=ds["observed"])
    idata = pm.sample(1000)
```