### PR TITLE
Better handling of multiple output nodes in logprob inference

### DIFF
--- a/pymc/dims/distributions/core.py
+++ b/pymc/dims/distributions/core.py
@@ -34,10 +34,18 @@ from pymc import SymbolicRandomVariable, modelcontext
 from pymc.dims.distributions.transforms import DimTransform, log_odds_transform, log_transform
 from pymc.distributions.distribution import _support_point, support_point
 from pymc.distributions.shape_utils import DimsWithEllipsis, convert_dims_with_ellipsis
-from pymc.logprob.abstract import MeasurableOp, _icdf, _logccdf, _logcdf, _logprob
+from pymc.logprob.abstract import (
+    MeasurableOp,
+    _icdf,
+    _logccdf,
+    _logcdf,
+    _logprob,
+    request_logprob,
+    supp_axes,
+)
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
 from pymc.logprob.tensor import MeasurableDimShuffle
-from pymc.logprob.utils import filter_measurable_variables
+from pymc.logprob.utils import filter_measurable_variables, get_related_valued_nodes
 from pymc.util import UNSET
 
 
@@ -102,9 +110,23 @@ def find_measurable_xtensor_from_tensor(fgraph, node) -> list[XTensorVariable] |
 
         new_out = MeasurableXTensorFromTensor(dims=node.op.dims, core_dims=core_dims)(measurable_x)
     else:
-        # If this happens we know there's no measurable transpose in between and we can
-        # safely infer the core_dims positionally when the inner logp is returned
-        new_out = MeasurableXTensorFromTensor(dims=node.op.dims, core_dims=None)(*node.inputs)
+        # There's no measurable transpose in between, so the dims are laid out in the order of
+        # the inner variable's axes, and the ones its density is over -- counted from the
+        # right -- index them directly.
+        [x] = node.inputs
+        axes = supp_axes(x)
+        if (
+            axes is not None
+            and axes != tuple(range(-len(axes), 0))
+            # Rewrites that compose on top read the support axes off the ndim of the density and
+            # assume they were the rightmost ones -- see `find_measurable_dimshuffles`. Nothing
+            # composes on top of a variable that is itself the conditioning point, so there is
+            # no one to misread it there.
+            and not get_related_valued_nodes(fgraph, node)
+        ):
+            return None
+        core_dims = None if axes is None else tuple(node.op.dims[axis] for axis in axes)
+        new_out = MeasurableXTensorFromTensor(dims=node.op.dims, core_dims=core_dims)(x)
     return [cast(XTensorVariable, new_out)]
 
 
