### PR TITLE
Fix hang in DEMetropolis due to progressbar

### DIFF
--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -24,8 +24,6 @@ from typing import TypeAlias
 import cloudpickle
 import numpy as np
 
-from rich.progress import BarColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn
-
 from pymc.backends import _ZarrChainBase
 from pymc.backends.base import BaseTrace
 from pymc.initial_point import PointType
@@ -105,13 +103,14 @@ def _sample_population(
         tune=tune,
         model=model,
         rngs=rngs,
-        progressbar=progressbar,
     )
 
+    # Start the display only after workers have been created, so forked workers
+    # cannot inherit Rich's refresh-thread locks or redirected output streams.
     with CustomProgress(disable=not progressbar) as progress:
         task = progress.add_task("[red]Sampling...", total=draws)
         for _ in sampling:
-            progress.update(task)
+            progress.update(task, advance=1)
 
     return
 
@@ -151,7 +150,7 @@ def warn_population_size(
 class PopulationStepper:
     """Wraps population of step methods to step them in parallel with single or multiprocessing."""
 
-    def __init__(self, steppers, parallelize: bool, progressbar: bool = True):
+    def __init__(self, steppers, parallelize: bool):
         """Use multiprocessing to parallelize chains.
 
         Falls back to sequential evaluation if multiprocessing fails.
@@ -165,15 +164,12 @@ class PopulationStepper:
             A collection of independent step methods, one for each chain.
         parallelize : bool
             Indicates if parallelization via multiprocessing is desired.
-        progressbar : bool
-            Should we display a progress bar showing relative progress?
         """
         self.nchains = len(steppers)
         self.is_parallelized = False
         self._primary_ends = []
         self._processes = []
         self._steppers = steppers
-        self._progress = None
         if parallelize:
             try:
                 # configure a child process for each stepper
@@ -182,35 +178,23 @@ class PopulationStepper:
                 )
                 import multiprocessing
 
-                with CustomProgress(
-                    "[progress.description]{task.description}",
-                    BarColumn(),
-                    "[progress.percentage]{task.percentage:>3.0f}%",
-                    TimeRemainingColumn(),
-                    TextColumn("/"),
-                    TimeElapsedColumn(),
-                    disable=not progressbar,
-                ) as self._progress:
-                    for c, stepper in enumerate(steppers):
-                        #     enumerate(progress_bar(steppers)) if progressbar else enumerate(steppers)
-                        # ):
-                        task = self._progress.add_task(description=f"Chain {c}")
-                        secondary_end, primary_end = multiprocessing.Pipe()
-                        stepper_dumps = cloudpickle.dumps(stepper, protocol=4)
-                        process = multiprocessing.Process(
-                            target=self.__class__._run_secondary,
-                            args=(c, stepper_dumps, secondary_end, task, self._progress),
-                            name=f"ChainWalker{c}",
-                        )
-                        # we want the child process to exit if the parent is terminated
-                        process.daemon = True
-                        # Starting the process might fail and takes time.
-                        # By doing it in the constructor, the sampling progress bar
-                        # will not be confused by the process start.
-                        process.start()
-                        self._primary_ends.append(primary_end)
-                        self._processes.append(process)
-                    self.is_parallelized = True
+                for c, stepper in enumerate(steppers):
+                    secondary_end, primary_end = multiprocessing.Pipe()
+                    stepper_dumps = cloudpickle.dumps(stepper, protocol=4)
+                    process = multiprocessing.Process(
+                        target=self.__class__._run_secondary,
+                        args=(c, stepper_dumps, secondary_end),
+                        name=f"ChainWalker{c}",
+                    )
+                    # we want the child process to exit if the parent is terminated
+                    process.daemon = True
+                    # Starting the process might fail and takes time.
+                    # By doing it in the constructor, the sampling progress bar
+                    # will not be confused by the process start.
+                    process.start()
+                    self._primary_ends.append(primary_end)
+                    self._processes.append(process)
+                self.is_parallelized = True
             except Exception:
                 _log.info(
                     "Population parallelization failed. "
@@ -240,7 +224,7 @@ class PopulationStepper:
         return
 
     @staticmethod
-    def _run_secondary(c, stepper_dumps, secondary_end, task, progress):
+    def _run_secondary(c, stepper_dumps, secondary_end):
         """Perform stepping of a chain from a separate process.
 
         Parameters
@@ -251,10 +235,6 @@ class PopulationStepper:
             a step method such as CompoundStep
         secondary_end : multiprocessing.connection.PipeConnection
             This is our connection to the main process
-        task : progress.Task
-            The progress task for this chain
-        progress : progress.Progress
-            The progress bar
         """
         try:
             stepper = cloudpickle.loads(stepper_dumps)
@@ -282,7 +262,6 @@ class PopulationStepper:
                 for popstep in population_steppers:
                     popstep.population = population
                 update = stepper.step(population[c])
-                progress.advance(task)
                 secondary_end.send(update)
         except Exception:
             _log.exception(f"ChainWalker{c}")
@@ -336,7 +315,6 @@ def _prepare_iter_population(
     tune: int,
     rngs: Sequence[np.random.Generator],
     model=None,
-    progressbar=True,
 ) -> Iterator[int]:
     """Prepare a PopulationStepper and traces for population sampling.
 
@@ -360,8 +338,6 @@ def _prepare_iter_population(
     rngs: sequence of random Generators
         A list of :py:class:`~numpy.random.Generator` objects, one for each chain
     model : Model (optional if in ``with`` context)
-    progressbar : bool
-        ``progressbar`` argument for the ``PopulationStepper``, (defaults to True)
 
     Returns
     -------
@@ -405,7 +381,7 @@ def _prepare_iter_population(
         steppers.append(chainstep)
 
     # 3. configure the PopulationStepper (expensive call)
-    popstep = PopulationStepper(steppers, parallelize, progressbar=progressbar)
+    popstep = PopulationStepper(steppers, parallelize)
 
     # Because the preparations above are expensive, the actual iterator is
     # in another method. This way the progbar will not be disturbed.


### PR DESCRIPTION
Start workers before activating the parent-only progress display to prevent them from inheriting Rich locks that can deadlock when emitting warnings.

Reported in https://discourse.pymc.io/t/demetropolis-stalls-with-progressbar-true/17925