### PR TITLE
Do not default to fork on macOS ARM when NumPy uses Accelerate

### DIFF
--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -85,6 +85,20 @@ def rebuild_exc(exc, tb):
     return exc
 
 
+def _numpy_uses_accelerate() -> bool:
+    """Return whether NumPy is linked against Apple Accelerate.
+
+    Accelerate's internal worker threads do not survive ``fork()``, so a forked
+    sampling worker crashes as soon as it reaches Accelerate's threaded BLAS
+    path. This is the same restriction that already applies to JAX below.
+    """
+    try:
+        blas = np.__config__.CONFIG["Build Dependencies"]["blas"]
+    except (AttributeError, KeyError, TypeError):
+        return False
+    return str(blas.get("name", "")).lower() == "accelerate"
+
+
 def _initialize_multiprocessing_context(
     mp_ctx: str | multiprocessing.context.BaseContext | None,
     *,
@@ -99,12 +113,28 @@ def _initialize_multiprocessing_context(
         # Related issue https://github.com/pymc-devs/pymc/issues/5339
         if mp_ctx is None and platform.system() == "Darwin":
             if platform.processor() == "arm":
-                mp_ctx = "fork"
-                if not quiet:
-                    logger.debug(
-                        "mp_ctx is set to 'fork' for MacOS with ARM architecture. "
-                        + "This might cause unexpected behavior with JAX, which is inherently multithreaded."
+                if _numpy_uses_accelerate():
+                    # Accelerate is not fork-safe, so keeping the 'fork' default
+                    # segfaults every worker on any model large enough to reach
+                    # its threaded BLAS path.
+                    mp_ctx = (
+                        "forkserver"
+                        if "forkserver" in multiprocessing.get_all_start_methods()
+                        else "spawn"
                     )
+                    if not quiet:
+                        logger.debug(
+                            f"mp_ctx is set to '{mp_ctx}' for MacOS with ARM architecture, "
+                            + "because NumPy is linked against Apple Accelerate, "
+                            + "whose threads do not survive fork()."
+                        )
+                else:
+                    mp_ctx = "fork"
+                    if not quiet:
+                        logger.debug(
+                            "mp_ctx is set to 'fork' for MacOS with ARM architecture. "
+                            + "This might cause unexpected behavior with JAX, which is inherently multithreaded."
+                        )
             else:
                 mp_ctx = "forkserver"
 

--- a/tests/sampling/test_parallel.py
+++ b/tests/sampling/test_parallel.py
@@ -42,6 +42,47 @@ def test_context():
             pm.sample(tune=2, draws=2, chains=2, cores=2, mp_ctx=ctx)
 
 
+class TestMpCtxAccelerateSwitch:
+    @staticmethod
+    def _macos_arm(monkeypatch, *, accelerate: bool):
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(platform, "processor", lambda: "arm")
+        monkeypatch.setattr(ps, "_numpy_uses_accelerate", lambda: accelerate)
+
+    def test_avoids_fork_when_numpy_uses_accelerate(self, monkeypatch):
+        self._macos_arm(monkeypatch, accelerate=True)
+        ctx = ps._initialize_multiprocessing_context(None)
+        assert ctx.get_start_method() != "fork"
+
+    def test_keeps_fork_without_accelerate(self, monkeypatch):
+        if "fork" not in multiprocessing.get_all_start_methods():
+            pytest.skip("fork start method not available on this platform")
+        self._macos_arm(monkeypatch, accelerate=False)
+        ctx = ps._initialize_multiprocessing_context(None)
+        assert ctx.get_start_method() == "fork"
+
+    def test_explicit_fork_is_still_honoured(self, monkeypatch):
+        if "fork" not in multiprocessing.get_all_start_methods():
+            pytest.skip("fork start method not available on this platform")
+        self._macos_arm(monkeypatch, accelerate=True)
+        ctx = ps._initialize_multiprocessing_context("fork")
+        assert ctx.get_start_method() == "fork"
+
+    @pytest.mark.parametrize(
+        ("blas_name", "expected"),
+        [("accelerate", True), ("Accelerate", True), ("openblas", False), (None, False)],
+    )
+    def test_detects_accelerate_from_numpy_config(self, monkeypatch, blas_name, expected):
+        blas = {} if blas_name is None else {"name": blas_name}
+        config = {"Build Dependencies": {"blas": blas}}
+        monkeypatch.setattr(np.__config__, "CONFIG", config, raising=False)
+        assert ps._numpy_uses_accelerate() is expected
+
+    def test_detection_survives_a_missing_config(self, monkeypatch):
+        monkeypatch.delattr(np.__config__, "CONFIG", raising=False)
+        assert ps._numpy_uses_accelerate() is False
+
+
 class TestMpCtxJaxSwitch:
     def test_switches_default_away_from_fork_under_jax(self):
         if ps._initialize_multiprocessing_context(None).get_start_method() != "fork":


### PR DESCRIPTION
Closes #8372.

`_initialize_multiprocessing_context` forces `mp_ctx = "fork"` on macOS ARM. Apple Accelerate's worker threads do not survive `fork()`, so once a model is large enough to reach Accelerate's threaded BLAS path every chain worker dies and `pm.sample` fails with `EOFError`.

@ricardoV94 pointed at the branch in the issue, so this changes only that branch: when NumPy is linked against Accelerate, pick `forkserver` — or `spawn` where `forkserver` is not available — instead of `fork`. That is the same escape the function already makes a few lines below for JAX, which is not fork-safe either.

When NumPy is not Accelerate-backed the default stays `fork`, so gh-3849 is unaffected, and an explicit `mp_ctx="fork"` is still honoured.

Detection reads NumPy's own build metadata:

```python
np.__config__.CONFIG["Build Dependencies"]["blas"]["name"] == "accelerate"
```

and returns `False` on any `AttributeError`/`KeyError`/`TypeError`, so an older or unusual NumPy simply keeps the current behaviour rather than raising.

## Tests

`TestMpCtxAccelerateSwitch` in `tests/sampling/test_parallel.py`, following the existing `TestMpCtxJaxSwitch` above it. The platform and the detector are monkeypatched, so the behaviour is exercised on every CI platform rather than only on macOS runners:

- Accelerate on macOS ARM does not choose `fork`
- without Accelerate the `fork` default is kept
- an explicit `mp_ctx="fork"` is still honoured
- the detector maps `accelerate` / `Accelerate` / `openblas` / a missing name correctly, and survives a missing `np.__config__.CONFIG`

Verified red before green rather than only green: with the helper present but the branch left as `mp_ctx = "fork"`, `test_avoids_fork_when_numpy_uses_accelerate` fails with `assert 'fork' != 'fork'` and the other seven still pass. With the fix, 12 passed / 1 skipped across `-k "MpCtx"`.

Run on macOS ARM with NumPy 2.4.6, where `_numpy_uses_accelerate()` returns `True` on this machine. I have not reproduced the original segfault itself — that needs the 500k-row model from the issue — so the evidence here is the start method actually selected, not a before/after crash.
