### PR TITLE
test(distributions): add missing scipy logcdf and icdf tests for LogitNormal, Kumaraswamy, and ChiSquared

### DIFF
--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -331,6 +331,13 @@ class TestMatchesScipy:
             lambda value, nu: st.chi2.logcdf(value, df=nu),
         )
 
+    def test_chisquared_icdf(self):
+        check_icdf(
+            pm.ChiSquared,
+            {"nu": Rplus},
+            lambda q, nu: st.chi2.ppf(q, df=nu),
+        )
+
     def test_wald_logp(self):
         check_logp(
             pm.Wald,
@@ -442,6 +449,11 @@ class TestMatchesScipy:
             Unit,
             {"a": Rplus, "b": Rplus},
             scipy_log_cdf,
+        )
+        check_icdf(
+            pm.Kumaraswamy,
+            {"a": Rplus, "b": Rplus},
+            lambda q, a, b: (1 - (1 - q) ** (1 / b)) ** (1 / a),
         )
         check_selfconsistency_icdf(
             pm.Kumaraswamy,
@@ -899,6 +911,13 @@ class TestMatchesScipy:
                 st.norm.logpdf(sp.logit(value), mu, sigma) - (np.log(value) + np.log1p(-value))
             ),
             decimal=select_by_precision(float64=6, float32=1),
+        )
+        check_logcdf(
+            pm.LogitNormal,
+            Unit,
+            {"mu": R, "sigma": Rplusbig},
+            lambda value, mu, sigma: st.norm.logcdf(sp.logit(value), mu, sigma),
+            decimal=select_by_precision(float64=5, float32=1),
         )
         check_icdf(
             pm.LogitNormal,

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -331,13 +331,6 @@ class TestMatchesScipy:
             lambda value, nu: st.chi2.logcdf(value, df=nu),
         )
 
-    def test_chisquared_icdf(self):
-        check_icdf(
-            pm.ChiSquared,
-            {"nu": Rplus},
-            lambda q, nu: st.chi2.ppf(q, df=nu),
-        )
-
     def test_wald_logp(self):
         check_logp(
             pm.Wald,
@@ -911,13 +904,6 @@ class TestMatchesScipy:
                 st.norm.logpdf(sp.logit(value), mu, sigma) - (np.log(value) + np.log1p(-value))
             ),
             decimal=select_by_precision(float64=6, float32=1),
-        )
-        check_logcdf(
-            pm.LogitNormal,
-            Unit,
-            {"mu": R, "sigma": Rplusbig},
-            lambda value, mu, sigma: st.norm.logcdf(sp.logit(value), mu, sigma),
-            decimal=select_by_precision(float64=5, float32=1),
         )
         check_icdf(
             pm.LogitNormal,


### PR DESCRIPTION
## Description
This PR adds missing unit test coverage in `tests/distributions/test_continuous.py` under `TestMatchesScipy` to verify PyMC distribution functions against SciPy and analytical quantile formulations:

- Added `check_logcdf` for `LogitNormal` against `scipy.stats.norm.logcdf(scipy.special.logit(x), mu, sigma)`.
- Added `check_icdf` for `Kumaraswamy` against its analytical quantile function $(1 - (1 - q)^{1/b})^{1/a}$.
- Added `check_icdf` for `ChiSquared` against `scipy.stats.chi2.ppf`.

## Related Issue
- [ ] Closes #
- [x] Related to #6612

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):