### PR TITLE
fix(gp): raise ValueError in set_boundary when boundary size L <= 0 (#8427)

### DIFF
--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -41,6 +41,11 @@ def set_boundary(X: TensorLike, c: numbers.Real | TensorLike) -> np.ndarray:
     S = (pt.max(X, axis=0) - pt.min(X, axis=0)) / 2.0
 
     L = (c * S).eval()  # eval() makes sure L is not changed with out-of-sample preds
+    if np.any(L <= 0):
+        raise ValueError(
+            "Boundary size L must be strictly positive for all dimensions. "
+            "Check that input data X has non-zero range (max - min > 0) for each feature column."
+        )
     return L
 
 

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -121,6 +121,11 @@ class TestHSGP(_BaseFixtures):
         L = pm.gp.hsgp_approx.set_boundary(X2s, c=2)
         assert np.all(L == 10)
 
+    def test_set_boundary_zero_range_raises(self):
+        X = np.ones((10, 2))
+        with pytest.raises(ValueError, match="Boundary size L must be strictly positive"):
+            pm.gp.hsgp_approx.set_boundary(X, c=1.5)
+
     def test_mean_invariance(self):
         X = np.linspace(0, 10, 100)[:, None]
         original_center = (np.max(X, axis=0) - np.min(X, axis=0)) / 2


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

## Description
In `pymc.gp.hsgp_approx.set_boundary(X, c)`, when input data `X` has zero range in any dimension (constant column where `pt.max(X) == pt.min(X)`), `L` evaluates to `0.0`, resulting in division by zero in `calc_eigenvalues`.

This PR adds `np.any(L <= 0)` validation in `set_boundary` to raise a clear `ValueError`, along with unit test `test_set_boundary_zero_range_raises` in `tests/gp/test_hsgp_approx.py`.

## Related Issue
- [x] Closes #8427
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
