### PR TITLE
Let the rng argument reach .dist()

### DIFF
--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -476,7 +476,6 @@ class Distribution(metaclass=DistributionMeta):
         cls,
         name: str,
         *args,
-        rng=None,
         dims: Dims | None = None,
         initval=None,
         observed=None,

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -84,6 +84,18 @@ class TestBugfixes:
         npt.assert_almost_equal(m.compile_logp()({"x": np.ones(10)}), 0 * 10)
 
 
+def test_rng_is_used_by_model_variable():
+    """`rng` must reach the RV whether or not the variable is named."""
+    rng = shared(np.random.default_rng(11))
+    unnamed = pm.Normal.dist(0.0, 1.0, rng=rng)
+    assert unnamed.owner.inputs[0] is rng
+
+    rng = shared(np.random.default_rng(11))
+    with pm.Model():
+        named = pm.Normal("x", 0.0, 1.0, rng=rng)
+    assert named.owner.inputs[0] is rng
+
+
 def test_all_distributions_have_support_points():
     import pymc.distributions as dist_module
 


### PR DESCRIPTION
`Distribution.__new__` takes `rng` as an explicit keyword and documents it:

```python
def __new__(
    cls,
    name: str,
    *args,
    rng=None,
    dims: Dims | None = None,
    ...
```

> **rng** : optional
>     Random number generator to use with the RandomVariable.

but the body never refers to it again. It ends with `cls.dist(*args, **kwargs)`, and since the explicit keyword has already captured `rng` out of `**kwargs`, it never reaches `.dist()`.

The result is that the argument works on an unnamed variable and is silently ignored on a named one:

```python
import numpy as np, pytensor, pymc as pm

rng = pytensor.shared(np.random.default_rng(11))
print(pm.Normal.dist(0.0, 1.0, rng=rng).owner.inputs[0] is rng)

rng = pytensor.shared(np.random.default_rng(11))
with pm.Model():
    x = pm.Normal("x", 0.0, 1.0, rng=rng)
print(x.owner.inputs[0] is rng)
```

On `main`:

```
True
False
```

With this PR both print `True`.

The fix is to drop the parameter rather than forward it explicitly, because that is how the other `.dist()`-only keywords already behave — neither `size` nor `shape` appears in the `__new__` signature, they are read out of `kwargs` a few lines above and passed through. Removing `rng` from the signature puts it on that same path. It is still accepted and still documented, so the docstring entry stays accurate and no call site changes.

Added `test_rng_is_used_by_model_variable`, which checks both spellings. It fails on `main` and passes here.

`tests/distributions/test_distribution.py` and `tests/model/test_core.py` show the same 5 failures before and after this change (`TestDiracDelta::test_dtype`, three `TestImputationMissingData`/`TestNested` cases) — they are unrelated to this and reproduce on a clean checkout in the same environment.

I couldn't find any test that passes `rng` to a named variable, which is probably why this went unnoticed — the existing `rng=` coverage all goes through `.dist()`.
