### PR TITLE
fix(sampling): preserve sample_dims coords when computing deterministics on thinned dataset

### DIFF
--- a/pymc/sampling/deterministic.py
+++ b/pymc/sampling/deterministic.py
@@ -173,9 +173,7 @@ def compute_deterministics(
 
     # Preserve thinned sample_dims coordinates from dataset to prevent NaN fill on coordinate mismatch (#8424)
     sample_coords = {
-        dim: group_dataset.coords[dim].values
-        for dim in sample_dims
-        if dim in group_dataset.coords
+        dim: group_dataset.coords[dim].values for dim in sample_dims if dim in group_dataset.coords
     }
     coords = {**coords, **sample_coords}
 

--- a/pymc/sampling/deterministic.py
+++ b/pymc/sampling/deterministic.py
@@ -171,6 +171,14 @@ def compute_deterministics(
 
     group_dataset: Dataset = dataset.dataset if isinstance(dataset, DataTree) else dataset
 
+    # Preserve thinned sample_dims coordinates from dataset to prevent NaN fill on coordinate mismatch (#8424)
+    sample_coords = {
+        dim: group_dataset.coords[dim].values
+        for dim in sample_dims
+        if dim in group_dataset.coords
+    }
+    coords = {**coords, **sample_coords}
+
     new_dataset = apply_function_over_dataset(
         fn,
         group_dataset[[rv.name for rv in model.free_RVs]],

--- a/tests/sampling/test_deterministic.py
+++ b/tests/sampling/test_deterministic.py
@@ -150,3 +150,16 @@ def test_docstring_example():
         pm.compute_deterministics(trace, extend_dataset=True)
 
     assert "mu" in trace.posterior
+
+
+def test_compute_deterministics_thinned_dataset():
+    with Model() as m:
+        intercept = Normal("intercept", 0, 1, shape=(5, 1))
+        det = Deterministic("det", intercept.cumsum())
+
+    idata = sample_prior_predictive(draws=10, model=m, var_names=["intercept"], random_seed=42)
+    thinned_idata = idata.sel(draw=slice(None, None, 2))
+    computed = compute_deterministics(thinned_idata.prior, extend_dataset=True, model=m, progressbar=False)
+
+    assert not np.isnan(computed["det"].values).any()
+    assert computed.sizes["draw"] == 5

--- a/tests/sampling/test_deterministic.py
+++ b/tests/sampling/test_deterministic.py
@@ -159,7 +159,9 @@ def test_compute_deterministics_thinned_dataset():
 
     idata = sample_prior_predictive(draws=10, model=m, var_names=["intercept"], random_seed=42)
     thinned_idata = idata.sel(draw=slice(None, None, 2))
-    computed = compute_deterministics(thinned_idata.prior, extend_dataset=True, model=m, progressbar=False)
+    computed = compute_deterministics(
+        thinned_idata.prior, extend_dataset=True, model=m, progressbar=False
+    )
 
     assert not np.isnan(computed["det"].values).any()
     assert computed.sizes["draw"] == 5


### PR DESCRIPTION
## Description
Fixes #8424.

When a posterior dataset is thinned (e.g. via idata.sel(draw=slice(None, None, 4))), computing downstream deterministic quantities with pm.compute_deterministics resulted in a coordinate length mismatch between the input dataset coordinates and default model coordinates, populating the computed deterministic array with NaN values without warning.

### Solution
Updated compute_deterministics in pymc/sampling/deterministic.py to prioritize and preserve the actual sample_dims coordinate values present in the input dataset.

### Testing
- Added 	est_compute_deterministics_thinned_dataset in 	ests/sampling/test_deterministic.py.
- Verified pytest test suite runs and passes cleanly.
