### PR TITLE
Drop the RV suffix from LKJCorr's print name

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -1487,7 +1487,7 @@ class LKJCholeskyCov:
 class LKJCorrRV(SymbolicRandomVariable):
     name = "lkjcorr"
     extended_signature = "[rng],[size],(),()->[rng],(n,n)"
-    _print_name = ("LKJCorrRV", "\\operatorname{LKJCorrRV}")
+    _print_name = ("LKJCorr", "\\operatorname{LKJCorr}")
 
     def make_node(self, rng, size, n, eta):
         n = pt.as_tensor_variable(n)

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -39,6 +39,7 @@ from pymc.distributions import (
     DirichletMultinomial,
     HalfNormal,
     KroneckerNormal,
+    LKJCorr,
     MvNormal,
     NegativeBinomial,
     Normal,
@@ -318,6 +319,14 @@ def test_truncated_repr():
 
     str_repr = model.str_repr(include_params=False)
     assert str_repr == "x ~ TruncatedGamma"
+
+
+def test_lkjcorr_repr():
+    with Model() as model:
+        x = LKJCorr("x", n=3, eta=1.0)
+
+    str_repr = model.str_repr(include_params=False)
+    assert str_repr == "x ~ LKJCorr"
 
 
 def test_custom_dist_repr():


### PR DESCRIPTION
`LKJCorrRV._print_name` still carries the `RV` class suffix, so the distribution renders under the `Op` name rather than the distribution name:

```python
with pm.Model() as model:
    x = pm.LKJCorr("x", n=3, eta=1.0)
    y = pm.MvStudentT("y", nu=3, mu=[0, 0], scale=np.eye(2))
```

```
x ~ LKJCorrRV(<constant>, 1)
y ~ MvStudentT(3, <constant>, <constant>)
```

and in LaTeX, which is what renders in a notebook:

```
$\text{x} \sim \operatorname{LKJCorrRV}(\text{<constant>},~1)$
```

Every other distribution strips the suffix — `MvStudentTRV` prints `MvStudentT`, `MatrixNormalRV` prints `MatrixNormal`, `CARRV` prints `CAR`. Of the 43 `_print_name` assignments in the package, this is the only one ending in `RV`.

After the change `str_repr` gives `x ~ LKJCorr(<constant>, 1)` and the LaTeX form matches.

Added `test_lkjcorr_repr` next to the existing `test_truncated_repr` / `test_custom_dist_repr` cases. It fails on `main` and passes here; `tests/test_printing.py` goes 18 -> 19 passing.
