### PR TITLE
Include alpha in the Wald support point and mean

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -1047,10 +1047,10 @@ class Wald(PositiveContinuous):
         return super().dist([mu, lam, alpha], **kwargs)
 
     def support_point(rv, size, mu, lam, alpha):
-        mu, _, _ = pt.broadcast_arrays(mu, lam, alpha)
+        mean, _ = pt.broadcast_arrays(mu + alpha, lam)
         if not rv_size_is_none(size):
-            mu = pt.full(size, mu)
-        return mu
+            mean = pt.full(size, mean)
+        return mean
 
     @staticmethod
     def get_mu_lam_phi(mu, lam, phi):

--- a/pymc/distributions/moments/means.py
+++ b/pymc/distributions/moments/means.py
@@ -442,7 +442,7 @@ def vonmisses_mean(op, rv, rng, size, mu, kappa):
 
 @_mean.register(WaldRV)
 def wald_mean(op, rv, rng, size, mu, lam, alpha):
-    return maybe_resize(pt.broadcast_arrays(mu, lam, alpha)[0], size)
+    return maybe_resize(pt.broadcast_arrays(mu + alpha, lam)[0], size)
 
 
 @_mean.register(WeibullBetaRV)

--- a/tests/distributions/moments/test_means.py
+++ b/tests/distributions/moments/test_means.py
@@ -188,6 +188,7 @@ from pymc.exceptions import UndefinedMomentException
         [Uniform, uniform, {"lower": -3, "upper": 2}, {"loc": -3, "scale": 5}],
         [VonMises, vonmises, {"mu": 2, "kappa": 2}, {"loc": 2, "kappa": 2}],
         [Wald, invgauss, {"mu": 2, "lam": 1}, {"mu": 2, "scale": 1}],
+        [Wald, invgauss, {"mu": 2, "lam": 1, "alpha": 3}, {"mu": 2, "scale": 1, "loc": 3}],
         [Weibull, weibull_min, {"alpha": 2, "beta": 2}, {"c": 2, "scale": 2}],
     ],
 )

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -1498,6 +1498,20 @@ class TestMoments:
         assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
+        "mu, lam, alpha, size, expected",
+        [
+            (2, 1, 3, None, 5),
+            (1, 1, np.arange(3), (2, 3), np.full((2, 3), 1 + np.arange(3))),
+        ],
+    )
+    def test_wald_support_point_with_alpha(self, mu, lam, alpha, size, expected):
+        # `alpha` shifts the support, so the support point has to shift with it,
+        # otherwise it can land outside the distribution's own support.
+        with pm.Model() as model:
+            pm.Wald("x", mu=mu, lam=lam, alpha=alpha, size=size)
+        assert_support_point_is_expected(model, expected)
+
+    @pytest.mark.parametrize(
         "alpha, beta, size, expected",
         [
             (1, 1, None, 1),


### PR DESCRIPTION
`Wald` is shifted by `alpha` — `rng_fn` returns `rng.wald(mu, lam) + alpha`, and `logp` computes `value - alpha` and returns `-inf` when that is `<= 0`. Its support is `(alpha, inf)` and its mean is `mu + alpha`.

Both moment implementations broadcast `alpha` for shape and then return `mu`, dropping the shift:

```python
def support_point(rv, size, mu, lam, alpha):
    mu, _, _ = pt.broadcast_arrays(mu, lam, alpha)
    ...
    return mu

def wald_mean(op, rv, rng, size, mu, lam, alpha):
    return maybe_resize(pt.broadcast_arrays(mu, lam, alpha)[0], size)
```

For a latent variable that places the starting value outside the distribution's own support whenever `mu <= alpha`:

```python
with pm.Model() as m:
    x = pm.Wald("x", mu=2, lam=1, alpha=3)
m.check_start_vals(m.initial_point())
```

```
before   initial_point x_log__ = 0.693147   ->  SamplingError: Initial evaluation ... failed!
after    initial_point x_log__ = 1.609438   ->  check_start_vals: OK
```

and the mean is short by `alpha`:

```
before   mean(Wald(mu=2, lam=1, alpha=3)) = 2.0
after    mean(Wald(mu=2, lam=1, alpha=3)) = 5.0
         empirical mean over 200k draws   = 4.997
```

Scope:

- With the default `alpha=0` nothing changes. I compared the support point and the mean before and after for the default, an explicit `alpha=0`, a vector `mu`, and the `phi` parametrisation — all bit-identical.
- Only the `alpha != 0` path moves, and there the current behaviour is a hard crash for a latent variable and a provably wrong mean, rather than a different-but-defensible value.
- Observed/likelihood `Wald` is unaffected, since `support_point` is not consulted there.

Added two `support_point` cases (scalar and a vector `alpha` with `size`) and a `test_mean_equal_to_scipy` row against `invgauss(mu=2, scale=1, loc=3)`. All three fail on `main` and pass here. `tests/distributions/test_continuous.py` and `tests/distributions/moments/test_means.py` together are 345 passed, 6 skipped, 1 xfailed.

One adjacent thing I did not touch: `Wald` is a `PositiveContinuous`, so its default transform maps to `(0, inf)` rather than `(alpha, inf)` — `Pareto` handles the analogous case via `BoundedContinuous` with `bound_args_indices`. Changing that would rename the transformed variable for all Wald users including the `alpha=0` default, so it seems worth treating separately. This fix stands on its own: it turns a guaranteed crash into a valid starting point.
