### PR TITLE
Fix docstrings that name parameters the functions do not have

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -263,7 +263,7 @@ class _DefaultTrace:
             Name of the variable.
         v: anything that can go into a numpy array (including a numpy array)
             The value of the `idx`th sample from variable `k`
-        ids: int
+        idx: int
             The index of the sample we are inserting into the trace.
         """
         value_shape = np.shape(v)

--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -538,14 +538,14 @@ class MultiTrace:
         ----------
         stat_name : str
             Name of the stat to fetch.
-        sampler_idx : int or None
-            Index of the sampler to get the stat from.
         burn : int
             Draws to skip from the start.
         thin : int
             Stepsize for the slice.
         combine : bool
             If True, results from `chains` will be concatenated.
+        chains : int or Sequence[int], optional
+            Chains to fetch the stat from. Defaults to all chains in the trace.
         squeeze : bool
             Return a single array element if the resulting list of
             values only has one element. If False, the result will

--- a/pymc/initial_point.py
+++ b/pymc/initial_point.py
@@ -230,8 +230,8 @@ def make_initial_point_expression(
     ----------
     free_rvs : list
         Tensors of free random variables in the model.
-    rvs_to_values : dict
-        Mapping of free random variable tensors to value variable tensors.
+    rvs_to_transforms : dict
+        Mapping of free random variable tensors to their transforms.
     initval_strategies : dict
         Mapping of free random variable tensors to initial value strategies.
         For example the `Model.initial_values` dictionary.

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -231,8 +231,8 @@ class PopulationStepper:
         ----------
         c : int
             number of this chain
-        stepper : BlockedStep
-            a step method such as CompoundStep
+        stepper_dumps : bytes
+            a step method such as CompoundStep, pickled with cloudpickle
         secondary_end : multiprocessing.connection.PipeConnection
             This is our connection to the main process
         """

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -688,7 +688,7 @@ def check_icdf(
         are compared between pymc and scipy methods. If n_samples is below the
         total number of combinations, a random subset is evaluated. Setting
         n_samples = -1, will return all possible combinations. Defaults to 100
-    skip_paradomain_outside_edge_test : Bool
+    skip_paramdomain_outside_edge_test : Bool
         Whether to run test 2., which checks that pymc distribution icdf
         returns nan for invalid parameter values outside the supported domain edge
 

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -196,7 +196,7 @@ def get_default_varnames(var_iterator, include_transformed):
 
     Parameters
     ----------
-    varname_iterator: iterator
+    var_iterator: iterator
         Elements will be cast to string to check whether it is transformed, and optionally filtered
     include_transformed: boolean
         Should transformed variable names be included in return value


### PR DESCRIPTION
## Description

Six Parameters entries name an argument the function doesn't accept, so following the docstring and passing that keyword raises `TypeError`. Docs only — no code touched.

| location | documented | actual |
|---|---|---|
| `testing.check_icdf` | `skip_paradomain_outside_edge_test` | `skip_paramdomain_outside_edge_test` |
| `util.get_default_varnames` | `varname_iterator` | `var_iterator` |
| `backends.arviz.InferenceDataConverter.insert` | `ids` | `idx` |
| `initial_point.make_initial_point_expression` | `rvs_to_values` | `rvs_to_transforms` |
| `sampling.population._run_secondary` | `stepper` | `stepper_dumps` |
| `backends.base.get_sampler_stats` | `sampler_idx` | (no such argument; `chains` was undocumented) |

Three of them are more than a rename:

**`make_initial_point_expression`** documented `rvs_to_values` as "Mapping of free random variable tensors to value variable tensors". The argument is `rvs_to_transforms: dict[TensorVariable, Transform]`, so the description was describing a different mapping as well as using a different name. Corrected both.

**`_run_secondary`** documented `stepper : BlockedStep`. The argument is `stepper_dumps`, and the first thing the body does is

```python
stepper = cloudpickle.loads(stepper_dumps)
```

so it's the cloudpickled step method, not the step method. Changed the type accordingly.

**`get_sampler_stats`** documented `sampler_idx : int or None`, which isn't in the signature, while `chains` — which is — had no entry at all, even though the `combine` entry refers to it ("If True, results from `chains` will be concatenated"). Replaced the phantom entry with `chains` and moved it into signature order.

`skip_paradomain_outside_edge_test` is worth calling out as a plain typo: it's the only occurrence of "paradomain" in the repository, and `check_logcdf` documents the same argument correctly as `skip_paramdomain_outside_edge_test`.

---

One I found but deliberately left alone, since it's your call rather than a typo: `pymc.Data` documents

```
    export_index_as_coords : bool
        Deprecated, previous version of "infer_dims_and_coords"
```

but `export_index_as_coords` isn't in the signature any more, and it isn't pulled out of `**kwargs` either — `**kwargs` goes straight to `pytensor.shared(arr, name, **kwargs)`, so passing it now raises rather than warning. Whether that entry should be dropped or kept as a historical note seemed like a decision for you; happy to include it here if you'd like it removed. (`model` is also undocumented there.)

## Related Issue

- [ ] Closes #
- [ ] Related to #

## Checklist

- [x] Checked that the pre-commit linting/style checks pass — `ruff check` and `ruff format --check` clean on all six files (the one `RUF036` in `testing.py:285` is pre-existing and on an untouched line)
- [ ] Included tests that prove the fix is effective — not applicable, docstring text only
- [x] Added necessary documentation (docstrings and/or example notebooks)

## Type of change

- [x] Documentation
