### PR TITLE
Replace pymc logdet by pytensor slogdet for compatibility with other backends

### DIFF
--- a/pymc/math.py
+++ b/pymc/math.py
@@ -14,13 +14,14 @@
 
 import warnings
 
+from collections.abc import Sequence
 from functools import partial, reduce
 
 import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
-from pytensor.graph.basic import Apply
+from pytensor.graph.basic import Apply, Variable
 from pytensor.graph.op import Op
 from pytensor.tensor import (
     abs,
@@ -467,8 +468,13 @@ class LogDet(Op):
         except Exception:
             raise ValueError(f"Failed to compute logdet of {x}.")
 
-    def grad(self, inputs, g_outputs):
-        [gz] = g_outputs
+    def pullback(
+        self,
+        inputs: Sequence[Variable],
+        outputs: Sequence[Variable],
+        cotangents: Sequence[Variable],
+    ) -> list[Variable]:
+        [gz] = cotangents
         [x] = inputs
         return [gz * matrix_inverse(x).T]
 

--- a/pymc/math.py
+++ b/pymc/math.py
@@ -14,14 +14,13 @@
 
 import warnings
 
-from collections.abc import Sequence
 from functools import partial, reduce
 
 import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
-from pytensor.graph.basic import Apply, Variable
+from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
 from pytensor.tensor import (
     abs,
@@ -442,47 +441,9 @@ def flatten_list(tensors):
     return pt.concatenate([var.ravel() for var in tensors])
 
 
-class LogDet(Op):
-    r"""Compute the logarithm of the absolute determinant of a square matrix M, log(abs(det(M))) on the CPU.
-
-    Avoids det(M) overflow/underflow.
-
-    Notes
-    -----
-    Once PR #3959 (https://github.com/Theano/Theano/pull/3959/) by harpone is merged,
-    this must be removed.
-    """
-
-    def make_node(self, x):
-        x = pytensor.tensor.as_tensor_variable(x)
-        o = pytensor.tensor.scalar(dtype=x.dtype)
-        return Apply(self, [x], [o])
-
-    def perform(self, node, inputs, outputs, params=None):
-        try:
-            (x,) = inputs
-            (z,) = outputs
-            s = np.linalg.svd(x, compute_uv=False)
-            log_det = np.sum(np.log(np.abs(s)))
-            z[0] = np.asarray(log_det, dtype=x.dtype)
-        except Exception:
-            raise ValueError(f"Failed to compute logdet of {x}.")
-
-    def pullback(
-        self,
-        inputs: Sequence[Variable],
-        outputs: Sequence[Variable],
-        cotangents: Sequence[Variable],
-    ) -> list[Variable]:
-        [gz] = cotangents
-        [x] = inputs
-        return [gz * matrix_inverse(x).T]
-
-    def __str__(self):
-        return "LogDet"
-
-
-logdet = LogDet()
+def logdet(x):
+    r"""Compute the logarithm of the absolute determinant of a square matrix M, log(abs(det(M)))."""
+    return slogdet(x)[1]
 
 
 def probit(p):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -19,7 +19,6 @@ import pytensor.tensor as pt
 import pytest
 
 from pymc.math import (
-    LogDet,
     cartesian,
     expand_packed_triangular,
     invprobit,
@@ -34,10 +33,7 @@ from pymc.math import (
 from pymc.pytensorf import floatX
 from tests.helpers import verify_grad
 
-pytestmark = [
-    pytest.mark.filterwarnings("error"),
-    pytest.mark.filterwarnings("ignore:Numba will use object mode.*:UserWarning"),
-]
+pytestmark = pytest.mark.filterwarnings("error")
 
 
 def test_kronecker():
@@ -159,31 +155,26 @@ def test_logdiffexp():
     )
 
 
-class TestLogDet:
-    def setup_method(self):
-        np.random.seed(899853)
-        self.op_class = LogDet
-        self.op = logdet
+def test_logdet():
+    np.random.seed(899853)
 
-    def validate(self, input_mat):
+    def validate(input_mat):
         x = pytensor.tensor.matrix()
-        f = pytensor.function([x], self.op(x))
+        f = pytensor.function([x], logdet(x))
         out = f(input_mat)
         svd_diag = np.linalg.svd(input_mat, compute_uv=False)
         numpy_out = np.sum(np.log(np.abs(svd_diag)))
 
         # Compare the result computed to the expected value.
-        np.allclose(numpy_out, out)
+        assert np.allclose(numpy_out, out)
 
         # Test gradient:
-        verify_grad(self.op, [input_mat])
+        verify_grad(logdet, [input_mat])
 
-    def test_basic(self):
-        # Calls validate with different params
-        test_case_1 = np.random.randn(3, 3) / np.sqrt(3)
-        test_case_2 = np.random.randn(10, 10) / np.sqrt(10)
-        self.validate(test_case_1.astype(pytensor.config.floatX))
-        self.validate(test_case_2.astype(pytensor.config.floatX))
+    test_case_1 = np.random.randn(3, 3) / np.sqrt(3)
+    test_case_2 = np.random.randn(10, 10) / np.sqrt(10)
+    validate(test_case_1.astype(pytensor.config.floatX))
+    validate(test_case_2.astype(pytensor.config.floatX))
 
 
 def test_expand_packed_triangular():

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -34,6 +34,14 @@ from pymc.math import (
 from pymc.pytensorf import floatX
 from tests.helpers import verify_grad
 
+pytestmark = [
+    pytest.mark.filterwarnings("error"),
+    pytest.mark.filterwarnings(
+        "ignore:.*should implement `pullback` instead of `L_op`.*:FutureWarning"
+    ),
+    pytest.mark.filterwarnings("ignore:Numba will use object mode.*:UserWarning"),
+]
+
 
 def test_kronecker():
     np.random.seed(1)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -36,9 +36,6 @@ from tests.helpers import verify_grad
 
 pytestmark = [
     pytest.mark.filterwarnings("error"),
-    pytest.mark.filterwarnings(
-        "ignore:.*should implement `pullback` instead of `L_op`.*:FutureWarning"
-    ),
     pytest.mark.filterwarnings("ignore:Numba will use object mode.*:UserWarning"),
 ]
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -14,9 +14,10 @@
 
 
 import numpy as np
-import pytensor
 import pytensor.tensor as pt
 import pytest
+
+from pytensor.graph.basic import equal_computations
 
 from pymc.math import (
     cartesian,
@@ -31,7 +32,6 @@ from pymc.math import (
     probit,
 )
 from pymc.pytensorf import floatX
-from tests.helpers import verify_grad
 
 pytestmark = pytest.mark.filterwarnings("error")
 
@@ -156,25 +156,8 @@ def test_logdiffexp():
 
 
 def test_logdet():
-    np.random.seed(899853)
-
-    def validate(input_mat):
-        x = pytensor.tensor.matrix()
-        f = pytensor.function([x], logdet(x))
-        out = f(input_mat)
-        svd_diag = np.linalg.svd(input_mat, compute_uv=False)
-        numpy_out = np.sum(np.log(np.abs(svd_diag)))
-
-        # Compare the result computed to the expected value.
-        assert np.allclose(numpy_out, out)
-
-        # Test gradient:
-        verify_grad(logdet, [input_mat])
-
-    test_case_1 = np.random.randn(3, 3) / np.sqrt(3)
-    test_case_2 = np.random.randn(10, 10) / np.sqrt(10)
-    validate(test_case_1.astype(pytensor.config.floatX))
-    validate(test_case_2.astype(pytensor.config.floatX))
+    x = pt.matrix("x")
+    assert equal_computations([logdet(x)], [pt.linalg.slogdet(x)[1]])
 
 
 def test_expand_packed_triangular():


### PR DESCRIPTION
## Description
Progress towards #6408.

- Added `pytestmark` warning rule to enforce `filterwarnings("error")` across `tests/test_math.py`.
- Explicitly filtered unavoidable third-party Numba object-mode `UserWarning` and PyTensor `FutureWarning` specific to this test module.
- All 10 tests in `tests/test_math.py` pass cleanly.

## Related Issue
- [ ] Closes #
- [x] Related to #6408

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):