### PR TITLE
Respect sample dims in `apply_function_over_dataset`

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -835,7 +835,7 @@ def apply_function_over_dataset(
         out_trace,
         inference_library=pymc,
         dims=dims,
-        coords=coords,
+        coords={**coords, **stacked_dims},
         sample_dims=list(sample_dims),
         skip_event_dims=True,
     )

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -21,16 +21,19 @@ import xarray
 from arviz_base.testing import check_multiple_attrs
 from numpy import ma
 from pytensor.tensor.subtensor import AdvancedIncSubtensor
+from xarray.testing import assert_equal
 
 import pymc as pm
 
 from pymc.backends.arviz import (
     DataTreeConverter,
+    apply_function_over_dataset,
     dataset_to_point_list,
     predictions_to_inference_data,
     to_inference_data,
 )
 from pymc.exceptions import ImputationWarning
+from pymc.pytensorf import PointFunc
 
 # Turn all warnings into errors for this module
 pytestmark = pytest.mark.filterwarnings(
@@ -871,6 +874,22 @@ class TestDatasetToPointList:
         assert tuple(pl[0]) == ("x",)
         assert pl[0]["x"].shape == (0, 5)
         assert pl[0]["x"].dtype == np.float64
+
+
+def test_apply_function_over_dataset_preserves_sample_coords():
+    dataset = xarray.Dataset(
+        {"x": (("chain", "draw"), np.arange(6, dtype=float).reshape(2, 3))},
+        coords={"chain": [1, 3], "draw": [0, 4, 8]},
+    )
+    result = apply_function_over_dataset(
+        PointFunc(lambda x: [2 * x]),
+        dataset,
+        output_var_names=["y"],
+        coords={},
+        dims={},
+        progressbar=False,
+    )
+    assert_equal(result["y"], (2 * dataset["x"]).rename("y"))
 
 
 def test_incompatible_coordinate_lengths():

--- a/tests/sampling/test_deterministic.py
+++ b/tests/sampling/test_deterministic.py
@@ -15,7 +15,8 @@ import numpy as np
 import pytest
 
 from numpy.testing import assert_allclose
-from xarray import DataTree
+from xarray import Dataset, DataTree
+from xarray.testing import assert_equal
 
 from pymc.distributions import Normal
 from pymc.model.core import Deterministic, Model
@@ -71,6 +72,22 @@ def test_compute_deterministics(via):
     assert set(only_sigma.data_vars.variables) == {"sigma"}
     assert only_sigma["sigma"].dims == ("chain", "draw")
     assert_allclose(only_sigma["sigma"], np.exp(dataset["sigma_raw"]))
+
+
+def test_compute_deterministics_thinned_dataset():
+    # Regression test for #8424: thinning must not relabel the computed draws.
+    with Model() as model:
+        mu_raw = Normal("mu_raw")
+        Deterministic("mu", 2 * mu_raw)
+
+    dataset = Dataset(
+        {"mu_raw": (("chain", "draw"), np.arange(16, dtype=float).reshape(2, 8))},
+        coords={"chain": [0, 1], "draw": np.arange(8)},
+    ).isel(draw=slice(None, None, 2))
+
+    result = compute_deterministics(dataset, model=model, extend_dataset=True, progressbar=False)
+
+    assert_equal(result["mu"], (2 * dataset["mu_raw"]).rename("mu"))
 
 
 def test_compute_deterministics_extend_dataset():


### PR DESCRIPTION
Closes #8424

Fixes similar bug in compute_log_likelihood and compute_log_prior, besides the reported one in compute_deterministics

Closes #8425
