### PR TITLE
Fix ADVI / pm.fit() progress bar rendering in Marimo notebooks (close…

### DIFF
--- a/pymc/progress_bar/marimo_progress.py
+++ b/pymc/progress_bar/marimo_progress.py
@@ -354,7 +354,7 @@ class MarimoSimpleProgress:
             self.loss = kwargs["loss"]
             refresh = True
         if refresh:
-            self._render()
+            self._render(force=True)
 
     def _render(self, force: bool = False) -> None:
         """Render HTML progress to marimo output."""

--- a/pymc/progress_bar/marimo_progress.py
+++ b/pymc/progress_bar/marimo_progress.py
@@ -275,6 +275,7 @@ class MarimoSimpleProgress:
         self.description = ""
         self.total = 0
         self.completed = 0
+        self.loss: str | None = None
         self._css_theme = DEFAULT_CSS if theme is None else theme
 
         self._mo_replace: Callable[[object], None] | None = None
@@ -302,13 +303,14 @@ class MarimoSimpleProgress:
     ) -> int:
         """Add a task (interface compatibility with CustomProgress).
 
-        Kwargs are ignored since MarimoSimpleProgress
-        only supports a single task initialized at construction.
+        Kwargs like loss are stored when provided.
         """
         self.description = description
         self.completed = completed
         if total is not None:
             self.total = total
+        if "loss" in kwargs:
+            self.loss = kwargs["loss"]
         self._render()
         return self._task_id
 
@@ -343,10 +345,13 @@ class MarimoSimpleProgress:
         completed : int, optional
             Set completed count
         **kwargs
-            Additional arguments ignored for compatibility
+            Additional arguments stored when provided (e.g. loss)
         """
         if completed is not None:
             self.completed = completed
+        if "loss" in kwargs:
+            self.loss = kwargs["loss"]
+            refresh = True
         if refresh:
             self._render()
 
@@ -391,12 +396,16 @@ class MarimoSimpleProgress:
         if pct >= 100:
             bar_class += " finished"
 
+        loss_header = "<th>Loss</th>" if self.loss is not None else ""
+        loss_cell = f"<td>{self.loss}</td>" if self.loss is not None else ""
+
         return f"""<style>{self._css_theme}</style>
 <table class="pymc-progress-table">
-<thead><tr><th>Progress</th><th>Samples</th><th>Speed</th><th>Elapsed</th><th>Remaining</th></tr></thead>
+<thead><tr><th>Progress</th><th>Samples</th>{loss_header}<th>Speed</th><th>Elapsed</th><th>Remaining</th></tr></thead>
 <tbody><tr>
 <td><div class="pymc-progress-bar-container"><div class="{bar_class}" style="width: {pct:.1f}%"></div></div></td>
 <td>{self.completed}/{self.total} ({pct:.0f}%)</td>
+{loss_cell}
 <td>{speed_str}</td>
 <td>{elapsed_str}</td>
 <td>{remaining_str}</td>

--- a/pymc/progress_bar/marimo_progress.py
+++ b/pymc/progress_bar/marimo_progress.py
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 from collections.abc import Callable
+from html import escape
 from time import perf_counter
 from typing import Any, Self
 
@@ -397,7 +398,7 @@ class MarimoSimpleProgress:
             bar_class += " finished"
 
         loss_header = "<th>Loss</th>" if self.loss is not None else ""
