### PR TITLE
Infer variable shapes when plotting instead of running them

### DIFF
--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -21,12 +21,12 @@ from os import path
 from typing import Any, cast
 
 from pytensor import function
+from pytensor.compile.mode import Mode
 from pytensor.graph.basic import Variable
 from pytensor.graph.traversal import ancestors, walk
 from pytensor.tensor.shape import Shape
 
 from pymc.model.core import modelcontext
-from pymc.pytensorf import _cheap_eval_mode
 from pymc.util import get_default_varnames, get_var_name
 
 __all__ = (
@@ -73,8 +73,15 @@ def create_plate_label_with_dim_length(
     )
 
 
+# Shape rewrites are needed here: without them, evaluating a random variable's
+# shape runs the variable itself, which fails for a CustomDist that was given no
+# `random` callable. With them the shape is inferred from the parameters and the
+# variable is never drawn from.
+_shape_eval_mode = Mode(linker="py", optimizer="fast_compile")
+
+
 def fast_eval(var):
-    return function([], var, mode=_cheap_eval_mode)()
+    return function([], var, mode=_shape_eval_mode)()
 
 
 class NodeType(str, Enum):

--- a/tests/test_model_graph.py
+++ b/tests/test_model_graph.py
@@ -643,6 +643,39 @@ def test_shape_without_dims() -> None:
     assert graph.edges() == []
 
 
+def test_custom_dist_without_random() -> None:
+    """A CustomDist with no `random` callable can still be plotted.
+
+    Getting the plates evaluates each variable's shape. Without shape rewrites
+    that runs the variable itself, which raises NotImplementedError here.
+    See https://github.com/pymc-devs/pymc/issues/8077.
+    """
+
+    def my_logp(value, mu, sigma):
+        return -0.5 * pt.log(2 * pt.pi * sigma**2) - 0.5 * ((value - mu) / sigma) ** 2
+
+    with pm.Model() as model:
+        mu = pm.Normal("mu", 0, 1)
+        sigma = pm.Exponential("sigma", 1)
+        pm.CustomDist("y", mu, sigma, logp=my_logp, shape=3)
+
+    graph = ModelGraph(model)
+
+    assert graph.get_plates() == [
+        Plate(
+            dim_info=DimInfo(names=(), lengths=()),
+            variables=[
+                NodeInfo(var=model["mu"], node_type=NodeType.FREE_RV),
+                NodeInfo(var=model["sigma"], node_type=NodeType.FREE_RV),
+            ],
+        ),
+        Plate(
+            dim_info=DimInfo(names=(None,), lengths=(3,)),
+            variables=[NodeInfo(var=model["y"], node_type=NodeType.FREE_RV)],
+        ),
+    ]
+
+
 def test_scalars_dim_info() -> None:
     with pm.Model() as model:
         pm.Normal("x")

--- a/tests/test_model_graph.py
+++ b/tests/test_model_graph.py
@@ -676,6 +676,30 @@ def test_custom_dist_without_random() -> None:
     ]
 
 
+def test_flat_variable() -> None:
+    """A model containing a Flat variable can be plotted.
+
+    Flat cannot be sampled from, so evaluating its shape by running it fails.
+    See https://github.com/pymc-devs/pymc/issues/8024.
+    """
+    with pm.Model() as model:
+        pm.Flat("intercept")
+        pm.Normal("y", mu=model["intercept"], sigma=1.0, shape=7)
+
+    graph = ModelGraph(model)
+
+    assert graph.get_plates() == [
+        Plate(
+            dim_info=DimInfo(names=(), lengths=()),
+            variables=[NodeInfo(var=model["intercept"], node_type=NodeType.FREE_RV)],
+        ),
+        Plate(
+            dim_info=DimInfo(names=(None,), lengths=(7,)),
+            variables=[NodeInfo(var=model["y"], node_type=NodeType.FREE_RV)],
+        ),
+    ]
+
+
 def test_scalars_dim_info() -> None:
     with pm.Model() as model:
         pm.Normal("x")


### PR DESCRIPTION
Closes #8077.

`ModelGraph.get_plates` gets every variable's shape through `fast_eval`, which compiled with `_cheap_eval_mode = Mode(linker="py", optimizer=None)`. With no rewrites, evaluating `rv.shape` computes the variable first and takes the shape of the result — so a `CustomDist` constructed without a `random` callable raises

```
NotImplementedError: Attempted to run random on the CustomDist 'CustomDist_y', but this method
had not been provided when the distribution was constructed.
```

and `model.to_graphviz()` fails on a model that is otherwise perfectly usable. Nothing here wants a draw; it only wants the shape.

Compiling that one evaluation with `fast_compile` lets the shape rewrites infer the shape from the parameters, and the variable is never run.

## It is not slower

That was the obvious objection, given the `# TODO: Evaluate all RV shapes at once ... avoids unnecessary function compiles` note just above the call site. Measured on a 200 000 element normal, mean of three evaluations:

| mode | time per evaluation |
|---|---|
| `optimizer=None` (before) | 0.002 s |
| `fast_compile` (after) | 0.001 s |

It comes out slightly ahead, because the old path was drawing a 200 000 element sample purely to discard everything but its shape.

## Tests

`test_custom_dist_without_random` in `tests/test_model_graph.py`, asserting the plates for the model from the issue.

Verified red before green: with the fix reverted the new test fails with exactly the `NotImplementedError` above; with it, the whole file passes, 41 tests.

## Scope

`fast_eval` is local to `model_graph.py` and has only these two call sites, so nothing else changes behaviour. `_cheap_eval_mode` itself is untouched — `pymc/printing.py` still uses it, and I have not checked whether it has the same problem there. Happy to look if you want that in the same PR.
