### PR TITLE
Add Pareto to pymc.dims

### DIFF
--- a/pymc/dims/distributions/scalar.py
+++ b/pymc/dims/distributions/scalar.py
@@ -303,7 +303,7 @@ class Weibull(PositiveDimDistribution):
 
 @copy_docstring(regular_dists.Pareto)
 class Pareto(PositiveDimDistribution):
-    def __new__(cls, name, alpha, m=1.0, *, default_transform=UNSET, observed=None, **kwargs):
+    def __new__(cls, name, alpha, m, default_transform=UNSET, observed=None, **kwargs):
         if observed is None and default_transform is UNSET:
             default_transform = IntervalTransform(m, float("inf"))
         return super().__new__(

--- a/pymc/dims/distributions/scalar.py
+++ b/pymc/dims/distributions/scalar.py
@@ -301,6 +301,28 @@ class Weibull(PositiveDimDistribution):
         return xop(alpha, beta, core_dims=core_dims, extra_dims=extra_dims, rng=rng, **kwargs)
 
 
+@copy_docstring(regular_dists.Pareto)
+class Pareto(PositiveDimDistribution):
+    def __new__(cls, name, alpha, m=1.0, *, default_transform=UNSET, observed=None, **kwargs):
+        if observed is None and default_transform is UNSET:
+            default_transform = IntervalTransform(m, float("inf"))
+        return super().__new__(
+            cls,
+            name,
+            alpha,
+            m,
+            default_transform=default_transform,
+            observed=observed,
+            **kwargs,
+        )
+
+    xrv_op = ptxr.pareto
+
+    @classmethod
+    def dist(cls, alpha, m, **kwargs):
+        return super().dist([alpha, m], **kwargs)
+
+
 @copy_docstring(regular_dists.Poisson)
 class Poisson(DimDistribution):
     xrv_op = ptxr.poisson

--- a/tests/dims/distributions/test_scalar.py
+++ b/tests/dims/distributions/test_scalar.py
@@ -34,6 +34,7 @@ from pymc.dims import (
     LogNormal,
     NegativeBinomial,
     Normal,
+    Pareto,
     Poisson,
     StudentT,
     TruncatedNormal,
@@ -311,6 +312,18 @@ def test_weibull():
 
     with Model(coords=coords) as reference_model:
         regular_distributions.Weibull("x", alpha=1, beta=2, dims="a")
+
+    assert_equivalent_random_graph(model, reference_model)
+    assert_equivalent_logp_graph(model, reference_model)
+
+
+def test_pareto():
+    coords = {"a": range(3)}
+    with Model(coords=coords) as model:
+        Pareto("x", alpha=2, m=5, dims="a")
+
+    with Model(coords=coords) as reference_model:
+        regular_distributions.Pareto("x", alpha=2, m=5, dims="a")
 
     assert_equivalent_random_graph(model, reference_model)
     assert_equivalent_logp_graph(model, reference_model)


### PR DESCRIPTION
`Pareto` is used as the default concentration hyperprior in several CLV models in `pymc-marketing` (e.g. `kappa_dropout` in BG/NBD), but is missing from `pymc.dims`. This wraps `pytensor.xtensor.random.pareto` following the existing pattern (`Exponential`, `Gamma`), with an `IntervalTransform(m, inf)` default transform via the `Uniform` `__new__` override so the transformed logp stays equivalent to the regular distribution.

`m` must be a constant for now (dims `IntervalTransform` limitation).
