### PR TITLE
Fix exponential transform logp at zero

### DIFF
--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -902,7 +902,7 @@ class ExpTransform(Transform):
         return pt.log(value)
 
     def log_jac_det(self, value, *inputs):
-        return -pt.log(value)
+        return pt.switch(value > 0, -pt.log(value), np.nan)
 
 
 class AbsTransform(Transform):

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -214,7 +214,7 @@ class TestTransform:
 
 
 def test_exp_transform_rv():
-    base_rv = pt.random.normal(0, 1, size=3, name="base_rv")
+    base_rv = pt.random.normal(0, 1, size=4, name="base_rv")
     y_rv = pt.exp(base_rv)
     y_rv.name = "y"
 
@@ -223,8 +223,8 @@ def test_exp_transform_rv():
     logcdf_fn = pytensor.function([y_vv], logcdf(y_rv, y_vv))
     icdf_fn = pytensor.function([y_vv], icdf(y_rv, y_vv))
 
-    y_val = [-2.0, 0.1, 0.3]
-    q_val = [0.2, 0.5, 0.9]
+    y_val = [-2.0, 0.0, 0.1, 0.3]
+    q_val = [0.2, 0.5, 0.7, 0.9]
     np.testing.assert_allclose(
         logp_fn(y_val),
         sp.stats.lognorm(s=1).logpdf(y_val),


### PR DESCRIPTION
## Description

The derived log-probability of an exponential transformation returned `nan` when evaluated at zero.

For `value == 0`, the inverse transformation produces `-inf`, while the Jacobian correction produces `+inf`. Adding these terms resulted in `nan`, even though zero is outside the support of the transformed distribution and should have log-probability `-inf`.

This change makes `ExpTransform.log_jac_det` mark non-positive values as outside the transform's support. The existing measurable-transform log-probability logic then converts them to `-inf`.

The existing exponential-transform test now includes zero and checks the result against SciPy's log-normal implementation.

Validation performed:

- Original issue reproducer returns `-inf`
- `tests/logprob/test_transforms.py`: 95 passed, 1 xfailed
- Ruff lint and formatting checks pass


## Related Issue

- [x] Closes #7717
- [ ] Related to #

## Checklist

- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

Documentation was not added because this fixes existing behavior without changing the public API. Ruff checks pass, but the complete pre-commit suite was not run locally.

## Type of change

- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):