@@ -129,25 +151,17 @@ def _to_xtensor(
     all_dims = (*extra_value_dims, *op.dims)
     # core_dims are not present in the generated variable, exclude them
     if op.core_dims is None:
-        # The core_dims of the inner rv are on the right
+        # Nothing said where they are, so assume the core_dims of the inner rv are on the right
         var_dims = all_dims[: var.ndim]
     else:
-        # We inferred where the core_dims are!
         var_dims = tuple(d for d in all_dims if d not in op.core_dims)
     return xtensor_from_tensor(var, dims=var_dims)
 
 
 @_logprob.register(MeasurableXTensorFromTensor)
 def measurable_xtensor_from_tensor_logprob(op, values, rv, **kwargs):
-    tensor_values = tuple(_to_tensor(op, v) for v in values)
-    rv_logps_tensor = _logprob(rv.owner.op, tensor_values, *rv.owner.inputs, **kwargs)
-    if not isinstance(rv_logps_tensor, tuple | list):
-        rv_logps_tensor = (rv_logps_tensor,)
-    rv_logps = tuple(
-        _to_xtensor(op, value, rv_logp)
-        for value, rv_logp in zip(values, rv_logps_tensor, strict=True)
-    )
-    return rv_logps[0] if len(rv_logps) == 1 else rv_logps
+    [value] = values
+    return _to_xtensor(op, value, request_logprob(rv, _to_tensor(op, value), **kwargs))
 
 
 @_logcdf.register(MeasurableXTensorFromTensor)

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -53,7 +53,7 @@ from pytensor.tensor.random.utils import normalize_size_param
 from pytensor.tensor.variable import TensorConstant, TensorVariable
 
 from pymc.distributions.custom import CustomDist
-from pymc.logprob.abstract import _logprob_helper
+from pymc.logprob.abstract import request_logprob
 from pymc.logprob.basic import TensorLike, icdf
 from pymc.pytensorf import normalize_rng_param
 
@@ -729,7 +729,7 @@ class TruncatedNormal(BoundedContinuous):
         else:
             norm = 0.0
 
-        logp = _logprob_helper(Normal.dist(mu, sigma), value) - norm
+        logp = request_logprob(Normal.dist(mu, sigma), value) - norm
 
         if is_lower_bounded:
             logp = pt.switch(value < lower, -np.inf, logp)
@@ -2381,7 +2381,7 @@ class HalfCauchy(PositiveContinuous):
         return beta
 
     def logp(value, beta):
-        res = pt.log(2) + _logprob_helper(Cauchy.dist(alpha=0, beta=beta), value)
+        res = pt.log(2) + request_logprob(Cauchy.dist(alpha=0, beta=beta), value)
         res = pt.switch(value >= 0, res, -np.inf)
         return check_parameters(
             res,

--- a/pymc/logprob/abstract.py
+++ b/pymc/logprob/abstract.py
@@ -39,13 +39,17 @@ import warnings
 
 from collections.abc import Sequence
 from functools import singledispatch
+from itertools import zip_longest
 
+from pytensor.configdefaults import config
 from pytensor.graph import Apply, Op, Variable
 from pytensor.graph.utils import MetaType
-from pytensor.tensor import TensorVariable, log1mexp
+from pytensor.tensor import TensorVariable, log1mexp, tensor
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.random.op import RandomVariable
+from pytensor.tensor.random.type import RandomType
+from pytensor.tensor.utils import broadcast_static_dim_lengths
 
 
 @singledispatch
@@ -61,18 +65,37 @@ def _logprob(
     of ``RandomVariable``.  If you want to implement new density/mass graphs
     for a ``RandomVariable``, register a new function on this dispatcher.
 
+    Calling the dispatcher directly asserts that ``values`` are all the values the density of
+    ``op``'s node is over -- something only a caller that collected them can claim. An
+    implementation that recurses into a measurable input holds just its own value, and must ask
+    through `request_logprob` instead.
     """
     raise NotImplementedError(f"Logprob method not implemented for {op}")
 
 
-def _logprob_helper(rv, *values, **kwargs):
-    """Help call `_logprob` dispatcher."""
-    logprob = _logprob(rv.owner.op, values, *rv.owner.inputs, **kwargs)
+def request_logprob(rv, value, **kwargs):
+    """Return the log-density term of `rv` at `value`, or a stand-in for it.
 
-    name = rv.name
-    if (not name) and (len(values) == 1):
-        name = values[0].name
-    if name:
+    This is how a `_logprob` implementation recurses into its measurable input: holding one
+    variable's value, it cannot promise that no other value reaches that variable's node. A node
+    with a single output a value could attach to cannot be asked for more, and is dispatched on
+    the spot; one that could be asked for more gets a `DensityQuery` placeholder, and
+    `resolve_density_queries` answers every request about the node in one `_logprob` call.
+
+    A node's values are therefore requested one variable at a time, each naming the output it
+    belongs to, which is what lets requests arriving by different routes be recognized as being
+    about the same node.
+
+    Of the three entry points, `logp` derives a variable's density from scratch and resolves
+    the queries it raises; `request_logprob` recurses within a derivation already underway; and
+    the `_logprob` dispatcher is called directly only with all of a node's values in hand.
+    """
+    if n_potential_valued_outputs(rv.owner) > 1:
+        return density_query(rv, value)
+
+    logprob = _logprob(rv.owner.op, (value,), *rv.owner.inputs, **kwargs)
+
+    if name := (rv.name or value.name):
         if isinstance(logprob, list | tuple):
             for i, term in enumerate(logprob):
                 term.name = f"{name}_logprob.{i}"
@@ -80,6 +103,18 @@ def _logprob_helper(rv, *values, **kwargs):
             logprob.name = f"{name}_logprob"
 
     return logprob
+
+
+def _logprob_helper(rv, *values, **kwargs):
+    warnings.warn(
+        "_logprob_helper has been renamed to request_logprob",
+        FutureWarning,
+        stacklevel=2,
+    )
+    if len(values) != 1:
+        # The old API let a caller hand over every value of a node at once
+        return _logprob(rv.owner.op, values, *rv.owner.inputs, **kwargs)
+    return request_logprob(rv, values[0], **kwargs)
 
 
 @singledispatch
@@ -170,7 +205,26 @@ def _icdf_helper(rv, value):
 
 
 class MeasurableOp(abc.ABC):
-    """An operation whose outputs can be assigned a measure/log-probability."""
+    """An operation whose outputs can be assigned a measure/log-probability.
+
+    ``supp_axes`` is meta-information about that measure: for each output, which of its axes the
+    measure is defined over, counted from the right so that they do not depend on how many batch
+    dimensions the variable carries. It is set when the Op is built, by whichever rewrite made
+    the variable measurable and therefore knows what the measure it wraps looks like. Derive it
+    from the node's inputs, so that nodes which compare equal necessarily agree on it.
+
+    There is one entry per output, in ``node.outputs`` order, so an output that carries no
+    measure of its own -- an RNG update, say -- pads the tuple with ``None``. That is not the
+    indexing of the ``values`` a ``_logprob`` implementation receives, which only ever covers
+    the outputs a value can attach to.
+
+    ``None`` -- the default, or a single entry of it -- means this Op was not told, which is not
+    the same as having no support axes. Whoever asks decides what to do without an answer; a
+    `DensityQuery` refuses, having no way to type the term it stands for. See #6360, which also
+    wants ``ndim_supp`` and a discrete/continuous/mixed ``type`` carried the same way.
+    """
+
+    supp_axes: tuple[tuple[int, ...] | None, ...] | None = None
 
 
 MeasurableOp.register(RandomVariable)
@@ -298,7 +352,7 @@ class PromisedValuedRV(Op):
     logp(ab, ab_value)
     ```
 
-    The density of `ab[2]` (that is `b`) depends on `ab_value[1]` and `ab_value[0] * 8`, but this is not apparent
+    The density of `ab[1]` (that is `b`) depends on `ab_value[1]` and `ab_value[0] * 8`, but this is not apparent
     in the IR representation because the values of `a` and `b` are merged together, and will only be split by the logp
     function (see why next). For the time being we introduce a PromisedValue to isolate the graphs of a and b, and
     freezing the dependency of `b` on `a` (not `a_base`).
@@ -325,3 +379,77 @@ class PromisedValuedRV(Op):
 
 
 promised_valued_rv = PromisedValuedRV()
+
+
+def supp_axes(var: Variable) -> tuple[int, ...] | None:
+    """The axes of `var` that a measure over it is defined over, if that is known.
+
+    Read off the Op that produced it -- see `MeasurableOp.supp_axes`. A RandomVariable is the
+    case everything else is built out of, and already carries the equivalent as `ndim_supp`.
+    """
+    node = var.owner
+    # getattr: RandomVariable is a virtual subclass of MeasurableOp, so it has no default
+    if (declared := getattr(node.op, "supp_axes", None)) is not None:
+        return declared[node.outputs.index(var)]
+    # RandomVariable and SymbolicRandomVariable say it as a count of rightmost axes; a
+    # SymbolicRandomVariable without a signature says nothing at all.
+    ndim_supp = getattr(node.op, "ndim_supp", None)
+    return None if ndim_supp is None else tuple(range(-ndim_supp, 0))
+
+
+class DensityQuery(Op):
+    r"""A deferred request for the log-density of a measurable variable at a value.
+
+    `request_logprob` normally recurses immediately, which bottoms out on one variable at a
+    time. That cannot work when the target is one output of a node whose density is joint over
+    several values: the density would be derived with the other values missing. Such a target
+    gets a `DensityQuery` instead, and `resolve_density_queries` answers every query on the same
+    node in a single `_logprob` call.
+
+    Because the queries are clients of the node they target, collecting them is a plain lookup
+    and answering them a plain multi-output replacement -- there is nothing upstream to rewire.
+
+    The output has to stand in for the term before the term exists, and a density reduces the
+    axes its variable is defined over, so the value's own type will not do: the term's type
+    drops the axes `supp_axes` declares from the shape the variable and the value broadcast to.
+    """
+
+    def make_node(self, rv, value):
+        assert isinstance(rv, Variable)
+        assert isinstance(value, Variable)
+        axes = supp_axes(rv)
+        if axes is None:
+            raise NotImplementedError(
+                f"{rv.owner.op} has several outputs whose values reach its density by separate "
+                f"paths, so it must declare which axes its measure is over. "
+                f"Set `supp_axes` on the Op."
+            )
+        # A density is continuous, whatever the dtype of the variable it measures.
+        dtype = value.type.dtype if value.type.dtype.startswith("float") else config.floatX
+        # A term is evaluated at the value and taken over the variable, so it comes out on the
+        # shape the two broadcast to.
+        shape = [
+            broadcast_static_dim_lengths(lengths)
+            for lengths in zip_longest(
+                reversed(rv.type.shape), reversed(value.type.shape), fillvalue=1
+            )
+        ][::-1]
+        shape = tuple(
+            length for axis, length in enumerate(shape, start=-len(shape)) if axis not in axes
+        )
+        return Apply(self, [rv, value], [tensor(dtype=dtype, shape=shape)])
+
+    def perform(self, node, inputs, out):
+        raise NotImplementedError("DensityQuery should not be present in the final graph!")
+
+
+density_query = DensityQuery()
+
+
+def n_potential_valued_outputs(node) -> int:
+    """How many outputs of `node` a value could be associated with -- all but its RNG outputs.
+
+    More than one means the node's density may be joint over them -- something only the op
+    knows -- so every value that does arrive has to reach `_logprob` in the same call.
+    """
+    return sum(not isinstance(out.type, RandomType) for out in node.outputs)

--- a/pymc/logprob/basic.py
+++ b/pymc/logprob/basic.py
@@ -36,32 +36,35 @@
 
 import warnings
 
+from collections import Counter
 from collections.abc import Sequence
 from typing import TypeAlias
 
 import numpy as np
 import pytensor.tensor as pt
 
-from pytensor.graph.basic import (
-    Constant,
-    Variable,
-)
+from pytensor.graph.basic import Variable
+from pytensor.graph.fg import FunctionGraph, Output
 from pytensor.graph.rewriting.basic import GraphRewriter, NodeRewriter
 from pytensor.graph.traversal import ancestors, walk
+from pytensor.tensor.random.type import RandomType
 
 from pymc.logprob.abstract import (
+    DensityQuery,
     MeasurableOp,
+    ValuedRV,
     _icdf_helper,
     _logccdf_helper,
     _logcdf_helper,
     _logprob,
-    _logprob_helper,
+    density_query,
+    request_logprob,
 )
 from pymc.logprob.rewriting import cleanup_ir, construct_ir_fgraph
 from pymc.logprob.transform_value import TransformValuesRewrite
 from pymc.logprob.transforms import Transform
 from pymc.logprob.utils import get_related_valued_nodes
-from pymc.pytensorf import expand_inner_graph, replace_vars_in_graphs
+from pymc.pytensorf import expand_inner_graph
 
 TensorLike: TypeAlias = Variable | float | np.ndarray
 
@@ -100,6 +103,88 @@ def _warn_rvs_in_inferred_graph(graph: Variable | Sequence[Variable]):
             "For example: `logp(model.replace_rvs_by_values([rv])[0], value)`",
             stacklevel=3,
         )
+
+
+def resolve_density_queries(terms, **logprob_kwargs):
+    """Replace every `DensityQuery` in `terms` by the density term it stands for.
+
+    Queried nodes are answered sinks-first: deriving a density can only raise new queries
+    about the answered node's own ancestors, so by a node's turn every query that could still
+    reach it has arrived, and one pass over the topological order is enough.
+
+    A node is answered with whatever values arrived. Only the op knows whether its outputs
+    are independent, and it says so by accepting or refusing the values it is handed.
+    """
+
+    def pending_queries(variables) -> list:
+        # The DensityQuery nodes still standing in for a density term
+        return [
+            var.owner
+            for var in ancestors(variables)
+            if var.owner is not None and isinstance(var.owner.op, DensityQuery)
+        ]
+
+    if not pending_queries(terms):
+        return list(terms)
+
+    fgraph = FunctionGraph(outputs=list(terms), clone=False)
+
+    set_aside: set = set()
+    while (
+        pending := {query.inputs[0].owner for query in pending_queries(fgraph.outputs)} - set_aside
+    ):
+        # Deriving a density can splice in subgraphs that did not exist before (an op that
+        # expands its inner graph, say), so the order is recomputed as the graph changes.
+        order = {apply: i for i, apply in enumerate(fgraph.toposort())}
+        node = max(pending, key=order.__getitem__)
+
+        queries = [
+            client
+            for out in node.outputs
+            for client, _ in fgraph.clients[out]
+            if isinstance(client.op, DensityQuery)
+        ]
+        if len({query.inputs[0] for query in queries}) != len(queries):
+            # Two queries about one variable (an abs recursing on both preimages, say) are
+            # not a joint density over distinct values. Left to be reported.
+            set_aside.add(node)
+            continue
+
+        node_terms = _logprob(
+            node.op,
+            [query.inputs[1] for query in queries],
+            *node.inputs,
+            **logprob_kwargs,
+        )
+        if not isinstance(node_terms, list | tuple):
+            node_terms = [node_terms]
+        replacements = []
+        for query, term in zip(queries, node_terms, strict=True):
+            # Whoever raised the query named the placeholder, the term it stood for not
+            # existing yet. Carry the name over rather than lose it with the placeholder.
+            if term.name is None:
+                term.name = query.outputs[0].name
+            replacements.append((query.outputs[0], term))
+        fgraph.replace_all(replacements, reason="resolve_density_queries", import_missing=True)
+
+    if pending := pending_queries(fgraph.outputs):
+        counts = Counter(query.inputs[0] for query in pending)
+        repeated = [var for var, n in counts.items() if n > 1]
+        raise NotImplementedError(f"More than one density term was requested for {repeated}.")
+    return list(fgraph.outputs)
+
+
+def _variables_leading_to_values(fgraph: FunctionGraph) -> set[Variable]:
+    """The variables from which a conditioning point is still reachable.
+
+    A node output that leads to a value elsewhere is one whose density term will be requested
+    later, through whatever measurable chain carries it there.
+    """
+    leads: set[Variable] = set()
+    for node in reversed(fgraph.toposort()):
+        if isinstance(node.op, ValuedRV) or any(out in leads for out in node.outputs):
+            leads.update(node.inputs)
+    return leads
 
 
 def logp(rv: Variable, value: Variable | TensorLike, warn_rvs=True, **kwargs) -> Variable:
@@ -191,12 +276,15 @@ def logp(rv: Variable, value: Variable | TensorLike, warn_rvs=True, **kwargs) ->
     if not isinstance(value, Variable):
         value = pt.as_tensor_variable(value, dtype=rv.dtype)
     try:
-        return _logprob_helper(rv, value, **kwargs)
+        # A query raised here is answered with this single value alone; the op decides
+        # whether its density can be derived from it.
+        [expr] = resolve_density_queries([request_logprob(rv, value, **kwargs)], **kwargs)
+        return expr
     except NotImplementedError:
         fgraph = construct_ir_fgraph({rv: value})
         [ir_valued_var] = fgraph.outputs
         [ir_rv, ir_value] = ir_valued_var.owner.inputs
-        expr = _logprob_helper(ir_rv, ir_value, **kwargs)
+        [expr] = resolve_density_queries([request_logprob(ir_rv, ir_value, **kwargs)], **kwargs)
         [expr] = cleanup_ir([expr])
         if warn_rvs:
             _warn_rvs_in_inferred_graph([expr])
@@ -526,22 +614,13 @@ def conditional_logp(
 
     # Walk the graph from its inputs to its outputs and construct the
     # log-probability
-    replacements = {}
-
-    # To avoid cloning the value variables (or ancestors of value variables),
-    # we map them to themselves in the `replacements` `dict`
-    # (i.e. entries already existing in `replacements` aren't cloned)
-    replacements.update(
-        {v: v for v in ancestors(rv_values.values()) if not isinstance(v, Constant)}
-    )
-
-    # Walk the graph from its inputs to its outputs and construct the
-    # log-probability
     values_to_logprobs = {}
     original_values = tuple(rv_values.values())
 
-    # TODO: This seems too convoluted, can we just replace all RVs by their values,
-    #  except for the fgraph outputs (for which we want to call _logprob on)?
+    # Rewiring below only ever cuts paths through already-processed nodes, which lie upstream
+    # of whatever is processed next, so this stays accurate for the rest of the walk.
+    leads_to_value = _variables_leading_to_values(fgraph)
+
     for node in fgraph.toposort():
         if not isinstance(node.op, MeasurableOp):
             continue
@@ -557,27 +636,51 @@ def conditional_logp(
             fgraph.outputs.index(valued_var.outputs[0]) for valued_var in valued_nodes
         ]
 
-        # Replace `RandomVariable`s in the inputs with value variables.
-        # Also, store the results in the `replacements` map for the nodes that follow.
-        for node_rv, node_value in zip(node_rvs, node_values):
-            replacements[node_rv] = node_value
+        valued_here = set(node_rvs)
+        if any(
+            out in leads_to_value
+            for out in node.outputs
+            if out not in valued_here and not isinstance(out.type, RandomType)
+        ):
+            # Not every output is valued right here. Whatever values the others lead to arrive
+            # through measurable chains that query this node once they are derived; defer, so
+            # that every value is answered in the same call.
+            node_logprobs = [
+                density_query(node_rv, node_value)
+                for node_rv, node_value in zip(node_rvs, node_values, strict=True)
+            ]
+        else:
+            node_logprobs = _logprob(
+                node.op,
+                node_values,
+                *node.inputs,
+                **kwargs,
+            )
 
-        remapped_vars = replace_vars_in_graphs(
-            graphs=node_values + list(node.inputs),
-            replacements=replacements,
-        )
-        node_values = remapped_vars[: len(node_values)]
-        node_inputs = remapped_vars[len(node_values) :]
+            if not isinstance(node_logprobs, list | tuple):
+                node_logprobs = [node_logprobs]
 
-        node_logprobs = _logprob(
-            node.op,
-            node_values,
-            *node_inputs,
-            **kwargs,
-        )
-
-        if not isinstance(node_logprobs, list | tuple):
-            node_logprobs = [node_logprobs]
+        # Everything downstream of a conditioning point sees the value from here on. Rewiring
+        # the graph we own, rather than substituting into cloned copies of it, keeps every node's
+        # identity -- which is what lets queries about one node be recognized as such.
+        for valued_node, node_value in zip(valued_nodes, node_values):
+            [valued_out] = valued_node.outputs
+            # A conditioning point that is one of the graph's own outputs is left alone.
+            # Rewiring it would detach it, pruning the node whose density it stands for.
+            clients = [
+                (client, input_idx)
+                for client, input_idx in fgraph.clients[valued_out]
+                if not isinstance(client.op, Output)
+            ]
+            if not clients:
+                continue
+            # A value may carry a looser static shape than the variable it stands for; filtering
+            # carries the more precise shape over as a `specify_shape`.
+            node_value = valued_out.type.filter_variable(node_value, allow_convert=True)
+            for client, input_idx in clients:
+                fgraph.change_node_input(
+                    client, input_idx, node_value, reason="conditional_logp", import_missing=True
+                )
 
         for node_output_idx, node_value, node_logprob in zip(
             node_output_idxs, node_values, node_logprobs
@@ -601,7 +704,8 @@ def conditional_logp(
         )
 
     # Ensure same order as input
-    logprobs = cleanup_ir(tuple(values_to_logprobs[v] for v in original_values))
+    logprobs = resolve_density_queries([values_to_logprobs[v] for v in original_values], **kwargs)
+    logprobs = cleanup_ir(tuple(logprobs))
 
     if warn_rvs:
         rvs_in_logp_expressions = _find_unallowed_rvs_in_graph(logprobs)

--- a/pymc/logprob/binary.py
+++ b/pymc/logprob/binary.py
@@ -28,7 +28,7 @@ from pymc.logprob.abstract import (
     _logccdf_helper,
     _logcdf_helper,
     _logprob,
-    _logprob_helper,
+    request_logprob,
 )
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
 from pymc.logprob.utils import check_potential_measurability, filter_measurable_variables
@@ -108,7 +108,7 @@ def comparison_logprob(op, values, base_rv, operand, **kwargs):
         raise TypeError(f"Unsupported scalar_op {op.scalar_op}")
 
     if base_rv.dtype.startswith("int"):
-        logpmf = _logprob_helper(base_rv, operand, **kwargs)
+        logpmf = request_logprob(base_rv, operand, **kwargs)
         logcdf_prev = _logcdf_helper(base_rv, operand - 1)
         if isinstance(op.scalar_op, LT):
             return pt.switch(condn_exp, logcdf_prev, pt.logaddexp(logccdf, logpmf))
@@ -156,6 +156,6 @@ measurable_ir_rewrites_db.register(
 def bitwise_not_logprob(op, values, base_rv, **kwargs):
     (value,) = values
 
-    logprob = _logprob_helper(base_rv, invert(value), **kwargs)
+    logprob = request_logprob(base_rv, invert(value), **kwargs)
 
     return logprob

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -74,6 +74,7 @@ from pymc.logprob.abstract import (
     _logcdf,
     _logcdf_helper,
     _logprob,
+    request_logprob,
 )
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
 from pymc.logprob.utils import (
@@ -215,7 +216,7 @@ def clip_logprob(op, values, base_rv, lower_bound, upper_bound, **kwargs):
     base_rv_op = base_rv.owner.op
     base_rv_inputs = base_rv.owner.inputs
 
-    logprob = _logprob(base_rv_op, (value,), *base_rv_inputs, **kwargs)
+    logprob = request_logprob(base_rv, value, **kwargs)
     logcdf = _logcdf(base_rv_op, value, *base_rv_inputs)
 
     if base_rv_op.name:

--- a/pymc/logprob/checks.py
+++ b/pymc/logprob/checks.py
@@ -42,7 +42,7 @@ from pytensor.raise_op import CheckAndRaise
 from pytensor.tensor import TensorVariable
 from pytensor.tensor.shape import SpecifyShape
 
-from pymc.logprob.abstract import MeasurableOp, _logprob, _logprob_helper
+from pymc.logprob.abstract import MeasurableOp, _logprob, request_logprob
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
 from pymc.logprob.utils import filter_measurable_variables, replace_rvs_by_values
 
@@ -56,7 +56,7 @@ def logprob_specify_shape(op, values, inner_rv, *shapes, **kwargs):
     (value,) = values
     # transfer specify_shape from rv to value
     value = pt.specify_shape(value, shapes)
-    return _logprob_helper(inner_rv, value)
+    return request_logprob(inner_rv, value)
 
 
 @node_rewriter([SpecifyShape])
@@ -93,7 +93,7 @@ def logprob_check_and_raise(op, values, inner_rv, *assertions, **kwargs):
     # transfer assertion from rv to value
     assertions = replace_rvs_by_values(assertions, rvs_to_values={inner_rv: value})
     value = op(value, *assertions)
-    return _logprob_helper(inner_rv, value)
+    return request_logprob(inner_rv, value)
 
 
 @node_rewriter([CheckAndRaise])

--- a/pymc/logprob/cumsum.py
+++ b/pymc/logprob/cumsum.py
@@ -41,7 +41,7 @@ from pytensor.graph.rewriting.basic import node_rewriter
 from pytensor.tensor import TensorVariable
 from pytensor.tensor.extra_ops import CumOp
 
-from pymc.logprob.abstract import MeasurableOp, _logprob, _logprob_helper
+from pymc.logprob.abstract import MeasurableOp, _logprob, request_logprob
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
 from pymc.logprob.utils import filter_measurable_variables
 
@@ -69,7 +69,7 @@ def logprob_cumsum(op, values, base_rv, **kwargs):
         axis=op.axis,
     )
 
-    cumsum_logp = _logprob_helper(base_rv, value_diff)
+    cumsum_logp = request_logprob(base_rv, value_diff)
 
     return cumsum_logp
 

--- a/pymc/logprob/linalg.py
+++ b/pymc/logprob/linalg.py
@@ -16,7 +16,7 @@ import pytensor.tensor as pt
 from pytensor.graph.rewriting.basic import node_rewriter
 from pytensor.tensor.math import _matmul
 
-from pymc.logprob.abstract import MeasurableBlockwise, MeasurableOp, _logprob, _logprob_helper
+from pymc.logprob.abstract import MeasurableBlockwise, MeasurableOp, _logprob, request_logprob
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
 from pymc.logprob.utils import check_potential_measurability, filter_measurable_variables
 
@@ -41,7 +41,7 @@ def logprob_measurable_matmul(op, values, l, r):  # noqa: E741
         x, A = l, r
         x_value = pt.linalg.solve(A.mT, y_value.mT).mT
 
-    x_logp = _logprob_helper(x, x_value)
+    x_logp = request_logprob(x, x_value)
 
     # The operation has a support dimensionality of 2
     # We need to reduce it if it's still present in the base logp

--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -68,7 +68,7 @@ from pymc.logprob.abstract import (
     MeasurableOp,
     PromisedValuedRV,
     _logprob,
-    _logprob_helper,
+    request_logprob,
     valued_rv,
 )
 from pymc.logprob.rewriting import (
@@ -350,7 +350,7 @@ def logprob_MixtureRV(op, values, *inputs: TensorVariable | slice | None, name=N
             # this intentional one-off?
             rv_m = rv_pull_down(rv[m_indices] if m_indices else rv)
             val_m = value[idx_m_on_axis]
-            logp_m = _logprob_helper(rv_m, val_m)
+            logp_m = request_logprob(rv_m, val_m)
             logp_val = pt.set_subtensor(logp_val[idx_m_on_axis], logp_m)
 
     else:
@@ -368,7 +368,7 @@ def logprob_MixtureRV(op, values, *inputs: TensorVariable | slice | None, name=N
 
         logp_val = 0.0
         for i, comp_rv in enumerate(comp_rvs):
-            comp_logp = _logprob_helper(comp_rv, value)
+            comp_logp = request_logprob(comp_rv, value)
             if join_axis_val is not None:
                 comp_logp = pt.squeeze(comp_logp, axis=join_axis_val)
             logp_val += ifelse(
@@ -436,8 +436,8 @@ def logprob_switch_mixture(op, values, switch_cond, component_true, component_fa
 
     return switch(
         switch_cond,
-        _logprob_helper(component_true, value),
-        _logprob_helper(component_false, value),
+        request_logprob(component_true, value),
+        request_logprob(component_false, value),
     )
 
 
@@ -573,6 +573,6 @@ measurable_ir_rewrites_db.register(
 def logprob_ifelse(op, values, if_var, rv_then, rv_else, **kwargs):
     """Compute the log-likelihood graph for an `IfElse`."""
     [value] = values
-    logps_then = _logprob_helper(rv_then, value, **kwargs)
-    logps_else = _logprob_helper(rv_else, value, **kwargs)
+    logps_then = request_logprob(rv_then, value, **kwargs)
+    logps_else = request_logprob(rv_else, value, **kwargs)
     return ifelse(if_var, logps_then, logps_else)

--- a/pymc/logprob/order.py
+++ b/pymc/logprob/order.py
@@ -59,7 +59,7 @@ from pymc.logprob.abstract import (
     MeasurableOp,
     _logcdf_helper,
     _logprob,
-    _logprob_helper,
+    request_logprob,
 )
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
 from pymc.logprob.utils import filter_measurable_variables
@@ -145,7 +145,7 @@ def max_logprob(op, values, base_rv, **kwargs):
 
     base_rv_shape = constant_fold(tuple(base_rv.shape), raise_not_constant=False)
     bcast_value = pt.broadcast_to(value, base_rv_shape)
-    logprob = _logprob_helper(base_rv, bcast_value)[0]
+    logprob = request_logprob(base_rv, bcast_value)[0]
     logcdf = _logcdf_helper(base_rv, bcast_value)[0]
 
     n = pt.prod(base_rv_shape)

--- a/pymc/logprob/scan.py
+++ b/pymc/logprob/scan.py
@@ -51,7 +51,7 @@ from pytensor.tensor.random.type import RandomType
 from pytensor.tensor.subtensor import IncSubtensor, Subtensor
 from pytensor.tensor.variable import TensorVariable
 
-from pymc.logprob.abstract import MeasurableOp, _logprob
+from pymc.logprob.abstract import MeasurableOp, _logprob, supp_axes
 from pymc.logprob.basic import conditional_logp
 from pymc.logprob.rewriting import (
     construct_ir_fgraph,
@@ -474,6 +474,19 @@ def find_measurable_scans(fgraph, node):
     )
     toposort_replace(temp_fgraph, inner_rvs_replacements)
     op = MeasurableScan(inner_inps, inner_outs, node.op.info, mode=copy(node.op.mode))
+    # A scan stacks each inner output over time on the left, so the axes its measure is over --
+    # counted from the right -- are the ones the inner variable was measured over. Outputs that
+    # are not valued here may still be asked about later, through a chain, so all of them answer.
+    declared_supp_axes: list[tuple[int, ...] | None] = []
+    for outer_idx in range(len(node.outputs)):
+        inner_idxs = mapping[outer_idx]
+        inner_out = inner_outs[inner_idxs[-1]] if inner_idxs else None
+        declared_supp_axes.append(
+            supp_axes(inner_out)
+            if (inner_out is not None and inner_out.owner is not None)
+            else None
+        )
+    op.supp_axes = tuple(declared_supp_axes)
     new_outs = op.make_node(*node.inputs).outputs
 
     old_outs = node.outputs

--- a/pymc/logprob/switch.py
+++ b/pymc/logprob/switch.py
@@ -50,7 +50,7 @@ from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.variable import TensorVariable
 
-from pymc.logprob.abstract import MeasurableElemwise, MeasurableOp, _logprob, _logprob_helper
+from pymc.logprob.abstract import MeasurableElemwise, MeasurableOp, _logprob, request_logprob
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
 from pymc.logprob.transforms import MeasurableTransform
 from pymc.logprob.utils import (
@@ -212,8 +212,8 @@ def logprob_switch_non_overlapping(op, values, cond, x, neg_branch, **kwargs):
 
     logp_expr = pt.switch(
         value_implies_true_branch,
-        _logprob_helper(x, value, **kwargs),
-        _logprob_helper(neg_branch, value, **kwargs),
+        request_logprob(x, value, **kwargs),
+        request_logprob(neg_branch, value, **kwargs),
     )
 
     return CheckParameterValue("switch non-overlapping scale > 0")(logp_expr, a_is_positive)

--- a/pymc/logprob/tensor.py
+++ b/pymc/logprob/tensor.py
@@ -62,8 +62,9 @@ from pymc.logprob.abstract import (
     _logcdf,
     _logcdf_helper,
     _logprob,
-    _logprob_helper,
     promised_valued_rv,
+    request_logprob,
+    supp_axes,
 )
 from pymc.logprob.censoring import MeasurableRound
 from pymc.logprob.rewriting import (
@@ -98,7 +99,7 @@ def logprob_make_vector(op, values, *base_rvs, **kwargs):
         base_rv.name = f"base_rv[{i}]"
         value.name = f"value[{i}]"
 
-    logps = [_logprob_helper(base_rv, value) for base_rv, value in base_rvs_to_values.items()]
+    logps = [request_logprob(base_rv, value) for base_rv, value in base_rvs_to_values.items()]
 
     # If the stacked variables depend on each other, we have to replace them by the respective values
     logps = replace_rvs_by_values(logps, rvs_to_values=base_rvs_to_values)
@@ -132,7 +133,7 @@ def logprob_join(op, values, *base_rvs, **kwargs):
 
     base_rvs_to_split_values = dict(zip(base_rvs, split_values))
     logps = [
-        _logprob_helper(base_var, split_value)
+        request_logprob(base_var, split_value)
         for base_var, split_value in base_rvs_to_split_values.items()
     ]
 
@@ -214,7 +215,11 @@ def find_measurable_splits(fgraph, node) -> list[TensorVariable] | None:
     if not filter_measurable_variables([x]):
         return None
 
-    return MeasurableSplit(node.op.len_splits, node.op.axis).make_node(x, splits).outputs
+    measurable_split = MeasurableSplit(node.op.len_splits, node.op.axis)
+    # A split carves up the variable but not its measure, so each part is measured over the
+    # same axes as the base. `None` when the base cannot say, which is an answer too.
+    measurable_split.supp_axes = (supp_axes(x),) * node.op.len_splits
+    return measurable_split.make_node(x, splits).outputs
 
 
 @_logprob.register(MeasurableSplit)
@@ -230,7 +235,7 @@ def logprob_split(op: MeasurableSplit, values, x, splits, **kwargs):
     # Reverse the effects of split on the value variable
     join_value = pt.join(axis, *values)
 
-    join_logp = _logprob_helper(x, join_value)
+    join_logp = request_logprob(x, join_value)
 
     reduced_dims = join_value.ndim - join_logp.ndim
 
@@ -277,7 +282,7 @@ def logprob_dimshuffle(op: MeasurableDimShuffle, values, base_var, **kwargs):
     undo_ds = [original_shuffle.index(i) for i in range(len(original_shuffle))]
     value = value.dimshuffle(undo_ds)
 
-    raw_logp = _logprob_helper(base_var, value)
+    raw_logp = request_logprob(base_var, value)
 
     # Re-apply original dimshuffle, ignoring any support dimensions consumed by
     # the logprob function. This assumes that support dimensions are always in
@@ -413,7 +418,7 @@ def broadcast_logprob(op, values, rv, *shape, **kwargs):
     rv_value = unbroadcast_value
     if broadcast_dims:
         rv_value = pt.expand_dims(rv_value, tuple(d - n_new_dims for d in broadcast_dims))
-    logp = _logprob_helper(rv, rv_value)
+    logp = request_logprob(rv, rv_value)
 
     # The broadcast dims are consumed like support dims and disappear from the logp
     core_ndim = rv_value.ndim - logp.ndim
@@ -528,7 +533,7 @@ def cast_logprob(op, values, base_var, **kwargs):
     # The cast is measure-preserving; the value is passed through as is.
     # Casting it back could silently map impossible values to possible ones
     # (e.g., 1.5 -> 1 for an integer base variable).
-    return _logprob_helper(base_var, value)
+    return request_logprob(base_var, value)
 
 
 @_logcdf.register(MeasurableCast)
@@ -586,7 +591,7 @@ def identity_logprob(op, values, base_var, **kwargs):
     # rewritten under trusted assumptions could return a finite logp where the honest
     # density would return -inf, just like a skipped support check.
     [value] = values
-    return _logprob_helper(base_var, value)
+    return request_logprob(base_var, value)
 
 
 @_logcdf.register(MeasurableScalarFromTensor)
@@ -660,7 +665,7 @@ def logprob_join_dims(op, values, base_var, **kwargs):
     unjoined_shape = [base_shape[i] for i in op.axis_range]
     unjoined_value = split_dims(value, shape=unjoined_shape, axis=op.start_axis)
 
-    raw_logp = _logprob_helper(base_var, unjoined_value)
+    raw_logp = request_logprob(base_var, unjoined_value)
 
     # Re-join the value dimensions, ignoring any support dimensions consumed by the
     # logprob function (assumed to be the rightmost positions). A join lying entirely
@@ -679,7 +684,7 @@ def logprob_split_dims(op, values, base_var, shape, **kwargs):
     n_axes = value.type.ndim - base_var.type.ndim + 1
     joined_value = join_dims(value, start_axis=op.axis, n_axes=n_axes)
 
-    raw_logp = _logprob_helper(base_var, joined_value)
+    raw_logp = request_logprob(base_var, joined_value)
 
     # Re-split the value dimensions, unless the split dimension was a support dimension
     # consumed by the logprob function (assumed to be the rightmost positions)

--- a/pymc/logprob/tensor.py
+++ b/pymc/logprob/tensor.py
@@ -89,8 +89,6 @@ class MeasurableMakeVector(MeasurableOp, MakeVector):
 @_logprob.register(MeasurableMakeVector)
 def logprob_make_vector(op, values, *base_rvs, **kwargs):
     """Compute the log-likelihood graph for a `MeasurableMakeVector`."""
-    # TODO: Sort out this circular dependency issue
-
     (value,) = values
 
     base_rvs = remove_promised_valued_rvs(base_rvs)

--- a/pymc/logprob/transform_value.py
+++ b/pymc/logprob/transform_value.py
@@ -24,7 +24,14 @@ from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.rewriting.basic import GraphRewriter, in2out, node_rewriter
 from pytensor.tensor.variable import TensorVariable
 
-from pymc.logprob.abstract import MeasurableOp, ValuedRV, _logprob, valued_rv
+from pymc.logprob.abstract import (
+    MeasurableOp,
+    ValuedRV,
+    _logprob,
+    n_potential_valued_outputs,
+    request_logprob,
+    valued_rv,
+)
 from pymc.logprob.rewriting import cleanup_ir_rewrites_db
 from pymc.logprob.transforms import Transform
 from pymc.logprob.utils import get_related_valued_nodes
@@ -84,10 +91,19 @@ def transformed_value_logprob(op, values, *rv_outs, use_jacobian=True, **kwargs)
     """
     rv_op = rv_outs[0].owner.op
     rv_inputs = rv_outs[0].owner.inputs
-    logprobs = _logprob(rv_op, values, *rv_inputs, **kwargs)
-
-    if not isinstance(logprobs, Sequence):
-        logprobs = [logprobs]
+    if len(rv_outs) == n_potential_valued_outputs(rv_outs[0].owner):
+        # Every value this node's density could be over was transformed here, so it can be
+        # asked for all of them at once.
+        logprobs = _logprob(rv_op, values, *rv_inputs, **kwargs)
+        if not isinstance(logprobs, Sequence):
+            logprobs = [logprobs]
+    else:
+        # The node's remaining values arrive by other routes. Request one output at a time, so
+        # that each request names the output it is about and all of them are answered together.
+        logprobs = [
+            request_logprob(rv_out, value, **kwargs)
+            for rv_out, value in zip(rv_outs, values, strict=True)
+        ]
 
     # Handle jacobian
     assert len(values) == len(logprobs) == len(op.transforms)

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -127,7 +127,7 @@ from pymc.logprob.abstract import (
     _logcdf,
     _logcdf_helper,
     _logprob,
-    _logprob_helper,
+    request_logprob,
 )
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
 from pymc.logprob.utils import (
@@ -227,12 +227,12 @@ def measurable_transform_logprob(op: MeasurableTransform, values, *inputs, **kwa
     if isinstance(backward_value, tuple):
         input_logprob = pt.logaddexp(
             *(
-                _logprob_helper(measurable_input, backward_val, **kwargs)
+                request_logprob(measurable_input, backward_val, **kwargs)
                 for backward_val in backward_value
             )
         )
     else:
-        input_logprob = _logprob_helper(measurable_input, backward_value)
+        input_logprob = request_logprob(measurable_input, backward_value)
 
     jacobian = op.transform_elemwise.log_jac_det(value, *other_inputs)
 

--- a/pymc/logprob/utils.py
+++ b/pymc/logprob/utils.py
@@ -298,13 +298,7 @@ def find_negated_var(var):
 
 
 def get_related_valued_nodes(fgraph: FunctionGraph, node: Apply) -> list[Apply]:
-    """Get all ValuedVars related to the same RV node.
-
-    Returns
-    -------
-        rv_node
-        valued_nodes
-    """
+    """Get all ValuedVars related to the same RV node."""
     clients = fgraph.clients
     return [
         client

--- a/tests/dims/distributions/test_core.py
+++ b/tests/dims/distributions/test_core.py
@@ -14,10 +14,14 @@
 import re
 
 import numpy as np
+import pytensor
+import pytensor.tensor as pt
 import pytest
 import scipy
 
+from pytensor.compile.builders import OpFromGraph
 from pytensor.xtensor import as_xtensor
+from pytensor.xtensor.basic import xtensor_from_tensor
 from xarray import DataArray
 
 import pymc as pm
@@ -25,6 +29,8 @@ import pymc as pm
 from pymc import dims as pmx
 from pymc import icdf, logccdf, logcdf, logp
 from pymc.dims import Normal
+from pymc.logprob.abstract import MeasurableOp, _logprob
+from pymc.logprob.basic import conditional_logp
 
 pytestmark = pytest.mark.filterwarnings(
     "error",
@@ -284,3 +290,70 @@ def test_density_helpers(rv_unique_dims, value_unique_dims, value_aligned):
         x_icdf.eval({x_value: DataArray(icdf_test_value, dims=x_value.dims)}),
         scipy.stats.norm.ppf(icdf_aligned_test_value, mean, sigma),
     )
+
+
+def test_joint_logp_over_mixed_xtensor_and_tensor_values():
+    """A joint logp whose values are a mix of dims and plain tensor variables.
+
+    Each value is valued on a different node -- the dims one through an XTensorFromTensor, the
+    tensor one directly on the measurable node -- but the logp still has to see both at once.
+    """
+
+    class MixedPairOp(MeasurableOp, OpFromGraph):
+        # The first value's density is over its trailing axis; the second's is elementwise
+        supp_axes = ((-1,), ())
+
+    @_logprob.register(MixedPairOp)
+    def mixed_pair_logp(op, values, *inputs, **kwargs):
+        assert len(values) == 2, f"joint logp needs both values, got {len(values)}"
+        v1, v2 = values
+        return v1.sum(axis=-1) + v2, pt.zeros_like(v2)
+
+    mu = pt.vector("mu", shape=(3,))
+    op = MixedPairOp(inputs=[mu], outputs=[pt.broadcast_to(mu[:, None], (3, 5)), mu * 2])
+    out1, out2 = op(mu)
+
+    y1 = xtensor_from_tensor(out1, dims=("trial", "obs"))  # dims dependent
+    v1, v2 = y1.type(), out2.type()  # out2 keeps its value as a plain tensor
+    logps = conditional_logp({y1: v1, out2: v2})
+
+    lp1, lp2 = logps[v1], logps[v2]
+    # Each term comes back in the flavour of its own value
+    assert lp1.type.dims == ("trial",)
+    assert not hasattr(lp2.type, "dims")
+
+    fn = pytensor.function([v1, v2], [lp1.values, lp2])
+    v1_test = np.arange(15, dtype="float64").reshape(3, 5)
+    v2_test = np.array([1.0, 2.0, 3.0])
+    got1, got2 = fn(v1_test, v2_test)
+    np.testing.assert_allclose(got1, v1_test.sum(axis=-1) + v2_test)
+    np.testing.assert_allclose(got2, np.zeros(3))
+
+
+def test_joint_logp_term_labelled_by_the_dims_that_survive():
+    """A density that is not over the rightmost dim still labels its term correctly.
+
+    The term's dims cannot be read off positionally: what is left after a density is taken
+    depends on which dims it was over, which only the Op knows.
+    """
+
+    class ReducesLeadingDim(MeasurableOp, OpFromGraph):
+        supp_axes = ((-2,),)  # the density is over "trial", not over "obs"
+
+    @_logprob.register(ReducesLeadingDim)
+    def reduces_leading_dim_logp(op, values, mu, **kwargs):
+        [v] = values
+        return v.sum(axis=0)
+
+    mu = pt.vector("mu", shape=(3,))
+    [out] = ReducesLeadingDim(inputs=[mu], outputs=[pt.broadcast_to(mu[:, None], (3, 5))])(
+        mu, return_list=True
+    )
+    y = xtensor_from_tensor(out, dims=("trial", "obs"))
+    v = y.type()
+
+    [lp] = conditional_logp({y: v}).values()
+    assert lp.type.dims == ("obs",)
+
+    v_test = np.arange(15, dtype="float64").reshape(3, 5)
+    np.testing.assert_allclose(lp.values.eval({v: v_test}), v_test.sum(axis=0))

--- a/tests/logprob/test_basic.py
+++ b/tests/logprob/test_basic.py
@@ -42,13 +42,16 @@ import pytensor.tensor as pt
 import pytest
 import scipy.stats.distributions as sp
 
+from pytensor.compile.builders import OpFromGraph
 from pytensor.graph.basic import equal_computations
+from pytensor.graph.rewriting.basic import SequentialGraphRewriter, in2out, node_rewriter
 from pytensor.graph.traversal import ancestors
 from pytensor.tensor.random.op import RandomVariable
 from scipy import stats
 
 import pymc as pm
 
+from pymc.logprob.abstract import MeasurableOp, ValuedRV, _logcdf, _logprob
 from pymc.logprob.basic import (
     conditional_logp,
     icdf,
@@ -57,6 +60,7 @@ from pymc.logprob.basic import (
     logp,
     transformed_conditional_logp,
 )
+from pymc.logprob.rewriting import logprob_rewrites_basic_query, logprob_rewrites_db
 from pymc.logprob.transforms import LogTransform
 from pymc.logprob.utils import replace_rvs_by_values
 from pymc.testing import assert_no_rvs
@@ -258,6 +262,118 @@ def test_joint_logp_basic():
     assert b_value_var in res_ancestors
     assert c_value_var in res_ancestors
     assert a_value_var in res_ancestors
+
+
+def test_joint_logp_over_multiple_values():
+    """An op whose logp is joint over several values must receive all of them in one call.
+
+    Each value used to be recursed on its own as soon as a measurable chain reached it, so a
+    node valued through a chain had its density silently derived over a subset of its values.
+    The values arrive in output order, and a subset is only interpretable if the op knows which
+    outputs it belongs to, so the rewrite that makes the op measurable records which of them
+    lead to a value.
+    """
+
+    class JointPairOp(OpFromGraph):
+        """Not yet measurable; `find_measurable_joint_pair` makes it so."""
+
+    class MeasurableJointPairOp(MeasurableOp, OpFromGraph):
+        # The first value's density is over its trailing axis; the second's is elementwise
+        supp_axes = ((-1,), ())
+        measured_outputs: tuple[bool, bool]
+
+    def variables_leading_to_values(fgraph):
+        # Like the pymc util of the same name, but through clients of any kind: at rewrite time
+        # the chains above this op have not yet been made measurable
+        leads = set()
+        for node in reversed(fgraph.toposort()):
+            if isinstance(node.op, ValuedRV) or any(out in leads for out in node.outputs):
+                leads.update(node.inputs)
+        return leads
+
+    @node_rewriter([JointPairOp])
+    def find_measurable_joint_pair(fgraph, node):
+        inner_inputs = [inp.type() for inp in node.op.fgraph.inputs]
+        measurable_op = MeasurableJointPairOp(
+            inputs=inner_inputs, outputs=node.op.fgraph.bind(inner_inputs)
+        )
+        leads_to_value = variables_leading_to_values(fgraph)
+        measurable_op.measured_outputs = tuple(out in leads_to_value for out in node.outputs)
+        return measurable_op(*node.inputs, return_list=True)
+
+    ir_rewriter = SequentialGraphRewriter(
+        in2out(find_measurable_joint_pair),
+        logprob_rewrites_db.query(logprob_rewrites_basic_query),
+    )
+
+    calls = []
+
+    @_logprob.register(MeasurableJointPairOp)
+    def joint_pair_logp(op, values, *inputs, **kwargs):
+        calls.append((op.measured_outputs, len(values)))
+        assert len(values) == sum(op.measured_outputs), "logp derived over a subset of values"
+        if op.measured_outputs == (True, True):
+            v1, v2 = values
+            # Deliberately non-separable: the whole joint term is assigned to the first value,
+            # and the second gets a placeholder shaped like a real term would be.
+            return v1.sum(axis=-1) + v2, pt.zeros_like(v2)
+        elif op.measured_outputs == (True, False):
+            [v1] = values
+            return v1.sum(axis=-1) + 100.0
+        else:
+            [v2] = values
+            return v2 - 100.0
+
+    @_logcdf.register(MeasurableJointPairOp)
+    def joint_pair_logcdf(op, value, *inputs, **kwargs):
+        # Censoring derives the base's marginal logcdf eagerly; the bounds lie outside the
+        # test values, so this term never survives into the evaluated branches
+        return pt.zeros_like(value)
+
+    mu = pt.vector("mu", shape=(3,))
+    op = JointPairOp(inputs=[mu], outputs=[pt.broadcast_to(mu[:, None], (3, 5)), mu * 2])
+    v1 = pt.matrix("v1", shape=(3, 5))
+    v2 = pt.vector("v2", shape=(3,))
+    v1_test = np.arange(15, dtype=v1.dtype).reshape(3, 5)
+    v2_test = np.array([1.0, 2.0, 3.0], dtype=v2.dtype)
+
+    # Both outputs measured: one value arrives through a measurable chain, the other directly
+    out1, out2 = op(mu)
+    logps = conditional_logp({out1 + 1: v1, out2: v2}, ir_rewriter=ir_rewriter)
+    assert calls == [((True, True), 2)]
+    fn = pytensor.function([v1, v2], [logps[v1], logps[v2]])
+    got1, got2 = fn(v1_test, v2_test)
+    np.testing.assert_allclose(got1, (v1_test - 1).sum(axis=-1) + v2_test)
+    np.testing.assert_allclose(got2, np.zeros(3))
+
+    # Both outputs measured, each through its own chain, one of them censoring: no value is
+    # attached to the joint node itself, and clip's logp must also reach it through the helper.
+    # The clipped value passes through unchanged and lies inside the bounds, so its term is the
+    # joint one untouched by the censoring branches.
+    calls.clear()
+    out1, out2 = op(mu)
+    logps = conditional_logp(
+        {out1 + 1: v1, pt.clip(out2, -1000.0, 1000.0): v2}, ir_rewriter=ir_rewriter
+    )
+    assert calls == [((True, True), 2)]
+    fn = pytensor.function([v1, v2], [logps[v1], logps[v2]])
+    got1, got2 = fn(v1_test, v2_test)
+    np.testing.assert_allclose(got1, (v1_test - 1).sum(axis=-1) + v2_test)
+    np.testing.assert_allclose(got2, np.zeros(3))
+
+    # Only the first output measured, through a chain
+    calls.clear()
+    out1, _ = op(mu)
+    [logp_v1] = conditional_logp({out1 + 1: v1}, ir_rewriter=ir_rewriter).values()
+    assert calls == [((True, False), 1)]
+    np.testing.assert_allclose(logp_v1.eval({v1: v1_test}), (v1_test - 1).sum(axis=-1) + 100.0)
+
+    # Only the second output measured, through a chain
+    calls.clear()
+    _, out2 = op(mu)
+    [logp_v2] = conditional_logp({out2 + 1: v2}, ir_rewriter=ir_rewriter).values()
+    assert calls == [((False, True), 1)]
+    np.testing.assert_allclose(logp_v2.eval({v2: v2_test}), (v2_test - 1) - 100.0)
 
 
 def test_model_unchanged_logprob_access():
@@ -467,11 +583,12 @@ def test_ir_ops_can_be_evaluated_with_warning():
         lam = pm.Exponential("lam")
         pm.CustomDist("y", lam, logp=my_logp, observed=[0, 1, 2])
 
+    # A dependency reaches the logp as its value, not as the ValuedRV standing for it, so the
+    # only IR op left here is the TransformedValue one (see #8100).
     with pytest.warns(
         UserWarning, match="TransformedValue should not be present in the final graph"
     ):
-        with pytest.warns(UserWarning, match="ValuedVar should not be present in the final graph"):
-            m.logp()
+        m.logp()
 
     assert _eval_values[0].sum() == 3
     assert _eval_values[1] == np.exp(-1.5)

--- a/tests/logprob/test_scan.py
+++ b/tests/logprob/test_scan.py
@@ -45,7 +45,7 @@ from pytensor.raise_op import assert_op
 from pytensor.scan.utils import ScanArgs
 from scipy import stats
 
-from pymc.logprob.abstract import _logprob_helper
+from pymc.logprob.abstract import request_logprob
 from pymc.logprob.basic import conditional_logp, logp
 from pymc.logprob.scan import (
     construct_scan,
@@ -63,7 +63,7 @@ def create_inner_out_logp(value_map):
     """
     res = []
     for old_inner_out_var, new_inner_in_var in value_map.items():
-        logp = _logprob_helper(old_inner_out_var, new_inner_in_var)
+        logp = request_logprob(old_inner_out_var, new_inner_in_var)
         if new_inner_in_var.name:
             logp.name = f"logp({new_inner_in_var.name})"
         res.append(logp)
@@ -134,7 +134,7 @@ def test_convert_outer_out_to_in_sit_sot():
         y_tm1.name = "y_tm1"
         mu = mu_tm1 + y_tm1 + 1
         mu.name = "mu_t"
-        logp = _logprob_helper(pt.random.normal(mu, 1.0), y_t)
+        logp = request_logprob(pt.random.normal(mu, 1.0), y_t)
         logp.name = "logp"
         return mu, logp
 
@@ -234,7 +234,7 @@ def test_convert_outer_out_to_in_mit_sot():
         y_t.name = "y_t"
         y_tm1.name = "y_tm1"
         y_tm2.name = "y_tm2"
-        logp = _logprob_helper(pt.random.normal(y_tm1 + y_tm2, 1.0), y_t)
+        logp = request_logprob(pt.random.normal(y_tm1 + y_tm2, 1.0), y_t)
         logp.name = "logp(y_t)"
         return logp
 
@@ -358,7 +358,7 @@ def test_scan_joint_logprob(require_inner_rewrites):
     def scan_fn(mus_t, sigma_t, Y_t_val, S_t_val, Gamma_t):
         S_t = pt.random.categorical(Gamma_t[0], name="S_t")
         Y_t = pt.random.normal(mus_t[S_t_val], sigma_t, name="Y_t")
-        Y_t_logp, S_t_logp = _logprob_helper(Y_t, Y_t_val), _logprob_helper(S_t, S_t_val)
+        Y_t_logp, S_t_logp = request_logprob(Y_t, Y_t_val), request_logprob(S_t, S_t_val)
         Y_t_logp.name = "log(Y_t=y_t)"
         S_t_logp.name = "log(S_t=s_t)"
         return Y_t_logp, S_t_logp
@@ -375,7 +375,7 @@ def test_scan_joint_logprob(require_inner_rewrites):
     Y_rv_logp.name = "logp(Y=y)"
     S_rv_logp.name = "logp(S=s)"
 
-    Gamma_logp = _logprob_helper(Gamma_rv, Gamma_vv)
+    Gamma_logp = request_logprob(Gamma_rv, Gamma_vv)
 
     y_logp_ref = Y_rv_logp.sum() + S_rv_logp.sum() + Gamma_logp.sum()
 

--- a/tests/logprob/test_tensor.py
+++ b/tests/logprob/test_tensor.py
@@ -534,6 +534,49 @@ class TestMeasurableSplit:
             scipy_dirichlet_logpdf(np.concatenate(x_parts_test, axis=1), alpha),
         )
 
+    def test_values_reached_through_measurable_chains(self):
+        # A split is joint over its outputs in that its logp has to re-join the values to
+        # recover the density of the base variable, so every value must reach it in the same
+        # call, no matter how many measurable steps stand between it and its part.
+        rng = np.random.default_rng(521)
+        mu = np.arange(6)
+        x = pt.random.normal(mu, 1.0, name="x")
+        x_parts = pt.split(x, splits_size=[2, 4], n_splits=2, axis=0)
+        x_parts_vv = [x_part.clone() for x_part in x_parts]
+        x_parts_test = [rng.normal(size=x_part.type.shape) for x_part in x_parts_vv]
+
+        # One part valued behind a shift, the other directly on the split node
+        logp_parts = list(
+            conditional_logp({x_parts[0] + 1: x_parts_vv[0], x_parts[1]: x_parts_vv[1]}).values()
+        )
+        logp_fn = pytensor.function(x_parts_vv, logp_parts)
+        logp_x1_eval, logp_x2_eval = logp_fn(*x_parts_test)
+        np.testing.assert_allclose(
+            logp_x1_eval,
+            st.norm.logpdf(x_parts_test[0] - 1, mu[:2]),
+        )
+        np.testing.assert_allclose(
+            logp_x2_eval,
+            st.norm.logpdf(x_parts_test[1], mu[2:]),
+        )
+
+        # Both parts valued behind a chain, so no value is attached to the split node itself
+        logp_parts = list(
+            conditional_logp(
+                {x_parts[0] + 1: x_parts_vv[0], x_parts[1] * 2: x_parts_vv[1]}
+            ).values()
+        )
+        logp_fn = pytensor.function(x_parts_vv, logp_parts)
+        logp_x1_eval, logp_x2_eval = logp_fn(*x_parts_test)
+        np.testing.assert_allclose(
+            logp_x1_eval,
+            st.norm.logpdf(x_parts_test[0] - 1, mu[:2]),
+        )
+        np.testing.assert_allclose(
+            logp_x2_eval,
+            st.norm.logpdf(x_parts_test[1] / 2, mu[2:]) - np.log(2),
+        )
+
     @pytest.mark.xfail(
         reason="Rewrite from partial split to split on subtensor not implemented yet"
     )


### PR DESCRIPTION
- **Drop two stale pieces of logprob documentation**
- **Derive a joint density in a single call, however its values are reached**
- **Let a dims variable take part in a joint density**
