### PR TITLE
Port find_MAP from pymc-extras and align it with pm.sample

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,7 @@ jobs:
           - |
             tests/tuning/test_scaling.py
             tests/tuning/test_starting.py
+            tests/tuning/test_scipy_interface.py
             tests/distributions/test_dist_math.py
             tests/distributions/test_transform.py
             tests/sampling/test_mcmc.py

--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
 # Base dependencies
 - arviz>=1.1.0,<2.0
+- better-optimize>=0.4.2,<1.0
 - blas
 - cachetools>=4.2.1,<7
 - cloudpickle

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
 # Base dependencies
 - arviz>=1.1.0,<2.0
+- better-optimize>=0.4.2,<1.0
 - blas
 - cachetools>=4.2.1,<7
 - cloudpickle

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
 # Base dependencies
 - arviz>=1.1.0,<2.0
+- better-optimize>=0.4.2,<1.0
 - cachetools>=4.2.1,<7
 - cloudpickle
 - numpy>=1.25.0

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
 # Base dependencies
 - arviz>=1.1.0,<2.0
+- better-optimize>=0.4.2,<1.0
 - blas
 - cachetools>=4.2.1,<7
 - cloudpickle

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
 # Base dependencies (see install guide for Windows)
 - arviz>=1.1.0,<2.0
+- better-optimize>=0.4.2,<1.0
 - blas
 - cachetools>=4.2.1,<7
 - cloudpickle

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
 # Base dependencies (see install guide for Windows)
 - arviz>=1.1.0,<2.0
+- better-optimize>=0.4.2,<1.0
 - blas
 - cachetools>=4.2.1,<7
 - cloudpickle

