### PR TITLE
Allow pytensor 3.3

### DIFF
--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -20,7 +20,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=3.2.2,<3.3
+- pytensor>=3.2.2,<3.4
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=3.2.2,<3.3
+- pytensor>=3.2.2,<3.4
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -11,7 +11,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=3.2.2,<3.3
+- pytensor>=3.2.2,<3.4
 - python-graphviz
 - rich>=13.7.1
 - scipy>=1.4.1

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -15,7 +15,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=3.2.2,<3.3
+- pytensor>=3.2.2,<3.4
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=3.2.2,<3.3
+- pytensor>=3.2.2,<3.4
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -16,7 +16,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=3.2.2,<3.3
+- pytensor>=3.2.2,<3.4
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
 pymc-sphinx-theme>=0.16.0
-pytensor>=3.2.2,<3.3
+pytensor>=3.2.2,<3.4
 pytest-cov>=2.5
 pytest>=3.0
 rich>=13.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cachetools>=4.2.1,<7
 cloudpickle
 numpy>=1.25.0
 pandas>=0.24.0
-pytensor>=3.2.2,<3.3
+pytensor>=3.2.2,<3.4
 rich>=13.7.1
 scipy>=1.4.1
 threadpoolctl>=3.1.0,<4.0.0


### PR DESCRIPTION
## Description

Raises the PyTensor upper bound from `<3.3` to `<3.4` so that the current PyTensor 3.3.x releases can be used with PyMC. The pin is updated in `requirements.txt`, `requirements-dev.txt` and the six `conda-envs/*.yml` files.

No source changes were needed: [PyTensor 3.3.0](https://github.com/pymc-devs/pytensor/releases/tag/rel-3.3.0) documents no breaking changes (free-threaded build support, MLX dispatches, and bugfixes), so the lower bound stays at `>=3.2.2` and both 3.2.x and 3.3.x remain supported.

### Testing

Ran the full test suite locally on Python 3.12 against PyTensor 3.3.0 and 3.2.4 with everything else held fixed. The two runs produce **identical** results — same 3444 passed, same 42 failed, and a byte-identical list of failing test ids:

```
pytest tests -n 8 --ignore=tests/step_methods
3.3.0: 42 failed, 3444 passed, 66 skipped, 21 xfailed
3.2.4: 42 failed, 3444 passed, 66 skipped, 21 xfailed
```

The 42 failures are unrelated to this change and reproduce on the currently-supported 3.2.4: 36 are `Multinomial` tests that only fail under `xdist` (they pass when the selection is run on its own, so they look like local test-pollution), and the rest are missing optional dependencies in my environment (`nutpie`, `h5py`). `tests/step_methods` was run separately because unrelated lambda-`id()`-based parametrization ids break xdist collection matching; it passes: `133 passed, 6 skipped`.

## Related Issue
- [ ] Closes #
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [x] Maintenance
