### PR TITLE
Fix broken canonical URLs in docs and add meta descriptions

### DIFF
--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -36,6 +36,7 @@ dependencies:
 - sphinx-notfound-page
 - sphinx>=1.5
 - sphinxext-rediraffe
+- sphinxext-opengraph
 - watermark
 - sphinx-remove-toctrees
 - mypy=1.19.1

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -33,6 +33,7 @@ dependencies:
 - sphinx-sitemap
 - sphinx>=5
 - sphinxext-rediraffe
+- sphinxext-opengraph
 - watermark
 - sphinx-remove-toctrees
 - pip:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "jupyter_sphinx",
     "sphinxext.rediraffe",
     "sphinx_sitemap",
+    "sphinxext.opengraph",
 ]
 
 # Don't auto-generate summary for class members.
@@ -341,8 +342,18 @@ def setup(app):
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = "pymc_sphinx_theme"
-html_baseurl = "https://www.pymc.io/projects/docs/"
-sitemap_url_scheme = f"{{lang}}{rtd_version}/{{link}}"
+# The canonical URL of every page points at the stable build, no matter which
+# version is being built: old and development versions of a page then transfer
+# their search ranking to the stable one instead of competing with it.
+html_baseurl = "https://www.pymc.io/projects/docs/en/stable/"
+sitemap_url_scheme = "{link}"
+
+# Open Graph tags plus a <meta name="description"> generated from page content
+# (search engines use it as the result snippet).
+ogp_site_url = "https://www.pymc.io/projects/docs/en/stable/"
+ogp_image = "https://www.pymc.io/_static/PyMC.jpg"
+ogp_use_first_image = True
+ogp_enable_meta_description = True
 
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,6 +27,7 @@ sphinx-design
 sphinx-notfound-page
 sphinx-remove-toctrees
 sphinx>=1.5
+sphinxext-opengraph
 sphinxext-rediraffe
 threadpoolctl>=3.1.0
 types-cachetools


### PR DESCRIPTION
## Bug

Every docs page currently ships a broken canonical tag. `html_baseurl` is set to `https://www.pymc.io/projects/docs/`, and Sphinx builds the canonical as `html_baseurl + pagename`, so e.g. the stable overview page declares

```
<link rel="canonical" href="https://www.pymc.io/projects/docs/learn/core_notebooks/pymc_overview.html">
```

— note the missing `/en/stable/`. That URL redirects to a 404. Consequences visible in Google Search Console (16-month export): ~5.3k 404s, "Duplicate, Google chose different canonical than user", and old versioned builds (660k impressions) competing with stable because nothing consolidates them.

## Fix

- `html_baseurl` now points at `https://www.pymc.io/projects/docs/en/stable/`, so every version's pages declare the stable page as canonical — the standard Read the Docs setup for ranking consolidation. Sitemap URLs are unchanged: the version prefix moves from `sitemap_url_scheme` into the base URL (verified against the live sitemap format).
- Add **sphinxext-opengraph**: docs pages currently have no `<meta name="description">` at all, so search engines pick arbitrary text as the snippet — `pymc_overview.html` alone had 550k impressions at 1.1% CTR. The extension generates a description from page content and adds Open Graph tags for link previews (same setup pymc.io and pymc-examples use). Added to both conda envs; `requirements-dev.txt` regenerated with the script.

One known trade-off: a page that exists only in `latest`/`dev` but not yet in `stable` will declare a canonical that 404s until the next release. That's the usual cost of stable-canonicals and far smaller than the current situation where *every* page's canonical is broken.

Companion PR on the website side: pymc-devs/pymc.io#124

🤖 Generated with [Claude Code](https://claude.com/claude-code)