--- a/pymc/model/transform/conditioning.py
+++ b/pymc/model/transform/conditioning.py
@@ -262,7 +262,7 @@ def change_value_transforms(
             w = pm.Binomial("w", n=9, p=p, observed=6)
 
         with change_value_transforms(base_m, {"p": logodds}) as transformed_p:
-            mean_q = pm.find_MAP()
+            mean_q = pm.find_MAP(return_inferencedata=False)
 
         with change_value_transforms(transformed_p, {"p": None}) as untransformed_p:
             new_p = untransformed_p["p"]
@@ -343,7 +343,7 @@ def remove_value_transforms(
         with pm.Model() as transformed_m:
             p = pm.Uniform("p", 0, 1)
             w = pm.Binomial("w", n=9, p=p, observed=6)
-            mean_q = pm.find_MAP()
+            mean_q = pm.find_MAP(return_inferencedata=False)
 
         with remove_value_transforms(transformed_m) as untransformed_m:
             new_p = untransformed_m["p"]

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -24,7 +24,7 @@ import sys
 import time
 import warnings
 
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1699,6 +1699,7 @@ def _init_jitter(
     jitter: bool,
     jitter_max_retries: int,
     logp_fn: Callable[[PointType], np.ndarray] | None = None,
+    jitter_rvs: Iterable[Variable] | None = None,
 ) -> list[PointType]:
     """Apply a uniform jitter in [-1, 1] to the test value as starting point in each chain.
 
@@ -1716,6 +1717,8 @@ def _init_jitter(
     logp_fn: Callable[[dict[str, np.ndarray]], np.ndarray | jax.Array] | None
         logp function that takes the output of initial point functions as input.
         If None, will use the results of model.compile_logp().
+    jitter_rvs: iterable of random variables, optional
+        Variables to jitter. Defaults to all free variables.
 
     Returns
     -------
@@ -1725,7 +1728,7 @@ def _init_jitter(
     ipfns = make_initial_point_fns_per_chain(
         model=model,
         overrides=initvals,
-        jitter_rvs=set(model.free_RVs) if jitter else set(),
+        jitter_rvs=set(model.free_RVs if jitter_rvs is None else jitter_rvs) if jitter else set(),
         chains=len(seeds),
     )
 
@@ -1958,7 +1961,13 @@ def init_nuts(
         cov = approx.std.eval() ** 2
         potential = quadpotential.QuadPotentialDiag(cov, rng=random_seed_list[0])
     elif init == "advi_map":
-        start = pm.find_MAP(include_transformed=True, seed=random_seed_list[0])
+        start = pm.find_MAP(
+            include_transformed=True,
+            random_seed=random_seed_list[0],
+            return_inferencedata=False,
+            progressbar=progressbar and not quiet,
+            compile_kwargs=compile_kwargs,
+        )
         approx = pm.MeanField(model=model, start=start)
         pm.fit(
             random_seed=random_seed_list[0],
@@ -1979,7 +1988,13 @@ def init_nuts(
         cov = approx.std.eval() ** 2
         potential = quadpotential.QuadPotentialDiag(cov, rng=random_seed_list[0])
     elif init == "map":
-        start = pm.find_MAP(include_transformed=True, seed=random_seed_list[0])
+        start = pm.find_MAP(
+            include_transformed=True,
+            random_seed=random_seed_list[0],
+            return_inferencedata=False,
+            progressbar=progressbar and not quiet,
+            compile_kwargs=compile_kwargs,
+        )
         cov = -pm.find_hessian(point=start, negate_output=False)
         initial_points = [start] * chains
         potential = quadpotential.QuadPotentialFull(cov, rng=random_seed_list[0])

--- a/pymc/tuning/scipy_interface.py
+++ b/pymc/tuning/scipy_interface.py
@@ -1,0 +1,278 @@
+#   Copyright 2024 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Compile model log-densities into the callables expected by ``scipy.optimize``."""
+
+import logging
+
+from collections.abc import Callable
+from importlib.util import find_spec
+from typing import Literal, cast, get_args
+
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+
+from better_optimize.constants import MINIMIZE_MODE_KWARGS, minimize_method
+from pytensor.compile import Function
+from pytensor.compile.mode import get_mode
+from pytensor.link.jax.linker import JAXLinker
+from pytensor.tensor import TensorVariable
+from scipy.optimize import OptimizeResult
+
+from pymc.pytensorf import compile, join_nonshared_inputs, rewrite_pregrad
+
+GradientBackend = Literal["pytensor", "jax"]
+VALID_BACKENDS = get_args(GradientBackend)
+
+_log = logging.getLogger(__name__)
+
+
+def set_optimizer_function_defaults(
+    method: str, use_grad: bool | None, use_hess: bool | None, use_hessp: bool | None
+) -> tuple[bool, bool, bool]:
+    """Resolve ``None`` gradient/hessian flags from what ``method`` can use, preferring hessp over hess."""
+    method_info = MINIMIZE_MODE_KWARGS[method]
+
+    if use_hess and use_hessp:
+        _log.warning(
+            'Both "use_hess" and "use_hessp" are set to True, but scipy.optimize.minimize never uses both at the '
+            'same time. When possible "use_hessp" is preferred because it is computationally more efficient. '
+            'Setting "use_hess" to False.'
+        )
+        use_hess = False
+
+    use_grad = use_grad if use_grad is not None else method_info["uses_grad"]
+
+    if use_hessp is not None and use_hess is None:
+        use_hess = not use_hessp
+    elif use_hess is not None and use_hessp is None:
+        use_hessp = not use_hess
+    elif use_hessp is None and use_hess is None:
+        use_hessp = method_info["uses_hessp"]
+        use_hess = method_info["uses_hess"] and not use_hessp
+
+    return bool(use_grad), bool(use_hess), bool(use_hessp)
+
+
+def _compile_grad_and_hess_to_jax(
+    f_fused: Callable, use_hess: bool, use_hessp: bool
+) -> tuple[Callable, Callable | None]:
+    """Derive gradient (and optionally hessian / hessp) of a JAX-compiled loss with ``jax`` autodiff."""
+    import jax
+
+    orig_loss_fn = f_fused.vm.jit_fn  # type: ignore[attr-defined]
+    f_hessp = None
+
+    if use_hess:
+
+        @jax.jit
+        def loss_fn_fused(x):
+            loss_and_grad = jax.value_and_grad(lambda x: orig_loss_fn(x)[0])(x)
+            hess = jax.hessian(lambda x: orig_loss_fn(x)[0])(x)
+            return *loss_and_grad, hess
+
+    else:
+
+        @jax.jit
+        def loss_fn_fused(x):
+            return jax.value_and_grad(lambda x: orig_loss_fn(x)[0])(x)
+
+    if use_hessp:
+
+        @jax.jit
+        def f_hessp(x, p):
+            _, u = jax.jvp(lambda x: loss_fn_fused(x)[1], (x,), (p,))
+            return jax.numpy.stack(u)
+
+    return loss_fn_fused, f_hessp
+
+
+def _compile_functions_for_scipy_optimize(
+    loss: TensorVariable,
+    inputs: list[TensorVariable],
+    compute_grad: bool,
+    compute_hess: bool,
+    compute_hessp: bool,
+    compile_kwargs: dict | None = None,
+) -> list[Function | None]:
+    """Compile ``loss`` over a single flat input into ``[f_fused, f_hessp]``.
+
+    ``f_fused`` returns the loss, optionally fused with its gradient and dense hessian
+    (``loss``, ``(loss, grad)`` or ``(loss, grad, hess)``). ``f_hessp`` is a separate
+    hessian-vector product function, or None. Without any derivative the list is ``[f_loss]``.
+    """
+    compile_kwargs = {} if compile_kwargs is None else compile_kwargs
+    loss = rewrite_pregrad(loss)
+
+    if not (compute_grad or compute_hess or compute_hessp):
+        return [compile(inputs, loss, **compile_kwargs)]
+
+    [flat_input] = inputs
+    f_hessp = None
+    if compute_hessp:
+        p = pt.tensor("p", shape=flat_input.type.shape)
+        hessp = pytensor.gradient.hessian_vector_product(loss, [flat_input], p)
+        f_hessp = compile([flat_input, p], hessp[0], **compile_kwargs)
+
+    outputs = [loss]
+    if compute_grad:
+        grad = cast(TensorVariable, pytensor.gradient.grad(loss, flat_input))
+        outputs.append(grad)
+    if compute_hess:
+        outputs.append(pytensor.gradient.jacobian(grad, [flat_input])[0])
+
+    return [compile(inputs, outputs, **compile_kwargs), f_hessp]
+
+
+def scipy_optimize_funcs_from_loss(
+    loss: TensorVariable,
+    inputs: list[TensorVariable],
+    initial_point_dict: dict[str, np.ndarray] | None = None,
+    use_grad: bool | None = None,
+    use_hess: bool | None = None,
+    use_hessp: bool | None = None,
+    gradient_backend: GradientBackend = "pytensor",
+    compile_kwargs: dict | None = None,
+    inputs_are_flat: bool = False,
+) -> tuple[Callable, Callable | None]:
+    """Compile ``loss`` into scipy-compatible ``(f_fused, f_hessp)`` callables of one flat vector.
+
+    Parameters
+    ----------
+    loss : TensorVariable
+        Scalar loss to minimize.
+    inputs : list of TensorVariable
+        Input variables, joined into a single raveled vector unless ``inputs_are_flat``.
+    initial_point_dict : dict, optional
+        Maps input names to values; only used to determine input shapes.
+    use_grad, use_hess, use_hessp : bool, optional
+        Which derivatives to compile into the returned functions.
+    gradient_backend : {"pytensor", "jax"}
+        Whether derivatives are taken symbolically by pytensor or by ``jax`` autodiff on the
+        compiled loss. The latter requires a JAX compile mode.
+    compile_kwargs : dict, optional
+        Keyword arguments passed on to :func:`pymc.compile`.
+    inputs_are_flat : bool
+        Set when ``inputs`` already is a single flat vector.
+
+    Returns
+    -------
+    f_fused : Callable
+        Returns the loss, optionally fused with the gradient and hessian.
+    f_hessp : Callable or None
+        Hessian-vector product function, if requested.
+    """
+    compile_kwargs = {} if compile_kwargs is None else compile_kwargs.copy()
+
+    if use_hess and not use_grad:
+        raise ValueError("Cannot compute hessian without also computing the gradient")
+    if gradient_backend not in VALID_BACKENDS:
+        raise ValueError(
+            f"Invalid gradient backend: {gradient_backend}. Must be one of {VALID_BACKENDS}"
+        )
+
+    use_jax_gradients = (gradient_backend == "jax") and use_grad
+    if use_jax_gradients:
+        if not find_spec("jax"):
+            raise ImportError("JAX must be installed to use JAX gradients")
+        mode = compile_kwargs.setdefault("mode", "JAX")
+        if not isinstance(get_mode(mode).linker, JAXLinker):
+            raise ValueError(
+                'jax gradients can only be used when ``compile_kwargs["mode"]`` is set to "JAX"'
+            )
+
+    if not isinstance(inputs, list):
+        inputs = [inputs]
+
+    if inputs_are_flat:
+        [flat_input] = inputs
+    else:
+        outputs, flat_input = join_nonshared_inputs(
+            point=initial_point_dict or {}, outputs=[loss], inputs=inputs
+        )
+        loss = cast(TensorVariable, outputs[0])
+
+    if use_jax_gradients:
+        # The jax autodiff path bypasses the pytensor function wrapper, so it cannot see shared variables.
+        from pymc.sampling.jax import _replace_shared_variables
+
+        [loss] = _replace_shared_variables([loss])
+
+    compute_grad = bool(use_grad and not use_jax_gradients)
+    compute_hess = bool(use_hess and not use_jax_gradients)
+    compute_hessp = bool(use_hessp and not use_jax_gradients)
+
+    funcs = _compile_functions_for_scipy_optimize(
+        loss=loss,
+        inputs=[flat_input],
+        compute_grad=compute_grad,
+        compute_hess=compute_hess,
+        compute_hessp=compute_hessp,
+        compile_kwargs=compile_kwargs,
+    )
+    f_fused: Callable = cast(Callable, funcs[0])
+    f_hessp: Callable | None = funcs[1] if compute_hessp else None
+
+    if use_jax_gradients:
+        f_fused, f_hessp = _compile_grad_and_hess_to_jax(f_fused, bool(use_hess), bool(use_hessp))
+
+    return f_fused, f_hessp
+
+
+def get_nearest_psd(A: np.ndarray) -> np.ndarray:
+    """Nearest (in Frobenius norm) positive semi-definite matrix to ``A``."""
+    C = (A + A.T) / 2
+    eigval, eigvec = np.linalg.eigh(C)
+    eigval[eigval < 0] = 0
+    return eigvec @ np.diag(eigval) @ eigvec.T
+
+
+def _compute_inverse_hessian(
+    optimizer_result: OptimizeResult | None,
+    optimal_point: np.ndarray | None,
+    f_fused: Callable | None,
+    f_hessp: Callable | None,
+    use_hess: bool,
+    method: minimize_method | Literal["BFGS", "L-BFGS-B"],
+) -> np.ndarray | None:
+    """Inverse hessian at the optimum, taken from the cheapest available source.
+
+    BFGS results carry an inverse hessian estimate, L-BFGS-B a ``LinearOperator`` of it. Otherwise the
+    hessian is rebuilt from ``f_hessp`` or the fused hessian output and inverted after PSD projection.
+    """
+    if optimal_point is None and optimizer_result is None:
+        raise ValueError("At least one of `optimal_point` or `optimizer_result` must be provided.")
+
+    x_star = np.asarray(optimizer_result.x if optimizer_result is not None else optimal_point)
+    n_vars = len(x_star)
+    basis = np.eye(n_vars)
+
+    # basinhopping nests the inner optimizer's result
+    inner_result = getattr(optimizer_result, "lowest_optimization_result", optimizer_result)
+    hess_inv = getattr(inner_result, "hess_inv", None)
+
+    if method == "BFGS" and optimizer_result is not None:
+        return hess_inv
+    if method == "L-BFGS-B" and optimizer_result is not None:
+        if hess_inv is None:
+            return None
+        return np.stack([hess_inv(basis[:, i]) for i in range(n_vars)], axis=-1)
+    if f_hessp is not None:
+        H = np.stack([f_hessp(x_star, basis[:, i]) for i in range(n_vars)], axis=-1)
+        return np.linalg.inv(get_nearest_psd(H))
+    if use_hess and f_fused is not None:
+        _, _, H = f_fused(x_star)
+        return np.linalg.inv(get_nearest_psd(H))
+    return None

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -12,258 +12,398 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-"""
-Created on Mar 12, 2011.
-
-@author: johnsalvatier
-"""
+"""Maximum a posteriori (MAP) estimation."""
 
 import warnings
 
 from collections.abc import Sequence
+from itertools import product
+from typing import Any, Literal, cast
 
 import numpy as np
 import pytensor.gradient as tg
+import pytensor.tensor as pt
+import xarray as xr
 
-from numpy import isfinite
-from pytensor.graph.basic import Variable
-from pytensor.utils import lazy_scipy_module
-from rich.console import Console
-from rich.progress import Progress, TextColumn
+from better_optimize import basinhopping, minimize
+from better_optimize.constants import MINIMIZE_MODE_KWARGS, minimize_method
+from pytensor.graph.replace import graph_replace
+from pytensor.tensor import TensorVariable
+from scipy.optimize import OptimizeResult
+from scipy.sparse.linalg import LinearOperator
+from xarray import DataTree
 
-import pymc as pm
-
-from pymc.blocking import DictToArrayBijection, RaveledVars
-from pymc.initial_point import make_initial_point_fn
-from pymc.model import modelcontext
-from pymc.progress_bar import CustomProgress, default_progress_theme
-from pymc.pytensorf import floatX, inputvars
+from pymc.backends.arviz import to_inference_data
+from pymc.backends.base import MultiTrace
+from pymc.backends.ndarray import NDArray
+from pymc.blocking import DictToArrayBijection, PointType, RaveledVars
+from pymc.initial_point import StartDict
+from pymc.model import Model, modelcontext
+from pymc.model.transform.optimization import freeze_dims_and_data
+from pymc.pytensorf import inputvars, resolve_backend_compile_kwargs
+from pymc.tuning.scipy_interface import (
+    _compute_inverse_hessian,
+    scipy_optimize_funcs_from_loss,
+    set_optimizer_function_defaults,
+)
 from pymc.util import (
+    RandomState,
     get_default_varnames,
+    get_random_generator,
     get_value_vars_from_user_vars,
 )
 from pymc.vartypes import discrete_types, typefilter
 
-optimize = lazy_scipy_module("optimize")
-
 __all__ = ["find_MAP"]
+
+_METHODS = {k.lower(): k for k in MINIMIZE_MODE_KWARGS} | {"basinhopping": "basinhopping"}
+_LEGACY_KWARGS = {"start": "initvals", "seed": "random_seed", "maxeval": "maxiter"}
+
+
+def _canonical_method(method: str) -> str:
+    try:
+        return _METHODS[method.lower()]
+    except (KeyError, AttributeError):
+        raise ValueError(f"Unknown method {method!r}. Valid methods are {list(_METHODS)}")
+
+
+def _value_var_names(vars: Sequence[TensorVariable], model: Model) -> list[str]:
+    try:
+        value_vars = get_value_vars_from_user_vars(vars, model)
+    except ValueError as exc:
+        # Accommodate Deterministics / Potentials by optimizing the free RVs they depend on
+        value_vars = inputvars(model.replace_rvs_by_values(vars))
+        if not value_vars:
+            raise exc
+        warnings.warn(
+            "Intermediate variables (such as Deterministic or Potential) were passed. "
+            "find_MAP will optimize the underlying free_RVs instead.",
+            UserWarning,
+        )
+    return [str(var.name) for var in value_vars]
+
+
+def _unpacked_names(point_map_info, model: Model) -> list[str]:
+    """One coordinate-aware label per scalar element of the raveled parameter vector."""
+    value_to_rv = {value.name: rv.name for value, rv in model.values_to_rvs.items()}
+    names = []
+    for name, shape, *_ in point_map_info:
+        if not shape:
+            names.append(name)
+            continue
+        dims = model.named_vars_to_dims.get(value_to_rv.get(name, name)) or ()
+        dims = dims if len(dims) == len(shape) else (None,) * len(shape)
+        axes = [
+            coord if (coord := model.coords.get(dim)) is not None and len(coord) == n else range(n)
+            for dim, n in zip(dims, shape)
+        ]
+        names.extend(f"{name}[{','.join(map(str, idx))}]" for idx in product(*axes))
+    return names
+
+
+def _fit_dataset(mu: RaveledVars, H_inv: np.ndarray | None, names: list[str]) -> xr.Dataset:
+    data = {"mean_vector": xr.DataArray(mu.data, dims=["rows"], coords={"rows": names})}
+    if H_inv is not None:
+        data["covariance_matrix"] = xr.DataArray(
+            H_inv, dims=["rows", "columns"], coords={"rows": names, "columns": names}
+        )
+    return xr.Dataset(data)
+
+
+def _optimizer_result_to_dataset(
+    result: OptimizeResult, method: str, names: list[str]
+) -> xr.Dataset:
+    """Store every field of a scipy ``OptimizeResult``, labelling per-parameter fields by ``names``."""
+    if "lowest_optimization_result" in result:
+        # basinhopping nests the inner optimizer's result; flatten it over the outer fields
+        result = OptimizeResult(
+            {k: v for k, v in result.items() if k != "lowest_optimization_result"}
+            | dict(result["lowest_optimization_result"])
+        )
+    vec: tuple[str, ...] = ("variables",)
+    mat: tuple[str, ...] = ("variables", "variables_aux")
+    data = {"method": xr.DataArray(method)}
+    for key, value in result.items():
+        if value is None:
+            continue
+        if isinstance(value, LinearOperator):
+            value = np.column_stack([value.matvec(e) for e in np.eye(len(names))])
+        elif key == "message":
+            value = str(value)
+        value = np.asarray(value)
+        if key in ("x", "jac", "hess", "hess_inv") and value.ndim in (1, 2):
+            dims = vec if value.ndim == 1 else mat
+        else:
+            dims = tuple(f"{key}_dim_{i}" for i in range(value.ndim))
+        data[key] = xr.DataArray(value, dims=dims)
+    coords = {d: names for d in mat if any(d in da.dims for da in data.values())}
+    return xr.Dataset(data, coords=coords)
 
 
 def find_MAP(
-    start=None,
-    vars: Sequence[Variable] | None = None,
-    method="L-BFGS-B",
-    return_raw=False,
-    include_transformed=True,
-    progressbar=True,
-    progressbar_theme=default_progress_theme,
-    maxeval=5000,
-    model=None,
-    *args,
-    seed: int | None = None,
-    **kwargs,
-):
-    """Find the local maximum a posteriori point given a model.
+    method: minimize_method | Literal["basinhopping"] = "L-BFGS-B",
+    *,
+    vars: Sequence[TensorVariable] | None = None,
+    use_grad: bool | None = None,
+    use_hess: bool | None = None,
+    use_hessp: bool | None = None,
+    initvals: StartDict | None = None,
+    jitter: bool = True,
+    jitter_max_retries: int = 10,
+    random_seed: RandomState = None,
+    progressbar: bool = True,
+    include_transformed: bool = False,
+    compute_hessian: bool = False,
+    return_inferencedata: bool = True,
+    idata_kwargs: dict[str, Any] | None = None,
+    freeze_model: bool = True,
+    model: Model | None = None,
+    backend: str | None = None,
+    compile_kwargs: dict | None = None,
+    **optimizer_kwargs,
+) -> DataTree | PointType:
+    """Find the local maximum a posteriori point of a model with ``scipy.optimize``.
 
     `find_MAP` should not be used to initialize the NUTS sampler. Simply call
-    ``pymc.sample()`` and it will automatically initialize NUTS in a better
-    way.
+    ``pymc.sample()`` and it will automatically initialize NUTS in a better way.
 
     Parameters
     ----------
-    start: `dict` of parameter values (Defaults to `model.initial_point`)
-        These values will be fixed and used for any free RandomVariables that are
-        not being optimized.
-    vars: list of TensorVariable
-        List of free RandomVariables to optimize the posterior with respect to.
-        Defaults to all continuous RVs in a model. The respective value variables
-        may also be passed instead.
-    method: string or callable, optional
-        Optimization algorithm. Defaults to 'L-BFGS-B' unless discrete variables are
-        specified in `vars`, then `Powell` which will perform better. For instructions
-        on use of a callable, refer to SciPy's documentation of `optimize.minimize`.
-    return_raw: bool, optional defaults to False
-        Whether to return the full output of scipy.optimize.minimize
-    include_transformed: bool, optional defaults to True
-        Flag for reporting automatically unconstrained transformed values in addition
-        to the constrained values
-    progressbar: bool, optional defaults to True
-        Whether to display a progress bar in the command line.
-    progressbar_theme: Theme, optional
-        Custom theme for the progress bar.
-    maxeval: int, optional, defaults to 5000
-        The maximum number of times the posterior distribution is evaluated.
-    model: Model (optional if in `with` context)
-    *args, **kwargs
-        Extra args passed to scipy.optimize.minimize
+    method : str
+        Optimization method. Any ``scipy.optimize.minimize`` method (Nelder-Mead, Powell, CG,
+        BFGS, L-BFGS-B, TNC, COBYLA, SLSQP, trust-constr, dogleg, trust-ncg, trust-exact,
+        trust-krylov, Newton-CG) or ``"basinhopping"``. Defaults to ``"L-BFGS-B"``.
+    vars : list of TensorVariable, optional
+        Free random variables (or their value variables) to optimize over. All other variables
+        are held fixed at their initial values. Defaults to all continuous variables. Passing
+        discrete variables switches to the gradient-free ``"powell"`` method.
+    use_grad, use_hess, use_hessp : bool, optional
+        Whether to compile and pass the gradient, hessian and hessian-vector product to the
+        optimizer. ``None`` (default) chooses based on ``method``. If gradients are requested
+        automatically but the model has none, ``"powell"`` is used instead.
+    initvals : dict, optional
+        Initial values for (transformed) variables, overriding the model defaults. Partial
+        initialization is permitted, as in :func:`pymc.sample`.
+    jitter : bool, default True
+        Add U(-1, 1) jitter to the initial point of the optimized variables, as ``pymc.sample``
+        does. This avoids getting stuck at saddle points of the default initial point (e.g.
+        products of zero-centered variables). Set ``random_seed`` for reproducible results.
+    jitter_max_retries : int
+        Maximum number of attempts at drawing a jittered initial point with finite log-probability.
+    random_seed : int, array-like of int, or Generator, optional
+        Seed for jitter and stochastic optimizers (basinhopping). With a fixed seed the result is
+        fully reproducible.
+    progressbar : bool, default True
+        Whether to display a progress bar.
+    include_transformed : bool, default False
+        Whether to also return the values of transformed (unconstrained) variables, e.g. ``sigma_log__``.
+    compute_hessian : bool, default False
+        Compute the inverse hessian at the optimum and store it as ``fit.covariance_matrix``.
+        Needed for a Laplace approximation, but expensive for large models.
+    return_inferencedata : bool, default True
+        If True return an :class:`arviz.InferenceData` with the MAP point as a single-draw
+        ``posterior`` (plus ``fit``, ``optimizer_result``, ``observed_data`` and
+        ``constant_data`` groups). If False return a ``dict`` mapping variable names to values.
+    idata_kwargs : dict, optional
+        Keyword arguments for :func:`pymc.to_inference_data`.
+    freeze_model : bool, default True
+        Freeze data and dimension lengths before compiling, which allows constant folding and
+        is required by some backends (JAX).
+    model : Model (optional if in ``with`` context)
+    backend : str, optional
+        Computational backend, one of "numba", "c" or "jax". Defaults to the PyTensor default mode.
+    compile_kwargs : dict, optional
+        Keyword arguments for the compiled functions. ``compile_kwargs["mode"]`` cannot be combined
+        with ``backend``. ``compile_kwargs["gradient_backend"]="jax"`` takes derivatives with
+        JAX autodiff instead of PyTensor (requires the JAX backend).
+    **optimizer_kwargs
+        Passed on to ``scipy.optimize.minimize`` (e.g. ``maxiter``, ``tol``), or
+        ``scipy.optimize.basinhopping`` when ``method="basinhopping"``, in which case
+        ``minimizer_kwargs["method"]`` selects the inner optimizer (default ``"L-BFGS-B"``).
 
-    Notes
-    -----
-    Older code examples used `find_MAP` to initialize the NUTS sampler,
-    but this is not an effective way of choosing starting values for sampling.
-    As a result, we have greatly enhanced the initialization of NUTS and
-    wrapped it inside ``pymc.sample()`` and you should thus avoid this method.
+    Returns
+    -------
+    arviz.InferenceData or dict
+        MAP estimate, see ``return_inferencedata``.
     """
-    model = modelcontext(model)
-
-    if vars is None:
-        vars = model.continuous_value_vars
-        if not vars:
-            raise ValueError("Model has no unobserved continuous variables.")
-    else:
-        try:
-            vars = get_value_vars_from_user_vars(vars, model)
-        except ValueError as exc:
-            # Accommodate case where user passed non-pure RV nodes
-            vars = inputvars(model.replace_rvs_by_values(vars))
-            if vars:
-                warnings.warn(
-                    "Intermediate variables (such as Deterministic or Potential) were passed. "
-                    "find_MAP will optimize the underlying free_RVs instead.",
-                    UserWarning,
-                )
-            else:
-                raise exc
-
-    disc_vars = list(typefilter(vars, discrete_types))
-    ipfn = make_initial_point_fn(
-        model=model,
-        jitter_rvs=set(),
-        return_transformed=True,
-        overrides=start,
-    )
-    start = ipfn(seed)
-    model.check_start_vals(start)
-
-    vars_dict = {var.name: var for var in vars}
-    x0 = DictToArrayBijection.map(
-        {var_name: value for var_name, value in start.items() if var_name in vars_dict}
-    )
-
-    # TODO: If the mapping is fixed, we can simply create graphs for the
-    # mapping and avoid all this bijection overhead
-    compiled_logp_func = DictToArrayBijection.mapf(model.compile_logp(jacobian=False), start)
-    logp_func = lambda x: compiled_logp_func(RaveledVars(x, x0.point_map_info))  # noqa: E731
-
-    rvs = [model.values_to_rvs[vars_dict[name]] for name, _, _, _ in x0.point_map_info]
-    try:
-        # This might be needed for calls to `dlogp_func`
-        # start_map_info = tuple((v.name, v.shape, v.dtype) for v in vars)
-        compiled_dlogp_func = DictToArrayBijection.mapf(
-            model.compile_dlogp(rvs, jacobian=False), start
-        )
-        dlogp_func = lambda x: compiled_dlogp_func(RaveledVars(x, x0.point_map_info))  # noqa: E731
-        compute_gradient = True
-    except (AttributeError, NotImplementedError, tg.NullTypeGradError):
-        compute_gradient = False
-
-    if disc_vars or not compute_gradient:
-        pm._log.warning(
-            "Warning: gradient not available."
-            + "(E.g. vars contains discrete variables). MAP "
-            + "estimates may not be accurate for the default "
-            + "parameters. Defaulting to non-gradient minimization "
-            + "'Powell'."
-        )
-        method = "Powell"
-
-    if compute_gradient and method != "Powell":
-        cost_func = CostFuncWrapper(maxeval, progressbar, progressbar_theme, logp_func, dlogp_func)
-    else:
-        cost_func = CostFuncWrapper(maxeval, progressbar, progressbar_theme, logp_func)
-        compute_gradient = False
-
-    with cost_func.progress:
-        try:
-            opt_result = optimize.minimize(
-                cost_func, x0.data, method=method, jac=compute_gradient, *args, **kwargs
+    if isinstance(method, dict):
+        optimizer_kwargs["start"], method = method, "L-BFGS-B"
+    for old, new in _LEGACY_KWARGS.items():
+        if old in optimizer_kwargs:
+            warnings.warn(
+                f"`{old}` is deprecated, use `{new}` instead.", FutureWarning, stacklevel=2
             )
-            mx0 = opt_result["x"]  # r -> opt_result
-        except (KeyboardInterrupt, StopIteration) as e:
-            mx0, opt_result = cost_func.previous_x, None
-            if isinstance(e, StopIteration):
-                pm._log.info(e)
-        finally:
-            cost_func.progress.update(cost_func.task, completed=cost_func.n_eval, refresh=True)
-
-    mx0 = RaveledVars(mx0, x0.point_map_info)
-    unobserved_vars = get_default_varnames(model.unobserved_value_vars, include_transformed)
-    unobserved_vars_values = model.compile_fn(inputs=model.value_vars, outs=unobserved_vars)(
-        DictToArrayBijection.rmap(mx0, start)
-    )
-    mx = {var.name: value for var, value in zip(unobserved_vars, unobserved_vars_values)}
-
+            optimizer_kwargs[new] = optimizer_kwargs.pop(old)
+    initvals = optimizer_kwargs.pop("initvals", initvals)
+    random_seed = optimizer_kwargs.pop("random_seed", random_seed)
+    return_raw = optimizer_kwargs.pop("return_raw", False)
     if return_raw:
-        return mx, opt_result
-    else:
-        return mx
-
-
-def allfinite(x):
-    return np.all(isfinite(x))
-
-
-class CostFuncWrapper:
-    def __init__(
-        self,
-        maxeval=5000,
-        progressbar=True,
-        progressbar_theme=default_progress_theme,
-        logp_func=None,
-        dlogp_func=None,
-    ):
-        self.n_eval = 0
-        self.maxeval = maxeval
-        self.logp_func = logp_func
-        if dlogp_func is None:
-            self.use_gradient = False
-            self.desc = "logp = {:,.5g}"
-        else:
-            self.dlogp_func = dlogp_func
-            self.use_gradient = True
-            self.desc = "logp = {:,.5g}, ||grad|| = {:,.5g}"
-        self.previous_x = None
-        self.progressbar = progressbar
-        self.progress = CustomProgress(
-            *Progress.get_default_columns(),
-            TextColumn("{task.fields[loss]}"),
-            console=Console(theme=progressbar_theme),
-            disable=not progressbar,
+        warnings.warn(
+            "`return_raw` is deprecated. The optimizer result is stored in the `optimizer_result` "
+            "group of the returned InferenceData.",
+            FutureWarning,
+            stacklevel=2,
         )
-        self.task = self.progress.add_task("MAP", total=maxeval, loss="")
+    if optimizer_kwargs.pop("progressbar_theme", None) is not None:
+        warnings.warn("`progressbar_theme` is ignored by find_MAP.", FutureWarning, stacklevel=2)
 
-    def __call__(self, x):
-        neg_value = np.float64(self.logp_func(floatX(x)))
-        value = -1.0 * neg_value
-        if self.use_gradient:
-            neg_grad = self.dlogp_func(floatX(x))
-            if np.all(np.isfinite(neg_grad)):
-                self.previous_x = x
-            grad = -1.0 * neg_grad
-            grad = grad.astype(np.float64)
-        else:
-            self.previous_x = x
-            grad = None
+    from pymc.sampling.mcmc import _init_jitter  # avoids a circular import
 
-        if self.n_eval % 10 == 0:
-            self.progress.update(self.task, loss=self.update_progress_desc(neg_value, grad))
+    model = cast(Model, modelcontext(model))
+    # Resolve which value variables to optimize, in model order, before freezing reorders the graph
+    names = (
+        {var.name for var in model.continuous_value_vars}
+        if vars is None
+        else set(_value_var_names(vars, model))
+    )
+    var_names = [str(var.name) for var in model.value_vars if var.name in names]
+    if freeze_model:
+        model = freeze_dims_and_data(model)
+    compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
+    gradient_backend = compile_kwargs.pop("gradient_backend", "pytensor")
+    idata_kwargs = {} if idata_kwargs is None else idata_kwargs
 
-        if self.n_eval > self.maxeval:
-            self.progress.update(self.task, loss=self.update_progress_desc(neg_value, grad))
-            raise StopIteration
+    value_vars = {var.name: var for var in model.value_vars}
+    vars = [value_vars[name] for name in var_names]
+    if not vars:
+        raise ValueError("Model has no unobserved continuous variables.")
+    discrete = typefilter(vars, discrete_types)
 
-        self.n_eval += 1
-        self.progress.update(self.task, completed=self.n_eval)
+    rng = get_random_generator(random_seed)
+    [start] = _init_jitter(
+        model,
+        initvals,
+        [int(rng.integers(2**30))],
+        jitter,
+        jitter_max_retries,
+        jitter_rvs=[model.values_to_rvs[var] for var in vars if var not in discrete],
+    )
 
-        if self.use_gradient:
-            return value, grad
-        else:
-            return value
+    method = _canonical_method(method)
+    do_basinhopping = method == "basinhopping"
+    minimizer_kwargs = dict(optimizer_kwargs.pop("minimizer_kwargs", {}))
+    if do_basinhopping:
+        method = _canonical_method(minimizer_kwargs.pop("method", "L-BFGS-B"))
 
-    def update_progress_desc(self, neg_value: float, grad: np.float64 = None) -> None:
-        if self.progressbar:
-            if grad is None:
-                return self.desc.format(neg_value)
-            else:
-                norm_grad = np.linalg.norm(grad)
-                return self.desc.format(neg_value, norm_grad)
+    auto_grad = use_grad is None
+    if auto_grad and discrete:
+        warnings.warn(
+            "Discrete variables are being optimized, so gradients are not available. "
+            f"Using the gradient-free method 'powell' instead of '{method}'.",
+            UserWarning,
+        )
+        method, use_grad = "powell", False
+    use_grad, use_hess, use_hessp = set_optimizer_function_defaults(
+        method, use_grad, use_hess, use_hessp
+    )
+
+    loss = -cast(TensorVariable, model.logp(jacobian=False))
+    if fixed := [var for var in model.value_vars if var not in vars]:
+        loss = graph_replace(loss, {var: pt.constant(start[var.name], var.name) for var in fixed})
+    x0 = DictToArrayBijection.map({name: start[name] for name in var_names})
+
+    def compile_funcs(use_grad, use_hess, use_hessp):
+        return scipy_optimize_funcs_from_loss(
+            loss=loss,
+            inputs=vars,
+            initial_point_dict=DictToArrayBijection.rmap(x0),
+            use_grad=use_grad,
+            use_hess=use_hess,
+            use_hessp=use_hessp,
+            gradient_backend=gradient_backend,
+            compile_kwargs=compile_kwargs,
+        )
+
+    try:
+        f_fused, f_hessp = compile_funcs(use_grad, use_hess, use_hessp)
+    except (NotImplementedError, tg.NullTypeGradError) as exc:
+        if not (auto_grad and use_grad):
+            raise
+        warnings.warn(
+            f"Gradient not available ({exc}). Using the gradient-free method 'powell' instead of "
+            f"'{method}'.",
+            UserWarning,
+        )
+        method, use_grad, use_hess, use_hessp = "powell", False, False, False
+        f_fused, f_hessp = compile_funcs(use_grad, use_hess, use_hessp)
+
+    out = f_fused(x0.data)
+    if not np.isfinite(out[0] if isinstance(out, tuple | list) else out):
+        model.check_start_vals(start)
+
+    if do_basinhopping:
+        minimizer_kwargs = {"method": method, "hessp": f_hessp, **minimizer_kwargs}
+        optimizer_kwargs.setdefault("rng", rng)
+        res = basinhopping(
+            func=f_fused,
+            x0=x0.data,
+            progressbar=progressbar,
+            minimizer_kwargs=minimizer_kwargs,
+            **optimizer_kwargs,
+        )
+    else:
+        res = minimize(
+            f=f_fused,
+            x0=x0.data,
+            hessp=f_hessp,
+            progressbar=progressbar,
+            method=method,
+            **optimizer_kwargs,
+        )
+
+    H_inv = None
+    if compute_hessian:
+        H_inv = _compute_inverse_hessian(res, None, f_fused, f_hessp, use_hess, method)
+        if H_inv is None:  # gradient-free optimizer: compile a hessian-vector product for it
+            _, f_hessp = compile_funcs(False, False, True)
+            H_inv = _compute_inverse_hessian(res, None, None, f_hessp, False, method)
+    x_star = RaveledVars(np.asarray(res.x), x0.point_map_info)
+    point = DictToArrayBijection.rmap(x_star, start)
+
+    # Free, transformed and deterministic values at the optimum; one-shot, so avoid a heavy compile
+    unobserved = model.unobserved_value_vars
+    fn = model.compile_fn(
+        unobserved,
+        inputs=model.value_vars,
+        point_fn=False,
+        on_unused_input="ignore",
+        mode="FAST_COMPILE",
+    )
+    values = dict(zip([var.name for var in unobserved], fn(**point)))
+
+    if not return_inferencedata:
+        result = {
+            var.name: values[var.name]
+            for var in get_default_varnames(unobserved, include_transformed)
+        }
+        return (result, res) if return_raw else result  # type: ignore[return-value]
+
+    trace = NDArray(
+        model=model,
+        fn=fn,
+        var_shapes={k: v.shape for k, v in values.items()},
+        var_dtypes={k: v.dtype for k, v in values.items()},
+    )
+    trace.setup(draws=1, chain=0)
+    trace.record(point, in_warmup=False)
+    trace.close()
+    # Label transformed values (e.g. ``sigma_log__``) with their RV's dims when the shapes match
+    dims = {
+        str(value.name): list(model.named_vars_to_dims[rv.name])
+        for value, rv in model.values_to_rvs.items()
+        if rv.name in model.named_vars_to_dims
+        and value.name in values
+        and values[value.name].shape == values[rv.name].shape
+    }
+    idata_kwargs = {**idata_kwargs, "dims": dims | idata_kwargs.get("dims", {})}
+    idata = to_inference_data(
+        MultiTrace([trace]), model=model, include_transformed=include_transformed, **idata_kwargs
+    )
+    labels = _unpacked_names(x0.point_map_info, model)
+    idata["fit"] = DataTree(dataset=_fit_dataset(x_star, H_inv, labels))
+    idata["optimizer_result"] = DataTree(
+        dataset=_optimizer_result_to_dataset(
+            res, "basinhopping" if do_basinhopping else method, labels
+        )
+    )
+    return (idata, res) if return_raw else idata  # type: ignore[return-value]

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -29,7 +29,7 @@ from better_optimize import basinhopping, minimize
 from better_optimize.constants import MINIMIZE_MODE_KWARGS, minimize_method
 from pytensor.graph.replace import graph_replace
 from pytensor.tensor import TensorVariable
-from scipy.optimize import OptimizeResult
+from scipy.optimize import LbfgsInvHessProduct, OptimizeResult
 from scipy.sparse.linalg import LinearOperator
 from xarray import DataTree
 
@@ -125,6 +125,13 @@ def _optimizer_result_to_dataset(
     data = {"method": xr.DataArray(method)}
     for key, value in result.items():
         if value is None:
+            continue
+        if isinstance(value, LbfgsInvHessProduct):
+            # L-BFGS-B's inverse Hessian is m correction pairs; densifying it is O(n^2) memory
+            for suffix, pairs in (("sk", value.sk), ("yk", value.yk)):
+                data[f"{key}_{suffix}"] = xr.DataArray(
+                    np.asarray(pairs), dims=("lbfgs_corrections", "variables")
+                )
             continue
         if isinstance(value, LinearOperator):
             value = np.column_stack([value.matvec(e) for e in np.eye(len(names))])

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 # See that file for comments about the need/usage of each dependency.
 
 arviz>=1.1.0,<2.0
+better-optimize>=0.4.2,<1.0
 cachetools>=4.2.1,<7
 cloudpickle
 ipython>=7.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 arviz>=1.1.0,<2.0
+better-optimize>=0.4.2,<1.0
 cachetools>=4.2.1,<7
 cloudpickle
 numpy>=1.25.0

--- a/tests/distributions/test_truncated.py
+++ b/tests/distributions/test_truncated.py
@@ -434,7 +434,7 @@ def test_truncated_inference():
             observed=obs,
         )
 
-        map = find_MAP(progressbar=False)
+        map = find_MAP(progressbar=False, return_inferencedata=False)
 
     assert np.isclose(map["lam"], lam_true, atol=0.1)
 

--- a/tests/gp/test_gp.py
+++ b/tests/gp/test_gp.py
@@ -41,7 +41,9 @@ class TestMarginalVsMarginalApprox:
             self.gp = pm.gp.Marginal(mean_func=mean_func, cov_func=cov_func)
             sigma = pm.HalfNormal("sigma", sigma=100)
             self.gp.marginal_likelihood("lik", self.x[:, None], self.y, sigma)
-            self.map_full = pm.find_MAP(method="bfgs")  # bfgs seems to work much better than lbfgsb
+            self.map_full = pm.find_MAP(
+                method="bfgs", return_inferencedata=False
+            )  # bfgs seems to work much better than lbfgsb
 
         self.x_new = np.linspace(-6, 6, 20)
 
@@ -71,7 +73,7 @@ class TestMarginalVsMarginalApprox:
             gp = pm.gp.MarginalApprox(mean_func=mean_func, cov_func=cov_func, approx=approx)
             sigma = pm.HalfNormal("sigma", sigma=100, initval=50.0)
             gp.marginal_likelihood("lik", self.x[:, None], self.x[:, None], self.y, sigma)
-            map_approx = pm.find_MAP(method="bfgs")
+            map_approx = pm.find_MAP(method="bfgs", return_inferencedata=False)
 
         # Check MAP gets approximately correct result
         npt.assert_allclose(self.map_full["c"], map_approx["c"], atol=0.01, rtol=0.1)

--- a/tests/model/transform/test_conditioning.py
+++ b/tests/model/transform/test_conditioning.py
@@ -334,7 +334,7 @@ def test_change_value_transforms():
         new_p = transformed_p["p"]
         assert transformed_p.rvs_to_transforms[new_p] == logodds
         assert transformed_p.rvs_to_values[new_p].name == "p_logodds__"
-        mean_q = pm.find_MAP(progressbar=False)
+        mean_q = pm.find_MAP(progressbar=False, return_inferencedata=False)
 
     with change_value_transforms(transformed_p, {"p": None}) as untransformed_p:
         new_p = untransformed_p["p"]

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -586,7 +586,7 @@ def test_sample_find_MAP_does_not_modify_start():
 
         # make sure find_Map does not modify the start dict
         start = {"untransformed": 2}
-        pm.find_MAP(start=start)
+        pm.find_MAP(initvals=start, progressbar=False)
         assert start == {"untransformed": 2}
 
         # make sure sample does not modify the start dict

--- a/tests/tuning/test_scipy_interface.py
+++ b/tests/tuning/test_scipy_interface.py
@@ -1,0 +1,134 @@
+#   Copyright 2024 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import numpy as np
+import pytest
+
+from pytensor import tensor as pt
+
+from pymc.tuning import scipy_interface
+from pymc.tuning.scipy_interface import (
+    get_nearest_psd,
+    scipy_optimize_funcs_from_loss,
+    set_optimizer_function_defaults,
+)
+
+
+@pytest.fixture
+def simple_loss_and_inputs():
+    x = pt.vector("x")
+    return pt.sum(x**2), [x]
+
+
+def test_get_nearest_psd_returns_psd():
+    psd = get_nearest_psd(np.array([[2, -3], [-3, 2]]))
+    np.testing.assert_allclose(psd, psd.T)
+    assert np.all(np.linalg.eigvalsh(psd) >= -1e-12)
+
+
+def test_get_nearest_psd_given_psd_input():
+    L = np.random.default_rng(0).normal(size=(2, 2))
+    A = L @ L.T
+    np.testing.assert_allclose(get_nearest_psd(A), A)
+
+
+def test_set_optimizer_function_defaults_warns_and_prefers_hessp(caplog):
+    with caplog.at_level("WARNING"):
+        use_grad, use_hess, use_hessp = set_optimizer_function_defaults(
+            "trust-ncg", True, True, True
+        )
+    assert caplog.messages[0].startswith('Both "use_hess" and "use_hessp" are set to True')
+    assert (use_grad, use_hess, use_hessp) == (True, False, True)
+
+
+def test_set_optimizer_function_defaults_infers_hess_and_hessp():
+    assert set_optimizer_function_defaults("trust-ncg", None, None, True) == (True, False, True)
+    assert set_optimizer_function_defaults("trust-ncg", None, True, None) == (True, True, False)
+    assert set_optimizer_function_defaults("trust-ncg", None, None, None) == (True, False, True)
+    assert set_optimizer_function_defaults("L-BFGS-B", None, None, None) == (True, False, False)
+    assert set_optimizer_function_defaults("powell", None, None, None) == (False, False, False)
+
+
+@pytest.mark.parametrize(
+    "compute_grad, compute_hess, compute_hessp",
+    [(False, False, False), (True, False, False), (True, True, False), (True, False, True)],
+)
+def test_compile_functions_for_scipy_optimize(
+    simple_loss_and_inputs, compute_grad, compute_hess, compute_hessp
+):
+    loss, inputs = simple_loss_and_inputs
+    funcs = scipy_interface._compile_functions_for_scipy_optimize(
+        loss,
+        inputs,
+        compute_grad=compute_grad,
+        compute_hess=compute_hess,
+        compute_hessp=compute_hessp,
+    )
+    x = np.array([1.0, 2.0])
+    if not compute_grad:
+        [f_loss] = funcs
+        assert np.isclose(f_loss(x), 5.0)
+        return
+
+    f_fused, f_hessp = funcs
+    loss_val, grad_val, *rest = f_fused(x)
+    assert np.isclose(loss_val, 5.0)
+    np.testing.assert_allclose(grad_val, 2 * x)
+    if compute_hess:
+        np.testing.assert_allclose(rest[0], 2 * np.eye(2))
+    if compute_hessp:
+        np.testing.assert_allclose(f_hessp(x, np.array([1.0, 0.0])), [2.0, 0.0])
+    else:
+        assert f_hessp is None
+
+
+def test_scipy_optimize_funcs_from_loss_invalid_args(simple_loss_and_inputs):
+    loss, inputs = simple_loss_and_inputs
+    point = {"x": np.array([1.0, 2.0])}
+    with pytest.raises(ValueError, match="Invalid gradient backend"):
+        scipy_optimize_funcs_from_loss(loss, inputs, point, use_grad=True, gradient_backend="foo")
+    with pytest.raises(ValueError, match="Cannot compute hessian without"):
+        scipy_optimize_funcs_from_loss(loss, inputs, point, use_grad=False, use_hess=True)
+    pytest.importorskip("jax")
+    with pytest.raises(ValueError, match="jax gradients can only be used"):
+        scipy_optimize_funcs_from_loss(
+            loss,
+            inputs,
+            point,
+            use_grad=True,
+            gradient_backend="jax",
+            compile_kwargs={"mode": "NUMBA"},
+        )
+
+
+@pytest.mark.parametrize("gradient_backend", ["pytensor", "jax"])
+def test_scipy_optimize_funcs_from_loss_jax(gradient_backend):
+    pytest.importorskip("jax")
+    x = pt.tensor("x", shape=(2,))
+    loss = (x[0] ** 2 + 2) + (x[0] * x[1] + 3)
+    f_fused, f_hessp = scipy_optimize_funcs_from_loss(
+        loss=loss,
+        inputs=[x],
+        initial_point_dict={"x": np.array([1.0, 2.0])},
+        use_grad=True,
+        use_hess=True,
+        use_hessp=True,
+        gradient_backend=gradient_backend,
+        compile_kwargs={"mode": "JAX"},
+    )
+    x_val = np.array([1.0, 2.0])
+    z, grad, hess = f_fused(x_val)
+    np.testing.assert_allclose(z, 8.0)
+    np.testing.assert_allclose(np.asarray(grad).squeeze(), [2 * x_val[0] + x_val[1], x_val[0]])
+    np.testing.assert_allclose(np.asarray(hess).squeeze(), [[2, 1], [1, 0]])
+    np.testing.assert_allclose(np.asarray(f_hessp(x_val, np.array([1.0, 0.0]))).squeeze(), [2, 1])

--- a/tests/tuning/test_starting.py
+++ b/tests/tuning/test_starting.py
@@ -18,7 +18,7 @@ import pytest
 import xarray as xr
 
 from numpy.testing import assert_allclose
-from scipy.optimize import OptimizeResult
+from scipy.optimize import LbfgsInvHessProduct, OptimizeResult
 from scipy.sparse.linalg import LinearOperator
 
 import pymc as pm
@@ -246,7 +246,8 @@ def test_find_MAP_inferencedata(
     assert ("covariance_matrix" in idata.fit) == compute_hessian
     assert idata.fit.rows.values.tolist() == ["mu", "sigma_log__"]
     assert idata.optimizer_result["method"].item() == method
-    assert ("hess_inv" in idata.optimizer_result) == (method in ("BFGS", "L-BFGS-B"))
+    assert ("hess_inv" in idata.optimizer_result) == (method == "BFGS")
+    assert ("hess_inv_sk" in idata.optimizer_result) == (method == "L-BFGS-B")
     for key in ("hess", "hess_inv"):
         if key in idata.optimizer_result:
             assert idata.optimizer_result[key].dims == ("variables", "variables_aux")
@@ -434,6 +435,19 @@ class TestOptimizerResultToDataset:
         assert ds["hess_inv"].dims == ("variables", "variables_aux")
         assert ds["hess_inv"].coords["variables_aux"].values.tolist() == self.names
         assert_allclose(ds["hess_inv"].values, 2 * np.eye(2))
+
+    def test_lbfgs_hess_inv_kept_low_rank(self):
+        rng = np.random.default_rng(0)
+        n, m = 2, 3
+        sk, yk = rng.normal(size=(m, n)), rng.normal(size=(m, n))
+        yk = yk + np.sign(np.sum(sk * yk, axis=1))[:, None] * sk  # keep s.y > 0
+        result = OptimizeResult(x=np.ones(n), hess_inv=LbfgsInvHessProduct(sk, yk))
+        ds = _optimizer_result_to_dataset(result, "L-BFGS-B", self.names)
+        assert "hess_inv" not in ds
+        for key, pairs in (("hess_inv_sk", sk), ("hess_inv_yk", yk)):
+            assert ds[key].dims == ("lbfgs_corrections", "variables")
+            assert ds[key].coords["variables"].values.tolist() == self.names
+            assert_allclose(ds[key].values, pairs)
 
     def test_basinhopping_nested_result(self):
         result = OptimizeResult(

--- a/tests/tuning/test_starting.py
+++ b/tests/tuning/test_starting.py
@@ -15,17 +15,31 @@ import re
 
 import numpy as np
 import pytest
+import xarray as xr
 
 from numpy.testing import assert_allclose
+from scipy.optimize import OptimizeResult
+from scipy.sparse.linalg import LinearOperator
 
 import pymc as pm
 
-from pymc.exceptions import ImputationWarning
+from pymc.exceptions import ImputationWarning, SamplingError
 from pymc.step_methods.metropolis import tune
 from pymc.testing import select_by_precision
 from pymc.tuning import find_MAP
+from pymc.tuning.starting import _optimizer_result_to_dataset
 from tests import models
 from tests.models import non_normal, simple_arbitrary_det, simple_model
+
+
+@pytest.fixture
+def normal_model():
+    rng = np.random.default_rng(sum(map(ord, "find_MAP")))
+    with pm.Model() as m:
+        mu = pm.Normal("mu")
+        sigma = pm.Exponential("sigma", 1)
+        pm.Normal("y_hat", mu=mu, sigma=sigma, observed=rng.normal(loc=3, scale=1.5, size=10))
+    return m
 
 
 @pytest.mark.parametrize("bounded", [False, True])
@@ -34,9 +48,10 @@ def test_mle_jacobian(bounded):
     truth = 10.0  # Simple normal model should give mu=10.0
     rtol = 1e-4  # this rtol should work on both floatX precisions
 
-    start, model, _ = models.simple_normal(bounded_prior=bounded)
-    with model:
-        map_estimate = find_MAP(method="BFGS", model=model)
+    _, model, _ = models.simple_normal(bounded_prior=bounded)
+    map_estimate = find_MAP(
+        method="BFGS", model=model, return_inferencedata=False, progressbar=False
+    )
     assert_allclose(map_estimate["mu_i"], truth, rtol=rtol)
 
 
@@ -50,7 +65,9 @@ def test_tune_not_inplace():
 def test_accuracy_normal():
     _, model, (mu, _) = simple_model()
     with model:
-        newstart = find_MAP(pm.Point(x=[-10.5, 100.5]))
+        newstart = find_MAP(
+            initvals=pm.Point(x=[-10.5, 100.5]), return_inferencedata=False, progressbar=False
+        )
         assert_allclose(
             newstart["x"], [mu, mu], atol=select_by_precision(float64=1e-5, float32=1e-4)
         )
@@ -59,7 +76,12 @@ def test_accuracy_normal():
 def test_accuracy_non_normal():
     _, model, (mu, _) = non_normal(4)
     with model:
-        newstart = find_MAP(pm.Point(x=[0.5, 0.01, 0.95, 0.99]))
+        newstart = find_MAP(
+            initvals=pm.Point(x=[0.5, 0.01, 0.95, 0.99]),
+            jitter=False,
+            return_inferencedata=False,
+            progressbar=False,
+        )
         assert_allclose(newstart["x"], mu, atol=select_by_precision(float64=1e-5, float32=1e-4))
 
 
@@ -76,10 +98,17 @@ def test_find_MAP_discrete():
         pm.Binomial("ss", n=n, p=p)
         pm.Binomial("s", n=n, p=p, observed=yes)
 
-        map_est1 = find_MAP()
-        map_est2 = find_MAP(vars=model.value_vars)
+        map_est1 = find_MAP(return_inferencedata=False, progressbar=False)
+        with pytest.warns(UserWarning, match="Discrete variables are being optimized"):
+            map_est2 = find_MAP(
+                vars=model.value_vars, return_inferencedata=False, progressbar=False
+            )
 
-    assert_allclose(map_est1["p"], 0.6086956533498806, atol=tol1, rtol=0)
+    # ss is held fixed at its (jittered-p dependent) initial value; conjugate MAP given ss
+    ss0 = map_est1["ss"]
+    assert_allclose(
+        map_est1["p"], (alpha + yes + ss0 - 1) / (alpha + beta + 2 * n - 2), atol=tol1, rtol=0
+    )
 
     assert_allclose(map_est2["p"], 0.695642178810167, atol=tol2, rtol=0)
     assert map_est2["ss"] == 14
@@ -87,8 +116,10 @@ def test_find_MAP_discrete():
 
 def test_find_MAP_no_gradient():
     _, model = simple_arbitrary_det()
-    with model:
-        find_MAP()
+    with pytest.warns(UserWarning, match="Gradient not available"):
+        find_MAP(model=model, progressbar=False)
+    with pytest.raises(Exception):
+        find_MAP(model=model, use_grad=True, progressbar=False)
 
 
 def test_find_MAP():
@@ -104,9 +135,9 @@ def test_find_MAP():
         pm.Normal("y", mu=mu, tau=sigma**-2, observed=data)
 
         # Test gradient minimization
-        map_est1 = find_MAP(progressbar=False)
-        # Test non-gradient minimization
-        map_est2 = find_MAP(progressbar=False, method="Powell")
+        map_est1 = find_MAP(progressbar=False, return_inferencedata=False)
+        # Test non-gradient minimization, with case-insensitive method name
+        map_est2 = find_MAP(progressbar=False, method="Powell", return_inferencedata=False)
 
     assert_allclose(map_est1["mu"], 0, atol=tol)
     assert_allclose(map_est1["sigma"], 1, atol=tol)
@@ -131,8 +162,9 @@ def test_find_MAP_issue_5923():
         pm.Normal("y", mu=mu, tau=sigma**-2, observed=data)
 
         start = {"mu": -0.5, "sigma": 1.25}
-        map_est1 = find_MAP(progressbar=False, vars=[mu, sigma], start=start)
-        map_est2 = find_MAP(progressbar=False, vars=[sigma, mu], start=start)
+        kwargs = {"progressbar": False, "initvals": start, "return_inferencedata": False}
+        map_est1 = find_MAP(vars=[mu, sigma], **kwargs)
+        map_est2 = find_MAP(vars=[sigma, mu], **kwargs)
 
     assert_allclose(map_est1["mu"], 0, atol=tol)
     assert_allclose(map_est1["sigma"], 1, atol=tol)
@@ -147,7 +179,9 @@ def test_find_MAP_issue_4488():
         with pytest.warns(ImputationWarning):
             x = pm.Gamma("x", alpha=3, beta=10, observed=np.array([1, np.nan]))
         y = pm.Deterministic("y", x + 1)
-        map_estimate = find_MAP()
+        map_estimate = find_MAP(
+            include_transformed=True, return_inferencedata=False, progressbar=False
+        )
 
     assert not set.difference({"x_unobserved", "x_unobserved_log__", "y"}, set(map_estimate.keys()))
     assert_allclose(map_estimate["x_unobserved"], 0.2, rtol=1e-4, atol=1e-4)
@@ -163,5 +197,250 @@ def test_find_MAP_warning_non_free_RVs():
 
         msg = "Intermediate variables (such as Deterministic or Potential) were passed"
         with pytest.warns(UserWarning, match=re.escape(msg)):
-            r = pm.find_MAP(vars=[det])
+            r = pm.find_MAP(vars=[det], jitter=False, return_inferencedata=False, progressbar=False)
         assert_allclose([r["x"], r["y"], r["det"]], [50, 50, 100])
+
+
+def test_find_MAP_vars_subset_holds_others_fixed(normal_model):
+    with normal_model:
+        r = find_MAP(
+            vars=[normal_model["mu"]],
+            initvals={"sigma": 2.0},
+            return_inferencedata=False,
+            progressbar=False,
+        )
+    assert_allclose(r["sigma"], 2.0)
+
+
+@pytest.mark.parametrize(
+    "method, use_grad, use_hess, use_hessp",
+    [
+        ("Newton-CG", True, True, False),
+        ("Newton-CG", True, False, True),
+        ("BFGS", True, False, False),
+        ("L-BFGS-B", True, False, False),
+        ("trust-exact", True, True, False),
+        ("powell", False, False, False),
+    ],
+)
+@pytest.mark.parametrize("include_transformed, compute_hessian", [(True, True), (False, False)])
+def test_find_MAP_inferencedata(
+    normal_model, method, use_grad, use_hess, use_hessp, include_transformed, compute_hessian
+):
+    idata = find_MAP(
+        method=method,
+        model=normal_model,
+        use_grad=use_grad,
+        use_hess=use_hess,
+        use_hessp=use_hessp,
+        progressbar=False,
+        include_transformed=include_transformed,
+        compute_hessian=compute_hessian,
+    )
+    for group in ["posterior", "fit", "optimizer_result", "observed_data"]:
+        assert group in idata.children
+
+    posterior = idata.posterior.dataset.squeeze(["chain", "draw"])
+    assert posterior["mu"].shape == () and posterior["sigma"].shape == ()
+    assert ("sigma_log__" in posterior) == include_transformed
+    assert ("covariance_matrix" in idata.fit) == compute_hessian
+    assert idata.fit.rows.values.tolist() == ["mu", "sigma_log__"]
+    assert idata.optimizer_result["method"].item() == method
+    assert ("hess_inv" in idata.optimizer_result) == (method in ("BFGS", "L-BFGS-B"))
+    for key in ("hess", "hess_inv"):
+        if key in idata.optimizer_result:
+            assert idata.optimizer_result[key].dims == ("variables", "variables_aux")
+
+
+@pytest.mark.parametrize("gradient_backend", ["jax", "pytensor"])
+def test_find_MAP_jax_backend(normal_model, gradient_backend):
+    pytest.importorskip("jax")
+    idata = find_MAP(
+        model=normal_model,
+        backend="jax",
+        compile_kwargs={"gradient_backend": gradient_backend},
+        compute_hessian=True,
+        progressbar=False,
+    )
+    assert idata.fit.covariance_matrix.shape == (2, 2)
+    assert_allclose(idata.posterior["mu"].item(), 3.0, atol=1.0)
+
+
+def test_find_MAP_return_inferencedata_consistent(normal_model):
+    kwargs = {
+        "model": normal_model,
+        "include_transformed": True,
+        "progressbar": False,
+        "random_seed": 1,
+    }
+    idata = find_MAP(**kwargs)
+    point = find_MAP(return_inferencedata=False, **kwargs)
+    assert set(point) == {"mu", "sigma", "sigma_log__"}
+    for name, value in point.items():
+        assert_allclose(idata.posterior[name].values.squeeze(), value)
+
+
+def test_find_MAP_idata_kwargs(normal_model):
+    idata = find_MAP(model=normal_model, idata_kwargs={"log_likelihood": True}, progressbar=False)
+    assert "log_likelihood" in idata.children
+    assert idata.log_likelihood["y_hat"].shape == (1, 1, 10)
+
+
+def test_find_MAP_shared_variables():
+    x_val = np.linspace(-1, 1, 20)
+    with pm.Model() as m:
+        x = pm.Data("x", x_val)
+        beta = pm.Normal("beta")
+        sigma = pm.Exponential("sigma", 1)
+        pm.Normal(
+            "y", beta * x, sigma, observed=2 * x_val + np.random.default_rng(0).normal(0, 0.1, 20)
+        )
+
+    idata = find_MAP(model=m, progressbar=False)
+    assert "x" in idata.constant_data
+    assert "y" in idata.observed_data
+    assert_allclose(idata.posterior["beta"].item(), 2.0, atol=0.1)
+
+
+@pytest.mark.parametrize("use_hess, use_hessp", [(True, False), (False, True)])
+def test_find_MAP_basinhopping(normal_model, use_hess, use_hessp):
+    idata = find_MAP(
+        method="basinhopping",
+        model=normal_model,
+        use_hess=use_hess,
+        use_hessp=use_hessp,
+        progressbar=False,
+        random_seed=1,
+        minimizer_kwargs={"method": "Newton-CG"},
+        niter=1,
+    )
+    assert idata.posterior["mu"].shape == (1, 1)
+    assert idata.optimizer_result["method"].item() == "basinhopping"
+
+
+def test_find_MAP_with_coords():
+    with pm.Model(coords={"group": [1, 2, 3, 4, 5]}) as m:
+        mu_loc = pm.Normal("mu_loc", 0, 1)
+        mu_scale = pm.HalfNormal("mu_scale", 1)
+        mu = pm.Normal("mu", mu_loc, mu_scale, dims=["group"])
+        sigma = pm.HalfNormal("sigma", 1, dims=["group"])
+        pm.Normal("obs", mu=mu, sigma=sigma, observed=np.random.normal(size=(10, 5)))
+
+    idata = find_MAP(model=m, progressbar=False, include_transformed=True)
+    posterior = idata.posterior.dataset.squeeze(["chain", "draw"])
+    assert posterior["mu"].dims == ("group",)
+    assert posterior["sigma"].shape == (5,)
+    assert posterior["sigma_log__"].dims == ("group",)
+    assert idata.fit.rows.values.tolist() == [
+        "mu_loc",
+        "mu_scale_log__",
+        *[f"mu[{i}]" for i in range(1, 6)],
+        *[f"sigma_log__[{i}]" for i in range(1, 6)],
+    ]
+
+
+def test_find_MAP_nonscalar_rv_without_dims():
+    with pm.Model(coords={"test": ["A", "B", "C"]}) as model:
+        x_loc = pm.Normal("x_loc", mu=0, sigma=1, dims=["test"])
+        x = pm.Normal("x", mu=x_loc, sigma=1, shape=(2, 3))
+        pm.Normal("y", mu=x, sigma=1, observed=np.random.randn(10, 2, 3))
+
+    idata = find_MAP(model=model, progressbar=False)
+    assert idata.posterior["x"].shape == (1, 1, 2, 3)
+    assert idata.fit.rows.values.tolist() == [
+        "x_loc[A]",
+        "x_loc[B]",
+        "x_loc[C]",
+        *[f"x[{i},{j}]" for i in range(2) for j in range(3)],
+    ]
+
+
+def test_find_MAP_jitter_escapes_saddle():
+    # https://github.com/pymc-devs/pymc-extras/issues/687
+    with pm.Model() as m:
+        w = pm.Normal("w")
+        z = pm.Normal("z")
+        pm.Normal("y", mu=w * z, sigma=0.1, observed=1.0)
+
+    kwargs = {"model": m, "progressbar": False, "return_inferencedata": False}
+    stuck = find_MAP(jitter=False, **kwargs)
+    assert_allclose([stuck["w"], stuck["z"]], 0.0)
+    r1 = find_MAP(random_seed=11, **kwargs)
+    r2 = find_MAP(random_seed=11, **kwargs)
+    assert_allclose(r1["w"] * r1["z"], 1.0, atol=0.05)
+    assert_allclose(r1["w"], r2["w"])
+
+
+def test_find_MAP_invalid_start_raises():
+    with pm.Model() as m:
+        pm.Uniform("x", 0, 1, default_transform=None)
+    with pytest.raises(SamplingError, match="Initial evaluation of model at starting point failed"):
+        find_MAP(model=m, initvals={"x": 2.0}, progressbar=False)
+
+
+def test_find_MAP_unknown_method(normal_model):
+    with pytest.raises(ValueError, match="Unknown method"):
+        find_MAP(method="gradient-descent", model=normal_model, progressbar=False)
+
+
+def test_find_MAP_legacy_kwargs(normal_model):
+    kwargs = {
+        "model": normal_model,
+        "progressbar": False,
+        "return_inferencedata": False,
+        "random_seed": 1,
+    }
+    with pytest.warns(FutureWarning, match="`start` is deprecated"):
+        r1 = find_MAP({"mu": 1.0}, **kwargs)
+    with pytest.warns(FutureWarning, match="`start` is deprecated"):
+        r2 = find_MAP(start={"mu": 1.0}, **kwargs)
+    assert_allclose(r1["mu"], r2["mu"])
+    with pytest.warns(FutureWarning, match="`seed` is deprecated"):
+        find_MAP(seed=1, **kwargs)
+    with pytest.warns(FutureWarning, match="`maxeval` is deprecated"):
+        find_MAP(maxeval=10, **kwargs)
+    with pytest.warns(FutureWarning, match="`return_raw` is deprecated"):
+        point, res = find_MAP(return_raw=True, **kwargs)
+    assert isinstance(res, OptimizeResult)
+    assert set(point) == {"mu", "sigma"}
+
+
+class TestOptimizerResultToDataset:
+    names = ["mu", "sigma_log__"]
+
+    def test_basic(self):
+        result = OptimizeResult(
+            x=np.array([1.0, 2.0]),
+            fun=0.5,
+            success=True,
+            message="done",
+            jac=np.array([0.1, 0.2]),
+            nit=5,
+            custom_stat=np.array([42, 43]),
+        )
+        ds = _optimizer_result_to_dataset(result, "BFGS", self.names)
+        assert isinstance(ds, xr.Dataset)
+        assert ds["x"].coords["variables"].values.tolist() == self.names
+        assert ds["jac"].dims == ("variables",)
+        assert ds["message"].item() == "done" and ds["method"].item() == "BFGS"
+        assert ds["custom_stat"].dims == ("custom_stat_dim_0",)
+        assert "variables_aux" not in ds.coords
+
+    def test_hess_inv_linear_operator(self):
+        result = OptimizeResult(
+            x=np.ones(2), hess_inv=LinearOperator((2, 2), matvec=lambda x: 2 * x)
+        )
+        ds = _optimizer_result_to_dataset(result, "L-BFGS-B", self.names)
+        assert ds["hess_inv"].dims == ("variables", "variables_aux")
+        assert ds["hess_inv"].coords["variables_aux"].values.tolist() == self.names
+        assert_allclose(ds["hess_inv"].values, 2 * np.eye(2))
+
+    def test_basinhopping_nested_result(self):
+        result = OptimizeResult(
+            x=np.ones(2),
+            lowest_optimization_result=OptimizeResult(x=np.zeros(2), hess_inv=3 * np.eye(2)),
+        )
+        ds = _optimizer_result_to_dataset(result, "basinhopping", self.names)
+        assert_allclose(ds["hess_inv"].values, 3 * np.eye(2))
+        assert_allclose(ds["x"].values, 0.0)
+        assert "lowest_optimization_result" not in ds


### PR DESCRIPTION
# Port `find_MAP` from pymc-extras into PyMC

Closes #7308.

## Summary

`pm.find_MAP` is rewritten on top of the `pymc_extras.find_MAP` implementation and aligned with
`pm.sample` in parameter names, defaults and conventions. The pymc-extras design (fused
loss/gradient/hessian functions compiled over one flat parameter vector, `better_optimize` for
the scipy interface and progress bar, `basinhopping` support, optional inverse-Hessian) is taken
as the base; where pymc-extras and `pm.sample` disagree, `pm.sample` wins.

Highlights:

- **Same compile pipeline as `pm.sample`.** `backend=` / `compile_kwargs=` go through
  `resolve_backend_compile_kwargs`, so the default backend is whatever PyTensor's default mode is
  (numba), exactly like NUTS. `compile_kwargs={"gradient_backend": "jax"}` follows the
  `pm.sample` convention for JAX autodiff instead of a top-level `gradient_backend` argument.
- **Same initial point machinery as `pm.sample`.** `initvals=`, `jitter=`, `jitter_max_retries=`
  and `random_seed=` are handled by the `_init_jitter` helper NUTS uses, which also fixes
  pymc-extras#687 (jitter never applied / broken with `freeze_model=True`).
- **Same output as `pm.sample`.** `return_inferencedata=True` (default) returns a `DataTree`
  built by `pm.to_inference_data` from a one-draw trace, so `posterior`, `observed_data`,
  `constant_data`, deterministics, coords/dims and `idata_kwargs` (`log_likelihood`, ...) all
  behave like a sampling run. Two extra groups carry the optimizer output: `fit`
  (`mean_vector`, optional `covariance_matrix`) and `optimizer_result` (every field of the scipy
  `OptimizeResult`, per-parameter fields labelled with coordinate-aware names such as
  `beta[Intercept]`). `return_inferencedata=False` returns the classic `{name: value}` dict.
- Optimizer methods are case-insensitive (`"bfgs"`, `"Powell"` keep working), `use_grad` /
  `use_hess` / `use_hessp` are user-controllable with method-based defaults, and
  `method="basinhopping"` is available.

## API

```python
find_MAP(
    method="L-BFGS-B", *,
    vars=None, use_grad=None, use_hess=None, use_hessp=None,
    initvals=None, jitter=True, jitter_max_retries=10, random_seed=None,
    progressbar=True, include_transformed=False, compute_hessian=False,
    return_inferencedata=True, idata_kwargs=None, freeze_model=True,
    model=None, backend=None, compile_kwargs=None,
    **optimizer_kwargs,
)
```

| old pymc | pymc-extras | this PR | note |
|---|---|---|---|
| `start` (positional) | `initvals` | `initvals` | `start=` and a positional dict still work with a `FutureWarning` |
| `seed` | `random_seed` | `random_seed` | `seed=` warns |
| `vars` | – | `vars` | kept; others held fixed at the initial point |
| – | `jitter_rvs` | `jitter=True` + `jitter_max_retries` | `pm.sample` semantics via `_init_jitter`; only optimized variables are jittered |
| `return_raw` | – | – | warns; result lives in `idata.optimizer_result` |
| `maxeval` | `maxiter` (via kwargs) | `maxiter` (via kwargs) | `maxeval=` warns and is forwarded |
| `progressbar_theme` | – | – | warns, ignored (progress bar comes from `better_optimize`) |
| `include_transformed=True` | `include_transformed=True` | `include_transformed=False` | `pm.sample` default |
| – | `gradient_backend` | `compile_kwargs["gradient_backend"]` | `pm.sample` convention |
| – | `compile_kwargs` | `backend` + `compile_kwargs` | `pm.sample` convention |
| dict | DataTree | `return_inferencedata` (default True) | Goal 1 |
| – | `compute_hessian`, `freeze_model` | same | kept from pymc-extras |

Behavioural differences vs. pymc-extras worth knowing:

- Transformed values go into `posterior` when `include_transformed=True` (the `pm.sample` pymc
  sampler convention) instead of a separate `unconstrained_posterior` group. They do get their
  RV's dims (`sigma_log__` has `group` dims), which `pm.sample` does not do.
- `constant_data` is only present when the model has constant data (converter behaviour).
- Parameter vector order in `fit` / `optimizer_result` follows model definition order rather
  than the post-freeze graph order.
- `compute_hessian=True` always delivers: for gradient-free methods a hessian-vector product is
  compiled after optimization (pymc-extras' `fit_laplace` had to do this itself).
- Discrete variables in `vars` and models without gradients fall back to `"powell"` with a
  warning **only** when `use_grad` was left at `None`; explicitly asking for gradients raises.
- Unknown / non-string methods raise `ValueError` instead of being forwarded to scipy.

### Large models and the Hessian

MAP estimation is mostly worth reaching for on models too large for full MCMC, so parameter
counts in the tens of thousands are normal here and anything O(n²) is a liability. `find_MAP`
therefore never materializes a dense n×n matrix unless asked: L-BFGS-B's inverse Hessian is
stored in `optimizer_result` as its m correction pairs (`hess_inv_sk` / `hess_inv_yk`, dims
`(lbfgs_corrections, variables)`) instead of being densified through n matvecs, which costs
8.7 GB transient at n = 19k for an object that is only 2·m·n floats. A dense
`fit.covariance_matrix` is only computed with `compute_hessian=True`, and `use_hess` defaults to
False for every method that can use `hessp` instead.

## Files

- `pymc/tuning/scipy_interface.py` (new): compile helpers ported from pymc-extras
  (`scipy_optimize_funcs_from_loss`, `set_optimizer_function_defaults`, `get_nearest_psd`,
  `_compute_inverse_hessian`). Names are kept so pymc-extras can re-export them.
- `pymc/tuning/starting.py`: the rewrite plus the idata helpers.
- `pymc/sampling/mcmc.py`: `init="map"` / `"advi_map"` call the new signature and forward
  `compile_kwargs` / `progressbar`; `_init_jitter` takes an optional `jitter_rvs`.
- `pymc/model/transform/conditioning.py`: docstring examples.
- `requirements*.txt`, `conda-envs/*.yml`: new dependency `better-optimize>=0.4.2,<1.0`
  (conda-forge and PyPI; depends only on numpy/scipy/rich/pandas/joblib/threadpoolctl, all
  already required or trivially available).
- Tests: `tests/tuning/test_starting.py` (existing tests adapted, pymc-extras tests ported, new
  tests for jitter/seeding, legacy kwargs, `idata_kwargs`, `vars` subsets, invalid start),
  `tests/tuning/test_scipy_interface.py` (new). Other callers in `tests/gp`, `tests/distributions`,
  `tests/model/transform` and `tests/sampling` updated to `return_inferencedata=False`.

## Decisions for reviewers

1. **`better-optimize` becomes a hard dependency.** It is what pymc-extras builds on (progress
   bar, fused-function detection, `maxiter` / tolerance defaults, early stopping,
   `basinhopping`). Reimplementing that inside PyMC would be ~300 lines of duplicated code, so
   the dependency looked like the more maintainable option. If that is not acceptable, the
   fallback is to vendor a minimal `minimize` wrapper.
2. **`return_inferencedata=True` by default.** This is the `pm.sample` convention but changes
   what `pm.find_MAP()` returns for every existing caller. A softer path would be
   `return_inferencedata=None` → warn and return a dict for one release. I went with the
   hard switch as specified; happy to add the transition if preferred.
3. **`include_transformed=False` by default.** Also the `pm.sample` default; both old pymc and
   pymc-extras defaulted to `True`.
4. **`jitter=True` by default**, like `pm.sample`, so the default initial point cannot park the
   optimizer on a saddle point (pymc-extras#687). Results are reproducible with `random_seed`.
   Variables held fixed via `vars` are not jittered; `_init_jitter` gained an optional
   `jitter_rvs` argument for that.
5. **`freeze_model=True` kept** from pymc-extras even though `pm.sample` has no such argument;
   it enables constant folding and keeps the JAX path working.
6. `progressbar_theme` is dropped. `better_optimize` owns the progress bar and does not take a
   rich theme.

## Follow-ups (separate PRs)

- pymc-extras: make `pymc_extras.find_MAP` re-export `pm.find_MAP`, import
  `scipy_optimize_funcs_from_loss` / `set_optimizer_function_defaults` /
  `_compute_inverse_hessian` from `pymc.tuning.scipy_interface` in `fit_laplace` and DADVI, and
  read `idata.posterior` instead of `idata.unconstrained_posterior`.
- Docs: the `find_MAP` example notebooks still index the returned dict.

## Checks run locally

- `tests/tuning` (53 tests), `tests/sampling/test_mcmc.py -k "find_MAP or init"`,
  `tests/model/transform/test_conditioning.py`, `tests/distributions/test_truncated.py`,
  `tests/gp/test_gp.py -k MarginalApprox`: all passing with the numba default backend; JAX
  paths exercised where `jax` is installed.
- `pre-commit run` on all changed files (ruff, format, license header, pip-from-conda) and
  `mypy` on the two tuning modules: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
