### PR TITLE
Raise on unrecognized sample() kwargs for external NUTS samplers

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -395,6 +395,20 @@ def _sample_external_nuts(
     compile_kwargs = compile_kwargs.copy()
     idata_kwargs = {} if idata_kwargs is None else idata_kwargs.copy()
 
+    if kwargs:
+        # Anything left in `kwargs` at this point is a `sample()` keyword argument
+        # that isn't recognized by this function and isn't one of the NUTS-kernel
+        # options nested under `nuts={...}` either. Previously these were silently
+        # swallowed here without ever reaching the sampler (e.g. a stray top-level
+        # `jitter=False` looked like it worked but was quietly ignored). Raise
+        # instead so a typo or an option that needs to move into `nuts={...}` is
+        # caught immediately rather than producing a silently wrong sample.
+        raise TypeError(
+            f"sample() got unexpected keyword arguments {sorted(kwargs)} for "
+            f"nuts_sampler={sampler!r}. Options for the underlying sampler must be "
+            "passed via the `nuts={...}` argument, e.g. `nuts={'jitter': False}`."
+        )
+
     if "backend" in nuts_kwargs:
         warnings.warn(
             "`backend` should be passed as a top-level argument to `pm.sample`, "

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -123,6 +123,52 @@ def test_jax_sampler_kwargs_routing():
     assert call_kwargs["nuts_kwargs"] == {"max_tree_depth": 7}
 
 
+@pytest.mark.parametrize("nuts_sampler", ["blackjax", "numpyro"])
+def test_jax_sampler_jitter_kwarg_routing(nuts_sampler):
+    # Regression test for #8352: `jitter` is a `sample_jax_nuts` argument, not a
+    # NUTS-kernel one, so it must be lifted out of `nuts={...}` the same way
+    # `chain_method` is (see test_jax_sampler_kwargs_routing above).
+    pytest.importorskip(nuts_sampler)
+
+    with mock.patch("pymc.sampling.jax.sample_jax_nuts") as mock_sampler:
+        with Model():
+            Normal("a")
+            sample(
+                nuts_sampler=nuts_sampler,
+                nuts={"jitter": False},
+                random_seed=1411,
+                progressbar=False,
+            )
+
+    call_kwargs = mock_sampler.call_args.kwargs
+    assert call_kwargs["jitter"] is False
+    assert "jitter" not in call_kwargs["nuts_kwargs"]
+
+
+@pytest.mark.parametrize("nuts_sampler", ["blackjax", "numpyro"])
+def test_external_nuts_sampler_rejects_stray_top_level_kwargs(nuts_sampler):
+    # Regression test for #8352: passing sampler options directly as a top-level
+    # `sample()` keyword (e.g. `jitter=False`, the pre-refactor calling
+    # convention) used to be silently swallowed by `_sample_external_nuts`'s
+    # catch-all `**kwargs` -- the option was neither applied nor reported, so a
+    # user could believe jitter was disabled while it silently stayed on. It
+    # must now raise so the mistake is caught immediately instead of producing
+    # a silently-wrong sample.
+    pytest.importorskip(nuts_sampler)
+
+    with Model():
+        Normal("a")
+        with pytest.raises(TypeError, match=r"unexpected keyword arguments \['jitter'\]"):
+            sample(
+                nuts_sampler=nuts_sampler,
+                jitter=False,
+                chains=1,
+                tune=5,
+                draws=5,
+                progressbar=False,
+            )
+
+
 @pytest.mark.parametrize("nuts_sampler", ["pymc", "nutpie", "blackjax", "numpyro"])
 def test_sample_var_names(nuts_sampler):
     if nuts_sampler != "pymc":


### PR DESCRIPTION
## Description

#8352 asked for a way to turn off init jitter when using an external NUTS sampler. Half of that got fixed already, as a side effect of #8369 — `nuts={"jitter": False}` works fine on `main` right now.

The part still broken is the calling style from before that refactor. `pm.sample(nuts_sampler="numpyro", jitter=False)` — jitter passed at the top level instead of nested in `nuts={}` — does nothing. No error, no warning. It just samples with jitter on anyway.

Reason: `_sample_external_nuts()` takes `**kwargs` as a catch-all, and nothing in the function ever reads it. Whatever lands there just evaporates. So this fixes the catch-all itself, not just the jitter case — it now raises a `TypeError` naming whatever unexpected keys showed up, telling you to use `nuts={...}` instead.

Added two tests. `test_external_nuts_sampler_rejects_stray_top_level_kwargs` is the one that actually covers this change — confirmed it fails with `DID NOT RAISE` on unpatched `main` and passes with the fix. `test_jax_sampler_jitter_kwarg_routing` covers the `nuts={"jitter": False}` path, which already worked before this PR (that's #8369's doing) — including it since it wasn't tested anywhere before now.

Ran `test_jax.py`, `test_mcmc_external.py`, and `test_mcmc.py` locally. Full pass on the first two. `test_mcmc_external.py` has some pre-existing flakiness unrelated to this — a couple of blackjax tests occasionally hit a `pmap`/jax version issue, and `test_step_args` has a statistical assertion that isn't always stable. Both reproduce identically on unpatched `main`, so not from this change.

## Related Issue

- [x] Closes #8352

## Checklist

- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)

## Type of change

- [x] Bug fix