-        loss_cell = f"<td>{self.loss}</td>" if self.loss is not None else ""
+        loss_cell = f"<td>{escape(str(self.loss))}</td>" if self.loss is not None else ""
 
         return f"""<style>{self._css_theme}</style>
 <table class="pymc-progress-table">

--- a/pymc/variational/inference.py
+++ b/pymc/variational/inference.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from rich.console import Console
 from rich.progress import Progress, TextColumn, track
+from rich.theme import Theme
 
 import pymc as pm
 
@@ -253,7 +254,9 @@ class Inference:
             progress = CustomProgress(
                 *Progress.get_default_columns(),
                 TextColumn("{task.fields[loss]}"),
-                console=Console(theme=progressbar_theme),
+                console=Console(
+                    theme=progressbar_theme if isinstance(progressbar_theme, Theme) else None
+                ),
             )
         try:
             with progress:

--- a/pymc/variational/inference.py
+++ b/pymc/variational/inference.py
@@ -23,7 +23,10 @@ from rich.progress import Progress, TextColumn, track
 
 import pymc as pm
 
-from pymc.progress_bar import CustomProgress, default_progress_theme
+from pymc.progress_bar import create_simple_progress, default_progress_theme
+from pymc.progress_bar.marimo_progress import MarimoSimpleProgress, in_marimo_notebook
+from pymc.progress_bar.progress import NullSimpleProgress
+from pymc.progress_bar.rich_progress import CustomProgress
 from pymc.pytensorf import resolve_backend_compile_kwargs
 from pymc.variational import test_functions
 from pymc.variational.approximations import Empirical, FullRank, MeanField
@@ -188,14 +191,15 @@ class Inference:
 
     def _iterate_without_loss(self, s, n, step_func, progressbar, progressbar_theme, callbacks):
         i = 0
+        progress = create_simple_progress(
+            progressbar=progressbar, progressbar_theme=progressbar_theme
+        )
         try:
-            with CustomProgress(
-                console=Console(theme=progressbar_theme), disable=not progressbar
-            ) as progress:
-                task = progress.add_task("Fitting", total=n)
+            with progress:
+                task = progress.add_task("Fitting", completed=0, total=n)
                 for i in range(n):
                     step_func()
-                    progress.update(task, advance=1)
+                    progress.advance(task, advance=1)
                     current_param = self.approx.params[0].get_value()
                     if np.isnan(current_param).any():
                         name_slc = []
@@ -239,17 +243,24 @@ class Inference:
         scores = np.empty(n)
         scores[:] = np.nan
         i = 0
-        try:
-            with CustomProgress(
+        if not progressbar:
+            progress = NullSimpleProgress()
+        elif in_marimo_notebook():
+            progress = MarimoSimpleProgress(
+                theme=progressbar_theme if isinstance(progressbar_theme, str) else None
+            )
+        else:
+            progress = CustomProgress(
                 *Progress.get_default_columns(),
                 TextColumn("{task.fields[loss]}"),
                 console=Console(theme=progressbar_theme),
-                disable=not progressbar,
-            ) as progress:
+            )
+        try:
+            with progress:
                 task = progress.add_task("Fitting:", total=n, loss="")
                 for i in range(n):
                     e = step_func()
-                    progress.update(task, advance=1)
+                    progress.advance(task, advance=1)
                     if np.isnan(e):
                         scores = scores[:i]
                         self.hist = np.concatenate([self.hist, scores])
@@ -279,8 +290,6 @@ class Inference:
                     scores[i] = e
                     if i % 10 == 0:
                         avg_loss = _infmean(scores[max(0, i - 1000) : i + 1])
-                        progress.update(task, loss=f"Average Loss = {avg_loss:,.5g}")
-                        avg_loss = scores[max(0, i - 1000) : i + 1].mean()
                         progress.update(task, loss=f"Average Loss = {avg_loss:,.5g}")
                     for callback in callbacks:
                         callback(self.approx, scores[: i + 1], i + s + 1)

--- a/tests/progress_bar/test_marimo.py
+++ b/tests/progress_bar/test_marimo.py
@@ -20,8 +20,12 @@ import pytest
 
 import pymc as pm
 
-from pymc.progress_bar import MCMCProgressBarManager, NutpieProgressBarManager
-from pymc.progress_bar.marimo_progress import MarimoProgressBackend
+from pymc.progress_bar import (
+    MCMCProgressBarManager,
+    NutpieProgressBarManager,
+    create_simple_progress,
+)
+from pymc.progress_bar.marimo_progress import MarimoProgressBackend, MarimoSimpleProgress
 
 
 class TestMarimoProgressBackend:
@@ -198,3 +202,33 @@ class TestMarimoProgressBackend:
         # Chain 0's row must be identical — elapsed and speed frozen
         html_after = backend._render_task_row(0, backend._task_state[0], [])
         assert html_at_finish == html_after
+
+
+class TestMarimoSimpleProgress:
+    @pytest.fixture(autouse=True)
+    def require_marimo(self):
+        pytest.importorskip("marimo")
+
+    def test_marimo_simple_progress_init_and_render(self):
+        with patch("pymc.progress_bar.progress.in_marimo_notebook", return_value=True):
+            progress = create_simple_progress(progressbar=True)
+            assert isinstance(progress, MarimoSimpleProgress)
+
+            progress.add_task("Fitting", completed=0, total=100, loss="Average Loss = 1.234")
+            html = progress._render_html()
+            assert "<th>Loss</th>" in html
+            assert "<td>Average Loss = 1.234</td>" in html
+
+            progress.update(task_id=0, loss="Average Loss = 0.567")
+            html_updated = progress._render_html()
+            assert "<td>Average Loss = 0.567</td>" in html_updated
+
+    def test_marimo_advi_fit_integration(self):
+        with (
+            patch("pymc.variational.inference.in_marimo_notebook", return_value=True),
+            patch("marimo.output.replace") as mock_replace,
+        ):
+            with pm.Model():
+                pm.Normal("x", 0, 1)
+                pm.fit(n=10, method="advi", progressbar=True)
+            assert mock_replace.called

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -695,13 +695,19 @@ def test_fit_with_loss_uses_marimo_progress_in_marimo():
 
     with (
         patch("pymc.variational.inference.in_marimo_notebook", return_value=True),
-        patch.object(MarimoSimpleProgress, "__enter__", return_value=None),
+        patch.object(MarimoSimpleProgress, "__enter__", return_value=None) as mock_enter,
         patch.object(MarimoSimpleProgress, "__exit__", return_value=None),
-        patch.object(MarimoSimpleProgress, "add_task", return_value=0),
-        patch.object(MarimoSimpleProgress, "advance"),
-        patch.object(MarimoSimpleProgress, "update"),
+        patch.object(MarimoSimpleProgress, "add_task", return_value=0) as mock_add_task,
+        patch.object(MarimoSimpleProgress, "advance") as mock_advance,
+        patch.object(MarimoSimpleProgress, "update") as mock_update,
     ):
         with pm.Model():
             pm.Normal("x", 0, 1)
             # score=True → _iterate_with_loss → should pick MarimoSimpleProgress
             pm.fit(n=10, score=True, progressbar=True)
+
+        # Prove the Marimo branch was actually taken, not silently skipped.
+        mock_enter.assert_called_once()
+        mock_add_task.assert_called_once()
+        assert mock_advance.call_count == 10
+        mock_update.assert_called_once()

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -671,3 +671,37 @@ class TestUntransformedData:
         # Unconstrained: p_simplex__ (shape 2, K-1 dims)
         assert "p_simplex__" in s.mean
         assert s.mean["p_simplex__"].values.shape == (2,)
+
+
+@pytest.mark.parametrize("score", [False])
+def test_fit_uses_create_simple_progress(score):
+    from unittest.mock import patch
+
+    with patch("pymc.variational.inference.create_simple_progress") as mock_csp:
+        with pm.Model():
+            pm.Normal("x", 0, 1)
+            pm.fit(n=10, score=score, progressbar=True)
+        assert mock_csp.called
+        mock_csp.assert_called_once_with(
+            progressbar=True, progressbar_theme=pm.progress_bar.default_progress_theme
+        )
+
+
+def test_fit_with_loss_uses_marimo_progress_in_marimo():
+    """_iterate_with_loss branches to MarimoSimpleProgress when inside Marimo."""
+    from unittest.mock import patch
+
+    from pymc.progress_bar.marimo_progress import MarimoSimpleProgress
+
+    with (
+        patch("pymc.variational.inference.in_marimo_notebook", return_value=True),
+        patch.object(MarimoSimpleProgress, "__enter__", return_value=None),
+        patch.object(MarimoSimpleProgress, "__exit__", return_value=None),
+        patch.object(MarimoSimpleProgress, "add_task", return_value=0),
+        patch.object(MarimoSimpleProgress, "advance"),
+        patch.object(MarimoSimpleProgress, "update"),
+    ):
+        with pm.Model():
+            pm.Normal("x", 0, 1)
+            # score=True → _iterate_with_loss → should pick MarimoSimpleProgress
+            pm.fit(n=10, score=True, progressbar=True)


### PR DESCRIPTION
…s #8405)

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

When running `pm.fit()` (e.g., ADVI) inside a Marimo notebook, the progress bar did not render live updates during fitting—it only appeared after the cell finished running.
While #8055 introduced `MarimoSimpleProgress` for `pm.sample()`, the variational inference routines in `pymc/variational/inference.py` (`_iterate_with_loss` and `_iterate_without_loss`) still used `CustomProgress` directly (which is terminal-only and flushes only at completion in Marimo).

**Summary of changes:**
- Updated `_iterate_without_loss` to use the `create_simple_progress()` factory.
- Updated `_iterate_with_loss` to route to `MarimoSimpleProgress` inside Marimo notebooks, while preserving `CustomProgress` with `TextColumn("{task.fields[loss]}")` for terminal runs so terminal loss display does not regress.
- Removed a redundant duplicate `.mean()` call in `_iterate_with_loss` that caused NaN issues early in training.
- Added tests in `tests/progress_bar/test_marimo.py` and `tests/variational/test_inference.py`.

<img width="1173" height="569" alt="Screenshot 2026-08-30 at 4 40 51 PM" src="https://github.com/user-attachments/assets/02fdc785-16ab-4b48-ad11-0c367746cd2e" />


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #8405
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
