### PR TITLE
feat(distributions): support symbolic eta in LKJCholeskyCov logp

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -1294,16 +1294,11 @@ def _LKJCholeksyCovRV_logp(op, values, rng, n, eta, sd_dist, **kwargs):
     det_invjac = pt.log(corr_diag) - idx * pt.log(sd_vals)
     det_invjac = det_invjac.sum()
 
-    # TODO: _lkj_normalizing_constant currently requires `eta` and `n` to be constants
+    # TODO: _lkj_normalizing_constant currently requires `n` to be a constant
     try:
         n = int(get_underlying_scalar_constant_value(n))
     except NotScalarConstantError:
         raise NotImplementedError("logp only implemented for constant `n`")
-
-    try:
-        eta = float(get_underlying_scalar_constant_value(eta))
-    except NotScalarConstantError:
-        raise NotImplementedError("logp only implemented for constant `eta`")
 
     norm = _lkj_normalizing_constant(eta, n)
 

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -975,6 +975,30 @@ class TestLKJCholeskCov:
             warnings.simplefilter("error")
             m.logp()
 
+    def test_lkj_cholesky_cov_symbolic_eta(self):
+        with pm.Model() as model:
+            eta = pm.HalfNormal("eta", sigma=1.0)
+            sd_dist = pm.Exponential.dist(1.0)
+            chol = pm.LKJCholeskyCov("chol", eta=eta, n=3, sd_dist=sd_dist)
+
+            logp_fn = model.compile_logp()
+            dlogp_fn = model.compile_dlogp()
+
+        ip = model.initial_point()
+        logp_val = logp_fn(ip)
+        assert np.isfinite(logp_val)
+
+        dlogp_val = dlogp_fn(ip)
+        assert dlogp_val.size == 7
+        assert np.all(np.isfinite(dlogp_val))
+
+        with pm.Model() as m_invalid:
+            n_sym = pt.lscalar("n")
+            sd_dist = pm.Exponential.dist(1.0)
+            pm.LKJCholeskyCov("chol_invalid", eta=2.0, n=n_sym, sd_dist=sd_dist, compute_corr=False)
+            with pytest.raises(NotImplementedError, match="logp only implemented for constant `n`"):
+                m_invalid.logp()
+
     @pytest.mark.parametrize(
         "sd_dist",
         [


### PR DESCRIPTION
## Description
This PR allows the `eta` parameter in `pm.LKJCholeskyCov` to be a symbolic/dynamic PyTensor variable (e.g., placing a prior such as `pm.HalfNormal` on `eta`), bringing it to feature parity with `LKJCorr.logp`.

- Removes the `try...except NotScalarConstantError` restriction on `eta` in `_LKJCholeksyCovRV_logp`.
- Preserves the scalar constant check for `n` (since static matrix dimensioning is required by PyTensor shape indexing).
- Updates the relevant TODO in `pymc/distributions/multivariate.py`.
- Adds unit tests in `tests/distributions/test_multivariate.py` verifying finite `logp` and `dlogp` evaluations with symbolic `eta`, as well as validating that non-constant `n` still raises `NotImplementedError`.

## Related Issue

- [x] Closes #8403 

## Checklist

- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->



## Type of change

<!--- Select one of the categories below by typing an `x` in the box -->

- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):